### PR TITLE
Validate required columns for built-in scorers for fail-fast

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -3,13 +3,13 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import mlflow
-from mlflow.exceptions import MlflowException
 from mlflow.genai.evaluation.utils import (
     _convert_scorer_to_legacy_metric,
     _convert_to_legacy_eval_set,
 )
-from mlflow.genai.scorers import BuiltInScorer, Scorer
+from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
+from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
 from mlflow.genai.utils.trace_utils import is_model_traced
 from mlflow.models.evaluation.base import (
     _get_model_from_deployment_endpoint_uri,
@@ -224,7 +224,7 @@ def evaluate(
         environments.
     """
     try:
-        from databricks.rag_eval.evaluation.metrics import Metric as DBAgentsMetric
+        import databricks.agents  # noqa: F401
     except ImportError:
         raise ImportError(
             "The `databricks-agents` package is required to use mlflow.genai.evaluate() "
@@ -237,32 +237,7 @@ def evaluate(
             "Please set the tracking URI to Databricks."
         )
 
-    if not scorers:
-        raise MlflowException.invalid_parameter_value(
-            "At least one scorer is required to evaluate a model."
-        )
-
-    builtin_scorers = []
-    custom_scorers = []
-
-    for scorer in scorers:
-        if isinstance(scorer, BuiltInScorer):
-            builtin_scorers.append(scorer)
-        elif isinstance(scorer, Scorer):
-            custom_scorers.append(scorer)
-        elif isinstance(scorer, DBAgentsMetric):
-            logger.warning(
-                f"{scorer} is a legacy metric and will soon be deprecated in future releases. "
-                "Please use the @scorer decorator or use builtin scorers instead."
-            )
-            custom_scorers.append(scorer)
-        else:
-            raise TypeError(
-                (
-                    f"Scorer {scorer} is not a valid scorer. Please use the @scorer decorator ",
-                    "to convert a function into a scorer or inherit from the Scorer class",
-                )
-            )
+    builtin_scorers, custom_scorers = validate_scorers(scorers)
 
     evaluation_config = {
         GENAI_CONFIG_NAME: {
@@ -278,6 +253,8 @@ def evaluate(
 
     # convert into a pandas dataframe with current evaluation set schema
     data = _convert_to_legacy_eval_set(data)
+
+    valid_data_for_builtin_scorers(data, builtin_scorers, predict_fn)
 
     if predict_fn:
         sample_input = data.iloc[0]["request"]

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -599,9 +599,6 @@ def rag_scorers() -> list[BuiltInScorer]:
 
 
 class MissingColumnsException(MlflowException):
-    scorer: str
-    missing_columns: list[str]
-
     def __init__(self, scorer: str, missing_columns: set[str]):
         self.scorer = scorer
         self.missing_columns = list(missing_columns)

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 from typing import Any
 
 from mlflow.entities import Assessment
+from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import BuiltInScorer
 
 GENAI_CONFIG_NAME = "databricks-agent"
@@ -12,6 +13,8 @@ class _BaseBuiltInScorer(BuiltInScorer):
     Base class for built-in scorers that share a common implementation. All built-in scorers should
     inherit from this class.
     """
+
+    required_columns: set[str] = {}
 
     def __call__(self, **kwargs):
         try:
@@ -44,16 +47,29 @@ class _BaseBuiltInScorer(BuiltInScorer):
             metrics.append(self.name)
         return config
 
+    def validate_columns(self, columns: set[str]) -> None:
+        missing_columns = self.required_columns - columns
+        if missing_columns:
+            raise MissingColumnsException(self.name, missing_columns)
+
+
+def _builtin_scorer(f):
+    """A decorator to mark a built-in scorer function for labeling purposes."""
+    f.__is_mlflow_builtin_scorer = True
+    return f
+
 
 # === Builtin Scorers ===
 class _ChunkRelevance(_BaseBuiltInScorer):
     name: str = "chunk_relevance"
+    required_columns: set[str] = {"inputs", "retrieved_context"}
 
     def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> list[Assessment]:
         """Evaluate chunk relevance for each context chunk."""
         return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
 
 
+@_builtin_scorer
 def chunk_relevance():
     """
     Chunk relevance measures whether each chunk is relevant to the input request.
@@ -100,12 +116,14 @@ def chunk_relevance():
 
 class _ContextSufficiency(_BaseBuiltInScorer):
     name: str = "context_sufficiency"
+    required_columns: set[str] = {"inputs", "retrieved_context", "expected_response"}
 
     def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> Assessment:
         """Evaluate context sufficiency based on retrieved documents."""
         return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
 
 
+@_builtin_scorer
 def context_sufficiency():
     """
     Context sufficiency evaluates whether the retrieved documents provide all necessary
@@ -147,6 +165,7 @@ def context_sufficiency():
 
 class _Groundedness(_BaseBuiltInScorer):
     name: str = "groundedness"
+    required_columns: set[str] = {"inputs", "outputs", "retrieved_context"}
 
     def __call__(
         self, *, inputs: Any, outputs: Any, retrieved_context: list[dict[str, Any]]
@@ -155,6 +174,7 @@ class _Groundedness(_BaseBuiltInScorer):
         return super().__call__(inputs=inputs, outputs=outputs, retrieved_context=retrieved_context)
 
 
+@_builtin_scorer
 def groundedness():
     """
     Groundedness assesses whether the agent's response is aligned with the information provided
@@ -198,6 +218,7 @@ def groundedness():
 
 class _GuidelineAdherence(_BaseBuiltInScorer):
     name: str = "guideline_adherence"
+    required_columns: set[str] = {"inputs", "outputs", "guidelines"}
 
     def __call__(
         self,
@@ -216,6 +237,7 @@ class _GuidelineAdherence(_BaseBuiltInScorer):
         )
 
 
+@_builtin_scorer
 def guideline_adherence():
     """
     Guideline adherence evaluates whether the agent's response follows specific constraints
@@ -277,6 +299,7 @@ def guideline_adherence():
 
 class _GlobalGuidelineAdherence(_GuidelineAdherence):
     guidelines: list[str]
+    required_columns: set[str] = {"inputs", "outputs"}
 
     def update_evaluation_config(self, evaluation_config) -> dict:
         config = deepcopy(evaluation_config)
@@ -298,6 +321,7 @@ class _GlobalGuidelineAdherence(_GuidelineAdherence):
         return super().__call__(inputs=inputs, outputs=outputs)
 
 
+@_builtin_scorer
 def global_guideline_adherence(
     guidelines: list[str],
     name: str = "guideline_adherence",
@@ -369,12 +393,14 @@ def global_guideline_adherence(
 
 class _RelevanceToQuery(_BaseBuiltInScorer):
     name: str = "relevance_to_query"
+    required_columns: set[str] = {"inputs", "outputs"}
 
     def __call__(self, *, inputs: Any, outputs: Any) -> Assessment:
         """Evaluate relevance to the user's query."""
         return super().__call__(inputs=inputs, outputs=outputs)
 
 
+@_builtin_scorer
 def relevance_to_query():
     """
     Relevance ensures that the agent's response directly addresses the user's input without
@@ -417,12 +443,14 @@ def relevance_to_query():
 
 class _Safety(_BaseBuiltInScorer):
     name: str = "safety"
+    required_columns: set[str] = {"inputs", "outputs"}
 
     def __call__(self, *, inputs: Any, outputs: Any) -> Assessment:
         """Evaluate safety of the response."""
         return super().__call__(inputs=inputs, outputs=outputs)
 
 
+@_builtin_scorer
 def safety():
     """
     Safety ensures that the agent's responses do not contain harmful, offensive, or toxic content.
@@ -464,12 +492,19 @@ def safety():
 
 class _Correctness(_BaseBuiltInScorer):
     name: str = "correctness"
+    required_columns: set[str] = {"inputs", "outputs"}
+
+    def validate_columns(self, columns: set[str]) -> None:
+        super().validate_columns(columns)
+        if "expected_response" not in columns and "expected_facts" not in columns:
+            raise MissingColumnsException(self.name, ["expected_response or expected_facts"])
 
     def __call__(self, *, inputs: Any, outputs: Any, expectations: list[str]) -> Assessment:
         """Evaluate correctness of the response against expectations."""
         return super().__call__(inputs=inputs, outputs=outputs, expectations=expectations)
 
 
+@_builtin_scorer
 def correctness():
     """
     Correctness ensures that the agent's responses are correct and accurate.
@@ -530,6 +565,7 @@ def correctness():
 
 
 # === Shorthand for all builtin RAG scorers ===
+@_builtin_scorer
 def rag_scorers() -> list[BuiltInScorer]:
     """
     Returns a list of built-in scorers for evaluating RAG models. Contains scorers
@@ -560,3 +596,15 @@ def rag_scorers() -> list[BuiltInScorer]:
         groundedness(),
         relevance_to_query(),
     ]
+
+
+class MissingColumnsException(MlflowException):
+    scorer: str
+    missing_columns: list[str]
+
+    def __init__(self, scorer: str, missing_columns: set[str]):
+        self.scorer = scorer
+        self.missing_columns = list(missing_columns)
+        super().__init__(
+            f"The following columns are required for the scorer {scorer}: {missing_columns}"
+        )

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -1,0 +1,138 @@
+import logging
+from collections import defaultdict
+from typing import Any, Callable, Optional
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers.base import BuiltInScorer, Scorer
+from mlflow.genai.scorers.builtin_scorers import MissingColumnsException
+
+try:
+    # `pandas` is not required for `mlflow-skinny`.
+    import pandas as pd
+except ImportError:
+    pass
+
+_logger = logging.getLogger(__name__)
+
+
+def validate_scorers(scorers: list[Any]) -> tuple[list[BuiltInScorer], list[Scorer]]:
+    """
+    Validate a list of specified scorers and split them into
+    a tuple of builtin scorers and custom scorers.
+
+    Args:
+        scorers: A list of scorers to validate.
+
+    Returns:
+        A tuple of builtin scorers and custom scorers.
+    """
+    from databricks.rag_eval.evaluation.metrics import Metric
+
+    if not isinstance(scorers, list):
+        raise MlflowException.invalid_parameter_value(
+            "The scorers argument must be a list of scorers."
+        )
+
+    if not scorers:
+        raise MlflowException.invalid_parameter_value(
+            "At least one scorer is required to evaluate a model."
+        )
+
+    builtin_scorers = []
+    custom_scorers = []
+    legacy_metrics = []
+
+    for scorer in scorers:
+        if isinstance(scorer, BuiltInScorer):
+            builtin_scorers.append(scorer)
+        elif isinstance(scorer, Scorer):
+            custom_scorers.append(scorer)
+        elif isinstance(scorer, Metric):
+            legacy_metrics.append(scorer)
+            custom_scorers.append(scorer)
+        elif isinstance(scorer, Callable) and getattr(scorer, "__is_mlflow_builtin_scorer", False):
+            raise MlflowException.invalid_parameter_value(
+                f"A built-in scorer {scorer.__name__} is specified, but the constructor function "
+                "is specified, not the scorer object itself. Please pass the returned scorer "
+                "object from the constructor function instead.\n"
+                "Example:\n"
+                "  - Correct:   `mlflow.genai.evaluate(scorers=[correctness()])`\n"
+                "  - Incorrect: `mlflow.genai.evaluate(scorers=[correctness])`"
+            )
+        else:
+            raise MlflowException.invalid_parameter_value(
+                f"Scorer {scorer} is not a valid scorer. Please use the @scorer decorator "
+                "to convert a function into a scorer or inherit from the Scorer class"
+            )
+
+    if legacy_metrics:
+        legacy_metric_names = [metric.name for metric in legacy_metrics]
+        _logger.warning(
+            f"Scorers {legacy_metric_names} are legacy metrics and will soon be deprecated "
+            "in future releases. Please use the builtin scorers defined in `mlflow.genai.scorers` "
+            "or custom scorers defined with the @scorer decorator instead."
+        )
+
+    return builtin_scorers, custom_scorers
+
+
+def valid_data_for_builtin_scorers(
+    data: "pd.DataFrame",
+    builtin_scorers: list[BuiltInScorer],
+    predict_fn: Optional[Callable] = None,
+) -> None:
+    """
+    Validate that the required columns are present in the data for running the builtin scorers.
+
+    Args:
+        data: The data to validate. This must be a pandas DataFrame converted to
+            the legacy evaluation set schema via `_convert_to_legacy_eval_set`.
+        builtin_scorers: The list of builtin scorers to validate the data for.
+        predict_fn: The predict function to validate the data for.
+    """
+    input_columns = set(data.columns.tolist())
+
+    # Revert the replacement of "inputs"->"request" and "outputs"->"response"
+    # in the upstream processing.
+    if "request" in input_columns:
+        input_columns.remove("request")
+        input_columns.add("inputs")
+    if "response" in input_columns:
+        input_columns.remove("response")
+        input_columns.add("outputs")
+
+    if predict_fn is not None:
+        # If the predict function is provided, the data doesn't need to
+        # contain the "outputs" column.
+        input_columns.add("outputs")
+
+    if "trace" in input_columns:
+        # Inputs and outputs are inferred from the trace.
+        input_columns |= {"inputs", "outputs"}
+
+    if predict_fn is not None or "trace" in input_columns:
+        # NB: The retrieved_context is only inferred when a trace contains a retriever span,
+        #     however, it is not impractical to check all traces and see if any of them
+        #     contains a retriever span (it is valid case that some trace misses a retriever
+        #     span). Therefore, we don't rigorously check the retrieved_context presence for
+        #     traces and let scorers handle the missing retrieved_context gracefully.
+        input_columns |= {"retrieved_context"}
+
+    # Missing column -> list of scorers that require the column.
+    missing_col_to_scorers = defaultdict(list)
+    for scorer in builtin_scorers:
+        try:
+            scorer.validate_columns(input_columns)
+        except MissingColumnsException as e:
+            for col in e.missing_columns:
+                missing_col_to_scorers[col].append(scorer.name)
+
+    if missing_col_to_scorers:
+        msg = (
+            "The input data is missing following columns that are required "
+            "by the specified scorers. Please make sure the data contains "
+            "all the required columns for computing scores."
+        )
+        for col, scorers in missing_col_to_scorers.items():
+            msg += f"\n - `{col}` is required by [{', '.join(scorers)}]."
+        raise MlflowException.invalid_parameter_value(msg)

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -1,0 +1,203 @@
+from unittest import mock
+
+import pandas as pd
+import pytest
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
+from mlflow.genai.scorers.base import BuiltInScorer, Scorer, scorer
+from mlflow.genai.scorers.builtin_scorers import (
+    chunk_relevance,
+    context_sufficiency,
+    correctness,
+    global_guideline_adherence,
+    groundedness,
+)
+from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
+
+
+def test_validate_scorers_valid():
+    @scorer
+    def custom_scorer(inputs, outputs):
+        return 1.0
+
+    builtin, custom = validate_scorers(
+        [
+            chunk_relevance(),
+            correctness(),
+            global_guideline_adherence(["Be polite", "Be kind"]),
+            custom_scorer,
+        ]
+    )
+
+    assert len(builtin) == 3
+    assert all(isinstance(scorer, BuiltInScorer) for scorer in builtin)
+    assert len(custom) == 1
+    assert isinstance(custom[0], Scorer)
+
+
+def test_validate_scorers_legacy_metric():
+    from databricks.agents.evals import metric
+
+    @metric
+    def legacy_metric_1(request, response):
+        return 1.0
+
+    @metric
+    def legacy_metric_2(request, response):
+        return 1.0
+
+    with mock.patch("mlflow.genai.scorers.validation._logger") as mock_logger:
+        builtin, custom = validate_scorers([legacy_metric_1, legacy_metric_2])
+
+    assert len(builtin) == 0
+    assert len(custom) == 2
+    mock_logger.warning.assert_called_once()
+    assert "legacy_metric_1" in mock_logger.warning.call_args[0][0]
+
+
+def test_validate_scorers_builtin_scorer_passed_as_function():
+    with pytest.raises(MlflowException, match=r"A built-in scorer chunk_relevance"):
+        validate_scorers([chunk_relevance])
+
+
+def test_validate_data():
+    data = pd.DataFrame(
+        {
+            "inputs": [{"question": "input1"}, {"question": "input2"}],
+            "outputs": ["output1", "output2"],
+            "retrieved_context": [{"context": "context1"}, {"context": "context2"}],
+        }
+    )
+
+    converted_date = _convert_to_legacy_eval_set(data)
+    valid_data_for_builtin_scorers(
+        data=converted_date,
+        builtin_scorers=[
+            chunk_relevance(),
+            groundedness(),
+            global_guideline_adherence(["Be polite", "Be kind"]),
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "expectations",
+    [
+        {
+            "expectations": [
+                {"expected_response": "response1"},
+                {"expected_response": "response2"},
+            ],
+        },
+    ],
+)
+def test_validate_data_with_expectations(expectations):
+    """Test that expectations are unwrapped and validated properly"""
+    data = pd.DataFrame(
+        {
+            "inputs": [{"question": "input1"}, {"question": "input2"}],
+            "outputs": ["output1", "output2"],
+            "retrieved_context": ["context1", "context2"],
+            **expectations,
+        }
+    )
+
+    converted_date = _convert_to_legacy_eval_set(data)
+    valid_data_for_builtin_scorers(
+        data=converted_date,
+        builtin_scorers=[
+            chunk_relevance(),
+            context_sufficiency(),  # requires expected_response
+        ],
+    )
+
+
+@pytest.mark.parametrize(
+    "expectations",
+    [
+        {"expected_facts": [["fact1", "fact2"], ["fact3"]]},
+        {"expected_response": ["expectation1", "expectation2"]},
+    ],
+)
+def test_validate_data_with_correctness(expectations):
+    """Correctness scorer requires one of expected_facts or expected_response"""
+    data = pd.DataFrame(
+        {
+            "inputs": [{"question": "input1"}, {"question": "input2"}],
+            "outputs": ["output1", "output2"],
+            **expectations,
+        }
+    )
+
+    converted_date = _convert_to_legacy_eval_set(data)
+    valid_data_for_builtin_scorers(
+        data=converted_date,
+        builtin_scorers=[correctness()],
+    )
+
+    with pytest.raises(MlflowException, match=r"The input data is missing following") as e:
+        valid_data_for_builtin_scorers(
+            data=pd.DataFrame({"inputs": ["input1"], "outputs": ["output1"]}),
+            builtin_scorers=[correctness()],
+        )
+
+    assert "expected_response or expected_facts" in str(e.value)
+
+
+def test_validate_data_missing_columns():
+    data = pd.DataFrame({"inputs": [{"question": "input1"}, {"question": "input2"}]})
+
+    converted_date = _convert_to_legacy_eval_set(data)
+
+    with pytest.raises(MlflowException, match=r"The input data is missing") as e:
+        valid_data_for_builtin_scorers(
+            data=converted_date,
+            builtin_scorers=[
+                chunk_relevance(),
+                groundedness(),
+                global_guideline_adherence(["Be polite", "Be kind"]),
+            ],
+        )
+
+    assert " - `outputs` is required by [groundedness, guideline_adherence]." in str(e.value)
+    assert " - `retrieved_context` is required by [chunk_relevance, groundedness]." in str(e.value)
+
+
+def test_validate_data_with_trace():
+    # When a trace is provided, the inputs, outputs, and retrieved_context are
+    # inferred from the trace.
+    with mlflow.start_span() as span:
+        span.set_inputs({"question": "What is the capital of France?"})
+        span.set_outputs("Paris")
+
+    trace = mlflow.get_trace(span.trace_id)
+    data = [{"trace": trace}, {"trace": trace}]
+
+    converted_date = _convert_to_legacy_eval_set(data)
+    valid_data_for_builtin_scorers(
+        data=converted_date,
+        builtin_scorers=[
+            chunk_relevance(),
+            groundedness(),
+            global_guideline_adherence(["Be polite", "Be kind"]),
+        ],
+    )
+
+
+def test_validate_data_with_predict_fn():
+    data = pd.DataFrame({"inputs": [{"question": "input1"}, {"question": "input2"}]})
+
+    converted_date = _convert_to_legacy_eval_set(data)
+
+    valid_data_for_builtin_scorers(
+        data=converted_date,
+        predict_fn=lambda x: x,
+        builtin_scorers=[
+            # Requires "outputs" but predict_fn will provide it
+            global_guideline_adherence(["Be polite", "Be kind"]),
+            # Requires "retrieved_context" but predict_fn will provide it
+            chunk_relevance(),
+        ],
+    )

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -13,7 +13,9 @@ import pytest
 from opentelemetry.sdk.trace import Event, ReadableSpan
 
 import mlflow
-from mlflow.entities import Trace, TraceData, TraceInfoV2
+from mlflow.entities import Trace, TraceData, TraceInfo, TraceInfoV2
+from mlflow.entities.trace_location import TraceLocation
+from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.ml_package_versions import FLAVOR_TO_MODULE_NAME
 from mlflow.tracing.client import TracingClient
@@ -125,6 +127,28 @@ def create_test_trace_info(
         status=status,
         request_metadata=request_metadata or {},
         tags=tags or {},
+    )
+
+
+def create_test_trace_info_v3(
+    trace_id,
+    experiment_id="test",
+    request_time=0,
+    execution_duration=1,
+    state=TraceState.OK,
+    trace_metadata=None,
+    tags=None,
+    assessments=None,
+):
+    return TraceInfo(
+        trace_id=trace_id,
+        trace_location=TraceLocation.from_experiment_id(experiment_id),
+        request_time=request_time,
+        execution_duration=execution_duration,
+        state=state,
+        trace_metadata=trace_metadata,
+        tags=tags,
+        assessments=assessments,
     )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15690?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15690/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15690/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15690/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Each built-in scorers require different set of columns ([ref](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/llm-judge-reference)).

In the legacy evaluator, even if the required columns are missing, it will run the entire job (without any exception) and logs the final result without the judges that requires missing columns. This is not great dev-loop. Therefore, this PR adds a validation mechanism to validate required columns before running the actual evaluation.


```
mlflow.genai.evaluate(
    data=[{
        "inputs": {"question": "What is MLflow?"},
        "outputs": "MLflow is a software"
    }],
    scorers=[
        correctness(),  # <- requires 'outputs', 'expected_response'
        groundedness(), # <- requires 'inputs', 'outputs', 'retrieved_context'
    ]
```

This should show an error message like

> The input data is missing following columns that are required by the specified scorers. Please make sure the data contains all the required columns for computing scores.
> - `expected_response or expected_facts` is required by [correctness].
> - `retrieved_context` is required by [groundedness].

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
