### PR TITLE
Fix langchain model serving

### DIFF
--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -215,6 +215,7 @@ def process_api_requests(
     callback_handlers: Optional[list[BaseCallbackHandler]] = None,
     convert_chat_responses: bool = False,
     params: Optional[dict[str, Any]] = None,
+    context: Optional[Context] = None,
 ):
     """
     Processes API requests in parallel.
@@ -224,6 +225,7 @@ def process_api_requests(
     retry_queue = queue.Queue()
     status_tracker = StatusTracker()  # single instance to track a collection of variables
     next_request = None  # variable to hold the next request to call
+    context = context or get_prediction_context()
 
     results = []
     errors = {}
@@ -256,7 +258,7 @@ def process_api_requests(
                     convert_chat_responses=convert_chat_responses,
                     did_perform_chat_conversion=did_perform_chat_conversion,
                     stream=False,
-                    prediction_context=get_prediction_context(),
+                    prediction_context=context,
                     params=params,
                 )
                 status_tracker.start_task()

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -94,7 +94,7 @@ class InferenceTableSpanExporter(SpanExporter):
                     #   populated in the scoring server by Agent Framework. If the model is not
                     #   deployed via agents.deploy(), the env var will not be set and the
                     #   experiment will be empty, even if the dual write itself is enabled.
-                    _logger.debug(
+                    _logger.warning(
                         "Dual write to MLflow backend is enabled, but experiment ID is not set "
                         "for the trace. Skipping trace export to MLflow backend."
                     )
@@ -110,7 +110,10 @@ class InferenceTableSpanExporter(SpanExporter):
                         )
                     )
                 except Exception as e:
-                    _logger.warning("Failed to export trace to MLflow backend. Error: %s", e)
+                    _logger.warning(
+                        f"Failed to export trace to MLflow backend. Error: {e}",
+                        stack_info=_logger.isEnabledFor(logging.DEBUG),
+                    )
 
     def _log_trace_to_mlflow_backend(self, trace: Trace):
         try:
@@ -120,3 +123,6 @@ class InferenceTableSpanExporter(SpanExporter):
 
         returned_trace_info = self._client.start_trace_v3(trace)
         self._client._upload_trace_data(returned_trace_info, trace.data)
+        _logger.debug(
+            f"Finished logging trace to MLflow backend. TraceInfo: {returned_trace_info.to_dict()} "
+        )

--- a/tests/langchain/sample_code/workflow.py
+++ b/tests/langchain/sample_code/workflow.py
@@ -1,0 +1,123 @@
+import json
+import os
+from typing import Any, Optional, Sequence, Union
+
+from langchain_core.language_models import LanguageModelLike
+from langchain_core.messages import AIMessage, ToolCall
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langchain_core.runnables import RunnableConfig, RunnableLambda
+from langchain_core.tools import BaseTool, tool
+from langchain_openai import ChatOpenAI
+from langgraph.graph import END, StateGraph
+from langgraph.graph.graph import CompiledGraph
+from langgraph.prebuilt import ToolNode
+
+import mlflow
+from mlflow.langchain.chat_agent_langgraph import (
+    ChatAgentState,
+    ChatAgentToolNode,
+)
+
+os.environ["OPENAI_API_KEY"] = "test"
+
+
+class FakeOpenAI(ChatOpenAI, extra="allow"):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._responses = iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[ToolCall(name="uc_tool_format", args={}, id="123")],
+                ),
+                AIMessage(
+                    content="",
+                    tool_calls=[ToolCall(name="lc_tool_format", args={}, id="456")],
+                ),
+                AIMessage(content="Successfully generated", id="789"),
+            ]
+        )
+
+    def _generate(self, *args, **kwargs):
+        return ChatResult(generations=[ChatGeneration(message=next(self._responses))])
+
+
+@tool
+def uc_tool_format() -> str:
+    """Returns uc tool format"""
+    return json.dumps(
+        {
+            "format": "SCALAR",
+            "value": '{"content":"hi","attachments":{"a":"b"},"custom_outputs":{"c":"d"}}',
+            "truncated": False,
+        }
+    )
+
+
+@tool
+def lc_tool_format() -> dict[str, Any]:
+    """Returns lc tool format"""
+    nums = [1, 2]
+    return {
+        "content": f"Successfully generated array of 2 random ints: {nums}.",
+        "attachments": {"key1": "attach1", "key2": "attach2"},
+        "custom_outputs": {"random_nums": nums},
+    }
+
+
+tools = [uc_tool_format, lc_tool_format]
+
+
+def create_tool_calling_agent(
+    model: LanguageModelLike,
+    tools: Union[ToolNode, Sequence[BaseTool]],
+    agent_prompt: Optional[str] = None,
+) -> CompiledGraph:
+    model = model.bind_tools(tools)
+
+    def should_continue(state: ChatAgentState):
+        messages = state["messages"]
+        last_message = messages[-1]
+        # If there are function calls, continue. else, end
+        if last_message.get("tool_calls"):
+            return "continue"
+        else:
+            return "end"
+
+    preprocessor = RunnableLambda(lambda state: state["messages"])
+    model_runnable = preprocessor | model
+
+    @mlflow.trace
+    def call_model(
+        state: ChatAgentState,
+        config: RunnableConfig,
+    ):
+        response = model_runnable.invoke(state, config)
+
+        return {"messages": [response]}
+
+    workflow = StateGraph(ChatAgentState)
+
+    workflow.add_node("agent", RunnableLambda(call_model))
+    workflow.add_node("tools", ChatAgentToolNode(tools))
+
+    workflow.set_entry_point("agent")
+    workflow.add_conditional_edges(
+        "agent",
+        should_continue,
+        {
+            "continue": "tools",
+            "end": END,
+        },
+    )
+    workflow.add_edge("tools", "agent")
+
+    return workflow.compile()
+
+
+mlflow.langchain.autolog()
+llm = FakeOpenAI()
+graph = create_tool_calling_agent(llm, tools)
+
+mlflow.models.set_model(graph)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15726?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15726/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15726/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15726/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix langchain model in databricks serving
1. context is passed through MLflowLangchainTracer in databricks serving, while we didn't use the context inside the tracer in process_api_requests but trying to get one from the current context, which doesn't exist. This PR fixes this issue by passing the context in the tracer to the API request.
2. In serving, inference_table span processor is used, updated the trace request_metadata to include modelId if there's an active model in the current context --> so when the trace is exported to mlflow backend the traces can be linked to the LoggedModel
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
