### PR TITLE
Fix the termination behavior of AsyncTraceExportQueue

### DIFF
--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -52,6 +52,7 @@ jobs:
         # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job
         #     to avoid overlooking unnecessary dependencies in the core tracing package.
         run: |
+          export PYTHONPATH=$(pwd)
           pytest tests/tracing --ignore tests/tracing/utils/test_otlp.py --import-mode=importlib
 
   # TODO: Add a job to run autologging tests against integrated libraries (latest versions)

--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -52,7 +52,6 @@ jobs:
         # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job
         #     to avoid overlooking unnecessary dependencies in the core tracing package.
         run: |
-          pytest tests/tracing/export/test_async_export_queue.py::test_async_queue_complete_task_process_finished
           pytest tests/tracing --ignore tests/tracing/utils/test_otlp.py --import-mode=importlib
 
   # TODO: Add a job to run autologging tests against integrated libraries (latest versions)

--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -52,6 +52,7 @@ jobs:
         # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job
         #     to avoid overlooking unnecessary dependencies in the core tracing package.
         run: |
+          pytest tests/tracing/export/test_async_export_queue.py::test_async_queue_complete_task_process_finished
           pytest tests/tracing --ignore tests/tracing/utils/test_otlp.py --import-mode=importlib
 
   # TODO: Add a job to run autologging tests against integrated libraries (latest versions)

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -107,8 +107,17 @@ class AsyncTraceExportQueue:
             task.handle()
             self._queue.task_done()
 
-        future = self._worker_threadpool.submit(_handle, task)
-        self._active_tasks.add(future)
+        try:
+            future = self._worker_threadpool.submit(_handle, task)
+            self._active_tasks.add(future)
+        except Exception as e:
+            # In case it fails to submit the task to the worker thread pool
+            # such as interpreter shutdown, handle the task in this thread
+            _logger.debug(
+                f"Failed to submit task to worker thread pool. Error: {e}",
+                exc_info=True,
+            )
+            _handle(task)
 
     def activate(self) -> None:
         """Activate the async queue to accept and handle incoming tasks."""

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -110,7 +110,7 @@ class AsyncTraceExportQueue:
         try:
             future = self._worker_threadpool.submit(_handle, task)
             self._active_tasks.add(future)
-        except Exception as e:
+        except RuntimeError as e:
             # In case it fails to submit the task to the worker thread pool
             # such as interpreter shutdown, handle the task in this thread
             _logger.debug(

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -1,7 +1,6 @@
 import atexit
 import logging
 import threading
-import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from queue import Empty, Queue
@@ -110,7 +109,7 @@ class AsyncTraceExportQueue:
         try:
             future = self._worker_threadpool.submit(_handle, task)
             self._active_tasks.add(future)
-        except RuntimeError as e:
+        except Exception as e:
             # In case it fails to submit the task to the worker thread pool
             # such as interpreter shutdown, handle the task in this thread
             _logger.debug(

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -1,6 +1,7 @@
 import atexit
 import logging
 import threading
+import time
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from queue import Empty, Queue

--- a/tests/tracing/export/test_async_export_queue.py
+++ b/tests/tracing/export/test_async_export_queue.py
@@ -12,12 +12,12 @@ def test_async_queue_handle_tasks():
 
     counter = 0
 
-    def _increment(delta):
+    def increment(delta):
         nonlocal counter
         counter += delta
 
     for _ in range(10):
-        task = Task(handler=_increment, args=(1,))
+        task = Task(handler=increment, args=(1,))
         queue.put(task)
 
     queue.flush(terminate=True)
@@ -29,13 +29,13 @@ def exporter_process(counter):
 
     queue = AsyncTraceExportQueue()
 
-    def _increment(counter):
+    def increment(counter):
         time.sleep(1)
         with counter.get_lock():
             counter.value += 1
 
     for _ in range(10):
-        task = Task(handler=_increment, args=(counter,))
+        task = Task(handler=increment, args=(counter,))
         queue.put(task)
 
 
@@ -52,7 +52,7 @@ def test_async_queue_complete_task_process_finished():
 def test_async_queue_activate_thread_safe(mock_atexit):
     queue = AsyncTraceExportQueue()
 
-    def _count_threads():
+    def count_threads():
         main_thread = threading.main_thread()
         return sum(
             t.is_alive()
@@ -66,14 +66,14 @@ def test_async_queue_activate_thread_safe(mock_atexit):
             executor.submit(queue.activate)
 
     assert queue.is_active()
-    assert _count_threads() > 0  # Logging thread + max 5 worker threads
+    assert count_threads() > 0  # Logging thread + max 5 worker threads
     mock_atexit.assert_called_once()
     mock_atexit.reset_mock()
 
     # 2. Validate flush (continue)
     queue.flush(terminate=False)
     assert queue.is_active()
-    assert _count_threads() > 0  # New threads should be created
+    assert count_threads() > 0  # New threads should be created
     mock_atexit.assert_not_called()  # Exit callback should not be registered again
 
     # 3. Validate flush with termination
@@ -82,7 +82,7 @@ def test_async_queue_activate_thread_safe(mock_atexit):
             executor.submit(queue.flush(terminate=True))
 
     assert not queue.is_active()
-    assert _count_threads() == 0
+    assert count_threads() == 0
 
 
 def test_async_queue_drop_task_when_full(monkeypatch):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15728?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15728/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15728/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15728/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR fixes the bahavior of AsyncTraceExportQueue at process termination. There was an issue that the trace publishing does not finish forever due to `cannot schedule new futures after shutdown` when the main process completes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
