### PR TITLE
Print a link to a UC registered model when logging it

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import sys
 import uuid
 from datetime import datetime
 from pathlib import Path
@@ -30,7 +31,11 @@ from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
 from mlflow.tracking.fluent import _use_logged_model
 from mlflow.utils.annotations import experimental
-from mlflow.utils.databricks_utils import get_databricks_runtime_version, is_in_databricks_runtime
+from mlflow.utils.databricks_utils import (
+    get_databricks_runtime_version,
+    get_workspace_url,
+    is_in_databricks_runtime,
+)
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -1108,6 +1113,18 @@ class Model:
             model_info = mlflow_model.get_model_info(model)
             if registered_model is not None:
                 model_info.registered_model_version = registered_model.version
+                # Add UC model version page link
+                if is_in_databricks_runtime():
+                    workspace_url = get_workspace_url()
+                    if workspace_url:
+                        uc_model_url = (
+                            f"{workspace_url}/explore/data/models/"
+                            f"{registered_model_name}/{registered_model.version}"
+                        )
+                        # Use sys.stdout.write to make the link clickable in the UI
+                        sys.stdout.write(
+                            f"🔗 View model version in Unity Catalog: {uc_model_url}\n"
+                        )
 
         # If the model signature is Mosaic AI Agent compatible, render a recipe for evaluation.
         from mlflow.models.display_utils import maybe_render_agent_eval_recipe

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -32,6 +32,7 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_
 from mlflow.tracking.fluent import _use_logged_model
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
+    _construct_databricks_uc_registered_model_url,
     get_databricks_runtime_version,
     get_workspace_url,
     is_in_databricks_runtime,
@@ -51,6 +52,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_MODEL_IS_EXTERNAL
 from mlflow.utils.uri import (
     append_to_uri_path,
     get_uri_scheme,
+    is_databricks_unity_catalog_uri,
     is_databricks_unity_catalog_uri,
 )
 

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -53,7 +53,6 @@ from mlflow.utils.uri import (
     append_to_uri_path,
     get_uri_scheme,
     is_databricks_unity_catalog_uri,
-    is_databricks_unity_catalog_uri,
 )
 
 _logger = logging.getLogger(__name__)
@@ -1119,14 +1118,10 @@ class Model:
                 # Add UC model version page link
                 registry_uri = mlflow.get_registry_uri()
                 if is_databricks_unity_catalog_uri(registry_uri):
-                    workspace_url = get_workspace_url()
-                    if workspace_url:
-                        # Convert dots to forward slashes for the URL path
-                        model_path = registered_model_name.replace(".", "/")
-                        uc_model_url = (
-                            f"{workspace_url}/explore/data/models/"
-                            f"{model_path}/version/{registered_model.version}"
-                        )
+                    uc_model_url = _construct_databricks_uc_registered_model_url(
+                        get_workspace_url(), registered_model_name, registered_model.version
+                    )
+                    if uc_model_url:
                         # Use sys.stdout.write to make the link clickable in the UI
                         sys.stdout.write(
                             f"🔗 View model version in Unity Catalog at: {uc_model_url}\n"

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -51,6 +51,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_MODEL_IS_EXTERNAL
 from mlflow.utils.uri import (
     append_to_uri_path,
     get_uri_scheme,
+    is_databricks_unity_catalog_uri,
 )
 
 _logger = logging.getLogger(__name__)
@@ -1114,16 +1115,19 @@ class Model:
             if registered_model is not None:
                 model_info.registered_model_version = registered_model.version
                 # Add UC model version page link
-                if is_in_databricks_runtime():
+                registry_uri = mlflow.get_registry_uri()
+                if is_databricks_unity_catalog_uri(registry_uri):
                     workspace_url = get_workspace_url()
                     if workspace_url:
+                        # Convert dots to forward slashes for the URL path
+                        model_path = registered_model_name.replace(".", "/")
                         uc_model_url = (
                             f"{workspace_url}/explore/data/models/"
-                            f"{registered_model_name}/{registered_model.version}"
+                            f"{model_path}/version/{registered_model.version}"
                         )
                         # Use sys.stdout.write to make the link clickable in the UI
                         sys.stdout.write(
-                            f"🔗 View model version in Unity Catalog: {uc_model_url}\n"
+                            f"🔗 View model version in Unity Catalog at: {uc_model_url}\n"
                         )
 
         # If the model signature is Mosaic AI Agent compatible, render a recipe for evaluation.

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -34,6 +34,7 @@ from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
     _construct_databricks_uc_registered_model_url,
     get_databricks_runtime_version,
+    get_workspace_id,
     get_workspace_url,
     is_in_databricks_runtime,
 )
@@ -1115,11 +1116,16 @@ class Model:
             model_info = mlflow_model.get_model_info(model)
             if registered_model is not None:
                 model_info.registered_model_version = registered_model.version
-                # Add UC model version page link
+
+                # Print a link to the UC model version page if the model is in UC.
                 registry_uri = mlflow.get_registry_uri()
-                if is_databricks_unity_catalog_uri(registry_uri):
+                workspace_url = get_workspace_url()
+                if workspace_url is not None and is_databricks_unity_catalog_uri(registry_uri):
                     uc_model_url = _construct_databricks_uc_registered_model_url(
-                        get_workspace_url(), registered_model_name, registered_model.version
+                        workspace_url,
+                        registered_model_name,
+                        registered_model.version,
+                        get_workspace_id(),
                     )
                     if uc_model_url:
                         # Use sys.stdout.write to make the link clickable in the UI

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1119,19 +1119,15 @@ class Model:
 
                 # Print a link to the UC model version page if the model is in UC.
                 registry_uri = mlflow.get_registry_uri()
-                workspace_url = get_workspace_url()
-                if workspace_url is not None and is_databricks_unity_catalog_uri(registry_uri):
+                if is_databricks_unity_catalog_uri(registry_uri) and (url := get_workspace_url()):
                     uc_model_url = _construct_databricks_uc_registered_model_url(
-                        workspace_url,
+                        url,
                         registered_model_name,
                         registered_model.version,
                         get_workspace_id(),
                     )
-                    if uc_model_url:
-                        # Use sys.stdout.write to make the link clickable in the UI
-                        sys.stdout.write(
-                            f"🔗 View model version in Unity Catalog at: {uc_model_url}\n"
-                        )
+                    # Use sys.stdout.write to make the link clickable in the UI
+                    sys.stdout.write(f"🔗 View model version in Unity Catalog at: {uc_model_url}\n")
 
         # If the model signature is Mosaic AI Agent compatible, render a recipe for evaluation.
         from mlflow.models.display_utils import maybe_render_agent_eval_recipe

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1127,7 +1127,10 @@ class Model:
                         get_workspace_id(),
                     )
                     # Use sys.stdout.write to make the link clickable in the UI
-                    sys.stdout.write(f"🔗 View model version in Unity Catalog at: {uc_model_url}\n")
+                    sys.stdout.write(
+                        f"🔗 View model version '{registered_model.version}' of "
+                        + f"'{registered_model_name}' in Unity Catalog at: {uc_model_url}\n"
+                    )
 
         # If the model signature is Mosaic AI Agent compatible, render a recipe for evaluation.
         from mlflow.models.display_utils import maybe_render_agent_eval_recipe

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1070,6 +1070,29 @@ def _construct_databricks_model_version_url(
     return model_version_url
 
 
+"""
+Get a Databricks URL for a given registered model version in UC.
+
+Args:
+    workspace_url: The URL of the workspace
+
+Returns:
+    Serving input example or None if the model has no serving input example.
+"""
+
+
+def _construct_databricks_uc_registered_model_url(
+    workspace_url: str, registered_model_name: str, version: str, workspace_id: Optional[str] = None
+) -> str:
+    uc_model_url = f"{workspace_url}/explore/data/models/"
+    model_name_as_url = registered_model_name.replace(".", "/")
+    uc_model_url += f"{model_name_as_url}/version/{version}"
+    if workspace_id and workspace_id != "0":
+        uc_model_url += "?o=" + str(workspace_id)
+
+    return uc_model_url
+
+
 def _get_databricks_creds_config(tracking_uri):
     # Note:
     # `_get_databricks_creds_config` reads credential token values or password and

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1071,13 +1071,16 @@ def _construct_databricks_model_version_url(
 
 
 """
-Get a Databricks URL for a given registered model version in UC.
+Get a Databricks URL for a given registered model version in Unity Catalog.
 
 Args:
-    workspace_url: The URL of the workspace
+    workspace_url: The URL of the workspace the registered model is in.
+    registered_model_name: The full name of the registered model containing the version.
+    version: The version of the registered model to create the URL for.
+    workspace_id: The ID of the workspace to include as a query parameter (if provided).
 
 Returns:
-    Serving input example or None if the model has no serving input example.
+    The Databricks URL for a registered model in Unity Catalog.
 """
 
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1085,13 +1085,9 @@ def _construct_databricks_uc_registered_model_url(
     Returns:
         The Databricks URL for a registered model in Unity Catalog.
     """
-    uc_model_url = f"{workspace_url}/explore/data/models/"
-    model_name_as_url = registered_model_name.replace(".", "/")
-    uc_model_url += f"{model_name_as_url}/version/{version}"
-    if workspace_id and workspace_id != "0":
-        uc_model_url += "?o=" + str(workspace_id)
-
-    return uc_model_url
+    path = registered_model_name.replace(".", "/")
+    query = f"?o={workspace_id}" if (workspace_id and workspace_id != "0") else ""
+    return f"{workspace_url}/explore/data/models/{path}/version/{version}{query}"
 
 
 def _get_databricks_creds_config(tracking_uri):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1070,23 +1070,21 @@ def _construct_databricks_model_version_url(
     return model_version_url
 
 
-"""
-Get a Databricks URL for a given registered model version in Unity Catalog.
-
-Args:
-    workspace_url: The URL of the workspace the registered model is in.
-    registered_model_name: The full name of the registered model containing the version.
-    version: The version of the registered model to create the URL for.
-    workspace_id: The ID of the workspace to include as a query parameter (if provided).
-
-Returns:
-    The Databricks URL for a registered model in Unity Catalog.
-"""
-
-
 def _construct_databricks_uc_registered_model_url(
     workspace_url: str, registered_model_name: str, version: str, workspace_id: Optional[str] = None
 ) -> str:
+    """
+    Get a Databricks URL for a given registered model version in Unity Catalog.
+
+    Args:
+        workspace_url: The URL of the workspace the registered model is in.
+        registered_model_name: The full name of the registered model containing the version.
+        version: The version of the registered model to create the URL for.
+        workspace_id: The ID of the workspace to include as a query parameter (if provided).
+
+    Returns:
+        The Databricks URL for a registered model in Unity Catalog.
+    """
     uc_model_url = f"{workspace_url}/explore/data/models/"
     model_name_as_url = registered_model_name.replace(".", "/")
     uc_model_url += f"{model_name_as_url}/version/{version}"

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -734,6 +734,7 @@ def test_model_log_with_unity_catalog_url(capsys):
             ),
         ) as mock_register,
     ):
+        orig_registry_uri = mlflow.get_registry_uri()
         mlflow.set_registry_uri("databricks-uc")
 
         # Create a test model and log it
@@ -768,3 +769,5 @@ def test_model_log_with_unity_catalog_url(capsys):
         mock_url.assert_called_once()
         mock_workspace_id.assert_called_once()
         mock_register.assert_called_once()
+        # Clean up the global variables set by the server
+        mlflow.set_registry_uri(orig_registry_uri)

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -758,7 +758,11 @@ def test_model_log_with_unity_catalog_url(capsys):
         expected_url = (
             "https://databricks.com/explore/data/models/name/mlflow/test_model/version/6?o=123\n"
         )
-        assert f"🔗 View model version in Unity Catalog at: {expected_url}" in captured.out
+        assert (
+            "🔗 View model version '6' of 'name.mlflow.test_model' in "
+            + f"Unity Catalog at: {expected_url}"
+            in captured.out
+        )
 
         # Ensure all the mocks are called using assert_called_once.
         mock_url.assert_called_once()

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -684,55 +684,6 @@ def test_save_model_with_prompts():
     assert associated_prompts[1].name == prompt_1.name
 
 
-def test_model_log_with_unity_catalog_url():
-    # Mock the necessary functions and environment
-    with (
-        mock.patch("mlflow.models.model.get_workspace_url", return_value="https://databricks.com"),
-        mock.patch("mlflow.models.model.get_workspace_id", return_value="123"),
-        mock.patch("sys.stdout.write") as mock_stdout,
-        mock.patch("mlflow.tracking._model_registry.fluent._register_model") as mock_register,
-    ):
-        mlflow.set_registry_uri("databricks-uc")
-
-        # Mock the registered model response
-        mock_register.return_value = ModelVersion(
-            name="name.mlflow.test_model",
-            version="6",
-            creation_timestamp=0,
-            last_updated_timestamp=0,
-            description="",
-            user_id="",
-            source="",
-            run_id="",
-            status="",
-            status_message="",
-            run_link="",
-        )
-
-        # Create a test model and log it
-        class MyModel(mlflow.pyfunc.PythonModel):
-            def predict(self, context, model_input: list[str], params=None):
-                return model_input
-
-        with mlflow.start_run():
-            model_info = mlflow.pyfunc.log_model(
-                registered_model_name="name.mlflow.test_model",
-                python_model=MyModel(),
-                input_example=["abc"],
-            )
-
-        # Verify the model info
-        assert model_info.registered_model_version == "6"
-
-        # Verify the URL was printed correctly
-        expected_url = (
-            "https://databricks.com/explore/data/models/name/mlflow/test_model/version/6?o=123"
-        )
-        mock_stdout.assert_called_once_with(
-            f"🔗 View model version in Unity Catalog at: {expected_url}\n"
-        )
-
-
 def test_logged_model_status():
     def predict_fn(model_input: list[str]):
         return model_input
@@ -757,3 +708,59 @@ def test_logged_model_status():
             )
     logged_model = mlflow.last_logged_model()
     assert logged_model.status == "FAILED"
+
+
+def test_model_log_with_unity_catalog_url(capsys):
+    # Mock the necessary functions and environment
+    with (
+        mock.patch(
+            "mlflow.models.model.get_workspace_url", return_value="https://databricks.com"
+        ) as mock_url,
+        mock.patch("mlflow.models.model.get_workspace_id", return_value="123") as mock_workspace_id,
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent._register_model",
+            return_value=ModelVersion(
+                name="name.mlflow.test_model",
+                version="6",
+                creation_timestamp=0,
+                last_updated_timestamp=0,
+                description="",
+                user_id="",
+                source="",
+                run_id="",
+                status="",
+                status_message="",
+                run_link="",
+            ),
+        ) as mock_register,
+    ):
+        mlflow.set_registry_uri("databricks-uc")
+
+        # Create a test model and log it
+        class MyModel(mlflow.pyfunc.PythonModel):
+            def predict(self, context, model_input: list[str], params=None):
+                return model_input
+
+        with mlflow.start_run():
+            model_info = mlflow.pyfunc.log_model(
+                registered_model_name="name.mlflow.test_model",
+                python_model=MyModel(),
+                input_example=["abc"],
+            )
+
+        # Verify the model info
+        assert model_info.registered_model_version == "6"
+
+        # Using capsys to capture output
+        captured = capsys.readouterr()
+
+        # Verify the URL was printed correctly
+        expected_url = (
+            "https://databricks.com/explore/data/models/name/mlflow/test_model/version/6?o=123\n"
+        )
+        assert f"🔗 View model version in Unity Catalog at: {expected_url}" in captured.out
+
+        # Ensure all the mocks are called using assert_called_once.
+        mock_url.assert_called_once()
+        mock_workspace_id.assert_called_once()
+        mock_register.assert_called_once()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ShaylanDias/mlflow/pull/15633?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15633/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15633/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15633/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Prints a link to a registered model version when one is logged from the MLflow client. This helps the user to jump directly to the model rather than needing to look it up in UC based on the printed name.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Ran the following code from a Databricks notebook:
```
import mlflow.pyfunc
import pandas as pd

# Define a simple PyFunc model
class DummyModel(mlflow.pyfunc.PythonModel):
    def predict(self, context, model_input):
        return model_input  # Echoes the input back

mlflow.set_registry_uri("databricks-uc")
catalog = "shaylan_dias"
schema = "mlflow"
model_name = "echo_model"
UC_MODEL_NAME = f"{catalog}.{schema}.{model_name}"

with mlflow.start_run():
    mlflow.pyfunc.log_model(
        artifact_path="model",
        python_model=DummyModel(),
        registered_model_name=UC_MODEL_NAME,
        input_example=pd.DataFrame([{"example": 1}])
    )
```

And received the output containing a functional link to UC:
<img width="1027" alt="Screenshot 2025-05-08 at 1 44 42 PM" src="https://github.com/user-attachments/assets/b447ba86-3d2c-4e48-a2fa-fe95a1d3c5f1" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Adds a link to a UC model version when one is registered from the client within a Databricks notebook.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
