### PR TITLE
Disable async logging in Databricks notebook and increase default queue size limit

### DIFF
--- a/docs/docs/tracing/api/how-to.mdx
+++ b/docs/docs/tracing/api/how-to.mdx
@@ -209,5 +209,5 @@ The following configurations are available for async logging:
 | Environment Variable | Description | Default Value |
 |----------------------|-------------|---------------|
 |`MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS`|The maximum number of worker threads to use for async trace logging.|`10`|
-|`MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE`|The maximum number of traces that can be queued for logging. Traces will be discarded if the queue is full.|`50`|
-|`MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`|Timeout in seconds for retrying failed trace logging. Namely, failed traces will be retried up to this timeout with backoff, after which they will be discarded.|`5`|
+|`MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE`|The maximum number of traces that can be queued for logging. Traces will be discarded if the queue is full.|`1000`|
+|`MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`|Timeout in seconds for retrying failed trace logging. Namely, failed traces will be retried up to this timeout with backoff, after which they will be discarded.|`500`|

--- a/docs/docs/tracing/production.mdx
+++ b/docs/docs/tracing/production.mdx
@@ -69,8 +69,8 @@ When using Lakehouse Monitoring for GenAI, MLflow logs traces asynchronously by 
 |----------------------|-------------|---------------|
 | `MLFLOW_ENABLE_ASYNC_TRACE_LOGGING` | Whether to log traces asynchronously. When set to `False`, traces will be logged in a blocking manner. | `True` |
 | `MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS` | The maximum number of worker threads to use for async trace logging per process. Increasing this allows higher throughput of trace logging, but also increases the CPU usage and memory consumption. | `10` |
-| `MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE` | The maximum number of traces that can be queued before being logged to backend by the worker threads. When the queue is full, new traces will be discarded. Increasing this allows higher durability of trace logging, but also increases the memory consumption. | `50` |
-| `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT` | The timeout in seconds for retrying failed trace logging. When a trace logging fails, it will be retried up to this timeout with backoff, after which it will be discarded. | `5` |
+| `MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE` | The maximum number of traces that can be queued before being logged to backend by the worker threads. When the queue is full, new traces will be discarded. Increasing this allows higher durability of trace logging, but also increases the memory consumption. | `1000` |
+| `MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT` | The timeout in seconds for retrying failed trace logging. When a trace logging fails, it will be retried up to this timeout with backoff, after which it will be discarded. | `500` |
 
 
 ## OpenTelemetry Integration

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -749,9 +749,9 @@ MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS = _EnvironmentVariable(
 
 #: Maximum number of export tasks to queue for async trace logging.
 #: When the queue is full, new export tasks will be dropped.
-#: (default: ``50``)
+#: (default: ``1000``)
 MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE = _EnvironmentVariable(
-    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE", int, 50
+    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE", int, 1000
 )
 
 

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -27,7 +27,12 @@ class MlflowV3SpanExporter(SpanExporter):
     """
 
     def __init__(self, tracking_uri: Optional[str] = None):
-        self._is_async_enabled = MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
+        # NB: We don't turn on async logging in Databricks notebook until we are
+        # confident that the async logging is working on the offline workload on
+        # Databricks, to derisk the inclusion to the standard image.
+        self._is_async_enabled = (
+            not is_in_databricks_notebook() and MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
+        )
         if self._is_async_enabled:
             self._async_queue = AsyncTraceExportQueue()
         self._client = TracingClient(tracking_uri)

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -27,12 +27,7 @@ class MlflowV3SpanExporter(SpanExporter):
     """
 
     def __init__(self, tracking_uri: Optional[str] = None):
-        # NB: We don't turn on async logging in Databricks notebook until we are
-        # confident that the async logging is working on the offline workload on
-        # Databricks, to derisk the inclusion to the standard image.
-        self._is_async_enabled = (
-            not is_in_databricks_notebook() and MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
-        )
+        self._is_async_enabled = self._should_enable_async_logging()
         if self._is_async_enabled:
             self._async_queue = AsyncTraceExportQueue()
         self._client = TracingClient(tracking_uri)
@@ -96,6 +91,21 @@ class MlflowV3SpanExporter(SpanExporter):
                 _logger.warning("No trace or trace info provided, unable to export")
         except Exception as e:
             _logger.warning(f"Failed to send trace to MLflow backend: {e}")
+
+    def _should_enable_async_logging(self):
+        if is_in_databricks_notebook():
+            # NB: We don't turn on async logging in Databricks notebook by default
+            # until we are confident that the async logging is working on the
+            # offline workload on Databricks, to derisk the inclusion to the
+            # standard image. When it is enabled explicitly via the env var, we
+            # will respect that.
+            return (
+                MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
+                if MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.is_set()
+                else False
+            )
+
+        return MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
 
     def _should_log_async(self):
         # During evaluate, the eval harness relies on the generated trace objects,

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -105,10 +105,15 @@ def test_export(experiment_id, is_async, monkeypatch):
     assert mlflow.get_last_active_trace_id() is not None
 
 
-def test_async_logging_disabled_in_notebook():
-    with mock.patch("mlflow.tracing.export.mlflow_v3.is_in_databricks_notebook", return_value=True):
-        exporter = MlflowV3SpanExporter()
-        assert not exporter._is_async_enabled
+@mock.patch("mlflow.tracing.export.mlflow_v3.is_in_databricks_notebook", return_value=True)
+def test_async_logging_disabled_in_databricks_notebook(mock_is_in_db_notebook, monkeypatch):
+    exporter = MlflowV3SpanExporter()
+    assert not exporter._is_async_enabled
+
+    # If the env var is set explicitly, we should respect that
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_TRACE_LOGGING", "True")
+    exporter = MlflowV3SpanExporter()
+    assert exporter._is_async_enabled
 
 
 @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -17,6 +17,7 @@ from mlflow.entities.trace_location import (
 from mlflow.entities.trace_state import TraceState
 from mlflow.protos import service_pb2 as pb
 from mlflow.tracing.destination import Databricks
+from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
 from mlflow.tracing.provider import _get_trace_exporter
 
 _EXPERIMENT_ID = "dummy-experiment-id"
@@ -102,6 +103,12 @@ def test_export(experiment_id, is_async, monkeypatch):
 
     # Last active trace ID should be set
     assert mlflow.get_last_active_trace_id() is not None
+
+
+def test_async_logging_disabled_in_notebook():
+    with mock.patch("mlflow.tracing.export.mlflow_v3.is_in_databricks_notebook", return_value=True):
+        exporter = MlflowV3SpanExporter()
+        assert not exporter._is_async_enabled
 
 
 @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15663?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15663/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15663/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15663/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Async trace logging is still in development. This PR disable it now in Databricks notebook to de-risk DBR 17 inclusion.

Also increasing the default queue size limit for async logging to avoid dropping traces too aggressively.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Verified tracing works in DB notebook + agent eval.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
