### PR TITLE
Print a link to a deployment job when connecting it to a registered model

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -88,13 +88,10 @@ from mlflow.utils._unity_catalog_utils import (
     uc_registered_model_tag_from_mlflow_tags,
 )
 from mlflow.utils.databricks_utils import (
-    _construct_databricks_job_url,
+    _print_databricks_deployment_job_url,
     get_databricks_host_creds,
-    get_workspace_id,
-    get_workspace_url,
     is_databricks_uri,
 )
-from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_JOB_ID,
     MLFLOW_DATABRICKS_JOB_RUN_ID,
@@ -362,10 +359,10 @@ class UcModelRegistryStore(BaseRestStore):
         )
         response_proto = self._call_endpoint(CreateRegisteredModelRequest, req_body)
         if deployment_job_id:
-            job_url = _construct_databricks_job_url(
-                get_workspace_url(), str(deployment_job_id), get_workspace_id()
+            _print_databricks_deployment_job_url(
+                model_name=full_name,
+                job_id=str(deployment_job_id),
             )
-            eprint(f"🔗 Linked deployment job to '{full_name}': {job_url}")
         return registered_model_from_uc_proto(response_proto.registered_model)
 
     def update_registered_model(self, name, description, deployment_job_id=None):
@@ -388,10 +385,10 @@ class UcModelRegistryStore(BaseRestStore):
         )
         response_proto = self._call_endpoint(UpdateRegisteredModelRequest, req_body)
         if deployment_job_id:
-            job_url = _construct_databricks_job_url(
-                get_workspace_url(), str(deployment_job_id), get_workspace_id()
+            _print_databricks_deployment_job_url(
+                model_name=full_name,
+                job_id=str(deployment_job_id),
             )
-            eprint(f"🔗 Linked deployment job to '{full_name}': {job_url}")
         return registered_model_from_uc_proto(response_proto.registered_model)
 
     def rename_registered_model(self, name, new_name):

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -90,6 +90,8 @@ from mlflow.utils._unity_catalog_utils import (
 from mlflow.utils.databricks_utils import (
     _construct_databricks_job_url,
     get_databricks_host_creds,
+    get_workspace_id,
+    get_workspace_url,
     is_databricks_uri,
 )
 from mlflow.utils.logging_utils import eprint
@@ -360,10 +362,10 @@ class UcModelRegistryStore(BaseRestStore):
         )
         response_proto = self._call_endpoint(CreateRegisteredModelRequest, req_body)
         if deployment_job_id:
-            eprint(
-                f"🔗 Linked deployment job to '{full_name}': "
-                f"{_construct_databricks_job_url(str(deployment_job_id))}"
+            job_url = _construct_databricks_job_url(
+                get_workspace_url(), str(deployment_job_id), get_workspace_id()
             )
+            eprint(f"🔗 Linked deployment job to '{full_name}': {job_url}")
         return registered_model_from_uc_proto(response_proto.registered_model)
 
     def update_registered_model(self, name, description, deployment_job_id=None):
@@ -386,10 +388,10 @@ class UcModelRegistryStore(BaseRestStore):
         )
         response_proto = self._call_endpoint(UpdateRegisteredModelRequest, req_body)
         if deployment_job_id:
-            eprint(
-                f"🔗 Linked deployment job to '{full_name}': "
-                f"{_construct_databricks_job_url(str(deployment_job_id))}"
+            job_url = _construct_databricks_job_url(
+                get_workspace_url(), str(deployment_job_id), get_workspace_id()
             )
+            eprint(f"🔗 Linked deployment job to '{full_name}': {job_url}")
         return registered_model_from_uc_proto(response_proto.registered_model)
 
     def rename_registered_model(self, name, new_name):

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -87,7 +87,12 @@ from mlflow.utils._unity_catalog_utils import (
     uc_model_version_tag_from_mlflow_tags,
     uc_registered_model_tag_from_mlflow_tags,
 )
-from mlflow.utils.databricks_utils import get_databricks_host_creds, is_databricks_uri
+from mlflow.utils.databricks_utils import (
+    _construct_databricks_job_url,
+    get_databricks_host_creds,
+    is_databricks_uri,
+)
+from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_JOB_ID,
     MLFLOW_DATABRICKS_JOB_RUN_ID,
@@ -354,6 +359,11 @@ class UcModelRegistryStore(BaseRestStore):
             )
         )
         response_proto = self._call_endpoint(CreateRegisteredModelRequest, req_body)
+        if deployment_job_id:
+            eprint(
+                f"🔗 Linked deployment job to '{full_name}': "
+                f"{_construct_databricks_job_url(str(deployment_job_id))}"
+            )
         return registered_model_from_uc_proto(response_proto.registered_model)
 
     def update_registered_model(self, name, description, deployment_job_id=None):
@@ -375,6 +385,11 @@ class UcModelRegistryStore(BaseRestStore):
             )
         )
         response_proto = self._call_endpoint(UpdateRegisteredModelRequest, req_body)
+        if deployment_job_id:
+            eprint(
+                f"🔗 Linked deployment job to '{full_name}': "
+                f"{_construct_databricks_job_url(str(deployment_job_id))}"
+            )
         return registered_model_from_uc_proto(response_proto.registered_model)
 
     def rename_registered_model(self, name, new_name):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -9,6 +9,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, NamedTuple, Optional, TypeVar
 
+from mlflow.utils.logging_utils import eprint
+
 if TYPE_CHECKING:
     from pyspark.sql.connect.session import SparkSession as SparkConnectSession
 
@@ -1109,11 +1111,24 @@ def _construct_databricks_uc_registered_model_url(
     return f"{workspace_url}/explore/data/models/{path}/version/{version}{query}"
 
 
-def _construct_databricks_job_url(
-    workspace_url: str, job_id: str, workspace_id: Optional[str] = None
+def _print_databricks_deployment_job_url(
+    model_name: str,
+    job_id: str,
+    workspace_url: Optional[str] = None,
+    workspace_id: Optional[str] = None,
 ) -> str:
+    if not workspace_url:
+        workspace_url = get_workspace_url()
+    if not workspace_id:
+        workspace_id = get_workspace_id()
+    # If there is no workspace_url, we cannot print the job URL
+    if not workspace_url:
+        return None
+
     query = f"?o={workspace_id}" if (workspace_id and workspace_id != "0") else ""
-    return f"{workspace_url}/jobs/{job_id}{query}"
+    job_url = f"{workspace_url}/jobs/{job_id}{query}"
+    eprint(f"🔗 Linked deployment job to '{model_name}': {job_url}")
+    return job_url
 
 
 def _get_databricks_creds_config(tracking_uri):

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1109,6 +1109,13 @@ def _construct_databricks_uc_registered_model_url(
     return f"{workspace_url}/explore/data/models/{path}/version/{version}{query}"
 
 
+def _construct_databricks_job_url(
+    workspace_url: str, job_id: str, workspace_id: Optional[str] = None
+) -> str:
+    query = f"?o={workspace_id}" if (workspace_id and workspace_id != "0") else ""
+    return f"{workspace_url}/jobs/{job_id}{query}"
+
+
 def _get_databricks_creds_config(tracking_uri):
     # Note:
     # `_get_databricks_creds_config` reads credential token values or password and

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -2070,10 +2070,10 @@ def test_store_use_presigned_url_store_when_enabled(monkeypatch):
 
 
 @mock_http_200
-def test_create_and_update_registered_model_print_job_url(store):
+def test_create_and_update_registered_model_print_job_url(mock_http, store):
     name = "model_for_job_url_test"
     description = "test model with job id"
-    deployment_job_id = "job-123"
+    deployment_job_id = "123"
 
     with (
         mock.patch(
@@ -2081,20 +2081,22 @@ def test_create_and_update_registered_model_print_job_url(store):
         ) as mock_print_url,
     ):
         # Should not print the job url when the deployment job id is None
-        store.update_registered_model(name=name, description=description, deployment_job_id=None)
+        store.create_registered_model(name=name, description=description, deployment_job_id=None)
+        store.create_registered_model(name=name, description=description, deployment_job_id="")
         mock_print_url.assert_not_called()
         # Should print the job url when the deployment job id is not None
-        store.update_registered_model(
+        store.create_registered_model(
             name=name, description=description, deployment_job_id=deployment_job_id
         )
         mock_print_url.assert_called_once_with(model_name=name, job_id=deployment_job_id)
         mock_print_url.reset_mock()
 
-        # Should not print the job url when the deployment job id is None
-        store.create_registered_model(name=name, description=description, deployment_job_id=None)
+        # Should not print the job url when the deployment job id is false-y
+        store.update_registered_model(name=name, description=description, deployment_job_id=None)
+        store.update_registered_model(name=name, description=description, deployment_job_id="")
         mock_print_url.assert_not_called()
         # Should print the job url when the deployment job id is not None
-        store.create_registered_model(
+        store.update_registered_model(
             name=name, description=description, deployment_job_id=deployment_job_id
         )
         mock_print_url.assert_called_once_with(model_name=name, job_id=deployment_job_id)

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -668,27 +668,30 @@ def test_print_databricks_deployment_job_url():
     job_id = "123"
     workspace_id = "456"
 
-    expected_url = "https://databricks.com/jobs/123?o=456"
+    expected_url_no_workspace = "https://databricks.com/jobs/123"
+    expected_url = f"{expected_url_no_workspace}?o=456"
     model_name = "main.models.name"
 
     with (
         mock.patch("mlflow.utils.databricks_utils.eprint") as mock_eprint,
         mock.patch("mlflow.utils.databricks_utils.get_workspace_url", return_value=workspace_url),
-        mock.patch("mlflow.utils.databricks_utils.get_workspace_id", return_value=workspace_id),
     ):
-        result = databricks_utils._print_databricks_deployment_job_url(
-            model_name=model_name,
-            job_id=job_id,
-        )
+        # Test case with a workspace ID
+        with mock.patch(
+            "mlflow.utils.databricks_utils.get_workspace_id", return_value=workspace_id
+        ):
+            result = databricks_utils._print_databricks_deployment_job_url(
+                model_name=model_name,
+                job_id=job_id,
+            )
 
-        assert result == expected_url
-        mock_eprint.assert_called_once_with(
-            f"🔗 Linked deployment job to '{model_name}': {expected_url}"
-        )
-        mock_eprint.reset_mock()
+            assert result == expected_url
+            mock_eprint.assert_called_once_with(
+                f"🔗 Linked deployment job to '{model_name}': {expected_url}"
+            )
+            mock_eprint.reset_mock()
 
-        # Test case without workspace ID
-        expected_url_no_workspace = "https://databricks.com/jobs/123"
+        # Test case without a workspace ID
         with mock.patch("mlflow.utils.databricks_utils.get_workspace_id", return_value=None):
             result_no_workspace = databricks_utils._print_databricks_deployment_job_url(
                 model_name=model_name,
@@ -699,4 +702,3 @@ def test_print_databricks_deployment_job_url():
             mock_eprint.assert_called_once_with(
                 f"🔗 Linked deployment job to '{model_name}': {expected_url_no_workspace}"
             )
-            mock_eprint.reset_mock()

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -661,3 +661,30 @@ def test_construct_databricks_logged_model_url():
     )
 
     assert result_no_workspace == expected_url_no_workspace
+
+
+def test_construct_databricks_job_url():
+    # Test case with workspace ID
+    workspace_url = "https://databricks.com"
+    job_id = "123"
+    workspace_id = "456"
+
+    expected_url = "https://databricks.com/jobs/123?o=456"
+
+    result = databricks_utils._construct_databricks_job_url(
+        workspace_url=workspace_url,
+        job_id=job_id,
+        workspace_id=workspace_id,
+    )
+
+    assert result == expected_url
+
+    # Test case without workspace ID
+    expected_url_no_workspace = "https://databricks.com/jobs/123"
+
+    result_no_workspace = databricks_utils._construct_databricks_job_url(
+        workspace_url=workspace_url,
+        job_id=job_id,
+    )
+
+    assert result_no_workspace == expected_url_no_workspace

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -663,28 +663,40 @@ def test_construct_databricks_logged_model_url():
     assert result_no_workspace == expected_url_no_workspace
 
 
-def test_construct_databricks_job_url():
-    # Test case with workspace ID
+def test_print_databricks_deployment_job_url():
     workspace_url = "https://databricks.com"
     job_id = "123"
     workspace_id = "456"
 
     expected_url = "https://databricks.com/jobs/123?o=456"
+    model_name = "main.models.name"
 
-    result = databricks_utils._construct_databricks_job_url(
-        workspace_url=workspace_url,
-        job_id=job_id,
-        workspace_id=workspace_id,
-    )
+    with (
+        mock.patch("mlflow.utils.databricks_utils.eprint") as mock_eprint,
+        mock.patch("mlflow.utils.databricks_utils.get_workspace_url", return_value=workspace_url),
+        mock.patch("mlflow.utils.databricks_utils.get_workspace_id", return_value=workspace_id),
+    ):
+        result = databricks_utils._print_databricks_deployment_job_url(
+            model_name=model_name,
+            job_id=job_id,
+        )
 
-    assert result == expected_url
+        assert result == expected_url
+        mock_eprint.assert_called_once_with(
+            f"🔗 Linked deployment job to '{model_name}': {expected_url}"
+        )
+        mock_eprint.reset_mock()
 
-    # Test case without workspace ID
-    expected_url_no_workspace = "https://databricks.com/jobs/123"
+        # Test case without workspace ID
+        expected_url_no_workspace = "https://databricks.com/jobs/123"
+        with mock.patch("mlflow.utils.databricks_utils.get_workspace_id", return_value=None):
+            result_no_workspace = databricks_utils._print_databricks_deployment_job_url(
+                model_name=model_name,
+                job_id=job_id,
+            )
 
-    result_no_workspace = databricks_utils._construct_databricks_job_url(
-        workspace_url=workspace_url,
-        job_id=job_id,
-    )
-
-    assert result_no_workspace == expected_url_no_workspace
+            assert result_no_workspace == expected_url_no_workspace
+            mock_eprint.assert_called_once_with(
+                f"🔗 Linked deployment job to '{model_name}': {expected_url_no_workspace}"
+            )
+            mock_eprint.reset_mock()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ShaylanDias/mlflow/pull/15742?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15742/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15742/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15742/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Prints a link to a deployment job when adding it to a registered model.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

#### No link when not specifying a deployment job:
<img width="684" alt="Screenshot 2025-05-14 at 5 20 04 PM" src="https://github.com/user-attachments/assets/1a38f216-0c1d-4a90-ba19-b1e8af30ed05" />
<img width="597" alt="Screenshot 2025-05-14 at 5 20 17 PM" src="https://github.com/user-attachments/assets/e92df174-6011-4851-bfa8-5f0e0502bf78" />
<img width="598" alt="Screenshot 2025-05-14 at 5 21 26 PM" src="https://github.com/user-attachments/assets/97aab3f3-6598-49c7-a83d-5fea646c0082" />
<img width="1244" alt="Screenshot 2025-05-14 at 7 15 24 PM" src="https://github.com/user-attachments/assets/2e45e592-ee5d-4d33-9940-925fceba6db7" />


#### Link is printed when a deployment job ID is provided:
<img width="1219" alt="Screenshot 2025-05-14 at 7 11 59 PM" src="https://github.com/user-attachments/assets/70340b85-6876-4299-93fc-da48363158bf" />
<img width="1226" alt="Screenshot 2025-05-14 at 7 14 46 PM" src="https://github.com/user-attachments/assets/9e8b443b-7057-4a7e-87d3-fa35ecf39c70" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Adds a link to the deployment job in the output when creating or updating a registered model with a deployment job.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
