### PR TITLE
Use `filter_string` when search for models matching `name` or `run_id`

### DIFF
--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -179,7 +179,6 @@ class RunsArtifactRepository(ArtifactRepository):
                 if not page.token:
                     break
                 page_token = page.token
-
             _logger.debug(
                 f"Failed to find any models with name {model_name} associated with the "
                 f"run {run_id}."

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -147,38 +147,33 @@ class RunsArtifactRepository(ArtifactRepository):
             run = client.get_run(run_id)
             [model_name, *rest] = artifact_path.split("/", 1)
             artifact_path = rest[0] if rest else "."
-            page_token = None
-            while True:
-                page = client.search_logged_models(
-                    experiment_ids=[run.info.experiment_id],
-                    # TODO: Use filter_string once the backend supports it
-                    # filter_string="...",
-                    page_token=page_token,
-                )
-                for model in page:
-                    # Return the first model that matches the run_id and artifact_path
-                    if model.source_run_id == run_id and model.name == model_name:
-                        repo = get_artifact_repository(model.artifact_location)
-                        # TODO: Disabled for now. Consider re-enabling this once we migrate docs
-                        # and examples to use the new model URI format.
-                        # color_warning(
-                        #     "`runs:/<run_id>/artifact_path` is deprecated for loading models, "
-                        #     "use `models:/<model_id>` instead. Alternatively, retrieve "
-                        #     "`model_info.model_uri` from the model_info returned by "
-                        #     "mlflow.<flavor>.log_model. For example: "
-                        #     "model_info = mlflow.<flavor>.log_model(...); "
-                        #     "model = mlflow.<flavor>.load_model(model_info.model_uri)",
-                        #     stacklevel=1,
-                        #     color="yellow",
-                        # )
-                        return repo.download_artifacts(
-                            artifact_path=artifact_path,  # root directory
-                            dst_path=dst_path,
-                        )
+            models = client.search_logged_models(
+                experiment_ids=[run.info.experiment_id],
+                filter_string=f"name = '{model_name}'",
+                max_results=1,
+            )
+            if models:
+                model = models[0]
+                # Return the first model that matches the run_id and artifact_path
+                if model.source_run_id == run_id and model.name == model_name:
+                    repo = get_artifact_repository(model.artifact_location)
+                    # TODO: Disabled for now. Consider re-enabling this once we migrate docs
+                    # and examples to use the new model URI format.
+                    # color_warning(
+                    #     "`runs:/<run_id>/artifact_path` is deprecated for loading models, "
+                    #     "use `models:/<model_id>` instead. Alternatively, retrieve "
+                    #     "`model_info.model_uri` from the model_info returned by "
+                    #     "mlflow.<flavor>.log_model. For example: "
+                    #     "model_info = mlflow.<flavor>.log_model(...); "
+                    #     "model = mlflow.<flavor>.load_model(model_info.model_uri)",
+                    #     stacklevel=1,
+                    #     color="yellow",
+                    # )
+                    return repo.download_artifacts(
+                        artifact_path=artifact_path,  # root directory
+                        dst_path=dst_path,
+                    )
 
-                if not page.token:
-                    break
-                page_token = page.token
             _logger.debug(
                 f"Failed to find any models with name {model_name} associated with the "
                 f"run {run_id}."

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -207,18 +207,10 @@ def _get_logged_models_from_run(source_run: str, model_name: str) -> list[Logged
     while True:
         logged_models_page = client.search_logged_models(
             experiment_ids=[source_run.info.experiment_id],
-            # TODO: Use filter_string once the backend supports it
-            # filter_string="...",
+            filter_string=f"name = {model_name} and source_run_id = '{source_run.info.run_id}'",
             page_token=page_token,
         )
-        logged_models.extend(
-            [
-                logged_model
-                for logged_model in logged_models_page
-                if logged_model.source_run_id == source_run.info.run_id
-                and logged_model.name == model_name
-            ]
-        )
+        logged_models.extend(logged_models_page)
         if not logged_models_page.token:
             break
         page_token = logged_models_page.token

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -208,6 +208,7 @@ def _get_logged_models_from_run(source_run: Run, model_name: str) -> list[Logged
     while True:
         logged_models_page = client.search_logged_models(
             experiment_ids=[source_run.info.experiment_id],
+            # TODO: Use 'source_run_id' once Databricks backend supports it
             filter_string=f"name = '{model_name}'",
             page_token=page_token,
         )

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -208,7 +208,7 @@ def _get_logged_models_from_run(source_run: Run, model_name: str) -> list[Logged
     while True:
         logged_models_page = client.search_logged_models(
             experiment_ids=[source_run.info.experiment_id],
-            # TODO: Use 'source_run_id' once Databricks backend supports it
+            # TODO: Filter by 'source_run_id' once Databricks backend supports it
             filter_string=f"name = '{model_name}'",
             page_token=page_token,
         )

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -208,7 +208,7 @@ def _get_logged_models_from_run(source_run: Run, model_name: str) -> list[Logged
     while True:
         logged_models_page = client.search_logged_models(
             experiment_ids=[source_run.info.experiment_id],
-            filter_string=f"name = {model_name}",
+            filter_string=f"name = '{model_name}'",
             page_token=page_token,
         )
         logged_models.extend(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15671?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15671/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15671/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15671/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Address a TODO for model search. Both OSS and Databricks backends support searching for models with name or run_id now.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
