### PR TITLE
Support predict_stream in dspy flavor

### DIFF
--- a/docs/docs/llms/dspy/index.mdx
+++ b/docs/docs/llms/dspy/index.mdx
@@ -182,6 +182,36 @@ print(response)
 }
 ```
 
+The MLflow PythonModel for DSPy supports streaming. To enable streaming, ensure the following conditions are met:
+
+1. Install `dspy` version greater than 2.6.23.
+2. Log your model with a signature.
+3. Ensure all outputs of your model are strings.
+
+```python
+stream_response = model.predict_stream("What kind of bear is best?")
+for output in stream_response:
+    print(output)
+```
+
+```python title="Output"
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": "The"}
+{
+    "predict_name": "prog.predict",
+    "signature_field_name": "reasoning",
+    "chunk": " question",
+}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " of"}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " what"}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " kind"}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " of"}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " bear"}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " is"}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " best"}
+{"predict_name": "prog.predict", "signature_field_name": "reasoning", "chunk": " is"}
+...
+```
+
 To load the DSPy program itself back instead of the PyFunc-wrapped model, use the <APILink fn="mlflow.dspy.load_model" /> function.
 
 ```python

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -27,6 +27,7 @@ from mlflow.models.signature import _infer_signature_from_input_example
 from mlflow.models.utils import _save_example
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.types.schema import DataType
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import disable_autologging_globally
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
@@ -174,9 +175,6 @@ def save_model(
     else:
         wrapped_dspy_model = DspyModelWrapper(model, dspy_settings, model_config)
 
-    with open(model_path, "wb") as f:
-        cloudpickle.dump(wrapped_dspy_model, f)
-
     flavor_options = {
         "model_path": model_subpath,
     }
@@ -193,6 +191,18 @@ def save_model(
     if saved_example and mlflow_model.signature is None:
         signature = _infer_signature_from_input_example(saved_example, wrapped_dspy_model)
         mlflow_model.signature = signature
+
+    streamable = False
+    # Set the output schema to the model wrapper to use it for streaming
+    if mlflow_model.signature and mlflow_model.signature.outputs:
+        wrapped_dspy_model.output_schema = mlflow_model.signature.outputs
+        # DSPy streaming only supports string outputs.
+        if all(spec.type == DataType.string for spec in mlflow_model.signature.outputs):
+            streamable = True
+
+    with open(model_path, "wb") as f:
+        cloudpickle.dump(wrapped_dspy_model, f)
+
     code_dir_subpath = _validate_and_copy_code_paths(code_paths, path)
 
     # Add flavor info to `mlflow_model`.
@@ -204,6 +214,7 @@ def save_model(
         code=code_dir_subpath,
         conda_env=_CONDA_ENV_FILE_NAME,
         python_env=_PYTHON_ENV_FILE_NAME,
+        streamable=streamable,
     )
 
     # Add model file size to `mlflow_model`.

--- a/mlflow/dspy/util.py
+++ b/mlflow/dspy/util.py
@@ -60,7 +60,7 @@ def log_dspy_dataset(dataset: list["Example"], file_name: str):
         for example in dataset:
             for k, v in example.items():
                 result[k].append(v)
-        mlflow.log_table(result, file_name)
+        mlflow.log_input(mlflow.data.from_numpy(result), file_name)
     except Exception as e:
         _logger.warning(f"Failed to log dataset: {e}")
 

--- a/mlflow/dspy/util.py
+++ b/mlflow/dspy/util.py
@@ -60,7 +60,7 @@ def log_dspy_dataset(dataset: list["Example"], file_name: str):
         for example in dataset:
             for k, v in example.items():
                 result[k].append(v)
-        mlflow.log_table(mlflow.data.from_numpy(result), file_name)
+        mlflow.log_table(result, file_name)
     except Exception as e:
         _logger.warning(f"Failed to log dataset: {e}")
 

--- a/mlflow/dspy/util.py
+++ b/mlflow/dspy/util.py
@@ -60,7 +60,7 @@ def log_dspy_dataset(dataset: list["Example"], file_name: str):
         for example in dataset:
             for k, v in example.items():
                 result[k].append(v)
-        mlflow.log_input(mlflow.data.from_numpy(result), file_name)
+        mlflow.log_table(mlflow.data.from_numpy(result), file_name)
     except Exception as e:
         _logger.warning(f"Failed to log dataset: {e}")
 

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -156,7 +156,7 @@ class DspyChatModelWrapper(DspyModelWrapper):
                 elif isinstance(output, dspy.Prediction):
                     role = output.get("role", "assistant")
                     choices.append(
-                        self._construct_chat_message(isinstance, json.dumps(outputs.toDict()))
+                        self._construct_chat_message(role, json.dumps(outputs.toDict()))
                     )
                 else:
                     raise MlflowException(

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -155,9 +155,7 @@ class DspyChatModelWrapper(DspyModelWrapper):
                     choices.append(self._construct_chat_message(role, json.dumps(outputs)))
                 elif isinstance(output, dspy.Prediction):
                     role = output.get("role", "assistant")
-                    choices.append(
-                        self._construct_chat_message(role, json.dumps(outputs.toDict()))
-                    )
+                    choices.append(self._construct_chat_message(role, json.dumps(outputs.toDict())))
                 else:
                     raise MlflowException(
                         f"Unsupported output type: {type(output)}. To log a DSPy model with task "

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -1,6 +1,9 @@
+import importlib.metadata
 import json
-import logging
-from typing import TYPE_CHECKING, Any, Optional
+from dataclasses import asdict, is_dataclass
+from typing import TYPE_CHECKING, Any, Optional, Union
+
+from packaging.version import Version
 
 if TYPE_CHECKING:
     import dspy
@@ -10,8 +13,7 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
 )
 from mlflow.pyfunc import PythonModel
-
-_logger = logging.getLogger(__name__)
+from mlflow.types.schema import DataType, Schema
 
 
 class DspyModelWrapper(PythonModel):
@@ -33,9 +35,53 @@ class DspyModelWrapper(PythonModel):
         self.model = model
         self.dspy_settings = dspy_settings
         self.model_config = model_config or {}
+        self.output_schema: Optional[Schema] = None
 
     def predict(self, inputs: Any, params: Optional[dict[str, Any]] = None):
         import dspy
+
+        converted_inputs = self._get_model_input(inputs)
+
+        with dspy.context(**self.dspy_settings):
+            if isinstance(inputs, dict):
+                return self.model(**converted_inputs).toDict()
+            else:
+                return self.model(converted_inputs).toDict()
+
+    def predict_stream(self, inputs: Any, params=None):
+        import dspy
+
+        converted_inputs = self._get_model_input(inputs)
+
+        self._validate_streaming()
+
+        stream_listeners = [
+            dspy.streaming.StreamListener(signature_field_name=spec.name)
+            for spec in self.output_schema
+        ]
+        stream_model = dspy.streamify(
+            self.model,
+            stream_listeners=stream_listeners,
+            async_streaming=False,
+            include_final_prediction_in_output_stream=False,
+        )
+
+        if isinstance(converted_inputs, dict):
+            outputs = stream_model(**converted_inputs)
+        else:
+            outputs = stream_model(converted_inputs)
+
+        with dspy.context(**self.dspy_settings):
+            for output in outputs:
+                if is_dataclass(output):
+                    yield asdict(output)
+                elif isinstance(output, dspy.Prediction):
+                    yield output.toDict()
+                else:
+                    yield output
+
+    def _get_model_input(self, inputs: Any) -> Union[str, dict[str, Any]]:
+        """Convert the PythonModel input into the DSPy program input"""
         import numpy as np
         import pandas as pd
 
@@ -58,11 +104,27 @@ class DspyModelWrapper(PythonModel):
                 )
             inputs = str(flatten[0])
 
-        with dspy.context(**self.dspy_settings):
-            if isinstance(inputs, dict):
-                return self.model(**inputs).toDict()
-            if isinstance(inputs, str):
-                return self.model(inputs).toDict()
+        return inputs
+
+    def _validate_streaming(
+        self,
+    ):
+        if Version(importlib.metadata.version("dspy")) <= Version("2.6.23"):
+            raise MlflowException(
+                "Streaming API is only supported in dspy 2.6.24 or later. "
+                "Please upgrade your dspy version."
+            )
+
+        if self.output_schema is None:
+            raise MlflowException(
+                "Output schema of the DSPy model is not set. Please log your DSPy "
+                "model with `signature` or `input_example` to use streaming API."
+            )
+
+        if any(spec.type != DataType.string for spec in self.output_schema):
+            raise MlflowException(
+                f"All output fields must be string to use streaming API. Got {self.output_schema}."
+            )
 
 
 class DspyChatModelWrapper(DspyModelWrapper):
@@ -70,18 +132,8 @@ class DspyChatModelWrapper(DspyModelWrapper):
 
     def predict(self, inputs: Any, params: Optional[dict[str, Any]] = None):
         import dspy
-        import pandas as pd
 
-        if isinstance(inputs, dict):
-            converted_inputs = inputs["messages"]
-        elif isinstance(inputs, pd.DataFrame):
-            converted_inputs = inputs.messages[0]
-        else:
-            raise MlflowException(
-                f"Unsupported input type: {type(inputs)}. To log a DSPy model with task "
-                "'llm/v1/chat', the input must be a dict or a pandas DataFrame.",
-                INVALID_PARAMETER_VALUE,
-            )
+        converted_inputs = self._get_model_input(inputs)
 
         # `dspy.settings` cannot be shared across threads, so we are setting the context at every
         # predict call.
@@ -90,54 +142,21 @@ class DspyChatModelWrapper(DspyModelWrapper):
 
         choices = []
         if isinstance(outputs, str):
-            choices.append(
-                {
-                    "index": 0,
-                    "message": {"role": "assistant", "content": outputs},
-                    "finish_reason": "stop",
-                }
-            )
+            choices.append(self._construct_chat_message("assistant", outputs))
         elif isinstance(outputs, dict):
             role = outputs.get("role", "assistant")
-            choices.append(
-                {
-                    "index": 0,
-                    "message": {"role": role, "content": json.dumps(outputs)},
-                    "finish_reason": "stop",
-                }
-            )
+            choices.append(self._construct_chat_message(role, json.dumps(outputs)))
         elif isinstance(outputs, dspy.Prediction):
-            choices.append(
-                {
-                    "index": 0,
-                    "message": {
-                        "role": "assistant",
-                        "content": json.dumps(outputs.toDict()),
-                    },
-                    "finish_reason": "stop",
-                }
-            )
+            choices.append(self._construct_chat_message("assistant", json.dumps(outputs.toDict())))
         elif isinstance(outputs, list):
             for output in outputs:
                 if isinstance(output, dict):
                     role = output.get("role", "assistant")
-                    choices.append(
-                        {
-                            "index": 0,
-                            "message": {"role": role, "content": json.dumps(outputs)},
-                            "finish_reason": "stop",
-                        }
-                    )
+                    choices.append(self._construct_chat_message(role, json.dumps(outputs)))
                 elif isinstance(output, dspy.Prediction):
+                    role = output.get("role", "assistant")
                     choices.append(
-                        {
-                            "index": 0,
-                            "message": {
-                                "role": role,
-                                "content": json.dumps(outputs.toDict()),
-                            },
-                            "finish_reason": "stop",
-                        }
+                        self._construct_chat_message(isinstance, json.dumps(outputs.toDict()))
                     )
                 else:
                     raise MlflowException(
@@ -155,3 +174,32 @@ class DspyChatModelWrapper(DspyModelWrapper):
             )
 
         return {"choices": choices}
+
+    def predict_stream(self, inputs: Any, params=None):
+        raise NotImplementedError(
+            "Streaming is not supported for DSPy model with task 'llm/v1/chat'."
+        )
+
+    def _get_model_input(self, inputs: Any) -> Union[str, list[dict[str, Any]]]:
+        import pandas as pd
+
+        if isinstance(inputs, dict):
+            return inputs["messages"]
+        if isinstance(inputs, pd.DataFrame):
+            return inputs.messages[0]
+
+        raise MlflowException(
+            f"Unsupported input type: {type(inputs)}. To log a DSPy model with task "
+            "'llm/v1/chat', the input must be a dict or a pandas DataFrame.",
+            INVALID_PARAMETER_VALUE,
+        )
+
+    def _construct_chat_message(self, role: str, content: str) -> dict[str, Any]:
+        return {
+            "index": 0,
+            "message": {
+                "role": role,
+                "content": content,
+            },
+            "finish_reason": "stop",
+        }

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -514,6 +514,7 @@ def test_dspy_auto_tracing_in_databricks_model_serving(with_dependencies_schema)
                     "reasoning": "No more responses",
                 },
             ]
+            * 2
         )
     )
 

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -392,8 +392,7 @@ def test_predict_stream_unsupported_schema(dummy_model):
     dspy_model = NumericalCoT()
     dspy.settings.configure(lm=dummy_model)
 
-    with mlflow.start_run():
-        model_info = mlflow.dspy.log_model(dspy_model, name="model")
+    model_info = mlflow.dspy.log_model(dspy_model, name="model")
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
 
     assert not loaded_model._model_meta.flavors["python_function"]["streamable"]
@@ -410,10 +409,9 @@ def test_predict_stream_success(dummy_model):
     dspy_model = CoT()
     dspy.settings.configure(lm=dummy_model)
 
-    with mlflow.start_run():
-        model_info = mlflow.dspy.log_model(
-            dspy_model, name="model", input_example={"question": "what is 2 + 2?"}
-        )
+    model_info = mlflow.dspy.log_model(
+        dspy_model, name="model", input_example={"question": "what is 2 + 2?"}
+    )
     loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
 
     assert loaded_model._model_meta.flavors["python_function"]["streamable"]

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -24,6 +24,12 @@ _DSPY_VERSION = Version(importlib.metadata.version("dspy"))
 
 _DSPY_UNDER_2_6 = _DSPY_VERSION < Version("2.6.0rc1")
 
+_DSPY_2_6_23_OR_OLDER = _DSPY_VERSION <= Version("2.6.23")
+skip_if_2_6_23_or_older = pytest.mark.skipif(
+    _DSPY_2_6_23_OR_OLDER,
+    reason="Streaming API is only supported in dspy 2.6.24 or later.",
+)
+
 _REASONING_KEYWORD = "rationale" if _DSPY_UNDER_2_6 else "reasoning"
 
 
@@ -41,6 +47,15 @@ class CoT(dspy.Module):
 
     def forward(self, question):
         return self.prog(question=question)
+
+
+class NumericalCoT(dspy.Module):
+    def __init__(self):
+        super().__init__()
+        self.prog = dspy.ChainOfThought("question -> answer: int")
+
+    def forward(self, question):
+        return self.prog(question=question).answer
 
 
 @pytest.fixture(autouse=True)
@@ -370,3 +385,61 @@ def test_infer_signature_from_input_examples(dummy_model):
                 ColSpec(name=_REASONING_KEYWORD, type="string"),
             ]
         )
+
+
+@skip_if_2_6_23_or_older
+def test_predict_stream_unsupported_schema(dummy_model):
+    dspy_model = NumericalCoT()
+    dspy.settings.configure(lm=dummy_model)
+
+    with mlflow.start_run():
+        model_info = mlflow.dspy.log_model(dspy_model, name="model")
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    assert not loaded_model._model_meta.flavors["python_function"]["streamable"]
+    output = loaded_model.predict_stream({"question": "What is 2 + 2?"})
+    with pytest.raises(
+        mlflow.exceptions.MlflowException,
+        match="This model does not support predict_stream method.",
+    ):
+        next(output)
+
+
+@skip_if_2_6_23_or_older
+def test_predict_stream_success(dummy_model):
+    dspy_model = CoT()
+    dspy.settings.configure(lm=dummy_model)
+
+    with mlflow.start_run():
+        model_info = mlflow.dspy.log_model(
+            dspy_model, name="model", input_example={"question": "what is 2 + 2?"}
+        )
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    assert loaded_model._model_meta.flavors["python_function"]["streamable"]
+    results = []
+
+    def dummy_streamify(*args, **kwargs):
+        yield dspy.streaming.StreamResponse(
+            predict_name="prog.predict",
+            signature_field_name="answer",
+            chunk="2",
+        )
+        yield dspy.streaming.StreamResponse(
+            predict_name="prog.predict",
+            signature_field_name=_REASONING_KEYWORD,
+            chunk="reason",
+        )
+
+    with mock.patch("dspy.streamify", return_value=dummy_streamify):
+        output = loaded_model.predict_stream({"question": "What is 2 + 2?"})
+        for o in output:
+            results.append(o)
+    assert results == [
+        {"predict_name": "prog.predict", "signature_field_name": "answer", "chunk": "2"},
+        {
+            "predict_name": "prog.predict",
+            "signature_field_name": _REASONING_KEYWORD,
+            "chunk": "reason",
+        },
+    ]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15678?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15678/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15678/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15678/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR introduces streaming support for DSPy program.

```python
import dspy
import mlflow


dspy_model = dspy.Predict("question -> answer")
with mlflow.start_run():
    model_info = mlflow.dspy.log_model(
        dspy_model,
        name="model",
        input_example={"question": "what is 2 + 2?"},
    )
model = mlflow.pyfunc.load_model(model_info.model_uri)
output = model.predict_stream({"question": "What kind of bear is best from your opinion?"})
for o in output:
    print(o)
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': 'The'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' question'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' of'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' what'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' kind'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' of'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' bear'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' is'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' best'}
# {'predict_name': 'prog.predict', 'signature_field_name': 'reasoning', 'chunk': ' is'}
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Streaming support for DSPy models

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
