### PR TITLE
Fix test failures in click 8.2

### DIFF
--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -1,4 +1,3 @@
-# test
 name: Test requirements
 
 on:

--- a/.github/workflows/requirements.yml
+++ b/.github/workflows/requirements.yml
@@ -1,3 +1,4 @@
+# test
 name: Test requirements
 
 on:

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -194,9 +194,7 @@ def run(
         try:
             backend_config = json.loads(backend_config)
         except ValueError as e:
-            raise click.UsageError(
-                "Specify only one of 'experiment-name' or 'experiment-id' options."
-            ) from e
+            raise click.UsageError(f"Invalid backend config JSON. Parse error: {e}") from e
     if backend == "kubernetes":
         if backend_config is None:
             raise click.UsageError("Specify 'backend_config' when using kubernetes mode.")
@@ -235,14 +233,12 @@ def _user_args_to_dict(arguments, argument_type="P"):
             name = split[0]
             value = split[1]
         else:
-            eprint(
+            raise click.UsageError(
                 f"Invalid format for -{argument_type} parameter: '{arg}'. "
                 f"Use -{argument_type} name=value."
             )
-            sys.exit(1)
         if name in user_dict:
-            eprint(f"Repeated parameter: '{name}'")
-            sys.exit(1)
+            raise click.UsageError(f"Repeated parameter: '{name}'")
         user_dict[name] = value
     return user_dict
 

--- a/mlflow/cli.py
+++ b/mlflow/cli.py
@@ -185,8 +185,7 @@ def run(
     local projects run from the project's root directory.
     """
     if experiment_id is not None and experiment_name is not None:
-        eprint("Specify only one of 'experiment-name' or 'experiment-id' options.")
-        sys.exit(1)
+        raise click.UsageError("Specify only one of 'experiment-name' or 'experiment-id' options.")
 
     param_dict = _user_args_to_dict(param_list)
     args_dict = _user_args_to_dict(docker_args, argument_type="A")
@@ -195,12 +194,12 @@ def run(
         try:
             backend_config = json.loads(backend_config)
         except ValueError as e:
-            eprint(f"Invalid backend config JSON. Parse error: {e}")
-            raise
+            raise click.UsageError(
+                "Specify only one of 'experiment-name' or 'experiment-id' options."
+            ) from e
     if backend == "kubernetes":
         if backend_config is None:
-            eprint("Specify 'backend_config' when using kubernetes mode.")
-            sys.exit(1)
+            raise click.UsageError("Specify 'backend_config' when using kubernetes mode.")
     try:
         projects.run(
             uri,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -584,16 +584,17 @@ def test_mlflow_artifact_only_prints_warning_for_configs():
         mock.patch("mlflow.store.tracking.sqlalchemy_store.SqlAlchemyStore"),
         mock.patch("mlflow.store.model_registry.sqlalchemy_store.SqlAlchemyStore"),
     ):
-        result = CliRunner(mix_stderr=False).invoke(
+        result = CliRunner().invoke(
             server,
             ["--artifacts-only", "--backend-store-uri", "sqlite:///my.db"],
             catch_exceptions=False,
         )
-        assert result.stderr.startswith(
+        msg = (
             "Usage: server [OPTIONS]\nTry 'server --help' for help.\n\nError: You are starting a "
             "tracking server in `--artifacts-only` mode and have provided a value for "
             "`--backend_store_uri`"
         )
+        assert msg in result.output
         assert result.exit_code != 0
         run_server_mock.assert_not_called()
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15798?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15798/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15798/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15798/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Click 8.2 was released last week. This version has some breaking changes and broke a couple tests. This PR fixes them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
