### PR TITLE
Fix logged model status during model logging

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -28,7 +28,7 @@ from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
-from mlflow.tracking.fluent import _logged_model_cm
+from mlflow.tracking.fluent import _use_logged_model
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import get_databricks_runtime_version, is_in_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
@@ -937,7 +937,7 @@ class Model:
                     else None,
                 )
 
-            with _logged_model_cm(model=model):
+            with _use_logged_model(model=model):
                 if run_id is not None:
                     client.log_outputs(
                         run_id=run_id, models=[LoggedModelOutput(model.model_id, step=step)]

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -13,7 +13,7 @@ import yaml
 from packaging.requirements import InvalidRequirement, Requirement
 
 import mlflow
-from mlflow.entities import LoggedModel, LoggedModelOutput, LoggedModelStatus, Metric
+from mlflow.entities import LoggedModel, LoggedModelOutput, Metric
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.environment_variables import MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING
 from mlflow.exceptions import MlflowException
@@ -28,6 +28,7 @@ from mlflow.store.artifact.runs_artifact_repo import RunsArtifactRepository
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
+from mlflow.tracking.fluent import _logged_model_cm
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import get_databricks_runtime_version, is_in_databricks_runtime
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
@@ -936,138 +937,148 @@ class Model:
                     else None,
                 )
 
-            if run_id is not None:
-                client.log_outputs(
-                    run_id=run_id, models=[LoggedModelOutput(model.model_id, step=step)]
-                )
-                log_model_metrics_for_step(
-                    client=client, model_id=model.model_id, run_id=run_id, step=step
-                )
-
-            if prompts is not None:
-                # Convert to URIs for serialization
-                prompts = [pr.uri if isinstance(pr, Prompt) else pr for pr in prompts]
-
-            mlflow_model = cls(
-                artifact_path=model.artifact_location,
-                model_uuid=model.model_id,
-                run_id=run_id,
-                metadata=metadata,
-                resources=resources,
-                auth_policy=auth_policy,
-                prompts=prompts,
-                model_id=model.model_id,
-            )
-            flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
-            # `save_model` calls `load_model` to infer the model requirements, which may result in
-            # __pycache__ directories being created in the model directory.
-            for pycache in Path(local_path).rglob("__pycache__"):
-                shutil.rmtree(pycache, ignore_errors=True)
-
-            if is_in_databricks_runtime():
-                _copy_model_metadata_for_uc_sharing(local_path, flavor)
-
-            serving_input = mlflow_model.get_serving_input(local_path)
-            # We check signature presence here as some flavors have a default signature as a
-            # fallback when not provided by user, which is set during flavor's save_model() call.
-            if mlflow_model.signature is None:
-                if serving_input is None:
-                    _logger.warning(
-                        _LOG_MODEL_MISSING_INPUT_EXAMPLE_WARNING, extra={"color": "red"}
+            with _logged_model_cm(model=model):
+                if run_id is not None:
+                    client.log_outputs(
+                        run_id=run_id, models=[LoggedModelOutput(model.model_id, step=step)]
                     )
-                elif tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks":
-                    _logger.warning(_LOG_MODEL_MISSING_SIGNATURE_WARNING, extra={"color": "red"})
+                    log_model_metrics_for_step(
+                        client=client, model_id=model.model_id, run_id=run_id, step=step
+                    )
 
-            env_vars = None
-            # validate input example works for serving when logging the model
-            if serving_input and kwargs.get("validate_serving_input", True):
-                from mlflow.models import validate_serving_input
-                from mlflow.utils.model_utils import RECORD_ENV_VAR_ALLOWLIST, env_var_tracker
+                if prompts is not None:
+                    # Convert to URIs for serialization
+                    prompts = [pr.uri if isinstance(pr, Prompt) else pr for pr in prompts]
 
-                with env_var_tracker() as tracked_env_names:
-                    try:
-                        validate_serving_input(
-                            model_uri=local_path,
-                            serving_input=serving_input,
-                        )
-                    except Exception as e:
+                mlflow_model = cls(
+                    artifact_path=model.artifact_location,
+                    model_uuid=model.model_id,
+                    run_id=run_id,
+                    metadata=metadata,
+                    resources=resources,
+                    auth_policy=auth_policy,
+                    prompts=prompts,
+                    model_id=model.model_id,
+                )
+                flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
+                # `save_model` calls `load_model` to infer the model requirements, which may result
+                # in __pycache__ directories being created in the model directory.
+                for pycache in Path(local_path).rglob("__pycache__"):
+                    shutil.rmtree(pycache, ignore_errors=True)
+
+                if is_in_databricks_runtime():
+                    _copy_model_metadata_for_uc_sharing(local_path, flavor)
+
+                serving_input = mlflow_model.get_serving_input(local_path)
+                # We check signature presence here as some flavors have a default signature as a
+                # fallback when not provided by user, which is set during flavor's save_model()
+                # call.
+                if mlflow_model.signature is None:
+                    if serving_input is None:
                         _logger.warning(
-                            f"Failed to validate serving input example {serving_input}. "
-                            "Alternatively, you can avoid passing input example and pass model "
-                            "signature instead when logging the model. To ensure the input example "
-                            "is valid prior to serving, please try calling "
-                            "`mlflow.models.validate_serving_input` on the model uri and serving "
-                            "input example. A serving input example can be generated from model "
-                            "input example using "
-                            "`mlflow.models.convert_input_example_to_serving_input` function.\n"
-                            f"Got error: {e}",
-                            exc_info=_logger.isEnabledFor(logging.DEBUG),
+                            _LOG_MODEL_MISSING_INPUT_EXAMPLE_WARNING, extra={"color": "red"}
                         )
-                    env_vars = (
-                        sorted(
-                            x
-                            for x in tracked_env_names
-                            if any(env_var in x for env_var in RECORD_ENV_VAR_ALLOWLIST)
+                    elif (
+                        tracking_uri == "databricks" or get_uri_scheme(tracking_uri) == "databricks"
+                    ):
+                        _logger.warning(
+                            _LOG_MODEL_MISSING_SIGNATURE_WARNING, extra={"color": "red"}
                         )
-                        or None
-                    )
-            if env_vars:
-                # Keep the environment variable file as it serves as a check
-                # for displaying tips in Databricks serving endpoint
-                env_var_path = Path(local_path, ENV_VAR_FILE_NAME)
-                env_var_path.write_text(ENV_VAR_FILE_HEADER + "\n".join(env_vars) + "\n")
-                if len(env_vars) <= 3:
-                    env_var_info = "[" + ", ".join(env_vars) + "]"
-                else:
-                    env_var_info = "[" + ", ".join(env_vars[:3]) + ", ... " + "]"
-                    f"(check file {ENV_VAR_FILE_NAME} in the model's artifact folder for full list"
-                    " of environment variable names)"
-                _logger.info(
-                    "Found the following environment variables used during model inference: "
-                    f"{env_var_info}. Please check if you need to set them when deploying the "
-                    "model. To disable this message, set environment variable "
-                    f"`{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
-                )
-                mlflow_model.env_vars = env_vars
-                # mlflow_model is updated, rewrite the MLmodel file
-                mlflow_model.save(os.path.join(local_path, MLMODEL_FILE_NAME))
 
-            client.log_model_artifacts(model.model_id, local_path)
-            # If the model was previously identified as external, delete the tag because the model
-            # now has artifacts in MLflow Model format
-            if model.tags.get(MLFLOW_MODEL_IS_EXTERNAL, "false").lower() == "true":
-                client.delete_logged_model_tag(model.model_id, MLFLOW_MODEL_IS_EXTERNAL)
-            client.finalize_logged_model(model.model_id, status=LoggedModelStatus.READY)
+                env_vars = None
+                # validate input example works for serving when logging the model
+                if serving_input and kwargs.get("validate_serving_input", True):
+                    from mlflow.models import validate_serving_input
+                    from mlflow.utils.model_utils import RECORD_ENV_VAR_ALLOWLIST, env_var_tracker
 
-            # Associate prompts to the model Run
-            # TODO: pass model_id to log_prompt
-            if prompts and run_id:
-                client = mlflow.MlflowClient()
-                for prompt in prompts:
-                    client.log_prompt(run_id, prompt)
-
-            # if the model_config kwarg is passed in, then log the model config as an params
-            if model_config := kwargs.get("model_config"):
-                if isinstance(model_config, str):
-                    try:
-                        file_extension = os.path.splitext(model_config)[1].lower()
-                        if file_extension == ".json":
-                            with open(model_config) as f:
-                                model_config = json.load(f)
-                        elif file_extension in [".yaml", ".yml"]:
-                            from mlflow.utils.model_utils import (
-                                _validate_and_get_model_config_from_file,
+                    with env_var_tracker() as tracked_env_names:
+                        try:
+                            validate_serving_input(
+                                model_uri=local_path,
+                                serving_input=serving_input,
                             )
-
-                            model_config = _validate_and_get_model_config_from_file(model_config)
-                        else:
+                        except Exception as e:
                             _logger.warning(
-                                "Unsupported file format for model config: %s. "
-                                "Failed to load model config.",
-                                model_config,
+                                f"Failed to validate serving input example {serving_input}. "
+                                "Alternatively, you can avoid passing input example and pass model "
+                                "signature instead when logging the model. To ensure the input "
+                                "example is valid prior to serving, please try calling "
+                                "`mlflow.models.validate_serving_input` on the model uri and "
+                                "serving input example. A serving input example can be generated "
+                                "from model input example using "
+                                "`mlflow.models.convert_input_example_to_serving_input` function.\n"
+                                f"Got error: {e}",
+                                exc_info=_logger.isEnabledFor(logging.DEBUG),
                             )
-                    except Exception as e:
-                        _logger.warning("Failed to load model config from %s: %s", model_config, e)
+                        env_vars = (
+                            sorted(
+                                x
+                                for x in tracked_env_names
+                                if any(env_var in x for env_var in RECORD_ENV_VAR_ALLOWLIST)
+                            )
+                            or None
+                        )
+                if env_vars:
+                    # Keep the environment variable file as it serves as a check
+                    # for displaying tips in Databricks serving endpoint
+                    env_var_path = Path(local_path, ENV_VAR_FILE_NAME)
+                    env_var_path.write_text(ENV_VAR_FILE_HEADER + "\n".join(env_vars) + "\n")
+                    if len(env_vars) <= 3:
+                        env_var_info = "[" + ", ".join(env_vars) + "]"
+                    else:
+                        env_var_info = "[" + ", ".join(env_vars[:3]) + ", ... " + "]"
+                        f"(check file {ENV_VAR_FILE_NAME} in the model's artifact folder for full "
+                        "list of environment variable names)"
+                    _logger.info(
+                        "Found the following environment variables used during model inference: "
+                        f"{env_var_info}. Please check if you need to set them when deploying the "
+                        "model. To disable this message, set environment variable "
+                        f"`{MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING.name}` to `false`."
+                    )
+                    mlflow_model.env_vars = env_vars
+                    # mlflow_model is updated, rewrite the MLmodel file
+                    mlflow_model.save(os.path.join(local_path, MLMODEL_FILE_NAME))
+
+                client.log_model_artifacts(model.model_id, local_path)
+                # If the model was previously identified as external, delete the tag because
+                # the model now has artifacts in MLflow Model format
+                if model.tags.get(MLFLOW_MODEL_IS_EXTERNAL, "false").lower() == "true":
+                    client.delete_logged_model_tag(model.model_id, MLFLOW_MODEL_IS_EXTERNAL)
+                # client.finalize_logged_model(model.model_id, status=LoggedModelStatus.READY)
+
+                # Associate prompts to the model Run
+                # TODO: pass model_id to log_prompt
+                if prompts and run_id:
+                    client = mlflow.MlflowClient()
+                    for prompt in prompts:
+                        client.log_prompt(run_id, prompt)
+
+                # if the model_config kwarg is passed in, then log the model config as an params
+                if model_config := kwargs.get("model_config"):
+                    if isinstance(model_config, str):
+                        try:
+                            file_extension = os.path.splitext(model_config)[1].lower()
+                            if file_extension == ".json":
+                                with open(model_config) as f:
+                                    model_config = json.load(f)
+                            elif file_extension in [".yaml", ".yml"]:
+                                from mlflow.utils.model_utils import (
+                                    _validate_and_get_model_config_from_file,
+                                )
+
+                                model_config = _validate_and_get_model_config_from_file(
+                                    model_config
+                                )
+                            else:
+                                _logger.warning(
+                                    "Unsupported file format for model config: %s. "
+                                    "Failed to load model config.",
+                                    model_config,
+                                )
+                        except Exception as e:
+                            _logger.warning(
+                                "Failed to load model config from %s: %s", model_config, e
+                            )
 
                 try:
                     from mlflow.models.utils import _flatten_nested_params
@@ -1080,7 +1091,10 @@ class Model:
                     params_to_log = model_config
 
                 try:
-                    mlflow.tracking.fluent.log_params(params_to_log or {}, run_id=run_id)
+                    # do not log params to run if run_id is None, since that could trigger
+                    # a new run to be created
+                    if run_id:
+                        mlflow.tracking.fluent.log_params(params_to_log or {}, run_id=run_id)
                 except Exception as e:
                     _logger.warning("Failed to log model config as params: %s", str(e))
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -2030,11 +2030,6 @@ class FileStore(AbstractStore):
         Returns:
             The updated model.
         """
-        if status != LoggedModelStatus.READY:
-            raise MlflowException(
-                f"Invalid model status: {status}. Expected statuses: [{LoggedModelStatus.READY}]",
-                databricks_pb2.INVALID_PARAMETER_VALUE,
-            )
         model_dict = self._get_model_dict(model_id)
         model = LoggedModel.from_dictionary(model_dict)
         model.status = status

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1820,12 +1820,6 @@ class SqlAlchemyStore(AbstractStore):
             session.commit()
 
     def finalize_logged_model(self, model_id: str, status: LoggedModelStatus) -> LoggedModel:
-        if status != LoggedModelStatus.READY:
-            raise MlflowException(
-                f"Invalid model status: {status}. Expected statuses: [{LoggedModelStatus.READY}]",
-                INVALID_PARAMETER_VALUE,
-            )
-
         with self.ManagedSessionMaker() as session:
             logged_model = session.query(SqlLoggedModel).get(model_id)
             if not logged_model:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -12,7 +12,7 @@ import os
 import threading
 from contextvars import ContextVar
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Generator, Optional, Union
 
 import mlflow
 from mlflow.entities import (
@@ -2129,6 +2129,23 @@ def initialize_logged_model(
     )
     _last_logged_model_id.set(model.model_id)
     return model
+
+
+@contextlib.contextmanager
+def _logged_model_cm(model: LoggedModel) -> Generator[LoggedModel, None, None]:
+    """
+    Context manager to wrap a LoggedModel and update the model
+    status after the context is exited.
+    If any exception occurs, the model status is set to FAILED.
+    Otherwise, it is set to READY.
+    """
+    try:
+        yield model
+    except Exception:
+        finalize_logged_model(model.model_id, LoggedModelStatus.FAILED)
+        raise
+    else:
+        finalize_logged_model(model.model_id, LoggedModelStatus.READY)
 
 
 def create_external_model(

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2132,7 +2132,7 @@ def initialize_logged_model(
 
 
 @contextlib.contextmanager
-def _logged_model_cm(model: LoggedModel) -> Generator[LoggedModel, None, None]:
+def _use_logged_model(model: LoggedModel) -> Generator[LoggedModel, None, None]:
     """
     Context manager to wrap a LoggedModel and update the model
     status after the context is exited.

--- a/tests/store/tracking/test_file_store_logged_model.py
+++ b/tests/store/tracking/test_file_store_logged_model.py
@@ -272,14 +272,13 @@ def test_finalize_logged_model(store):
     assert logged_model.params == updated_model.params
     assert logged_model.metrics == updated_model.metrics
 
+    updated_model = store.finalize_logged_model(logged_model.model_id, LoggedModelStatus.FAILED)
+    assert updated_model.status == str(LoggedModelStatus.FAILED)
+
 
 def test_finalize_logged_model_errors(store):
     with pytest.raises(MlflowException, match=r"Model '1234' not found"):
         store.finalize_logged_model("1234", LoggedModelStatus.READY)
-
-    logged_model = store.create_logged_model()
-    with pytest.raises(MlflowException, match=r"Invalid model status"):
-        store.finalize_logged_model(logged_model.model_id, LoggedModelStatus.UNSPECIFIED)
 
 
 def test_search_logged_models_experiment_ids(store):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4825,8 +4825,8 @@ def test_finalize_logged_model(store: SqlAlchemyStore):
     store.finalize_logged_model(model.model_id, status=LoggedModelStatus.READY)
     assert store.get_logged_model(model.model_id).status == LoggedModelStatus.READY
 
-    with pytest.raises(MlflowException, match="Invalid model status: UNSPECIFIED"):
-        store.finalize_logged_model(model.model_id, status=LoggedModelStatus.UNSPECIFIED)
+    store.finalize_logged_model(model.model_id, status=LoggedModelStatus.FAILED)
+    assert store.get_logged_model(model.model_id).status == LoggedModelStatus.FAILED
 
     with pytest.raises(MlflowException, match="not found"):
         store.finalize_logged_model("does-not-exist", status=LoggedModelStatus.READY)

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2519,8 +2519,8 @@ def test_finalize_logged_model(mlflow_client: MlflowClient):
     finalized_model = mlflow_client.finalize_logged_model(model.model_id, LoggedModelStatus.READY)
     assert finalized_model.status == LoggedModelStatus.READY
 
-    with pytest.raises(MlflowException, match="Invalid model status"):
-        mlflow_client.finalize_logged_model(model.model_id, LoggedModelStatus.UNSPECIFIED)
+    finalized_model = mlflow_client.finalize_logged_model(model.model_id, LoggedModelStatus.FAILED)
+    assert finalized_model.status == LoggedModelStatus.FAILED
 
 
 def test_delete_logged_model(mlflow_client: MlflowClient):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15645?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15645/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15645/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15645/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
If model logging fails, we should set LoggedModel's status to FAILED instead of PENDING.
We don't wrap actions like 'register model' in the context manager since that could be a different issue, but model logging might still succeed.
As part of the implementation: found that a leaked run could occur when we log params and no runs exist --> fixed it in this PR as well.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
