### PR TITLE
Update scorer docstring

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -1,10 +1,11 @@
 import functools
 import inspect
-from typing import Callable, Literal, Optional, Union
+from typing import Any, Callable, Literal, Optional, Union
 
 from pydantic import BaseModel
 
 from mlflow.entities import Assessment
+from mlflow.entities.trace import Trace
 
 
 class Scorer(BaseModel):
@@ -14,36 +15,105 @@ class Scorer(BaseModel):
     def __call__(
         self,
         *,
-        inputs=None,
-        outputs=None,
-        expectations=None,
-        trace=None,
+        inputs: Any = None,
+        outputs: Any = None,
+        expectations: Optional[dict[str, Any]] = None,
+        trace: Optional[Trace] = None,
         **kwargs,
     ) -> Union[int, float, bool, str, Assessment, list[Assessment]]:
         # TODO: make sure scorer's signature is simply equal to whatever keys are
         # in the eval dataset once we migrate from the agent eval harness
+        # Currently, the evaluation harness only passes the following reserved
+        # extra keyword arguments. This will be fully flexible once we migrate off
+        # the agent eval harness.
+        # - retrieved_context (optional): Retrieved context, can be from your
+        #   input eval dataset or from trace
+        # - custom_expected (optional): Custom expected results from input eval dataset
+        # - custom_inputs (optional): Custom inputs from your input eval dataset
+        # - custom_outputs (optional): Custom outputs from the agent's response
+        # - tool_calls (optional): Tool calls from the agent's response.
         """
+        Implement the custom scorer's logic here.
 
-        Args:
-            inputs (optional): A single input to the target model/app.
-            outputs (optional): A single output from the target model/app.
-            expectations (optional): Ground truth, or a dictionary of ground
-                truths for individual output fields.
-            trace (optional): Json representation of a trace object corresponding to
-                the prediction for the row. Required when any of scorers requires a
-                trace in order to compute assessments/scores.
-            **kwargs (optional): Additional keyword arguments passed to the scorer. The scorer
-                can take additional keyword arguments that are a part of the input eval dataset.
-                NB: Currently, the evaluation harness only passes the following reserved
-                    extra keyword arguments. This will be fully flexible once we migrate off
-                    the agent eval harness.
 
-                    - retrieved_context (optional): Retrieved context, can be from your
-                        input eval dataset or from trace
-                    - custom_expected (optional): Custom expected results from input eval dataset
-                    - custom_inputs (optional): Custom inputs from your input eval dataset
-                    - custom_outputs (optional): Custom outputs from the agent's response
-                    - tool_calls (optional): Tool calls from the agent's response.
+        The scorer will be called for each row in the input evaluation dataset.
+
+        You scorer doesn't need to have all the parameters defined in the base
+        signature. You can define a custom scorer with only the parameters you need.
+        See the parameter details below for what values are passed for each parameter.
+
+        .. list-table::
+            :widths: 20 20 20 20
+            :header-rows: 1
+
+            * - Parameter
+              - Description
+              - Source
+
+            * - `inputs`
+              - A single input to the target model/app.
+              - Derived from either dataset or trace.
+                - When the dataset contains `inputs` column, the value will be
+                    passed as is.
+                - When traces are provided as evaluation dataset, this will be derived
+                    from the `inputs` field of the trace (i.e. inputs captured as the
+                    root span of the trace).
+            * - `outputs`
+              - A single output from the target model/app.
+              - Derived from either dataset, trace, or output of `predict_fn`.
+                - When the dataset contains `outputs` column, the value will be
+                    passed as is.
+                - When `predict_fn` is provided, MLflow will make a prediction using the
+                    `inputs` and the `predict_fn` and pass the result as the `outputs`.
+                - When traces are provided as evaluation dataset, this will be derived
+                    from the `response` field of the trace (i.e. outputs captured as the
+                    root span of the trace).
+            * - `expectations`
+              - Ground truth or any expectation for each prediction e.g., expected retrieved docs.
+              - Derived from either dataset or trace.
+                - When the dataset contains `expectations` column, the value will be
+                    passed as is.
+                - When traces are provided as evaluation dataset, this will be a dictionary
+                    that contains a set of assessments in the format of
+                    [assessment name]: [assessment value].
+            * - `trace`
+              - A trace object corresponding to the prediction for the row.
+              - Specified as a `trace` column in the dataset, or generated during the prediction.
+            * - **kwargs
+              - Additional keyword arguments passed to the scorer.
+              - Must be specified as extra columns in the input dataset.
+
+        Example:
+
+            .. code-block:: python
+
+                class NotEmpty(BaseScorer):
+                    name = "not_empty"
+
+                    def __call__(self, *, outputs) -> bool:
+                        return outputs != ""
+
+
+                class ExactMatch(BaseScorer):
+                    name = "exact_match"
+
+                    def __call__(self, *, outputs, expectations) -> bool:
+                        return outputs == expectations["expected_response"]
+
+
+                class NumToolCalls(BaseScorer):
+                    name = "num_tool_calls"
+
+                    def __call__(self, *, trace) -> int:
+                        spans = trace.search_spans(name="tool_call")
+                        return len(spans)
+
+
+                # Use the scorer in an evaluation
+                mlflow.genai.evaluate(
+                    data=data,
+                    scorers=[NotEmpty(), ExactMatch(), NumToolCalls()],
+                )
         """
         raise NotImplementedError("Implementation of __call__ is required for Scorer class")
 
@@ -68,9 +138,79 @@ def scorer(
     ] = None,
 ):
     """
-    Syntactic sugar that ensures the decorated function has the correct parameters (with inputs
-    as required, outputs, expectations, trace as optional) and returns float | bool |
-    str | Assessment.
+    A decorator to define a custom scorer that can be used in `mlflow.genai.evaluate()`.
+
+    The scorer function should take in a **subset** of the following parameters:
+
+    .. list-table::
+        :widths: 20 20 20 20
+        :header-rows: 1
+
+        * - Parameter
+          - Description
+          - Source
+
+        * - `inputs`
+          - A single input to the target model/app.
+          - Derived from either dataset or trace.
+            - When the dataset contains `inputs` column, the value will be
+              passed as is.
+            - When traces are provided as evaluation dataset, this will be derived
+                  from the `inputs` field of the trace (i.e. inputs captured as the
+                  root span of the trace).
+        * - `outputs`
+          - A single output from the target model/app.
+          - Derived from either dataset, trace, or output of `predict_fn`.
+            - When the dataset contains `outputs` column, the value will be
+                passed as is.
+            - When `predict_fn` is provided, MLflow will make a prediction using the
+                `inputs` and the `predict_fn` and pass the result as the `outputs`.
+            - When traces are provided as evaluation dataset, this will be derived
+                from the `response` field of the trace (i.e. outputs captured as the
+                root span of the trace).
+        * - `expectations`
+          - Ground truth or any expectation for each prediction e.g., expected retrieved docs.
+          - Derived from either dataset or trace.
+            - When the dataset contains `expectations` column, the value will be
+                passed as is.
+            - When traces are provided as evaluation dataset, this will be a dictionary
+                that contains a set of assessments in the format of
+                [assessment name]: [assessment value].
+        * - `trace`
+          - A trace object corresponding to the prediction for the row.
+          - Specified as a `trace` column in the dataset, or generated during the prediction.
+        * - **kwargs
+          - Additional keyword arguments passed to the scorer.
+          - Must be specified as extra columns in the input dataset.
+
+    Example:
+
+        .. code-block:: python
+
+            from mlflow.genai.scorers import scorer
+
+
+            @scorer
+            def not_empty(outputs) -> bool:
+                return outputs != ""
+
+
+            @scorer
+            def exact_match(outputs, expectations) -> bool:
+                return outputs == expectations["expected_response"]
+
+
+            @scorer
+            def num_tool_calls(trace) -> int:
+                spans = trace.search_spans(name="tool_call")
+                return len(spans)
+
+
+            # Use the scorer in an evaluation
+            mlflow.genai.evaluate(
+                data=data,
+                scorers=[not_empty, exact_match, num_tool_calls],
+            )
     """
 
     if func is None:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -38,7 +38,7 @@ class Scorer(BaseModel):
 
         The scorer will be called for each row in the input evaluation dataset.
 
-        You scorer doesn't need to have all the parameters defined in the base
+        Your scorer doesn't need to have all the parameters defined in the base
         signature. You can define a custom scorer with only the parameters you need.
         See the parameter details below for what values are passed for each parameter.
 
@@ -64,12 +64,12 @@ class Scorer(BaseModel):
                 - When the dataset contains `outputs` column, the value will be
                     passed as is.
                 - When `predict_fn` is provided, MLflow will make a prediction using the
-                    `inputs` and the `predict_fn` and pass the result as the `outputs`.
+                    `inputs` and the `predict_fn`, and pass the result as the `outputs`.
                 - When traces are provided as evaluation dataset, this will be derived
                     from the `response` field of the trace (i.e. outputs captured as the
                     root span of the trace).
             * - `expectations`
-              - Ground truth or any expectation for each prediction e.g., expected retrieved docs.
+              - Ground truth or any expectation for each prediction, e.g. expected retrieved docs.
               - Derived from either dataset or trace.
                 - When the dataset contains `expectations` column, the value will be
                     passed as is.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15688?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15688/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15688/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15688/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Update docstring for the `@scorer` decorator and the base `Scorer` class to be more descriptive.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
