### PR TITLE
Fix `test_model_pip_requirements_pin_numpy_when_pandas_included`

### DIFF
--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -2197,6 +2197,8 @@ def test_model_as_code_pycache_cleaned_up():
 def test_model_pip_requirements_pin_numpy_when_pandas_included():
     class TestModel(mlflow.pyfunc.PythonModel):
         def predict(self, context, model_input, params=None):
+            import pandas as pd  # noqa: F401
+
             return model_input
 
     expected_mlflow_version = _mlflow_major_version_string()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15751?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15751/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15751/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15751/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`test_model_pip_requirements_pin_numpy_when_pandas_included` is failing on master:

https://github.com/mlflow/malflow/actions/runs/15037677369/job/42262350020?pr=15746

```
__________ test_model_pip_requirements_pin_numpy_when_pandas_included __________

    def test_model_pip_requirements_pin_numpy_when_pandas_included():
        class TestModel(mlflow.pyfunc.PythonModel):
            def predict(self, context, model_input, params=None):
                return model_input
    
        expected_mlflow_version = _mlflow_major_version_string()
    
        # no numpy when pandas > 2.1.2
        with mlflow.start_run():
            model_info = mlflow.pyfunc.log_model(
                name="model", python_model=TestModel(), input_example="abc"
            )
>           _assert_pip_requirements(
                model_info.model_uri,
                [
                    expected_mlflow_version,
                    f"cloudpickle=={cloudpickle.__version__}",
                    f"pandas=={pandas.__version__}",
                ],
                strict=True,
            )

TestModel  = <class 'tests.pyfunc.test_model_export_with_class_and_artifacts.test_model_pip_requirements_pin_numpy_when_pandas_included.<locals>.TestModel'>
expected_mlflow_version = 'mlflow==3.0.0.dev0'
model_info = <mlflow.models.model.ModelInfo object at 0x7fbb21fa1370>

tests/pyfunc/test_model_export_with_class_and_artifacts.py:2209: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

model_uri = 'models:/m-867f8be974084587834f47fc7a0baae9'
requirements = {'cloudpickle==3.1.1', 'mlflow==3.0.0.dev0', 'pandas==2.2.3'}
constraints = None, strict = True

    def _assert_pip_requirements(model_uri, requirements, constraints=None, strict=False):
        """
        Loads the pip requirements (and optionally constraints) from `model_uri` and compares them
        to `requirements` (and `constraints`).
    
        If `strict` is True, evaluate `set(requirements) == set(loaded_requirements)`.
        Otherwise, evaluate `set(requirements) <= set(loaded_requirements)`.
        """
        from mlflow.utils.environment import (
            _CONDA_ENV_FILE_NAME,
            _CONSTRAINTS_FILE_NAME,
            _REQUIREMENTS_FILE_NAME,
            _get_pip_deps,
        )
        from mlflow.utils.yaml_utils import read_yaml
    
        local_path = _download_artifact_from_uri(model_uri)
        txt_reqs = _read_lines(os.path.join(local_path, _REQUIREMENTS_FILE_NAME))
        conda_reqs = _get_pip_deps(read_yaml(local_path, _CONDA_ENV_FILE_NAME))
        compare_func = set.__eq__ if strict else set.__le__
        requirements = set(requirements)
>       assert compare_func(requirements, set(txt_reqs))
E       AssertionError

_CONDA_ENV_FILE_NAME = 'conda.yaml'
_CONSTRAINTS_FILE_NAME = 'constraints.txt'
_REQUIREMENTS_FILE_NAME = 'requirements.txt'
_get_pip_deps = <function _get_pip_deps at 0x7fbba341b4c0>
compare_func = <slot wrapper '__eq__' of 'set' objects>
conda_reqs = ['mlflow==3.0.0.dev0', 'cloudpickle==3.1.1']
constraints = None
local_path = '/home/runner/work/mlflow/mlflow/mlruns/0/models/m-867f8be974084587834f47fc7a0baae9/artifacts'
model_uri  = 'models:/m-867f8be974084587834f47fc7a0baae9'
read_yaml  = <function read_yaml at 0x7fbbbcadadc0>
requirements = {'cloudpickle==3.1.1', 'mlflow==3.0.0.dev0', 'pandas==2.2.3'}
strict     = True
txt_reqs   = ['mlflow==3.0.0.dev0', 'cloudpickle==3.1.1']
```

Not sure why it started failing but this PR fixes it.


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
