### PR TITLE
Update `request_id` argument in `mlflow.set_trace_tag`/`m,lflow.delete_trace_tag` APIs

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -945,13 +945,14 @@ def update_current_trace(
         trace.info.tags.update(tags or {})
 
 
-def set_trace_tag(request_id: str, key: str, value: str):
+@request_id_backward_compatible
+def set_trace_tag(trace_id: str, key: str, value: str):
     """
     Set a tag on the trace with the given trace ID.
 
     The trace can be an active one or the one that has already ended and recorded in the
     backend. Below is an example of setting a tag on an active trace. You can replace the
-    ``request_id`` parameter to set a tag on an already ended trace.
+    ``trace_id`` parameter to set a tag on an already ended trace.
 
     .. code-block:: python
         :test:
@@ -959,25 +960,26 @@ def set_trace_tag(request_id: str, key: str, value: str):
         import mlflow
 
         with mlflow.start_span(name="span") as span:
-            mlflow.set_trace_tag(span.request_id, "key", "value")
+            mlflow.set_trace_tag(span.trace_id, "key", "value")
 
     Args:
-        request_id: The ID of the trace to set the tag on.
+        trace_id: The ID of the trace to set the tag on.
         key: The string key of the tag. Must be at most 250 characters long, otherwise
             it will be truncated when stored.
         value: The string value of the tag. Must be at most 250 characters long, otherwise
             it will be truncated when stored.
     """
-    TracingClient().set_trace_tag(request_id, key, value)
+    TracingClient().set_trace_tag(trace_id, key, value)
 
 
-def delete_trace_tag(request_id: str, key: str) -> None:
+@request_id_backward_compatible
+def delete_trace_tag(trace_id: str, key: str) -> None:
     """
     Delete a tag on the trace with the given trace ID.
 
     The trace can be an active one or the one that has already ended and recorded in the
     backend. Below is an example of deleting a tag on an active trace. You can replace the
-    ``request_id`` parameter to delete a tag on an already ended trace.
+    ``trace_id`` parameter to delete a tag on an already ended trace.
 
     .. code-block:: python
         :test:
@@ -985,15 +987,15 @@ def delete_trace_tag(request_id: str, key: str) -> None:
         import mlflow
 
         with mlflow.start_span("my_span") as span:
-            mlflow.set_trace_tag(span.request_id, "key", "value")
-            mlflow.delete_trace_tag(span.request_id, "key")
+            mlflow.set_trace_tag(span.trace_id, "key", "value")
+            mlflow.delete_trace_tag(span.trace_id, "key")
 
     Args:
-        request_id: The ID of the trace to delete the tag from.
+        trace_id: The ID of the trace to delete the tag from.
         key: The string key of the tag. Must be at most 250 characters long, otherwise
             it will be truncated when stored.
     """
-    TracingClient().delete_trace_tag(request_id, key)
+    TracingClient().delete_trace_tag(trace_id, key)
 
 
 @experimental

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1145,7 +1145,7 @@ def test_search_traces_with_run_id():
     def _create_trace(name, tags=None):
         with mlflow.start_span(name=name) as span:
             for k, v in (tags or {}).items():
-                TracingClient().set_trace_tag(request_id=span.request_id, key=k, value=v)
+                mlflow.set_trace_tag(trace_id=span.request_id, key=k, value=v)
         return span.request_id
 
     def _get_names(traces):
@@ -1590,3 +1590,25 @@ def test_log_trace_success(inputs, outputs, intermediate_outputs):
     assert root_span.name == "test"
     assert root_span.start_time_ns == start_time_ms * 1000000
     assert root_span.end_time_ns == (start_time_ms + execution_time_ms) * 1000000
+
+
+def test_set_delete_trace_tag():
+    with mlflow.start_span("span1") as span:
+        trace_id = span.trace_id
+
+    mlflow.set_trace_tag(trace_id=trace_id, key="key1", value="value1")
+    trace = mlflow.get_trace(trace_id=trace_id)
+    assert trace.info.tags["key1"] == "value1"
+
+    mlflow.delete_trace_tag(trace_id=trace_id, key="key1")
+    trace = mlflow.get_trace(trace_id=trace_id)
+    assert "key1" not in trace.info.tags
+
+    # Test with request_id kwarg (backward compatibility)
+    mlflow.set_trace_tag(request_id=trace_id, key="key3", value="value3")
+    trace = mlflow.get_trace(request_id=trace_id)
+    assert trace.info.tags["key3"] == "value3"
+
+    mlflow.delete_trace_tag(request_id=trace_id, key="key3")
+    trace = mlflow.get_trace(request_id=trace_id)
+    assert "key3" not in trace.info.tags


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15642?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15642/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15642/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15642/merge
```

</p>
</details>

### What changes are proposed in this pull request?

We've renamed `request_id` to `trace_id` and updated most of APIs, but missed these two APIs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
