### PR TITLE
Split models test into 4 groups

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -245,9 +245,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        group: [1, 2]
+        group: [1, 2, 3, 4]
         include:
-          - splits: 2
+          - splits: 4
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/untracked
@@ -263,7 +263,7 @@ jobs:
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/models
+          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --durations=30 tests/models
 
   # NOTE: numpy is pinned in this suite due to its heavy reliance on shap, which internally uses
   # references to the now fully deprecated (as of 1.24.x) numpy types (i.e., np.bool).

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -26,7 +26,11 @@ from tests.tracing.helper import get_traces
 def remove_pip_index_env(monkeypatch):
     # Remove PIP_EXTRA_INDEX_URL env var to avoid UV searching
     # for other packages from this index
-    monkeypatch.delenv("PIP_EXTRA_INDEX_URL", raising=False)
+    env_var = os.environ.get("PIP_EXTRA_INDEX_URL")
+    if env_var:
+        urls = env_var.split(" ")
+        urls = list(set(urls) - {"https://download.pytorch.org/whl/cpu"})
+        monkeypatch.setenv("PIP_EXTRA_INDEX_URL", " ".join(urls))
 
 
 @pytest.mark.parametrize(

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -22,6 +22,13 @@ from mlflow.utils.env_manager import CONDA, LOCAL, UV, VIRTUALENV
 from tests.tracing.helper import get_traces
 
 
+@pytest.fixture(autouse=True)
+def remove_pip_index_env(monkeypatch):
+    # Remove PIP_EXTRA_INDEX_URL env var to avoid UV searching
+    # for other packages from this index
+    monkeypatch.delenv("PIP_EXTRA_INDEX_URL", raising=False)
+
+
 @pytest.mark.parametrize(
     ("input_data", "expected_data", "content_type"),
     [

--- a/tests/models/test_python_api.py
+++ b/tests/models/test_python_api.py
@@ -30,7 +30,11 @@ def remove_pip_index_env(monkeypatch):
     if env_var:
         urls = env_var.split(" ")
         urls = list(set(urls) - {"https://download.pytorch.org/whl/cpu"})
-        monkeypatch.setenv("PIP_EXTRA_INDEX_URL", " ".join(urls))
+        try:
+            os.environ["PIP_EXTRA_INDEX_URL"] = " ".join(urls)
+            yield
+        finally:
+            os.environ["PIP_EXTRA_INDEX_URL"] = env_var
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15709?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15709/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15709/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15709/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
`models` test takes longer than 30 minutes, splitting it into 4 groups in this PR and add duration limit.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
