### PR TITLE
Add Validation for Nonempty Model ID in Logged Model Client Rest Store APIs

### DIFF
--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -914,11 +914,21 @@ class RestStore(AbstractStore):
         Returns:
             The fetched model.
         """
+        if not model_id:
+            raise MlflowException(
+                "Parameter `model_id` must be specified",
+                databricks_pb2.INVALID_PARAMETER_VALUE,
+            )
         endpoint = get_logged_model_endpoint(model_id)
         response_proto = self._call_endpoint(GetLoggedModel, endpoint=endpoint)
         return LoggedModel.from_proto(response_proto.model)
 
     def delete_logged_model(self, model_id) -> None:
+        if not model_id:
+            raise MlflowException(
+                "Parameter `model_id` must be specified",
+                databricks_pb2.INVALID_PARAMETER_VALUE,
+            )
         request = DeleteLoggedModel(model_id=model_id)
         endpoint = get_logged_model_endpoint(model_id)
         self._call_endpoint(
@@ -1004,6 +1014,11 @@ class RestStore(AbstractStore):
         Returns:
             The updated model.
         """
+        if not model_id:
+            raise MlflowException(
+                "Parameter `model_id` must be specified",
+                databricks_pb2.INVALID_PARAMETER_VALUE,
+            )
         endpoint = get_logged_model_endpoint(model_id)
         json_body = message_to_json(
             FinalizeLoggedModel(model_id=model_id, status=status.to_proto())
@@ -1024,6 +1039,11 @@ class RestStore(AbstractStore):
         Returns:
             None
         """
+        if not model_id:
+            raise MlflowException(
+                "Parameter `model_id` must be specified",
+                databricks_pb2.INVALID_PARAMETER_VALUE,
+            )
         endpoint = get_logged_model_endpoint(model_id)
         json_body = message_to_json(SetLoggedModelTags(tags=[tag.to_proto() for tag in tags]))
         self._call_endpoint(SetLoggedModelTags, json_body=json_body, endpoint=f"{endpoint}/tags")
@@ -1039,6 +1059,11 @@ class RestStore(AbstractStore):
         Returns:
             The model with the specified tag removed.
         """
+        if not model_id:
+            raise MlflowException(
+                "Parameter `model_id` must be specified",
+                databricks_pb2.INVALID_PARAMETER_VALUE,
+            )
         endpoint = get_logged_model_endpoint(model_id)
         self._call_endpoint(DeleteLoggedModelTag, endpoint=f"{endpoint}/tags/{key}")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/raymondzhou-db/mlflow/pull/15662?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15662/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15662/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15662/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Add validation in the following client APIs for logged models that `model_id` should be nonempty. Otherwise due to route definitions in the Databricks backend beyond the control of MLflow service, we will get some unhelpful user error messages when `model_id` is an empty string
- `finalize_logged_model`
- `get_logged_model`
- `delete_logged_model`
- `set_logged_model_tags`
- `delete_logged_model_tag`

This was originally discovered for `delete_logged_model`, but I added the same validation for related APIs where it doesn't make sense for `model_id` to be empty

![image](https://github.com/user-attachments/assets/e7221393-cac5-48a4-bf76-84a455bfbfa7)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

![image](https://github.com/user-attachments/assets/ebbbfa82-a109-450d-8c9c-04e61275dbdd)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
