### PR TITLE
Allow passing extra columns to scorer

### DIFF
--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,4 +1,3 @@
-import inspect
 import json
 from typing import TYPE_CHECKING, Any, Optional, Union
 
@@ -225,10 +224,7 @@ def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
             "tool_calls": tool_calls,
             **kwargs,
         }
-        # Filter to only the parameters the scorer actually expects
-        sig = inspect.signature(scorer)
-        filtered = {k: v for k, v in merged.items() if k in sig.parameters}
-        return scorer(**filtered)
+        return scorer.run(**merged)
 
     return metric(
         eval_fn=eval_fn,

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -138,6 +138,7 @@ def _convert_expectations_to_legacy_columns(df: "pd.DataFrame") -> "pd.DataFrame
         # Process each row individually to handle mixed types
         for idx, value in df["expectations"].items():
             if isinstance(value, dict):
+                value = value.copy()
                 # Reserved expectation keys is propagated as a new column
                 for field in AgentEvaluationReserverKey.get_all():
                     if field in value:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -32,9 +32,13 @@ class Scorer(BaseModel):
                 and all(isinstance(item, (Assessment, LegacyAssessment)) for item in result)
             )
         ):
+            if isinstance(result, list) and len(result) > 0:
+                result_type = "list[" + type(result[0]).__name__ + "]"
+            else:
+                result_type = type(result).__name__
             raise ValueError(
                 f"{self.name} must return one of int, float, bool, str, "
-                f"Assessment, or list[Assessment]. Got {type(result).__name__}"
+                f"Assessment, or list[Assessment]. Got {result_type}"
             )
         return result
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -6,11 +6,37 @@ from pydantic import BaseModel
 
 from mlflow.entities import Assessment
 from mlflow.entities.trace import Trace
+from mlflow.evaluation import Assessment as LegacyAssessment
 
 
 class Scorer(BaseModel):
     name: str
     aggregations: Optional[list] = None
+
+    def run(self, *, inputs=None, outputs=None, expectations=None, trace=None, **kwargs):
+        merged = {
+            "inputs": inputs,
+            "outputs": outputs,
+            "expectations": expectations,
+            "trace": trace,
+            **kwargs,
+        }
+        # Filter to only the parameters the function actually expects
+        sig = inspect.signature(self.__call__)
+        filtered = {k: v for k, v in merged.items() if k in sig.parameters}
+        result = self(**filtered)
+        if not (
+            isinstance(result, (int, float, bool, str, Assessment, LegacyAssessment))
+            or (
+                isinstance(result, list)
+                and all(isinstance(item, (Assessment, LegacyAssessment)) for item in result)
+            )
+        ):
+            raise ValueError(
+                f"{self.name} must return one of int, float, bool, str, "
+                f"Assessment, or list[Assessment]. Got {type(result).__name__}"
+            )
+        return result
 
     def __call__(
         self,
@@ -228,30 +254,17 @@ def scorer(
         return functools.partial(scorer, name=name, aggregations=aggregations)
 
     class CustomScorer(Scorer):
-        def __call__(self, *, inputs=None, outputs=None, expectations=None, trace=None, **kwargs):
-            merged = {
-                "inputs": inputs,
-                "outputs": outputs,
-                "expectations": expectations,
-                "trace": trace,
-                **kwargs,
-            }
-            # Filter to only the parameters the function actually expects
-            sig = inspect.signature(func)
-            filtered = {k: v for k, v in merged.items() if k in sig.parameters}
-            result = func(**filtered)
-            if not (
-                isinstance(result, (int, float, bool, str, Assessment))
-                or (
-                    isinstance(result, list)
-                    and all(isinstance(item, Assessment) for item in result)
-                )
-            ):
-                raise ValueError(
-                    f"{func.__name__} must return one of int, float, bool, str, "
-                    f"Assessment, or list[Assessment]. Got {type(result).__name__}"
-                )
-            return result
+        def __call__(self, *args, **kwargs):
+            return func(*args, **kwargs)
+
+    # Update the __call__ method's signature to match the original function
+    # but add 'self' as the first parameter. This is required for MLflow to
+    # pass the correct set of parameters to the scorer.
+    signature = inspect.signature(func)
+    params = list(signature.parameters.values())
+    new_params = [inspect.Parameter("self", inspect.Parameter.POSITIONAL_OR_KEYWORD)] + params
+    new_signature = signature.replace(parameters=new_params)
+    CustomScorer.__call__.__signature__ = new_signature
 
     return CustomScorer(
         name=name or func.__name__,

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -6,7 +6,6 @@ from pydantic import BaseModel
 
 from mlflow.entities import Assessment
 from mlflow.entities.trace import Trace
-from mlflow.evaluation import Assessment as LegacyAssessment
 
 
 class Scorer(BaseModel):
@@ -14,6 +13,8 @@ class Scorer(BaseModel):
     aggregations: Optional[list] = None
 
     def run(self, *, inputs=None, outputs=None, expectations=None, trace=None, **kwargs):
+        from mlflow.evaluation import Assessment as LegacyAssessment
+
         merged = {
             "inputs": inputs,
             "outputs": outputs,

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -24,17 +24,6 @@ def mock_init_auth():
         yield
 
 
-@pytest.fixture(scope="module")
-def spark():
-    try:
-        from pyspark.sql import SparkSession
-
-        with SparkSession.builder.getOrCreate() as spark:
-            yield spark
-    except RuntimeError:
-        pytest.skip("Can't create a Spark session")
-
-
 @pytest.fixture(autouse=True)
 def spoof_tracking_uri_check():
     # NB: The mlflow.genai.evaluate() API is only runnable when the tracking URI is set

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -20,6 +20,17 @@ if importlib.util.find_spec("databricks.agents") is None:
     pytest.skip(reason="databricks-agents is not installed", allow_module_level=True)
 
 
+@pytest.fixture(scope="module")
+def spark():
+    try:
+        from pyspark.sql import SparkSession
+
+        with SparkSession.builder.getOrCreate() as spark:
+            yield spark
+    except RuntimeError:
+        pytest.skip("Can't create a Spark session")
+
+
 @pytest.fixture
 def sample_dict_data_single():
     return [

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -27,8 +27,8 @@ def spark():
 
         with SparkSession.builder.getOrCreate() as spark:
             yield spark
-    except RuntimeError:
-        pytest.skip("Can't create a Spark session")
+    except Exception as e:
+        pytest.skip(f"Failed to create a spark session: {e}")
 
 
 @pytest.fixture

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -1,5 +1,5 @@
-import importlib
 from collections import defaultdict
+import importlib
 from unittest.mock import patch
 
 import pandas as pd
@@ -11,20 +11,11 @@ from mlflow.entities import Assessment
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.genai import Scorer, scorer
-from mlflow.genai.evaluation.utils import _convert_scorer_to_legacy_metric
-from mlflow.models import Model
-from mlflow.models.evaluation.base import _get_model_from_function
-from mlflow.pyfunc import PyFuncModel
 
 if importlib.util.find_spec("databricks.agents") is None:
     pytest.skip(reason="databricks-agents is not installed", allow_module_level=True)
 
 agent_sdk_version = Version(importlib.import_module("databricks.agents").__version__)
-
-
-def mock_init_auth(config_instance):
-    config_instance.host = "https://databricks.com/"
-    config_instance._header_factory = lambda: {}
 
 
 def always_yes(inputs, outputs, expectations, trace):
@@ -38,31 +29,6 @@ class AlwaysYesScorer(Scorer):
 
 @pytest.fixture
 def sample_data():
-    return pd.DataFrame(
-        {
-            "request": [
-                {"message": [{"role": "user", "content": "What is Spark??"}]},
-                {
-                    "messages": [
-                        {"role": "user", "content": "How can you minimize data shuffling in Spark?"}
-                    ]
-                },
-            ],
-            "response": [
-                {"choices": [{"message": {"content": "actual response for first question"}}]},
-                {"choices": [{"message": {"content": "actual response for second question"}}]},
-            ],
-            "expected_response": [
-                "expected response for first question",
-                "expected response for second question",
-            ],
-        }
-    )
-
-
-@pytest.fixture
-def sample_new_data():
-    # sample data for new eval dataset format for mlflow.genai.evaluate()
     return pd.DataFrame(
         {
             "inputs": [
@@ -87,16 +53,7 @@ def sample_new_data():
 
 @pytest.mark.parametrize("dummy_scorer", [AlwaysYesScorer(name="always_yes"), scorer(always_yes)])
 def test_scorer_existence_in_metrics(sample_data, dummy_scorer):
-    legacy_metric = _convert_scorer_to_legacy_metric(dummy_scorer)
-
-    # patch is needed for databricks-agent tests
-    with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        result = mlflow.evaluate(
-            data=sample_data,
-            model_type="databricks-agent",
-            extra_metrics=[legacy_metric],
-        )
-
+    result = mlflow.genai.evaluate(data=sample_data, scorers=[dummy_scorer])
     assert any("always_yes" in metric for metric in result.metrics.keys())
 
 
@@ -105,16 +62,7 @@ def test_scorer_existence_in_metrics(sample_data, dummy_scorer):
 )
 def test_scorer_name_works(sample_data, dummy_scorer):
     _SCORER_NAME = "always_no"
-
-    legacy_metric = _convert_scorer_to_legacy_metric(dummy_scorer)
-
-    with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        result = mlflow.evaluate(
-            data=sample_data,
-            model_type="databricks-agent",
-            extra_metrics=[legacy_metric],
-        )
-
+    result = mlflow.genai.evaluate(data=sample_data, scorers=[dummy_scorer])
     assert any(_SCORER_NAME in metric for metric in result.metrics.keys())
 
 
@@ -132,23 +80,17 @@ def test_scorer_is_called_with_correct_arguments(sample_data):
         )
         return 0.0
 
-    legacy_metric = _convert_scorer_to_legacy_metric(dummy_scorer)
 
-    with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        mlflow.evaluate(
-            data=sample_data,
-            model_type="databricks-agent",
-            extra_metrics=[legacy_metric],
-        )
+    mlflow.genai.evaluate(data=sample_data, scorers=[dummy_scorer])
 
     assert len(actual_call_args_list) == len(sample_data)
 
     # Prepare expected arguments, keyed by expected_response for matching
     sample_data_set = defaultdict(set)
     for i in range(len(sample_data)):
-        sample_data_set["inputs"].add(str(sample_data["request"][i]))
-        sample_data_set["outputs"].add(str(sample_data["response"][i]))
-        sample_data_set["expectations"].add(str(sample_data["expected_response"][i]))
+        sample_data_set["inputs"].add(str(sample_data["inputs"][i]))
+        sample_data_set["outputs"].add(str(sample_data["outputs"][i]))
+        sample_data_set["expectations"].add(str(sample_data["expectations"][i]))
 
     for actual_args in actual_call_args_list:
         # do any check since actual passed input could be reformatted and larger than sample input
@@ -162,15 +104,40 @@ def test_scorer_is_called_with_correct_arguments(sample_data):
         )
 
 
+def test_scorer_receives_extra_arguments():
+    received_args = []
+
+    @scorer
+    def dummy_scorer(inputs, outputs, retrieved_context) -> float:
+        received_args.append((inputs, outputs, retrieved_context))
+        return 0
+
+    mlflow.genai.evaluate(
+        data=[
+            {
+                "inputs": {"question": "What is Spark?"},
+                "outputs": "actual response for first question",
+                "retrieved_context": [{"doc_uri": "document_1", "content": "test"}],
+            },
+        ],
+        scorers=[dummy_scorer],
+    )
+
+    inputs, outputs, retrieved_context = received_args[0]
+    assert inputs == {"question": "What is Spark?"}
+    assert outputs == "actual response for first question"
+    assert retrieved_context == [{"doc_uri": "document_1", "content": "test"}]
+
+
 def test_trace_passed_correctly():
     @mlflow.trace
-    def predict_fn(inputs):
-        return "output: " + str(inputs)
+    def predict_fn(question):
+        return "output: " + str(question)
 
     actual_call_args_list = []
 
     @scorer
-    def dummy_scorer(inputs, outputs, expectations, trace):
+    def dummy_scorer(inputs, outputs, trace):
         actual_call_args_list.append(
             {
                 "inputs": inputs,
@@ -180,29 +147,24 @@ def test_trace_passed_correctly():
         )
         return 0.0
 
-    legacy_metric = _convert_scorer_to_legacy_metric(dummy_scorer)
-
-    pyfunc_model = PyFuncModel(
-        model_meta=Model(),
-        model_impl=_get_model_from_function(predict_fn),
+    data = [
+        {"inputs": {"question": "input1"}},
+        {"inputs": {"question": "input2"}},
+    ]
+    mlflow.genai.evaluate(
+        predict_fn=predict_fn,
+        data=data,
+        scorers=[dummy_scorer],
     )
-
-    data = pd.DataFrame({"request": ["input1", "input2", "input3"]})
-
-    with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        mlflow.evaluate(
-            model=pyfunc_model,
-            data=data,
-            extra_metrics=[legacy_metric],
-            model_type="databricks-agent",
-        )
 
     assert len(actual_call_args_list) == len(data)
     for actual_args in actual_call_args_list:
         assert actual_args["trace"] is not None
         trace = actual_args["trace"]
         # check if the input is present in the trace
-        assert any(str(data["request"][i]) in str(trace.data.request) for i in range(len(data)))
+        assert any(
+            str(data[i]["inputs"]["question"]) in str(trace.data.request) for i in range(len(data))
+        )
         # check if predict_fn was run by making output it starts with "output:"
         assert "output:" in str(trace.data.response)[:10]
 
@@ -239,7 +201,7 @@ def test_trace_passed_correctly():
         ],
     ],
 )
-def test_scorer_on_genai_evaluate(sample_new_data, scorer_return):
+def test_scorer_on_genai_evaluate(sample_data, scorer_return):
     # Skip if `databricks-agents` SDK is not 1.x. It doesn't
     # support the `mlflow.entities.Assessment` type.
     is_return_assessment = isinstance(scorer_return, Assessment) or (
@@ -252,32 +214,31 @@ def test_scorer_on_genai_evaluate(sample_new_data, scorer_return):
     def dummy_scorer(inputs, outputs):
         return scorer_return
 
-    with patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        results = mlflow.genai.evaluate(
-            data=sample_new_data,
-            scorers=[dummy_scorer],
-        )
+    results = mlflow.genai.evaluate(
+        data=sample_data,
+        scorers=[dummy_scorer],
+    )
 
-        assert any("metric/dummy_scorer" in metric for metric in results.metrics.keys())
+    assert any("metric/dummy_scorer" in metric for metric in results.metrics.keys())
 
-        dummy_scorer_cols = [
-            col for col in results.result_df.keys() if "dummy_scorer" in col and "value" in col
-        ]
-        dummy_scorer_values = set()
-        for col in dummy_scorer_cols:
-            for _val in results.result_df[col]:
-                dummy_scorer_values.add(_val)
+    dummy_scorer_cols = [
+        col for col in results.result_df.keys() if "dummy_scorer" in col and "value" in col
+    ]
+    dummy_scorer_values = set()
+    for col in dummy_scorer_cols:
+        for _val in results.result_df[col]:
+            dummy_scorer_values.add(_val)
 
-        scorer_return_values = set()
-        if isinstance(scorer_return, list):
-            for _assessment in scorer_return:
-                scorer_return_values.add(_assessment.feedback.value)
-        elif isinstance(scorer_return, Assessment):
-            scorer_return_values.add(scorer_return.feedback.value)
-        else:
-            scorer_return_values.add(scorer_return)
+    scorer_return_values = set()
+    if isinstance(scorer_return, list):
+        for _assessment in scorer_return:
+            scorer_return_values.add(_assessment.feedback.value)
+    elif isinstance(scorer_return, Assessment):
+        scorer_return_values.add(scorer_return.feedback.value)
+    else:
+        scorer_return_values.add(scorer_return)
 
-        assert dummy_scorer_values == scorer_return_values
+    assert dummy_scorer_values == scorer_return_values
 
 
 def test_builtin_scorers_are_callable():

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -1,5 +1,5 @@
-from collections import defaultdict
 import importlib
+from collections import defaultdict
 from unittest.mock import patch
 
 import pandas as pd
@@ -80,7 +80,6 @@ def test_scorer_is_called_with_correct_arguments(sample_data):
         )
         return 0.0
 
-
     mlflow.genai.evaluate(data=sample_data, scorers=[dummy_scorer])
 
     assert len(actual_call_args_list) == len(sample_data)
@@ -90,7 +89,9 @@ def test_scorer_is_called_with_correct_arguments(sample_data):
     for i in range(len(sample_data)):
         sample_data_set["inputs"].add(str(sample_data["inputs"][i]))
         sample_data_set["outputs"].add(str(sample_data["outputs"][i]))
-        sample_data_set["expectations"].add(str(sample_data["expectations"][i]))
+        sample_data_set["expectations"].add(
+            str(sample_data["expectations"][i]["expected_response"])
+        )
 
     for actual_args in actual_call_args_list:
         # do any check since actual passed input could be reformatted and larger than sample input


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15737?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15737/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15737/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15737/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The custom scorer takes reserved arguments like `inputs`, `outputs`, `expectations`, `trace`, but also additional column defined in the dataset. For example, following scorer can be defined if the input dataset includes `retrieved_context` column.

```
@scorer 
def my_scorer(inputs, outputs, retrieved_context):
    ...
```

However, currently the extra args like `retrieved_context` is not propagated to the custom scorer property, because the inspect check [here](https://github.com/mlflow/mlflow/blob/48aafa952e44582463ae5cd10715081876286d93/mlflow/genai/evaluation/utils.py#L149-L150) actually checks the signature of `CustomScorer` class [here](https://github.com/mlflow/mlflow/blob/48aafa952e44582463ae5cd10715081876286d93/mlflow/genai/scorers/base.py#L220), rather than the underlying scorer function. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
