### PR TITLE
Introduce `MLFLOW_LOGGING_LEVEL` environment variable

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -799,3 +799,9 @@ MLFLOW_SEARCH_TRACES_MAX_THREADS = _EnvironmentVariable(
     int,
     max(32, (os.cpu_count() or 1) * 4),
 )
+
+
+#: Specifies the logging level for MLflow. This can be set to any valid logging level
+#: (e.g., "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL").
+#: (default: ``None``).
+MLFLOW_LOGGING_LEVEL = _EnvironmentVariable("MLFLOW_LOGGING_LEVEL", str, None)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -802,6 +802,7 @@ MLFLOW_SEARCH_TRACES_MAX_THREADS = _EnvironmentVariable(
 
 
 #: Specifies the logging level for MLflow. This can be set to any valid logging level
-#: (e.g., "DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL").
+#: (e.g., "DEBUG", "INFO"). This environment must be set before importing mlflow to take
+#: effect. To modify the logging level after importing mlflow, use `importlib.reload(mlflow)`.
 #: (default: ``None``).
 MLFLOW_LOGGING_LEVEL = _EnvironmentVariable("MLFLOW_LOGGING_LEVEL", str, None)

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -159,3 +159,10 @@ def suppress_logs(module: str, filter_regex: re.Pattern):
         yield
     finally:
         logger.removeFilter(filter)
+
+
+def _debug(s: str) -> None:
+    """
+    Debug function to test logging level.
+    """
+    logging.getLogger(__name__).debug(s)

--- a/mlflow/utils/logging_utils.py
+++ b/mlflow/utils/logging_utils.py
@@ -4,6 +4,8 @@ import logging.config
 import re
 import sys
 
+from mlflow.environment_variables import MLFLOW_LOGGING_LEVEL
+
 # Logging format example:
 # 2018/11/20 12:36:37 INFO mlflow.sagemaker: Creating new SageMaker endpoint
 LOGGING_LINE_FORMAT = "%(asctime)s %(levelname)s %(name)s: %(message)s"
@@ -119,7 +121,7 @@ def _configure_mlflow_loggers(root_module_name):
             "loggers": {
                 root_module_name: {
                     "handlers": ["mlflow_handler"],
-                    "level": "INFO",
+                    "level": (MLFLOW_LOGGING_LEVEL.get() or "INFO").upper(),
                     "propagate": False,
                 },
             },

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -10,6 +10,7 @@ import pytest
     [
         ("DEBUG", True),
         ("INFO", False),
+        ("NOTSET", False),
     ],
 )
 def test_logging_level(log_level: str, expected: bool) -> None:

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,9 +1,9 @@
 import logging
+import os
 import re
 import subprocess
 import sys
 import uuid
-import os
 from io import StringIO
 
 import pytest

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,129 +1,28 @@
-import logging
-import re
+import subprocess
 import sys
-from io import StringIO
+import uuid
 
 import pytest
 
-import mlflow
-from mlflow.utils import logging_utils
-from mlflow.utils.logging_utils import eprint, suppress_logs
 
-logger = logging.getLogger(mlflow.__name__)
+@pytest.mark.parametrize(
+    ("log_level", "expected"),
+    [
+        ("DEBUG", True),
+        ("INFO", False),
+    ],
+)
+def test_logging_level(log_level: str, expected: bool) -> None:
+    random_str = str(uuid.uuid4())
+    stdout = subprocess.check_output(
+        [
+            sys.executable,
+            "-c",
+            f"from mlflow.utils.logging_utils import _debug; _debug({random_str!r})",
+        ],
+        env={"MLFLOW_LOGGING_LEVEL": log_level},
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
 
-LOGGING_FNS_TO_TEST = [logger.info, logger.warning, logger.critical, eprint]
-
-
-@pytest.fixture(autouse=True)
-def reset_stderr():
-    prev_stderr = sys.stderr
-    yield
-    sys.stderr = prev_stderr
-
-
-@pytest.fixture(autouse=True)
-def reset_logging_enablement():
-    yield
-    logging_utils.enable_logging()
-
-
-@pytest.fixture(autouse=True)
-def reset_logging_level():
-    level_before = logger.level
-    yield
-    logger.setLevel(level_before)
-
-
-class SampleStream:
-    def __init__(self):
-        self.content = None
-        self.flush_count = 0
-
-    def write(self, text):
-        self.content = (self.content or "") + text
-
-    def flush(self):
-        self.flush_count += 1
-
-    def reset(self):
-        self.content = None
-        self.flush_count = 0
-
-
-@pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
-def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
-    stream1 = SampleStream()
-    stream2 = SampleStream()
-    message_content = "test message"
-
-    sys.stderr = stream1
-    assert stream1.content is None
-    logging_fn(message_content)
-    assert message_content in stream1.content
-    assert stream2.content is None
-    stream1.reset()
-
-    sys.stderr = stream2
-    assert stream2.content is None
-    logging_fn(message_content)
-    assert message_content in stream2.content
-    assert stream1.content is None
-
-
-@pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
-def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
-    stream = SampleStream()
-    sys.stderr = stream
-    message_content = "test message"
-
-    assert stream.content is None
-    logging_fn(message_content)
-    assert message_content in stream.content
-    stream.reset()
-
-    logging_utils.disable_logging()
-    logging_fn(message_content)
-    assert stream.content is None
-    stream.reset()
-
-    logging_utils.enable_logging()
-    assert stream.content is None
-    logging_fn(message_content)
-    assert message_content in stream.content
-
-
-def test_event_logging_stream_flushes_properly():
-    stream = SampleStream()
-    sys.stderr = stream
-
-    eprint("foo", flush=True)
-    assert "foo" in stream.content
-    assert stream.flush_count > 0
-
-
-def test_debug_logs_emitted_correctly_when_configured():
-    stream = SampleStream()
-    sys.stderr = stream
-
-    logger.setLevel(logging.DEBUG)
-    logger.debug("test debug")
-    assert "test debug" in stream.content
-
-
-def test_suppress_logs():
-    module = "test_logger"
-    logger = logging.getLogger(module)
-
-    message = "This message should be suppressed."
-
-    capture_stream = StringIO()
-    stream_handler = logging.StreamHandler(capture_stream)
-    logger.addHandler(stream_handler)
-
-    logger.error(message)
-    assert message in capture_stream.getvalue()
-
-    capture_stream.truncate(0)
-    with suppress_logs(module, re.compile("This .* be suppressed.")):
-        logger.error(message)
-    assert len(capture_stream.getvalue()) == 0
+    assert (random_str in stdout) is expected

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -1,8 +1,134 @@
+import logging
+import re
 import subprocess
 import sys
 import uuid
+from io import StringIO
 
 import pytest
+
+import mlflow
+from mlflow.utils import logging_utils
+from mlflow.utils.logging_utils import eprint, suppress_logs
+
+logger = logging.getLogger(mlflow.__name__)
+
+LOGGING_FNS_TO_TEST = [logger.info, logger.warning, logger.critical, eprint]
+
+
+@pytest.fixture(autouse=True)
+def reset_stderr():
+    prev_stderr = sys.stderr
+    yield
+    sys.stderr = prev_stderr
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_enablement():
+    yield
+    logging_utils.enable_logging()
+
+
+@pytest.fixture(autouse=True)
+def reset_logging_level():
+    level_before = logger.level
+    yield
+    logger.setLevel(level_before)
+
+
+class SampleStream:
+    def __init__(self):
+        self.content = None
+        self.flush_count = 0
+
+    def write(self, text):
+        self.content = (self.content or "") + text
+
+    def flush(self):
+        self.flush_count += 1
+
+    def reset(self):
+        self.content = None
+        self.flush_count = 0
+
+
+@pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
+def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
+    stream1 = SampleStream()
+    stream2 = SampleStream()
+    message_content = "test message"
+
+    sys.stderr = stream1
+    assert stream1.content is None
+    logging_fn(message_content)
+    assert message_content in stream1.content
+    assert stream2.content is None
+    stream1.reset()
+
+    sys.stderr = stream2
+    assert stream2.content is None
+    logging_fn(message_content)
+    assert message_content in stream2.content
+    assert stream1.content is None
+
+
+@pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
+def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
+    stream = SampleStream()
+    sys.stderr = stream
+    message_content = "test message"
+
+    assert stream.content is None
+    logging_fn(message_content)
+    assert message_content in stream.content
+    stream.reset()
+
+    logging_utils.disable_logging()
+    logging_fn(message_content)
+    assert stream.content is None
+    stream.reset()
+
+    logging_utils.enable_logging()
+    assert stream.content is None
+    logging_fn(message_content)
+    assert message_content in stream.content
+
+
+def test_event_logging_stream_flushes_properly():
+    stream = SampleStream()
+    sys.stderr = stream
+
+    eprint("foo", flush=True)
+    assert "foo" in stream.content
+    assert stream.flush_count > 0
+
+
+def test_debug_logs_emitted_correctly_when_configured():
+    stream = SampleStream()
+    sys.stderr = stream
+
+    logger.setLevel(logging.DEBUG)
+    logger.debug("test debug")
+    assert "test debug" in stream.content
+
+
+def test_suppress_logs():
+    module = "test_logger"
+    logger = logging.getLogger(module)
+
+    message = "This message should be suppressed."
+
+    capture_stream = StringIO()
+    stream_handler = logging.StreamHandler(capture_stream)
+    logger.addHandler(stream_handler)
+
+    logger.error(message)
+    assert message in capture_stream.getvalue()
+
+    capture_stream.truncate(0)
+    with suppress_logs(module, re.compile("This .* be suppressed.")):
+        logger.error(message)
+    assert len(capture_stream.getvalue()) == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 import sys
 import uuid
+import os
 from io import StringIO
 
 import pytest
@@ -147,7 +148,7 @@ def test_logging_level(log_level: str, expected: bool) -> None:
             "-c",
             f"from mlflow.utils.logging_utils import _debug; _debug({random_str!r})",
         ],
-        env={"MLFLOW_LOGGING_LEVEL": log_level},
+        env=os.environ.copy() | {"MLFLOW_LOGGING_LEVEL": log_level},
         stderr=subprocess.STDOUT,
         text=True,
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15756?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15756/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15756/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15756/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Introduce `MLFLOW_LOGGING_LEVEL` environment variable to set the logging level with an environment variable. Useful when you need to debug mlflow in environments such as model serving.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
