### PR TITLE
log_feedback(): Use Source

### DIFF
--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -210,7 +210,8 @@ def log_feedback(
         trace_id: The ID of the trace.
         name: The name of the feedback assessment e.g., "faithfulness"
         source: The source of the feedback assessment. Must be an instance of
-                :py:class:`~mlflow.entities.AssessmentSource`. If not provided, defaults to CODE source type.
+                :py:class:`~mlflow.entities.AssessmentSource`. If not provided, defaults to
+                CODE source type.
         value: The value of the feedback. Must be one of the following types:
             - float
             - int
@@ -279,7 +280,7 @@ def log_feedback(
             source_type=Type.LLM_JUDGE,
             source_id="faithfulness-judge",
         )
-        
+
         error = AssessmentError(
             error_code="RATE_LIMIT_EXCEEDED",
             error_message="Rate limit for the judge exceeded.",

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -210,8 +210,8 @@ def log_feedback(
         trace_id: The ID of the trace.
         name: The name of the feedback assessment e.g., "faithfulness"
         source: The source of the feedback assessment. Must be either an instance of
-                :py:class:`~mlflow.entities.AssessmentSource` or a string that is a valid value in the
-                AssessmentSourceType enum. If not provided, defaults to CODE source type.
+                :py:class:`~mlflow.entities.AssessmentSource` or a string that is a valid value
+                in the AssessmentSourceType enum. If not provided, defaults to CODE source type.
         value: The value of the feedback. Must be one of the following types:
             - float
             - int

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -275,6 +275,11 @@ def log_feedback(
         import mlflow
         from mlflow.entities.assessment import AssessmentError
 
+        source = AssessmentSource(
+            source_type=Type.LLM_JUDGE,
+            source_id="faithfulness-judge",
+        )
+        
         error = AssessmentError(
             error_code="RATE_LIMIT_EXCEEDED",
             error_message="Rate limit for the judge exceeded.",

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -209,9 +209,8 @@ def log_feedback(
     Args:
         trace_id: The ID of the trace.
         name: The name of the feedback assessment e.g., "faithfulness"
-        source: The source of the feedback assessment. Must be either an instance of
-                :py:class:`~mlflow.entities.AssessmentSource` or a string that is a valid value
-                in the AssessmentSourceType enum. If not provided, defaults to CODE source type.
+        source: The source of the feedback assessment. Must be an instance of
+                :py:class:`~mlflow.entities.AssessmentSource`. If not provided, defaults to CODE source type.
         value: The value of the feedback. Must be one of the following types:
             - float
             - int
@@ -285,6 +284,7 @@ def log_feedback(
             trace_id="1234",
             name="faithfulness",
             error=error,
+            source=source,
         )
 
     """
@@ -295,7 +295,7 @@ def log_feedback(
     if source is None:
         source = AssessmentSource(
             source_type=AssessmentSourceType.CODE,
-            source_id="log_feedback_default",
+            source_id="default",
         )
     elif not isinstance(source, AssessmentSource):
         raise MlflowException.invalid_parameter_value(

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -75,7 +75,6 @@ def test_log_expectation_invalid_parameters(tracking_uri):
         )
 
 
-
 def test_update_expectation(store, tracking_uri):
     mlflow.update_expectation(
         assessment_id="1234",

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -74,13 +74,6 @@ def test_log_expectation_invalid_parameters(tracking_uri):
             source=_HUMAN_ASSESSMENT_SOURCE,
         )
 
-    with pytest.raises(MlflowException, match=r"`source` must be an instance of"):
-        mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            value=1.0,
-            source=None,
-        )
 
 
 def test_update_expectation(store, tracking_uri):
@@ -187,12 +180,13 @@ def test_log_feedback_invalid_parameters(tracking_uri):
             source=_LLM_ASSESSMENT_SOURCE,
         )
 
+    # Test with a non-AssessmentSource object that is not None
     with pytest.raises(MlflowException, match=r"`source` must be an instance of"):
         mlflow.log_feedback(
             trace_id="1234",
             name="faithfulness",
             value=1.0,
-            source=None,
+            source="invalid_source_type",
         )
 
 
@@ -305,3 +299,20 @@ def test_search_traces_with_assessments(store, tracking_uri):
 
     # We no longer expect get_trace_info to be called
     assert store.get_trace_info.call_count == 0
+
+
+def test_log_feedback_default_source(store, tracking_uri):
+    # Test that the default CODE source is used when no source is provided
+    mlflow.log_feedback(
+        trace_id="1234",
+        name="faithfulness",
+        value=1.0,
+    )
+
+    assert store.create_assessment.call_count == 1
+    assessment = store.create_assessment.call_args[0][0]
+    assert assessment.name == "faithfulness"
+    assert assessment.trace_id == "1234"
+    assert assessment.source.source_type == AssessmentSourceType.CODE
+    assert assessment.source.source_id == "log_feedback_default"
+    assert assessment.feedback.value == 1.0

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -313,5 +313,5 @@ def test_log_feedback_default_source(store, tracking_uri):
     assert assessment.name == "faithfulness"
     assert assessment.trace_id == "1234"
     assert assessment.source.source_type == AssessmentSourceType.CODE
-    assert assessment.source.source_id == "log_feedback_default"
+    assert assessment.source.source_id == "default"
     assert assessment.feedback.value == 1.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/15697?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15697/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15697/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15697/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This pull request makes the source parameter optional in the mlflow.log_feedback function by providing a default CODE source type when none is specified. This change improves the user experience by eliminating the need to reason about the source parameter in simple use cases, while maintaining full functionality when source specification is desired. The implementation includes proper test coverage to ensure the new default behavior works correctly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
There is now a default value (CODE) for log_feedback(), if no source type is specified. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
