### PR TITLE
Remove `markdown` and `jinja` from mlflow depedencies

### DIFF
--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -29,13 +29,10 @@ requires-python = ">=3.9"
 dependencies = [
   "mlflow-skinny==3.0.0.dev0",
   "Flask<4",
-  "Jinja2<4,>=2.11; platform_system != 'Windows'",
-  "Jinja2<4,>=3.0; platform_system == 'Windows'",
   "alembic<2,!=1.10.0",
   "docker<8,>=4.0.0",
   "graphene<4",
   "gunicorn<24; platform_system != 'Windows'",
-  "markdown<4,>=3.3",
   "matplotlib<4",
   "numpy<3",
   "pandas<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,8 +28,6 @@ classifiers = [
 requires-python = ">=3.9"
 dependencies = [
   "Flask<4",
-  "Jinja2<4,>=2.11; platform_system != 'Windows'",
-  "Jinja2<4,>=3.0; platform_system == 'Windows'",
   "alembic<2,!=1.10.0",
   "cachetools<6,>=5.0.0",
   "click<9,>=7.0",
@@ -41,7 +39,6 @@ dependencies = [
   "graphene<4",
   "gunicorn<24; platform_system != 'Windows'",
   "importlib_metadata<9,>=3.7.0,!=4.7.0",
-  "markdown<4,>=3.3",
   "matplotlib<4",
   "numpy<3",
   "opentelemetry-api<3,>=1.9.0",

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -13,8 +13,5 @@ gunicorn<24; platform_system != 'Windows'
 waitress<4; platform_system == 'Windows'
 scikit-learn<2
 pyarrow<20,>=4.0.0
-markdown<4,>=3.3
-Jinja2<4,>=2.11; platform_system != 'Windows'
-Jinja2<4,>=3.0; platform_system == 'Windows'
 matplotlib<4
 graphene<4

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -55,25 +55,6 @@ pyarrow:
   minimum: "4.0.0"
   max_major_version: 19
 
-markdown:
-  pip_release: markdown
-  minimum: "3.3"
-  max_major_version: 3
-
-Jinja2-non-windows:
-  pip_release: Jinja2
-  minimum: "2.11"
-  max_major_version: 3
-  markers: "platform_system != 'Windows'"
-
-Jinja2-windows:
-  pip_release: Jinja2
-  # `mlflow.pyfunc.spark_udf` doesn't work properly with Jinja2==2.11 on Windows.
-  # See https://github.com/mlflow/mlflow/pull/6931 for more information.
-  minimum: "3.0"
-  max_major_version: 3
-  markers: "platform_system == 'Windows'"
-
 matplotlib:
   pip_release: matplotlib
   max_major_version: 3


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15680?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15680/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15680/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15680/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

MLflow 3.0 doesn't require `markdown` and `jinja`. MLflow 2.x did for Recipes. This PR removes them from mlflow dependencies.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
