### PR TITLE
Support `IN` and `NOT IN` for FileStore.search_logged_models

### DIFF
--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -1891,7 +1891,9 @@ class SearchLoggedModelsUtils(SearchUtils):
 
     @classmethod
     def validate_list_supported(cls, key: str) -> None:
-        pass
+        """
+        Override to allow logged model attributes to be used with IN/NOT IN.
+        """
 
     @classmethod
     def filter_logged_models(cls, models: list[LoggedModel], filter_string: Optional[str] = None):

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -921,6 +921,9 @@ class SearchUtils:
 
     @classmethod
     def _check_valid_identifier_list(cls, tup: tuple[Any, ...]) -> None:
+        """
+        Validate that `tup` is a non-empty tuple of strings.
+        """
         if len(tup) == 0:
             raise MlflowException(
                 "While parsing a list in the query,"

--- a/mlflow/utils/search_utils.py
+++ b/mlflow/utils/search_utils.py
@@ -923,7 +923,7 @@ class SearchUtils:
     def _parse_list_from_sql_token(cls, token):
         try:
             str_or_tuple = ast.literal_eval(token.value)
-            return [str_or_tuple] if isinstance(str_or_tuple, str) else str_or_tuple
+            return (str_or_tuple,) if isinstance(str_or_tuple, str) else str_or_tuple
         except SyntaxError as e:
             raise MlflowException(
                 "While parsing a list in the query,"

--- a/tests/store/tracking/test_file_store_logged_model.py
+++ b/tests/store/tracking/test_file_store_logged_model.py
@@ -532,6 +532,29 @@ def test_search_logged_models_filter_string(store):
     )
     assert_models_match(models, [logged_models[0]])
 
+    model = logged_models[0]
+    for val in (
+        # A single item without a comma
+        f"('{model.name}')",
+        # A single item with a comma
+        f"('{model.name}',)",
+        # Multiple items
+        f"('{model.name}', 'foo')",
+    ):
+        # IN
+        models = store.search_logged_models(
+            experiment_ids=[exp_id],
+            filter_string=f"name IN {val}",
+        )
+        assert [m.name for m in models] == [model.name]
+        assert models.token is None
+        # NOT IN
+        models = store.search_logged_models(
+            experiment_ids=[exp_id],
+            filter_string=f"name NOT IN {val}",
+        )
+        assert model.name not in [m.name for m in models]
+
 
 def test_search_logged_models_order_by(store):
     exp_id = store.create_experiment("test")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15731?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15731/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15731/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15731/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Support `IN` and `NOT IN` for FileStore.search_logged_models.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
