### PR TITLE
Rename `mlflow.evaluate` to `mlflow.models.evaluate` and show warnings in databricks

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -237,7 +237,7 @@ if not IS_TRACING_SDK_ONLY:
         set_system_metrics_samples_before_logging,
         set_system_metrics_sampling_interval,
     )
-    from mlflow.models import evaluate
+    from mlflow.models.evaluation.deprecated import evaluate
     from mlflow.models.evaluation.validation import validate_evaluation_results
     from mlflow.projects import run
     from mlflow.tracking._model_registry.fluent import (

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -285,7 +285,7 @@ def evaluate(
             logger.info("Annotating predict_fn with tracing since it is not already traced.")
             predict_fn = mlflow.trace(predict_fn)
 
-    result = mlflow.evaluate(
+    result = mlflow.models.evaluate(
         # Wrap the prediction function to unwrap the inputs dictionary into keyword arguments.
         model=(lambda request: predict_fn(**request)) if predict_fn else None,
         data=data,
@@ -293,6 +293,7 @@ def evaluate(
         extra_metrics=extra_metrics,
         model_type=GENAI_CONFIG_NAME,
         model_id=model_id,
+        _called_from_genai_evaluate=True,
     )
 
     return EvaluationResult(

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -7,6 +7,7 @@ import pathlib
 import signal
 import urllib
 import urllib.parse
+import warnings
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
@@ -1589,10 +1590,11 @@ def evaluate(  # noqa: D417
     from mlflow.utils import env_manager as _EnvManager
 
     if not _called_from_genai_evaluate and model_type == "databricks-agent":
-        _logger.warning(
+        warnings.warn(
             "The 'databricks-agent' model type is deprecated in MLflow 3.0.0. For "
             "evaluating LLMs and GenAI applications, please migrate to the new "
-            "`mlflow.genai.evaluate` API."
+            "`mlflow.genai.evaluate` API.",
+            FutureWarning,
         )
 
     # Inference params are currently only supported for passing a deployment endpoint as the model.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1590,8 +1590,9 @@ def evaluate(  # noqa: D417
 
     if not _called_from_genai_evaluate and model_type == "databricks-agent":
         _logger.warning(
-            "'databricks-agent' model type is deprecated in MLflow 3.0.0. Please use the "
-            "new `mlflow.genai.evaluate` API to evaluate LLMs and GenAI applications.",
+            "The 'databricks-agent' model type is deprecated in MLflow 3.0.0. For "
+            "evaluating LLMs and GenAI applications, please migrate to the new "
+            "`mlflow.genai.evaluate` API."
         )
 
     # Inference params are currently only supported for passing a deployment endpoint as the model.

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -7,6 +7,7 @@ import pathlib
 import signal
 import urllib
 import urllib.parse
+import warnings
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
@@ -1108,6 +1109,7 @@ def evaluate(  # noqa: D417
     model_config=None,
     inference_params=None,
     model_id=None,
+    _called_from_genai_evaluate=False,
 ):
     '''
     Evaluate the model performance on given data and selected metrics.
@@ -1577,6 +1579,8 @@ def evaluate(  # noqa: D417
                   evaluation results (e.g. metrics and traces) will be linked. If `model_id` is not
                   specified but `model` is specified, the ID from `model` will be used.
 
+        _called_from_genai_evaluate: (Optional) Only used internally.
+
     Returns:
         An :py:class:`mlflow.models.EvaluationResult` instance containing
         metrics of evaluating the model with the given dataset.
@@ -1584,6 +1588,13 @@ def evaluate(  # noqa: D417
     from mlflow.models.evaluation.evaluator_registry import _model_evaluation_registry
     from mlflow.pyfunc import PyFuncModel, _load_model_or_server, _ServedPyFuncModel
     from mlflow.utils import env_manager as _EnvManager
+
+    if not _called_from_genai_evaluate and model_type == "databricks-agent":
+        warnings.warn(
+            "'databricks-agent' model type is deprecated in MLflow 3.0.0. Please use the "
+            "new `mlflow.genai.evaluate` API to evaluate LLMs and GenAI applications.",
+            DeprecationWarning,
+        )
 
     # Inference params are currently only supported for passing a deployment endpoint as the model.
     # TODO: We should support inference_params for other model types

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -7,7 +7,6 @@ import pathlib
 import signal
 import urllib
 import urllib.parse
-import warnings
 from abc import ABCMeta, abstractmethod
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
@@ -1590,10 +1589,9 @@ def evaluate(  # noqa: D417
     from mlflow.utils import env_manager as _EnvManager
 
     if not _called_from_genai_evaluate and model_type == "databricks-agent":
-        warnings.warn(
+        _logger.warning(
             "'databricks-agent' model type is deprecated in MLflow 3.0.0. Please use the "
             "new `mlflow.genai.evaluate` API to evaluate LLMs and GenAI applications.",
-            DeprecationWarning,
         )
 
     # Inference params are currently only supported for passing a deployment endpoint as the model.

--- a/mlflow/models/evaluation/deprecated.py
+++ b/mlflow/models/evaluation/deprecated.py
@@ -13,14 +13,12 @@ def evaluate(*args, **kwargs):
     tracking_uri = mlflow.get_tracking_uri()
     if is_databricks_uri(tracking_uri):
         _logger.warning(
-            "The `mlflow.evaluate` API is deprecated in MLflow 3.0.0. MLflow provides "
-            "new API for evaluating your models or applications.\n"
-            " - To evaluate traditional ML or deep learning models, please use "
-            "    `mlflow.models.evaluate` instead. It is 100% compatible with the old "
-            "    `mlflow.evaluate` API.\n"
-            " - To evaluate LLMs or GenAI applications, please use the new "
-            "    `mlflow.genai.evaluate` API. It provides more powerful features and "
-            "    easy interface for evaluating LLMs and GenAI applications.",
-            DeprecationWarning,
+            "The `mlflow.evaluate` API has been deprecated as of MLflow 3.0.0. "
+            "Please use these improved alternatives:\n\n"
+            " - For traditional ML or deep learning models: Use `mlflow.models.evaluate`, "
+            "which maintains full compatibility with the original `mlflow.evaluate` API.\n\n"
+            " - For LLMs or GenAI applications: Use the new `mlflow.genai.evaluate` API, "
+            "which offers enhanced features specifically designed for evaluating "
+            "LLMs and GenAI applications.\n",
         )
     return model_evaluate(*args, **kwargs)

--- a/mlflow/models/evaluation/deprecated.py
+++ b/mlflow/models/evaluation/deprecated.py
@@ -1,0 +1,24 @@
+import functools
+import warnings
+
+import mlflow
+from mlflow.models.evaluation import evaluate as model_evaluate
+from mlflow.utils.uri import is_databricks_uri
+
+
+@functools.wraps(model_evaluate)
+def evaluate(*args, **kwargs):
+    tracking_uri = mlflow.get_tracking_uri()
+    if is_databricks_uri(tracking_uri):
+        warnings.warn(
+            "The `mlflow.evaluate` API is deprecated in MLflow 3.0.0. MLflow provides "
+            "new API for evaluating your models or applications."
+            " - To evaluate traditional ML or deep learning models, please use "
+            "    `mlflow.models.evaluate` instead. It is 100% compatible with the old "
+            "    `mlflow.evaluate` API."
+            " - To evaluate LLMs or GenAI applications, please use the new "
+            "    `mlflow.genai.evaluate` API. It provides more powerful features and "
+            "    easy interface for evaluating LLMs and GenAI applications.",
+            DeprecationWarning,
+        )
+    return model_evaluate(*args, **kwargs)

--- a/mlflow/models/evaluation/deprecated.py
+++ b/mlflow/models/evaluation/deprecated.py
@@ -1,24 +1,23 @@
 import functools
-import logging
+import warnings
 
 import mlflow
 from mlflow.models.evaluation import evaluate as model_evaluate
 from mlflow.utils.uri import is_databricks_uri
-
-_logger = logging.getLogger(__name__)
 
 
 @functools.wraps(model_evaluate)
 def evaluate(*args, **kwargs):
     tracking_uri = mlflow.get_tracking_uri()
     if is_databricks_uri(tracking_uri):
-        _logger.warning(
+        warnings.warn(
             "The `mlflow.evaluate` API has been deprecated as of MLflow 3.0.0. "
-            "Please use these improved alternatives:\n\n"
+            "Please use these new alternatives:\n\n"
             " - For traditional ML or deep learning models: Use `mlflow.models.evaluate`, "
             "which maintains full compatibility with the original `mlflow.evaluate` API.\n\n"
             " - For LLMs or GenAI applications: Use the new `mlflow.genai.evaluate` API, "
             "which offers enhanced features specifically designed for evaluating "
             "LLMs and GenAI applications.\n",
+            FutureWarning,
         )
     return model_evaluate(*args, **kwargs)

--- a/mlflow/models/evaluation/deprecated.py
+++ b/mlflow/models/evaluation/deprecated.py
@@ -1,21 +1,23 @@
 import functools
-import warnings
+import logging
 
 import mlflow
 from mlflow.models.evaluation import evaluate as model_evaluate
 from mlflow.utils.uri import is_databricks_uri
+
+_logger = logging.getLogger(__name__)
 
 
 @functools.wraps(model_evaluate)
 def evaluate(*args, **kwargs):
     tracking_uri = mlflow.get_tracking_uri()
     if is_databricks_uri(tracking_uri):
-        warnings.warn(
+        _logger.warning(
             "The `mlflow.evaluate` API is deprecated in MLflow 3.0.0. MLflow provides "
-            "new API for evaluating your models or applications."
+            "new API for evaluating your models or applications.\n"
             " - To evaluate traditional ML or deep learning models, please use "
             "    `mlflow.models.evaluate` instead. It is 100% compatible with the old "
-            "    `mlflow.evaluate` API."
+            "    `mlflow.evaluate` API.\n"
             " - To evaluate LLMs or GenAI applications, please use the new "
             "    `mlflow.genai.evaluate` API. It provides more powerful features and "
             "    easy interface for evaluating LLMs and GenAI applications.",

--- a/tests/evaluate/test_deprecated.py
+++ b/tests/evaluate/test_deprecated.py
@@ -30,7 +30,7 @@ def test_global_evaluate_deprecation(mock_logger, tracking_uri):
     if tracking_uri.startswith("databricks"):
         mock_logger.warning.assert_called_once()
         assert mock_logger.warning.call_args[0][0].startswith(
-            "The `mlflow.evaluate` API is deprecated"
+            "The `mlflow.evaluate` API has been deprecated"
         )
     else:
         mock_logger.warning.assert_not_called()

--- a/tests/evaluate/test_deprecated.py
+++ b/tests/evaluate/test_deprecated.py
@@ -1,0 +1,66 @@
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+import mlflow
+
+
+@pytest.fixture(params=["databricks", "local"])
+def tracking_uri(request):
+    if request.param == "databricks":
+        uri = "databricks"
+        with patch("mlflow.get_tracking_uri", return_value=uri):
+            yield uri
+    else:
+        uri = "sqlite://"
+        with patch("mlflow.get_tracking_uri", return_value=uri):
+            yield uri
+
+
+@patch("mlflow.models.evaluation.deprecated.warnings")
+def test_global_evaluate_deprecation(mock_warnings, tracking_uri):
+    data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+    # Issue a warning when mlflow.evaluate is used in Databricks
+    mlflow.evaluate(
+        data=data,
+        model=lambda x: x["x"] * 2,
+        extra_metrics=[mlflow.metrics.latency()],
+    )
+    if tracking_uri.startswith("databricks"):
+        mock_warnings.warn.assert_called_once()
+        assert mock_warnings.warn.call_args[0][0].startswith(
+            "The `mlflow.evaluate` API is deprecated"
+        )
+    else:
+        mock_warnings.assert_not_called()
+    mock_warnings.reset_mock()
+
+    # No warning when mlflow.models.evaluate is used
+    mlflow.models.evaluate(
+        data=data,
+        model=lambda x: x["x"] * 2,
+        extra_metrics=[mlflow.metrics.latency()],
+    )
+    mock_warnings.assert_not_called()
+
+
+def test_databricks_agent_evaluate_deprecation():
+    data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
+
+    # Warning should be shown when "databricks-agent" model type is used
+    with (
+        patch("mlflow.models.evaluation.base.warnings") as mock_warnings,
+        patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
+    ):
+        mlflow.models.evaluate(
+            data=data,
+            model=lambda x: x["x"] * 2,
+            model_type="databricks-agent",
+            extra_metrics=[mlflow.metrics.latency()],
+        )
+    mock_warnings.warn.assert_called_once()
+    assert mock_warnings.warn.call_args[0][0].startswith(
+        "'databricks-agent' model type is deprecated"
+    )
+    mock_evaluate_impl.assert_called_once()

--- a/tests/evaluate/test_deprecated.py
+++ b/tests/evaluate/test_deprecated.py
@@ -18,8 +18,8 @@ def tracking_uri(request):
             yield uri
 
 
-@patch("mlflow.models.evaluation.deprecated.warnings")
-def test_global_evaluate_deprecation(mock_warnings, tracking_uri):
+@patch("mlflow.models.evaluation.deprecated._logger")
+def test_global_evaluate_deprecation(mock_logger, tracking_uri):
     data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     # Issue a warning when mlflow.evaluate is used in Databricks
     mlflow.evaluate(
@@ -28,13 +28,13 @@ def test_global_evaluate_deprecation(mock_warnings, tracking_uri):
         extra_metrics=[mlflow.metrics.latency()],
     )
     if tracking_uri.startswith("databricks"):
-        mock_warnings.warn.assert_called_once()
-        assert mock_warnings.warn.call_args[0][0].startswith(
+        mock_logger.warning.assert_called_once()
+        assert mock_logger.warning.call_args[0][0].startswith(
             "The `mlflow.evaluate` API is deprecated"
         )
     else:
-        mock_warnings.assert_not_called()
-    mock_warnings.reset_mock()
+        mock_logger.warning.assert_not_called()
+    mock_logger.reset_mock()
 
     # No warning when mlflow.models.evaluate is used
     mlflow.models.evaluate(
@@ -42,4 +42,4 @@ def test_global_evaluate_deprecation(mock_warnings, tracking_uri):
         model=lambda x: x["x"] * 2,
         extra_metrics=[mlflow.metrics.latency()],
     )
-    mock_warnings.assert_not_called()
+    mock_logger.warning.assert_not_called()

--- a/tests/evaluate/test_deprecated.py
+++ b/tests/evaluate/test_deprecated.py
@@ -1,3 +1,5 @@
+import warnings
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pandas as pd
@@ -8,42 +10,39 @@ import mlflow
 _TEST_DATA = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
 
 
-@pytest.fixture
-def mock_warnings():
-    with patch("mlflow.models.evaluation.deprecated.warnings") as mock_warnings:
-        yield mock_warnings
-
-
-def test_global_evaluate_warn_in_databricks(mock_warnings):
+def test_global_evaluate_warn_in_databricks():
     with patch("mlflow.get_tracking_uri", return_value="databricks"):
+        with pytest.warns(FutureWarning, match="The `mlflow.evaluate` API has been deprecated"):
+            mlflow.evaluate(
+                data=_TEST_DATA,
+                model=lambda x: x["x"] * 2,
+                extra_metrics=[mlflow.metrics.latency()],
+            )
+
+
+@contextmanager
+def no_future_warning():
+    with warnings.catch_warnings():
+        # Translate future warning into an exception
+        warnings.simplefilter("error", FutureWarning)
+        yield
+
+
+def test_global_evaluate_does_not_warn_outside_databricks():
+    with no_future_warning():
         mlflow.evaluate(
             data=_TEST_DATA,
             model=lambda x: x["x"] * 2,
             extra_metrics=[mlflow.metrics.latency()],
         )
 
-    mock_warnings.warn.assert_called_once()
-    assert mock_warnings.warn.call_args[0][0].startswith(
-        "The `mlflow.evaluate` API has been deprecated"
-    )
-
-
-def test_global_evaluate_does_not_warn_outside_databricks(mock_warnings):
-    mlflow.evaluate(
-        data=_TEST_DATA,
-        model=lambda x: x["x"] * 2,
-        extra_metrics=[mlflow.metrics.latency()],
-    )
-    mock_warnings.warn.assert_not_called()
-
 
 @pytest.mark.parametrize("tracking_uri", ["databricks", "sqlite://"])
-def test_models_evaluate_does_not_warn(tracking_uri, mock_warnings):
+def test_models_evaluate_does_not_warn(tracking_uri):
     with patch("mlflow.get_tracking_uri", return_value=tracking_uri):
-        mlflow.models.evaluate(
-            data=_TEST_DATA,
-            model=lambda x: x["x"] * 2,
-            extra_metrics=[mlflow.metrics.latency()],
-        )
-
-    mock_warnings.warn.assert_not_called()
+        with no_future_warning():
+            mlflow.models.evaluate(
+                data=_TEST_DATA,
+                model=lambda x: x["x"] * 2,
+                extra_metrics=[mlflow.metrics.latency()],
+            )

--- a/tests/evaluate/test_deprecated.py
+++ b/tests/evaluate/test_deprecated.py
@@ -18,8 +18,8 @@ def tracking_uri(request):
             yield uri
 
 
-@patch("mlflow.models.evaluation.deprecated._logger")
-def test_global_evaluate_deprecation(mock_logger, tracking_uri):
+@patch("mlflow.models.evaluation.deprecated.warnings")
+def test_global_evaluate_deprecation(mock_warnings, tracking_uri):
     data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     # Issue a warning when mlflow.evaluate is used in Databricks
     mlflow.evaluate(
@@ -28,13 +28,13 @@ def test_global_evaluate_deprecation(mock_logger, tracking_uri):
         extra_metrics=[mlflow.metrics.latency()],
     )
     if tracking_uri.startswith("databricks"):
-        mock_logger.warning.assert_called_once()
-        assert mock_logger.warning.call_args[0][0].startswith(
+        mock_warnings.warn.assert_called_once()
+        assert mock_warnings.warn.call_args[0][0].startswith(
             "The `mlflow.evaluate` API has been deprecated"
         )
     else:
-        mock_logger.warning.assert_not_called()
-    mock_logger.reset_mock()
+        mock_warnings.warn.assert_not_called()
+    mock_warnings.reset_mock()
 
     # No warning when mlflow.models.evaluate is used
     mlflow.models.evaluate(
@@ -42,4 +42,4 @@ def test_global_evaluate_deprecation(mock_logger, tracking_uri):
         model=lambda x: x["x"] * 2,
         extra_metrics=[mlflow.metrics.latency()],
     )
-    mock_logger.warning.assert_not_called()
+    mock_warnings.warning.assert_not_called()

--- a/tests/evaluate/test_deprecated.py
+++ b/tests/evaluate/test_deprecated.py
@@ -43,24 +43,3 @@ def test_global_evaluate_deprecation(mock_warnings, tracking_uri):
         extra_metrics=[mlflow.metrics.latency()],
     )
     mock_warnings.assert_not_called()
-
-
-def test_databricks_agent_evaluate_deprecation():
-    data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
-
-    # Warning should be shown when "databricks-agent" model type is used
-    with (
-        patch("mlflow.models.evaluation.base.warnings") as mock_warnings,
-        patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
-    ):
-        mlflow.models.evaluate(
-            data=data,
-            model=lambda x: x["x"] * 2,
-            model_type="databricks-agent",
-            extra_metrics=[mlflow.metrics.latency()],
-        )
-    mock_warnings.warn.assert_called_once()
-    assert mock_warnings.warn.call_args[0][0].startswith(
-        "'databricks-agent' model type is deprecated"
-    )
-    mock_evaluate_impl.assert_called_once()

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1,3 +1,4 @@
+import warnings
 from importlib import import_module
 from unittest import mock
 from unittest.mock import patch
@@ -285,15 +286,15 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
     with (
         patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True),
         patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
-        patch("mlflow.models.evaluation.base.warnings") as mock_warnings,
+        warnings.catch_warnings(),
     ):
+        warnings.simplefilter("error", FutureWarning)
         mlflow.genai.evaluate(
-            data=[{"inputs": "Hello", "outputs": "Hi"}],
-            scorers=[groundedness()],
+            data=[{"inputs": {"question": "Hello"}, "outputs": "Hi"}],
+            scorers=[safety()],
         )
 
     mock_evaluate_impl.assert_called_once()
-    mock_warnings.warn.assert_not_called()
 
     # Warning should be shown when "databricks-agent" model type is used with direct call
     data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -264,6 +264,7 @@ def test_evaluate_passes_model_id_to_mlflow_evaluate():
             model_type="databricks-agent",
             extra_metrics=[],
             model_id="test_model_id",
+            _called_from_genai_evaluate=True,
         )
 
 

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -285,7 +285,7 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
     with (
         patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True),
         patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
-        patch("mlflow.models.evaluation.deprecated.warnings") as mock_warnings,
+        patch("mlflow.models.evaluation.deprecated._logger") as mock_logger,
     ):
         mlflow.genai.evaluate(
             data=[{"inputs": "Hello", "outputs": "Hi"}],
@@ -293,12 +293,12 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
         )
 
     mock_evaluate_impl.assert_called_once()
-    mock_warnings.assert_not_called()
+    mock_logger.warning.assert_not_called()
 
     # Warning should be shown when "databricks-agent" model type is used with direct call
     data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     with (
-        patch("mlflow.models.evaluation.base.warnings") as mock_warnings,
+        patch("mlflow.models.evaluation.base._logger") as mock_logger,
         patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
     ):
         mlflow.models.evaluate(
@@ -307,8 +307,8 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
             model_type="databricks-agent",
             extra_metrics=[mlflow.metrics.latency()],
         )
-    mock_warnings.warn.assert_called_once()
-    assert mock_warnings.warn.call_args[0][0].startswith(
+    mock_logger.warning.assert_called_once()
+    assert mock_logger.warning.call_args[0][0].startswith(
         "'databricks-agent' model type is deprecated"
     )
     mock_evaluate_impl.assert_called_once()

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -274,3 +274,22 @@ def test_no_scorers(mock_get_tracking_uri):
 
     with pytest.raises(MlflowException, match=r"At least one scorer is required"):
         mlflow.genai.evaluate(data=[{"inputs": "Hello", "outputs": "Hi"}], scorers=[])
+
+
+def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
+    """
+    MLflow shows a warning when model_type="databricks-agent" is used for mlflow.evaluate()
+    API. This test verifies that the warning is not shown when mlflow.genai.evaluate() is used.
+    """
+    with (
+        patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True),
+        patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
+        patch("mlflow.models.evaluation.deprecated.warnings") as mock_warnings,
+    ):
+        mlflow.genai.evaluate(
+            data=[{"inputs": "Hello", "outputs": "Hi"}],
+            scorers=[groundedness()],
+        )
+
+    mock_evaluate_impl.assert_called_once()
+    mock_warnings.assert_not_called()

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -285,7 +285,7 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
     with (
         patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True),
         patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
-        patch("mlflow.models.evaluation.deprecated._logger") as mock_logger,
+        patch("mlflow.models.evaluation.base.warnings") as mock_warnings,
     ):
         mlflow.genai.evaluate(
             data=[{"inputs": "Hello", "outputs": "Hi"}],
@@ -293,12 +293,12 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
         )
 
     mock_evaluate_impl.assert_called_once()
-    mock_logger.warning.assert_not_called()
+    mock_warnings.warn.assert_not_called()
 
     # Warning should be shown when "databricks-agent" model type is used with direct call
     data = pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]})
     with (
-        patch("mlflow.models.evaluation.base._logger") as mock_logger,
+        patch("mlflow.models.evaluation.base.warnings") as mock_warnings,
         patch("mlflow.models.evaluation.base._evaluate") as mock_evaluate_impl,
     ):
         mlflow.models.evaluate(
@@ -307,8 +307,8 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
             model_type="databricks-agent",
             extra_metrics=[mlflow.metrics.latency()],
         )
-    mock_logger.warning.assert_called_once()
-    assert mock_logger.warning.call_args[0][0].startswith(
+    mock_warnings.warn.assert_called_once()
+    assert mock_warnings.warn.call_args[0][0].startswith(
         "The 'databricks-agent' model type is deprecated"
     )
     mock_evaluate_impl.assert_called_once()

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -309,6 +309,6 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
         )
     mock_logger.warning.assert_called_once()
     assert mock_logger.warning.call_args[0][0].startswith(
-        "'databricks-agent' model type is deprecated"
+        "The 'databricks-agent' model type is deprecated"
     )
     mock_evaluate_impl.assert_called_once()

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -269,7 +269,7 @@ def test_scorer_receives_correct_data(data_fixture, request):
 
 
 def test_input_is_required_if_trace_is_not_provided():
-    with patch("mlflow.evaluate") as mock_evaluate:
+    with patch("mlflow.models.evaluate") as mock_evaluate:
         with pytest.raises(MlflowException, match="inputs.*required"):
             mlflow.genai.evaluate(
                 data=pd.DataFrame({"outputs": ["Paris"]}),
@@ -294,7 +294,7 @@ def test_input_is_optional_if_trace_is_provided():
 
     trace = mlflow.get_trace(span.trace_id)
 
-    with patch("mlflow.evaluate") as mock_evaluate:
+    with patch("mlflow.models.evaluate") as mock_evaluate:
         mlflow.genai.evaluate(
             data=pd.DataFrame({"trace": [trace]}),
             scorers=[safety()],


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15730?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15730/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15730/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15730/merge
```

</p>
</details>

### What changes are proposed in this pull request?

As discussed offline, we will split `mlflow.evaluate` into two APIs:

1. `mlflow.models.evaluate` for traditional ML/DL
2. `mlflow.genai.evaluate` for GenAI.

The former just works as-is indeed. So this PR introduces a logic to show warning when it is executed via `mlflow.evaluate`. We should show this warning only in Databricks, because `mlflow.genai.evaluate` is not quite ready in OSS yet. With the same reason, this PR doesn't update docs and examples.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
2025/05/14 09:35:38 WARNING mlflow.models.evaluation.deprecated: The `mlflow.evaluate` API has been deprecated as of MLflow 3.0.0. Please use these improved alternatives:

 - For traditional ML or deep learning models: Use `mlflow.models.evaluate`, which maintains full compatibility with the original `mlflow.evaluate` API.

 - For LLMs or GenAI applications: Use the new `mlflow.genai.evaluate` API, which offers enhanced features specifically designed for evaluating LLMs and GenAI applications.
```

```
2025/05/14 09:35:40 WARNING mlflow.models.evaluation.base: 'databricks-agent' model type is deprecated in MLflow 3.0.0. Please use the new `mlflow.genai.evaluate` API to evaluate LLMs and GenAI applications.
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
