### PR TITLE
[2.22.1] Show search trace error message

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -88,7 +88,9 @@ jobs:
       - name: Import check
         run: |
           source .venv/bin/activate
-          python tests/check_mlflow_lazily_imports_ml_packages.py
+          # `-I` is used to avoid importing modules from user-specific site-packages
+          # that might conflict with the built-in modules (e.g. `types`).
+          python -I tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
         run: |
           source .venv/bin/activate

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -219,7 +219,7 @@ def filter_versions(
         f"Minimum version {min_ver} is not in the list of versions for {flavor}"
     )
     assert max_ver in versions or allow_unreleased_max_version, (
-        f"Minimum version {max_ver} is not in the list of versions for {flavor}"
+        f"Maximum version {max_ver} is not in the list of versions for {flavor}"
     )
     assert all(v in versions for v in unsupported), (
         f"Unsupported versions {unsupported} are not in the list of versions for {flavor}"

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -233,15 +233,13 @@ class Span:
         """
         if trace_id := _get_trace_id_if_v3_format(data):
             raise MlflowException(
-                f"Failed to load trace with ID {trace_id}. This trace was created with MLflow 3.x, "
-                f"but you are currently using MLflow {mlflow.__version__}. These versions use "
-                "different trace formats and the current MLflow client is not compatible with "
-                "the new format. To properly search and view traces from both MLflow 2.x and 3.x, "
-                "please upgrade your MLflow client to version 3.x.\n"
+                f"Failed to load trace with ID {trace_id}. It was created with MLflow 3.x, "
+                f"but you're using MLflow {mlflow.__version__}, which cannot load traces created "
+                "with MLflow 3.x. To properly search and view traces from both MLflow 2.x and 3.x, "
+                "run this command to upgrade MLflow and restart your python process:\n"
                 "```\n"
                 "pip install 'mlflow>=3.0.0'\n"
-                "```\n"
-                "Note: You will need to restart your Python process after upgrading MLflow."
+                "```"
             )
 
         try:

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -327,8 +327,7 @@ def _get_trace_id_if_v3_format(data: dict[str, Any]) -> Optional[str]:
         try:
             trace_id_bytes = base64.b64decode(data["trace_id"])
             otel_trace_id = int.from_bytes(trace_id_bytes, byteorder="big", signed=False)
-            mlflow_trace_id = "tr-" + encode_trace_id(otel_trace_id)
-            return mlflow_trace_id
+            return "tr-" + encode_trace_id(otel_trace_id)
         except Exception:
             pass
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -265,7 +265,7 @@ spacy:
 
   models:
     minimum: "3.4.4"
-    maximum: "3.8.5"
+    maximum: "3.8.6"
     python:
       ">= 3.8.4": "3.10"
     requirements:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -265,7 +265,7 @@ spacy:
 
   models:
     minimum: "3.4.4"
-    maximum: "3.8.6"
+    maximum: "3.8.4"
     python:
       ">= 3.8.4": "3.10"
     requirements:

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -128,7 +128,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "3.4.4",
-            "maximum": "3.8.6"
+            "maximum": "3.8.4"
         }
     },
     "statsmodels": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -128,7 +128,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "models": {
             "minimum": "3.4.4",
-            "maximum": "3.8.5"
+            "maximum": "3.8.6"
         }
     },
     "statsmodels": {

--- a/tests/check_mlflow_lazily_imports_ml_packages.py
+++ b/tests/check_mlflow_lazily_imports_ml_packages.py
@@ -17,7 +17,8 @@ def main():
         "fastai",
         "h2o",
         "lightgbm",
-        "mleap",
+        # Skipping deprecated flavor
+        # "mleap",
         "onnx",
         "pytorch_lightning",
         "pyspark.ml",

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -225,3 +225,21 @@ def test_from_dict_raises_when_request_id_is_empty():
                 "events": [],
             }
         )
+
+
+def test_from_dict_raises_for_v3_format():
+    v3_span_dict = {
+        "name": "test span",
+        "trace_id": "MTIzNDU2Nzg5MDEyMzQ1Ng==",
+        "span_id": "MTIzNDU2Nzg=",
+        "parent_span_id": None,
+        "start_time_unix_nano": 1234567890,
+        "end_time_unix_nano": 1234567891,
+        "status": {"code": 1, "message": "OK"},
+        "attributes": {"mlflow.request_id": {"string_value": "tr-123"}},
+        "events": [],
+        "trace_state": "",
+    }
+
+    with pytest.raises(MlflowException, match=r"Failed to load trace with ID"):
+        Span.from_dict(v3_span_dict)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15807?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15807/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15807/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15807
```

</p>
</details>

### What changes are proposed in this pull request?

MLflow 2.x client cannot load trace from 3.x client because of the different schema. This PR adds a helpful error message when loading v3 traces from 2.x client and prompt users to update client version.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

![Screenshot 2025-05-20 at 15 43 21](https://github.com/user-attachments/assets/6d4e462a-a7ba-413a-8be7-4bd26bc736eb)


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
