### PR TITLE
[WIP] Overhaul assessment APIs

### DIFF
--- a/docs/api_reference/source/python_api/mlflow.rst
+++ b/docs/api_reference/source/python_api/mlflow.rst
@@ -6,11 +6,17 @@ mlflow
     :undoc-members:
     :exclude-members:
         MlflowClient,
+        add_trace,
         trace,
         start_span,
         start_span_no_context,
         get_trace,
         search_traces,
+        log_assessment,
+        log_expectation,
+        log_feedback,
+        update_assessment,
+        delete_assessment,
         get_current_active_span,
         get_last_active_trace_id,
         create_external_model,
@@ -38,6 +44,11 @@ guidance on how to use these tracing APIs, please refer to the `Tracing Fluent A
 .. autofunction:: mlflow.search_traces
 .. autofunction:: mlflow.get_current_active_span
 .. autofunction:: mlflow.get_last_active_trace_id
+.. autofunction:: mlflow.add_trace
+.. autofunction:: mlflow.log_assessment
+.. autofunction:: mlflow.update_assessment
+.. autofunction:: mlflow.delete_assessment
+
 .. automodule:: mlflow.tracing
     :members:
     :undoc-members:

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -158,12 +158,11 @@ if MLFLOW_CONFIGURE_LOGGING.get() is True:
 
 # Core modules required for mlflow-tracing
 from mlflow.tracing.assessment import (
-    delete_expectation,
-    delete_feedback,
+    delete_assessment,
+    log_assessment,
     log_expectation,
     log_feedback,
-    update_expectation,
-    update_feedback,
+    update_assessment,
 )
 from mlflow.tracing.fluent import (
     add_trace,
@@ -213,12 +212,11 @@ __all__ = [
     "trace",
     "update_current_trace",
     # Assessment APIs
-    "delete_expectation",
-    "delete_feedback",
+    "delete_assessment",
+    "log_assessment",
+    "update_assessment",
     "log_expectation",
     "log_feedback",
-    "update_expectation",
-    "update_feedback",
 ]
 
 # Only import these modules when mlflow or mlflow-skinny is installed i.e. not importing them

--- a/mlflow/entities/__init__.py
+++ b/mlflow/entities/__init__.py
@@ -8,6 +8,8 @@ from mlflow.entities.assessment import (
     AssessmentError,
     AssessmentSource,
     AssessmentSourceType,
+    Expectation,
+    Feedback,
 )
 from mlflow.entities.dataset import Dataset
 from mlflow.entities.dataset_input import DatasetInput
@@ -99,4 +101,6 @@ __all__ = [
     "AssessmentError",
     "AssessmentSource",
     "AssessmentSourceType",
+    "Expectation",
+    "Feedback",
 ]

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -11,7 +11,7 @@ from google.protobuf.timestamp_pb2 import Timestamp
 
 from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.entities.assessment_error import AssessmentError
-from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType  # noqa: F401
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.protos.assessments_pb2 import Assessment as ProtoAssessment
 from mlflow.protos.assessments_pb2 import Expectation as ProtoExpectation
@@ -33,46 +33,24 @@ FeedbackValueType = Union[PbValueType, dict[str, PbValueType], list[PbValueType]
 @dataclass
 class Assessment(_MlflowObject):
     """
-    An abstraction for annotating a trace. An Assessment should be one of the following types:
+    Base class for assessments that can be attached to a trace.
+    An Assessment should be one of the following types:
 
     - Expectations: A label that represents the expected value for a particular operation.
         For example, an expected answer for a user question from a chatbot.
     - Feedback: A label that represents the feedback on the quality of the operation.
         Feedback can come from different sources, such as human judges, heuristic scorers,
         or LLM-as-a-Judge.
-
-    You can log an assessment to a trace using the :py:func:`mlflow.log_expectation` or
-    :py:func:`mlflow.log_feedback` functions.
-
-    Args:
-        name: The name of the assessment.
-        source: The source of the assessment.
-        trace_id: The ID of the trace associated with the assessment. If unset, the assessment
-            is not associated with any trace yet.
-        expectation: The expectation value of the assessment.
-        feedback: The feedback value of the assessment.  Only one of `expectation` or `feedback`
-            should be specified.
-        rationale: The rationale / justification for the assessment.
-        metadata: The metadata associated with the assessment.
-        span_id: The ID of the span associated with the assessment, if the assessment should
-            be associated with a particular span in the trace.
-        create_time_ms: The creation time of the assessment in milliseconds. If unset, the
-            current time is used.
-        last_update_time_ms: The last update time of the assessment in milliseconds.
-            If unset, the current time is used.
-        assessment_id: The ID of the assessment. This must be generated in the backend.
     """
 
     name: str
-    source: AssessmentSource
+    source: Optional[AssessmentSource] = None
     # NB: The trace ID is optional because the assessment object itself may be created
     #   standalone. For example, a custom metric function returns an assessment object
     #   without a trace ID. That said, the trace ID is required when logging the
     #   assessment to a trace in the backend eventually.
     #   https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/custom-metrics#-metric-decorator
     trace_id: Optional[str] = None
-    expectation: Optional[Expectation] = None
-    feedback: Optional[Feedback] = None
     rationale: Optional[str] = None
     metadata: Optional[dict[str, str]] = None
     span_id: Optional[str] = None
@@ -85,6 +63,10 @@ class Assessment(_MlflowObject):
     # Deprecated, use `error` in Feedback instead. Just kept for backward compatibility
     # and will be removed in the 3.0.0 release.
     error: Optional[AssessmentError] = None
+    # Deprecated, to create an assessment with an expectation or feedback, use the
+    # `Expectation` or `Feedback` classes instead.
+    expectation: Optional[ExpectationValue] = None
+    feedback: Optional[FeedbackValue] = None
 
     def __post_init__(self):
         if (self.expectation is not None) + (self.feedback is not None) != 1:
@@ -110,6 +92,20 @@ class Assessment(_MlflowObject):
             self.create_time_ms = current_time
         if self.last_update_time_ms is None:
             self.last_update_time_ms = current_time
+
+        if not isinstance(self.source, AssessmentSource):
+            raise MlflowException.invalid_parameter_value(
+                "`source` must be an instance of `AssessmentSource`. "
+                f"Got {type(self.source)} instead."
+            )
+
+    @property
+    def value(self):
+        if self.expectation:
+            return self.expectation.value
+        elif self.feedback:
+            return self.feedback.value
+        return None
 
     def to_proto(self):
         assessment = ProtoAssessment()
@@ -142,11 +138,11 @@ class Assessment(_MlflowObject):
     @classmethod
     def from_proto(cls, proto):
         if proto.WhichOneof("value") == "expectation":
-            expectation = Expectation.from_proto(proto.expectation)
+            expectation = ExpectationValue.from_proto(proto.expectation)
             feedback = None
         elif proto.WhichOneof("value") == "feedback":
             expectation = None
-            feedback = Feedback.from_proto(proto.feedback)
+            feedback = FeedbackValue.from_proto(proto.feedback)
         else:
             expectation = None
             feedback = None
@@ -187,12 +183,142 @@ class Assessment(_MlflowObject):
             source=AssessmentSource.from_dictionary(d["source"]),
             create_time_ms=create_time_ms,
             last_update_time_ms=last_update_time_ms,
-            expectation=Expectation.from_dictionary(e) if (e := d.get("expectation")) else None,
-            feedback=Feedback.from_dictionary(f) if (f := d.get("feedback")) else None,
+            expectation=ExpectationValue.from_dictionary(e)
+            if (e := d.get("expectation"))
+            else None,
+            feedback=FeedbackValue.from_dictionary(f) if (f := d.get("feedback")) else None,
             rationale=d.get("rationale"),
             metadata=d.get("metadata"),
             span_id=d.get("span_id"),
         )
+
+
+@experimental
+@dataclass
+class Feedback(Assessment):
+    """
+    Represents feedback about the output of an operation. For example, if the response from a
+    generative AI application to a particular user query is correct, then a human or LLM judge
+    may provide feedback with the value ``"correct"``.
+
+    Args:
+        name: The name of the assessment.
+        value: The feedback value. This can be one of the following types:
+            - float
+            - int
+            - str
+            - bool
+            - list of values of the same types as above
+            - dict with string keys and values of the same types as above
+        error: An optional error associated with the feedback. This is used to indicate
+            that the feedback is not valid or cannot be processed.
+        rationale: The rationale / justification for the feedback.
+        source: The source of the assessment. If not provided, the default source is CODE.
+        trace_id: The ID of the trace associated with the assessment. If unset, the assessment
+            is not associated with any trace yet.
+            should be specified.
+        metadata: The metadata associated with the assessment.
+        span_id: The ID of the span associated with the assessment, if the assessment should
+            be associated with a particular span in the trace.
+        create_time_ms: The creation time of the assessment in milliseconds. If unset, the
+            current time is used.
+        last_update_time_ms: The last update time of the assessment in milliseconds.
+            If unset, the current time is used.
+
+    Example:
+
+        .. code-block:: python
+
+            from mlflow.entities import AssessmentSource, Feedback
+
+            feedback = Feedback(
+                name="correctness",
+                value=True,
+                rationale="The response is correct.",
+                source=AssessmentSource(
+                    source_type="HUMAN",
+                    source_id="john@example.com",
+                ),
+                metadata={"project": "my-project"},
+            )
+    """
+
+    value: Optional[FeedbackValueType] = None
+    error: Optional[AssessmentError] = None
+
+    def __post_init__(self):
+        if self.value is None and self.error is None:
+            raise MlflowException.invalid_parameter_value(
+                "Either `value` or `error` must be provided.",
+            )
+
+        self.feedback = FeedbackValue(value=self.value, error=self.error)
+
+        # Default to CODE source if not provided
+        if self.source is None:
+            self.source = AssessmentSource(
+                source_type=AssessmentSourceType.CODE, source_id="default"
+            )
+
+        super().__post_init__()
+
+
+@experimental
+@dataclass
+class Expectation(Assessment):
+    """
+    Represents an expectation about the output of an operation, such as the expected response
+    that a generative AI application should provide to a particular user query.
+
+    Args:
+        name: The name of the assessment.
+        value: The expected value of the operation. This can be any JSON-serializable value.
+        source: The source of the assessment. If not provided, the default source is HUMAN.
+        trace_id: The ID of the trace associated with the assessment. If unset, the assessment
+            is not associated with any trace yet.
+            should be specified.
+        metadata: The metadata associated with the assessment.
+        span_id: The ID of the span associated with the assessment, if the assessment should
+            be associated with a particular span in the trace.
+        create_time_ms: The creation time of the assessment in milliseconds. If unset, the
+            current time is used.
+        last_update_time_ms: The last update time of the assessment in milliseconds.
+            If unset, the current time is used.
+
+    Example:
+
+        .. code-block:: python
+
+            from mlflow.entities import AssessmentSource, Expectation
+
+            expectation = Expectation(
+                name="expected_response",
+                value="The capital of France is Paris.",
+                source=AssessmentSource(
+                    source_type=AssessmentSourceType.HUMAN,
+                    source_id="john@example.com",
+                ),
+                metadata={"project": "my-project"},
+            )
+    """
+
+    value: Any
+
+    def __post_init__(self):
+        if self.value is None:
+            raise MlflowException.invalid_parameter_value(
+                "The `value` field must be specified.",
+            )
+
+        self.expectation = ExpectationValue(value=self.value)
+
+        # Default to CODE source if not provided
+        if self.source is None:
+            self.source = AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="default"
+            )
+
+        super().__post_init__()
 
 
 _JSON_SERIALIZATION_FORMAT = "JSON_FORMAT"
@@ -200,14 +326,8 @@ _JSON_SERIALIZATION_FORMAT = "JSON_FORMAT"
 
 @experimental
 @dataclass
-class Expectation(_MlflowObject):
-    """
-    Represents an expectation about the output of an operation, such as the expected response
-    that a generative AI application should provide to a particular user query.
-
-    Args:
-        value: The expected value of the operation. This can be any JSON-serializable value.
-    """
+class ExpectationValue(_MlflowObject):
+    """Represents an expectation value."""
 
     value: Any
 
@@ -255,23 +375,8 @@ class Expectation(_MlflowObject):
 
 @experimental
 @dataclass
-class Feedback(_MlflowObject):
-    """
-    Represents feedback about the output of an operation. For example, if the response from a
-    generative AI application to a particular user query is correct, then a human or LLM judge
-    may provide feedback with the value ``"correct"``.
-
-    Args:
-        value: The feedback value. This can be one of the following types:
-            - float
-            - int
-            - str
-            - bool
-            - list of values of the same types as above
-            - dict with string keys and values of the same types as above
-        error: An optional error associated with the feedback. This is used to indicate
-            that the feedback is not valid or cannot be processed.
-    """
+class FeedbackValue(_MlflowObject):
+    """Represents a feedback value."""
 
     value: FeedbackValueType
     error: Optional[AssessmentError] = None
@@ -283,8 +388,8 @@ class Feedback(_MlflowObject):
         )
 
     @classmethod
-    def from_proto(cls, proto) -> "Feedback":
-        return Feedback(
+    def from_proto(cls, proto) -> "FeedbackValue":
+        return FeedbackValue(
             value=MessageToDict(proto.value),
             error=AssessmentError.from_proto(proto.error) if proto.HasField("error") else None,
         )

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -6,50 +6,55 @@ from mlflow.entities.assessment import (
     Expectation,
     Feedback,
     FeedbackValueType,
-    experimental,
 )
-from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
-from mlflow.exceptions import MlflowException
+from mlflow.entities.assessment_source import AssessmentSource
 from mlflow.tracing.client import TracingClient
+from mlflow.utils.annotations import experimental
 
 
 @experimental
-def log_expectation(
-    trace_id: str,
-    name: str,
-    source: AssessmentSource,
-    value: Any,
-    metadata: Optional[dict[str, Any]] = None,
-    span_id: Optional[str] = None,
-) -> Assessment:
+def log_assessment(trace_id: str, assessment: Assessment) -> Assessment:
     """
     .. important::
 
         This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
 
-    Logs an expectation (e.g. ground truth label) to a Trace.
+    Logs an assessment to a Trace. The assessment can be an expectation or a feedback.
 
-    Args:
-        trace_id: The ID of the trace.
-        name: The name of the expectation assessment e.g., "expected_answer
-        source: The source of the expectation assessment. Must be an instance of
-                :py:class:`~mlflow.entities.AssessmentSource`.
-        value: The value of the expectation. It can be any JSON-serializable value.
-        metadata: Additional metadata for the expectation.
-        span_id: The ID of the span associated with the expectation, if it needs be
-                associated with a specific span in the trace.
+    - Expectation: A label that represents the expected value for a particular operation.
+        For example, an expected answer for a user question from a chatbot.
+    - Feedback: A label that represents the feedback on the quality of the operation.
+        Feedback can come from different sources, such as human judges, heuristic scorers,
+        or LLM-as-a-Judge.
 
-    Returns:
-        :py:class:`~mlflow.entities.Assessment`: The created expectation assessment.
+    The following code annotates a trace with a feedback provided by LLM-as-a-Judge.
 
-    Example:
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities import AssessmentSource, AssessmentSourceType, Feedback
+
+        source = AssessmentSource(
+            source_type=AssessmentSourceType.LLM_JUDGE,
+            source_id="faithfulness-judge",
+        )
+
+        feedback = Feedback(
+            name="faithfulness",
+            source=source,
+            value=0.9,
+            rationale="The model is faithful to the input.",
+            metadata={"model": "gpt-4o-mini"},
+        )
+
+        mlflow.log_assessment(trace_id="1234", assessment=feedback)
 
     The following code annotates a trace with human-provided ground truth.
 
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+        from mlflow.entities import AssessmentSource, AssessmentSourceType, Expectation
 
         # Specify the annotator information as a source.
         source = AssessmentSource(
@@ -57,12 +62,13 @@ def log_expectation(
             source_id="john@example.com",
         )
 
-        mlflow.log_expectation(
-            trace_id="1234",
+        expectation = Expectation(
             name="expected_answer",
             value=42,
             source=source,
         )
+
+        mlflow.log_assessment(trace_id="1234", assessment=expectation)
 
     The expectation value can be any JSON-serializable value. For example, you may
      record the full LLM message as the expectation value.
@@ -70,10 +76,13 @@ def log_expectation(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+        from mlflow.entities.assessment import (
+            AssessmentSource,
+            AssessmentSourceType,
+            Expectation,
+        )
 
-        mlflow.log_expectation(
-            trace_id="1234",
+        expectation = Expectation(
             name="expected_message",
             # Full LLM message including expected tool calls
             value={
@@ -92,32 +101,78 @@ def log_expectation(
                 source_id="john@example.com",
             ),
         )
-    """
-    if value is None:
-        raise MlflowException.invalid_parameter_value("Expectation value cannot be None.")
 
-    if not isinstance(source, AssessmentSource):
-        raise MlflowException.invalid_parameter_value(
-            f"`source` must be an instance of `AssessmentSource`. Got {type(source)} instead."
+        mlflow.log_assessment(trace_id="1234", assessment=expectation)
+
+    You can also log an error information during the feedback generation process. To do so,
+    provide an instance of :py:class:`~mlflow.entities.AssessmentError` to the `error`
+    parameter, and leave the `value` parameter as `None`.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.entities import AssessmentError, Feedback
+
+        error = AssessmentError(
+            error_code="RATE_LIMIT_EXCEEDED",
+            error_message="Rate limit for the judge exceeded.",
         )
 
-    return TracingClient().log_assessment(
-        trace_id=trace_id,
-        name=name,
-        source=source,
-        expectation=Expectation(value) if value is not None else None,
-        metadata=metadata,
-        span_id=span_id,
-    )
+        feedback = Feedback(
+            trace_id="1234",
+            name="faithfulness",
+            error=error,
+        )
+        mlflow.log_assessment(trace_id="1234", assessment=feedback)
+
+
+    """
+    TracingClient().log_assessment(trace_id, assessment)
 
 
 @experimental
-def update_expectation(
+def log_expectation(
+    trace_id: str,
+    name: str,
+    value: Any,
+    source: Optional[AssessmentSource] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    span_id: Optional[str] = None,
+) -> Assessment:
+    """
+    DEPRECATED: Use :py:func:`~mlflow.log_assessment` instead.
+
+    Logs an expectation (e.g. ground truth label) to a Trace.
+
+    Args:
+        trace_id: The ID of the trace.
+        name: The name of the expectation assessment e.g., "expected_answer
+        value: The value of the expectation. It can be any JSON-serializable value.
+        source: The source of the expectation assessment. Must be an instance of
+                :py:class:`~mlflow.entities.AssessmentSource`. If not provided,
+                default to CODE source type.
+        metadata: Additional metadata for the expectation.
+        span_id: The ID of the span associated with the expectation, if it needs be
+                associated with a specific span in the trace.
+
+    Returns:
+        :py:class:`~mlflow.entities.Assessment`: The created expectation assessment.
+    """
+    assessment = Expectation(
+        name=name,
+        source=source,
+        value=value,
+        metadata=metadata,
+        span_id=span_id,
+    )
+    return TracingClient().log_assessment(trace_id, assessment)
+
+
+@experimental
+def update_assessment(
     trace_id: str,
     assessment_id: str,
-    name: Optional[str] = None,
-    value: Any = None,
-    metadata: Optional[dict[str, Any]] = None,
+    assessment: Assessment,
 ) -> Assessment:
     """
     .. important::
@@ -129,9 +184,7 @@ def update_expectation(
     Args:
         trace_id: The ID of the trace.
         assessment_id: The ID of the expectation assessment to update.
-        name: The updated name of the expectation. Specify only when updating the name.
-        value: The updated value of the expectation. Specify only when updating the value.
-        metadata: Additional metadata for the expectation. Specify only when updating the metadata.
+        assessment: The updated assessment.
 
     Returns:
         :py:class:`~mlflow.entities.Assessment`: The updated feedback assessment.
@@ -144,46 +197,41 @@ def update_expectation(
     .. code-block:: python
 
         import mlflow
-        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+        from mlflow.entities import Expectation, ExpectationValue
 
         # Create an expectation with value 42.
-        assessment = mlflow.log_expectation(
+        response = mlflow.log_assessment(
             trace_id="1234",
-            name="expected_answer",
-            value=42,
-            # Original annotator
-            source=AssessmentSource(
-                source_type=AssessmentSourceType.HUMAN,
-                source_id="bob@example.com",
-            ),
+            assessment=Expectation(name="expected_answer", value=42),
         )
+        assessment_id = response.assessment_id
 
         # Update the expectation with a new value 43.
-        mlflow.update_expectation(
-            trace_id="1234", assessment_id=assessment.assessment_id, value=43
+        mlflow.update_assessment(
+            trace_id="1234",
+            assessment_id=assessment.assessment_id,
+            assessment=Expectation(name="expected_answer", value=43),
         )
     """
     return TracingClient().update_assessment(
         assessment_id=assessment_id,
         trace_id=trace_id,
-        name=name,
-        expectation=Expectation(value) if value is not None else None,
-        metadata=metadata,
+        assessment=assessment,
     )
 
 
 @experimental
-def delete_expectation(trace_id: str, assessment_id: str):
+def delete_assessment(trace_id: str, assessment_id: str):
     """
     .. important::
 
         This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
 
-    Deletes an expectation associated with a trace.
+    Deletes an assessment associated with a trace.
 
     Args:
         trace_id: The ID of the trace.
-        assessment_id: The ID of the expectation assessment to delete.
+        assessment_id: The ID of the assessment to delete.
     """
     return TracingClient().delete_assessment(trace_id=trace_id, assessment_id=assessment_id)
 
@@ -192,26 +240,21 @@ def delete_expectation(trace_id: str, assessment_id: str):
 def log_feedback(
     trace_id: str,
     name: str,
-    source: Optional[AssessmentSource] = None,
     value: Optional[FeedbackValueType] = None,
+    source: Optional[AssessmentSource] = None,
     error: Optional[AssessmentError] = None,
     rationale: Optional[str] = None,
     metadata: Optional[dict[str, Any]] = None,
     span_id: Optional[str] = None,
 ) -> Assessment:
     """
-    .. important::
-
-        This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
+    DEPRECATED: Use :py:func:`~mlflow.log_assessment` instead.
 
     Logs feedback to a Trace.
 
     Args:
         trace_id: The ID of the trace.
         name: The name of the feedback assessment e.g., "faithfulness"
-        source: The source of the feedback assessment. Must be an instance of
-                :py:class:`~mlflow.entities.AssessmentSource`. If not provided, defaults to
-                CODE source type.
         value: The value of the feedback. Must be one of the following types:
             - float
             - int
@@ -219,6 +262,9 @@ def log_feedback(
             - bool
             - list of values of the same types as above
             - dict with string keys and values of the same types as above
+        source: The source of the feedback assessment. Must be an instance of
+                :py:class:`~mlflow.entities.AssessmentSource`. If not provided, defaults to
+                CODE source type
         error: An error object representing any issues encountered while computing the
             feedback, e.g., a timeout error from an LLM judge. Either this or `value`
             must be provided.
@@ -229,173 +275,15 @@ def log_feedback(
 
     Returns:
         :py:class:`~mlflow.entities.Assessment`: The created feedback assessment.
-
-    Example:
-
-    The following code annotates a trace with a feedback provided by LLM-as-a-Judge.
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
-
-        source = AssessmentSource(
-            source_type=AssessmentSourceType.LLM_JUDGE,
-            source_id="faithfulness-judge",
-        )
-
-        mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            source=source,
-            value=0.9,
-            rationale="The model is faithful to the input.",
-            metadata={"model": "gpt-4o-mini"},
-        )
-
-    You can also use the function without specifying a source, in which case CODE source type
-    will be used by default:
-
-    .. code-block:: python
-
-        import mlflow
-
-        mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            value=0.9,
-            rationale="The model is faithful to the input.",
-        )
-
-    You can also log an error information during the feedback generation process. To do so,
-    provide an instance of :py:class:`~mlflow.entities.AssessmentError` to the `error`
-    parameter, and leave the `value` parameter as `None`.
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.entities.assessment import AssessmentError
-
-        source = AssessmentSource(
-            source_type=Type.LLM_JUDGE,
-            source_id="faithfulness-judge",
-        )
-
-        error = AssessmentError(
-            error_code="RATE_LIMIT_EXCEEDED",
-            error_message="Rate limit for the judge exceeded.",
-        )
-
-        mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            error=error,
-            source=source,
-        )
-
     """
-    if value is None and error is None:
-        raise MlflowException.invalid_parameter_value("Either `value` or `error` must be provided.")
 
-    # If source is not provided, use CODE as the default source type
-    if source is None:
-        source = AssessmentSource(
-            source_type=AssessmentSourceType.CODE,
-            source_id="default",
-        )
-    elif not isinstance(source, AssessmentSource):
-        raise MlflowException.invalid_parameter_value(
-            f"`source` must be an instance of `AssessmentSource`. Got {type(source)} instead."
-        )
-
-    return TracingClient().log_assessment(
-        trace_id=trace_id,
+    assessment = Feedback(
         name=name,
         source=source,
-        feedback=Feedback(value, error),
+        value=value,
+        error=error,
         rationale=rationale,
         metadata=metadata,
         span_id=span_id,
     )
-
-
-@experimental
-def update_feedback(
-    trace_id: str,
-    assessment_id: str,
-    name: Optional[str] = None,
-    value: Optional[FeedbackValueType] = None,
-    rationale: Optional[str] = None,
-    metadata: Optional[dict[str, Any]] = None,
-) -> Assessment:
-    """
-    .. important::
-
-        This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
-
-    Updates an existing feedback in a Trace.
-
-
-    Args:
-        trace_id: The ID of the trace.
-        assessment_id: The ID of the feedback assessment to update.
-        name: The updated name of the feedback. Specify only when updating the name.
-        value: The updated value of the feedback. Specify only when updating the value.
-        rationale: The updated rationale of the feedback. Specify only when updating the rationale.
-        metadata: Additional metadata for the feedback. Specify only when updating the metadata.
-
-    Returns:
-        :py:class:`~mlflow.entities.Assessment`: The updated feedback assessment.
-
-    Example:
-
-    The following code updates an existing feedback with a new value.
-    To update other fields, provide the corresponding parameters.
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
-
-        # Create a feedback with value 0.9.
-        assessment = mlflow.log_feedback(
-            trace_id="1234",
-            name="faithfulness",
-            value=0.9,
-            source=AssessmentSource(
-                source_type=AssessmentSourceType.LLM_JUDGE,
-                source_id="gpt-4o-mini",
-            ),
-        )
-
-        # Update the feedback with a new value 0.95.
-        mlflow.update_feedback(
-            trace_id="1234",
-            assessment_id=assessment.assessment_id,
-            value=0.95,
-        )
-    """
-    return TracingClient().update_assessment(
-        trace_id=trace_id,
-        assessment_id=assessment_id,
-        name=name,
-        feedback=Feedback(value) if value is not None else None,
-        rationale=rationale,
-        metadata=metadata,
-    )
-
-
-@experimental
-def delete_feedback(trace_id: str, assessment_id: str):
-    """
-    .. important::
-
-        This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
-
-    Deletes feedback associated with a trace.
-
-    Args:
-        trace_id: The ID of the trace.
-        assessment_id: The ID of the feedback assessment to delete.
-    """
-    return TracingClient().delete_assessment(trace_id=trace_id, assessment_id=assessment_id)
+    return TracingClient().log_assessment(trace_id, assessment)

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -7,8 +7,8 @@ from mlflow.entities.assessment import (
     Assessment,
     AssessmentError,
     AssessmentSource,
-    Expectation,
-    Feedback,
+    ExpectationValue,
+    FeedbackValue,
 )
 from mlflow.exceptions import MlflowException
 from mlflow.protos.assessments_pb2 import Assessment as ProtoAssessment
@@ -24,7 +24,7 @@ def test_assessment_creation():
         "create_time_ms": 123456789,
         "last_update_time_ms": 123456789,
         "expectation": None,
-        "feedback": Feedback(0.9),
+        "feedback": FeedbackValue(0.9),
         "rationale": "Rationale text",
         "metadata": {"key1": "value1"},
         "span_id": "span_id",
@@ -38,7 +38,7 @@ def test_assessment_creation():
     assessment_with_error = Assessment(
         **{
             **default_params,
-            "feedback": Feedback(
+            "feedback": FeedbackValue(
                 None, AssessmentError(error_code="E001", error_message="An error occurred.")
             ),
         }
@@ -51,7 +51,7 @@ def test_assessment_creation():
     assessment_with_value_and_error = Assessment(
         **{
             **default_params,
-            "feedback": Feedback(value=1, error=AssessmentError(error_code="E001")),
+            "feedback": FeedbackValue(value=1, error=AssessmentError(error_code="E001")),
         }
     )
     assert assessment_with_value_and_error.feedback.value == 1
@@ -62,7 +62,7 @@ def test_assessment_creation():
         **{
             **default_params,
             "error": AssessmentError(error_code="E001", error_message="An error occurred."),
-            "feedback": Feedback(None),
+            "feedback": FeedbackValue(None),
         }
     )
     assert assessment_legacy_error.feedback.error.error_code == "E001"
@@ -84,27 +84,27 @@ def test_assessment_equality():
     # Valid assessments
     assessment_1 = Assessment(
         source=source_1,
-        feedback=Feedback(0.9),
+        feedback=FeedbackValue(0.9),
         **common_args,
     )
     assessment_2 = Assessment(
         source=source_2,
-        feedback=Feedback(0.9),
+        feedback=FeedbackValue(0.9),
         **common_args,
     )
     assessment_3 = Assessment(
         source=source_1,
-        feedback=Feedback(0.8),
+        feedback=FeedbackValue(0.8),
         **common_args,
     )
     assessment_4 = Assessment(
         source=source_3,
-        feedback=Feedback(0.9),
+        feedback=FeedbackValue(0.9),
         **common_args,
     )
     assessment_5 = Assessment(
         source=source_1,
-        feedback=Feedback(
+        feedback=FeedbackValue(
             None,
             AssessmentError(
                 error_code="E002",
@@ -115,7 +115,7 @@ def test_assessment_equality():
     )
     assessment_6 = Assessment(
         source=source_1,
-        feedback=Feedback(
+        feedback=FeedbackValue(
             None,
             AssessmentError(
                 error_code="E001",
@@ -143,11 +143,13 @@ def test_assessment_value_validation():
     }
 
     # Valid cases
-    Assessment(expectation=Expectation("MLflow"), **common_args)
-    Assessment(feedback=Feedback("This is correct."), **common_args)
-    Assessment(feedback=Feedback(None, error=AssessmentError(error_code="E001")), **common_args)
+    Assessment(expectation=ExpectationValue("MLflow"), **common_args)
+    Assessment(feedback=FeedbackValue("This is correct."), **common_args)
     Assessment(
-        feedback=Feedback("This is correct.", AssessmentError(error_code="E001")),
+        feedback=FeedbackValue(None, error=AssessmentError(error_code="E001")), **common_args
+    )
+    Assessment(
+        feedback=FeedbackValue("This is correct.", AssessmentError(error_code="E001")),
         **common_args,
     )
 
@@ -158,16 +160,16 @@ def test_assessment_value_validation():
     # Invalid case: both feedback and expectation specified
     with pytest.raises(MlflowException, match=r"Exactly one of"):
         Assessment(
-            expectation=Expectation("MLflow"),
-            feedback=Feedback("This is correct."),
+            expectation=ExpectationValue("MLflow"),
+            feedback=FeedbackValue("This is correct."),
             **common_args,
         )
 
     # Invalid case: All three are set
     with pytest.raises(MlflowException, match=r"Exactly one of"):
         Assessment(
-            expectation=Expectation("MLflow"),
-            feedback=Feedback("This is correct.", AssessmentError(error_code="E001")),
+            expectation=ExpectationValue("MLflow"),
+            feedback=FeedbackValue("This is correct.", AssessmentError(error_code="E001")),
             **common_args,
         )
 
@@ -175,13 +177,15 @@ def test_assessment_value_validation():
 @pytest.mark.parametrize(
     ("expectation", "feedback"),
     [
-        (Expectation("MLflow"), None),
-        (Expectation({"complex": {"expectation": ["structure"]}}), None),
-        (None, Feedback("This is correct.")),
-        (None, Feedback(None, AssessmentError(error_code="E001"))),
+        (ExpectationValue("MLflow"), None),
+        (ExpectationValue({"complex": {"expectation": ["structure"]}}), None),
+        (None, FeedbackValue("This is correct.")),
+        (None, FeedbackValue(None, AssessmentError(error_code="E001"))),
         (
             None,
-            Feedback(None, AssessmentError(error_code="E001", error_message="An error occurred.")),
+            FeedbackValue(
+                None, AssessmentError(error_code="E001", error_message="An error occurred.")
+            ),
         ),
     ],
 )
@@ -260,11 +264,11 @@ def test_assessment_conversion(expectation, feedback, source, metadata):
     ids=["string", "integer", "float", "boolean"],
 )
 def test_expectation_proto_conversion(value):
-    expectation = Expectation(value)
+    expectation = ExpectationValue(value)
     proto = expectation.to_proto()
     assert isinstance(proto, ProtoExpectation)
 
-    result = Expectation.from_proto(proto)
+    result = ExpectationValue.from_proto(proto)
     assert result.value == expectation.value
 
 
@@ -279,13 +283,13 @@ def test_expectation_proto_conversion(value):
     ],
 )
 def test_expectation_serialization(value):
-    expectation = Expectation(value)
+    expectation = ExpectationValue(value)
     proto = expectation.to_proto()
 
     assert proto.HasField("serialized_value")
     assert proto.serialized_value.serialization_format == "JSON_FORMAT"
 
-    result = Expectation.from_proto(proto)
+    result = ExpectationValue.from_proto(proto)
     assert result.value == expectation.value
 
 
@@ -294,7 +298,7 @@ def test_expectation_invalid_values():
         pass
 
     with pytest.raises(MlflowException, match="Expectation value must be JSON-serializable"):
-        Expectation(CustomObject()).to_proto()
+        ExpectationValue(CustomObject()).to_proto()
 
     # Test invalid serialization format
     proto = ProtoExpectation()
@@ -302,4 +306,4 @@ def test_expectation_invalid_values():
     proto.serialized_value.value = '{"key": "value"}'
 
     with pytest.raises(MlflowException, match="Unknown serialization format"):
-        Expectation.from_proto(proto)
+        ExpectationValue.from_proto(proto)

--- a/tests/entities/test_trace_info_v3.py
+++ b/tests/entities/test_trace_info_v3.py
@@ -1,5 +1,4 @@
 from mlflow.entities.assessment import (
-    Assessment,
     AssessmentError,
     AssessmentSource,
     Expectation,
@@ -11,33 +10,26 @@ from mlflow.entities.trace_state import TraceState
 
 
 def test_trace_info_v3():
+    common_args = {
+        "trace_id": "trace_id",
+        "name": "relevance",
+        "source": AssessmentSource(source_type="HUMAN", source_id="user_1"),
+        "create_time_ms": 123456789,
+        "last_update_time_ms": 123456789,
+        "rationale": "Rationale text",
+        "metadata": {"key1": "value1"},
+        "span_id": "span_id",
+    }
+
     assessments = [
-        Assessment(
-            trace_id="trace_id",
-            name="relevance",
-            source=AssessmentSource(source_type="HUMAN", source_id="user_1"),
-            create_time_ms=123456789,
-            last_update_time_ms=123456789,
-            expectation=expectation,
-            feedback=feedback,
-            rationale="Rationale text",
-            metadata={"key1": "value1"},
-            span_id="span_id",
-        )
-        for expectation, feedback in [
-            (
-                None,
-                Feedback(
-                    0.9,
-                    error=AssessmentError(error_code="error_code", error_message="Error message"),
-                ),
-            ),
-            (
-                Expectation(0.8),
-                None,
-            ),
-        ]
+        Feedback(
+            value=0.9,
+            error=AssessmentError(error_code="error_code", error_message="Error message"),
+            **common_args,
+        ),
+        Expectation(value=0.8, **common_args),
     ]
+
     trace_info = TraceInfo(
         trace_id="trace_id",
         client_request_id="client_request_id",

--- a/tests/entities/test_trace_info_v3.py
+++ b/tests/entities/test_trace_info_v3.py
@@ -1,4 +1,5 @@
 from mlflow.entities.assessment import (
+    Assessment,
     AssessmentError,
     AssessmentSource,
     Expectation,
@@ -10,26 +11,33 @@ from mlflow.entities.trace_state import TraceState
 
 
 def test_trace_info_v3():
-    common_args = {
-        "trace_id": "trace_id",
-        "name": "relevance",
-        "source": AssessmentSource(source_type="HUMAN", source_id="user_1"),
-        "create_time_ms": 123456789,
-        "last_update_time_ms": 123456789,
-        "rationale": "Rationale text",
-        "metadata": {"key1": "value1"},
-        "span_id": "span_id",
-    }
-
     assessments = [
-        Feedback(
-            value=0.9,
-            error=AssessmentError(error_code="error_code", error_message="Error message"),
-            **common_args,
-        ),
-        Expectation(value=0.8, **common_args),
+        Assessment(
+            trace_id="trace_id",
+            name="relevance",
+            source=AssessmentSource(source_type="HUMAN", source_id="user_1"),
+            create_time_ms=123456789,
+            last_update_time_ms=123456789,
+            expectation=expectation,
+            feedback=feedback,
+            rationale="Rationale text",
+            metadata={"key1": "value1"},
+            span_id="span_id",
+        )
+        for expectation, feedback in [
+            (
+                None,
+                Feedback(
+                    0.9,
+                    error=AssessmentError(error_code="error_code", error_message="Error message"),
+                ),
+            ),
+            (
+                Expectation(0.8),
+                None,
+            ),
+        ]
     ]
-
     trace_info = TraceInfo(
         trace_id="trace_id",
         client_request_id="client_request_id",

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -3,7 +3,14 @@ from unittest import mock
 import pytest
 
 import mlflow
-from mlflow.entities.assessment import Assessment, AssessmentError, Expectation, Feedback
+from mlflow.entities.assessment import (
+    AssessmentError,
+    AssessmentSource,
+    Expectation,
+    ExpectationValue,
+    Feedback,
+    FeedbackValue,
+)
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info_v2 import TraceInfoV2
@@ -42,14 +49,24 @@ _LLM_ASSESSMENT_SOURCE = AssessmentSource(
 )
 
 
-def test_log_expectation(store, tracking_uri):
-    mlflow.log_expectation(
-        trace_id="1234",
-        name="expected_answer",
-        value="MLflow",
-        source=_HUMAN_ASSESSMENT_SOURCE,
-        metadata={"key": "value"},
-    )
+@pytest.mark.parametrize("legacy_api", [True, False])
+def test_log_expectation(store, tracking_uri, legacy_api):
+    if legacy_api:
+        mlflow.log_expectation(
+            trace_id="1234",
+            name="expected_answer",
+            value="MLflow",
+            source=_HUMAN_ASSESSMENT_SOURCE,
+            metadata={"key": "value"},
+        )
+    else:
+        feedback = Expectation(
+            name="expected_answer",
+            value="MLflow",
+            source=_HUMAN_ASSESSMENT_SOURCE,
+            metadata={"key": "value"},
+        )
+        mlflow.log_assessment(trace_id="1234", assessment=feedback)
 
     assert store.create_assessment.call_count == 1
     assessment = store.create_assessment.call_args[0][0]
@@ -66,9 +83,8 @@ def test_log_expectation(store, tracking_uri):
 
 
 def test_log_expectation_invalid_parameters(tracking_uri):
-    with pytest.raises(MlflowException, match=r"Expectation value cannot be None."):
-        mlflow.log_expectation(
-            trace_id="1234",
+    with pytest.raises(MlflowException, match=r"The `value` field must be specified."):
+        Expectation(
             name="expected_answer",
             value=None,
             source=_HUMAN_ASSESSMENT_SOURCE,
@@ -76,32 +92,44 @@ def test_log_expectation_invalid_parameters(tracking_uri):
 
 
 def test_update_expectation(store, tracking_uri):
-    mlflow.update_expectation(
+    assessment = Expectation(name="expected_answer", value="MLflow")
+    mlflow.update_assessment(
         assessment_id="1234",
         trace_id="tr-1234",
-        value="MLflow",
+        assessment=assessment,
     )
 
     assert store.update_assessment.call_count == 1
     call_args = store.update_assessment.call_args[1]
     assert call_args["trace_id"] == "tr-1234"
     assert call_args["assessment_id"] == "1234"
-    assert call_args["name"] is None
-    assert call_args["expectation"] == Expectation(value="MLflow")
+    assert call_args["name"] == "expected_answer"
+    assert call_args["expectation"] == ExpectationValue(value="MLflow")
     assert call_args["feedback"] is None
     assert call_args["rationale"] is None
     assert call_args["metadata"] is None
 
 
-def test_log_feedback(store, tracking_uri):
-    mlflow.log_feedback(
-        trace_id="1234",
-        name="faithfulness",
-        value=1.0,
-        source=_LLM_ASSESSMENT_SOURCE,
-        rationale="This answer is very faithful.",
-        metadata={"model": "gpt-4o-mini"},
-    )
+@pytest.mark.parametrize("legacy_api", [True, False])
+def test_log_feedback(store, tracking_uri, legacy_api):
+    if legacy_api:
+        mlflow.log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            value=1.0,
+            source=_LLM_ASSESSMENT_SOURCE,
+            rationale="This answer is very faithful.",
+            metadata={"model": "gpt-4o-mini"},
+        )
+    else:
+        feedback = Feedback(
+            name="faithfulness",
+            value=1.0,
+            source=_LLM_ASSESSMENT_SOURCE,
+            rationale="This answer is very faithful.",
+            metadata={"model": "gpt-4o-mini"},
+        )
+        mlflow.log_assessment(trace_id="1234", assessment=feedback)
 
     assert store.create_assessment.call_count == 1
     assessment = store.create_assessment.call_args[0][0]
@@ -118,16 +146,29 @@ def test_log_feedback(store, tracking_uri):
     assert assessment.metadata == {"model": "gpt-4o-mini"}
 
 
-def test_log_feedback_with_error(store, tracking_uri):
-    mlflow.log_feedback(
-        trace_id="1234",
-        name="faithfulness",
-        source=_LLM_ASSESSMENT_SOURCE,
-        error=AssessmentError(
-            error_code="RATE_LIMIT_EXCEEDED",
-            error_message="Rate limit for the judge exceeded.",
-        ),
-    )
+@pytest.mark.parametrize("legacy_api", [True, False])
+def test_log_feedback_with_error(store, tracking_uri, legacy_api):
+    if legacy_api:
+        mlflow.log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            source=_LLM_ASSESSMENT_SOURCE,
+            error=AssessmentError(
+                error_code="RATE_LIMIT_EXCEEDED",
+                error_message="Rate limit for the judge exceeded.",
+            ),
+        )
+    else:
+        feedback = Feedback(
+            name="faithfulness",
+            value=None,
+            source=_LLM_ASSESSMENT_SOURCE,
+            error=AssessmentError(
+                error_code="RATE_LIMIT_EXCEEDED",
+                error_message="Rate limit for the judge exceeded.",
+            ),
+        )
+        mlflow.log_assessment(trace_id="1234", assessment=feedback)
 
     assert store.create_assessment.call_count == 1
     assessment = store.create_assessment.call_args[0][0]
@@ -144,17 +185,30 @@ def test_log_feedback_with_error(store, tracking_uri):
     assert assessment.rationale is None
 
 
-def test_log_feedback_with_value_and_error(store, tracking_uri):
-    mlflow.log_feedback(
-        trace_id="1234",
-        name="faithfulness",
-        source=_LLM_ASSESSMENT_SOURCE,
-        value=0.5,
-        error=AssessmentError(
-            error_code="RATE_LIMIT_EXCEEDED",
-            error_message="Rate limit for the judge exceeded.",
-        ),
-    )
+@pytest.mark.parametrize("legacy_api", [True, False])
+def test_log_feedback_with_value_and_error(store, tracking_uri, legacy_api):
+    if legacy_api:
+        mlflow.log_feedback(
+            trace_id="1234",
+            name="faithfulness",
+            source=_LLM_ASSESSMENT_SOURCE,
+            value=0.5,
+            error=AssessmentError(
+                error_code="RATE_LIMIT_EXCEEDED",
+                error_message="Rate limit for the judge exceeded.",
+            ),
+        )
+    else:
+        feedback = Feedback(
+            name="faithfulness",
+            value=0.5,
+            source=_LLM_ASSESSMENT_SOURCE,
+            error=AssessmentError(
+                error_code="RATE_LIMIT_EXCEEDED",
+                error_message="Rate limit for the judge exceeded.",
+            ),
+        )
+        mlflow.log_assessment(trace_id="1234", assessment=feedback)
 
     assert store.create_assessment.call_count == 1
     assessment = store.create_assessment.call_args[0][0]
@@ -173,7 +227,7 @@ def test_log_feedback_with_value_and_error(store, tracking_uri):
 
 def test_log_feedback_invalid_parameters(tracking_uri):
     with pytest.raises(MlflowException, match=r"Either `value` or `error` must be provided."):
-        mlflow.log_feedback(
+        Feedback(
             trace_id="1234",
             name="faithfulness",
             source=_LLM_ASSESSMENT_SOURCE,
@@ -181,7 +235,7 @@ def test_log_feedback_invalid_parameters(tracking_uri):
 
     # Test with a non-AssessmentSource object that is not None
     with pytest.raises(MlflowException, match=r"`source` must be an instance of"):
-        mlflow.log_feedback(
+        Feedback(
             trace_id="1234",
             name="faithfulness",
             value=1.0,
@@ -190,27 +244,31 @@ def test_log_feedback_invalid_parameters(tracking_uri):
 
 
 def test_update_feedback(store, tracking_uri):
-    mlflow.update_feedback(
-        assessment_id="1234",
-        trace_id="tr-1234",
+    feedback = Feedback(
+        name="faithfulness",
         value=1.0,
         rationale="This answer is very faithful.",
         metadata={"model": "gpt-4o-mini"},
+    )
+    mlflow.update_assessment(
+        assessment_id="1234",
+        trace_id="tr-1234",
+        assessment=feedback,
     )
 
     assert store.update_assessment.call_count == 1
     call_args = store.update_assessment.call_args[1]
     assert call_args["trace_id"] == "tr-1234"
     assert call_args["assessment_id"] == "1234"
-    assert call_args["name"] is None
+    assert call_args["name"] == "faithfulness"
     assert call_args["expectation"] is None
-    assert call_args["feedback"] == Feedback(value=1.0)
+    assert call_args["feedback"] == FeedbackValue(value=1.0)
     assert call_args["rationale"] == "This answer is very faithful."
     assert call_args["metadata"] == {"model": "gpt-4o-mini"}
 
 
-def test_delete_expectation(store, tracking_uri):
-    mlflow.delete_expectation(trace_id="tr-1234", assessment_id="1234")
+def test_delete_assessment(store, tracking_uri):
+    mlflow.delete_assessment(trace_id="tr-1234", assessment_id="1234")
 
     assert store.delete_assessment.call_count == 1
     call_args = store.delete_assessment.call_args[1]
@@ -218,16 +276,10 @@ def test_delete_expectation(store, tracking_uri):
     assert call_args["trace_id"] == "tr-1234"
 
 
-def test_delete_feedback(store, tracking_uri):
-    mlflow.delete_feedback(trace_id="tr-5678", assessment_id="5678")
-
-    assert store.delete_assessment.call_count == 1
-    call_args = store.delete_assessment.call_args[1]
-    assert call_args["assessment_id"] == "5678"
-    assert call_args["trace_id"] == "tr-5678"
-
-
 def test_assessment_apis_only_available_in_databricks():
+    with pytest.raises(MlflowException, match=r"This API is currently only available"):
+        mlflow.log_assessment(trace_id="1234", assessment=Feedback(name="test", value=1.0))
+
     with pytest.raises(MlflowException, match=r"This API is currently only available"):
         mlflow.log_expectation(
             trace_id="1234", name="expected_answer", value="MLflow", source=_HUMAN_ASSESSMENT_SOURCE
@@ -239,27 +291,25 @@ def test_assessment_apis_only_available_in_databricks():
         )
 
     with pytest.raises(MlflowException, match=r"This API is currently only available"):
-        mlflow.update_expectation(trace_id="1234", assessment_id="1234", value=1.0)
+        mlflow.update_assessment(
+            trace_id="1234",
+            assessment_id="1234",
+            assessment=Feedback(name="faithfulness", value=1.0),
+        )
 
     with pytest.raises(MlflowException, match=r"This API is currently only available"):
-        mlflow.update_feedback(trace_id="1234", assessment_id="1234", value=1.0)
-
-    with pytest.raises(MlflowException, match=r"This API is currently only available"):
-        mlflow.delete_expectation(trace_id="1234", assessment_id="1234")
-
-    with pytest.raises(MlflowException, match=r"This API is currently only available"):
-        mlflow.delete_feedback(trace_id="1234", assessment_id="1234")
+        mlflow.delete_assessment(trace_id="1234", assessment_id="1234")
 
 
 def test_search_traces_with_assessments(store, tracking_uri):
     # Create a trace info with an assessment
-    assessment = Assessment(
+    assessment = Feedback(
         trace_id="test",
         name="test",
+        value="test",
         source=AssessmentSource(source_id="test", source_type=AssessmentSourceType.HUMAN),
         create_time_ms=0,
         last_update_time_ms=0,
-        feedback=Feedback("test"),
     )
 
     trace_info = TraceInfoV2(
@@ -302,11 +352,12 @@ def test_search_traces_with_assessments(store, tracking_uri):
 
 def test_log_feedback_default_source(store, tracking_uri):
     # Test that the default CODE source is used when no source is provided
-    mlflow.log_feedback(
+    feedback = Feedback(
         trace_id="1234",
         name="faithfulness",
         value=1.0,
     )
+    mlflow.log_assessment(trace_id="1234", assessment=feedback)
 
     assert store.create_assessment.call_count == 1
     assessment = store.create_assessment.call_args[0][0]
@@ -315,3 +366,21 @@ def test_log_feedback_default_source(store, tracking_uri):
     assert assessment.source.source_type == AssessmentSourceType.CODE
     assert assessment.source.source_id == "default"
     assert assessment.feedback.value == 1.0
+
+
+def test_log_expectation_default_source(store, tracking_uri):
+    # Test that the default CODE source is used when no source is provided
+    expectation = Expectation(
+        trace_id="1234",
+        name="expected_answer",
+        value="MLflow",
+    )
+    mlflow.log_assessment(trace_id="1234", assessment=expectation)
+
+    assert store.create_assessment.call_count == 1
+    assessment = store.create_assessment.call_args[0][0]
+    assert assessment.name == "expected_answer"
+    assert assessment.trace_id == "1234"
+    assert assessment.source.source_type == AssessmentSourceType.HUMAN
+    assert assessment.source.source_id == "default"
+    assert assessment.expectation.value == "MLflow"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15724?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15724/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15724/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15724/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Changing the literature of assessment APIs based on recent feedbacks from RC.

**Problem 1: The logging API is not flexible**
Previously, we have the following APis
- `mlflow.log_feedback`
- `mlflow.log_expectations`

These APIs takes the field of assessment in a flatten parameters, for example,

```
mlflow.log_feedback(name="correctness", value=True, ...)
```

However, this doesn't fit nicely with the use case where users want to log assessment object returned from built-in judges.

```
assessment = judge.correctness(inputs="...", outputs="...")
mlflow.log_feedback(
    trace_id=trace_id,
    name=assessment.name,
    value=assessment.value,
    source=...
)
```

**Problem 2: The `Assessment` constructor is hard to use**
One common use case for assessment is to return it from a custom scorer
```
@scorer 
def politeness(inputs, outputs)
    return Assessment(
        name="politeness",
        feedback=FeedbackValue(value=True),
        rationale="the answer is polite",
        source=...,
    )
```
However, it is not very clean because we basically combine two different objects into one class - feedback and expectation. They have different nature, for example, `error` is only available for feedback. Reasoning which parameter can be used for which type is a bit of challenge.


**Solution: Introduce `log_assessment` API, and add `Feedback`/`Expectation` classes that subclasses `Assessment`.**
To overcome the problem 1, this PR introduces `mlflow.log_assessment(trace_id, assessment` API. With this API, users can simply log whatever assessment they've got like:

```
mlflow.log_assessment(trace_id, judge.correctness(inputs="...", outputs="..."))
```

Subsequently, we need to make the construction of assessment easy. Then to address problem 2, this PR introduces two subclasses of `Assessment` - `Feedback` and `Expectation`. Using these two classes, users can construct assessments with the desired type, without reasoning which parameters to use.

```
@scorer 
def politeness(inputs, outputs)
    return Feedback(
        name="politeness",
        value=True,
        rationale="the answer is polite",
        source=...,
    )
```

**Backward compatibility**
With the addition of `mlflow.log_assessment` API, we want to remove the `log_feedback` and `log_expectation` APIs. However, they are used inside agent eval harness, so we cannot remove it right away. The other `update_assessment` and `delete_assessment` is safe to remove.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests (-> test with agent eval)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
