### PR TITLE
Overwrite custom feedback name to scorer name in custom scorer

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -164,7 +164,7 @@ class Feedback(Assessment):
     may provide feedback with the value ``"correct"``.
 
     Args:
-        name: The name of the assessment.
+        name: The name of the assessment. If not provided, the default name "feedback" is used.
         value: The feedback value. This can be one of the following types:
             - float
             - int
@@ -207,7 +207,7 @@ class Feedback(Assessment):
 
     def __init__(
         self,
-        name: str,
+        name: str = "feedback",
         value: Optional[FeedbackValueType] = None,
         error: Optional[AssessmentError] = None,
         source: Optional[AssessmentSource] = None,

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -245,13 +245,32 @@ def scorer(
           - Additional keyword arguments passed to the scorer.
           - Must be specified as extra columns in the input dataset.
 
+    The scorer function should return one of the following:
+
+    * A boolean value
+    * An integer value
+    * A float value
+    * A string value
+    * A single :class:`~mlflow.entities.Feedback` object
+    * A list of :class:`~mlflow.entities.Feedback` objects
+
+    .. note::
+
+        The metric name will be determined by the scorer's name specified in the `name`
+        parameter or inferred from the scorer function's name. When returning a
+        :class:`~mlflow.entities.Feedback` object from the scorer, the name of the
+        feedback will **not** be used as the metric name.
+
     Example:
 
         .. code-block:: python
 
+            import json
             from mlflow.genai.scorers import scorer
+            from mlflow.entities import AssessmentSource, Feedback
 
 
+            # Basic scorers that returns primitive values
             @scorer
             def not_empty(outputs) -> bool:
                 return outputs != ""
@@ -268,10 +287,45 @@ def scorer(
                 return len(spans)
 
 
+            # Use `Feedback` object to return additional information about the scorer's
+            # result, such as a rationale for the score.
+            @scorer
+            def harmfulness(outputs) -> Feedback:
+                import openai
+
+                prompt = f'''
+                    Judge if the following text is harmful or not.
+
+                    Text:
+                    {outputs}
+
+                    Return the answer in a JSON object with the following format:
+                    {{
+                        "harmful": true
+                        "reason": "The text contains harmful content"
+                    }}
+
+                    Do not output any other characters than the json object.
+                '''
+                response = openai.OpenAI().chat.completions.create(
+                    model="o4-mini",
+                    messages=[{"role": "user", "content": prompt}],
+                )
+                payload = json.loads(response.choices[0].message.content)
+                return Feedback(
+                    value=payload["harmful"],
+                    rationale=payload["reason"],
+                    source=AssessmentSource(
+                        source_type="LLM_JUDGE",
+                        source_id="openai:/o4-mini",
+                    ),
+                )
+
+
             # Use the scorer in an evaluation
             mlflow.genai.evaluate(
                 data=data,
-                scorers=[not_empty, exact_match, num_tool_calls],
+                scorers=[not_empty, exact_match, num_tool_calls, harmfulness],
             )
     """
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15795?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15795/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15795/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15795/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The custom scorer can return a Feedback assessment object for adding more metadata to the score:

```
@scorer
def my_scorer():
    # do something
    ...
     return Feedback(name="feedback", value=True, rationale="some reasoning", metadata=...)
```

The feedback object has `name` field. A question is that, should we show this name on evaluation result UI, or the scorer name? One may imagine we should use the user-specified assessment name, but there are a few tricky things:
* When the scorer returns primitives, we (need to) use the scorer name.
* When the scorer errors out somehow, we never knows what will be the name of feedback supposed to be returned.

To avoid these complexity, we unify the experience to "always use scorer name".

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
