### PR TITLE
Support passing stack trace via AssessmentError

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import time
+import traceback
 from dataclasses import dataclass
 from typing import Any, Optional, Union
 
@@ -232,9 +233,13 @@ class Feedback(Assessment):
             source = AssessmentSource(source_type=AssessmentSourceType.CODE)
 
         if isinstance(error, Exception):
+            stack_trace_string = (
+                "".join(traceback.format_tb(error.__traceback__)) if error.__traceback__ else None
+            )
             error = AssessmentError(
                 error_message=str(error),
                 error_code=error.__class__.__name__,
+                stack_trace=stack_trace_string,
             )
 
         super().__init__(

--- a/mlflow/entities/assessment_error.py
+++ b/mlflow/entities/assessment_error.py
@@ -5,6 +5,9 @@ from mlflow.entities._mlflow_object import _MlflowObject
 from mlflow.protos.assessments_pb2 import AssessmentError as ProtoAssessmentError
 from mlflow.utils.annotations import experimental
 
+_STACK_TRACE_TRUNCATION_PREFIX = "[Stack trace is truncated]\n...\n"
+_STACK_TRACE_TRUNCATION_LENGTH = 1000
+
 
 @experimental
 @dataclass
@@ -22,6 +25,7 @@ class AssessmentError(_MlflowObject):
         error = AssessmentError(
             error_code="RATE_LIMIT_EXCEEDED",
             error_message="Rate limit for the judge exceeded.",
+            stack_trace="...",
         )
 
         mlflow.log_feedback(
@@ -35,16 +39,25 @@ class AssessmentError(_MlflowObject):
     Args:
         error_code: The error code.
         error_message: The detailed error message. Optional.
+        stack_trace: The stack trace of the error. Truncated to 1000 characters
+            before being logged to MLflow. Optional.
     """
 
     error_code: str
     error_message: Optional[str] = None
+    stack_trace: Optional[str] = None
 
     def to_proto(self):
         error = ProtoAssessmentError()
         error.error_code = self.error_code
         if self.error_message:
             error.error_message = self.error_message
+        if self.stack_trace:
+            if len(self.stack_trace) > _STACK_TRACE_TRUNCATION_LENGTH:
+                trunc_len = _STACK_TRACE_TRUNCATION_LENGTH - len(_STACK_TRACE_TRUNCATION_PREFIX)
+                error.stack_trace = _STACK_TRACE_TRUNCATION_PREFIX + self.stack_trace[-trunc_len:]
+            else:
+                error.stack_trace = self.stack_trace
         return error
 
     @classmethod
@@ -52,10 +65,15 @@ class AssessmentError(_MlflowObject):
         return cls(
             error_code=proto.error_code,
             error_message=proto.error_message or None,
+            stack_trace=proto.stack_trace or None,
         )
 
     def to_dictionary(self):
-        return {"error_code": self.error_code, "error_message": self.error_message}
+        return {
+            "error_code": self.error_code,
+            "error_message": self.error_message,
+            "stack_trace": self.stack_trace,
+        }
 
     @classmethod
     def from_dictionary(cls, error_dict):

--- a/mlflow/java/client/src/main/java/org/mlflow/api/proto/Assessments.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/api/proto/Assessments.java
@@ -1013,6 +1013,35 @@ public final class Assessments {
      */
     com.google.protobuf.ByteString
         getErrorMessageBytes();
+
+    /**
+     * <pre>
+     * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+     * </pre>
+     *
+     * <code>optional string stack_trace = 3;</code>
+     * @return Whether the stackTrace field is set.
+     */
+    boolean hasStackTrace();
+    /**
+     * <pre>
+     * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+     * </pre>
+     *
+     * <code>optional string stack_trace = 3;</code>
+     * @return The stackTrace.
+     */
+    java.lang.String getStackTrace();
+    /**
+     * <pre>
+     * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+     * </pre>
+     *
+     * <code>optional string stack_trace = 3;</code>
+     * @return The bytes for stackTrace.
+     */
+    com.google.protobuf.ByteString
+        getStackTraceBytes();
   }
   /**
    * Protobuf type {@code mlflow.assessments.AssessmentError}
@@ -1029,6 +1058,7 @@ public final class Assessments {
     private AssessmentError() {
       errorCode_ = "";
       errorMessage_ = "";
+      stackTrace_ = "";
     }
 
     @java.lang.Override
@@ -1072,6 +1102,12 @@ public final class Assessments {
               com.google.protobuf.ByteString bs = input.readBytes();
               bitField0_ |= 0x00000002;
               errorMessage_ = bs;
+              break;
+            }
+            case 26: {
+              com.google.protobuf.ByteString bs = input.readBytes();
+              bitField0_ |= 0x00000004;
+              stackTrace_ = bs;
               break;
             }
             default: {
@@ -1215,6 +1251,66 @@ public final class Assessments {
       }
     }
 
+    public static final int STACK_TRACE_FIELD_NUMBER = 3;
+    private volatile java.lang.Object stackTrace_;
+    /**
+     * <pre>
+     * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+     * </pre>
+     *
+     * <code>optional string stack_trace = 3;</code>
+     * @return Whether the stackTrace field is set.
+     */
+    @java.lang.Override
+    public boolean hasStackTrace() {
+      return ((bitField0_ & 0x00000004) != 0);
+    }
+    /**
+     * <pre>
+     * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+     * </pre>
+     *
+     * <code>optional string stack_trace = 3;</code>
+     * @return The stackTrace.
+     */
+    @java.lang.Override
+    public java.lang.String getStackTrace() {
+      java.lang.Object ref = stackTrace_;
+      if (ref instanceof java.lang.String) {
+        return (java.lang.String) ref;
+      } else {
+        com.google.protobuf.ByteString bs = 
+            (com.google.protobuf.ByteString) ref;
+        java.lang.String s = bs.toStringUtf8();
+        if (bs.isValidUtf8()) {
+          stackTrace_ = s;
+        }
+        return s;
+      }
+    }
+    /**
+     * <pre>
+     * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+     * </pre>
+     *
+     * <code>optional string stack_trace = 3;</code>
+     * @return The bytes for stackTrace.
+     */
+    @java.lang.Override
+    public com.google.protobuf.ByteString
+        getStackTraceBytes() {
+      java.lang.Object ref = stackTrace_;
+      if (ref instanceof java.lang.String) {
+        com.google.protobuf.ByteString b = 
+            com.google.protobuf.ByteString.copyFromUtf8(
+                (java.lang.String) ref);
+        stackTrace_ = b;
+        return b;
+      } else {
+        return (com.google.protobuf.ByteString) ref;
+      }
+    }
+
     private byte memoizedIsInitialized = -1;
     @java.lang.Override
     public final boolean isInitialized() {
@@ -1235,6 +1331,9 @@ public final class Assessments {
       if (((bitField0_ & 0x00000002) != 0)) {
         com.google.protobuf.GeneratedMessageV3.writeString(output, 2, errorMessage_);
       }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        com.google.protobuf.GeneratedMessageV3.writeString(output, 3, stackTrace_);
+      }
       unknownFields.writeTo(output);
     }
 
@@ -1249,6 +1348,9 @@ public final class Assessments {
       }
       if (((bitField0_ & 0x00000002) != 0)) {
         size += com.google.protobuf.GeneratedMessageV3.computeStringSize(2, errorMessage_);
+      }
+      if (((bitField0_ & 0x00000004) != 0)) {
+        size += com.google.protobuf.GeneratedMessageV3.computeStringSize(3, stackTrace_);
       }
       size += unknownFields.getSerializedSize();
       memoizedSize = size;
@@ -1275,6 +1377,11 @@ public final class Assessments {
         if (!getErrorMessage()
             .equals(other.getErrorMessage())) return false;
       }
+      if (hasStackTrace() != other.hasStackTrace()) return false;
+      if (hasStackTrace()) {
+        if (!getStackTrace()
+            .equals(other.getStackTrace())) return false;
+      }
       if (!unknownFields.equals(other.unknownFields)) return false;
       return true;
     }
@@ -1293,6 +1400,10 @@ public final class Assessments {
       if (hasErrorMessage()) {
         hash = (37 * hash) + ERROR_MESSAGE_FIELD_NUMBER;
         hash = (53 * hash) + getErrorMessage().hashCode();
+      }
+      if (hasStackTrace()) {
+        hash = (37 * hash) + STACK_TRACE_FIELD_NUMBER;
+        hash = (53 * hash) + getStackTrace().hashCode();
       }
       hash = (29 * hash) + unknownFields.hashCode();
       memoizedHashCode = hash;
@@ -1431,6 +1542,8 @@ public final class Assessments {
         bitField0_ = (bitField0_ & ~0x00000001);
         errorMessage_ = "";
         bitField0_ = (bitField0_ & ~0x00000002);
+        stackTrace_ = "";
+        bitField0_ = (bitField0_ & ~0x00000004);
         return this;
       }
 
@@ -1467,6 +1580,10 @@ public final class Assessments {
           to_bitField0_ |= 0x00000002;
         }
         result.errorMessage_ = errorMessage_;
+        if (((from_bitField0_ & 0x00000004) != 0)) {
+          to_bitField0_ |= 0x00000004;
+        }
+        result.stackTrace_ = stackTrace_;
         result.bitField0_ = to_bitField0_;
         onBuilt();
         return result;
@@ -1524,6 +1641,11 @@ public final class Assessments {
         if (other.hasErrorMessage()) {
           bitField0_ |= 0x00000002;
           errorMessage_ = other.errorMessage_;
+          onChanged();
+        }
+        if (other.hasStackTrace()) {
+          bitField0_ |= 0x00000004;
+          stackTrace_ = other.stackTrace_;
           onChanged();
         }
         this.mergeUnknownFields(other.unknownFields);
@@ -1744,6 +1866,114 @@ public final class Assessments {
   }
   bitField0_ |= 0x00000002;
         errorMessage_ = value;
+        onChanged();
+        return this;
+      }
+
+      private java.lang.Object stackTrace_ = "";
+      /**
+       * <pre>
+       * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+       * </pre>
+       *
+       * <code>optional string stack_trace = 3;</code>
+       * @return Whether the stackTrace field is set.
+       */
+      public boolean hasStackTrace() {
+        return ((bitField0_ & 0x00000004) != 0);
+      }
+      /**
+       * <pre>
+       * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+       * </pre>
+       *
+       * <code>optional string stack_trace = 3;</code>
+       * @return The stackTrace.
+       */
+      public java.lang.String getStackTrace() {
+        java.lang.Object ref = stackTrace_;
+        if (!(ref instanceof java.lang.String)) {
+          com.google.protobuf.ByteString bs =
+              (com.google.protobuf.ByteString) ref;
+          java.lang.String s = bs.toStringUtf8();
+          if (bs.isValidUtf8()) {
+            stackTrace_ = s;
+          }
+          return s;
+        } else {
+          return (java.lang.String) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+       * </pre>
+       *
+       * <code>optional string stack_trace = 3;</code>
+       * @return The bytes for stackTrace.
+       */
+      public com.google.protobuf.ByteString
+          getStackTraceBytes() {
+        java.lang.Object ref = stackTrace_;
+        if (ref instanceof String) {
+          com.google.protobuf.ByteString b = 
+              com.google.protobuf.ByteString.copyFromUtf8(
+                  (java.lang.String) ref);
+          stackTrace_ = b;
+          return b;
+        } else {
+          return (com.google.protobuf.ByteString) ref;
+        }
+      }
+      /**
+       * <pre>
+       * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+       * </pre>
+       *
+       * <code>optional string stack_trace = 3;</code>
+       * @param value The stackTrace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStackTrace(
+          java.lang.String value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        stackTrace_ = value;
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+       * </pre>
+       *
+       * <code>optional string stack_trace = 3;</code>
+       * @return This builder for chaining.
+       */
+      public Builder clearStackTrace() {
+        bitField0_ = (bitField0_ & ~0x00000004);
+        stackTrace_ = getDefaultInstance().getStackTrace();
+        onChanged();
+        return this;
+      }
+      /**
+       * <pre>
+       * Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+       * </pre>
+       *
+       * <code>optional string stack_trace = 3;</code>
+       * @param value The bytes for stackTrace to set.
+       * @return This builder for chaining.
+       */
+      public Builder setStackTraceBytes(
+          com.google.protobuf.ByteString value) {
+        if (value == null) {
+    throw new NullPointerException();
+  }
+  bitField0_ |= 0x00000004;
+        stackTrace_ = value;
         onChanged();
         return this;
       }
@@ -8704,30 +8934,31 @@ public final class Assessments {
       ".SourceTypeB\004\370\206\031\001\022\027\n\tsource_id\030\002 \001(\tB\004\370\206" +
       "\031\001\"M\n\nSourceType\022\033\n\027SOURCE_TYPE_UNSPECIF" +
       "IED\020\000\022\t\n\005HUMAN\020\001\022\r\n\tLLM_JUDGE\020\002\022\010\n\004CODE\020" +
-      "\003\"<\n\017AssessmentError\022\022\n\nerror_code\030\001 \001(\t" +
-      "\022\025\n\rerror_message\030\002 \001(\t\"\277\001\n\013Expectation\022" +
-      "%\n\005value\030\002 \001(\0132\026.google.protobuf.Value\022I" +
-      "\n\020serialized_value\030\003 \001(\0132/.mlflow.assess" +
-      "ments.Expectation.SerializedValue\032>\n\017Ser" +
-      "ializedValue\022\034\n\024serialization_format\030\001 \001" +
-      "(\t\022\r\n\005value\030\002 \001(\t\"e\n\010Feedback\022%\n\005value\030\002" +
-      " \001(\0132\026.google.protobuf.Value\0222\n\005error\030\003 " +
-      "\001(\0132#.mlflow.assessments.AssessmentError" +
-      "\"\261\004\n\nAssessment\022\025\n\rassessment_id\030\001 \001(\t\022\035" +
-      "\n\017assessment_name\030\002 \001(\tB\004\370\206\031\001\022\020\n\010trace_i" +
-      "d\030\003 \001(\t\022\017\n\007span_id\030\004 \001(\t\0224\n\006source\030\005 \001(\013" +
-      "2$.mlflow.assessments.AssessmentSource\022/" +
-      "\n\013create_time\030\006 \001(\0132\032.google.protobuf.Ti" +
-      "mestamp\0224\n\020last_update_time\030\007 \001(\0132\032.goog" +
-      "le.protobuf.Timestamp\0220\n\010feedback\030\t \001(\0132" +
-      "\034.mlflow.assessments.FeedbackH\000\0226\n\013expec" +
-      "tation\030\n \001(\0132\037.mlflow.assessments.Expect" +
-      "ationH\000\022\021\n\trationale\030\013 \001(\t\0226\n\005error\030\014 \001(" +
-      "\0132#.mlflow.assessments.AssessmentErrorB\002" +
-      "\030\001\022>\n\010metadata\030\r \003(\0132,.mlflow.assessment" +
-      "s.Assessment.MetadataEntry\032/\n\rMetadataEn" +
-      "try\022\013\n\003key\030\001 \001(\t\022\r\n\005value\030\002 \001(\t:\0028\001B\007\n\005v" +
-      "alueB\031\n\024org.mlflow.api.proto\220\001\001"
+      "\003\"Q\n\017AssessmentError\022\022\n\nerror_code\030\001 \001(\t" +
+      "\022\025\n\rerror_message\030\002 \001(\t\022\023\n\013stack_trace\030\003" +
+      " \001(\t\"\277\001\n\013Expectation\022%\n\005value\030\002 \001(\0132\026.go" +
+      "ogle.protobuf.Value\022I\n\020serialized_value\030" +
+      "\003 \001(\0132/.mlflow.assessments.Expectation.S" +
+      "erializedValue\032>\n\017SerializedValue\022\034\n\024ser" +
+      "ialization_format\030\001 \001(\t\022\r\n\005value\030\002 \001(\t\"e" +
+      "\n\010Feedback\022%\n\005value\030\002 \001(\0132\026.google.proto" +
+      "buf.Value\0222\n\005error\030\003 \001(\0132#.mlflow.assess" +
+      "ments.AssessmentError\"\261\004\n\nAssessment\022\025\n\r" +
+      "assessment_id\030\001 \001(\t\022\035\n\017assessment_name\030\002" +
+      " \001(\tB\004\370\206\031\001\022\020\n\010trace_id\030\003 \001(\t\022\017\n\007span_id\030" +
+      "\004 \001(\t\0224\n\006source\030\005 \001(\0132$.mlflow.assessmen" +
+      "ts.AssessmentSource\022/\n\013create_time\030\006 \001(\013" +
+      "2\032.google.protobuf.Timestamp\0224\n\020last_upd" +
+      "ate_time\030\007 \001(\0132\032.google.protobuf.Timesta" +
+      "mp\0220\n\010feedback\030\t \001(\0132\034.mlflow.assessment" +
+      "s.FeedbackH\000\0226\n\013expectation\030\n \001(\0132\037.mlfl" +
+      "ow.assessments.ExpectationH\000\022\021\n\trational" +
+      "e\030\013 \001(\t\0226\n\005error\030\014 \001(\0132#.mlflow.assessme" +
+      "nts.AssessmentErrorB\002\030\001\022>\n\010metadata\030\r \003(" +
+      "\0132,.mlflow.assessments.Assessment.Metada" +
+      "taEntry\032/\n\rMetadataEntry\022\013\n\003key\030\001 \001(\t\022\r\n" +
+      "\005value\030\002 \001(\t:\0028\001B\007\n\005valueB\031\n\024org.mlflow." +
+      "api.proto\220\001\001"
     };
     descriptor = com.google.protobuf.Descriptors.FileDescriptor
       .internalBuildGeneratedFileFrom(descriptorData,
@@ -8747,7 +8978,7 @@ public final class Assessments {
     internal_static_mlflow_assessments_AssessmentError_fieldAccessorTable = new
       com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
         internal_static_mlflow_assessments_AssessmentError_descriptor,
-        new java.lang.String[] { "ErrorCode", "ErrorMessage", });
+        new java.lang.String[] { "ErrorCode", "ErrorMessage", "StackTrace", });
     internal_static_mlflow_assessments_Expectation_descriptor =
       getDescriptor().getMessageTypes().get(2);
     internal_static_mlflow_assessments_Expectation_fieldAccessorTable = new

--- a/mlflow/protos/assessments.proto
+++ b/mlflow/protos/assessments.proto
@@ -35,6 +35,9 @@ message AssessmentError {
   optional string error_code = 1;
 
   optional string error_message = 2;
+
+  // Stack trace of the error. Truncated to 1000 characters to avoid making TraceInfo too large.
+  optional string stack_trace = 3;
 }
 
 // An expectation for the values or guidelines for the outputs that a model or agent should produce

--- a/mlflow/protos/assessments_pb2.py
+++ b/mlflow/protos/assessments_pb2.py
@@ -21,7 +21,7 @@ if Version(google.protobuf.__version__).major >= 5:
   from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11\x61ssessments.proto\x12\x12mlflow.assessments\x1a\x10\x64\x61tabricks.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc6\x01\n\x10\x41ssessmentSource\x12J\n\x0bsource_type\x18\x01 \x01(\x0e\x32/.mlflow.assessments.AssessmentSource.SourceTypeB\x04\xf8\x86\x19\x01\x12\x17\n\tsource_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"M\n\nSourceType\x12\x1b\n\x17SOURCE_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05HUMAN\x10\x01\x12\r\n\tLLM_JUDGE\x10\x02\x12\x08\n\x04\x43ODE\x10\x03\"<\n\x0f\x41ssessmentError\x12\x12\n\nerror_code\x18\x01 \x01(\t\x12\x15\n\rerror_message\x18\x02 \x01(\t\"\xbf\x01\n\x0b\x45xpectation\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12I\n\x10serialized_value\x18\x03 \x01(\x0b\x32/.mlflow.assessments.Expectation.SerializedValue\x1a>\n\x0fSerializedValue\x12\x1c\n\x14serialization_format\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"e\n\x08\x46\x65\x65\x64\x62\x61\x63k\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12\x32\n\x05\x65rror\x18\x03 \x01(\x0b\x32#.mlflow.assessments.AssessmentError\"\xb1\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08trace_id\x18\x03 \x01(\t\x12\x0f\n\x07span_id\x18\x04 \x01(\t\x12\x34\n\x06source\x18\x05 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12\x36\n\x05\x65rror\x18\x0c \x01(\x0b\x32#.mlflow.assessments.AssessmentErrorB\x02\x18\x01\x12>\n\x08metadata\x18\r \x03(\x0b\x32,.mlflow.assessments.Assessment.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05valueB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11\x61ssessments.proto\x12\x12mlflow.assessments\x1a\x10\x64\x61tabricks.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc6\x01\n\x10\x41ssessmentSource\x12J\n\x0bsource_type\x18\x01 \x01(\x0e\x32/.mlflow.assessments.AssessmentSource.SourceTypeB\x04\xf8\x86\x19\x01\x12\x17\n\tsource_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"M\n\nSourceType\x12\x1b\n\x17SOURCE_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05HUMAN\x10\x01\x12\r\n\tLLM_JUDGE\x10\x02\x12\x08\n\x04\x43ODE\x10\x03\"Q\n\x0f\x41ssessmentError\x12\x12\n\nerror_code\x18\x01 \x01(\t\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x13\n\x0bstack_trace\x18\x03 \x01(\t\"\xbf\x01\n\x0b\x45xpectation\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12I\n\x10serialized_value\x18\x03 \x01(\x0b\x32/.mlflow.assessments.Expectation.SerializedValue\x1a>\n\x0fSerializedValue\x12\x1c\n\x14serialization_format\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"e\n\x08\x46\x65\x65\x64\x62\x61\x63k\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12\x32\n\x05\x65rror\x18\x03 \x01(\x0b\x32#.mlflow.assessments.AssessmentError\"\xb1\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08trace_id\x18\x03 \x01(\t\x12\x0f\n\x07span_id\x18\x04 \x01(\t\x12\x34\n\x06source\x18\x05 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12\x36\n\x05\x65rror\x18\x0c \x01(\x0b\x32#.mlflow.assessments.AssessmentErrorB\x02\x18\x01\x12>\n\x08metadata\x18\r \x03(\x0b\x32,.mlflow.assessments.Assessment.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05valueB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
 
   _globals = globals()
   _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -44,17 +44,17 @@ if Version(google.protobuf.__version__).major >= 5:
     _globals['_ASSESSMENTSOURCE_SOURCETYPE']._serialized_start=244
     _globals['_ASSESSMENTSOURCE_SOURCETYPE']._serialized_end=321
     _globals['_ASSESSMENTERROR']._serialized_start=323
-    _globals['_ASSESSMENTERROR']._serialized_end=383
-    _globals['_EXPECTATION']._serialized_start=386
-    _globals['_EXPECTATION']._serialized_end=577
-    _globals['_EXPECTATION_SERIALIZEDVALUE']._serialized_start=515
-    _globals['_EXPECTATION_SERIALIZEDVALUE']._serialized_end=577
-    _globals['_FEEDBACK']._serialized_start=579
-    _globals['_FEEDBACK']._serialized_end=680
-    _globals['_ASSESSMENT']._serialized_start=683
-    _globals['_ASSESSMENT']._serialized_end=1244
-    _globals['_ASSESSMENT_METADATAENTRY']._serialized_start=1188
-    _globals['_ASSESSMENT_METADATAENTRY']._serialized_end=1235
+    _globals['_ASSESSMENTERROR']._serialized_end=404
+    _globals['_EXPECTATION']._serialized_start=407
+    _globals['_EXPECTATION']._serialized_end=598
+    _globals['_EXPECTATION_SERIALIZEDVALUE']._serialized_start=536
+    _globals['_EXPECTATION_SERIALIZEDVALUE']._serialized_end=598
+    _globals['_FEEDBACK']._serialized_start=600
+    _globals['_FEEDBACK']._serialized_end=701
+    _globals['_ASSESSMENT']._serialized_start=704
+    _globals['_ASSESSMENT']._serialized_end=1265
+    _globals['_ASSESSMENT_METADATAENTRY']._serialized_start=1209
+    _globals['_ASSESSMENT_METADATAENTRY']._serialized_end=1256
   # @@protoc_insertion_point(module_scope)
 
 else:
@@ -77,7 +77,7 @@ else:
   from google.protobuf import timestamp_pb2 as google_dot_protobuf_dot_timestamp__pb2
 
 
-  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11\x61ssessments.proto\x12\x12mlflow.assessments\x1a\x10\x64\x61tabricks.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc6\x01\n\x10\x41ssessmentSource\x12J\n\x0bsource_type\x18\x01 \x01(\x0e\x32/.mlflow.assessments.AssessmentSource.SourceTypeB\x04\xf8\x86\x19\x01\x12\x17\n\tsource_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"M\n\nSourceType\x12\x1b\n\x17SOURCE_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05HUMAN\x10\x01\x12\r\n\tLLM_JUDGE\x10\x02\x12\x08\n\x04\x43ODE\x10\x03\"<\n\x0f\x41ssessmentError\x12\x12\n\nerror_code\x18\x01 \x01(\t\x12\x15\n\rerror_message\x18\x02 \x01(\t\"\xbf\x01\n\x0b\x45xpectation\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12I\n\x10serialized_value\x18\x03 \x01(\x0b\x32/.mlflow.assessments.Expectation.SerializedValue\x1a>\n\x0fSerializedValue\x12\x1c\n\x14serialization_format\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"e\n\x08\x46\x65\x65\x64\x62\x61\x63k\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12\x32\n\x05\x65rror\x18\x03 \x01(\x0b\x32#.mlflow.assessments.AssessmentError\"\xb1\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08trace_id\x18\x03 \x01(\t\x12\x0f\n\x07span_id\x18\x04 \x01(\t\x12\x34\n\x06source\x18\x05 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12\x36\n\x05\x65rror\x18\x0c \x01(\x0b\x32#.mlflow.assessments.AssessmentErrorB\x02\x18\x01\x12>\n\x08metadata\x18\r \x03(\x0b\x32,.mlflow.assessments.Assessment.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05valueB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
+  DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11\x61ssessments.proto\x12\x12mlflow.assessments\x1a\x10\x64\x61tabricks.proto\x1a\x1cgoogle/protobuf/struct.proto\x1a\x1fgoogle/protobuf/timestamp.proto\"\xc6\x01\n\x10\x41ssessmentSource\x12J\n\x0bsource_type\x18\x01 \x01(\x0e\x32/.mlflow.assessments.AssessmentSource.SourceTypeB\x04\xf8\x86\x19\x01\x12\x17\n\tsource_id\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\"M\n\nSourceType\x12\x1b\n\x17SOURCE_TYPE_UNSPECIFIED\x10\x00\x12\t\n\x05HUMAN\x10\x01\x12\r\n\tLLM_JUDGE\x10\x02\x12\x08\n\x04\x43ODE\x10\x03\"Q\n\x0f\x41ssessmentError\x12\x12\n\nerror_code\x18\x01 \x01(\t\x12\x15\n\rerror_message\x18\x02 \x01(\t\x12\x13\n\x0bstack_trace\x18\x03 \x01(\t\"\xbf\x01\n\x0b\x45xpectation\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12I\n\x10serialized_value\x18\x03 \x01(\x0b\x32/.mlflow.assessments.Expectation.SerializedValue\x1a>\n\x0fSerializedValue\x12\x1c\n\x14serialization_format\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t\"e\n\x08\x46\x65\x65\x64\x62\x61\x63k\x12%\n\x05value\x18\x02 \x01(\x0b\x32\x16.google.protobuf.Value\x12\x32\n\x05\x65rror\x18\x03 \x01(\x0b\x32#.mlflow.assessments.AssessmentError\"\xb1\x04\n\nAssessment\x12\x15\n\rassessment_id\x18\x01 \x01(\t\x12\x1d\n\x0f\x61ssessment_name\x18\x02 \x01(\tB\x04\xf8\x86\x19\x01\x12\x10\n\x08trace_id\x18\x03 \x01(\t\x12\x0f\n\x07span_id\x18\x04 \x01(\t\x12\x34\n\x06source\x18\x05 \x01(\x0b\x32$.mlflow.assessments.AssessmentSource\x12/\n\x0b\x63reate_time\x18\x06 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x34\n\x10last_update_time\x18\x07 \x01(\x0b\x32\x1a.google.protobuf.Timestamp\x12\x30\n\x08\x66\x65\x65\x64\x62\x61\x63k\x18\t \x01(\x0b\x32\x1c.mlflow.assessments.FeedbackH\x00\x12\x36\n\x0b\x65xpectation\x18\n \x01(\x0b\x32\x1f.mlflow.assessments.ExpectationH\x00\x12\x11\n\trationale\x18\x0b \x01(\t\x12\x36\n\x05\x65rror\x18\x0c \x01(\x0b\x32#.mlflow.assessments.AssessmentErrorB\x02\x18\x01\x12>\n\x08metadata\x18\r \x03(\x0b\x32,.mlflow.assessments.Assessment.MetadataEntry\x1a/\n\rMetadataEntry\x12\x0b\n\x03key\x18\x01 \x01(\t\x12\r\n\x05value\x18\x02 \x01(\t:\x02\x38\x01\x42\x07\n\x05valueB\x19\n\x14org.mlflow.api.proto\x90\x01\x01')
 
 
 
@@ -159,16 +159,16 @@ else:
     _ASSESSMENTSOURCE_SOURCETYPE._serialized_start=244
     _ASSESSMENTSOURCE_SOURCETYPE._serialized_end=321
     _ASSESSMENTERROR._serialized_start=323
-    _ASSESSMENTERROR._serialized_end=383
-    _EXPECTATION._serialized_start=386
-    _EXPECTATION._serialized_end=577
-    _EXPECTATION_SERIALIZEDVALUE._serialized_start=515
-    _EXPECTATION_SERIALIZEDVALUE._serialized_end=577
-    _FEEDBACK._serialized_start=579
-    _FEEDBACK._serialized_end=680
-    _ASSESSMENT._serialized_start=683
-    _ASSESSMENT._serialized_end=1244
-    _ASSESSMENT_METADATAENTRY._serialized_start=1188
-    _ASSESSMENT_METADATAENTRY._serialized_end=1235
+    _ASSESSMENTERROR._serialized_end=404
+    _EXPECTATION._serialized_start=407
+    _EXPECTATION._serialized_end=598
+    _EXPECTATION_SERIALIZEDVALUE._serialized_start=536
+    _EXPECTATION_SERIALIZEDVALUE._serialized_end=598
+    _FEEDBACK._serialized_start=600
+    _FEEDBACK._serialized_end=701
+    _ASSESSMENT._serialized_start=704
+    _ASSESSMENT._serialized_end=1265
+    _ASSESSMENT_METADATAENTRY._serialized_start=1209
+    _ASSESSMENT_METADATAENTRY._serialized_end=1256
   # @@protoc_insertion_point(module_scope)
 

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -372,7 +372,7 @@ def test_feedback_from_exception(stack_trace_length):
     # Mock traceback.format_tb to simulate long stack trace
     with patch(
         "mlflow.entities.assessment.traceback.format_tb",
-        return_value=["A" * (stack_trace_length  - 9) + "last line"]
+        return_value=["A" * (stack_trace_length - 9) + "last line"],
     ):
         feedback = Feedback(error=err)
     assert feedback.error.error_code == "ValueError"

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -1,5 +1,6 @@
 import json
 import time
+from unittest.mock import patch
 
 import pytest
 
@@ -360,8 +361,30 @@ def test_feedback_value_proto_dict_conversion(value, error):
     assert result.error == result.error
 
 
-def test_feedback_from_exception():
-    feedback = Feedback(error=ValueError("An error occurred."))
+@pytest.mark.parametrize("stack_trace_length", [500, 2000])
+def test_feedback_from_exception(stack_trace_length):
+    err = None
+    try:
+        raise ValueError("An error occurred.")
+    except ValueError as e:
+        err = e
 
+    # Mock traceback.format_tb to simulate long stack trace
+    with patch(
+        "mlflow.entities.assessment.traceback.format_tb",
+        return_value=["A" * (stack_trace_length  - 9) + "last line"]
+    ):
+        feedback = Feedback(error=err)
     assert feedback.error.error_code == "ValueError"
     assert feedback.error.error_message == "An error occurred."
+    assert feedback.error.stack_trace is not None
+
+    proto = feedback.to_proto()
+    assert len(proto.feedback.error.stack_trace) == min(stack_trace_length, 1000)
+    assert proto.feedback.error.stack_trace.endswith("last line")
+    if stack_trace_length > 1000:
+        assert proto.feedback.error.stack_trace.startswith("[Stack trace is truncated]\n...\n")
+
+    recovered = Feedback.from_proto(feedback.to_proto())
+    assert feedback.error.error_code == recovered.error.error_code
+    assert feedback.error.error_message == recovered.error.error_message


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15806?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15806/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15806/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15806/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Support logging error stack trace in `AssessmentError`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
from datetime import datetime
import json
import mlflow
from mlflow.entities import Feedback
from mlflow.genai.scorers import scorer

@scorer
def my_scorer(inputs):
    try:
        serialized = json.dumps(inputs)
        return Feedback(value=serialized, rationale="automatic")
    except Exception as e:
        return Feedback(error=e)
          
print(my_scorer({"foo": "bar"}))
print(my_scorer(datetime.now()))
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
