### PR TITLE
Tracing destinations: Add validation for case where neither experiment ID nor experiment name specified

### DIFF
--- a/tests/tracing/test_destination.py
+++ b/tests/tracing/test_destination.py
@@ -1,23 +1,96 @@
+from unittest import mock
+
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.destination import Databricks
+from mlflow.tracing.destination import Databricks, MlflowExperiment
+
+
+def test_set_destination_mlflow_experiment():
+    # With experiment_id
+    destination = MlflowExperiment(experiment_id="123")
+    assert destination.type == "experiment"
+    assert destination.experiment_id == "123"
+    assert destination.experiment_name is None
+    assert destination.tracking_uri is None
+
+    # With numeric experiment_id (should be converted to string)
+    destination = MlflowExperiment(experiment_id=123)
+    assert destination.experiment_id == "123"
+
+    # With experiment_name
+    destination = MlflowExperiment(experiment_name="Default")
+    assert destination.experiment_name == "Default"
+    assert destination.experiment_id == "0"
+
+    # With both experiment_name and matching experiment_id
+    destination = MlflowExperiment(experiment_name="Default", experiment_id="0")
+    assert destination.experiment_id == "0"
+    assert destination.experiment_name == "Default"
+
+    # With tracking_uri
+    destination = MlflowExperiment(experiment_id="123", tracking_uri="http://localhost:5000")
+    assert destination.tracking_uri == "http://localhost:5000"
+
+    # Should use active experiment when neither experiment_id nor name is provided
+    destination = MlflowExperiment()
+    assert destination.experiment_id is not None
+
+    # With mismatched experiment_id and experiment_name
+    with pytest.raises(
+        MlflowException,
+        match=r"experiment_id and experiment_name must refer to the same experiment",
+    ):
+        MlflowExperiment(experiment_name="Default", experiment_id="123")
+
+    # Test when no experiment_id/name is provided and no active experiment
+    with mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value=None):
+        with pytest.raises(
+            MlflowException,
+            match=r"No experiment_id or experiment_name provided and no active experiment found",
+        ):
+            MlflowExperiment()
 
 
 def test_set_destination_databricks():
+    # With experiment_id
     destination = Databricks(experiment_id="123")
     assert destination.type == "databricks"
     assert destination.experiment_id == "123"
 
+    # With numeric experiment_id (should be converted to string)
     destination = Databricks(experiment_id=123)
     assert destination.experiment_id == "123"
 
+    # With experiment_name
     destination = Databricks(experiment_name="Default")
     assert destination.experiment_name == "Default"
     assert destination.experiment_id == "0"
 
+    # With both experiment_name and matching experiment_id
     destination = Databricks(experiment_name="Default", experiment_id="0")
     assert destination.experiment_id == "0"
+    assert destination.experiment_name == "Default"
 
-    with pytest.raises(MlflowException, match=r"experiment_id and experiment_name must"):
+    # With tracking_uri (inherited from MlflowExperiment)
+    destination = Databricks(experiment_id="123", tracking_uri="http://localhost:5000")
+    assert destination.tracking_uri == "http://localhost:5000"
+
+    # Should use active experiment when neither experiment_id nor name is provided
+    destination = Databricks()
+    assert destination.experiment_id is not None
+
+    # With mismatched experiment_id and experiment_name
+    with pytest.raises(
+        MlflowException,
+        match=r"experiment_id and experiment_name must refer to the same experiment",
+    ):
         Databricks(experiment_name="Default", experiment_id="123")
+
+    # Test when no experiment_id/name is provided and no active experiment
+    with mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value=None):
+        with pytest.raises(
+            MlflowException,
+            match=r"No experiment_id or experiment_name provided and no active experiment found",
+        ):
+            Databricks()


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Tracing destinations: Add validation for case where neither experiment ID nor experiment name specified

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
