### PR TITLE
Package model environment when registering model

### DIFF
--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -67,12 +67,13 @@ def register_model(
             waits for five minutes. Specify 0 or None to skip waiting.
         tags: A dictionary of key-value pairs that are converted into
             :py:class:`mlflow.entities.model_registry.ModelVersionTag` objects.
-        env_pack: If specified, the model dependencies will first be installed into the current Python
-            environment, and then the complete environment will be packaged and included in the
-            registered model artifacts. This is useful when deploying the model to a serving
-            environment like Databricks Model Serving.
+        env_pack: If specified, the model dependencies will first be installed into the current
+            Python environment, and then the complete environment will be packaged and included
+            in the registered model artifacts. This is useful when deploying the model to a
+            serving environment like Databricks Model Serving.
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
+
     Returns:
         Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
         backend.
@@ -182,7 +183,7 @@ def _register_model(
     model_id = _parse_model_id_if_present(model_uri) if not model_id else model_id
 
     if env_pack == "databricks_model_serving":
-        eprint(f"Packing environment for Databricks Model Serving...")
+        eprint("Packing environment for Databricks Model Serving...")
         with pack_env_for_databricks_model_serving(
             model_uri,
             enforce_pip_requirements=True,
@@ -238,7 +239,9 @@ def _register_model(
 
     if env_pack == "databricks_model_serving":
         eprint(
-            f"Staging model {create_version_response.name} version {create_version_response.version} for Databricks Model Serving..."
+            f"Staging model {create_version_response.name} "
+            f"version {create_version_response.version} "
+            "for Databricks Model Serving..."
         )
         stage_model_for_databricks_model_serving(
             model_name=create_version_response.name,

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -71,6 +71,7 @@ def register_model(
             Python environment, and then the complete environment will be packaged and included
             in the registered model artifacts. This is useful when deploying the model to a
             serving environment like Databricks Model Serving.
+
             .. Note:: Experimental: This parameter may change or be removed in a future
                                     release without warning.
 

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -31,7 +31,9 @@ from mlflow.utils.databricks_utils import (
     _construct_databricks_uc_registered_model_url,
     get_workspace_id,
     get_workspace_url,
+    stage_model_for_databricks_model_serving,
 )
+from mlflow.utils.env_pack import EnvPackType, pack_env_for_databricks_model_serving
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.uri import is_databricks_unity_catalog_uri
 
@@ -44,6 +46,7 @@ def register_model(
     await_registration_for=DEFAULT_AWAIT_MAX_SLEEP_SECONDS,
     *,
     tags: Optional[dict[str, Any]] = None,
+    env_pack: Optional[EnvPackType] = None,
 ) -> ModelVersion:
     """Create a new model version in model registry for the model files specified by ``model_uri``.
 
@@ -64,7 +67,12 @@ def register_model(
             waits for five minutes. Specify 0 or None to skip waiting.
         tags: A dictionary of key-value pairs that are converted into
             :py:class:`mlflow.entities.model_registry.ModelVersionTag` objects.
-
+        env_pack: If specified, the model dependencies will first be installed into the current Python
+            environment, and then the complete environment will be packaged and included in the
+            registered model artifacts. This is useful when deploying the model to a serving
+            environment like Databricks Model Serving.
+            .. Note:: Experimental: This parameter may change or be removed in a future
+                                    release without warning.
     Returns:
         Single :py:class:`mlflow.entities.model_registry.ModelVersion` object created by
         backend.
@@ -103,6 +111,7 @@ def register_model(
         name=name,
         await_registration_for=await_registration_for,
         tags=tags,
+        env_pack=env_pack,
     )
 
 
@@ -113,6 +122,7 @@ def _register_model(
     *,
     tags: Optional[dict[str, Any]] = None,
     local_model_path=None,
+    env_pack: Optional[EnvPackType] = None,
 ) -> ModelVersion:
     client = MlflowClient()
     try:
@@ -170,6 +180,15 @@ def _register_model(
 
     # Otherwise if the uri is of the form models:/..., try to get the model_id from the uri directly
     model_id = _parse_model_id_if_present(model_uri) if not model_id else model_id
+
+    if env_pack == "databricks_model_serving":
+        eprint(f"Packing environment for Databricks Model Serving...")
+        with pack_env_for_databricks_model_serving(
+            model_uri,
+            enforce_pip_requirements=True,
+        ) as artifacts_path_with_env:
+            client.log_model_artifacts(model_id, artifacts_path_with_env)
+
     create_version_response = client._create_model_version(
         name=name,
         source=source,
@@ -215,6 +234,15 @@ def _register_model(
         client.set_logged_model_tags(
             model_id,
             {mlflow_tags.MLFLOW_MODEL_VERSIONS: json.dumps(new_value)},
+        )
+
+    if env_pack == "databricks_model_serving":
+        eprint(
+            f"Staging model {create_version_response.name} version {create_version_response.version} for Databricks Model Serving..."
+        )
+        stage_model_for_databricks_model_serving(
+            model_name=create_version_response.name,
+            model_version=create_version_response.version,
         )
 
     return create_version_response

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -244,10 +244,17 @@ def _register_model(
             f"version {create_version_response.version} "
             "for Databricks Model Serving..."
         )
-        stage_model_for_databricks_model_serving(
-            model_name=create_version_response.name,
-            model_version=create_version_response.version,
-        )
+        try:
+            stage_model_for_databricks_model_serving(
+                model_name=create_version_response.name,
+                model_version=create_version_response.version,
+            )
+        except Exception as e:
+            eprint(
+                f"Failed to stage model for Databricks Model Serving: {e!s}. "
+                "The model was registered successfully and is available for serving, but may take "
+                "longer to deploy."
+            )
 
     return create_version_response
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1431,6 +1431,6 @@ def stage_model_for_databricks_model_serving(model_name: str, model_version: str
         json={
             "model_name": model_name,
             "model_version": model_version,
-        }
+        },
     )
     augmented_raise_for_status(response)

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1242,8 +1242,8 @@ class DatabricksRuntimeVersion(NamedTuple):
     minor: int
 
     @classmethod
-    def parse(cls):
-        dbr_version = get_databricks_runtime_version()
+    def parse(cls, databricks_runtime: Optional[str] = None):
+        dbr_version = databricks_runtime or get_databricks_runtime_version()
         try:
             dbr_version_splits = dbr_version.split(".", maxsplit=2)
             if dbr_version_splits[0] == "client":

--- a/mlflow/utils/env_pack.py
+++ b/mlflow/utils/env_pack.py
@@ -20,7 +20,6 @@ EnvPackType = Literal["databricks_model_serving"]
 _ARTIFACT_PATH = "_databricks"
 _MODEL_VERSION_TAR = "model_version.tar"
 _MODEL_ENVIRONMENT_TAR = "model_environment.tar"
-_SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING = (2, 3)
 
 
 def _tar(root_path: Path, tar_path: Path) -> tarfile.TarFile:
@@ -66,14 +65,10 @@ def pack_env_for_databricks_model_serving(
         ...     pass
     """
     dbr_version = DatabricksRuntimeVersion.parse()
-    if (
-        not dbr_version.is_client_image
-        or dbr_version.major not in _SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING
-    ):
+    if not dbr_version.is_client_image:
         raise ValueError(
-            f"Serverless environment of versions "
-            f"{_SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING} is required when packing "
-            f"environment for Databricks Model Serving. Current version: {dbr_version}"
+            f"Serverless environment is required when packing environment for Databricks Model "
+            f"Serving. Current version: {dbr_version}"
         )
 
     with tempfile.TemporaryDirectory() as temp_dir:

--- a/mlflow/utils/env_pack.py
+++ b/mlflow/utils/env_pack.py
@@ -93,11 +93,15 @@ def pack_env_for_databricks_model_serving(
                 "Model must have been created in a Databricks runtime environment. "
                 "Missing 'databricks_runtime' field in MLmodel file."
             )
-        if model_dict["databricks_runtime"] != get_databricks_runtime_version():
+
+        current_runtime = DatabricksRuntimeVersion.parse()
+        model_runtime = DatabricksRuntimeVersion.parse(model_dict["databricks_runtime"])
+        if current_runtime.major != model_runtime.major:
             raise ValueError(
                 f"Runtime version mismatch. Model was created with runtime "
-                f"{model_dict['databricks_runtime']}, "
-                f"but current runtime is {get_databricks_runtime_version()}"
+                f"{model_dict['databricks_runtime']} (major version {model_runtime.major}), "
+                f"but current runtime is {get_databricks_runtime_version()} "
+                f"(major version {current_runtime.major})"
             )
 
         if enforce_pip_requirements:

--- a/mlflow/utils/env_pack.py
+++ b/mlflow/utils/env_pack.py
@@ -1,0 +1,126 @@
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import yaml
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Literal, Generator
+
+from mlflow.artifacts import download_artifacts
+from mlflow.models.model import MLMODEL_FILE_NAME
+from mlflow.utils.databricks_utils import DatabricksRuntimeVersion, get_databricks_runtime_version
+from mlflow.utils.environment import _REQUIREMENTS_FILE_NAME
+from mlflow.utils.logging_utils import eprint
+
+EnvPackType = Literal["databricks_model_serving"]
+
+_ARTIFACT_PATH = "_databricks"
+_MODEL_VERSION_TAR = "model_version.tar"
+_MODEL_ENVIRONMENT_TAR = "model_environment.tar"
+_SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING = (2, 3)
+
+
+def _tar(root_path: Path, tar_path: Path) -> tarfile.TarFile:
+    """
+    Package all files under root_path into a tar at tar_path, excluding __pycache__, *.pyc, and wheels_info.json.
+    """
+
+    def exclude(tarinfo: tarfile.TarInfo):
+        name = tarinfo.name
+        base = Path(name).name
+        if "__pycache__" in name or base.endswith(".pyc") or base == "wheels_info.json":
+            return None
+        return tarinfo
+
+    # Pull in symlinks
+    with tarfile.open(tar_path, "w", dereference=True) as tar:
+        tar.add(root_path, arcname=".", filter=exclude)
+    return tar
+
+
+# TODO: Check pip requirements using uv instead.
+@contextmanager
+def pack_env_for_databricks_model_serving(
+    model_uri: str,
+    *,
+    enforce_pip_requirements: bool = False,
+) -> Generator[str, None, None]:
+    """
+    Generate Databricks artifacts for fast deployment.
+
+    Args:
+        model_uri: The URI of the model to package.
+        enforce_pip_requirements: Whether to enforce pip requirements installation.
+
+    Yields:
+        str: The path to the local artifacts directory containing the model artifacts and environment.
+
+    Example:
+        >>> with pack_env_for_databricks_model_serving("models:/my-model/1") as artifacts_dir:
+        ...     # Use artifacts_dir here
+        ...     pass
+    """
+    dbr_version = DatabricksRuntimeVersion.parse()
+    if (
+        not dbr_version.is_client_image
+        or dbr_version.major
+        not in _SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING
+    ):
+        raise ValueError(
+            f"Serverless environment of versions {_SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING} is required when packing environment for Databricks Model Serving. Current version: {dbr_version}"
+        )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Download model artifacts. Keep this separate from temp_dir to avoid noise in packaged artifacts.
+        local_artifacts_dir = Path(download_artifacts(artifact_uri=model_uri))
+        
+        # Check runtime version consistency
+        # We read the MLmodel file directly instead of using Model.to_dict() because to_dict() adds
+        # the current runtime version via get_databricks_runtime_version(), which would prevent us
+        # from detecting runtime version mismatches.
+        mlmodel_path = local_artifacts_dir / MLMODEL_FILE_NAME
+        with open(mlmodel_path) as f:
+            model_dict = yaml.safe_load(f)
+        if "databricks_runtime" not in model_dict:
+            raise ValueError(
+                f"Model must have been created in a Databricks runtime environment. "
+                f"Missing 'databricks_runtime' field in MLmodel file."
+            )
+        if model_dict["databricks_runtime"] != get_databricks_runtime_version():
+            raise ValueError(
+                f"Runtime version mismatch. Model was created with runtime {model_dict['databricks_runtime']}, "
+                f"but current runtime is {get_databricks_runtime_version()}"
+            )
+
+        if enforce_pip_requirements:
+            eprint("Installing model requirements...")
+            try:
+                subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "pip",
+                        "install",
+                        "-r",
+                        str(local_artifacts_dir / _REQUIREMENTS_FILE_NAME),
+                    ],
+                    check=True,
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.STDOUT,
+                    text=True,
+                )
+            except subprocess.CalledProcessError as e:
+                eprint("Error installing requirements:")
+                eprint(e.stdout)
+                raise
+
+        # Package model artifacts and env into temp_dir/_databricks
+        temp_artifacts_dir = Path(temp_dir) / _ARTIFACT_PATH
+        temp_artifacts_dir.mkdir(exist_ok=False)
+        _tar(local_artifacts_dir, temp_artifacts_dir / _MODEL_VERSION_TAR)
+        _tar(Path(sys.prefix), temp_artifacts_dir / _MODEL_ENVIRONMENT_TAR)
+        shutil.move(str(temp_artifacts_dir), local_artifacts_dir)
+
+        yield str(local_artifacts_dir)

--- a/mlflow/utils/env_pack.py
+++ b/mlflow/utils/env_pack.py
@@ -3,10 +3,11 @@ import subprocess
 import sys
 import tarfile
 import tempfile
-import yaml
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Literal, Generator
+from typing import Generator, Literal
+
+import yaml
 
 from mlflow.artifacts import download_artifacts
 from mlflow.models.model import MLMODEL_FILE_NAME
@@ -24,7 +25,8 @@ _SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING = (2, 3)
 
 def _tar(root_path: Path, tar_path: Path) -> tarfile.TarFile:
     """
-    Package all files under root_path into a tar at tar_path, excluding __pycache__, *.pyc, and wheels_info.json.
+    Package all files under root_path into a tar at tar_path, excluding __pycache__, *.pyc, and
+    wheels_info.json.
     """
 
     def exclude(tarinfo: tarfile.TarInfo):
@@ -55,7 +57,8 @@ def pack_env_for_databricks_model_serving(
         enforce_pip_requirements: Whether to enforce pip requirements installation.
 
     Yields:
-        str: The path to the local artifacts directory containing the model artifacts and environment.
+        str: The path to the local artifacts directory containing the model artifacts and
+            environment.
 
     Example:
         >>> with pack_env_for_databricks_model_serving("models:/my-model/1") as artifacts_dir:
@@ -65,17 +68,19 @@ def pack_env_for_databricks_model_serving(
     dbr_version = DatabricksRuntimeVersion.parse()
     if (
         not dbr_version.is_client_image
-        or dbr_version.major
-        not in _SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING
+        or dbr_version.major not in _SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING
     ):
         raise ValueError(
-            f"Serverless environment of versions {_SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING} is required when packing environment for Databricks Model Serving. Current version: {dbr_version}"
+            f"Serverless environment of versions "
+            f"{_SUPPORTED_CLIENT_IMAGE_MAJOR_VERSIONS_FOR_MODEL_SERVING} is required when packing "
+            f"environment for Databricks Model Serving. Current version: {dbr_version}"
         )
 
     with tempfile.TemporaryDirectory() as temp_dir:
-        # Download model artifacts. Keep this separate from temp_dir to avoid noise in packaged artifacts.
+        # Download model artifacts. Keep this separate from temp_dir to avoid noise in packaged
+        # artifacts.
         local_artifacts_dir = Path(download_artifacts(artifact_uri=model_uri))
-        
+
         # Check runtime version consistency
         # We read the MLmodel file directly instead of using Model.to_dict() because to_dict() adds
         # the current runtime version via get_databricks_runtime_version(), which would prevent us
@@ -85,12 +90,13 @@ def pack_env_for_databricks_model_serving(
             model_dict = yaml.safe_load(f)
         if "databricks_runtime" not in model_dict:
             raise ValueError(
-                f"Model must have been created in a Databricks runtime environment. "
-                f"Missing 'databricks_runtime' field in MLmodel file."
+                "Model must have been created in a Databricks runtime environment. "
+                "Missing 'databricks_runtime' field in MLmodel file."
             )
         if model_dict["databricks_runtime"] != get_databricks_runtime_version():
             raise ValueError(
-                f"Runtime version mismatch. Model was created with runtime {model_dict['databricks_runtime']}, "
+                f"Runtime version mismatch. Model was created with runtime "
+                f"{model_dict['databricks_runtime']}, "
                 f"but current runtime is {get_databricks_runtime_version()}"
             )
 

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -345,20 +345,32 @@ def test_register_model_with_env_pack(tmp_path, mock_dbr_version):
     (mock_artifacts_dir / "requirements.txt").write_text("numpy==1.21.0")
 
     with (
-        mock.patch("mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)),
+        mock.patch(
+            "mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)
+        ),
         mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
-        mock.patch("mlflow.tracking._model_registry.fluent.pack_env_for_databricks_model_serving") as mock_pack_env,
-        mock.patch("mlflow.tracking._model_registry.fluent.stage_model_for_databricks_model_serving") as mock_stage_model,
-        mock.patch("mlflow.MlflowClient._create_model_version", return_value=ModelVersion("Model 1", "1", creation_timestamp=123)),
-        mock.patch("mlflow.MlflowClient.get_model_version", return_value=ModelVersion("Model 1", "1", creation_timestamp=123)),
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.pack_env_for_databricks_model_serving"
+        ) as mock_pack_env,
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.stage_model_for_databricks_model_serving"
+        ) as mock_stage_model,
+        mock.patch(
+            "mlflow.MlflowClient._create_model_version",
+            return_value=ModelVersion("Model 1", "1", creation_timestamp=123),
+        ),
+        mock.patch(
+            "mlflow.MlflowClient.get_model_version",
+            return_value=ModelVersion("Model 1", "1", creation_timestamp=123),
+        ),
         mock.patch("mlflow.MlflowClient.log_model_artifacts") as mock_log_artifacts,
     ):
         # Set up the mock pack_env to yield a path
         mock_pack_env.return_value.__enter__.return_value = str(mock_artifacts_dir)
-        
+
         # Call register_model with env_pack
         register_model("models:/test-model/1", "Model 1", env_pack="databricks_model_serving")
-        
+
         # Verify pack_env was called with correct arguments
         mock_pack_env.assert_called_once_with(
             "models:/test-model/1",

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -331,7 +331,6 @@ def mock_dbr_version():
             is_client_image=True,
             major=2,  # Supported version
             minor=0,
-            patch=0,
         ),
     ):
         yield

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -15,6 +15,7 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_ALREADY_EXISTS,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
+from mlflow.utils.databricks_utils import DatabricksRuntimeVersion
 
 
 def test_register_model_with_runs_uri():
@@ -319,3 +320,59 @@ with mlflow.start_run() as run:
     # Register the model with MLflow 3.x
     model_uri = out.read_text().strip()
     mlflow.register_model(model_uri, "model")
+
+
+@pytest.fixture
+def mock_dbr_version():
+    """Mock DatabricksRuntimeVersion to simulate a supported client image."""
+    with mock.patch(
+        "mlflow.utils.databricks_utils.DatabricksRuntimeVersion.parse",
+        return_value=DatabricksRuntimeVersion(
+            is_client_image=True,
+            major=2,  # Supported version
+            minor=0,
+            patch=0,
+        ),
+    ):
+        yield
+
+
+def test_register_model_with_env_pack(tmp_path, mock_dbr_version):
+    """Test that register_model correctly integrates with environment packing functionality."""
+    # Mock download_artifacts to return a path
+    mock_artifacts_dir = tmp_path / "artifacts"
+    mock_artifacts_dir.mkdir()
+    (mock_artifacts_dir / "requirements.txt").write_text("numpy==1.21.0")
+
+    with (
+        mock.patch("mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)),
+        mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
+        mock.patch("mlflow.tracking._model_registry.fluent.pack_env_for_databricks_model_serving") as mock_pack_env,
+        mock.patch("mlflow.tracking._model_registry.fluent.stage_model_for_databricks_model_serving") as mock_stage_model,
+        mock.patch("mlflow.MlflowClient._create_model_version", return_value=ModelVersion("Model 1", "1", creation_timestamp=123)),
+        mock.patch("mlflow.MlflowClient.get_model_version", return_value=ModelVersion("Model 1", "1", creation_timestamp=123)),
+        mock.patch("mlflow.MlflowClient.log_model_artifacts") as mock_log_artifacts,
+    ):
+        # Set up the mock pack_env to yield a path
+        mock_pack_env.return_value.__enter__.return_value = str(mock_artifacts_dir)
+        
+        # Call register_model with env_pack
+        register_model("models:/test-model/1", "Model 1", env_pack="databricks_model_serving")
+        
+        # Verify pack_env was called with correct arguments
+        mock_pack_env.assert_called_once_with(
+            "models:/test-model/1",
+            enforce_pip_requirements=True,
+        )
+
+        # Verify log_model_artifacts was called with correct arguments
+        mock_log_artifacts.assert_called_once_with(
+            None,
+            str(mock_artifacts_dir),
+        )
+
+        # Verify stage_model was called with correct arguments
+        mock_stage_model.assert_called_once_with(
+            model_name="Model 1",
+            model_version="1",
+        )

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+import requests
 
 import mlflow
 from mlflow import MlflowClient, register_model
@@ -386,4 +387,66 @@ def test_register_model_with_env_pack(tmp_path, mock_dbr_version):
         mock_stage_model.assert_called_once_with(
             model_name="Model 1",
             model_version="1",
+        )
+
+
+def test_register_model_with_env_pack_staging_failure(tmp_path, mock_dbr_version):
+    """Test that register_model handles staging failure gracefully."""
+    # Mock download_artifacts to return a path
+    mock_artifacts_dir = tmp_path / "artifacts"
+    mock_artifacts_dir.mkdir()
+    (mock_artifacts_dir / "requirements.txt").write_text("numpy==1.21.0")
+
+    with (
+        mock.patch(
+            "mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)
+        ),
+        mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.pack_env_for_databricks_model_serving"
+        ) as mock_pack_env,
+        mock.patch(
+            "mlflow.tracking._model_registry.fluent.stage_model_for_databricks_model_serving",
+            side_effect=requests.exceptions.HTTPError("Staging failed"),
+        ) as mock_stage_model,
+        mock.patch(
+            "mlflow.MlflowClient._create_model_version",
+            return_value=ModelVersion("Model 1", "1", creation_timestamp=123),
+        ),
+        mock.patch(
+            "mlflow.MlflowClient.get_model_version",
+            return_value=ModelVersion("Model 1", "1", creation_timestamp=123),
+        ),
+        mock.patch("mlflow.MlflowClient.log_model_artifacts") as mock_log_artifacts,
+        mock.patch("mlflow.tracking._model_registry.fluent.eprint") as mock_eprint,
+    ):
+        # Set up the mock pack_env to yield a path
+        mock_pack_env.return_value.__enter__.return_value = str(mock_artifacts_dir)
+
+        # Call register_model with env_pack
+        register_model("models:/test-model/1", "Model 1", env_pack="databricks_model_serving")
+
+        # Verify pack_env was called with correct arguments
+        mock_pack_env.assert_called_once_with(
+            "models:/test-model/1",
+            enforce_pip_requirements=True,
+        )
+
+        # Verify log_model_artifacts was called with correct arguments
+        mock_log_artifacts.assert_called_once_with(
+            None,
+            str(mock_artifacts_dir),
+        )
+
+        # Verify stage_model was called with correct arguments
+        mock_stage_model.assert_called_once_with(
+            model_name="Model 1",
+            model_version="1",
+        )
+
+        # Verify warning message was printed
+        mock_eprint.assert_any_call(
+            "Failed to stage model for Databricks Model Serving: Staging failed. "
+            "The model was registered successfully and is available for serving, but may take "
+            "longer to deploy."
         )

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -705,63 +705,69 @@ def test_print_databricks_deployment_job_url():
             )
 
 
-def test_databricks_runtime_version_parse():
+@pytest.mark.parametrize(
+    ("version_str", "expected_is_client", "expected_major", "expected_minor"),
+    [
+        ("client.2.0", True, 2, 0),
+        ("client.3.1", True, 3, 1),
+        ("13.2", False, 13, 2),
+        ("15.4", False, 15, 4),
+    ],
+)
+def test_databricks_runtime_version_parse(
+    version_str,
+    expected_is_client,
+    expected_major,
+    expected_minor,
+):
     """Test that DatabricksRuntimeVersion.parse() correctly parses version strings."""
-    # Test client image versions
-    version = DatabricksRuntimeVersion.parse("client.2.0")
-    assert version.is_client_image is True
-    assert version.major == 2
-    assert version.minor == 0
-
-    version = DatabricksRuntimeVersion.parse("client.3.1")
-    assert version.is_client_image is True
-    assert version.major == 3
-    assert version.minor == 1
-
-    # Test non-client image versions
-    version = DatabricksRuntimeVersion.parse("13.2")
-    assert version.is_client_image is False
-    assert version.major == 13
-    assert version.minor == 2
-
-    version = DatabricksRuntimeVersion.parse("15.4")
-    assert version.is_client_image is False
-    assert version.major == 15
-    assert version.minor == 4
+    version = DatabricksRuntimeVersion.parse(version_str)
+    assert version.is_client_image == expected_is_client
+    assert version.major == expected_major
+    assert version.minor == expected_minor
 
 
-def test_databricks_runtime_version_parse_default(monkeypatch):
+@pytest.mark.parametrize(
+    ("env_version", "expected_is_client", "expected_major", "expected_minor"),
+    [
+        ("client.2.0", True, 2, 0),
+        ("13.2", False, 13, 2),
+    ],
+)
+def test_databricks_runtime_version_parse_default(
+    monkeypatch,
+    env_version,
+    expected_is_client,
+    expected_major,
+    expected_minor,
+):
     """Test that DatabricksRuntimeVersion.parse() works without arguments."""
-    # Test with client image version
-    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "client.2.0")
+    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", env_version)
     version = DatabricksRuntimeVersion.parse()
-    assert version.is_client_image is True
-    assert version.major == 2
-    assert version.minor == 0
+    assert version.is_client_image == expected_is_client
+    assert version.major == expected_major
+    assert version.minor == expected_minor
 
-    # Test with non-client image version
-    monkeypatch.setenv("DATABRICKS_RUNTIME_VERSION", "13.2")
-    version = DatabricksRuntimeVersion.parse()
-    assert version.is_client_image is False
-    assert version.major == 13
-    assert version.minor == 2
 
-    # Test with no environment variable set
-    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION")
+def test_databricks_runtime_version_parse_default_no_env(monkeypatch):
+    """Test that DatabricksRuntimeVersion.parse() raises error when no environment variable is
+    set.
+    """
+    monkeypatch.delenv("DATABRICKS_RUNTIME_VERSION", raising=False)
     with pytest.raises(Exception, match="Failed to parse databricks runtime version"):
         DatabricksRuntimeVersion.parse()
 
 
-def test_databricks_runtime_version_parse_invalid():
+@pytest.mark.parametrize(
+    "invalid_version",
+    [
+        "invalid",
+        "client",
+        "client.invalid",
+        "13",
+    ],
+)
+def test_databricks_runtime_version_parse_invalid(invalid_version):
     """Test that DatabricksRuntimeVersion.parse() raises error for invalid version strings."""
     with pytest.raises(Exception, match="Failed to parse databricks runtime version"):
-        DatabricksRuntimeVersion.parse("invalid")
-
-    with pytest.raises(Exception, match="Failed to parse databricks runtime version"):
-        DatabricksRuntimeVersion.parse("client")
-
-    with pytest.raises(Exception, match="Failed to parse databricks runtime version"):
-        DatabricksRuntimeVersion.parse("client.invalid")
-
-    with pytest.raises(Exception, match="Failed to parse databricks runtime version"):
-        DatabricksRuntimeVersion.parse("13")
+        DatabricksRuntimeVersion.parse(invalid_version)

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -172,12 +172,12 @@ def test_pack_env_for_databricks_model_serving_unsupported_version():
                 pass
 
 
-def test_pack_env_for_databricks_model_serving_runtime_version_check(temp_dir, mock_dbr_version):
+def test_pack_env_for_databricks_model_serving_runtime_version_check(temp_path, mock_dbr_version):
     """Test that pack_env_for_databricks_model_serving correctly checks runtime version
     compatibility.
     """
     # Mock download_artifacts to return a path
-    mock_artifacts_dir = temp_dir / "artifacts"
+    mock_artifacts_dir = temp_path / "artifacts"
     mock_artifacts_dir.mkdir()
 
     # Create MLmodel file with different runtime version
@@ -204,10 +204,10 @@ def test_pack_env_for_databricks_model_serving_runtime_version_check(temp_dir, m
                 pass
 
 
-def test_pack_env_for_databricks_model_serving_missing_runtime_version(temp_dir, mock_dbr_version):
+def test_pack_env_for_databricks_model_serving_missing_runtime_version(temp_path, mock_dbr_version):
     """Test that pack_env_for_databricks_model_serving requires databricks_runtime field."""
     # Mock download_artifacts to return a path
-    mock_artifacts_dir = temp_dir / "artifacts"
+    mock_artifacts_dir = temp_path / "artifacts"
     mock_artifacts_dir.mkdir()
 
     # Create MLmodel file without databricks_runtime field

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -175,12 +175,12 @@ def test_pack_env_for_databricks_model_serving_unsupported_version():
                 pass
 
 
-def test_pack_env_for_databricks_model_serving_runtime_version_check(temp_path, mock_dbr_version):
+def test_pack_env_for_databricks_model_serving_runtime_version_check(tmp_path, mock_dbr_version):
     """Test that pack_env_for_databricks_model_serving correctly checks runtime version
     compatibility.
     """
     # Mock download_artifacts to return a path
-    mock_artifacts_dir = temp_path / "artifacts"
+    mock_artifacts_dir = tmp_path / "artifacts"
     mock_artifacts_dir.mkdir()
 
     # Create MLmodel file with different runtime version
@@ -207,10 +207,10 @@ def test_pack_env_for_databricks_model_serving_runtime_version_check(temp_path, 
                 pass
 
 
-def test_pack_env_for_databricks_model_serving_missing_runtime_version(temp_path, mock_dbr_version):
+def test_pack_env_for_databricks_model_serving_missing_runtime_version(tmp_path, mock_dbr_version):
     """Test that pack_env_for_databricks_model_serving requires databricks_runtime field."""
     # Mock download_artifacts to return a path
-    mock_artifacts_dir = temp_path / "artifacts"
+    mock_artifacts_dir = tmp_path / "artifacts"
     mock_artifacts_dir.mkdir()
 
     # Create MLmodel file without databricks_runtime field

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -144,7 +144,10 @@ def test_pack_env_for_databricks_model_serving_pip_requirements_error(tmp_path, 
         )
         mock_run.side_effect = subprocess.CalledProcessError(1, "pip install", "Error message")
 
-        with pytest.raises(subprocess.CalledProcessError, match="Error message"):
+        with pytest.raises(
+            subprocess.CalledProcessError,
+            match="Command 'pip install' returned non-zero exit status 1.",
+        ):
             with env_pack.pack_env_for_databricks_model_serving(
                 "models:/test/1", enforce_pip_requirements=True
             ):

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -3,9 +3,9 @@ import sys
 import tarfile
 from pathlib import Path
 from unittest import mock
-import yaml
 
 import pytest
+import yaml
 
 from mlflow.utils import env_pack
 from mlflow.utils.databricks_utils import DatabricksRuntimeVersion
@@ -48,10 +48,10 @@ def test_tar_function_path_handling(tmp_path):
         assert names == {".", "./test.txt"}
 
 
-def test_pack_env_for_databricks_model_serving_pip_requirements(
-    tmp_path, mock_dbr_version
-):
-    """Test that pack_env_for_databricks_model_serving correctly handles pip requirements installation."""
+def test_pack_env_for_databricks_model_serving_pip_requirements(tmp_path, mock_dbr_version):
+    """Test that pack_env_for_databricks_model_serving correctly handles pip requirements
+    installation.
+    """
     # Mock download_artifacts to return a path
     mock_artifacts_dir = tmp_path / "artifacts"
     mock_artifacts_dir.mkdir()
@@ -60,10 +60,12 @@ def test_pack_env_for_databricks_model_serving_pip_requirements(
     # Create MLmodel file with correct runtime version
     mlmodel_path = mock_artifacts_dir / "MLmodel"
     mlmodel_path.write_text(
-        yaml.dump({
-            "databricks_runtime": "client.2.0",
-            "flavors": {"python_function": {"model_path": "model.pkl"}},
-        })
+        yaml.dump(
+            {
+                "databricks_runtime": "client.2.0",
+                "flavors": {"python_function": {"model_path": "model.pkl"}},
+            }
+        )
     )
 
     with (
@@ -72,7 +74,9 @@ def test_pack_env_for_databricks_model_serving_pip_requirements(
             return_value=str(mock_artifacts_dir),
         ),
         mock.patch("subprocess.run") as mock_run,
-        mock.patch("mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"),
+        mock.patch(
+            "mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"
+        ),
     ):
         # Mock subprocess.run to simulate successful pip install
         mock_run.return_value = mock.Mock(returncode=0)
@@ -83,13 +87,9 @@ def test_pack_env_for_databricks_model_serving_pip_requirements(
             artifacts_path = Path(artifacts_dir)
             assert artifacts_path.exists()
             assert (artifacts_path / env_pack._ARTIFACT_PATH).exists()
+            assert (artifacts_path / env_pack._ARTIFACT_PATH / env_pack._MODEL_VERSION_TAR).exists()
             assert (
-                artifacts_path / env_pack._ARTIFACT_PATH / env_pack._MODEL_VERSION_TAR
-            ).exists()
-            assert (
-                artifacts_path
-                / env_pack._ARTIFACT_PATH
-                / env_pack._MODEL_ENVIRONMENT_TAR
+                artifacts_path / env_pack._ARTIFACT_PATH / env_pack._MODEL_ENVIRONMENT_TAR
             ).exists()
 
             # Verify subprocess.run was called with correct arguments
@@ -109,9 +109,7 @@ def test_pack_env_for_databricks_model_serving_pip_requirements(
             assert kwargs["text"] is True
 
 
-def test_pack_env_for_databricks_model_serving_pip_requirements_error(
-    tmp_path, mock_dbr_version
-):
+def test_pack_env_for_databricks_model_serving_pip_requirements_error(tmp_path, mock_dbr_version):
     """Test that pack_env_for_databricks_model_serving correctly handles pip install errors."""
     # Mock download_artifacts to return a path
     mock_artifacts_dir = tmp_path / "artifacts"
@@ -121,10 +119,12 @@ def test_pack_env_for_databricks_model_serving_pip_requirements_error(
     # Create MLmodel file with correct runtime version
     mlmodel_path = mock_artifacts_dir / "MLmodel"
     mlmodel_path.write_text(
-        yaml.dump({
-            "databricks_runtime": "client.2.0",
-            "flavors": {"python_function": {"model_path": "model.pkl"}},
-        })
+        yaml.dump(
+            {
+                "databricks_runtime": "client.2.0",
+                "flavors": {"python_function": {"model_path": "model.pkl"}},
+            }
+        )
     )
 
     with (
@@ -134,17 +134,17 @@ def test_pack_env_for_databricks_model_serving_pip_requirements_error(
         ),
         mock.patch("subprocess.run") as mock_run,
         mock.patch("mlflow.utils.env_pack.eprint") as mock_eprint,
-        mock.patch("mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"),
+        mock.patch(
+            "mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"
+        ),
     ):
         mock_run.return_value = mock.Mock(
             returncode=1,
             stdout="ERROR: Could not find a version that satisfies the requirement invalid-package",
         )
-        mock_run.side_effect = subprocess.CalledProcessError(
-            1, "pip install", "Error message"
-        )
+        mock_run.side_effect = subprocess.CalledProcessError(1, "pip install", "Error message")
 
-        with pytest.raises(subprocess.CalledProcessError):
+        with pytest.raises(subprocess.CalledProcessError, match="Error message"):
             with env_pack.pack_env_for_databricks_model_serving(
                 "models:/test/1", enforce_pip_requirements=True
             ):
@@ -173,23 +173,31 @@ def test_pack_env_for_databricks_model_serving_unsupported_version():
 
 
 def test_pack_env_for_databricks_model_serving_runtime_version_check(temp_dir, mock_dbr_version):
-    """Test that pack_env_for_databricks_model_serving correctly checks runtime version compatibility."""
+    """Test that pack_env_for_databricks_model_serving correctly checks runtime version
+    compatibility.
+    """
     # Mock download_artifacts to return a path
     mock_artifacts_dir = temp_dir / "artifacts"
     mock_artifacts_dir.mkdir()
-    
+
     # Create MLmodel file with different runtime version
     mlmodel_path = mock_artifacts_dir / "MLmodel"
     mlmodel_path.write_text(
-        yaml.dump({
-            "databricks_runtime": "client.3.0",  # Different from mock_dbr_version
-            "flavors": {"python_function": {"model_path": "model.pkl"}},
-        })
+        yaml.dump(
+            {
+                "databricks_runtime": "client.3.0",  # Different from mock_dbr_version
+                "flavors": {"python_function": {"model_path": "model.pkl"}},
+            }
+        )
     )
 
     with (
-        mock.patch("mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)),
-        mock.patch("mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"),
+        mock.patch(
+            "mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)
+        ),
+        mock.patch(
+            "mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"
+        ),
     ):
         with pytest.raises(ValueError, match="Runtime version mismatch"):
             with env_pack.pack_env_for_databricks_model_serving("models:/test-model/1"):
@@ -201,16 +209,22 @@ def test_pack_env_for_databricks_model_serving_missing_runtime_version(temp_dir,
     # Mock download_artifacts to return a path
     mock_artifacts_dir = temp_dir / "artifacts"
     mock_artifacts_dir.mkdir()
-    
+
     # Create MLmodel file without databricks_runtime field
     mlmodel_path = mock_artifacts_dir / "MLmodel"
     mlmodel_path.write_text(
-        yaml.dump({
-            "flavors": {"python_function": {"model_path": "model.pkl"}},
-        })
+        yaml.dump(
+            {
+                "flavors": {"python_function": {"model_path": "model.pkl"}},
+            }
+        )
     )
 
-    with mock.patch("mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)):
-        with pytest.raises(ValueError, match="Model must have been created in a Databricks runtime environment"):
+    with mock.patch(
+        "mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)
+    ):
+        with pytest.raises(
+            ValueError, match="Model must have been created in a Databricks runtime environment"
+        ):
             with env_pack.pack_env_for_databricks_model_serving("models:/test-model/1"):
                 pass

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -1,0 +1,216 @@
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+from unittest import mock
+import yaml
+
+import pytest
+
+from mlflow.utils import env_pack
+from mlflow.utils.databricks_utils import DatabricksRuntimeVersion
+
+
+@pytest.fixture
+def mock_dbr_version():
+    with mock.patch.object(
+        DatabricksRuntimeVersion,
+        "parse",
+        return_value=mock.Mock(
+            is_client_image=True,
+            major=2,
+            minor=0,
+            patch=0,
+        ),
+    ):
+        yield
+
+
+def test_tar_function_path_handling(tmp_path):
+    """Test that _tar function correctly handles Path objects."""
+    # Create test files
+    root_dir = tmp_path / "root"
+    root_dir.mkdir()
+    (root_dir / "test.txt").write_text("test content")
+    (root_dir / "__pycache__").mkdir()
+    (root_dir / "__pycache__" / "test.pyc").write_text("bytecode")
+    (root_dir / "wheels_info.json").write_text("{}")
+
+    # Create tar file
+    tar_path = tmp_path / "test.tar"
+    env_pack._tar(root_dir, tar_path)
+
+    # Verify tar contents
+    with tarfile.open(tar_path) as tar:
+        members = tar.getmembers()
+        names = {m.name for m in members}
+
+        assert names == {".", "./test.txt"}
+
+
+def test_pack_env_for_databricks_model_serving_pip_requirements(
+    tmp_path, mock_dbr_version
+):
+    """Test that pack_env_for_databricks_model_serving correctly handles pip requirements installation."""
+    # Mock download_artifacts to return a path
+    mock_artifacts_dir = tmp_path / "artifacts"
+    mock_artifacts_dir.mkdir()
+    (mock_artifacts_dir / "requirements.txt").write_text("numpy==1.21.0")
+
+    # Create MLmodel file with correct runtime version
+    mlmodel_path = mock_artifacts_dir / "MLmodel"
+    mlmodel_path.write_text(
+        yaml.dump({
+            "databricks_runtime": "client.2.0",
+            "flavors": {"python_function": {"model_path": "model.pkl"}},
+        })
+    )
+
+    with (
+        mock.patch(
+            "mlflow.utils.env_pack.download_artifacts",
+            return_value=str(mock_artifacts_dir),
+        ),
+        mock.patch("subprocess.run") as mock_run,
+        mock.patch("mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"),
+    ):
+        # Mock subprocess.run to simulate successful pip install
+        mock_run.return_value = mock.Mock(returncode=0)
+        with env_pack.pack_env_for_databricks_model_serving(
+            "models:/test-model/1", enforce_pip_requirements=True
+        ) as artifacts_dir:
+            # Verify artifacts directory exists and contains expected files
+            artifacts_path = Path(artifacts_dir)
+            assert artifacts_path.exists()
+            assert (artifacts_path / env_pack._ARTIFACT_PATH).exists()
+            assert (
+                artifacts_path / env_pack._ARTIFACT_PATH / env_pack._MODEL_VERSION_TAR
+            ).exists()
+            assert (
+                artifacts_path
+                / env_pack._ARTIFACT_PATH
+                / env_pack._MODEL_ENVIRONMENT_TAR
+            ).exists()
+
+            # Verify subprocess.run was called with correct arguments
+            mock_run.assert_called_once()
+            args, kwargs = mock_run.call_args
+            assert args[0] == [
+                sys.executable,
+                "-m",
+                "pip",
+                "install",
+                "-r",
+                str(mock_artifacts_dir / "requirements.txt"),
+            ]
+            assert kwargs["check"] is True
+            assert kwargs["stdout"] == subprocess.PIPE
+            assert kwargs["stderr"] == subprocess.STDOUT
+            assert kwargs["text"] is True
+
+
+def test_pack_env_for_databricks_model_serving_pip_requirements_error(
+    tmp_path, mock_dbr_version
+):
+    """Test that pack_env_for_databricks_model_serving correctly handles pip install errors."""
+    # Mock download_artifacts to return a path
+    mock_artifacts_dir = tmp_path / "artifacts"
+    mock_artifacts_dir.mkdir()
+    (mock_artifacts_dir / "requirements.txt").write_text("invalid-package==1.0.0")
+
+    # Create MLmodel file with correct runtime version
+    mlmodel_path = mock_artifacts_dir / "MLmodel"
+    mlmodel_path.write_text(
+        yaml.dump({
+            "databricks_runtime": "client.2.0",
+            "flavors": {"python_function": {"model_path": "model.pkl"}},
+        })
+    )
+
+    with (
+        mock.patch(
+            "mlflow.utils.env_pack.download_artifacts",
+            return_value=str(mock_artifacts_dir),
+        ),
+        mock.patch("subprocess.run") as mock_run,
+        mock.patch("mlflow.utils.env_pack.eprint") as mock_eprint,
+        mock.patch("mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"),
+    ):
+        mock_run.return_value = mock.Mock(
+            returncode=1,
+            stdout="ERROR: Could not find a version that satisfies the requirement invalid-package",
+        )
+        mock_run.side_effect = subprocess.CalledProcessError(
+            1, "pip install", "Error message"
+        )
+
+        with pytest.raises(subprocess.CalledProcessError):
+            with env_pack.pack_env_for_databricks_model_serving(
+                "models:/test/1", enforce_pip_requirements=True
+            ):
+                pass
+
+        # Verify error messages were printed
+        mock_eprint.assert_any_call("Error installing requirements:")
+        mock_eprint.assert_any_call("Error message")
+
+
+def test_pack_env_for_databricks_model_serving_unsupported_version():
+    """Test that pack_env_for_databricks_model_serving raises error for unsupported versions."""
+    with mock.patch.object(
+        DatabricksRuntimeVersion,
+        "parse",
+        return_value=mock.Mock(
+            is_client_image=True,
+            major=1,  # Unsupported version
+            minor=0,
+            patch=0,
+        ),
+    ):
+        with pytest.raises(ValueError, match="Serverless environment of versions"):
+            with env_pack.pack_env_for_databricks_model_serving("models:/test/1"):
+                pass
+
+
+def test_pack_env_for_databricks_model_serving_runtime_version_check(temp_dir, mock_dbr_version):
+    """Test that pack_env_for_databricks_model_serving correctly checks runtime version compatibility."""
+    # Mock download_artifacts to return a path
+    mock_artifacts_dir = temp_dir / "artifacts"
+    mock_artifacts_dir.mkdir()
+    
+    # Create MLmodel file with different runtime version
+    mlmodel_path = mock_artifacts_dir / "MLmodel"
+    mlmodel_path.write_text(
+        yaml.dump({
+            "databricks_runtime": "client.3.0",  # Different from mock_dbr_version
+            "flavors": {"python_function": {"model_path": "model.pkl"}},
+        })
+    )
+
+    with (
+        mock.patch("mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)),
+        mock.patch("mlflow.utils.env_pack.get_databricks_runtime_version", return_value="client.2.0"),
+    ):
+        with pytest.raises(ValueError, match="Runtime version mismatch"):
+            with env_pack.pack_env_for_databricks_model_serving("models:/test-model/1"):
+                pass
+
+
+def test_pack_env_for_databricks_model_serving_missing_runtime_version(temp_dir, mock_dbr_version):
+    """Test that pack_env_for_databricks_model_serving requires databricks_runtime field."""
+    # Mock download_artifacts to return a path
+    mock_artifacts_dir = temp_dir / "artifacts"
+    mock_artifacts_dir.mkdir()
+    
+    # Create MLmodel file without databricks_runtime field
+    mlmodel_path = mock_artifacts_dir / "MLmodel"
+    mlmodel_path.write_text(
+        yaml.dump({
+            "flavors": {"python_function": {"model_path": "model.pkl"}},
+        })
+    )
+
+    with mock.patch("mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)):
+        with pytest.raises(ValueError, match="Model must have been created in a Databricks runtime environment"):
+            with env_pack.pack_env_for_databricks_model_serving("models:/test-model/1"):
+                pass

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -152,17 +152,17 @@ def test_pack_env_for_databricks_model_serving_pip_requirements_error(tmp_path, 
 
 
 def test_pack_env_for_databricks_model_serving_unsupported_version():
-    """Test that pack_env_for_databricks_model_serving raises error for unsupported versions."""
+    """Test that pack_env_for_databricks_model_serving raises error for non-client image."""
     with mock.patch.object(
         DatabricksRuntimeVersion,
         "parse",
         return_value=DatabricksRuntimeVersion(
-            is_client_image=True,
-            major=1,  # Unsupported version
+            is_client_image=False,  # Not a client image
+            major=13,
             minor=0,
         ),
     ):
-        with pytest.raises(ValueError, match="Serverless environment of versions"):
+        with pytest.raises(ValueError, match="Serverless environment is required"):
             with env_pack.pack_env_for_databricks_model_serving("models:/test/1"):
                 pass
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This adds a new optional argument `env_pack` to the `mlflow.register_model` function. When provided with value `"databricks_model_serving"`, the registration process will perform the following:
1. Add `_databricks/*.tar` files to the model's artifacts;
2. Upload the model with added `_databricks/*.tar` to UC;
3. Call Databricks' stageModelDeployment API.

The `_databricks/model_version.tar` file contains the original model artifact content before modification.

The `_databricks/model_environment.tar` file contains the current active Notebook Python environment with model dependencies installed. Note that it may not include libraries pre-installed in the Notebook environment. This is desired to minimize the file size, and the serving environment will have the same pre-installed libraries as well.

Usage example:
```python
with mlflow.start_run() as run:
    model_info = mlflow.pyfunc.log_model(name="my-model", python_model=model, signature=signature)

mlflow.register_model(
    model_info.model_uri,
    "main.default.mlflow-test",
    env_pack="databricks_model_serving"
)
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

[Test model](https://e2-dogfood.staging.cloud.databricks.com/ml/experiments/4171322111985565/models/m-bd63fac1e1264542a8debfefad4e4960/artifacts?o=6051921418418893): No extra deps; model size 30KB; env size 59MB

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add a new optional argument `env_pack` to `mlflow.register_model` which will pack the model environment from a Databricks Serverless Notebook to be used in Databricks Model Serving.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
