### PR TITLE
Relax built-in scorer validation to info message

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -109,7 +109,6 @@ def chunk_relevance():
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=[chunk_relevance()])
-        print(result)
     """
     return _ChunkRelevance()
 
@@ -158,7 +157,6 @@ def context_sufficiency():
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=[context_sufficiency()])
-        print(result)
     """
     return _ContextSufficiency()
 
@@ -211,7 +209,6 @@ def groundedness():
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=[groundedness()])
-        print(result)
     """
     return _Groundedness()
 
@@ -292,7 +289,6 @@ def guideline_adherence():
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=[guideline_adherence()])
-        print(result)
     """
     return _GuidelineAdherence()
 
@@ -386,7 +382,6 @@ def global_guideline_adherence(
             data=data,
             scorers=[guideline, english, clarify],
         )
-        print(result)
     """
     return _GlobalGuidelineAdherence(guidelines=guidelines, name=name)
 
@@ -436,7 +431,6 @@ def relevance_to_query():
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=[relevance_to_query()])
-        print(result)
     """
     return _RelevanceToQuery()
 
@@ -485,7 +479,6 @@ def safety():
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=[safety()])
-        print(result)
     """
     return _Safety()
 
@@ -564,7 +557,6 @@ def correctness():
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=[correctness()])
-        print(result)
     """
     return _Correctness()
 
@@ -576,7 +568,7 @@ def rag_scorers() -> list[BuiltInScorer]:
     Returns a list of built-in scorers for evaluating RAG models. Contains scorers
     chunk_relevance, context_sufficiency, groundedness, and relevance_to_query.
 
-    Example (with evaluate):
+    Example:
 
     .. code-block:: python
 
@@ -593,13 +585,43 @@ def rag_scorers() -> list[BuiltInScorer]:
             }
         ]
         result = mlflow.genai.evaluate(data=data, scorers=rag_scorers())
-        print(result)
     """
     return [
         chunk_relevance(),
         context_sufficiency(),
         groundedness(),
         relevance_to_query(),
+    ]
+
+
+@_builtin_scorer
+def all_scorers() -> list[BuiltInScorer]:
+    """
+    Returns a list of all built-in scorers.
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import all_scorers
+
+        data = [
+            {
+                "inputs": {"question": "What is the capital of France?"},
+                "outputs": "The capital of France is Paris.",
+                "retrieved_context": [
+                    {"content": "Paris is the capital city of France."},
+                ],
+            }
+        ]
+        result = mlflow.genai.evaluate(data=data, scorers=all_scorers())
+    """
+    return rag_scorers() + [
+        correctness(),
+        guideline_adherence(),
+        safety(),
+        correctness(),
     ]
 
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -618,7 +618,6 @@ def all_scorers() -> list[BuiltInScorer]:
         result = mlflow.genai.evaluate(data=data, scorers=all_scorers())
     """
     return rag_scorers() + [
-        correctness(),
         guideline_adherence(),
         safety(),
         correctness(),

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -28,14 +28,12 @@ def validate_scorers(scorers: list[Any]) -> tuple[list[BuiltInScorer], list[Scor
     """
     from databricks.rag_eval.evaluation.metrics import Metric
 
-    if not isinstance(scorers, list):
+    if not isinstance(scorers, list) or len(scorers) == 0:
         raise MlflowException.invalid_parameter_value(
-            "The scorers argument must be a list of scorers."
-        )
-
-    if not scorers:
-        raise MlflowException.invalid_parameter_value(
-            "At least one scorer is required to evaluate a model."
+            "The `scorers` argument must be a list of scorers with at least one scorer. "
+            "If you are unsure about which scorer to use, you can specify "
+            "`scorers=mlflow.genai.scorers.all_scorers()` to jump start with all "
+            "available built-in scorers."
         )
 
     builtin_scorers = []
@@ -142,9 +140,8 @@ def valid_data_for_builtin_scorers(
 
     if missing_col_to_scorers:
         msg = (
-            "The input data is missing following columns or fields that are required "
-            "by the specified scorers. Please make sure the data contains all the "
-            "required columns or fields for computing scores."
+            "The input data is missing following columns that are required by the specified "
+            "scorers. The results will be null for those scorers."
         )
         for col, scorers in missing_col_to_scorers.items():
             if col.startswith("expectations/"):
@@ -155,4 +152,4 @@ def valid_data_for_builtin_scorers(
                 )
             else:
                 msg += f"\n - `{col}` column is required by [{', '.join(scorers)}]."
-        raise MlflowException.invalid_parameter_value(msg)
+        _logger.info(msg)

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -287,7 +287,7 @@ def test_no_scorers(mock_get_tracking_uri):
     with pytest.raises(TypeError, match=r"evaluate\(\) missing 1 required positional"):
         mlflow.genai.evaluate(data=[{"inputs": "Hello", "outputs": "Hi"}])
 
-    with pytest.raises(MlflowException, match=r"At least one scorer is required"):
+    with pytest.raises(MlflowException, match=r"The `scorers` argument must be a list of"):
         mlflow.genai.evaluate(data=[{"inputs": "Hello", "outputs": "Hi"}], scorers=[])
 
 

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -10,7 +10,7 @@ from mlflow.genai.scorers import (
     relevance_to_query,
     safety,
 )
-from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
+from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, all_scorers, correctness
 
 
 def normalize_config(config):
@@ -21,18 +21,14 @@ def normalize_config(config):
 
 
 ALL_SCORERS = [
-    chunk_relevance(),
-    context_sufficiency(),
-    groundedness(),
-    guideline_adherence(),
     global_guideline_adherence(["Be polite", "Be kind"]),
-    relevance_to_query(),
-    safety(),
+    *all_scorers(),
 ]
 
 expected = {
     GENAI_CONFIG_NAME: {
         "metrics": [
+            "correctness",
             "chunk_relevance",
             "context_sufficiency",
             "groundedness",
@@ -51,11 +47,21 @@ expected = {
     "scorers",
     [
         ALL_SCORERS,
-        [*ALL_SCORERS] + [*ALL_SCORERS],  # duplicate scorers
+        ALL_SCORERS + ALL_SCORERS,  # duplicate scorers
         rag_scorers()
-        + [global_guideline_adherence(["Be polite", "Be kind"]), guideline_adherence(), safety()],
+        + [
+            global_guideline_adherence(["Be polite", "Be kind"]),
+            guideline_adherence(),
+            correctness(),
+            safety(),
+        ],
         [*rag_scorers()]
-        + [global_guideline_adherence(["Be polite", "Be kind"]), guideline_adherence(), safety()],
+        + [
+            global_guideline_adherence(["Be polite", "Be kind"]),
+            guideline_adherence(),
+            correctness(),
+            safety(),
+        ],
     ],
 )
 def test_scorers_and_rag_scorers_config(scorers):
@@ -71,6 +77,7 @@ def test_scorers_and_rag_scorers_config(scorers):
     [
         (chunk_relevance(), "chunk_relevance"),
         (context_sufficiency(), "context_sufficiency"),
+        (correctness(), "correctness"),
         (groundedness(), "groundedness"),
         (guideline_adherence(), "guideline_adherence"),
         (relevance_to_query(), "relevance_to_query"),

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -17,6 +17,12 @@ from mlflow.genai.scorers.builtin_scorers import (
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
 
 
+@pytest.fixture
+def mock_logger():
+    with mock.patch("mlflow.genai.scorers.validation._logger") as mock_logger:
+        yield mock_logger
+
+
 def test_validate_scorers_valid():
     @scorer
     def custom_scorer(inputs, outputs):
@@ -62,7 +68,7 @@ def test_validate_scorers_builtin_scorer_passed_as_function():
         validate_scorers([chunk_relevance])
 
 
-def test_validate_data():
+def test_validate_data(mock_logger):
     data = pd.DataFrame(
         {
             "inputs": [{"question": "input1"}, {"question": "input2"}],
@@ -80,6 +86,7 @@ def test_validate_data():
             global_guideline_adherence(["Be polite", "Be kind"]),
         ],
     )
+    mock_logger.info.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -93,7 +100,7 @@ def test_validate_data():
         },
     ],
 )
-def test_validate_data_with_expectations(expectations):
+def test_validate_data_with_expectations(expectations, mock_logger):
     """Test that expectations are unwrapped and validated properly"""
     data = pd.DataFrame(
         {
@@ -112,6 +119,7 @@ def test_validate_data_with_expectations(expectations):
             context_sufficiency(),  # requires expected_response
         ],
     )
+    mock_logger.info.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -121,7 +129,7 @@ def test_validate_data_with_expectations(expectations):
         {"expected_response": ["expectation1", "expectation2"]},
     ],
 )
-def test_validate_data_with_correctness(expectations):
+def test_validate_data_with_correctness(expectations, mock_logger):
     """Correctness scorer requires one of expected_facts or expected_response"""
     data = pd.DataFrame(
         {
@@ -137,37 +145,37 @@ def test_validate_data_with_correctness(expectations):
         builtin_scorers=[correctness()],
     )
 
-    with pytest.raises(MlflowException, match=r"The input data is missing following") as e:
-        valid_data_for_builtin_scorers(
-            data=pd.DataFrame({"inputs": ["input1"], "outputs": ["output1"]}),
-            builtin_scorers=[correctness()],
-        )
+    valid_data_for_builtin_scorers(
+        data=pd.DataFrame({"inputs": ["input1"], "outputs": ["output1"]}),
+        builtin_scorers=[correctness()],
+    )
 
-    assert "expected_response or expected_facts" in str(e.value)
+    mock_logger.info.assert_called_once()
+    message = mock_logger.info.call_args[0][0]
+    assert "expected_response or expected_facts" in message
 
 
-def test_validate_data_missing_columns():
+def test_validate_data_missing_columns(mock_logger):
     data = pd.DataFrame({"inputs": [{"question": "input1"}, {"question": "input2"}]})
 
     converted_date = _convert_to_legacy_eval_set(data)
 
-    with pytest.raises(MlflowException, match=r"The input data is missing") as e:
-        valid_data_for_builtin_scorers(
-            data=converted_date,
-            builtin_scorers=[
-                chunk_relevance(),
-                groundedness(),
-                global_guideline_adherence(["Be polite", "Be kind"]),
-            ],
-        )
-
-    assert " - `outputs` column is required by [groundedness, guideline_adherence]." in str(e.value)
-    assert " - `retrieved_context` column is required by [chunk_relevance, groundedness]." in str(
-        e.value
+    valid_data_for_builtin_scorers(
+        data=converted_date,
+        builtin_scorers=[
+            chunk_relevance(),
+            groundedness(),
+            global_guideline_adherence(["Be polite", "Be kind"]),
+        ],
     )
 
+    mock_logger.info.assert_called_once()
+    msg = mock_logger.info.call_args[0][0]
+    assert " - `outputs` column is required by [groundedness, guideline_adherence]." in msg
+    assert " - `retrieved_context` column is required by [chunk_relevance, groundedness]." in msg
 
-def test_validate_data_with_trace():
+
+def test_validate_data_with_trace(mock_logger):
     # When a trace is provided, the inputs, outputs, and retrieved_context are
     # inferred from the trace.
     with mlflow.start_span() as span:
@@ -186,9 +194,10 @@ def test_validate_data_with_trace():
             global_guideline_adherence(["Be polite", "Be kind"]),
         ],
     )
+    mock_logger.info.assert_not_called()
 
 
-def test_validate_data_with_predict_fn():
+def test_validate_data_with_predict_fn(mock_logger):
     data = pd.DataFrame({"inputs": [{"question": "input1"}, {"question": "input2"}]})
 
     converted_date = _convert_to_legacy_eval_set(data)
@@ -203,3 +212,5 @@ def test_validate_data_with_predict_fn():
             chunk_relevance(),
         ],
     )
+
+    mock_logger.info.assert_not_called()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15768?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15768/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15768/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15768/merge
```

</p>
</details>

### What changes are proposed in this pull request?

We've added https://github.com/mlflow/mlflow/pull/15690 to fail-first when the input data doesn't have required columns specified by the builtin scorers.

However, eval team pointed out this is too restrictive. Users should be able to do sth like this as jump start
```
mlflow.genai.evaluate(data=data, scorers=all_scorers())
```
Therefore, this PR downgrade the validation to just show info message.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
