### PR TITLE
Print a links to logged models and UC registered model versions when they are created

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -783,3 +783,10 @@ _MLFLOW_CREATE_LOGGED_MODEL_PARAMS_BATCH_SIZE = _EnvironmentVariable(
 _MLFLOW_LOG_LOGGED_MODEL_PARAMS_BATCH_SIZE = _EnvironmentVariable(
     "_MLFLOW_LOG_LOGGED_MODEL_PARAMS_BATCH_SIZE", int, 100
 )
+
+#: A boolean flag that enables printing URLs for logged and registered models when
+#: they are created.
+#: (default: ``True``)
+MLFLOW_PRINT_MODEL_URLS_ON_CREATION = _BooleanEnvironmentVariable(
+    "MLFLOW_PRINT_MODEL_URLS_ON_CREATION", True
+)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -35,7 +35,10 @@ from mlflow.tracking.fluent import (
 )
 from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
+    _construct_databricks_logged_model_url,
     get_databricks_runtime_version,
+    get_workspace_id,
+    get_workspace_url,
     is_in_databricks_runtime,
 )
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
@@ -943,6 +946,10 @@ class Model:
                     if tags is not None
                     else None,
                 )
+                logged_model_url = _construct_databricks_logged_model_url(
+                    get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
+                )
+                _logger.info(f"🔗 Logged model created at: {logged_model_url}")
 
             with _use_logged_model(model=model):
                 if run_id is not None:
@@ -968,9 +975,6 @@ class Model:
                     model_id=model.model_id,
                 )
                 flavor.save_model(path=local_path, mlflow_model=mlflow_model, **kwargs)
-
-                ### Print a link to the model here
-
                 # `save_model` calls `load_model` to infer the model requirements, which may result
                 # in __pycache__ directories being created in the model directory.
                 for pycache in Path(local_path).rglob("__pycache__"):

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -52,6 +52,7 @@ from mlflow.utils.environment import (
     _write_requirements_to_file,
 )
 from mlflow.utils.file_utils import TempDir
+from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import MLFLOW_MODEL_IS_EXTERNAL
 from mlflow.utils.uri import (
     append_to_uri_path,
@@ -949,7 +950,7 @@ class Model:
                 logged_model_url = _construct_databricks_logged_model_url(
                     get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
                 )
-                _logger.info(f"🔗 Logged model created at: {logged_model_url}")
+                eprint(f"🔗 Logged model created at: {logged_model_url}")
 
             with _use_logged_model(model=model):
                 if run_id is not None:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -947,10 +947,11 @@ class Model:
                     if tags is not None
                     else None,
                 )
-                logged_model_url = _construct_databricks_logged_model_url(
-                    get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
-                )
-                eprint(f"🔗 Logged model created at: {logged_model_url}")
+                if is_in_databricks_runtime():
+                    logged_model_url = _construct_databricks_logged_model_url(
+                        get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
+                    )
+                    eprint(f"🔗 Logged model created at: {logged_model_url}")
 
             with _use_logged_model(model=model):
                 if run_id is not None:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -15,7 +15,10 @@ from packaging.requirements import InvalidRequirement, Requirement
 import mlflow
 from mlflow.entities import LoggedModel, LoggedModelOutput, Metric
 from mlflow.entities.model_registry.prompt import Prompt
-from mlflow.environment_variables import MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING
+from mlflow.environment_variables import (
+    MLFLOW_PRINT_MODEL_URLS_ON_CREATION,
+    MLFLOW_RECORD_ENV_VARS_IN_MODEL_LOGGING,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.models.auth_policy import AuthPolicy
 from mlflow.models.resources import Resource, ResourceType, _ResourceBuilder
@@ -948,7 +951,7 @@ class Model:
                     if tags is not None
                     else None,
                 )
-                if is_databricks_uri(tracking_uri):
+                if MLFLOW_PRINT_MODEL_URLS_ON_CREATION.get() and is_databricks_uri(tracking_uri):
                     logged_model_url = _construct_databricks_logged_model_url(
                         get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
                     )

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -57,6 +57,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_MODEL_IS_EXTERNAL
 from mlflow.utils.uri import (
     append_to_uri_path,
     get_uri_scheme,
+    is_databricks_uri,
 )
 
 _logger = logging.getLogger(__name__)
@@ -947,11 +948,11 @@ class Model:
                     if tags is not None
                     else None,
                 )
-                if is_in_databricks_runtime():
+                if is_databricks_uri(tracking_uri):
                     logged_model_url = _construct_databricks_logged_model_url(
                         get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
                     )
-                    eprint(f"🔗 Logged model created at: {logged_model_url}")
+                    eprint(f"🔗 Created Logged Model at: {logged_model_url}")
 
             with _use_logged_model(model=model):
                 if run_id is not None:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -952,7 +952,7 @@ class Model:
                     logged_model_url = _construct_databricks_logged_model_url(
                         get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
                     )
-                    eprint(f"🔗 Created Logged Model at: {logged_model_url}")
+                    eprint(f"🔗 View Logged Model at: {logged_model_url}")
 
             with _use_logged_model(model=model):
                 if run_id is not None:

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -187,7 +187,7 @@ def _register_model(
     if is_databricks_unity_catalog_uri(registry_uri) and (url := get_workspace_url()):
         uc_model_url = _construct_databricks_uc_registered_model_url(
             url,
-            name,
+            create_version_response.name,
             create_version_response.version,
             get_workspace_id(),
         )

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -6,6 +6,7 @@ import mlflow
 from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry import ModelVersion, Prompt, RegisteredModel
 from mlflow.entities.run import Run
+from mlflow.environment_variables import MLFLOW_PRINT_MODEL_URLS_ON_CREATION
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.registry_utils import require_prompt_registry
 from mlflow.protos.databricks_pb2 import (
@@ -184,7 +185,11 @@ def _register_model(
     )
     # Print a link to the UC model version page if the model is in UC.
     registry_uri = mlflow.get_registry_uri()
-    if is_databricks_unity_catalog_uri(registry_uri) and (url := get_workspace_url()):
+    if (
+        MLFLOW_PRINT_MODEL_URLS_ON_CREATION.get()
+        and is_databricks_unity_catalog_uri(registry_uri)
+        and (url := get_workspace_url())
+    ):
         uc_model_url = _construct_databricks_uc_registered_model_url(
             url,
             create_version_response.name,

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1070,6 +1070,25 @@ def _construct_databricks_model_version_url(
     return model_version_url
 
 
+def _construct_databricks_logged_model_url(
+    workspace_url: str, experiment_id: str, model_id: str, workspace_id: Optional[str] = None
+) -> str:
+    """
+    Get a Databricks URL for a given registered model version in Unity Catalog.
+
+    Args:
+        workspace_url: The URL of the workspace the registered model is in.
+        experiment_id: The ID of the experiment the model is logged to.
+        model_id: The ID of the logged model to create the URL for.
+        workspace_id: The ID of the workspace to include as a query parameter (if provided).
+
+    Returns:
+        The Databricks URL for a registered model in Unity Catalog.
+    """
+    query = f"?o={workspace_id}" if (workspace_id and workspace_id != "0") else ""
+    return f"{workspace_url}/ml/experiments/{experiment_id}/{model_id}{query}"
+
+
 def _construct_databricks_uc_registered_model_url(
     workspace_url: str, registered_model_name: str, version: str, workspace_id: Optional[str] = None
 ) -> str:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1086,7 +1086,7 @@ def _construct_databricks_logged_model_url(
         The Databricks URL for a registered model in Unity Catalog.
     """
     query = f"?o={workspace_id}" if (workspace_id and workspace_id != "0") else ""
-    return f"{workspace_url}/ml/experiments/{experiment_id}/{model_id}{query}"
+    return f"{workspace_url}/ml/experiments/{experiment_id}/models/{model_id}{query}"
 
 
 def _construct_databricks_uc_registered_model_url(

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -15,7 +15,6 @@ from packaging.version import Version
 from scipy.sparse import csc_matrix
 
 import mlflow
-from mlflow.entities.model_registry import ModelVersion
 from mlflow.exceptions import MlflowException
 from mlflow.models import Model, ModelSignature, infer_signature, set_model, validate_schema
 from mlflow.models.model import METADATA_FILES, SET_MODEL_ERROR
@@ -708,66 +707,3 @@ def test_logged_model_status():
             )
     logged_model = mlflow.last_logged_model()
     assert logged_model.status == "FAILED"
-
-
-def test_model_log_with_unity_catalog_url(capsys):
-    # Mock the necessary functions and environment
-    with (
-        mock.patch(
-            "mlflow.models.model.get_workspace_url", return_value="https://databricks.com"
-        ) as mock_url,
-        mock.patch("mlflow.models.model.get_workspace_id", return_value="123") as mock_workspace_id,
-        mock.patch(
-            "mlflow.tracking._model_registry.fluent._register_model",
-            return_value=ModelVersion(
-                name="name.mlflow.test_model",
-                version="6",
-                creation_timestamp=0,
-                last_updated_timestamp=0,
-                description="",
-                user_id="",
-                source="",
-                run_id="",
-                status="",
-                status_message="",
-                run_link="",
-            ),
-        ) as mock_register,
-    ):
-        orig_registry_uri = mlflow.get_registry_uri()
-        mlflow.set_registry_uri("databricks-uc")
-
-        # Create a test model and log it
-        class MyModel(mlflow.pyfunc.PythonModel):
-            def predict(self, context, model_input: list[str], params=None):
-                return model_input
-
-        with mlflow.start_run():
-            model_info = mlflow.pyfunc.log_model(
-                registered_model_name="name.mlflow.test_model",
-                python_model=MyModel(),
-                input_example=["abc"],
-            )
-
-        # Verify the model info
-        assert model_info.registered_model_version == "6"
-
-        # Using capsys to capture output
-        captured = capsys.readouterr()
-
-        # Verify the URL was printed correctly
-        expected_url = (
-            "https://databricks.com/explore/data/models/name/mlflow/test_model/version/6?o=123\n"
-        )
-        assert (
-            "🔗 View model version '6' of 'name.mlflow.test_model' in "
-            + f"Unity Catalog at: {expected_url}"
-            in captured.out
-        )
-
-        # Ensure all the mocks are called using assert_called_once.
-        mock_url.assert_called_once()
-        mock_workspace_id.assert_called_once()
-        mock_register.assert_called_once()
-        # Clean up the global variables set by the server
-        mlflow.set_registry_uri(orig_registry_uri)

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -198,7 +198,7 @@ def test_prompt_associate_with_run(tmp_path):
     assert prompts[0].version == 1
 
 
-def test_register_model_prints_uc_model_version_url():
+def test_register_model_prints_uc_model_version_url(monkeypatch):
     orig_registry_uri = mlflow.get_registry_uri()
     mlflow.set_registry_uri("databricks-uc")
     workspace_id = "123"
@@ -240,5 +240,12 @@ def test_register_model_prints_uc_model_version_url():
         mock_create_version.assert_called_once()
         mock_get_logged_model.assert_called_once()
         mock_set_logged_model_tags.assert_called_once()
+
+        # Test that the URL is not printed when the environment variable is set to false
+        mock_eprint.reset_mock()
+        monkeypatch.setenv("MLFLOW_PRINT_MODEL_URLS_ON_CREATION", "false")
+        register_model(f"models:/{model_id}", name)
+        mock_eprint.assert_called_with("Created version '1' of model 'name.mlflow.test_model'.")
+
     # Clean up the global variables set by the server
     mlflow.set_registry_uri(orig_registry_uri)

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -640,7 +640,7 @@ def test_construct_databricks_logged_model_url():
     model_id = "model_789"
     workspace_id = "123"
 
-    expected_url = "https://databricks.com/ml/experiments/123456/model_789?o=123"
+    expected_url = "https://databricks.com/ml/experiments/123456/models/model_789?o=123"
 
     result = databricks_utils._construct_databricks_logged_model_url(
         workspace_url=workspace_url,
@@ -652,7 +652,7 @@ def test_construct_databricks_logged_model_url():
     assert result == expected_url
 
     # Test case without workspace ID
-    expected_url_no_workspace = "https://databricks.com/ml/experiments/123456/model_789"
+    expected_url_no_workspace = "https://databricks.com/ml/experiments/123456/models/model_789"
 
     result_no_workspace = databricks_utils._construct_databricks_logged_model_url(
         workspace_url=workspace_url,

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -631,3 +631,33 @@ def test_construct_databricks_uc_registered_model_url():
     )
 
     assert result_no_workspace == expected_url_no_workspace
+
+
+def test_construct_databricks_logged_model_url():
+    # Test case with workspace ID
+    workspace_url = "https://databricks.com"
+    experiment_id = "123456"
+    model_id = "model_789"
+    workspace_id = "123"
+
+    expected_url = "https://databricks.com/ml/experiments/123456/model_789?o=123"
+
+    result = databricks_utils._construct_databricks_logged_model_url(
+        workspace_url=workspace_url,
+        experiment_id=experiment_id,
+        model_id=model_id,
+        workspace_id=workspace_id,
+    )
+
+    assert result == expected_url
+
+    # Test case without workspace ID
+    expected_url_no_workspace = "https://databricks.com/ml/experiments/123456/model_789"
+
+    result_no_workspace = databricks_utils._construct_databricks_logged_model_url(
+        workspace_url=workspace_url,
+        experiment_id=experiment_id,
+        model_id=model_id,
+    )
+
+    assert result_no_workspace == expected_url_no_workspace


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ShaylanDias/mlflow/pull/15723?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15723/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15723/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15723/merge
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/pull/15633

### What changes are proposed in this pull request?

In order to make it easier for users to find models that they create this does two things:
1. Makes calls to `register_model` print a link to the model if it is registered in Databricks UC
2. Makes calls to `log_model` print a link to the logged model if running in Databricks runtime

We accomplish 1. by moving logic introduced in https://github.com/mlflow/mlflow/pull/15633 inward into the `_register_model` call so that it applies to both the case that a model is registered during a `log_model` call and the case where the model is registered via a direct `register_model` call.

We accomplish 2. by adding a helper to construct logged model URLs and printing the result immediately after creating the logged model.

We also control this URL logging with an environment variable `MLFLOW_PRINT_MODEL_URLS_ON_CREATION` so users can remove the URLs if they find them annoying or unnecessary.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Log the model and register in one go
<img width="1240" alt="Screenshot 2025-05-13 at 11 34 33 PM" src="https://github.com/user-attachments/assets/ee7e3540-2c6e-440c-ab2d-80c50a63a7dc" />


#### Log model and register separately:
<img width="1253" alt="Screenshot 2025-05-13 at 11 33 20 PM" src="https://github.com/user-attachments/assets/469aea53-d317-4b87-9a45-1f620d41514d" />
<img width="1333" alt="Screenshot 2025-05-13 at 11 33 04 PM" src="https://github.com/user-attachments/assets/12197257-9a44-4419-a6c9-9b44a0eedff9" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds links to the output to both logged models and registered models in UC

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
