### PR TITLE
Prompt acl

### DIFF
--- a/mlflow/server/auth/client.py
+++ b/mlflow/server/auth/client.py
@@ -535,3 +535,15 @@ class AuthServiceClient:
             "DELETE",
             json={"name": name, "username": username},
         )
+
+    def create_prompt_permission(self, prompt_name: str, username: str, permission: str):
+        return self.create_registered_model_permission(prompt_name, username, permission)
+
+    def get_prompt_permission(self, prompt_name: str, username: str):
+        return self.get_registered_model_permission(prompt_name, username)
+
+    def update_prompt_permission(self, prompt_name: str, username: str, permission: str):
+        self.update_registered_model_permission(prompt_name, username, permission)
+
+    def delete_prompt_permission(self, prompt_name: str, username: str):
+        self.delete_registered_model_permission(prompt_name, username)

--- a/mlflow/server/auth/client.py
+++ b/mlflow/server/auth/client.py
@@ -537,13 +537,129 @@ class AuthServiceClient:
         )
 
     def create_prompt_permission(self, prompt_name: str, username: str, permission: str):
+        """
+        Create a permission on an registered prompt for a user.
+
+        Args:
+            prompt_name: The name of the registered prompt.
+            username: The username.
+            permission: Permission to grant. Must be one of "READ", "EDIT", "MANAGE" and
+                "NO_PERMISSIONS".
+
+        Raises:
+            mlflow.exceptions.RestException: if the user does not exist,
+                or a permission already exists for this registered prompt user pair,
+                or if the permission is invalid.
+                Does not require ``prompt_name`` to be an existing registered prompt.
+
+        Returns:
+            A single :py:class:`mlflow.server.auth.entities.RegisteredModelPermission` object.
+        """
         return self.create_registered_model_permission(prompt_name, username, permission)
 
     def get_prompt_permission(self, prompt_name: str, username: str):
+        """
+        Get an registered prompt permission for a user.
+
+        Args:
+            prompt_name: The name of the registered prompt.
+            username: The username.
+
+        Raises:
+            mlflow.exceptions.RestException: if the user does not
+                exist, or no permission exists for this registered prompt user pair. Note that the
+                default permission will still be effective even if no permission exists.
+
+        Returns:
+             A single :py:class:`mlflow.server.auth.entities.RegisteredModelPermission` object.
+
+        .. code-block:: bash
+            :caption: Example
+
+            export MLFLOW_TRACKING_USERNAME=admin
+            export MLFLOW_TRACKING_PASSWORD=password
+
+        .. code-block:: python
+
+            from mlflow.server.auth.client import AuthServiceClient
+
+            client = AuthServiceClient("tracking_uri")
+            client.create_user("newuser", "newpassword")
+            client.create_prompt_permission("myregisteredprompt", "newuser", "READ")
+            rmp = client.get_prompt_permission("myregisteredprompt", "newuser")
+
+            print(f"name: {rmp.name}")
+            print(f"user_id: {rmp.user_id}")
+            print(f"permission: {rmp.permission}")
+
+        .. code-block:: text
+            :caption: Output
+
+            name: myregisteredprompt
+            user_id: 3
+            permission: READ
+        """
         return self.get_registered_model_permission(prompt_name, username)
 
     def update_prompt_permission(self, prompt_name: str, username: str, permission: str):
+        """
+        Update an existing registered prompt permission for a user.
+
+        Args:
+            prompt_name: The name of the registered prompt.
+            username: The username.
+            permission: New permission to grant. Must be one of "READ", "EDIT", "MANAGE" and
+                "NO_PERMISSIONS".
+
+        Raises:
+            mlflow.exceptions.RestException: if the user does not exist, or no permission exists for
+                this registered prompt user pair, or if the permission is invalid.
+
+        .. code-block:: bash
+            :caption: Example
+
+            export MLFLOW_TRACKING_USERNAME=admin
+            export MLFLOW_TRACKING_PASSWORD=password
+
+        .. code-block:: python
+
+            from mlflow.server.auth.client import AuthServiceClient
+
+            client = AuthServiceClient("tracking_uri")
+            client.create_user("newuser", "newpassword")
+            client.create_prompt_permission("myregisteredprompt", "newuser", "READ")
+            client.update_prompt_permission("myregisteredprompt", "newuser", "EDIT")
+        """
         self.update_registered_model_permission(prompt_name, username, permission)
 
     def delete_prompt_permission(self, prompt_name: str, username: str):
+        """
+        Delete an existing registered prompt permission for a user.
+
+        Args:
+            prompt_name: The name of the registered prompt.
+            username: The username.
+
+        Raises:
+            mlflow.exceptions.RestException: if the user does not exist,
+                or no permission exists for this registered prompt user pair,
+                or if the permission is invalid.
+                Note that the default permission will still be effective even
+                after the permission has been deleted.
+
+        .. code-block:: bash
+            :caption: Example
+
+            export MLFLOW_TRACKING_USERNAME=admin
+            export MLFLOW_TRACKING_PASSWORD=password
+
+        .. code-block:: python
+
+            from mlflow.server.auth.client import AuthServiceClient
+
+            client = AuthServiceClient("tracking_uri")
+            client.create_user("newuser", "newpassword")
+            client.create_prompt_permission("myregisteredprompt", "newuser", "READ")
+            client.delete_prompt_permission("myregisteredprompt", "newuser")
+        """
         self.delete_registered_model_permission(prompt_name, username)

--- a/tests/server/auth/test_client.py
+++ b/tests/server/auth/test_client.py
@@ -336,3 +336,76 @@ def test_client_delete_registered_model_permission(client, monkeypatch):
 
     with User(username, password, monkeypatch), assert_unauthorized():
         client.delete_registered_model_permission(name, username)
+
+
+def test_client_create_prompt_permission(client, monkeypatch):
+    name = random_str()
+    username, password = create_user(client.tracking_uri)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        rmp = client.create_prompt_permission(name, username, PERMISSION)
+    assert rmp.name == name
+    assert rmp.permission == PERMISSION
+
+    with assert_unauthenticated():
+        client.create_prompt_permission(name, username, PERMISSION)
+
+    with User(username, password, monkeypatch), assert_unauthorized():
+        client.create_prompt_permission(name, username, PERMISSION)
+
+
+def test_client_get_prompt_permission(client, monkeypatch):
+    name = random_str()
+    username, password = create_user(client.tracking_uri)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_prompt_permission(name, username, PERMISSION)
+        rmp = client.get_prompt_permission(name, username)
+    assert rmp.name == name
+    assert rmp.permission == PERMISSION
+
+    with assert_unauthenticated():
+        client.get_prompt_permission(name, username)
+
+    with User(username, password, monkeypatch), assert_unauthorized():
+        client.get_prompt_permission(name, username)
+
+
+def test_client_update_prompt_permission(client, monkeypatch):
+    name = random_str()
+    username, password = create_user(client.tracking_uri)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_prompt_permission(name, username, PERMISSION)
+        client.update_prompt_permission(name, username, NEW_PERMISSION)
+        rmp = client.get_prompt_permission(name, username)
+    assert rmp.name == name
+    assert rmp.permission == NEW_PERMISSION
+
+    with assert_unauthenticated():
+        client.update_prompt_permission(name, username, PERMISSION)
+
+    with User(username, password, monkeypatch), assert_unauthorized():
+        client.update_prompt_permission(name, username, PERMISSION)
+
+
+def test_client_delete_prompt_permission(client, monkeypatch):
+    name = random_str()
+    username, password = create_user(client.tracking_uri)
+
+    with User(ADMIN_USERNAME, ADMIN_PASSWORD, monkeypatch):
+        client.create_prompt_permission(name, username, PERMISSION)
+        client.delete_prompt_permission(name, username)
+        with pytest.raises(
+            MlflowException,
+            match=rf"Registered model permission with name={name} "
+            rf"and username={username} not found",
+        ) as exception_context:
+            client.get_prompt_permission(name, username)
+        assert exception_context.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)
+
+    with assert_unauthenticated():
+        client.delete_prompt_permission(name, username)
+
+    with User(username, password, monkeypatch), assert_unauthorized():
+        client.delete_prompt_permission(name, username)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/15780?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15780/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15780/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15780/merge
```

</p>
</details>

### Related Issues/PRs

Fix #15712 

### What changes are proposed in this pull request?

Add support for Prompt ACLs

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Allows ACL support for prompts

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations


#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
