### PR TITLE
Fix environment variable name mismatch for `MLFLOW_CONFIGURE_LOGGING`

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -34,9 +34,6 @@ from mlflow.version import IS_TRACING_SDK_ONLY, VERSION
 
 __version__ = VERSION
 
-import os
-import warnings
-
 import mlflow.mismatch
 
 # `check_version_mismatch` must be called here before importing any other modules
@@ -156,15 +153,8 @@ if TYPE_CHECKING:
         xgboost,
     )
 
-if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower() == "false":
-    warnings.warn(
-        "MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, "
-        f"please use {MLFLOW_CONFIGURE_LOGGING.name} instead.",
-        FutureWarning,
-    )
-elif MLFLOW_CONFIGURE_LOGGING.get() is True:
+if MLFLOW_CONFIGURE_LOGGING.get() is True:
     _configure_mlflow_loggers(root_module_name=__name__)
-
 
 # Core modules required for mlflow-tracing
 from mlflow.tracing.assessment import (

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -35,7 +35,8 @@ from mlflow.version import IS_TRACING_SDK_ONLY, VERSION
 __version__ = VERSION
 
 import mlflow.mismatch
-
+import os
+import warnings
 # `check_version_mismatch` must be called here before importing any other modules
 with contextlib.suppress(Exception):
     mlflow.mismatch._check_version_mismatch()
@@ -153,8 +154,11 @@ if TYPE_CHECKING:
         xgboost,
     )
 
-if MLFLOW_CONFIGURE_LOGGING.get() is True:
+if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower == "false":
+    warnings.warn("MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, please use MLFLOW_CONFIGURE_LOGGING instead", FutureWarning)
+elif MLFLOW_CONFIGURE_LOGGING.get() is True:
     _configure_mlflow_loggers(root_module_name=__name__)
+
 
 # Core modules required for mlflow-tracing
 from mlflow.tracing.assessment import (

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -34,9 +34,11 @@ from mlflow.version import IS_TRACING_SDK_ONLY, VERSION
 
 __version__ = VERSION
 
-import mlflow.mismatch
 import os
 import warnings
+
+import mlflow.mismatch
+
 # `check_version_mismatch` must be called here before importing any other modules
 with contextlib.suppress(Exception):
     mlflow.mismatch._check_version_mismatch()
@@ -154,8 +156,12 @@ if TYPE_CHECKING:
         xgboost,
     )
 
-if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower == "false":
-    warnings.warn("MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, please use MLFLOW_CONFIGURE_LOGGING instead", FutureWarning)
+if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower() == "false":
+    warnings.warn(
+        "MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, "
+        f"please use {MLFLOW_CONFIGURE_LOGGING.name} instead.",
+        FutureWarning,
+    )
 elif MLFLOW_CONFIGURE_LOGGING.get() is True:
     _configure_mlflow_loggers(root_module_name=__name__)
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -8,7 +8,7 @@ MLflow's environment variables adhere to the following naming conventions:
 import os
 import warnings
 from pathlib import Path
-from mlflow.utils.logging_utils import _configure_mlflow_loggers
+
 class _EnvironmentVariable:
     """
     Represents an environment variable.
@@ -557,10 +557,7 @@ MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE = _EnvironmentVariable(
 #: logging handlers and formatters.
 #: (default: ``True``)
 MLFLOW_CONFIGURE_LOGGING = _BooleanEnvironmentVariable("MLFLOW_CONFIGURE_LOGGING", True)
-if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower == "false":
-    warnings.warn("MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, please use MLFLOW_CONFIGURE_LOGGING instead", FutureWarning)
-elif MLFLOW_CONFIGURE_LOGGING.get() is True:
-    _configure_mlflow_loggers(root_module_name=__name__)
+
 #: If set to True, the following entities will be truncated to their maximum length:
 #: - Param value
 #: - Tag value
@@ -810,3 +807,11 @@ MLFLOW_SEARCH_TRACES_MAX_THREADS = _EnvironmentVariable(
 #: effect. To modify the logging level after importing mlflow, use `importlib.reload(mlflow)`.
 #: (default: ``None``).
 MLFLOW_LOGGING_LEVEL = _EnvironmentVariable("MLFLOW_LOGGING_LEVEL", str, None)
+
+# Import at the end to avoid circular imports
+from mlflow.utils.logging_utils import _configure_mlflow_loggers
+
+if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower == "false":
+    warnings.warn("MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, please use MLFLOW_CONFIGURE_LOGGING instead", FutureWarning)
+elif MLFLOW_CONFIGURE_LOGGING.get() is True:
+    _configure_mlflow_loggers(root_module_name=__name__)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -807,11 +807,3 @@ MLFLOW_SEARCH_TRACES_MAX_THREADS = _EnvironmentVariable(
 #: effect. To modify the logging level after importing mlflow, use `importlib.reload(mlflow)`.
 #: (default: ``None``).
 MLFLOW_LOGGING_LEVEL = _EnvironmentVariable("MLFLOW_LOGGING_LEVEL", str, None)
-
-# Import at the end to avoid circular imports
-from mlflow.utils.logging_utils import _configure_mlflow_loggers
-
-if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower == "false":
-    warnings.warn("MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, please use MLFLOW_CONFIGURE_LOGGING instead", FutureWarning)
-elif MLFLOW_CONFIGURE_LOGGING.get() is True:
-    _configure_mlflow_loggers(root_module_name=__name__)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -6,9 +6,9 @@ MLflow's environment variables adhere to the following naming conventions:
 """
 
 import os
+import warnings
 from pathlib import Path
-
-
+from mlflow.utils.logging_utils import _configure_mlflow_loggers
 class _EnvironmentVariable:
     """
     Represents an environment variable.
@@ -557,7 +557,10 @@ MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE = _EnvironmentVariable(
 #: logging handlers and formatters.
 #: (default: ``True``)
 MLFLOW_CONFIGURE_LOGGING = _BooleanEnvironmentVariable("MLFLOW_CONFIGURE_LOGGING", True)
-
+if os.environ.get("MLFLOW_LOGGING_CONFIGURE_LOGGING", "true").lower == "false":
+    warnings.warn("MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be removed in a future release, please use MLFLOW_CONFIGURE_LOGGING instead", FutureWarning)
+elif MLFLOW_CONFIGURE_LOGGING.get() is True:
+    _configure_mlflow_loggers(root_module_name=__name__)
 #: If set to True, the following entities will be truncated to their maximum length:
 #: - Param value
 #: - Tag value

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -71,7 +71,7 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
         super().__init__(name, bool, default)
 
     def get(self):
-        # A workaround for https://github.com/mlflow/mlflow/issues/15764
+        # TODO: Remove this block in MLflow 3.2.0
         if self.name == MLFLOW_CONFIGURE_LOGGING.name and (
             val := os.getenv("MLFLOW_LOGGING_CONFIGURE_LOGGING")
         ):

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -556,7 +556,7 @@ MLFLOW_ASYNC_LOGGING_THREADPOOL_SIZE = _EnvironmentVariable(
 #: If set to True, mlflow will configure ``mlflow.<module_name>`` loggers with
 #: logging handlers and formatters.
 #: (default: ``True``)
-MLFLOW_CONFIGURE_LOGGING = _BooleanEnvironmentVariable("MLFLOW_LOGGING_CONFIGURE_LOGGING", True)
+MLFLOW_CONFIGURE_LOGGING = _BooleanEnvironmentVariable("MLFLOW_CONFIGURE_LOGGING", True)
 
 #: If set to True, the following entities will be truncated to their maximum length:
 #: - Param value

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -6,6 +6,7 @@ MLflow's environment variables adhere to the following naming conventions:
 """
 
 import os
+import warnings
 from pathlib import Path
 
 
@@ -70,6 +71,18 @@ class _BooleanEnvironmentVariable(_EnvironmentVariable):
         super().__init__(name, bool, default)
 
     def get(self):
+        # A workaround for https://github.com/mlflow/mlflow/issues/15764
+        if self.name == MLFLOW_CONFIGURE_LOGGING.name and (
+            val := os.getenv("MLFLOW_LOGGING_CONFIGURE_LOGGING")
+        ):
+            warnings.warn(
+                "Environment variable MLFLOW_LOGGING_CONFIGURE_LOGGING is deprecated and will be "
+                f"removed in a future release. Please use {MLFLOW_CONFIGURE_LOGGING.name} instead.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            return val.lower() in ["true", "1"]
+
         if not self.defined:
             return self.default
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -8,6 +8,7 @@ MLflow's environment variables adhere to the following naming conventions:
 import os
 from pathlib import Path
 
+
 class _EnvironmentVariable:
     """
     Represents an environment variable.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -6,7 +6,6 @@ MLflow's environment variables adhere to the following naming conventions:
 """
 
 import os
-import warnings
 from pathlib import Path
 
 class _EnvironmentVariable:

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -5,7 +5,6 @@ import subprocess
 import sys
 import uuid
 from io import StringIO
-import importlib
 import pytest
 
 import mlflow

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -103,35 +103,6 @@ def test_event_logging_stream_flushes_properly():
     assert "foo" in stream.content
     assert stream.flush_count > 0
 
-def test_mlflow_configure_logging_env_var():
-    # Save original state
-    original_loggers = [h for h in logging.getLogger("mlflow").handlers]
-    original_value = MLFLOW_CONFIGURE_LOGGING.get()
-    try:
-          # Remove all handlers
-          logger = logging.getLogger("mlflow")
-          for handler in list(logger.handlers):
-              logger.removeHandler(handler)
-
-          # Test with env var set to False
-          os.environ["MLFLOW_CONFIGURE_LOGGING"] = "False"
-          # Force reload mlflow to apply environment variable
-          
-          importlib.reload(mlflow)
-          # Should have no handlers since env var is False
-          assert len([h for h in logging.getLogger("mlflow").handlers]) == 0
-          # Test with env var set to True
-          os.environ["MLFLOW_CONFIGURE_LOGGING"] = "True"
-          importlib.reload(mlflow)
-          # Should have handlers now
-          assert len([h for h in logging.getLogger("mlflow").handlers]) > 0
-    finally:
-          # Restore original state
-          if original_value is True:
-              os.environ["MLFLOW_CONFIGURE_LOGGING"] = "True"
-          else:
-              os.environ.pop("MLFLOW_CONFIGURE_LOGGING", None)
-          importlib.reload(mlflow)
 
 def test_debug_logs_emitted_correctly_when_configured():
     stream = SampleStream()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rahuja23/mlflow/pull/15786?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15786/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15786/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15786/merge
```

</p>
</details>

### Related Issues/PRs
Close #15764 

### What changes are proposed in this pull request?

**Issue**:  There was an inconsistency between the Python variable name (MLFLOW_CONFIGURE_LOGGING) and the environment variable name it checked for (MLFLOW_LOGGING_CONFIGURE_LOGGING).
**Fix**: I have updated the code in environment_variables.py to make the Python variable check for MLFLOW_CONFIGURE_LOGGING environment  variable instead, aligning the names.
**Testing**: I have added test_mlflow_configure_logging_env_var() to tests/utils/test_logging_utils.py that verifies:
    - When MLFLOW_CONFIGURE_LOGGING=False, MLflow doesn't configure loggers
    - When MLFLOW_CONFIGURE_LOGGING=True, MLflow does configure loggers

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
