### PR TITLE
[1/2] Drop support for Python 3.9

### DIFF
--- a/.devcontainer/Dockerfile.devcontainer
+++ b/.devcontainer/Dockerfile.devcontainer
@@ -4,7 +4,7 @@ WORKDIR /mlflow
 COPY mlflow/server/js .
 RUN yarn install --silent && yarn build
 
-FROM python:3.9.18
+FROM python:3.10.16
 
 ARG TARGETPLATFORM
 

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -66,7 +66,7 @@ docker run \
    -w /mlflow \
    -v $(pwd)/requirements:/mlflow/requirements:ro \
    -v $(pwd)/.devcontainer/pip-compile.sh:/mlflow/pip-compile.sh \
-   python:3.9.18 ./pip-compile.sh
+   python:3.10.16 ./pip-compile.sh
 docker cp $NAME:/tmp/requirements.txt .devcontainer/requirements.txt
 docker rm -f -v $NAME
 ```

--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -30,9 +30,13 @@ runs:
             python_version="3.9.18"
           fi
         elif [[ "$python_version" == "3.10" ]]; then
-          python_version="3.10.14"
+          if [ ${{ runner.os }} == "Windows" ]; then
+            python_version="3.10.11"
+          else
+            python_version="3.10.16"
+          fi
         else
-          echo "Invalid python version: '$python_version'. Must be '3.8', '3.9', or '3.10'."
+          echo "Invalid python version: '$python_version'. Must be '3.9', or '3.10'."
           exit 1
         fi
         echo "version=$python_version" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-bullseye
+FROM python:3.10-bullseye
 
 WORKDIR /home/mlflow
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -312,7 +312,7 @@ def infer_python_version(package: str, version: str) -> str:
     """
     Infer the minimum Python version required by the package.
     """
-    candidates = ("3.10",)
+    candidates = ("3.10", "3.11")
     if rp := _requires_python(package, version):
         spec = SpecifierSet(rp)
         return next(filter(spec.contains, candidates), candidates[0])

--- a/examples/llama_index/workflow/pyproject.toml
+++ b/examples/llama_index/workflow/pyproject.toml
@@ -2,7 +2,7 @@
 package-mode = false
 
 [tool.poetry.dependencies]
-python = ">=3.9,<3.13"
+python = ">=3.10,<3.13"
 mlflow = ">=2.17.0"
 llama-index = ">=0.11.0"
 llama-index-postprocessor-rankgpt-rerank = "*"

--- a/examples/mlflow_artifacts/Dockerfile
+++ b/examples/mlflow_artifacts/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 WORKDIR /app
 

--- a/examples/mlflow_artifacts/Dockerfile.dev
+++ b/examples/mlflow_artifacts/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 WORKDIR /app
 

--- a/examples/supply_chain_security/python_env.yaml
+++ b/examples/supply_chain_security/python_env.yaml
@@ -1,9 +1,9 @@
-python: "3.9"
+python: "3.10"
 build_dependencies:
   - pip
 dependencies:
-  - numpy==1.21.4
-  - pandas==1.3.2
-  - scipy==1.7.2
-  - scikit-learn==0.24.2
+  - numpy
+  - pandas
+  - scipy
+  - scikit-learn
   - mlflow

--- a/mlflow/models/docker_utils.py
+++ b/mlflow/models/docker_utils.py
@@ -25,8 +25,12 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y python3.9 python3.9-distutils \
-    && ln -s -f $(which python3.9) /usr/bin/python \
+RUN apt install -y software-properties-common \
+    && apt update \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update \
+    && apt install -y python3.10 python3.10-distutils \
+    && ln -s -f $(which python3.10) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 RUN pip install virtualenv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ exclude = ["tests", "tests.*"]
 
 [tool.ruff]
 line-length = 100
-target-version = "py39"
+target-version = "py310"
 required-version = "0.11.13"
 force-exclude = true
 extend-include = ["*.ipynb"]

--- a/tests/db/Dockerfile
+++ b/tests/db/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 ARG DEPENDENCIES
 

--- a/tests/db/Dockerfile.mssql
+++ b/tests/db/Dockerfile.mssql
@@ -1,4 +1,4 @@
-FROM amd64/python:3.9
+FROM amd64/python:3.10
 
 ARG DEPENDENCIES
 

--- a/tests/projects/test_docker_projects.py
+++ b/tests/projects/test_docker_projects.py
@@ -290,7 +290,7 @@ def test_docker_build_image_local(tmp_path):
     dockerfile = tmp_path.joinpath("Dockerfile")
     dockerfile.write_text(
         """
-FROM python:3.9
+FROM python:3.10
 RUN pip --version
 """
     )

--- a/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_install_mlflow_virtualenv
@@ -13,8 +13,12 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y python3.9 python3.9-distutils \
-    && ln -s -f $(which python3.9) /usr/bin/python \
+RUN apt install -y software-properties-common \
+    && apt update \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update \
+    && apt install -y python3.10 python3.10-distutils \
+    && ln -s -f $(which python3.10) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 RUN pip install virtualenv

--- a/tests/resources/dockerfile/Dockerfile_java_flavor
+++ b/tests/resources/dockerfile/Dockerfile_java_flavor
@@ -13,8 +13,12 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y python3.9 python3.9-distutils \
-    && ln -s -f $(which python3.9) /usr/bin/python \
+RUN apt install -y software-properties-common \
+    && apt update \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update \
+    && apt install -y python3.10 python3.10-distutils \
+    && ln -s -f $(which python3.10) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 RUN pip install virtualenv

--- a/tests/resources/dockerfile/Dockerfile_no_model_uri
+++ b/tests/resources/dockerfile/Dockerfile_no_model_uri
@@ -13,8 +13,12 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y python3.9 python3.9-distutils \
-    && ln -s -f $(which python3.9) /usr/bin/python \
+RUN apt install -y software-properties-common \
+    && apt update \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update \
+    && apt install -y python3.10 python3.10-distutils \
+    && ln -s -f $(which python3.10) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 RUN pip install virtualenv

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv
@@ -13,8 +13,12 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y python3.9 python3.9-distutils \
-    && ln -s -f $(which python3.9) /usr/bin/python \
+RUN apt install -y software-properties-common \
+    && apt update \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update \
+    && apt install -y python3.10 python3.10-distutils \
+    && ln -s -f $(which python3.10) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 RUN pip install virtualenv

--- a/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
+++ b/tests/resources/dockerfile/Dockerfile_sagemaker_virtualenv_no_java
@@ -13,8 +13,12 @@ RUN git clone \
     https://github.com/pyenv/pyenv.git /root/.pyenv
 ENV PYENV_ROOT="/root/.pyenv"
 ENV PATH="$PYENV_ROOT/bin:$PATH"
-RUN apt install -y python3.9 python3.9-distutils \
-    && ln -s -f $(which python3.9) /usr/bin/python \
+RUN apt install -y software-properties-common \
+    && apt update \
+    && add-apt-repository -y ppa:deadsnakes/ppa \
+    && apt update \
+    && apt install -y python3.10 python3.10-distutils \
+    && ln -s -f $(which python3.10) /usr/bin/python \
     && wget https://bootstrap.pypa.io/get-pip.py -O /tmp/get-pip.py \
     && python /tmp/get-pip.py
 RUN pip install virtualenv

--- a/tests/resources/example_docker_project/Dockerfile
+++ b/tests/resources/example_docker_project/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.10
 
 RUN apt-get update -y && apt-get install build-essential -y
 RUN pip install mlflow

--- a/tests/resources/example_mlflow_1x_sklearn_model/MLmodel
+++ b/tests/resources/example_mlflow_1x_sklearn_model/MLmodel
@@ -4,7 +4,7 @@ flavors:
     loader_module: mlflow.sklearn
     model_path: model.pkl
     predict_fn: predict
-    python_version: 3.9.18
+    python_version: 3.10.16
   sklearn:
     code: null
     pickled_model: model.pkl

--- a/tests/resources/example_mlflow_1x_sklearn_model/conda.yaml
+++ b/tests/resources/example_mlflow_1x_sklearn_model/conda.yaml
@@ -1,7 +1,7 @@
 channels:
   - conda-forge
 dependencies:
-  - python=3.9.18
+  - python=3.10.16
   - pip<=23.0.1
   - pip:
       - mlflow

--- a/tests/resources/example_mlflow_1x_sklearn_model/python_env.yaml
+++ b/tests/resources/example_mlflow_1x_sklearn_model/python_env.yaml
@@ -1,4 +1,4 @@
-python: 3.9.18
+python: 3.10.16
 build_dependencies:
   - pip==23.0.1
   - setuptools==58.1.0

--- a/tests/resources/example_project/conda.yaml
+++ b/tests/resources/example_project/conda.yaml
@@ -4,7 +4,7 @@ name: tutorial
 channels:
   - defaults
 dependencies:
-  - python=3.9
+  - python=3.10
   - pip:
       - -e ../../../
       - psutil

--- a/tests/resources/example_virtualenv_conda_project/conda.yaml
+++ b/tests/resources/example_virtualenv_conda_project/conda.yaml
@@ -2,7 +2,7 @@ name: virtualenv-conda
 channels:
   - conda-forge
 dependencies:
-  - python=3.9.18
+  - python=3.10.16
   - numpy
   - pip
   - pip:

--- a/tests/resources/example_virtualenv_conda_project/entrypoint.py
+++ b/tests/resources/example_virtualenv_conda_project/entrypoint.py
@@ -20,7 +20,7 @@ parser.add_argument(
 args = parser.parse_args()
 if args.test:
     assert "VIRTUAL_ENV" in os.environ
-    assert sys.version_info[:3] == (3, 9, 18), sys.version_info
+    assert sys.version_info[:3] == (3, 10, 16), sys.version_info
     assert sklearn.__version__ == "1.4.2", sklearn.__version__
 
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])

--- a/tests/resources/example_virtualenv_no_python_env/entrypoint.py
+++ b/tests/resources/example_virtualenv_no_python_env/entrypoint.py
@@ -20,7 +20,7 @@ parser.add_argument(
 args = parser.parse_args()
 if args.test:
     assert "VIRTUAL_ENV" in os.environ
-    assert sys.version_info[:3] == (3, 9, 18), sys.version_info
+    assert sys.version_info[:3] == (3, 10, 16), sys.version_info
     assert sklearn.__version__ == "1.4.2", sklearn.__version__
 
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])

--- a/tests/resources/example_virtualenv_no_python_env/python_env.yaml
+++ b/tests/resources/example_virtualenv_no_python_env/python_env.yaml
@@ -1,4 +1,4 @@
-python: "3.9.18"
+python: "3.10.16"
 build_dependencies:
   - pip
 dependencies:

--- a/tests/resources/example_virtualenv_project/entrypoint.py
+++ b/tests/resources/example_virtualenv_project/entrypoint.py
@@ -20,7 +20,7 @@ parser.add_argument(
 args = parser.parse_args()
 if args.test:
     assert "VIRTUAL_ENV" in os.environ
-    assert sys.version_info[:3] == (3, 9, 18), sys.version_info
+    assert sys.version_info[:3] == (3, 10, 16), sys.version_info
     assert sklearn.__version__ == "1.4.2", sklearn.__version__
 
 X = np.array([[-1, -1], [-2, -1], [1, 1], [2, 1]])

--- a/tests/resources/example_virtualenv_project/python_env.yaml
+++ b/tests/resources/example_virtualenv_project/python_env.yaml
@@ -1,4 +1,4 @@
-python: "3.9.18"
+python: "3.10.16"
 build_dependencies:
   - pip
 dependencies:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15788?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15788/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15788/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15788/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

Python 3.9 will read EOL on 2025-10. Many major python packages have already drop its support. In this repo, we run both for 3.9 and 3.10, but that means some tests need to pass on both versions, which is painful.

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
