### PR TITLE
Derive request and expectations from traces

### DIFF
--- a/mlflow/data/pandas_dataset.py
+++ b/mlflow/data/pandas_dataset.py
@@ -132,7 +132,7 @@ class PandasDataset(Dataset, PyFuncConvertibleDatasetMixin):
         try:
             return _infer_schema(self._df)
         except Exception as e:
-            _logger.warning("Failed to infer schema for Pandas dataset. Exception: %s", e)
+            _logger.debug("Failed to infer schema for Pandas dataset. Exception: %s", e)
             return None
 
     def to_pyfunc(self) -> PyFuncInputsOutputs:

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -191,9 +191,7 @@ def evaluate(
                 - outputs (optional): Column containing model or app outputs.
                   If this column is present, `predict_fn` must not be provided.
 
-                - expectations (optional): Column containing ground truth or
-                  dictionary of ground truths. If this column contains a single string,
-                  it is assumed to be the expected response for the row.
+                - expectations (optional): Column containing a dictionary of ground truths.
 
             The input dataframe can contain extra columns that will be directly passed to
             the scorers. For example, you can pass a dataframe with `retrieved_context`

--- a/mlflow/genai/evaluation/constant.py
+++ b/mlflow/genai/evaluation/constant.py
@@ -1,0 +1,23 @@
+class AgentEvaluationReserverKey:
+    """
+    Expectation column names that are used by Agent Evaluation.
+    Ref: https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/evaluation-schema
+    """
+
+    EXPECTED_RESPONSE = "expected_response"
+    EXPECTED_RETRIEVED_CONTEXT = "expected_retrieved_context"
+    EXPECTED_FACTS = "expected_facts"
+    GUIDELINES = "guidelines"
+
+    @classmethod
+    def get_all(cls) -> set[str]:
+        return {
+            cls.EXPECTED_RESPONSE,
+            cls.EXPECTED_RETRIEVED_CONTEXT,
+            cls.EXPECTED_FACTS,
+            cls.GUIDELINES,
+        }
+
+
+# A column name for storing custom expectations dictionary in Agent Evaluation.
+AGENT_EVAL_CUSTOM_EXPECTATION_KEY = "custom_expected"

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from mlflow.data.evaluation_dataset import EvaluationDataset
@@ -24,6 +25,14 @@ if TYPE_CHECKING:
         EvaluationDatasetTypes = Union[pd.DataFrame, list[dict], EvaluationDataset]
 
 
+AGENT_EVAL_RESERVED_EXPECTATION_KEYS = {
+    "expected_response",
+    "expected_retrieved_context",
+    "expected_facts",
+}
+AGENT_EVAL_CUSTOM_EXPECTATION_KEY = "custom_expected"
+
+
 def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame":
     """
     Takes in a dataset in the format that mlflow.genai.evaluate() expects and converts it into
@@ -44,7 +53,6 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
                 raise MlflowException.invalid_parameter_value(
                     "Every item in the list must be a dictionary."
                 )
-
         df = pd.DataFrame(data)
     elif isinstance(data, pd.DataFrame):
         # Data is already a pd DataFrame, just copy it
@@ -76,32 +84,86 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
             "key to wrap the value into a dictionary."
         )
 
-    renamed_df = df.rename(columns=column_mapping)
 
-    if "trace" not in renamed_df.columns and column_mapping["inputs"] not in renamed_df.columns:
+    if not any(col in df.columns for col in ("trace", "inputs")):
         raise MlflowException.invalid_parameter_value(
             "Either `inputs` or `trace` column is required in the dataset. Please provide inputs "
             "for every datapoint or provide a trace."
         )
 
+
+    return (
+        df.rename(columns=column_mapping)
+        .pipe(_extract_request_from_trace)
+        .pipe(_extract_expectations_from_trace)
+        .pipe(_convert_expectations_to_legacy_columns)
+    )
+
+
+
+def _extract_request_from_trace(df: "pd.DataFrame") -> "pd.DataFrame":
+    """
+    Add `request` columns to the dataframe if it is not already present.
+    This is for compatibility with mlflow.evaluate() that requires `request` column.
+    """
+    if "trace" not in df.columns:
+        return df
+
+    if "request" not in df.columns:
+        df["request"] = df["trace"].apply(lambda trace: json.loads(trace.data.request))
+    return df
+
+
+def _extract_expectations_from_trace(df: "pd.DataFrame") -> "pd.DataFrame":
+    """
+    Add `expectations` columns to the dataframe from assessments
+    stored in the traces, if the "expectations" column is not already present.
+    """
+    if "trace" not in df.columns:
+        return df
+
+    expectations_column = []
+    for trace in df["trace"]:
+        expectations = {}
+        for assessment in trace.info.assessments or []:
+            if assessment.expectation is not None:
+                expectations[assessment.name] = assessment.expectation.value
+        expectations_column.append(expectations)
+    # If no trace has assessments, not add the column
+    if all(len(expectations) == 0 for expectations in expectations_column):
+        return df
+
+    df["expectations"] = expectations_column
+    return df
+
+
+def _convert_expectations_to_legacy_columns(df: "pd.DataFrame") -> "pd.DataFrame":
     # expand out expectations into separate columns
     if "expectations" in df.columns:
-        for field in ["expected_response", "expected_retrieved_context", "expected_facts"]:
-            renamed_df[field] = None
+        for field in [*AGENT_EVAL_RESERVED_EXPECTATION_KEYS, AGENT_EVAL_CUSTOM_EXPECTATION_KEY]:
+            df[field] = None
 
         # Process each row individually to handle mixed types
         for idx, value in df["expectations"].items():
             if isinstance(value, dict):
-                for field in ["expected_response", "expected_retrieved_context", "expected_facts"]:
+                # Reserved expectation keys is propagated as a new column
+                for field in AGENT_EVAL_RESERVED_EXPECTATION_KEYS:
                     if field in value:
-                        renamed_df.at[idx, field] = value[field]
-            # Non-dictionary values go to expected_response
-            elif value is not None:
-                renamed_df.at[idx, "expected_response"] = value
+                        df.at[idx, field] = value.pop(field, None)
+                # Other columns go to custom_expected
+                if value:
+                    df.at[idx, AGENT_EVAL_CUSTOM_EXPECTATION_KEY] = value
 
-        renamed_df.drop(columns=["expectations"], inplace=True)
+            # String values go to expected_response
+            else:
+                raise MlflowException.invalid_parameter_value(
+                    "Expectations must be a dictionary in the form of [name of expectation]: "
+                    '[value], e.g., `{"expectations": {"expected_response": "..."}`'
+                )
 
-    return renamed_df
+        df.drop(columns=["expectations"], inplace=True)
+
+    return df
 
 
 def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
@@ -135,11 +197,22 @@ def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
         tool_calls: Optional[list[Any]],
         **kwargs,
     ) -> Union[int, float, bool, str, Assessment, list[Assessment]]:
+        # Condense all expectations into a single dict
+        expectations = {}
+        if expected_response is not None:
+            expectations["expected_response"] = expected_response
+        if expected_facts is not None:
+            expectations["expected_facts"] = expected_facts
+        if expected_retrieved_context is not None:
+            expectations["expected_retrieved_context"] = expected_retrieved_context
+        if custom_expected is not None:
+            expectations.update(custom_expected)
+
         # TODO: scorer.aggregations require a refactor on the agents side
         merged = {
             "inputs": request,
             "outputs": response,
-            "expectations": expected_response,
+            "expectations": expectations,
             "trace": trace,
             "guidelines": guidelines,
             "retrieved_context": retrieved_context,

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -29,6 +29,7 @@ AGENT_EVAL_RESERVED_EXPECTATION_KEYS = {
     "expected_response",
     "expected_retrieved_context",
     "expected_facts",
+    "guidelines",
 }
 AGENT_EVAL_CUSTOM_EXPECTATION_KEY = "custom_expected"
 
@@ -90,7 +91,6 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
             "Either `inputs` or `trace` column is required in the dataset. Please provide inputs "
             "for every datapoint or provide a trace."
         )
-
 
     return (
         df.rename(columns=column_mapping)

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -1,5 +1,3 @@
-# TODO: Remove this file once `databricks-agents` releases a new version that's compatible with
-# trace v3.
 from unittest import mock
 
 import pytest
@@ -7,8 +5,35 @@ import pytest
 from mlflow.entities import TraceInfoV2
 
 
+# TODO: Remove this fixture once `databricks-agents` releases a new version that's compatible with
+# trace v3
 @pytest.fixture(scope="module", autouse=True)
 def mock_trace_info():
     # Monkey patch TraceInfo (V3) to use TraceInfoV2
     with mock.patch("mlflow.entities.TraceInfo", wraps=TraceInfoV2):
+        yield
+
+
+def mock_init_auth(config_instance):
+    config_instance.host = "https://databricks.com/"
+    config_instance._header_factory = lambda: {}
+
+
+@pytest.fixture(scope="module")
+def spark():
+    try:
+        from pyspark.sql import SparkSession
+
+        with SparkSession.builder.getOrCreate() as spark:
+            yield spark
+    except RuntimeError:
+        pytest.skip("Can't create a Spark session")
+
+
+@pytest.fixture(autouse=True)
+def spoof_tracking_uri_check():
+    # NB: The mlflow.genai.evaluate() API is only runnable when the tracking URI is set
+    # to Databricks. However, we cannot test against real Databricks server in CI, so
+    # we spoof the check by patching the is_databricks_uri() function.
+    with mock.patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True):
         yield

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -14,9 +14,14 @@ def mock_trace_info():
         yield
 
 
-def mock_init_auth(config_instance):
-    config_instance.host = "https://databricks.com/"
-    config_instance._header_factory = lambda: {}
+@pytest.fixture(autouse=True)
+def mock_init_auth():
+    def mocked_init_auth(config_instance):
+        config_instance.host = "https://databricks.com/"
+        config_instance._header_factory = lambda: {}
+
+    with mock.patch("databricks.sdk.config.Config.init_auth", new=mocked_init_auth):
+        yield
 
 
 @pytest.fixture(scope="module")

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1,14 +1,177 @@
+from importlib import import_module
 from unittest import mock
 from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from packaging.version import Version
 
 import mlflow
 from mlflow.exceptions import MlflowException
+from mlflow.entities.assessment import Assessment, Expectation, Feedback
+from mlflow.entities.assessment_source import AssessmentSource
+from mlflow.entities.span import SpanType
+from mlflow.genai.scorers.base import scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, safety
 
 from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
+from tests.genai.conftest import mock_init_auth
+
+_IS_AGENT_SDK_V1 = Version(import_module("databricks.agents").__version__).major >= 1
+
+
+class TestModel:
+    def predict(self, question: str) -> str:
+        return "I don't know"
+
+
+@scorer
+def exact_match(outputs, expectations):
+    return outputs == expectations["expected_response"]
+
+
+@scorer
+def max_length(outputs, expectations):
+    return len(outputs) <= expectations["max_length"]
+
+
+@scorer
+def relevance(inputs, outputs):
+    return Assessment(
+        name="relevance",
+        feedback=Feedback(value="yes"),
+        rationale="The response is relevant to the question",
+        source=AssessmentSource(source_id="gpt", source_type="LLM_JUDGE"),
+    )
+
+
+@scorer
+def has_trace(trace):
+    return trace is not None
+
+
+@pytest.mark.skipif(not _IS_AGENT_SDK_V1, reason="Databricks Agent SDK v1 is required")
+def test_evaluate_with_static_dataset():
+    data = [
+        {
+            "inputs": {"question": "What is MLflow?"},
+            "outputs": "MLflow is a tool for ML",
+            "expectations": {
+                "expected_response": "MLflow is a tool for ML",
+                "max_length": 100,
+            },
+        },
+        {
+            "inputs": {"question": "What is Spark?"},
+            "outputs": "Spark is a fast data processing engine",
+            "expectations": {
+                "expected_response": "Spark is a fast data processing engine",
+                "max_length": 1,
+            },
+        },
+    ]
+
+    with mock.patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
+        result = mlflow.genai.evaluate(
+            data=data,
+            scorers=[exact_match, max_length, relevance, has_trace],
+        )
+
+    metrics = result.metrics
+    assert metrics["metric/exact_match/average"] == 1.0
+    assert metrics["metric/max_length/average"] == 0.5
+    assert metrics["metric/relevance/relevance/average"] == 1.0
+    assert metrics["metric/has_trace/average"] == 1.0
+
+
+@pytest.mark.skipif(not _IS_AGENT_SDK_V1, reason="Databricks Agent SDK v1 is required")
+def test_evaluate_with_predict_fn():
+    data = [
+        {
+            "inputs": {"question": "What is MLflow?"},
+            "expectations": {
+                "expected_response": "MLflow is a tool for ML",
+                "max_length": 100,
+            },
+        },
+        {
+            "inputs": {"question": "What is Spark?"},
+            "expectations": {
+                "expected_response": "Spark is a fast data processing engine",
+                "max_length": 1,
+            },
+        },
+    ]
+    model = TestModel()
+
+    with mock.patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
+        result = mlflow.genai.evaluate(
+            predict_fn=model.predict,
+            data=data,
+            scorers=[exact_match, max_length, relevance, has_trace],
+        )
+
+    metrics = result.metrics
+    assert metrics["metric/exact_match/average"] == 0.0
+    assert metrics["metric/max_length/average"] == 0.5
+    assert metrics["metric/relevance/relevance/average"] == 1.0
+    assert metrics["metric/has_trace/average"] == 1.0
+
+
+@pytest.mark.skipif(not _IS_AGENT_SDK_V1, reason="Databricks Agent SDK v1 is required")
+def test_evaluate_with_traces():
+    questions = ["What is MLflow?", "What is Spark?"]
+
+    @mlflow.trace(span_type=SpanType.AGENT)
+    def predict(question: str) -> str:
+        return TestModel().predict(question)
+
+    for question in questions:
+        predict(question)
+
+    data = mlflow.search_traces()
+
+    # OSS MLflow backend doesn't support assessment APIs now, so we need to manually add them
+    data.iloc[0]["trace"].info.assessments = [
+        Assessment(
+            name="expected_response",
+            trace_id="tr-123",
+            expectation=Expectation(value="MLflow is a tool for ML"),
+            source=AssessmentSource(source_id="me", source_type="HUMAN"),
+        ),
+        Assessment(
+            name="max_length",
+            trace_id="tr-123",
+            expectation=Expectation(value=100),
+            source=AssessmentSource(source_id="me", source_type="HUMAN"),
+        ),
+    ]
+    data.iloc[1]["trace"].info.assessments = [
+        Assessment(
+            name="expected_response",
+            trace_id="tr-123",
+            expectation=Expectation(value="Spark is a fast data processing engine"),
+            source=AssessmentSource(source_id="me", source_type="HUMAN"),
+        ),
+        Assessment(
+            name="max_length",
+            trace_id="tr-123",
+            expectation=Expectation(value=1),
+            source=AssessmentSource(source_id="me", source_type="HUMAN"),
+        ),
+    ]
+
+    with mock.patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
+        result = mlflow.genai.evaluate(
+            data=data,
+            scorers=[exact_match, max_length, relevance, has_trace],
+        )
+
+    metrics = result.metrics
+    assert metrics["metric/exact_match/average"] == 0.0
+    assert metrics["metric/max_length/average"] == 0.5
+    assert metrics["metric/relevance/relevance/average"] == 1.0
+    assert metrics["metric/has_trace/average"] == 1.0
 
 
 def mock_init_auth(config_instance):

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -7,10 +7,10 @@ import pytest
 from packaging.version import Version
 
 import mlflow
-from mlflow.exceptions import MlflowException
 from mlflow.entities.assessment import Assessment, Expectation, Feedback
 from mlflow.entities.assessment_source import AssessmentSource
 from mlflow.entities.span import SpanType
+from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, safety
 

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -1,4 +1,6 @@
 import importlib
+import os
+from typing import Any, Literal
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -6,37 +8,17 @@ import pytest
 
 import mlflow
 from mlflow.exceptions import MlflowException
+from mlflow.entities.assessment import Assessment, Expectation, Feedback
+from mlflow.entities.assessment_source import AssessmentSource
+from mlflow.entities.span import SpanType
 from mlflow.genai import scorer
 from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
 from mlflow.genai.scorers.builtin_scorers import safety
 
+from tests.genai.conftest import mock_init_auth
+
 if importlib.util.find_spec("databricks.agents") is None:
     pytest.skip(reason="databricks-agents is not installed", allow_module_level=True)
-
-
-def mock_init_auth(config_instance):
-    config_instance.host = "https://databricks.com/"
-    config_instance._header_factory = lambda: {}
-
-
-@pytest.fixture(scope="module")
-def spark():
-    try:
-        from pyspark.sql import SparkSession
-
-        with SparkSession.builder.getOrCreate() as spark:
-            yield spark
-    except RuntimeError:
-        pytest.skip("Can't create a Spark session")
-
-
-@pytest.fixture(autouse=True)
-def spoof_tracking_uri_check():
-    # NB: The mlflow.genai.evaluate() API is only runnable when the tracking URI is set
-    # to Databricks. However, we cannot test against real Databricks server in CI, so
-    # we spoof the check by patching the is_databricks_uri() function.
-    with patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True):
-        yield
 
 
 @pytest.fixture
@@ -45,7 +27,7 @@ def sample_dict_data_single():
         {
             "inputs": {"question": "What is Spark?"},
             "outputs": "actual response for first question",
-            "expectations": "expected response for first question",
+            "expectations": {"expected_response": "expected response for first question"},
         },
     ]
 
@@ -56,7 +38,7 @@ def sample_dict_data_multiple():
         {
             "inputs": {"question": "What is Spark?"},
             "outputs": "actual response for first question",
-            "expectations": "expected response for first question",
+            "expectations": {"expected_response": "expected response for first question"},
             # Additional columns required by the judges
             "retrieved_context": [
                 {
@@ -72,8 +54,30 @@ def sample_dict_data_multiple():
         {
             "inputs": {"question": "How can you minimize data shuffling in Spark?"},
             "outputs": "actual response for second question",
-            "expectations": "expected response for second question",
+            "expectations": {"expected_response": "expected response for second question"},
             "retrieved_context": [],
+        },
+    ]
+
+
+@pytest.fixture
+def sample_dict_data_multiple_with_custom_expectations():
+    return [
+        {
+            "inputs": {"question": "What is Spark?"},
+            "outputs": "actual response for first question",
+            "expectations": {
+                "expected_response": "expected response for first question",
+                "my_custom_expectation": "custom expectation for the first question",
+            },
+        },
+        {
+            "inputs": {"question": "How can you minimize data shuffling in Spark?"},
+            "outputs": "actual response for second question",
+            "expectations": {
+                "expected_response": "expected response for second question",
+                "my_custom_expectation": "custom expectation for the second question",
+            },
         },
     ]
 
@@ -90,15 +94,96 @@ def sample_spark_data(sample_pd_data, spark):
     return spark.createDataFrame(sample_pd_data)
 
 
-@pytest.mark.parametrize(
-    "data_fixture",
-    ["sample_dict_data_single", "sample_dict_data_multiple", "sample_pd_data", "sample_spark_data"],
-)
+_ALL_DATA_FIXTURES = [
+    "sample_dict_data_single",
+    "sample_dict_data_multiple",
+    "sample_dict_data_multiple_with_custom_expectations",
+    "sample_pd_data",
+    "sample_spark_data",
+]
+
+
+class TestModel:
+    @mlflow.trace(span_type=SpanType.AGENT)
+    def predict(self, question: str) -> str:
+        response = self.call_llm(messages=[{"role": "user", "content": question}])
+        return response["choices"][0]["message"]["content"]
+
+    @mlflow.trace(span_type=SpanType.LLM)
+    def call_llm(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
+        return {"choices": [{"message": {"role": "assistant", "content": "I don't know"}}]}
+
+
+def get_test_traces(type=Literal["pandas", "list"]):
+    model = TestModel()
+
+    model.predict("What is MLflow?")
+    traces = mlflow.search_traces(return_type=type, order_by=["timestamp_ms ASC"])
+
+    # Add assessments. Since log_assessment API is not supported in OSS MLflow yet, we
+    # need to add it to the trace info manually.
+    source = AssessmentSource(source_id="test", source_type="HUMAN")
+    trace = traces[0] if type == "list" else traces.iloc[0]["trace"]
+    trace.info.assessments.extend(
+        [
+            # 1. Expectation with reserved name "expected_response"
+            Assessment(
+                name="expected_response",
+                source=source,
+                trace_id=trace.info.trace_id,
+                expectation=Expectation(value="expected response for first question"),
+            ),
+            # 2. Expectation with reserved name "expected_facts"
+            Assessment(
+                name="expected_facts",
+                source=source,
+                trace_id=trace.info.trace_id,
+                expectation=Expectation(value=["fact1", "fact2"]),
+            ),
+            # 3. Expectation with custom name "ground_truth"
+            Assessment(
+                name="my_custom_expectation",
+                source=source,
+                trace_id=trace.info.trace_id,
+                expectation=Expectation(value="custom expectation for the first question"),
+            ),
+            # 4. Non-expectation assessment
+            Assessment(
+                name="feedback",
+                source=source,
+                trace_id=trace.info.trace_id,
+                feedback=Feedback(value="some feedback"),
+            ),
+        ]
+    )
+    return [{"trace": trace} for trace in traces] if type == "list" else traces
+
+
+@pytest.mark.parametrize("input_type", ["list", "pandas"])
+def test_convert_to_legacy_eval_traces(input_type):
+    sample_data = get_test_traces(type=input_type)
+    data = _convert_to_legacy_eval_set(sample_data)
+
+    assert "trace" in data.columns
+
+    # "request" column should be derived from the trace
+    assert "request" in data.columns
+    assert list(data["request"]) == [{"question": "What is MLflow?"}]
+
+    assert data["expected_response"][0] == "expected response for first question"
+    assert data["expected_facts"][0] == ["fact1", "fact2"]
+    assert data["custom_expected"][0] == {
+        "my_custom_expectation": "custom expectation for the first question"
+    }
+    # Assessment with type "Feedback" should not be present in the transformed data
+    assert "feedback" not in data.columns
+
+
+@pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)
 def test_convert_to_legacy_eval_set_has_no_errors(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)
 
-    with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        transformed_data = _convert_to_legacy_eval_set(sample_data)
+    transformed_data = _convert_to_legacy_eval_set(sample_data)
 
     assert "request" in transformed_data.columns
     assert "response" in transformed_data.columns
@@ -110,10 +195,7 @@ def test_convert_to_legacy_eval_set_invalid_inputs():
         _convert_to_legacy_eval_set([{"inputs": "not a dict"}])
 
 
-@pytest.mark.parametrize(
-    "data_fixture",
-    ["sample_dict_data_single", "sample_dict_data_multiple", "sample_pd_data", "sample_spark_data"],
-)
+@pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)
 def test_scorer_receives_correct_data(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)
 
@@ -147,6 +229,24 @@ def test_scorer_receives_correct_data(data_fixture, request):
         assert set(all_inputs) == set(expected_inputs)
         assert set(all_outputs) == set(expected_outputs)
         assert set(all_expectations) == set(expected_expectations)
+    all_inputs, all_outputs, all_expectations = zip(*received_args)
+
+    expected_inputs = [
+        "What is Spark?",
+        "How can you minimize data shuffling in Spark?",
+    ][: len(sample_data)]
+    expected_outputs = [
+        "actual response for first question",
+        "actual response for second question",
+    ][: len(sample_data)]
+    expected_expectations = [
+        "expected response for first question",
+        "expected response for second question",
+    ][: len(sample_data)]
+
+    assert set(all_inputs) == set(expected_inputs)
+    assert set(all_outputs) == set(expected_outputs)
+    assert set(all_expectations) == set(expected_expectations)
 
 
 def test_input_is_required_if_trace_is_not_provided():
@@ -178,10 +278,39 @@ def test_input_is_optional_if_trace_is_provided():
         mock_evaluate.assert_called_once()
 
 
-@pytest.mark.parametrize(
-    "data_fixture",
-    ["sample_dict_data_single", "sample_dict_data_multiple", "sample_pd_data", "sample_spark_data"],
+# TODO: Remove this skip once databricks-agents 1.0 is released
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") == "true",
+    reason="Skipping test in CI because this test requires Agent SDK pre-release wheel",
 )
+@pytest.mark.parametrize("input_type", ["list", "pandas"])
+def test_scorer_receives_correct_data_with_trace_data(input_type):
+    sample_data = get_test_traces(type=input_type)
+    received_args = []
+
+    @scorer
+    def dummy_scorer(inputs, outputs, expectations, trace):
+        received_args.append((inputs, outputs, expectations, trace))
+        return 0
+
+    with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
+        mlflow.genai.evaluate(
+            data=sample_data,
+            scorers=[dummy_scorer],
+        )
+
+    inputs, outputs, expectations, trace = received_args[0]
+    assert inputs == {"question": "What is MLflow?"}
+    assert outputs == "I don't know"
+    assert expectations == {
+        "expected_response": "expected response for first question",
+        "expected_facts": ["fact1", "fact2"],
+        "my_custom_expectation": "custom expectation for the first question",
+    }
+    assert isinstance(trace, Trace)
+
+
+@pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)
 def test_predict_fn_receives_correct_data(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)
 
@@ -202,3 +331,10 @@ def test_predict_fn_receives_correct_data(data_fixture, request):
         expected_contents = ["What is Spark?", "How can you minimize data shuffling in Spark?"]
         # Using set because eval harness runs predict_fn in parallel
         assert set(received_args) == set(expected_contents[: len(sample_data)])
+
+    received_args.pop(0)  # Remove the one-time prediction to check if a model is traced
+    assert len(received_args) == len(sample_data)
+    received_contents = [arg["messages"][0]["content"] for arg in received_args]
+    expected_contents = ["What is Spark?", "How can you minimize data shuffling in Spark?"][: len(sample_data)]
+    # Using set because eval harness runs predict_fn in parallel
+    assert set(received_contents) == set(expected_contents)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15687?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15687/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15687/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15687/merge
```

</p>
</details>

### What changes are proposed in this pull request?

When traces are provided as a dataset to the `mlflow.genai.evaluate` API, it shouldn't require any additional columns.

To make this work, we need to extract a few fields from trace into dataframe columns, since the legacy agent evaluator requires them.
* `request` field should be derived from `trace.data.request`
* `expected_response`, `expected_facts`, `expected_retrieved_contxt` fields should be derived from an assessment in `trace.info.assessments` with the respective name.
* Other custom labels should also be derived from trace assessments and unwrapped to `custom_expected` column.

For example, let's say we have a trace like this (dummy code):
```
Trace(
   info={
       "trace_id": "tr-123",
       ...
       "assessments": [
           Asssessment(name="expected_response", expectation={"value": "MLflow is a software"}, ...),
           Asssessment(name="expected_facts", expectation={"value": ["fact1", "fact2"], ...),
           Asssessment(name="custom_label", expectation={"value": "some label"}, ...),
      ],
   },
   data={
        "spans": [Span(...)],
        "request": "What is MLflow?",
        "response": "MLflow is a tool",
   }
)
```

Then it should be unwrapped into the following format, as a legacy evaluation dataset.

| request | response | expected_response | expected_facts | custom_expected | trace |
|:--:|:--:|:--:|:--:|:--:|
| "What is MLflow?" | "MLflow is a tool" | "MLflow is a software" | ["fact1", "fact2"] | {"custom_label": "some label"} | Trace(...)|

They will be then converted back when passed to a scorer
```
@scorer
def my_scorer(inputs, outputs, expectations, trace):
    print(inputs) # "What is MLflow?"
    print(outputs) # "MLflow is a tool"
    print(expectations)  # {"expected_response": "MLflow is a software", "expected_facts": ["fact1", "fact2"], "custom_label": "some_label"}
```

Also adding more test coverages.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
