### PR TITLE
Pass `inputs` as keyword arguments to the predict_fn

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -87,7 +87,7 @@ def evaluate(
         def faster_than_one_second(inputs, outputs, trace):
             return trace.info.execution_duration < 1000
 
-    **2. Use DataFrame or dictionary with "inputs", "outputs", "expectations" columns.
+    **2. Use DataFrame or dictionary with "inputs", "outputs", "expectations" columns.**
 
     Alternatively, you can pass inputs, outputs, and expectations (ground truth) as
     a column in the dataframe (or equivalent list of dictionaries).

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -44,12 +44,188 @@ def evaluate(
     model_id: Optional[str] = None,
 ) -> EvaluationResult:
     """
-    TODO: updating docstring with real examples and API links
+    Evaluate the performance of a generative AI model/application using specified
+    data and scorers.
+
+    This function allows you to evaluate a model's performance on a given dataset
+    using various scoring criteria. It supports both built-in scorers provided by
+    MLflow and custom scorers. The evaluation results include metrics and detailed
+    per-row assessments.
+
+    There are three different ways to use this function:
+
+    **1. Use Traces to evaluate the model/application.**
+
+    The `data` parameter takes a DataFrame with `trace` column, which contains a
+    single trace object corresponding to the prediction for the row. This dataframe
+    is easily obtained from the existing traces stored in MLflow, by using the
+    :py:func:`mlflow.search_traces` function.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import correctness, safety
+        import pandas as pd
+
+        trace_df = mlflow.search_traces(model_id="<my-model-id>")
+
+        mlflow.genai.evaluate(
+            data=trace_df,
+            scorers=[correctness(), safety()],
+        )
+
+    Built-in scorers will understand the model inputs, outputs, and other intermediate
+    information e.g. retrieved context, from the trace object. You can also access to
+    the trace object from the custom scorer function by using the `trace` parameter.
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import scorer
+
+
+        @scorer
+        def faster_than_one_second(inputs, outputs, trace):
+            return trace.info.execution_duration < 1000
+
+    **2. Use DataFrame or dictionary with "inputs", "outputs", "expectations" columns.
+
+    Alternatively, you can pass inputs, outputs, and expectations (ground truth) as
+    a column in the dataframe (or equivalent list of dictionaries).
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import correctness
+        import pandas as pd
+
+        data = pd.DataFrame(
+            [
+                {
+                    "inputs": {"question": "What is MLflow?"},
+                    "outputs": "MLflow is an ML platform",
+                    "expectations": "MLflow is an ML platform",
+                },
+                {
+                    "inputs": {"question": "What is Spark?"},
+                    "outputs": "I don't know",
+                    "expectations": "Spark is a data engine",
+                },
+            ]
+        )
+
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=[correctness()],
+        )
+
+    **3. Pass `predict_fn` and input samples (and optionally expectations).**
+
+    If you want to generate the outputs and traces on-the-fly from your input samples,
+    you can pass a callable to the `predict_fn` parameter. In this case, MLflow will
+    pass the inputs to the `predict_fn` as keyword arguments. Therefore, the "inputs"
+    column must be a dictionary with the parameter names as keys.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import correctness, safety
+        import openai
+
+        # Create a dataframe with input samples
+        data = pd.DataFrame(
+            [
+                {"inputs": {"question": "What is MLflow?"}},
+                {"inputs": {"question": "What is Spark?"}},
+            ]
+        )
+
+
+        # Define a predict function to evaluate. The "inputs" column will be
+        # passed to the prediction function as keyword arguments.
+        def predict_fn(question: str) -> str:
+            response = openai.OpenAI().chat.completions.create(
+                model="gpt-4o-mini",
+                messages=[{"role": "user", "content": question}],
+            )
+            return response.choices[0].message.content
+
+
+        mlflow.genai.evaluate(
+            data=data,
+            predict_fn=predict_fn,
+            scorers=[correctness(), safety()],
+        )
+
+    Args:
+        data: Dataset for the evaluation. Must be one of the following formats:
+
+            * An EvaluationDataset entity
+            * Pandas DataFrame
+            * Spark DataFrame
+            * List of dictionaries
+
+            The dataset must include either of the following columns:
+
+            1. `trace` column that contains a single trace object corresponding
+                to the prediction for the row.
+
+                If this column is present, MLflow extracts inputs, outputs, assessments,
+                and other intermediate information e.g. retrieved context, from the trace
+                object and uses them for scoring. When this column is present, the
+                `predict_fn` parameter must not be provided.
+
+            2. `inputs`, `outputs`, `expectations` columns.
+
+                Alternatively, you can pass inputs, outputs, and expectations(ground
+                truth) as a column in the dataframe (or equivalent list of dictionaries).
+
+                - inputs (required): Column containing inputs for evaluation. The value
+                    must be a dictionary. When `predict_fn` is provided, MLflow will pass
+                    the inputs to the `predict_fn` as keyword arguments. For example,
+
+                      * predict_fn: `def predict_fn(question: str, context: str) -> str`
+                      * inputs column: `{"question": "What is MLflow?",
+                        "context": "MLflow is an ML platform"}`
+                      * predict_fn will receive "What is MLflow?" as the first argument (`question`)
+                          and "MLflow is an ML platform" as the second argument (`context`)
+
+                - outputs (optional): Column containing model/app outputs.
+                  If this column is present, `predict_fn` must not be provided.
+
+                - expectations (optional): Column containing ground truth or
+                    dictionary of ground truths. If this column contains a single string,
+                    it is assumed to be the expected response for the row.
+
+            The input dataframe can contain extra columns that will be directly passed to
+            the scorers. For example, you can pass a dataframe with `retrieved_context`
+            column to use a scorer that takes `retrieved_context` as a parameter.
+
+            For list of dictionaries, each dict should follow the above schema.
+
+        predict_fn: Target function to evaluate. Will be executed for each input row to
+            generate outputs and traces for scoring.
+
+        scorers: List of Scorer objects that produce evaluation scores from inputs, outputs
+            and other context. Can use MLflow's built-in scorers or custom scorers.
+
+        model_id: Optional model identifier (e.g. "models:/my-model/1") to associate with
+            the evaluation results. Can also set globally via mlflow.set_active_model().
+
+    Returns:
+        EvaluationResult containing:
+            - run_id: ID of the MLflow run containing evaluation results
+            - metrics: Dictionary of aggregate metrics from all scorers
+            - result_df: Pandas DataFrame with per-row inputs, outputs, and scores
+
+    Note:
+        This function is only supported on Databricks. The tracking URI must be
+        set to Databricks.
 
     .. warning::
 
         This function is not thread-safe. Please do not use it in multi-threaded
         environments.
+<<<<<<< HEAD
 
     Args:
         data: Dataset for the evaluation. It must be one of the following format:
@@ -100,6 +276,8 @@ def evaluate(
 
                     mlflow.evaluate(data, ...)
 
+=======
+>>>>>>> ff4233e7b (Pass `inputs` as keyword arguments to the predict_fn)
     """
     try:
         from databricks.rag_eval.evaluation.metrics import Metric as DBAgentsMetric
@@ -164,7 +342,8 @@ def evaluate(
             predict_fn = mlflow.trace(predict_fn)
 
     result = mlflow.evaluate(
-        model=predict_fn,
+        # Wrap the prediction function to unwrap the inputs dictionary into keyword arguments.
+        model=(lambda request: predict_fn(**request)) if predict_fn else None,
         data=data,
         evaluator_config=evaluation_config,
         extra_metrics=extra_metrics,
@@ -192,12 +371,11 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
     Example:
         .. code-block:: python
 
-            data = (
-                pd.DataFrame(
-                    {
-                        "inputs": ["What is MLflow?", "What is Spark?"],
-                    }
-                ),
+            data = pd.DataFrame(
+                [
+                    {"inputs": {"messages": [{"role": "user", "content": "What is MLflow?"}]}},
+                    {"inputs": {"question": [{"role": "user", "content": "What is Spark?"}]}},
+                ]
             )
             predict_fn = mlflow.genai.to_predict_fn("endpoints:/chat")
             mlflow.genai.evaluate(

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -180,22 +180,20 @@ def evaluate(
                 truth) as a column in the dataframe (or equivalent list of dictionaries).
 
                 - inputs (required): Column containing inputs for evaluation. The value
-                    must be a dictionary. When `predict_fn` is provided, MLflow will pass
-                    the inputs to the `predict_fn` as keyword arguments. For example,
+                  must be a dictionary. When `predict_fn` is provided, MLflow will pass
+                  the inputs to the `predict_fn` as keyword arguments. For example,
 
-                      * predict_fn: `def predict_fn(question: str, context: str) -> str`
-                      * inputs column: `{"question": "What is MLflow?",
-                          "context": "MLflow is an ML platform"}`
-                      * `predict_fn` will receive "What is MLflow?" as the first argument
-                          (`question`) and "MLflow is an ML platform" as the second
-                          argument (`context`)
+                  * predict_fn: `def predict_fn(question: str, context: str) -> str`
+                  * inputs: `{"question": "What is MLflow?", "context": "MLflow is an ML platform"}`
+                  * `predict_fn` will receive "What is MLflow?" as the first argument
+                    (`question`) and "MLflow is an ML platform" as the second argument (`context`)
 
-                - outputs (optional): Column containing model/app outputs.
+                - outputs (optional): Column containing model or app outputs.
                   If this column is present, `predict_fn` must not be provided.
 
                 - expectations (optional): Column containing ground truth or
-                    dictionary of ground truths. If this column contains a single string,
-                    it is assumed to be the expected response for the row.
+                  dictionary of ground truths. If this column contains a single string,
+                  it is assumed to be the expected response for the row.
 
             The input dataframe can contain extra columns that will be directly passed to
             the scorers. For example, you can pass a dataframe with `retrieved_context`

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -185,9 +185,10 @@ def evaluate(
 
                       * predict_fn: `def predict_fn(question: str, context: str) -> str`
                       * inputs column: `{"question": "What is MLflow?",
-                        "context": "MLflow is an ML platform"}`
-                      * predict_fn will receive "What is MLflow?" as the first argument (`question`)
-                          and "MLflow is an ML platform" as the second argument (`context`)
+                          "context": "MLflow is an ML platform"}`
+                      * `predict_fn` will receive "What is MLflow?" as the first argument
+                          (`question`) and "MLflow is an ML platform" as the second
+                          argument (`context`)
 
                 - outputs (optional): Column containing model/app outputs.
                   If this column is present, `predict_fn` must not be provided.
@@ -202,56 +203,6 @@ def evaluate(
 
             For list of dictionaries, each dict should follow the above schema.
 
-        predict_fn: Target function to evaluate. Will be executed for each input row to
-            generate outputs and traces for scoring.
-
-        scorers: List of Scorer objects that produce evaluation scores from inputs, outputs
-            and other context. Can use MLflow's built-in scorers or custom scorers.
-
-        model_id: Optional model identifier (e.g. "models:/my-model/1") to associate with
-            the evaluation results. Can also set globally via mlflow.set_active_model().
-
-    Returns:
-        EvaluationResult containing:
-            - run_id: ID of the MLflow run containing evaluation results
-            - metrics: Dictionary of aggregate metrics from all scorers
-            - result_df: Pandas DataFrame with per-row inputs, outputs, and scores
-
-    Note:
-        This function is only supported on Databricks. The tracking URI must be
-        set to Databricks.
-
-    .. warning::
-
-        This function is not thread-safe. Please do not use it in multi-threaded
-        environments.
-<<<<<<< HEAD
-
-    Args:
-        data: Dataset for the evaluation. It must be one of the following format:
-
-            * A EvaluationDataset entity
-            * Pandas DataFrame
-            * Spark DataFrame
-            * List of dictionary
-
-            If a dataframe is specified, it must contain the following schema:
-
-            - inputs (optional): A column that contains a single input. This is required
-              unless trace is provided.
-            - outputs (optional): A column that contains a single output from the
-              target model/app. If the predict_fn is provided, this is generated
-              by MLflow so not required.
-            - expectations (optional): A column that contains a ground truth, or a
-              dictionary of ground truths for individual output fields.
-            - trace (optional): A column that contains a single trace object
-              corresponding to the prediction for the row. Only required when
-              any of scorers requires a trace in order to compute
-              assessments/metrics.
-
-            If a list of dictionary is passed, each dictionary should contain keys
-            following the above schema.
-
         scorers: A list of Scorer objects that produces evaluation scores from
             inputs, outputs, and other additional contexts. MLflow provides pre-defined
             scorers, but you can also define custom ones.
@@ -263,21 +214,18 @@ def evaluate(
             The function must emit a single trace per call. If it doesn't, decorate
             the function with @mlflow.trace decorator to ensure a trace to be emitted.
 
-        model_id: Optional. Specify an ID of the model e.g. models:/my-model/1 to
-            associate the evaluation result with. There are several ways to associate
-            model with association.
+        model_id: Optional model identifier (e.g. "models:/my-model/1") to associate with
+            the evaluation results. Can be also set globally via the
+            :py:func:`mlflow.set_active_model` function.
 
-            1. Use the ``model_id`` parameters.
-            2. Use the ``mlflow.set_active_model()`` function to set model ID to global context.
+    Note:
+        This function is only supported on Databricks. The tracking URI must be
+        set to Databricks.
 
-               .. code-block:: python
+    .. warning::
 
-                    mlflow.set_active_model(model_id="xyz")
-
-                    mlflow.evaluate(data, ...)
-
-=======
->>>>>>> ff4233e7b (Pass `inputs` as keyword arguments to the predict_fn)
+        This function is not thread-safe. Please do not use it in multi-threaded
+        environments.
     """
     try:
         from databricks.rag_eval.evaluation.metrics import Metric as DBAgentsMetric

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -70,7 +70,7 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
     sample_row = df.iloc[0]
     if "inputs" in sample_row and not isinstance(sample_row["inputs"], dict):
         raise MlflowException.invalid_parameter_value(
-            "The 'inputs' column must be a dictionary. If you want to pass a single"
+            "The 'inputs' column must be a dictionary. If you want to pass a single "
             "argument to the `predict_fn`, use the argument name as the key in the "
             "dictionary. If you don't pass a `predict_fn`, you can use any string "
             "key to wrap the value into a dictionary."

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -44,10 +44,6 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
                 raise MlflowException.invalid_parameter_value(
                     "Every item in the list must be a dictionary."
                 )
-            if "inputs" not in item:
-                raise MlflowException.invalid_parameter_value(
-                    "Every item in the list must have an 'inputs' key."
-                )
 
         df = pd.DataFrame(data)
     elif isinstance(data, pd.DataFrame):
@@ -69,6 +65,16 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
                 "The `pyspark` package is required to use mlflow.genai.evaluate() "
                 "Please install it with `pip install pyspark`."
             )
+
+    # Verify format of the input using the first row
+    sample_row = df.iloc[0]
+    if "inputs" in sample_row and not isinstance(sample_row["inputs"], dict):
+        raise MlflowException.invalid_parameter_value(
+            "The 'inputs' column must be a dictionary. If you want to pass a single"
+            "argument to the `predict_fn`, use the argument name as the key in the "
+            "dictionary. If you don't pass a `predict_fn`, you can use any string "
+            "key to wrap the value into a dictionary."
+        )
 
     renamed_df = df.rename(columns=column_mapping)
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -42,7 +42,7 @@ def is_model_traced(predict_fn: Callable, sample_input: Any):
 
         NoOpTracer.start_span = _patched_start_span
         try:
-            predict_fn(sample_input)
+            predict_fn(**sample_input)
         except Exception as e:
             _logger.debug(
                 "Tried to make a single prediction to check if the model is traced, "

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -1168,8 +1168,6 @@ class _PythonModelPyfuncWrapper:
         self.signature = signature
 
     def _convert_input(self, model_input):
-        import pandas as pd
-
         hints = self.python_model.predict_type_hints
         # we still need this for backwards compatibility
         if isinstance(model_input, pd.DataFrame):

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -6,7 +6,7 @@ import pytest
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, groundedness
+from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, safety
 
 from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
 
@@ -90,14 +90,14 @@ def test_evaluate_passes_model_id_to_mlflow_evaluate():
             data=data,
             predict_fn=model,
             model_id="test_model_id",
-            scorers=[groundedness()],
+            scorers=[safety()],
         )
 
         # Verify the call was made with the right parameters
         mock_evaluate.assert_called_once_with(
-            model=model,
+            model=mock.ANY,
             data=mock.ANY,
-            evaluator_config={GENAI_CONFIG_NAME: {"metrics": ["groundedness"]}},
+            evaluator_config={GENAI_CONFIG_NAME: {"metrics": ["safety"]}},
             model_type="databricks-agent",
             extra_metrics=[],
             model_id="test_model_id",

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -7,10 +7,8 @@ import pytest
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.genai import scorer
-from mlflow.genai.evaluation.utils import (
-    _convert_to_legacy_eval_set,
-)
-from mlflow.genai.scorers.builtin_scorers import groundedness
+from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
+from mlflow.genai.scorers.builtin_scorers import safety
 
 if importlib.util.find_spec("databricks.agents") is None:
     pytest.skip(reason="databricks-agents is not installed", allow_module_level=True)
@@ -45,10 +43,8 @@ def spoof_tracking_uri_check():
 def sample_dict_data_single():
     return [
         {
-            "inputs": "What is the difference between reduceByKey and groupByKey in Spark?",
-            "outputs": {
-                "choices": [{"message": {"content": "actual response for first question"}}]
-            },
+            "inputs": {"question": "What is Spark?"},
+            "outputs": "actual response for first question",
             "expectations": "expected response for first question",
         },
     ]
@@ -58,10 +54,8 @@ def sample_dict_data_single():
 def sample_dict_data_multiple():
     return [
         {
-            "inputs": "What is the difference between reduceByKey and groupByKey in Spark?",
-            "outputs": {
-                "choices": [{"message": {"content": "actual response for first question"}}]
-            },
+            "inputs": {"question": "What is Spark?"},
+            "outputs": "actual response for first question",
             "expectations": "expected response for first question",
             # Additional columns required by the judges
             "retrieved_context": [
@@ -76,14 +70,8 @@ def sample_dict_data_multiple():
             ],
         },
         {
-            "inputs": {
-                "messages": [
-                    {"role": "user", "content": "How can you minimize data shuffling in Spark?"}
-                ]
-            },
-            "outputs": {
-                "choices": [{"message": {"content": "actual response for second question"}}]
-            },
+            "inputs": {"question": "How can you minimize data shuffling in Spark?"},
+            "outputs": "actual response for second question",
             "expectations": "expected response for second question",
             "retrieved_context": [],
         },
@@ -117,6 +105,11 @@ def test_convert_to_legacy_eval_set_has_no_errors(data_fixture, request):
     assert "expected_response" in transformed_data.columns
 
 
+def test_convert_to_legacy_eval_set_invalid_inputs():
+    with pytest.raises(MlflowException, match="The 'inputs' column must be a dictionary"):
+        _convert_to_legacy_eval_set([{"inputs": "not a dict"}])
+
+
 @pytest.mark.parametrize(
     "data_fixture",
     ["sample_dict_data_single", "sample_dict_data_multiple", "sample_pd_data", "sample_spark_data"],
@@ -128,13 +121,7 @@ def test_scorer_receives_correct_data(data_fixture, request):
 
     @scorer
     def dummy_scorer(inputs, outputs, expectations):
-        received_args.append(
-            {
-                "inputs": inputs,
-                "outputs": outputs,
-                "expectations": expectations,
-            }
-        )
+        received_args.append((inputs["question"], outputs, expectations))
         return 0
 
     with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
@@ -143,17 +130,9 @@ def test_scorer_receives_correct_data(data_fixture, request):
             scorers=[dummy_scorer],
         )
 
-        assert len(received_args) == len(sample_data)
-        assert set(received_args[0].keys()) == set({"inputs", "outputs", "expectations"})
-
-        all_inputs, all_outputs, all_expectations = [], [], []
-        for arg in received_args:
-            all_inputs.append(arg["inputs"]["messages"][0]["content"])
-            all_outputs.append(arg["outputs"]["choices"][0]["message"]["content"])
-            all_expectations.append(arg["expectations"])
-
+        all_inputs, all_outputs, all_expectations = zip(*received_args)
         expected_inputs = [
-            "What is the difference between reduceByKey and groupByKey in Spark?",
+            "What is Spark?",
             "How can you minimize data shuffling in Spark?",
         ][: len(sample_data)]
         expected_outputs = [
@@ -175,14 +154,14 @@ def test_input_is_required_if_trace_is_not_provided():
         with pytest.raises(MlflowException, match="inputs.*required"):
             mlflow.genai.evaluate(
                 data=pd.DataFrame({"outputs": ["Paris"]}),
-                scorers=[groundedness()],
+                scorers=[safety()],
             )
 
         mock_evaluate.assert_not_called()
 
         mlflow.genai.evaluate(
             data=pd.DataFrame({"inputs": ["What is the capital of France?"], "outputs": ["Paris"]}),
-            scorers=[groundedness()],
+            scorers=[safety()],
         )
         mock_evaluate.assert_called_once()
 
@@ -191,7 +170,7 @@ def test_input_is_optional_if_trace_is_provided():
     with patch("mlflow.evaluate") as mock_evaluate:
         mlflow.genai.evaluate(
             data=pd.DataFrame({"outputs": ["Paris"], "trace": [MagicMock()]}),
-            scorers=[groundedness()],
+            scorers=[safety()],
         )
 
         mock_evaluate.assert_called_once()
@@ -206,22 +185,18 @@ def test_predict_fn_receives_correct_data(data_fixture, request):
 
     received_args = []
 
-    def predict_fn(inputs):
-        received_args.append(inputs)
-        return inputs
+    def predict_fn(question: str):
+        received_args.append(question)
+        return question
 
     with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
         mlflow.genai.evaluate(
             predict_fn=predict_fn,
             data=sample_data,
-            scorers=[groundedness()],
+            scorers=[safety()],
         )
         received_args.pop(0)  # Remove the one-time prediction to check if a model is traced
         assert len(received_args) == len(sample_data)
-        received_contents = [arg["messages"][0]["content"] for arg in received_args]
-        expected_contents = [
-            "What is the difference between reduceByKey and groupByKey in Spark?",
-            "How can you minimize data shuffling in Spark?",
-        ][: len(sample_data)]
+        expected_contents = ["What is Spark?", "How can you minimize data shuffling in Spark?"]
         # Using set because eval harness runs predict_fn in parallel
-        assert set(received_contents) == set(expected_contents)
+        assert set(received_args) == set(expected_contents[: len(sample_data)])

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -160,7 +160,9 @@ def test_input_is_required_if_trace_is_not_provided():
         mock_evaluate.assert_not_called()
 
         mlflow.genai.evaluate(
-            data=pd.DataFrame({"inputs": ["What is the capital of France?"], "outputs": ["Paris"]}),
+            data=pd.DataFrame(
+                {"inputs": [{"question": "What is the capital of France?"}], "outputs": ["Paris"]}
+            ),
             scorers=[safety()],
         )
         mock_evaluate.assert_called_once()

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1,8 +1,5 @@
-from unittest.mock import patch
-
 import pytest
 
-import mlflow.genai
 from mlflow.genai.scorers import (
     chunk_relevance,
     context_sufficiency,
@@ -67,30 +64,6 @@ def test_scorers_and_rag_scorers_config(scorers):
         evaluation_config = scorer.update_evaluation_config(evaluation_config)
 
     assert normalize_config(evaluation_config) == normalize_config(expected)
-
-
-def test_evaluate_parameters():
-    data = []
-    with (
-        patch("mlflow.get_tracking_uri", return_value="databricks"),
-        patch("mlflow.genai.evaluation.base.is_model_traced", return_value=True),
-        patch("mlflow.genai.evaluation.base._convert_to_legacy_eval_set", return_value=data),
-        patch("mlflow.evaluate") as mock_evaluate,
-    ):
-        mlflow.genai.evaluate(
-            data=data,
-            scorers=ALL_SCORERS,
-        )
-
-        # Verify the call was made with the right parameters
-        mock_evaluate.assert_called_once_with(
-            model=None,
-            data=data,
-            evaluator_config=expected,
-            extra_metrics=[],
-            model_type=GENAI_CONFIG_NAME,
-            model_id=None,
-        )
 
 
 @pytest.mark.parametrize(

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -41,7 +41,7 @@ def sample_data():
     return pd.DataFrame(
         {
             "request": [
-                "What is the difference between reduceByKey and groupByKey in Spark?",
+                {"message": [{"role": "user", "content": "What is Spark??"}]},
                 {
                     "messages": [
                         {"role": "user", "content": "How can you minimize data shuffling in Spark?"}
@@ -66,7 +66,7 @@ def sample_new_data():
     return pd.DataFrame(
         {
             "inputs": [
-                "What is the difference between reduceByKey and groupByKey in Spark?",
+                {"message": [{"role": "user", "content": "What is Spark??"}]},
                 {
                     "messages": [
                         {"role": "user", "content": "How can you minimize data shuffling in Spark?"}

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -83,7 +83,7 @@ def mock_openai_env(monkeypatch):
 )
 def test_is_traced(predict_fn_generator, with_tracing, expected_traced):
     predict_fn = predict_fn_generator(with_tracing=with_tracing)
-    sample_input = {"messages": [{"role": "user", "content": "test"}]}
+    sample_input = {"request": {"messages": [{"role": "user", "content": "test"}]}}
     is_actually_traced = is_model_traced(predict_fn, sample_input)
     assert is_actually_traced == expected_traced
 
@@ -91,5 +91,5 @@ def test_is_traced(predict_fn_generator, with_tracing, expected_traced):
     assert len(get_traces()) == 0
 
     # Make a prediction normally
-    predict_fn(sample_input)
+    predict_fn(**sample_input)
     assert len(get_traces()) == (1 if expected_traced else 0)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15660?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15660/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15660/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15660/merge
```

</p>
</details>

### What changes are proposed in this pull request?

**Context**
In current implementation of Agent Evaluation, the prediction callable specified as `model` takes a single input argument only. For example, the following is [an official example](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/evaluate-agent) of evaluating a simple LLM call.

This causes a bit of inconvenience. For example, this is the [official example](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/evaluate-agent) of evaluating traces.
```
# Define a very simple system-prompt agent.
@mlflow.trace(span_type="AGENT")
def llama3_agent(messages):
  SYSTEM_PROMPT = """
    You are a chatbot that answers questions about Databricks.
    For requests unrelated to Databricks, reject the request.
  """
  return get_deploy_client("databricks").predict(
    endpoint="databricks-meta-llama-3-3-70b-instruct",
    inputs={"messages": [{"role": "system", "content": SYSTEM_PROMPT}, *messages]}
  )

# Dataset
eval_set = [{
  "request": {"messages": [{"role": "user", "content": "What is the difference between reduceByKey and groupByKey in Databricks Spark?"}]}
}, {
  "request": "What is the weather today?",
}]

# Evaluate the Agent with the evaluation set and log it to the MLFlow run "system_prompt_v0".
with mlflow.start_run(run_name="system_prompt_v0") as run:
  mlflow.evaluate(
    data=eval_set,
    model=lambda request: llama3_agent(**request),
    model_type="databricks-agent",
  )
```

The key thing here is that, the original predict function takes in `messages` as a key. This is the standard OpenAI format and is required to render the chat UI. To workaround this, the example adds `lambda request: llama3_agent(**request)`, which is *ok* but not clean.

Therefore, the new `mlflow.genai.evaluate` will take a bit different approach. When a dictionary to `inputs` column, it will  it as a keyword arguments and unwrap them when calling `predict_fn`. With this, users can pass the function directly like this
```
# Evaluate the Agent with the evaluation set and log it to the MLFlow run "system_prompt_v0".
mlflow.genai.evaluate(
    data=eval_set,
    predict_fn=llama3_agent,
)
```


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
