### PR TITLE
Avoid using short timeout for trace logging for read path

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -750,9 +750,9 @@ MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE = _EnvironmentVariable(
 
 
 #: Timeout seconds for retrying trace logging.
-#: (default: ``5``)
+#: (default: ``15``)
 MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT = _EnvironmentVariable(
-    "MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", int, 5
+    "MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", int, 15
 )
 
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -750,9 +750,9 @@ MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE = _EnvironmentVariable(
 
 
 #: Timeout seconds for retrying trace logging.
-#: (default: ``15``)
+#: (default: ``500``)
 MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT = _EnvironmentVariable(
-    "MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", int, 15
+    "MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", int, 500
 )
 
 

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -17,6 +17,7 @@ from mlflow.azure.client import (
     put_block_list,
 )
 from mlflow.environment_variables import (
+    MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT,
     MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE,
     MLFLOW_MULTIPART_UPLOAD_CHUNK_SIZE,
     MLFLOW_MULTIPART_UPLOAD_MINIMUM_FILE_SIZE,
@@ -240,7 +241,10 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
                 raise MlflowTraceDataCorrupted(request_id=self.resource.id) from e
 
     def upload_trace_data(self, trace_data: str) -> None:
-        [cred], _ = self.resource.get_credentials(cred_type=_CredentialType.WRITE)
+        [cred], _ = self.resource.get_credentials(
+            cred_type=_CredentialType.WRITE,
+            timeout=MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT.get(),
+        )
         with write_local_temp_trace_data_file(trace_data) as temp_file:
             if cred.type == ArtifactCredentialType.AZURE_ADLS_GEN2_SAS_URI:
                 self._azure_adls_gen2_upload_file(

--- a/mlflow/store/artifact/databricks_artifact_repo_resources.py
+++ b/mlflow/store/artifact/databricks_artifact_repo_resources.py
@@ -5,7 +5,6 @@ from enum import Enum
 from typing import Any, Callable, Optional
 
 from mlflow.entities.file_info import FileInfo
-from mlflow.environment_variables import MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT
 from mlflow.protos.databricks_artifacts_pb2 import (
     DatabricksMlflowArtifactsService,
     GetCredentialsForLoggedModelDownload,
@@ -265,6 +264,7 @@ class _Trace(_Resource):
         cred_type: _CredentialType,
         paths: Optional[list[str]] = None,
         page_token: Optional[str] = None,
+        timeout: Optional[int] = None,
     ) -> tuple[list[ArtifactCredentialInfo], Optional[str]]:
         res = self.call_endpoint(
             DatabricksMlflowArtifactsService,
@@ -274,7 +274,7 @@ class _Trace(_Resource):
                 else GetCredentialsForTraceDataUpload
             ),
             path_params={"request_id": self.id},
-            retry_timeout_seconds=MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT.get(),
+            retry_timeout_seconds=timeout,
         )
         cred_inf = ArtifactCredentialInfo(
             signed_uri=res.credential_info.signed_uri,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -219,6 +219,7 @@ def get_workspace_client(
 ):
     from databricks.sdk import WorkspaceClient
     from databricks.sdk.config import Config
+
     if use_secret_scope_token:
         kwargs = {"host": host, "token": token}
     else:

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -209,7 +209,7 @@ def http_request(
         raise MlflowException(f"API request to {url} failed with exception {e}")
 
 
-@lru_cache(maxsize=1)
+@lru_cache(maxsize=5)
 def get_workspace_client(
     use_secret_scope_token,
     host,
@@ -219,7 +219,6 @@ def get_workspace_client(
 ):
     from databricks.sdk import WorkspaceClient
     from databricks.sdk.config import Config
-
     if use_secret_scope_token:
         kwargs = {"host": host, "token": token}
     else:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15648?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15648/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15648/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15648/merge
```

</p>
</details>

### What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/15611 tried to reduce the trace logging timeout, because the default timeout `MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT` is too long (500 sec) and has a risk of eating up async logging queue. However, it unexpectedly change the timeout for other "read" APIs such as `search_traces()`.

This PR fixes it and only apply the short timeout to `start_trace_v3` and `upload_trace_data` operations, which are only used for logging traces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

It's a bit hard to artificially cause 429 in backend, so just checked if the timeout is correctly passed to [http_request](https://github.com/mlflow/mlflow/blob/d8566998bfb2f376d6be7403aac0759a0758a0e2/mlflow/utils/rest_utils.py#L47):

![Screenshot 2025-05-09 at 18 42 03](https://github.com/user-attachments/assets/b55fa755-4b49-47c8-ab9e-c37d8328bcd0)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
