### PR TITLE
Increase default number of threads for trace span downloads during search

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -794,4 +794,6 @@ MLFLOW_PRINT_MODEL_URLS_ON_CREATION = _BooleanEnvironmentVariable(
 #: If unspecified the number of threads (at least 32) is determined by the available
 #: number of CPU cores.
 #: (default: ``None``)
-MLFLOW_TRACE_SEARCH_MAX_THREADS = _EnvironmentVariable("MLFLOW_TRACE_SEARCH_MAX_THREADS", int, None)
+MLFLOW_SEARCH_TRACES_MAX_THREADS = _EnvironmentVariable(
+    "MLFLOW_SEARCH_TRACES_MAX_THREADS", int, None
+)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -793,5 +793,9 @@ MLFLOW_PRINT_MODEL_URLS_ON_CREATION = _BooleanEnvironmentVariable(
 #: Maximum number of threads to use when downloading traces during search operations.
 #: (default: ``max(32, (# of system CPUs * 4)``)
 MLFLOW_SEARCH_TRACES_MAX_THREADS = _EnvironmentVariable(
-    "MLFLOW_SEARCH_TRACES_MAX_THREADS", int, max(32, (os.cpu_count() or 1) * 4)
+    # Threads used to download traces during search are network IO-bound (waiting for downloads)
+    # rather than CPU-bound, so we want more threads than CPU cores
+    "MLFLOW_SEARCH_TRACES_MAX_THREADS",
+    int,
+    max(32, (os.cpu_count() or 1) * 4),
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -789,3 +789,9 @@ _MLFLOW_LOG_LOGGED_MODEL_PARAMS_BATCH_SIZE = _EnvironmentVariable(
 MLFLOW_PRINT_MODEL_URLS_ON_CREATION = _BooleanEnvironmentVariable(
     "MLFLOW_PRINT_MODEL_URLS_ON_CREATION", True
 )
+
+#: Maximum number of threads to use when downloading traces during search operations.
+#: If unspecified the number of threads (at least 32) is determined by the available
+#: number of CPU cores.
+#: (default: ``None``)
+MLFLOW_TRACE_SEARCH_MAX_THREADS = _EnvironmentVariable("MLFLOW_TRACE_SEARCH_MAX_THREADS", int, None)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -791,9 +791,7 @@ MLFLOW_PRINT_MODEL_URLS_ON_CREATION = _BooleanEnvironmentVariable(
 )
 
 #: Maximum number of threads to use when downloading traces during search operations.
-#: If unspecified the number of threads (at least 32) is determined by the available
-#: number of CPU cores.
-#: (default: ``None``)
+#: (default: ``max(32, (# of system CPUs * 4)``)
 MLFLOW_SEARCH_TRACES_MAX_THREADS = _EnvironmentVariable(
-    "MLFLOW_SEARCH_TRACES_MAX_THREADS", int, None
+    "MLFLOW_SEARCH_TRACES_MAX_THREADS", int, max(32, (os.cpu_count() or 1) * 4)
 )

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -346,7 +346,12 @@ class TracingClient:
                     trace_data = TraceData.from_dict(json.loads(trace_data))
                 else:
                     # For offline traces, download data from artifact storage
+                    import time
+
+                    start = time.time()
                     trace_data = self._download_trace_data(trace_info)
+                    end = time.time()
+                    print("DOWNLOAD TIME", end - start)
             except MlflowTraceDataException as e:
                 _logger.warning(
                     (
@@ -363,10 +368,11 @@ class TracingClient:
         next_max_results = max_results
         next_token = page_token
 
-        # Use minimum of 16 threads or 4x CPU count (whichever is larger)
+        # Use minimum of 32 threads or 4x CPU count (whichever is larger)
         # This is important because these threads are network IO-bound (waiting for downloads)
         # rather than CPU-bound, so we want more threads than CPU cores to maximize throughput
-        max_workers = max(16, os.cpu_count() * 4)
+        max_workers = max(32, os.cpu_count() * 4)
+        print(f"Using {max_workers} threads for downloading traces")
         executor = ThreadPoolExecutor(max_workers=max_workers) if include_spans else nullcontext()
         with executor:
             while len(traces) < max_results:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -365,7 +365,7 @@ class TracingClient:
         next_token = page_token
 
         # Get configured max workers from environment variable or use default
-        # Use minimum of 16 threads or 4x CPU count (whichever is larger)
+        # Use minimum of 32 threads or 4x CPU count (whichever is larger)
         # This is important because these threads are network IO-bound (waiting for downloads)
         # rather than CPU-bound, so we want more threads than CPU cores to maximize throughput
         configured_max_workers = MLFLOW_SEARCH_TRACES_MAX_THREADS.get()

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from typing import Any, Optional, Union
@@ -364,16 +363,10 @@ class TracingClient:
         next_max_results = max_results
         next_token = page_token
 
-        # Get configured max workers from environment variable or use default
-        # Use minimum of 32 threads or 4x CPU count (whichever is larger)
-        # This is important because these threads are network IO-bound (waiting for downloads)
-        # rather than CPU-bound, so we want more threads than CPU cores to maximize throughput
-        configured_max_workers = MLFLOW_SEARCH_TRACES_MAX_THREADS.get()
-        max_workers = (
-            configured_max_workers
-            if configured_max_workers is not None
-            else max(32, os.cpu_count() * 4)
-        )
+        # Get max workers from environment variable
+        # These threads are network IO-bound (waiting for downloads)
+        # rather than CPU-bound, so we want more threads than CPU cores
+        max_workers = MLFLOW_SEARCH_TRACES_MAX_THREADS.get()
         executor = ThreadPoolExecutor(max_workers=max_workers) if include_spans else nullcontext()
         with executor:
             while len(traces) < max_results:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -363,9 +363,6 @@ class TracingClient:
         next_max_results = max_results
         next_token = page_token
 
-        # Get max workers from environment variable
-        # These threads are network IO-bound (waiting for downloads)
-        # rather than CPU-bound, so we want more threads than CPU cores
         max_workers = MLFLOW_SEARCH_TRACES_MAX_THREADS.get()
         executor = ThreadPoolExecutor(max_workers=max_workers) if include_spans else nullcontext()
         with executor:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/15750?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15750/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15750/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15750/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Increase default number of threads for trace span downloads during search. Currently, the default number of workers results in suboptimally high latency for `search_traces()` calls that attempt to achieve a large number of traces (e.g. > 100). Adding threads reduces latency substantially (> 1 minute latency for reading 2,000 traces to < 20 seconds on a Databricks classic cluster). This is critical for workflows that export traces to alternative storage (e.g. Delta tables).

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
