### PR TITLE
Improve error message for artifact donwload failure with runs URI

### DIFF
--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -186,8 +186,8 @@ class RunsArtifactRepository(ArtifactRepository):
 
             raise MlflowException(
                 f"Failed to download artifacts from {full_path}. "
-                f"Searched for a model with name {model_name!r} associated with the run {run_id}, "
-                f"but no such model was found."
+                f"No model named {model_name!r} was found for run {run_id}. "
+                f"Please ensure that you've specified the correct model name or artifact path."
             ) from e
 
     def _download_file(self, remote_file_path, local_path):

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -185,7 +185,7 @@ class RunsArtifactRepository(ArtifactRepository):
             )
 
             raise MlflowException(
-                f"Failed to download artifacts from {full_path} due to: {e}. "
+                f"Failed to download artifacts from {full_path}. "
                 f"Searched for a model with name {model_name!r} associated with the run {run_id}, "
                 f"but no such model was found."
             ) from e

--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -134,7 +134,7 @@ class RunsArtifactRepository(ArtifactRepository):
         """
         try:
             return self.repo.download_artifacts(artifact_path, dst_path)
-        except Exception:
+        except Exception as e:
             from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 
             full_path = f"{self.artifact_uri}/{artifact_path}"
@@ -184,7 +184,11 @@ class RunsArtifactRepository(ArtifactRepository):
                 f"run {run_id}."
             )
 
-            raise  # raise the original exception if no matching model is found
+            raise MlflowException(
+                f"Failed to download artifacts from {full_path} due to: {e}. "
+                f"Searched for a model with name {model_name!r} associated with the run {run_id}, "
+                f"but no such model was found."
+            ) from e
 
     def _download_file(self, remote_file_path, local_path):
         """


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15822?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15822/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15822/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15822/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Improve the message  for artifact donwload failure with runs URI: 

```python
import mlflow


class Model(mlflow.pyfunc.PythonModel):
    def load_context(self, context):
        pass

    def predict(self, context, model_input):
        pass


with mlflow.start_run() as run:
    mlflow.pyfunc.log_model(python_model=Model(), name="foo")


mlflow.pyfunc.load_model(f"runs:/{run.info.run_id}/bar")
```

Before

```
OSError: No such file or directory: '/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlruns/0/d93bbc359f8f4a71bcbe1874168aafae/artifacts/bar'
```

After

```
mlflow.exceptions.MlflowException: Failed to download artifacts from runs:/d93bbc359f8f4a71bcbe1874168aafae/bar due to: No such file or directory: '/Users/harutaka.kawamura/Desktop/repositories/mlflow/mlruns/0/d93bbc359f8f4a71bcbe1874168aafae/artifacts/bar'. Searched for a model with name 'bar' associated with the run d93bbc359f8f4a71bcbe1874168aafae, but no such model was found.
```


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
