### PR TITLE
Show more helpful warnings for invalid dataset/predict_fn

### DIFF
--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,6 +1,8 @@
 import json
-from typing import TYPE_CHECKING, Any, Optional, Union
+import logging
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
+import mlflow
 from mlflow.data.evaluation_dataset import EvaluationDataset
 from mlflow.entities import Assessment, Trace
 from mlflow.exceptions import MlflowException
@@ -9,6 +11,7 @@ from mlflow.genai.evaluation.constant import (
     AgentEvaluationReserverKey,
 )
 from mlflow.genai.scorers import Scorer
+from mlflow.genai.utils.trace_utils import is_model_traced
 from mlflow.models import EvaluationMetric
 
 try:
@@ -26,6 +29,9 @@ if TYPE_CHECKING:
         ]
     except ImportError:
         EvaluationDatasetTypes = Union[pd.DataFrame, list[dict], EvaluationDataset]
+
+
+_logger = logging.getLogger(__name__)
 
 
 def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame":
@@ -73,20 +79,15 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
                 "Please install it with `pip install pyspark`."
             )
 
-    # Verify format of the input using the first row
-    sample_row = df.iloc[0]
-    if "inputs" in sample_row and not isinstance(sample_row["inputs"], dict):
-        raise MlflowException.invalid_parameter_value(
-            "The 'inputs' column must be a dictionary. If you want to pass a single "
-            "argument to the `predict_fn`, use the argument name as the key in the "
-            "dictionary. If you don't pass a `predict_fn`, you can use any string "
-            "key to wrap the value into a dictionary."
-        )
-
     if not any(col in df.columns for col in ("trace", "inputs")):
         raise MlflowException.invalid_parameter_value(
             "Either `inputs` or `trace` column is required in the dataset. Please provide inputs "
             "for every datapoint or provide a trace."
+        )
+
+    if len(df) == 0:
+        raise MlflowException.invalid_parameter_value(
+            "The dataset is empty. Please provide a non-empty dataset."
         )
 
     return (
@@ -234,3 +235,13 @@ def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
         eval_fn=eval_fn,
         name=scorer.name,
     )
+
+
+def _convert_predict_fn(predict_fn: Callable, sample_input: Any) -> Callable:
+    if predict_fn:
+        if not is_model_traced(predict_fn, sample_input):
+            _logger.info("Annotating predict_fn with tracing since it is not already traced.")
+            predict_fn = mlflow.trace(predict_fn)
+
+    # Wrap the prediction function to unwrap the inputs dictionary into keyword arguments.
+    return lambda request: predict_fn(**request)

--- a/mlflow/genai/utils/data_validation.py
+++ b/mlflow/genai/utils/data_validation.py
@@ -1,14 +1,51 @@
 import inspect
-from typing import TYPE_CHECKING, Callable, Optional
+import logging
+from typing import Any, Callable, Optional
 
 from mlflow.exceptions import MlflowException
+from mlflow.tracing.provider import trace_disabled
 
-if TYPE_CHECKING:
-    import pandas as pd
+_logger = logging.getLogger(__name__)
 
 
-def validate_inputs_column_format(
-    inputs: "pd.Series", predict_fn: Optional[Callable] = None
+def validate_inputs_is_dict(sample_input: Any):
+    if not isinstance(sample_input, dict):
+        # If the input value is string, use it in the code example
+        sample_value = sample_input if isinstance(sample_input, str) else "What is MLflow?"
+        input_example = {"query": sample_value}
+
+        code_example = _construct_code_example(input_example=input_example)
+        raise MlflowException.invalid_parameter_value(
+            "The 'inputs' column must be a dictionary of field names and values. "
+            f"For example:\n{code_example}"
+        )
+
+
+def check_model_prediction(predict_fn: Callable, sample_input: Any) -> bool:
+    """
+    Validate if the predict function executes properly with the provided input.
+
+    Args:
+        predict_fn: The predict function to be evaluated.
+        sample_input: A sample input to the model.
+    """
+    _logger.info("Testing model prediction with the first sample in the dataset.")
+
+    # Wrap the function to add a decorator for disabling tracing
+    @trace_disabled
+    def _check():
+        predict_fn(**sample_input)
+
+    try:
+        _check()
+    except Exception as e:
+        # Check input format and raise friendly message for typical error patterns
+        _validate_function_and_input_compatibility(predict_fn, sample_input, e)
+        _logger.debug(f"Failed to run predict_fn with input: {sample_input}", exc_info=e)
+
+
+def _validate_function_and_input_compatibility(
+    predict_fn: Callable, sample_input: dict[str, Any], e: Exception
 ) -> Callable:
     """
     Validate the data format in the input column against the predict_fn.
@@ -16,74 +53,94 @@ def validate_inputs_column_format(
     The input column must contain a dictionary of field names and values. When the
     predict_fn is provided, the field names must match the arguments of the predict_fn.
     """
-    # Check if the predict_fn has dynamic positional arguments (e.g. *args)
-    # MLflow doesn't support such function as predict_fn, so instruct users to wrap
-    # it into another function with explicit keyword arguments.
-    if _has_dynamic_positional_arguments(predict_fn):
-        code_example = _construct_code_example(
-            predict_wrapper_body=(
-                "    # Invoke the original predict function with positional arguments\n"
-                f"    return {predict_fn.__name__}(param1, param2)\n"
-            ),
-            predict_wrapper_params=["param1", "param2"],
-            input_example={"param1": "value1", "param2": "value2"},
-        )
-        raise MlflowException.invalid_parameter_value(
-            "The `predict_fn` has dynamic positional arguments (e.g. `*args`), "
-            "so it cannot be used as a `predict_fn`. Please wrap it into another "
-            "function that accepts explicit keyword arguments.\n"
-            f"Example:\n\n{code_example}\n"
-        )
-
-    if predict_fn and not _get_arguments(predict_fn):
+    params = inspect.signature(predict_fn).parameters
+    if not params:
         raise MlflowException.invalid_parameter_value(
             "`predict_fn` must accept at least one argument."
-        )
+        ) from e
 
-    sample_input = inputs.iloc[0]
-    if not isinstance(sample_input, dict):
-        # If the predict_fn is provided, use its first argument in th code example
-        sample_key = _get_arguments(predict_fn)[0] if predict_fn else "query"
-        # If the input value is string, use it in the code example
-        sample_value = sample_input if isinstance(sample_input, str) else "What is MLflow?"
-        input_example = {sample_key: sample_value}
+    # Check for *args-style parameters which aren't supported
+    if _has_variable_positional_arguments(params):
+        _raise_args_not_supported_error(predict_fn, e)
 
-        if predict_fn:
-            code_example = _construct_code_example(
-                predict_fn_name=predict_fn.__name__,
-                input_example=input_example,
-            )
-            raise MlflowException.invalid_parameter_value(
-                "The 'inputs' column must be a dictionary with the parameter names of "
-                f"the `predict_fn` as keys. For example:\n{code_example}"
-            )
-        else:
-            code_example = _construct_code_example(input_example=input_example)
-            raise MlflowException.invalid_parameter_value(
-                "The 'inputs' column must be a dictionary of field names and values."
-                f"For example:\n{code_example}"
-            )
+    # Check if input keys match function parameters
+    if not _has_required_keyword_arguments(params, sample_input.keys()):
+        _raise_input_mismatch_error(predict_fn, params, e)
+
+    # For other errors, show a generic error message
+    raise MlflowException.invalid_parameter_value(
+        "Failed to run the prediction function specified in the `predict_fn` "
+        "parameter. Please make sure that the input dictionary contains the "
+        f"keys that match with the `predict_fn` parameters. Error: {e}\n\n"
+    ) from e
 
 
-def _has_dynamic_positional_arguments(fn: Optional[Callable] = None) -> bool:
-    """Check if the function has dynamic positional arguments (e.g. *args)."""
-    if fn is None:
-        return False
-    sig = inspect.signature(fn)
-    return any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in sig.parameters.values())
+def _has_variable_positional_arguments(params: inspect.Signature) -> bool:
+    """Check if the function has variable positional arguments."""
+    return any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params.values())
 
 
-def _get_arguments(fn: Callable) -> list[str]:
-    """Get the arguments of the function."""
-    sig = inspect.signature(fn)
-    return [p.name for p in sig.parameters.values()]
+def _has_required_keyword_arguments(params: inspect.Signature, required_args: list[str]) -> bool:
+    """Check if the function accepts the specified keyword arguments."""
+    func_args = []
+
+    for name, param in params.items():
+        # If the function has **kwargs, it accepts all keyword arguments
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+
+        func_args.append(name)
+
+    # Required argument must be a subset of the function's arguments
+    return set(required_args) <= set(func_args)
+
+
+def _raise_args_not_supported_error(predict_fn: Callable, e: Exception) -> None:
+    """Raise an error for functions using *args which aren't supported."""
+    code_example = _construct_code_example(
+        predict_wrapper_body=(
+            "    # Invoke the original predict function with positional arguments\n"
+            f"    return {predict_fn.__name__}(param1, param2)"
+        ),
+        predict_wrapper_params=["param1", "param2"],
+        input_example={"param1": "value1", "param2": "value2"},
+    )
+
+    raise MlflowException.invalid_parameter_value(
+        "The `predict_fn` has dynamic positional arguments (e.g. `*args`), "
+        "so it cannot be used as a `predict_fn`. Please wrap it into another "
+        "function that accepts explicit keyword arguments.\n"
+        f"Example:\n\n{code_example}\n"
+    ) from e
+
+
+def _raise_input_mismatch_error(
+    predict_fn: Callable, params: inspect.Signature, e: Exception
+) -> None:
+    """Raise an error when input keys don't match function parameters."""
+    param_names = list(params.keys())
+    input_example = {arg: f"value{i + 1}" for i, arg in enumerate(param_names[:3])}
+
+    if len(param_names) > 3:
+        input_example["..."] = "..."
+
+    code_example = _construct_code_example(
+        predict_fn_name=predict_fn.__name__,
+        input_example=input_example,
+    )
+
+    raise MlflowException.invalid_parameter_value(
+        "The `inputs` column must be a dictionary with the parameter names of "
+        f"the `predict_fn` as keys. It seems the specified keys do not match "
+        f"with the `predict_fn`'s arguments. Correct example:\n{code_example}"
+    ) from e
 
 
 def _construct_code_example(
+    input_example: dict[str, str],
     predict_fn_name: Optional[str] = None,
     predict_wrapper_body: Optional[str] = None,
     predict_wrapper_params: Optional[list[str]] = None,
-    input_example: Optional[dict[str, str]] = None,
 ) -> str:
     """
     Construct a code example for the predict_fn.
@@ -93,7 +150,7 @@ def _construct_code_example(
     if predict_wrapper_body:
         params = ", ".join(predict_wrapper_params)
         code.append(f"def predict_fn({params}):")
-        code.append(predict_wrapper_body)
+        code.append(predict_wrapper_body + "\n")
 
     code.append("data = [")
     code.append("    {")

--- a/mlflow/genai/utils/data_validation.py
+++ b/mlflow/genai/utils/data_validation.py
@@ -1,0 +1,115 @@
+import inspect
+from typing import TYPE_CHECKING, Callable, Optional
+
+from mlflow.exceptions import MlflowException
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+
+def validate_inputs_column_format(
+    inputs: "pd.Series", predict_fn: Optional[Callable] = None
+) -> Callable:
+    """
+    Validate the data format in the input column against the predict_fn.
+
+    The input column must contain a dictionary of field names and values. When the
+    predict_fn is provided, the field names must match the arguments of the predict_fn.
+    """
+    # Check if the predict_fn has dynamic positional arguments (e.g. *args)
+    # MLflow doesn't support such function as predict_fn, so instruct users to wrap
+    # it into another function with explicit keyword arguments.
+    if _has_dynamic_positional_arguments(predict_fn):
+        code_example = _construct_code_example(
+            predict_wrapper_body=(
+                "    # Invoke the original predict function with positional arguments\n"
+                f"    return {predict_fn.__name__}(param1, param2)\n"
+            ),
+            predict_wrapper_params=["param1", "param2"],
+            input_example={"param1": "value1", "param2": "value2"},
+        )
+        raise MlflowException.invalid_parameter_value(
+            "The `predict_fn` has dynamic positional arguments (e.g. `*args`), "
+            "so it cannot be used as a `predict_fn`. Please wrap it into another "
+            "function that accepts explicit keyword arguments.\n"
+            f"Example:\n\n{code_example}\n"
+        )
+
+    if predict_fn and not _get_arguments(predict_fn):
+        raise MlflowException.invalid_parameter_value(
+            "`predict_fn` must accept at least one argument."
+        )
+
+    sample_input = inputs.iloc[0]
+    if not isinstance(sample_input, dict):
+        # If the predict_fn is provided, use its first argument in th code example
+        sample_key = _get_arguments(predict_fn)[0] if predict_fn else "query"
+        # If the input value is string, use it in the code example
+        sample_value = sample_input if isinstance(sample_input, str) else "What is MLflow?"
+        input_example = {sample_key: sample_value}
+
+        if predict_fn:
+            code_example = _construct_code_example(
+                predict_fn_name=predict_fn.__name__,
+                input_example=input_example,
+            )
+            raise MlflowException.invalid_parameter_value(
+                "The 'inputs' column must be a dictionary with the parameter names of "
+                f"the `predict_fn` as keys. For example:\n{code_example}"
+            )
+        else:
+            code_example = _construct_code_example(input_example=input_example)
+            raise MlflowException.invalid_parameter_value(
+                "The 'inputs' column must be a dictionary of field names and values."
+                f"For example:\n{code_example}"
+            )
+
+
+def _has_dynamic_positional_arguments(fn: Optional[Callable] = None) -> bool:
+    """Check if the function has dynamic positional arguments (e.g. *args)."""
+    if fn is None:
+        return False
+    sig = inspect.signature(fn)
+    return any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in sig.parameters.values())
+
+
+def _get_arguments(fn: Callable) -> list[str]:
+    """Get the arguments of the function."""
+    sig = inspect.signature(fn)
+    return [p.name for p in sig.parameters.values()]
+
+
+def _construct_code_example(
+    predict_fn_name: Optional[str] = None,
+    predict_wrapper_body: Optional[str] = None,
+    predict_wrapper_params: Optional[list[str]] = None,
+    input_example: Optional[dict[str, str]] = None,
+) -> str:
+    """
+    Construct a code example for the predict_fn.
+    """
+    code = ["```python"]
+
+    if predict_wrapper_body:
+        params = ", ".join(predict_wrapper_params)
+        code.append(f"def predict_fn({params}):")
+        code.append(predict_wrapper_body)
+
+    code.append("data = [")
+    code.append("    {")
+    code.append('        "inputs": {')
+    for k, v in input_example.items():
+        code.append(f'            "{k}": "{v}",')
+    code.append("        }")
+    code.append("    }")
+    code.append("]\n")
+
+    if predict_wrapper_body:
+        code.append("mlflow.genai.evaluate(predict_fn=predict_fn, data=data, ...)")
+    elif predict_fn_name:
+        code.append(f"mlflow.genai.evaluate(predict_fn={predict_fn_name}, data=data, ...)")
+    else:
+        code.append("mlflow.genai.evaluate(data=data, scorers=...)")
+
+    code.append("```")
+    return "\n".join(code)

--- a/mlflow/genai/utils/data_validation.py
+++ b/mlflow/genai/utils/data_validation.py
@@ -48,11 +48,11 @@ def _validate_function_and_input_compatibility(
 
     # Check for *args-style parameters which aren't supported
     if _has_variable_positional_arguments(params):
-        _raise_args_not_supported_error(predict_fn, e)
+        _raise_args_not_supported_error(e)
 
     # Check if input keys match function parameters
     if not _has_required_keyword_arguments(params, sample_input.keys()):
-        _raise_input_mismatch_error(predict_fn, params, e)
+        _raise_input_mismatch_error(params, e)
 
     # For other errors, show a generic error message
     raise MlflowException.invalid_parameter_value(

--- a/mlflow/genai/utils/data_validation.py
+++ b/mlflow/genai/utils/data_validation.py
@@ -8,7 +8,7 @@ from mlflow.tracing.provider import trace_disabled
 _logger = logging.getLogger(__name__)
 
 
-def check_model_prediction(predict_fn: Callable, sample_input: Any) -> bool:
+def check_model_prediction(predict_fn: Callable, sample_input: Any):
     """
     Validate if the predict function executes properly with the provided input.
 
@@ -28,7 +28,7 @@ def check_model_prediction(predict_fn: Callable, sample_input: Any) -> bool:
     except Exception as e:
         # Check input format and raise friendly message for typical error patterns
         _validate_function_and_input_compatibility(predict_fn, sample_input, e)
-        _logger.debug(f"Failed to run predict_fn with input: {sample_input}", exc_info=e)
+        _logger.debug(f"Failed to run predict_fn with input: {sample_input}", exc_info=True)
 
 
 def _validate_function_and_input_compatibility(
@@ -47,12 +47,10 @@ def _validate_function_and_input_compatibility(
         ) from e
 
     # Check for *args-style parameters which aren't supported
-    if _has_variable_positional_arguments(params):
-        _raise_args_not_supported_error(e)
+    _validate_no_var_args(params, e)
 
     # Check if input keys match function parameters
-    if not _has_required_keyword_arguments(params, sample_input.keys()):
-        _raise_input_mismatch_error(params, e)
+    _validate_input_keys_match_function_params(params, sample_input.keys(), e)
 
     # For other errors, show a generic error message
     raise MlflowException.invalid_parameter_value(
@@ -67,22 +65,10 @@ def _has_variable_positional_arguments(params: inspect.Signature) -> bool:
     return any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params.values())
 
 
-def _has_required_keyword_arguments(params: inspect.Signature, required_args: list[str]) -> bool:
-    """Check if the function accepts the specified keyword arguments."""
-    func_args = []
+def _validate_no_var_args(params: inspect.Signature, e: Exception):
+    if not any(p.kind == inspect.Parameter.VAR_POSITIONAL for p in params.values()):
+        return
 
-    for name, param in params.items():
-        # If the function has **kwargs, it accepts all keyword arguments
-        if param.kind == inspect.Parameter.VAR_KEYWORD:
-            return True
-
-        func_args.append(name)
-
-    # Required argument must be a subset of the function's arguments
-    return set(required_args) <= set(func_args)
-
-
-def _raise_args_not_supported_error(e: Exception):
     """Raise an error for functions using *args which aren't supported."""
     code_sample = """```python
 def predict_fn(param1, param2):
@@ -110,7 +96,14 @@ mlflow.genai.evaluate(predict_fn=predict_fn, data=data, ...)
     ) from e
 
 
-def _raise_input_mismatch_error(params: inspect.Signature, e: Exception):
+def _validate_input_keys_match_function_params(
+    params: inspect.Signature,
+    input_keys: list[str],
+    e: Exception,
+):
+    if _has_required_keyword_arguments(params, input_keys):
+        return
+
     """Raise an error when input keys don't match function parameters."""
     param_names = list(params.keys())
     input_example = {arg: f"value{i + 1}" for i, arg in enumerate(param_names[:3])}
@@ -118,20 +111,37 @@ def _raise_input_mismatch_error(params: inspect.Signature, e: Exception):
     if len(param_names) > 3:
         input_example["..."] = "..."
 
-    code_sample = ["```python"]
-    code_sample.append("data = [")
-    code_sample.append("    {")
-    code_sample.append('        "inputs": {')
-    for k, v in input_example.items():
-        code_sample.append(f'            "{k}": "{v}",')
-    code_sample.append("        }")
-    code_sample.append("    }")
-    code_sample.append("]")
-    code_sample.append("```")
-    code_sample = "\n".join(code_sample)
+    code_sample = "\n".join(
+        [
+            "```python",
+            "data = [",
+            "    {",
+            '        "inputs": {',
+            *(f'            "{k}": "{v}",' for k, v in input_example.items()),
+            "        }",
+            "    }",
+            "]",
+            "```",
+        ]
+    )
 
     raise MlflowException.invalid_parameter_value(
         "The `inputs` column must be a dictionary with the parameter names of "
         f"the `predict_fn` as keys. It seems the specified keys do not match "
         f"with the `predict_fn`'s arguments. Correct example:\n\n{code_sample}"
     ) from e
+
+
+def _has_required_keyword_arguments(params: inspect.Signature, required_args: list[str]) -> bool:
+    """Check if the function accepts the specified keyword arguments."""
+    func_args = []
+
+    for name, param in params.items():
+        # If the function has **kwargs, it accepts all keyword arguments
+        if param.kind == inspect.Parameter.VAR_KEYWORD:
+            return True
+
+        func_args.append(name)
+
+    # Required argument must be a subset of the function's arguments
+    return set(required_args) <= set(func_args)

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -3,57 +3,54 @@ from typing import Any, Callable
 
 from opentelemetry.trace import NoOpTracer
 
-from mlflow.exceptions import MlflowException
-from mlflow.tracing.provider import trace_disabled
+import mlflow
+from mlflow.genai.utils.data_validation import check_model_prediction
 
 _logger = logging.getLogger(__name__)
 
 
-def is_model_traced(predict_fn: Callable, sample_input: Any) -> bool:
+def convert_predict_fn(predict_fn: Callable, sample_input: Any) -> Callable:
     """
-    Check if the predict function is being traced without logging to the database.
+    Check the predict_fn is callable and add trace decorator if it is not already traced.
+    """
+    with NoOpTracerPatcher() as counter:
+        check_model_prediction(predict_fn, sample_input)
+
+    if counter.count == 0:
+        predict_fn = mlflow.trace(predict_fn)
+
+    # Wrap the prediction function to unwrap the inputs dictionary into keyword arguments.
+    return lambda request: predict_fn(**request)
+
+
+class NoOpTracerPatcher:
+    """
+    A context manager to count the number of times NoOpTracer's start_span is called.
 
     The check is done in the following steps so it doesn't have any side effects:
-        1. Disable tracing.
-        2. Patch the NoOpTracer.start_span method to count the number of times it is called.
-            NoOpTracer is used when tracing is disabled.
-        3. Call the predict function with the sample input.
-        4. Restore the original NoOpTracer.start_span method and re-enable tracing.
+    1. Disable tracing.
+    2. Patch the NoOpTracer.start_span method to count the number of times it is called.
+        NoOpTracer is used when tracing is disabled.
+    3. Call the predict function with the sample input.
+    4. Restore the original NoOpTracer.start_span method and re-enable tracing.
+
 
     WARNING: This function is not thread-safe. We do not provide support for running
         `mlflow.genai.evaluate` in multi-threaded environments.`
-
-    Args:
-        predict_fn: The predict function to be evaluated.
-        sample_input: A sample input to the model.
-
-    Returns:
-        True if the function is being traced, False otherwise.
     """
 
-    @trace_disabled
-    def _check():
-        original = NoOpTracer.start_span
-        counter = 0
+    def __init__(self):
+        self.count = 0
 
-        def _patched_start_span(self, *args, **kwargs):
-            nonlocal counter
-            counter += 1
-            return original(self, *args, **kwargs)
+    def __enter__(self):
+        self.original = NoOpTracer.start_span
+
+        def _patched_start_span(_self, *args, **kwargs):
+            self.count += 1
+            return self.original(_self, *args, **kwargs)
 
         NoOpTracer.start_span = _patched_start_span
-        try:
-            predict_fn(**sample_input)
-        except Exception as e:
-            raise MlflowException.invalid_parameter_value(
-                "Failed to run the prediction function specified in the `predict_fn` "
-                "parameter. Please make sure that the input dictionary contains the "
-                "keys that match with the `predict_fn` parameters. Set log level to "
-                f"DEBUG to see the error details. Error: {e}",
-                exc_info=_logger.isEnabledFor(logging.DEBUG),
-            )
+        return self
 
-        NoOpTracer.start_span = original
-        return counter > 0
-
-    return _check()
+    def __exit__(self, exc_type, exc_value, traceback):
+        NoOpTracer.start_span = self.original

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -16,7 +16,7 @@ from mlflow.genai.scorers.base import scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, safety
 
 from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
-from tests.genai.conftest import mock_init_auth
+from tests.tracing.helper import get_traces
 
 _IS_AGENT_SDK_V1 = Version(import_module("databricks.agents").__version__).major >= 1
 
@@ -72,11 +72,10 @@ def test_evaluate_with_static_dataset():
         },
     ]
 
-    with mock.patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        result = mlflow.genai.evaluate(
-            data=data,
-            scorers=[exact_match, max_length, relevance, has_trace],
-        )
+    result = mlflow.genai.evaluate(
+        data=data,
+        scorers=[exact_match, max_length, relevance, has_trace],
+    )
 
     metrics = result.metrics
     assert metrics["metric/exact_match/average"] == 1.0
@@ -84,9 +83,14 @@ def test_evaluate_with_static_dataset():
     assert metrics["metric/relevance/relevance/average"] == 1.0
     assert metrics["metric/has_trace/average"] == 1.0
 
+    # Exact number of traces should be generated
+    traces = get_traces()
+    assert len(traces) == len(data)
+
 
 @pytest.mark.skipif(not _IS_AGENT_SDK_V1, reason="Databricks Agent SDK v1 is required")
-def test_evaluate_with_predict_fn():
+@pytest.mark.parametrize("is_predict_fn_traced", [True, False])
+def test_evaluate_with_predict_fn(is_predict_fn_traced):
     data = [
         {
             "inputs": {"question": "What is MLflow?"},
@@ -104,13 +108,13 @@ def test_evaluate_with_predict_fn():
         },
     ]
     model = TestModel()
+    predict_fn = mlflow.trace(model.predict) if is_predict_fn_traced else model.predict
 
-    with mock.patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        result = mlflow.genai.evaluate(
-            predict_fn=model.predict,
-            data=data,
-            scorers=[exact_match, max_length, relevance, has_trace],
-        )
+    result = mlflow.genai.evaluate(
+        predict_fn=predict_fn,
+        data=data,
+        scorers=[exact_match, max_length, relevance, has_trace],
+    )
 
     metrics = result.metrics
     assert metrics["metric/exact_match/average"] == 0.0
@@ -118,9 +122,14 @@ def test_evaluate_with_predict_fn():
     assert metrics["metric/relevance/relevance/average"] == 1.0
     assert metrics["metric/has_trace/average"] == 1.0
 
+    # Exact number of traces should be generated
+    traces = get_traces()
+    assert len(traces) == len(data)
+
 
 @pytest.mark.skipif(not _IS_AGENT_SDK_V1, reason="Databricks Agent SDK v1 is required")
-def test_evaluate_with_traces():
+@pytest.mark.parametrize("pass_full_dataframe", [True, False])
+def test_evaluate_with_traces(pass_full_dataframe):
     questions = ["What is MLflow?", "What is Spark?"]
 
     @mlflow.trace(span_type=SpanType.AGENT)
@@ -131,6 +140,7 @@ def test_evaluate_with_traces():
         predict(question)
 
     data = mlflow.search_traces()
+    assert len(data) == len(questions)
 
     # OSS MLflow backend doesn't support assessment APIs now, so we need to manually add them
     data.iloc[0]["trace"].info.assessments = [
@@ -162,11 +172,13 @@ def test_evaluate_with_traces():
         ),
     ]
 
-    with mock.patch("databricks.sdk.config.Config.init_auth", new=mock_init_auth):
-        result = mlflow.genai.evaluate(
-            data=data,
-            scorers=[exact_match, max_length, relevance, has_trace],
-        )
+    if not pass_full_dataframe:
+        data = data[["trace"]]
+
+    result = mlflow.genai.evaluate(
+        data=data,
+        scorers=[exact_match, max_length, relevance, has_trace],
+    )
 
     metrics = result.metrics
     assert metrics["metric/exact_match/average"] == 0.0
@@ -174,10 +186,8 @@ def test_evaluate_with_traces():
     assert metrics["metric/relevance/relevance/average"] == 1.0
     assert metrics["metric/has_trace/average"] == 1.0
 
-
-def mock_init_auth(config_instance):
-    config_instance.host = "https://databricks.com/"
-    config_instance._header_factory = lambda: {}
+    # Assessments should be added to the traces in-place and no new trace should be created
+    assert len(get_traces()) == len(questions)
 
 
 @mock.patch("mlflow.deployments.get_deploy_client")
@@ -326,3 +336,22 @@ def test_genai_evaluate_does_not_warn_about_deprecated_model_type():
         "The 'databricks-agent' model type is deprecated"
     )
     mock_evaluate_impl.assert_called_once()
+
+
+@pytest.mark.parametrize("pass_full_dataframe", [True, False])
+def test_trace_input_can_contain_string_input(pass_full_dataframe):
+    """
+    The `inputs` column must be a dictionary when a static dataset is provided.
+    However, when a trace is provided, it doesn't need to be validated and the
+    harness can handle it nicely.
+    """
+    with mlflow.start_span() as span:
+        span.set_inputs("What is MLflow?")
+        span.set_outputs("MLflow is a tool for ML")
+
+    traces = mlflow.search_traces()
+    if not pass_full_dataframe:
+        traces = traces[["trace"]]
+
+    # Harness should run without an error
+    mlflow.genai.evaluate(data=traces, scorers=[safety()])

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -253,8 +253,8 @@ def test_evaluate_passes_model_id_to_mlflow_evaluate():
     # Tracking URI = databricks is required to use mlflow.genai.evaluate()
     mlflow.set_tracking_uri("databricks")
     data = [
-        {"inputs": {"foo": "bar"}, "outputs": "response from model"},
-        {"inputs": {"baz": "qux"}, "outputs": "response from model"},
+        {"inputs": {"x": "bar"}, "outputs": "response from model"},
+        {"inputs": {"x": "qux"}, "outputs": "response from model"},
     ]
 
     with mock.patch("mlflow.models.evaluate") as mock_evaluate:

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -220,11 +220,6 @@ def test_convert_to_legacy_eval_set_has_no_errors(data_fixture, request):
     assert "expectations" in transformed_data.columns
 
 
-def test_convert_to_legacy_eval_set_invalid_inputs():
-    with pytest.raises(MlflowException, match="The 'inputs' column must be a dictionary"):
-        _convert_to_legacy_eval_set([{"inputs": "not a dict"}])
-
-
 @pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)
 def test_scorer_receives_correct_data(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)

--- a/tests/genai/utils/test_data_validation.py
+++ b/tests/genai/utils/test_data_validation.py
@@ -1,0 +1,114 @@
+import pandas as pd
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.utils.data_validation import validate_inputs_column_format
+
+
+def _extract_code_example(e: MlflowException) -> str:
+    """Extract the code example from the exception message."""
+    return e.message.split("```python")[1].split("```")[0]
+
+
+def test_validate_inputs_column_format_dynamic_args():
+    def fn(*args, key: str, **kwargs):
+        return "response"
+
+    inputs = pd.Series([{"key": "value"}])
+
+    with pytest.raises(MlflowException, match=r"The `predict_fn` has dynamic") as e:
+        validate_inputs_column_format(inputs, fn)
+
+    expected_code_example = """
+def predict_fn(param1, param2):
+    # Invoke the original predict function with positional arguments
+    return fn(param1, param2)
+
+data = [
+    {
+        "inputs": {
+            "param1": "value1",
+            "param2": "value2",
+        }
+    }
+]
+
+mlflow.genai.evaluate(predict_fn=predict_fn, data=data, ...)
+"""
+    assert _extract_code_example(e.value) == expected_code_example
+
+
+def test_validate_inputs_column_format_string_input():
+    inputs = pd.Series(["What is the capital of France?", "What is the capital of Germany?"])
+
+    with pytest.raises(MlflowException, match=r"The 'inputs' column must be a dictionary of") as e:
+        validate_inputs_column_format(inputs, predict_fn=None)
+
+    expected_code_example = """
+data = [
+    {
+        "inputs": {
+            "query": "What is the capital of France?",
+        }
+    }
+]
+
+mlflow.genai.evaluate(data=data, scorers=...)
+"""
+    assert _extract_code_example(e.value) == expected_code_example
+
+
+def test_validate_inputs_column_format_string_input_with_predict_fn():
+    def fn(question: str, context: str):
+        return "response"
+
+    inputs = pd.Series(["What is the capital of France?", "What is the capital of Germany?"])
+
+    with pytest.raises(MlflowException, match=r"The 'inputs' column must be a dictionary") as e:
+        validate_inputs_column_format(inputs, fn)
+
+    expected_code_example = """
+data = [
+    {
+        "inputs": {
+            "question": "What is the capital of France?",
+        }
+    }
+]
+
+mlflow.genai.evaluate(predict_fn=fn, data=data, ...)
+"""
+    assert _extract_code_example(e.value) == expected_code_example
+
+
+def test_validate_inputs_column_format_non_string_input():
+    def fn(question: str):
+        return "response"
+
+    inputs = pd.Series([["a", "b", "c"], ["d", "e", "f"]])
+
+    with pytest.raises(MlflowException, match=r"The 'inputs' column must be a dictionary") as e:
+        validate_inputs_column_format(inputs, fn)
+
+    expected_code_example = """
+data = [
+    {
+        "inputs": {
+            "question": "What is MLflow?",
+        }
+    }
+]
+
+mlflow.genai.evaluate(predict_fn=fn, data=data, ...)
+"""
+    assert _extract_code_example(e.value) == expected_code_example
+
+
+def test_validate_inputs_column_format_predict_fn_with_no_arg():
+    def fn():
+        return "response"
+
+    inputs = pd.Series(["What is the capital of France?", "What is the capital of Germany?"])
+
+    with pytest.raises(MlflowException, match=r"`predict_fn` must accept at least"):
+        validate_inputs_column_format(inputs, fn)

--- a/tests/genai/utils/test_data_validation.py
+++ b/tests/genai/utils/test_data_validation.py
@@ -1,8 +1,11 @@
-import pandas as pd
 import pytest
 
+import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.genai.utils.data_validation import validate_inputs_column_format
+from mlflow.genai.scorers.builtin_scorers import safety
+from mlflow.genai.utils.data_validation import check_model_prediction
+
+from tests.tracing.helper import get_traces
 
 
 def _extract_code_example(e: MlflowException) -> str:
@@ -10,14 +13,108 @@ def _extract_code_example(e: MlflowException) -> str:
     return e.message.split("```python")[1].split("```")[0]
 
 
-def test_validate_inputs_column_format_dynamic_args():
-    def fn(*args, key: str, **kwargs):
+@pytest.mark.parametrize(
+    ("predict_fn", "sample_input"),
+    [
+        # Single argument
+        (lambda question: None, {"question": "What is the capital of France?"}),
+        # Multiple arguments
+        (
+            lambda question, context: None,
+            {
+                "question": "What is the capital of France?",
+                "context": "France is a country in Europe.",
+            },
+        ),
+        # Unnamed keyword arguments
+        (lambda **kwargs: None, {"question": "What is the capital of France?"}),
+        # Mix of named and unnamed keyword arguments
+        (
+            lambda question, **kwargs: None,
+            {
+                "question": "What is the capital of France?",
+                "context": "France is a country in Europe.",
+            },
+        ),
+        # Non-string value
+        (
+            lambda messages: None,
+            {
+                "messages": [
+                    {"role": "user", "content": "What is the capital of France?"},
+                    {"role": "assistant", "content": "Paris"},
+                ],
+            },
+        ),
+    ],
+)
+def test_check_model_prediction(predict_fn, sample_input):
+    check_model_prediction(predict_fn, sample_input)
+
+    # No trace should be logged during the check
+    assert len(get_traces()) == 0
+
+    traced_predict_fn = mlflow.trace(predict_fn)
+    check_model_prediction(traced_predict_fn, sample_input)
+
+    # A trace should be logged during the check
+    assert len(get_traces()) == 0
+
+    # Running the traced function normally should pass and generate a trace
+    traced_predict_fn(**sample_input)
+    assert len(get_traces()) == 1
+
+
+def test_check_model_prediction_class_methods():
+    class MyClass:
+        def predict(self, question: str, context: str):
+            return "response"
+
+        @classmethod
+        def predict_cls(cls, question: str, context: str):
+            return "response"
+
+        @staticmethod
+        def predict_static(question: str, context: str):
+            return "response"
+
+    sample_input = {
+        "question": "What is the capital of France?",
+        "context": "France is a country in Europe.",
+    }
+
+    check_model_prediction(MyClass().predict, sample_input)
+    check_model_prediction(MyClass.predict_cls, sample_input)
+    check_model_prediction(MyClass.predict_static, sample_input)
+
+    assert len(get_traces()) == 0
+
+    # Validate traced version
+    check_model_prediction(mlflow.trace(MyClass().predict), sample_input)
+    check_model_prediction(mlflow.trace(MyClass.predict_cls), sample_input)
+    check_model_prediction(mlflow.trace(MyClass.predict_static), sample_input)
+
+    assert len(get_traces()) == 0
+
+
+def test_check_model_prediction_no_args():
+    def fn():
         return "response"
 
-    inputs = pd.Series([{"key": "value"}])
+    with pytest.raises(MlflowException, match=r"`predict_fn` must accept at least one argument."):
+        check_model_prediction(fn, {"question": "What is the capital of France?"})
+
+
+def test_check_model_prediction_variable_args():
+    """
+    If the function has variable positional arguments (*args), it is not supported.
+    """
+
+    def fn(*args):
+        return "response"
 
     with pytest.raises(MlflowException, match=r"The `predict_fn` has dynamic") as e:
-        validate_inputs_column_format(inputs, fn)
+        check_model_prediction(fn, {"question": "What is the capital of France?"})
 
     expected_code_example = """
 def predict_fn(param1, param2):
@@ -38,17 +135,92 @@ mlflow.genai.evaluate(predict_fn=predict_fn, data=data, ...)
     assert _extract_code_example(e.value) == expected_code_example
 
 
-def test_validate_inputs_column_format_string_input():
-    inputs = pd.Series(["What is the capital of France?", "What is the capital of Germany?"])
+def test_check_model_prediction_unmatched_keys():
+    def fn(role: str, content: str):
+        return "response"
 
-    with pytest.raises(MlflowException, match=r"The 'inputs' column must be a dictionary of") as e:
-        validate_inputs_column_format(inputs, predict_fn=None)
+    sample_input = {"messages": [{"role": "user", "content": "What is the capital of France?"}]}
+
+    with pytest.raises(
+        MlflowException, match=r"The `inputs` column must be a dictionary with"
+    ) as e:
+        check_model_prediction(fn, sample_input)
 
     expected_code_example = """
 data = [
     {
         "inputs": {
-            "query": "What is the capital of France?",
+            "role": "value1",
+            "content": "value2",
+        }
+    }
+]
+
+mlflow.genai.evaluate(predict_fn=fn, data=data, ...)
+"""
+    assert _extract_code_example(e.value) == expected_code_example
+
+
+def test_check_model_prediction_unmatched_keys_with_many_args():
+    def fn(param1, param2, param3, param4, param5):
+        return "response"
+
+    sample_input = {"question": "What is the capital of France?"}
+
+    with pytest.raises(
+        MlflowException, match=r"The `inputs` column must be a dictionary with"
+    ) as e:
+        check_model_prediction(fn, sample_input)
+
+    # The code snippet shouldn't show more than three parameters
+    expected_code_example = """
+data = [
+    {
+        "inputs": {
+            "param1": "value1",
+            "param2": "value2",
+            "param3": "value3",
+            "...": "...",
+        }
+    }
+]
+
+mlflow.genai.evaluate(predict_fn=fn, data=data, ...)
+"""
+    assert _extract_code_example(e.value) == expected_code_example
+
+
+def test_check_model_prediction_unmatched_keys_with_variable_kwargs():
+    def fn(question: str, **kwargs):
+        return "response"
+
+    sample_input = {"query": "What is the capital of France?"}
+    with pytest.raises(MlflowException, match=r"Failed to run the prediction function"):
+        check_model_prediction(fn, sample_input)
+
+
+def test_check_model_prediction_unknown_error():
+    def fn(question: str):
+        raise ValueError("Unknown error")
+
+    sample_input = {"question": "What is the capital of France?"}
+    with pytest.raises(MlflowException, match=r"Failed to run the prediction function"):
+        check_model_prediction(fn, sample_input)
+
+
+def test_validate_input_is_dict():
+    data = [{"inputs": "A string question", "outputs": "A string response"}]
+
+    with pytest.raises(
+        MlflowException, match=r"The 'inputs' column must be a dictionary of field names"
+    ) as e:
+        mlflow.genai.evaluate(data=data, scorers=[safety()])
+
+    expected_code_example = """
+data = [
+    {
+        "inputs": {
+            "query": "A string question",
         }
     }
 ]
@@ -56,59 +228,3 @@ data = [
 mlflow.genai.evaluate(data=data, scorers=...)
 """
     assert _extract_code_example(e.value) == expected_code_example
-
-
-def test_validate_inputs_column_format_string_input_with_predict_fn():
-    def fn(question: str, context: str):
-        return "response"
-
-    inputs = pd.Series(["What is the capital of France?", "What is the capital of Germany?"])
-
-    with pytest.raises(MlflowException, match=r"The 'inputs' column must be a dictionary") as e:
-        validate_inputs_column_format(inputs, fn)
-
-    expected_code_example = """
-data = [
-    {
-        "inputs": {
-            "question": "What is the capital of France?",
-        }
-    }
-]
-
-mlflow.genai.evaluate(predict_fn=fn, data=data, ...)
-"""
-    assert _extract_code_example(e.value) == expected_code_example
-
-
-def test_validate_inputs_column_format_non_string_input():
-    def fn(question: str):
-        return "response"
-
-    inputs = pd.Series([["a", "b", "c"], ["d", "e", "f"]])
-
-    with pytest.raises(MlflowException, match=r"The 'inputs' column must be a dictionary") as e:
-        validate_inputs_column_format(inputs, fn)
-
-    expected_code_example = """
-data = [
-    {
-        "inputs": {
-            "question": "What is MLflow?",
-        }
-    }
-]
-
-mlflow.genai.evaluate(predict_fn=fn, data=data, ...)
-"""
-    assert _extract_code_example(e.value) == expected_code_example
-
-
-def test_validate_inputs_column_format_predict_fn_with_no_arg():
-    def fn():
-        return "response"
-
-    inputs = pd.Series(["What is the capital of France?", "What is the capital of Germany?"])
-
-    with pytest.raises(MlflowException, match=r"`predict_fn` must accept at least"):
-        validate_inputs_column_format(inputs, fn)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15759?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15759/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15759/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15759/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Adding more concrete exception messages for the format of input data is not compatible with the `predict_fn` signature (or vice-verse).

This is the required format:
* The values in `inputs` column must be dictionaries.
* If `predict_fn` is specified, its parameters must match with dictionary key.
    * For example, if the function is `def predict(question: str, content: str)`, the input should be `{"inputs": {"question": "...", "content": ".."}}`
  

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Unmatched field names between input and predict_fn**

```
eval_set = [
    {"inputs": {"query": "What is MLflow?", "content": "MLflow is an open source platform"}},
    {"inputs": {"query": "What is Spark?", "content": "MLflow is a distributed computing engine"}},
]

def predict(question: str, context: str):
     return "I don't know"

result = mlflow.genai.evaluate(
    data=eval_set,
    predict_fn=predict,
    scorers=[mlflow.genai.scorers.relevance_to_query()],
)
```

> MlflowException: The `inputs` column must be a dictionary with the parameter names of the `predict_fn` as keys. It seems the specified keys do not match with the `predict_fn`'s arguments. Correct example:
>
> ```python
> data = [
>     {
>         "inputs": {
>             "question": "value1",
>             "context": "value2",
>         }
>     }
> ]
> ```

**Predict function with variable positional args (*args)**

```
eval_set = [
    {"inputs": {"query": "What is MLflow?", "content": "MLflow is an open source platform"}},
    {"inputs": {"query": "What is Spark?", "content": "MLflow is a distributed computing engine"}},
]

def predict(*args):
     return "I don't know"

result = mlflow.genai.evaluate(
    data=eval_set,
    predict_fn=predict,
    scorers=[mlflow.genai.scorers.relevance_to_query()],
)
```

> MlflowException: The `predict_fn` has dynamic positional arguments (e.g. `*args`), so it cannot be used as a `predict_fn`. Please wrap it into another function that accepts explicit keyword arguments.
> Example:

> ```python
> def predict_fn(param1, param2):
>     # Invoke the original predict function with positional arguments
>     return fn(param1, param2)
> 
> data = [
>     {
>         "inputs": {
>             "param1": "value1",
>             "param2": "value2",
>         }
>     }
> ]
> 
> mlflow.genai.evaluate(predict_fn=predict_fn, data=data, ...)
> ```

**Other random exceptions**
```
eval_set = [
    {"inputs": {"question": "What is MLflow?"}},
    {"inputs": {"question": "What is Spark?"}},
]

def predict(question: str):
    raise ValueError("test")

result = mlflow.genai.evaluate(
    data=eval_set,
    predict_fn=predict,
    scorers=[mlflow.genai.scorers.relevance_to_query()],
)
```

> MlflowException: Failed to run the prediction function specified in the `predict_fn` parameter. Please make sure that the input dictionary contains the keys that match with the `predict_fn` parameters. Error: test


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
