### PR TITLE
Only print out logged model URL when workspace URL is available

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -952,10 +952,14 @@ class Model:
                     else None,
                 )
                 if MLFLOW_PRINT_MODEL_URLS_ON_CREATION.get() and is_databricks_uri(tracking_uri):
-                    logged_model_url = _construct_databricks_logged_model_url(
-                        get_workspace_url(), model.experiment_id, model.model_id, get_workspace_id()
-                    )
-                    eprint(f"🔗 View Logged Model at: {logged_model_url}")
+                    if workspace_url := get_workspace_url():
+                        logged_model_url = _construct_databricks_logged_model_url(
+                            workspace_url,
+                            model.experiment_id,
+                            model.model_id,
+                            get_workspace_id(),
+                        )
+                        eprint(f"🔗 View Logged Model at: {logged_model_url}")
 
             with _use_logged_model(model=model):
                 if run_id is not None:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -951,15 +951,18 @@ class Model:
                     if tags is not None
                     else None,
                 )
-                if MLFLOW_PRINT_MODEL_URLS_ON_CREATION.get() and is_databricks_uri(tracking_uri):
-                    if workspace_url := get_workspace_url():
-                        logged_model_url = _construct_databricks_logged_model_url(
-                            workspace_url,
-                            model.experiment_id,
-                            model.model_id,
-                            get_workspace_id(),
-                        )
-                        eprint(f"🔗 View Logged Model at: {logged_model_url}")
+                if (
+                    MLFLOW_PRINT_MODEL_URLS_ON_CREATION.get()
+                    and is_databricks_uri(tracking_uri)
+                    and (workspace_url := get_workspace_url())
+                ):
+                    logged_model_url = _construct_databricks_logged_model_url(
+                        workspace_url,
+                        model.experiment_id,
+                        model.model_id,
+                        get_workspace_id(),
+                    )
+                    eprint(f"🔗 View Logged Model at: {logged_model_url}")
 
             with _use_logged_model(model=model):
                 if run_id is not None:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15747?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15747/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15747/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15747/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This code:

```python
import mlflow


mlflow.set_tracking_uri("databricks")
mlflow.set_experiment("/Users/harutaka.kawamura@databricks.com/test-test")
params = {f"p_{i}": i for i in range(300)}
mlflow.sklearn.log_model({"fake_model": 1}, name="test_model", params=params)
```

prints out on my machine, not on Databricks:

```
🔗 View Logged Model at: None/ml/experiments/73303758146083/models/m-62cc8eaa646e458697916c9f4f00dfb4
                         ^^^^^
```

This PR should fix it.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
