### PR TITLE
Make sure no scorers are run by default

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -132,7 +132,11 @@ def evaluate(
                 )
             )
 
-    evaluation_config = {}
+    evaluation_config = {
+        GENAI_CONFIG_NAME: {
+            "metrics": [],
+        }
+    }
     for _scorer in builtin_scorers:
         evaluation_config = _scorer.update_evaluation_config(evaluation_config)
 

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -10,6 +10,7 @@ from mlflow.genai import scorer
 from mlflow.genai.evaluation.utils import (
     _convert_to_legacy_eval_set,
 )
+from mlflow.genai.scorers.builtin_scorers import groundedness
 
 if importlib.util.find_spec("databricks.agents") is None:
     pytest.skip(reason="databricks-agents is not installed", allow_module_level=True)
@@ -111,14 +112,9 @@ def test_convert_to_legacy_eval_set_has_no_errors(data_fixture, request):
     with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
         transformed_data = _convert_to_legacy_eval_set(sample_data)
 
-        assert "request" in transformed_data.columns
-        assert "response" in transformed_data.columns
-        assert "expected_response" in transformed_data.columns
-
-        mlflow.evaluate(
-            data=transformed_data,
-            model_type="databricks-agent",
-        )
+    assert "request" in transformed_data.columns
+    assert "response" in transformed_data.columns
+    assert "expected_response" in transformed_data.columns
 
 
 @pytest.mark.parametrize(
@@ -179,12 +175,14 @@ def test_input_is_required_if_trace_is_not_provided():
         with pytest.raises(MlflowException, match="inputs.*required"):
             mlflow.genai.evaluate(
                 data=pd.DataFrame({"outputs": ["Paris"]}),
+                scorers=[groundedness()],
             )
 
         mock_evaluate.assert_not_called()
 
         mlflow.genai.evaluate(
             data=pd.DataFrame({"inputs": ["What is the capital of France?"], "outputs": ["Paris"]}),
+            scorers=[groundedness()],
         )
         mock_evaluate.assert_called_once()
 
@@ -193,6 +191,7 @@ def test_input_is_optional_if_trace_is_provided():
     with patch("mlflow.evaluate") as mock_evaluate:
         mlflow.genai.evaluate(
             data=pd.DataFrame({"outputs": ["Paris"], "trace": [MagicMock()]}),
+            scorers=[groundedness()],
         )
 
         mock_evaluate.assert_called_once()
@@ -215,6 +214,7 @@ def test_predict_fn_receives_correct_data(data_fixture, request):
         mlflow.genai.evaluate(
             predict_fn=predict_fn,
             data=sample_data,
+            scorers=[groundedness()],
         )
         received_args.pop(0)  # Remove the one-time prediction to check if a model is traced
         assert len(received_args) == len(sample_data)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We default to running no scorers instead of running harmfulness and relevance scorers by default.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
