### PR TITLE
Few updates on assessment APIs

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -155,6 +155,9 @@ class Assessment(_MlflowObject):
             )
 
 
+DEFAULT_FEEDBACK_NAME = "feedback"
+
+
 @experimental
 @dataclass
 class Feedback(Assessment):
@@ -207,9 +210,9 @@ class Feedback(Assessment):
 
     def __init__(
         self,
-        name: str = "feedback",
+        name: str = DEFAULT_FEEDBACK_NAME,
         value: Optional[FeedbackValueType] = None,
-        error: Optional[AssessmentError] = None,
+        error: Optional[Union[Exception, AssertionError]] = None,
         source: Optional[AssessmentSource] = None,
         trace_id: Optional[str] = None,
         metadata: Optional[dict[str, str]] = None,
@@ -226,6 +229,12 @@ class Feedback(Assessment):
         # Default to CODE source if not provided
         if source is None:
             source = AssessmentSource(source_type=AssessmentSourceType.CODE)
+
+        if error is not None and isinstance(error, Exception):
+            error = AssessmentError(
+                error_message=str(error),
+                error_code=error.__class__.__name__,
+            )
 
         super().__init__(
             name=name,

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -176,7 +176,8 @@ class Feedback(Assessment):
             - list of values of the same types as above
             - dict with string keys and values of the same types as above
         error: An optional error associated with the feedback. This is used to indicate
-            that the feedback is not valid or cannot be processed.
+            that the feedback is not valid or cannot be processed. Accepts an exception
+            object, or an :py:class:`~mlflow.entities.Expectation` object.
         rationale: The rationale / justification for the feedback.
         source: The source of the assessment. If not provided, the default source is CODE.
         trace_id: The ID of the trace associated with the assessment. If unset, the assessment
@@ -212,7 +213,7 @@ class Feedback(Assessment):
         self,
         name: str = DEFAULT_FEEDBACK_NAME,
         value: Optional[FeedbackValueType] = None,
-        error: Optional[Union[Exception, AssertionError]] = None,
+        error: Optional[Union[Exception, AssessmentError]] = None,
         source: Optional[AssessmentSource] = None,
         trace_id: Optional[str] = None,
         metadata: Optional[dict[str, str]] = None,
@@ -230,7 +231,7 @@ class Feedback(Assessment):
         if source is None:
             source = AssessmentSource(source_type=AssessmentSourceType.CODE)
 
-        if error is not None and isinstance(error, Exception):
+        if isinstance(error, Exception):
             error = AssessmentError(
                 error_message=str(error),
                 error_code=error.__class__.__name__,

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional
 
 from mlflow.entities.assessment import (
+    DEFAULT_FEEDBACK_NAME,
     Assessment,
     AssessmentError,
     Expectation,
@@ -118,6 +119,7 @@ def log_assessment(trace_id: str, assessment: Assessment) -> Assessment:
 
 @experimental
 def log_expectation(
+    *,
     trace_id: str,
     name: str,
     value: Any,
@@ -126,9 +128,7 @@ def log_expectation(
     span_id: Optional[str] = None,
 ) -> Assessment:
     """
-    DEPRECATED: Use :py:func:`~mlflow.log_assessment` instead.
-
-    Logs an expectation (e.g. ground truth label) to a Trace.
+    Logs an expectation (e.g. ground truth label) to a Trace. This API only takes keyword arguments.
 
     Args:
         trace_id: The ID of the trace.
@@ -224,8 +224,9 @@ def delete_assessment(trace_id: str, assessment_id: str):
 
 @experimental
 def log_feedback(
+    *,
     trace_id: str,
-    name: str,
+    name: str = DEFAULT_FEEDBACK_NAME,
     value: Optional[FeedbackValueType] = None,
     source: Optional[AssessmentSource] = None,
     error: Optional[AssessmentError] = None,
@@ -234,13 +235,12 @@ def log_feedback(
     span_id: Optional[str] = None,
 ) -> Assessment:
     """
-    DEPRECATED: Use :py:func:`~mlflow.log_assessment` instead.
-
-    Logs feedback to a Trace.
+    Logs feedback to a Trace. This API only takes keyword arguments.
 
     Args:
         trace_id: The ID of the trace.
-        name: The name of the feedback assessment e.g., "faithfulness"
+        name: The name of the feedback assessment e.g., "faithfulness". Defaults to
+            "feedback" if not provided.
         value: The value of the feedback. Must be one of the following types:
             - float
             - int

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from mlflow.entities.assessment import (
     DEFAULT_FEEDBACK_NAME,
@@ -229,7 +229,7 @@ def log_feedback(
     name: str = DEFAULT_FEEDBACK_NAME,
     value: Optional[FeedbackValueType] = None,
     source: Optional[AssessmentSource] = None,
-    error: Optional[AssessmentError] = None,
+    error: Optional[Union[Expectation, AssessmentError]] = None,
     rationale: Optional[str] = None,
     metadata: Optional[dict[str, Any]] = None,
     span_id: Optional[str] = None,
@@ -252,8 +252,9 @@ def log_feedback(
                 :py:class:`~mlflow.entities.AssessmentSource`. If not provided, defaults to
                 CODE source type
         error: An error object representing any issues encountered while computing the
-            feedback, e.g., a timeout error from an LLM judge. Either this or `value`
-            must be provided.
+            feedback, e.g., a timeout error from an LLM judge. Accepts an exception
+            object, or an :py:class:`~mlflow.entities.Expectation` object. Either
+            this or `value` must be provided.
         rationale: The rationale / justification for the feedback.
         metadata: Additional metadata for the feedback.
         span_id: The ID of the span associated with the feedback, if it needs be

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -358,3 +358,10 @@ def test_feedback_value_proto_dict_conversion(value, error):
     result = FeedbackValue.from_dictionary(feedback_dict)
     assert result.value == result.value
     assert result.error == result.error
+
+
+def test_feedback_from_exception():
+    feedback = Feedback(error=ValueError("An error occurred."))
+
+    assert feedback.error.error_code == "ValueError"
+    assert feedback.error.error_message == "An error occurred."

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -268,8 +268,6 @@ def test_builtin_scorers_are_callable():
 @pytest.mark.parametrize(
     ("scorer_return", "expected_feedback_name"),
     [
-        # Single primitive value -> should be named to "my_scorer"
-        (42, "my_scorer"),
         # Single feedback object with default name -> should be renamed to "my_scorer"
         (Feedback(value=42, rationale="rationale"), "my_scorer"),
         # Single feedback object with custom name -> should NOT be renamed to "my_scorer"

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -268,19 +268,15 @@ def test_builtin_scorers_are_callable():
 @pytest.mark.parametrize(
     ("scorer_return", "expected_feedback_name"),
     [
+        # Single primitive value -> should be named to "my_scorer"
+        (42, "my_scorer"),
         # Single feedback object with default name -> should be renamed to "my_scorer"
-        (
-            Feedback(value=42, rationale="It's the answer to everything"),
-            "my_scorer",
-        ),
-        # Single feedback object -> should be renamed to "my_scorer"
-        (
-            Feedback(name="big_question", value=42, rationale="It's the answer to everything"),
-            "my_scorer",
-        ),
+        (Feedback(value=42, rationale="rationale"), "my_scorer"),
+        # Single feedback object with custom name -> should NOT be renamed to "my_scorer"
+        (Feedback(name="custom_name", value=42, rationale="rationale"), "custom_name"),
     ],
 )
-def test_custom_scorer_overwrites_feedback_name(scorer_return, expected_feedback_name):
+def test_custom_scorer_overwrites_default_feedback_name(scorer_return, expected_feedback_name):
     @scorer
     def my_scorer(inputs, outputs):
         return scorer_return

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -384,3 +384,11 @@ def test_log_expectation_default_source(store, tracking_uri):
     assert assessment.source.source_type == AssessmentSourceType.HUMAN
     assert assessment.source.source_id == "default"
     assert assessment.expectation.value == "MLflow"
+
+
+def test_log_feedback_and_exception_blocks_positional_args():
+    with pytest.raises(TypeError, match=r"log_feedback\(\) takes 0 positional"):
+        mlflow.log_feedback("tr-1234", "faithfulness", 1.0)
+
+    with pytest.raises(TypeError, match=r"log_expectation\(\) takes 0 positional"):
+        mlflow.log_expectation("tr-1234", "expected_answer", "MLflow")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15803?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15803/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15803/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15803/merge
```

</p>
</details>

### What changes are proposed in this pull request?

A few updates on assessments API
* Make `log_feedback` and `log_expectations` API only accept keyword arguments, so that we can add new field later on (without worrying about the position).
* Update `Feedback` to accept a raw exception object to `error` argument for convenience.
* Update custom scorer to only overwrite feedback name when the default name is used.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
