### PR TITLE
Check logged model existence and raise helpful error

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -247,6 +247,7 @@ if not IS_TRACING_SDK_ONLY:
         search_model_versions,
         search_prompts,
         search_registered_models,
+        set_model_version_tag,
         set_prompt_alias,
     )
     from mlflow.tracking.fluent import (
@@ -364,6 +365,7 @@ if not IS_TRACING_SDK_ONLY:
         "set_active_model",
         "set_experiment_tag",
         "set_experiment_tags",
+        "set_model_version_tag",
         "set_registry_uri",
         "set_system_metrics_node_id",
         "set_system_metrics_samples_before_logging",

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -450,6 +450,29 @@ def search_model_versions(
     )
 
 
+def set_model_version_tag(
+    name: str,
+    version: Optional[str] = None,
+    key: Optional[str] = None,
+    value: Any = None,
+) -> None:
+    """
+    Set a tag for the model version.
+
+    Args:
+        name: Registered model name.
+        version: Registered model version.
+        key: Tag key to log. key is required.
+        value: Tag value to log. value is required.
+    """
+    return MlflowClient().set_model_version_tag(
+        name=name,
+        version=version,
+        key=key,
+        value=value,
+    )
+
+
 @experimental
 @require_prompt_registry
 def register_prompt(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -97,6 +97,7 @@ from mlflow.utils.annotations import deprecated, experimental
 from mlflow.utils.async_logging.run_operations import RunOperations
 from mlflow.utils.databricks_utils import (
     get_databricks_run_url,
+    is_in_databricks_runtime,
 )
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.mlflow_tags import (
@@ -5287,6 +5288,20 @@ class MlflowClient:
             None
         """
         _validate_model_id_specified(model_id)
+        try:
+            self._tracking_client.get_logged_model(model_id)
+        except Exception as e:
+            reason = (
+                "the logged model may exist in a different workspace, "
+                if is_in_databricks_runtime()
+                else ""
+            )
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to get logged model with ID {model_id}. "
+                f"You may not have access to the logged model, {reason}or the "
+                "logged model may have been deleted. If you are attempting to log parameters "
+                "to a Model Version, this is not supported."
+            ) from e
         return self._tracking_client.log_model_params(model_id, params)
 
     @experimental
@@ -5346,6 +5361,20 @@ class MlflowClient:
             None
         """
         _validate_model_id_specified(model_id)
+        try:
+            self._tracking_client.get_logged_model(model_id)
+        except Exception as e:
+            reason = (
+                "the logged model may exist in a different workspace, "
+                if is_in_databricks_runtime()
+                else ""
+            )
+            raise MlflowException.invalid_parameter_value(
+                f"Failed to get logged model with ID {model_id}. "
+                f"You may not have access to the logged model, {reason}or the "
+                "logged model may have been deleted. If you are attempting to "
+                "set tags on a Model Version, use `set_model_version_tag` instead."
+            ) from e
         self._tracking_client.set_logged_model_tags(model_id, tags)
 
     @experimental

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5291,16 +5291,16 @@ class MlflowClient:
         try:
             self._tracking_client.get_logged_model(model_id)
         except Exception as e:
-            reason = (
+            extra_error_reason = (
                 "the logged model may exist in a different workspace, "
                 if is_in_databricks_runtime()
                 else ""
             )
             raise MlflowException.invalid_parameter_value(
                 f"Failed to get logged model with ID {model_id}. "
-                f"You may not have access to the logged model, {reason}or the "
+                f"You may not have access to the logged model, {extra_error_reason}or the "
                 "logged model may have been deleted. If you are attempting to log parameters "
-                "to a Model Version, this is not supported."
+                "to a Registered Model Version, this is not supported."
             ) from e
         return self._tracking_client.log_model_params(model_id, params)
 
@@ -5364,16 +5364,16 @@ class MlflowClient:
         try:
             self._tracking_client.get_logged_model(model_id)
         except Exception as e:
-            reason = (
+            extra_error_reason = (
                 "the logged model may exist in a different workspace, "
                 if is_in_databricks_runtime()
                 else ""
             )
             raise MlflowException.invalid_parameter_value(
                 f"Failed to get logged model with ID {model_id}. "
-                f"You may not have access to the logged model, {reason}or the "
+                f"You may not have access to the logged model, {extra_error_reason}or the "
                 "logged model may have been deleted. If you are attempting to "
-                "set tags on a Model Version, use `set_model_version_tag` instead."
+                "set tags on a Registered Model Version, use `set_model_version_tag` instead."
             ) from e
         self._tracking_client.set_logged_model_tags(model_id, tags)
 

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -249,3 +249,22 @@ def test_register_model_prints_uc_model_version_url(monkeypatch):
 
     # Clean up the global variables set by the server
     mlflow.set_registry_uri(orig_registry_uri)
+
+
+def test_set_model_version_tag():
+    class TestModel(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input):
+            return model_input
+
+    mlflow.pyfunc.log_model(name="model", python_model=TestModel(), registered_model_name="Model 1")
+
+    mv = MlflowClient().get_model_version("Model 1", "1")
+    assert mv.tags == {}
+    mlflow.set_model_version_tag(
+        name="Model 1",
+        version=1,
+        key="key",
+        value="value",
+    )
+    mv = MlflowClient().get_model_version("Model 1", "1")
+    assert mv.tags == {"key": "value"}

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2196,3 +2196,8 @@ def test_log_metrics_link_to_active_model():
     assert logged_model.model_id == model.model_id
     assert len(logged_model.metrics) == 2
     assert {m.key: m.value for m in logged_model.metrics} == {"metric1": 1, "metric2": 2}
+
+
+def test_set_logged_model_tags_error():
+    with pytest.raises(MlflowException, match="You may not have access to the logged model"):
+        mlflow.set_logged_model_tags("non-existing-model-id", {"tag": "value"})


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/15794?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15794/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15794/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15794/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
1. For `set_logged_model_tags` and `log_model_params` APIs, if users pass a model_id that they don't have access then the error message doesn't provide helpful guidance. Updated in this PR.
2. Added `set_model_version_tag` API in fluent APIs for easier usage. Didn't include 'stage' param because the param is marked as deprecated for a long time.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
