### PR TITLE
Fix `mlflow.genai.to_predict_fn` implementation

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -11,7 +11,6 @@ from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
 from mlflow.genai.utils.trace_utils import is_model_traced
-from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.models.evaluation.base import (
     _is_model_deployment_endpoint_uri,
 )
@@ -339,6 +338,7 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
         )
 
     from mlflow.deployments import get_deploy_client
+    from mlflow.metrics.genai.model_utils import _parse_model_uri
 
     client = get_deploy_client("databricks")
     _, endpoint = _parse_model_uri(endpoint_uri)

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -11,8 +11,8 @@ from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
 from mlflow.genai.utils.trace_utils import is_model_traced
+from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.models.evaluation.base import (
-    _get_model_from_deployment_endpoint_uri,
     _is_model_deployment_endpoint_uri,
 )
 from mlflow.utils.uri import is_databricks_uri
@@ -291,19 +291,46 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
         A predict function that can be used to make predictions.
 
     Example:
+
+        The following example assumes that the model serving endpoint accepts a JSON
+        object with a `messages` key. Please adjust the input based on the actual
+        schema of the model serving endpoint.
+
         .. code-block:: python
 
-            data = pd.DataFrame(
-                [
-                    {"inputs": {"messages": [{"role": "user", "content": "What is MLflow?"}]}},
-                    {"inputs": {"question": [{"role": "user", "content": "What is Spark?"}]}},
-                ]
-            )
+            from mlflow.genai.scorers import all_scorers
+
+            data = [
+                {
+                    "inputs": {
+                        "messages": [
+                            {"role": "system", "content": "You are a helpful assistant."},
+                            {"role": "user", "content": "What is MLflow?"},
+                        ]
+                    }
+                },
+                {
+                    "inputs": {
+                        "messages": [
+                            {"role": "system", "content": "You are a helpful assistant."},
+                            {"role": "user", "content": "What is Spark?"},
+                        ]
+                    }
+                },
+            ]
             predict_fn = mlflow.genai.to_predict_fn("endpoints:/chat")
             mlflow.genai.evaluate(
                 data=data,
                 predict_fn=predict_fn,
+                scorers=all_scorers,
             )
+
+        You can also directly invoke the function to validate if the endpoint works
+        properly with your input schema.
+
+        .. code-block:: python
+
+            predict_fn(**data[0]["inputs"])
     """
     if not _is_model_deployment_endpoint_uri(endpoint_uri):
         raise ValueError(
@@ -311,8 +338,30 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
             f"deployment endpoint URI."
         )
 
-    model = _get_model_from_deployment_endpoint_uri(endpoint_uri)
-    if model is None:
-        raise ValueError(f"Model not found for endpoint URI: {endpoint_uri}")
+    from mlflow.deployments import get_deploy_client
 
-    return model.predict
+    client = get_deploy_client("databricks")
+    _, endpoint = _parse_model_uri(endpoint_uri)
+
+    # NB: Wrap the function to show better docstring and change signature to `model_inputs`
+    #   to unnamed keyword arguments. This is necessary because we pass input samples as
+    #   keyword arguments to the predict function.
+    def predict_fn(**kwargs):
+        # NB: Manually set inputs and outputs rather than using @mlflow.trace decorator,
+        #   because we want to record keyword arguments with names rather than **kwargs.
+        with mlflow.start_span(name="predict") as span:
+            span.set_inputs(kwargs)
+            span.set_attribute("endpoint", endpoint_uri)
+            result = client.predict(endpoint=endpoint, inputs=kwargs)
+            span.set_outputs(result)
+            return result
+
+    predict_fn.__doc__ = f"""
+A wrapper function for invoking the model serving endpoint `{endpoint_uri}`.
+
+Args:
+    **kwargs: The input samples to be passed to the model serving endpoint.
+        For example, if the endpoint accepts a JSON object with a `messages` key,
+        the input sample should be a dictionary with a `messages` key.
+    """
+    return predict_fn


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15771?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15771/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15771/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15771/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.genai.to_predict_fn` function is added as a convenient API to get a callable from model serving endpoint name. An example usage is like this

```
data = {
    "inputs": {"messages": [{"role": "user", "content": "what is MLflow?"}]}
    "inputs": {"messages": [{"role": "user", "content": "what is Spark?"}]}
}

predict_fn = mlflow.genai.to_predict_fn("endpoints:/my-chat")

mlflow.genai.evaluate(
    predict_fn=predict_fn,
    data=data,
    scorers=...
)
```

Under the hood, it is implemented by re-using the existing [_get_model_from_deployment_endpoint_uri](https://github.com/mlflow/mlflow/blob/e115ae032fc30b12677958348a64e7ad3958fbda/mlflow/models/evaluation/base.py#L1082) function that has been used in `mlflow.evaluate`. It returns a special pyfunc wrapper [ModelFromDeploymentEndpoint](https://github.com/mlflow/mlflow/blob/master/mlflow/pyfunc/model.py#L1261) for predicting on the endpoint.

However, it has several problems:
* The pyfunc wrapper includes unnecessary chat conversion.
* The signature of the predict function is not aligned with what we want for evaluation.
* The docstring shown with `help(fn)` is cryptic.

This PR fixes these issues by directly using the deployment client. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2025-05-16 at 14 29 51](https://github.com/user-attachments/assets/c974c438-9dda-44be-a877-9713fb553b8d)



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
