### PR TITLE
Improve built scorer syntax

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -324,7 +324,7 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
 
         .. code-block:: python
 
-            from mlflow.genai.scorers import all_scorers
+            from mlflow.genai.scorers import get_all_scorers
 
             data = [
                 {
@@ -348,7 +348,7 @@ def to_predict_fn(endpoint_uri: str) -> Callable:
             mlflow.genai.evaluate(
                 data=data,
                 predict_fn=predict_fn,
-                scorers=all_scorers,
+                scorers=get_all_scorers(),
             )
 
         You can also directly invoke the function to validate if the endpoint works

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -75,7 +75,7 @@ def evaluate(
 
         mlflow.genai.evaluate(
             data=trace_df,
-            scorers=[correctness(), safety()],
+            scorers=[correctness, safety],
         )
 
     Built-in scorers will understand the model inputs, outputs, and other intermediate
@@ -157,7 +157,7 @@ def evaluate(
         mlflow.genai.evaluate(
             data=data,
             predict_fn=predict_fn,
-            scorers=[correctness(), safety()],
+            scorers=[correctness, safety],
         )
 
     Args:

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -1,27 +1,33 @@
 from mlflow.genai.scorers.base import BuiltInScorer, Scorer, scorer
 from mlflow.genai.scorers.builtin_scorers import (
-    all_scorers,
     chunk_relevance,
     context_sufficiency,
     correctness,
+    get_all_scorers,
+    get_rag_scorers,
     groundedness,
     guideline_adherence,
-    rag_scorers,
     relevance_to_query,
     safety,
 )
 
 __all__ = [
     "BuiltInScorer",
+    "ChunkRelevance",
+    "ContextSufficiency",
+    "Correctness",
+    "Groundedness",
+    "GuidelineAdherence",
+    "RelevanceToQuery",
     "Scorer",
     "scorer",
     "chunk_relevance",
     "context_sufficiency",
     "correctness",
+    "get_all_scorers",
+    "get_rag_scorers",
     "groundedness",
     "guideline_adherence",
-    "all_scorers",
-    "rag_scorers",
     "relevance_to_query",
     "safety",
 ]

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -683,15 +683,26 @@ correctness = Correctness()
 # === Shorthand for all builtin RAG scorers ===
 def get_rag_scorers():
     """
-    Returns a list of all built-in RAG scorers.
+    Returns a list of built-in scorers for evaluating RAG models. Contains scorers
+    chunk_relevance, context_sufficiency, groundedness, and relevance_to_query.
 
     Example:
 
     .. code-block:: python
 
+        import mlflow
         from mlflow.genai.scorers import get_rag_scorers
 
-        mlflow.genai.evaluate(data=data, scorers=get_rag_scorers())
+        data = [
+            {
+                "inputs": {"question": "What is the capital of France?"},
+                "outputs": "The capital of France is Paris.",
+                "retrieved_context": [
+                    {"content": "Paris is the capital city of France."},
+                ],
+            }
+        ]
+        result = mlflow.genai.evaluate(data=data, scorers=get_rag_scorers())
     """
     return [
         chunk_relevance,
@@ -709,9 +720,19 @@ def get_all_scorers():
 
     .. code-block:: python
 
+        import mlflow
         from mlflow.genai.scorers import get_all_scorers
 
-        mlflow.genai.evaluate(data=data, scorers=get_all_scorers())
+        data = [
+            {
+                "inputs": {"question": "What is the capital of France?"},
+                "outputs": "The capital of France is Paris.",
+                "retrieved_context": [
+                    {"content": "Paris is the capital city of France."},
+                ],
+            }
+        ]
+        result = mlflow.genai.evaluate(data=data, scorers=get_all_scorers())
     """
     return get_rag_scorers() + [
         guideline_adherence,

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -17,14 +17,14 @@ class _BaseBuiltInScorer(BuiltInScorer):
     inherit from this class.
     """
 
-    required_columns: set[str] = {}
+    required_columns: set[str] = set()
 
     # Avoid direct mutation of built-in scorer fields like name. Overriding the default setting must
-    # be done through the `configure` method. This is because the short-hand syntax like
+    # be done through the `with_config` method. This is because the short-hand syntax like
     # `mlflow.genai.scorers.chunk_relevance` returns a single instance rather than a new instance.
     def __setattr__(self, name: str, value: Any) -> None:
         raise MlflowException(
-            "Built-in scorer fields are immutable. Please use the `configure` method to "
+            "Built-in scorer fields are immutable. Please use the `with_config` method to "
             "get a new instance with the custom field values.",
             error_code=BAD_REQUEST,
         )
@@ -54,9 +54,9 @@ class _BaseBuiltInScorer(BuiltInScorer):
             raise ValueError("This scorer isn't recognized since it doesn't have a name.")
 
     @abstractmethod
-    def configure(self, **kwargs) -> Any:
+    def with_config(self, **kwargs) -> "_BaseBuiltInScorer":
         """
-        Configure the scorer with additional parameters, such as name, global guidelines, etc.
+        Get a new scorer instance with the given configuration, such as name, global guidelines.
 
         Override this method with the appropriate config keys. This method must return the scorer
         instance itself with the updated configuration.
@@ -84,9 +84,8 @@ class ChunkRelevance(_BaseBuiltInScorer):
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
-    Importing `from mlflow.genai.scorers import chunk_relevance` gives you an instance
-    of this scorer with default setting. You can override the setting by calling the
-    :py:meth:`configure` method.
+    Use `mlflow.genai.scorers.chunk_relevance` to get an instance of this scorer with
+    default setting. You can override the setting by the :py:meth:`with_config` method.
 
     Example (direct usage):
 
@@ -149,9 +148,9 @@ class ChunkRelevance(_BaseBuiltInScorer):
         """
         return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
 
-    def configure(self, *, name: str = "chunk_relevance") -> "ChunkRelevance":
+    def with_config(self, *, name: str = "chunk_relevance") -> "ChunkRelevance":
         """
-        Configure the scorer with additional parameters such as name.
+        Get a new scorer instance with a specified name.
 
         Args:
             name: The name of the scorer. Default is "chunk_relevance".
@@ -168,9 +167,8 @@ class ContextSufficiency(_BaseBuiltInScorer):
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
-    Importing `from mlflow.genai.scorers import context_sufficiency` gives you an instance
-    of this scorer with default setting. You can override the setting by calling the
-    :py:meth:`configure` method.
+    Use `mlflow.genai.scorers.context_sufficiency` to get an instance of this scorer with
+    default setting. You can override the setting by the :py:meth:`with_config` method.
 
     Example (direct usage):
 
@@ -207,9 +205,9 @@ class ContextSufficiency(_BaseBuiltInScorer):
         """Evaluate context sufficiency based on retrieved documents."""
         return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
 
-    def configure(self, *, name: str = "context_sufficiency") -> "ContextSufficiency":
+    def with_config(self, *, name: str = "context_sufficiency") -> "ContextSufficiency":
         """
-        Configure the scorer with additional parameters such as name.
+        Get a new scorer instance with a specified name.
 
         Args:
             name: The name of the scorer. Default is "context_sufficiency".
@@ -226,9 +224,8 @@ class Groundedness(_BaseBuiltInScorer):
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
-    Importing `from mlflow.genai.scorers import groundedness` gives you an instance
-    of this scorer with default setting. You can override the setting by calling the
-    :py:meth:`configure` method.
+    Use `mlflow.genai.scorers.groundedness` to get an instance of this scorer with
+    default setting. You can override the setting by the :py:meth:`with_config` method.
 
     Example (direct usage):
 
@@ -269,9 +266,9 @@ class Groundedness(_BaseBuiltInScorer):
         """Evaluate groundedness of response against context."""
         return super().__call__(inputs=inputs, outputs=outputs, retrieved_context=retrieved_context)
 
-    def configure(self, *, name: str = "groundedness") -> "Groundedness":
+    def with_config(self, *, name: str = "groundedness") -> "Groundedness":
         """
-        Configure the scorer with additional parameters such as name.
+        Get a new scorer instance with a specified name.
 
         Args:
             name: The name of the scorer. Default is "groundedness".
@@ -291,9 +288,8 @@ class GuidelineAdherence(_BaseBuiltInScorer):
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
-    Importing `from mlflow.genai.scorers import guideline_adherence` gives you an instance
-    of this scorer with default setting. You can override the setting by calling the
-    :py:meth:`configure` method.
+    Use `mlflow.genai.scorers.guideline_adherence` to get an instance of this scorer with
+    default setting. You can override the setting by the :py:meth:`with_config` method.
 
     There are two different ways to specify judges, depending on the use case:
 
@@ -310,7 +306,7 @@ class GuidelineAdherence(_BaseBuiltInScorer):
         from mlflow.genai.scorers import guideline_adherence
 
         # Create a global judge
-        english = guideline_adherence.configure(
+        english = guideline_adherence.with_config(
             name="english_guidelines",
             global_guidelines=["The response must be in English"],
         )
@@ -331,11 +327,11 @@ class GuidelineAdherence(_BaseBuiltInScorer):
         import mlflow
         from mlflow.genai.scorers import guideline_adherence
 
-        english = guideline_adherence.configure(
+        english = guideline_adherence.with_config(
             name="english",
             global_guidelines=["The response must be in English"],
         )
-        clarify = guideline_adherence.configure(
+        clarify = guideline_adherence.with_config(
             name="clarify",
             global_guidelines=["The response must be clear, coherent, and concise"],
         )
@@ -433,14 +429,14 @@ class GuidelineAdherence(_BaseBuiltInScorer):
             guidelines_context=guidelines_context,
         )
 
-    def configure(
+    def with_config(
         self,
         *,
         name: str = "guideline_adherence",
         global_guidelines: Optional[list[str]] = None,
     ) -> "GuidelineAdherence":
         """
-        Configure the scorer with additional parameters
+        Get a new scorer instance with the given name and global guidelines.
 
         Args:
             name: The name of the scorer. Default is "guideline_adherence".
@@ -456,7 +452,7 @@ class GuidelineAdherence(_BaseBuiltInScorer):
 
             from mlflow.genai.scorers import guideline_adherence
 
-            is_english = guideline_adherence.configure(
+            is_english = guideline_adherence.with_config(
                 name="is_english", global_guidelines=["The response must be in English"]
             )
 
@@ -474,9 +470,8 @@ class RelevanceToQuery(_BaseBuiltInScorer):
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
-    Importing `from mlflow.genai.scorers import relevance_to_query` gives you an instance
-    of this scorer with default setting. You can override the setting by calling the
-    :py:meth:`configure` method.
+    Use `mlflow.genai.scorers.relevance_to_query` to get an instance of this scorer with
+    default setting. You can override the setting by the :py:meth:`with_config` method.
 
     Example (direct usage):
 
@@ -514,9 +509,9 @@ class RelevanceToQuery(_BaseBuiltInScorer):
         """Evaluate relevance to the user's query."""
         return super().__call__(inputs=inputs, outputs=outputs)
 
-    def configure(self, *, name: str = "relevance_to_query") -> "RelevanceToQuery":
+    def with_config(self, *, name: str = "relevance_to_query") -> "RelevanceToQuery":
         """
-        Configure the scorer with additional parameters such as name.
+        Get a new scorer instance with a specified name.
 
         Args:
             name: The name of the scorer. Default is "relevance_to_query".
@@ -532,9 +527,8 @@ class Safety(_BaseBuiltInScorer):
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
-    Importing `from mlflow.genai.scorers import safety` gives you an instance
-    of this scorer with default setting. You can override the setting by calling the
-    :py:meth:`configure` method.
+    Use `mlflow.genai.scorers.safety` to get an instance of this scorer with
+    default setting. You can override the setting by the :py:meth:`with_config` method.
 
     Example (direct usage):
 
@@ -572,9 +566,9 @@ class Safety(_BaseBuiltInScorer):
         """Evaluate safety of the response."""
         return super().__call__(inputs=inputs, outputs=outputs)
 
-    def configure(self, *, name: str = "safety") -> "Safety":
+    def with_config(self, *, name: str = "safety") -> "Safety":
         """
-        Configure the scorer with additional parameters such as name.
+        Get a new scorer instance with a specified name.
 
         Args:
             name: The name of the scorer. Default is "safety".
@@ -590,9 +584,8 @@ class Correctness(_BaseBuiltInScorer):
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
-    Importing `from mlflow.genai.scorers import correctness` gives you an instance
-    of this scorer with default setting. You can override the setting by calling the
-    :py:meth:`configure` method.
+    Use `mlflow.genai.scorers.correctness` to get an instance of this scorer with
+    default setting. You can override the setting by the :py:meth:`with_config` method.
 
     Example (direct usage):
 
@@ -660,12 +653,12 @@ class Correctness(_BaseBuiltInScorer):
         """Evaluate correctness of the response against expectations."""
         return super().__call__(inputs=inputs, outputs=outputs, expectations=expectations)
 
-    def configure(self, *, name: str = "correctness") -> "Correctness":
+    def with_config(self, *, name: str = "correctness") -> "Correctness":
         """
-        Configure the scorer with additional parameters such as name.
+        Get a new scorer instance with a specified name.
 
         Args:
-            name: The name of the scorer. Default is "correctness".
+            name: The new name of the scorer. Default is "correctness".
         """
         return Correctness(name=name)
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -681,18 +681,43 @@ correctness = Correctness()
 
 
 # === Shorthand for all builtin RAG scorers ===
-rag_scorers = [
-    chunk_relevance,
-    context_sufficiency,
-    groundedness,
-    relevance_to_query,
-]
+def get_rag_scorers():
+    """
+    Returns a list of all built-in RAG scorers.
 
-all_scorers = rag_scorers + [
-    guideline_adherence,
-    safety,
-    correctness,
-]
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import get_rag_scorers
+
+        mlflow.genai.evaluate(data=data, scorers=get_rag_scorers())
+    """
+    return [
+        chunk_relevance,
+        context_sufficiency,
+        groundedness,
+        relevance_to_query,
+    ]
+
+
+def get_all_scorers():
+    """
+    Returns a list of all built-in scorers.
+
+    Example:
+
+    .. code-block:: python
+
+        from mlflow.genai.scorers import get_all_scorers
+
+        mlflow.genai.evaluate(data=data, scorers=get_all_scorers())
+    """
+    return get_rag_scorers() + [
+        guideline_adherence,
+        safety,
+        correctness,
+    ]
 
 
 class MissingColumnsException(MlflowException):

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -681,7 +681,8 @@ correctness = Correctness()
 
 
 # === Shorthand for all builtin RAG scorers ===
-def get_rag_scorers():
+@experimental
+def get_rag_scorers() -> list[BuiltInScorer]:
     """
     Returns a list of built-in scorers for evaluating RAG models. Contains scorers
     chunk_relevance, context_sufficiency, groundedness, and relevance_to_query.
@@ -712,7 +713,8 @@ def get_rag_scorers():
     ]
 
 
-def get_all_scorers():
+@experimental
+def get_all_scorers() -> list[BuiltInScorer]:
     """
     Returns a list of all built-in scorers.
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1,9 +1,11 @@
+from abc import abstractmethod
 from copy import deepcopy
 from typing import Any, Optional
 
 from mlflow.entities import Assessment
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import BuiltInScorer
+from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.utils.annotations import experimental
 
 GENAI_CONFIG_NAME = "databricks-agent"
@@ -16,6 +18,16 @@ class _BaseBuiltInScorer(BuiltInScorer):
     """
 
     required_columns: set[str] = {}
+
+    # Avoid direct mutation of built-in scorer fields like name. Overriding the default setting must
+    # be done through the `configure` method. This is because the short-hand syntax like
+    # `mlflow.genai.scorers.chunk_relevance` returns a single instance rather than a new instance.
+    def __setattr__(self, name: str, value: Any) -> None:
+        raise MlflowException(
+            "Built-in scorer fields are immutable. Please use the `configure` method to "
+            "get a new instance with the custom field values.",
+            error_code=BAD_REQUEST,
+        )
 
     def __call__(self, **kwargs):
         try:
@@ -41,6 +53,15 @@ class _BaseBuiltInScorer(BuiltInScorer):
         else:
             raise ValueError("This scorer isn't recognized since it doesn't have a name.")
 
+    @abstractmethod
+    def configure(self, **kwargs) -> Any:
+        """
+        Configure the scorer with additional parameters, such as name, global guidelines, etc.
+
+        Override this method with the appropriate config keys. This method must return the scorer
+        instance itself with the updated configuration.
+        """
+
     def update_evaluation_config(self, evaluation_config) -> dict:
         config = deepcopy(evaluation_config)
         metrics = config.setdefault(GENAI_CONFIG_NAME, {}).setdefault("metrics", [])
@@ -54,30 +75,18 @@ class _BaseBuiltInScorer(BuiltInScorer):
             raise MissingColumnsException(self.name, missing_columns)
 
 
-def _builtin_scorer(f):
-    """A decorator to mark a built-in scorer function for labeling purposes."""
-    f.__is_mlflow_builtin_scorer = True
-    return f
-
-
 # === Builtin Scorers ===
-class _ChunkRelevance(_BaseBuiltInScorer):
-    name: str = "chunk_relevance"
-    required_columns: set[str] = {"inputs", "retrieved_context"}
-
-    def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> list[Assessment]:
-        """Evaluate chunk relevance for each context chunk."""
-        return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
-
-
-@_builtin_scorer
 @experimental
-def chunk_relevance():
+class ChunkRelevance(_BaseBuiltInScorer):
     """
     Chunk relevance measures whether each chunk is relevant to the input request.
 
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Importing `from mlflow.genai.scorers import chunk_relevance` gives you an instance
+    of this scorer with default setting. You can override the setting by calling the
+    :py:meth:`configure` method.
 
     Example (direct usage):
 
@@ -86,7 +95,7 @@ def chunk_relevance():
         import mlflow
         from mlflow.genai.scorers import chunk_relevance
 
-        assessment = chunk_relevance()(
+        assessment = chunk_relevance(
             inputs={"question": "What is the capital of France?"},
             retrieved_context=[
                 {"content": "Paris is the capital city of France."},
@@ -110,29 +119,58 @@ def chunk_relevance():
                 ],
             }
         ]
-        result = mlflow.genai.evaluate(data=data, scorers=[chunk_relevance()])
+        result = mlflow.genai.evaluate(data=data, scorers=[chunk_relevance])
     """
-    return _ChunkRelevance()
 
+    name: str = "chunk_relevance"
+    required_columns: set[str] = {"inputs", "retrieved_context"}
 
-class _ContextSufficiency(_BaseBuiltInScorer):
-    name: str = "context_sufficiency"
-    required_columns: set[str] = {"inputs", "retrieved_context", "expectations/expected_response"}
+    def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> list[Assessment]:
+        """
+        Evaluate chunk relevance for each context chunk.
 
-    def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> Assessment:
-        """Evaluate context sufficiency based on retrieved documents."""
+        Args:
+            inputs: The input data.
+            retrieved_context: The retrieved context.
+
+        Returns:
+            A list of assessments evaluating the relevance of each context chunk.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.genai.scorers import chunk_relevance
+
+            assessments = chunk_relevance(
+                inputs={"question": "What is the capital of France?"},
+                retrieved_context=[{"content": "Paris is the capital city of France."}],
+            )
+        """
         return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
 
+    def configure(self, *, name: str = "chunk_relevance") -> "ChunkRelevance":
+        """
+        Configure the scorer with additional parameters such as name.
 
-@_builtin_scorer
+        Args:
+            name: The name of the scorer. Default is "chunk_relevance".
+        """
+        return ChunkRelevance(name=name)
+
+
 @experimental
-def context_sufficiency():
+class ContextSufficiency(_BaseBuiltInScorer):
     """
     Context sufficiency evaluates whether the retrieved documents provide all necessary
     information to generate the expected response.
 
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Importing `from mlflow.genai.scorers import context_sufficiency` gives you an instance
+    of this scorer with default setting. You can override the setting by calling the
+    :py:meth:`configure` method.
 
     Example (direct usage):
 
@@ -141,7 +179,7 @@ def context_sufficiency():
         import mlflow
         from mlflow.genai.scorers import context_sufficiency
 
-        assessment = context_sufficiency()(
+        assessment = context_sufficiency(
             inputs={"question": "What is the capital of France?"},
             retrieved_context=[{"content": "Paris is the capital city of France."}],
         )
@@ -159,31 +197,38 @@ def context_sufficiency():
                 "retrieved_context": [{"content": "Paris is the capital city of France."}],
             }
         ]
-        result = mlflow.genai.evaluate(data=data, scorers=[context_sufficiency()])
+        result = mlflow.genai.evaluate(data=data, scorers=[context_sufficiency])
     """
-    return _ContextSufficiency()
+
+    name: str = "context_sufficiency"
+    required_columns: set[str] = {"inputs", "retrieved_context", "expectations/expected_response"}
+
+    def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> Assessment:
+        """Evaluate context sufficiency based on retrieved documents."""
+        return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
+
+    def configure(self, *, name: str = "context_sufficiency") -> "ContextSufficiency":
+        """
+        Configure the scorer with additional parameters such as name.
+
+        Args:
+            name: The name of the scorer. Default is "context_sufficiency".
+        """
+        return ContextSufficiency(name=name)
 
 
-class _Groundedness(_BaseBuiltInScorer):
-    name: str = "groundedness"
-    required_columns: set[str] = {"inputs", "outputs", "retrieved_context"}
-
-    def __call__(
-        self, *, inputs: Any, outputs: Any, retrieved_context: list[dict[str, Any]]
-    ) -> Assessment:
-        """Evaluate groundedness of response against context."""
-        return super().__call__(inputs=inputs, outputs=outputs, retrieved_context=retrieved_context)
-
-
-@_builtin_scorer
 @experimental
-def groundedness():
+class Groundedness(_BaseBuiltInScorer):
     """
     Groundedness assesses whether the agent's response is aligned with the information provided
     in the retrieved context.
 
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Importing `from mlflow.genai.scorers import groundedness` gives you an instance
+    of this scorer with default setting. You can override the setting by calling the
+    :py:meth:`configure` method.
 
     Example (direct usage):
 
@@ -192,7 +237,7 @@ def groundedness():
         import mlflow
         from mlflow.genai.scorers import groundedness
 
-        assessment = groundedness()(
+        assessment = groundedness(
             inputs={"question": "What is the capital of France?"},
             outputs="The capital of France is Paris.",
             retrieved_context=[{"content": "Paris is the capital city of France."}],
@@ -212,12 +257,137 @@ def groundedness():
                 "retrieved_context": [{"content": "Paris is the capital city of France."}],
             }
         ]
-        result = mlflow.genai.evaluate(data=data, scorers=[groundedness()])
+        result = mlflow.genai.evaluate(data=data, scorers=[groundedness])
     """
-    return _Groundedness()
+
+    name: str = "groundedness"
+    required_columns: set[str] = {"inputs", "outputs", "retrieved_context"}
+
+    def __call__(
+        self, *, inputs: Any, outputs: Any, retrieved_context: list[dict[str, Any]]
+    ) -> Assessment:
+        """Evaluate groundedness of response against context."""
+        return super().__call__(inputs=inputs, outputs=outputs, retrieved_context=retrieved_context)
+
+    def configure(self, *, name: str = "groundedness") -> "Groundedness":
+        """
+        Configure the scorer with additional parameters such as name.
+
+        Args:
+            name: The name of the scorer. Default is "groundedness".
+
+        Returns:
+            The updated Groundedness scorer instance.
+        """
+        return Groundedness(name=name)
 
 
-class _GuidelineAdherence(_BaseBuiltInScorer):
+@experimental
+class GuidelineAdherence(_BaseBuiltInScorer):
+    """
+    Guideline adherence evaluates whether the agent's response follows specific constraints
+    or instructions provided in the guidelines.
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Importing `from mlflow.genai.scorers import guideline_adherence` gives you an instance
+    of this scorer with default setting. You can override the setting by calling the
+    :py:meth:`configure` method.
+
+    There are two different ways to specify judges, depending on the use case:
+
+    **1. Global Guidelines**
+
+    If you want to evaluate all the response with a single set of guidelines, you can specify
+    the guidelines in the `guidelines` parameter of this scorer.
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import guideline_adherence
+
+        # Create a global judge
+        english = guideline_adherence.configure(
+            name="english_guidelines",
+            global_guidelines=["The response must be in English"],
+        )
+        assessment = english(
+            inputs={"question": "What is the capital of France?"},
+            outputs="The capital of France is Paris.",
+        )
+        print(assessment)
+
+    Example (with evaluate):
+
+    In the following example, the guidelines specified in the `english` and `clarify` scorers
+    will be uniformly applied to all the examples in the dataset. The evaluation result will
+    contains two scores "english" and "clarify".
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import guideline_adherence
+
+        english = guideline_adherence.configure(
+            name="english",
+            global_guidelines=["The response must be in English"],
+        )
+        clarify = guideline_adherence.configure(
+            name="clarify",
+            global_guidelines=["The response must be clear, coherent, and concise"],
+        )
+
+        data = [
+            {
+                "inputs": {"question": "What is the capital of France?"},
+                "outputs": "The capital of France is Paris.",
+            },
+            {
+                "inputs": {"question": "What is the capital of Germany?"},
+                "outputs": "The capital of Germany is Berlin.",
+            },
+        ]
+        mlflow.genai.evaluate(data=data, scorers=[english, clarify])
+
+    **2. Per-Example Guidelines**
+
+    When you have a different set of guidelines for each example, you can specify the guidelines
+    in the `guidelines` field of the `expectations` column of the input dataset. Alternatively,
+    you can annotate a trace with "guidelines" expectation and use the trace as an input data.
+
+    Example:
+
+    In this example, the guidelines specified in the `guidelines` field of the `expectations`
+    column will be applied to each example individually. The evaluation result will contain a
+    single "guideline_adherence" score.
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import guideline_adherence
+
+        data = [
+            {
+                "inputs": {"question": "What is the capital of France?"},
+                "outputs": "The capital of France is Paris.",
+                "expectations": {
+                    "guidelines": ["The response must be factual and concise"],
+                },
+            },
+            {
+                "inputs": {"question": "How to learn Python?"},
+                "outputs": "You can read a book or take a course.",
+                "expectations": {
+                    "guidelines": ["The response must be helpful and encouraging"],
+                },
+            },
+        ]
+        mlflow.genai.evaluate(data=data, scorers=[guideline_adherence])
+    """
+
     name: str = "guideline_adherence"
     global_guidelines: Optional[list[str]] = None
     required_columns: set[str] = {"inputs", "outputs"}
@@ -263,126 +433,40 @@ class _GuidelineAdherence(_BaseBuiltInScorer):
             guidelines_context=guidelines_context,
         )
 
+    def configure(
+        self,
+        *,
+        name: str = "guideline_adherence",
+        global_guidelines: Optional[list[str]] = None,
+    ) -> "GuidelineAdherence":
+        """
+        Configure the scorer with additional parameters
 
-@_builtin_scorer
+        Args:
+            name: The name of the scorer. Default is "guideline_adherence".
+            global_guidelines: A list of global guidelines to be used for evaluation.
+                If not provided, the scorer will use the per-row guidelines in the input dataset.
+
+        Returns:
+            The updated GuidelineAdherence scorer instance.
+
+        Example:
+
+        .. code-block:: python
+
+            from mlflow.genai.scorers import guideline_adherence
+
+            is_english = guideline_adherence.configure(
+                name="is_english", global_guidelines=["The response must be in English"]
+            )
+
+            mlflow.genai.evaluate(data=data, scorers=[is_english])
+        """
+        return GuidelineAdherence(name=name, global_guidelines=global_guidelines)
+
+
 @experimental
-def guideline_adherence(
-    global_guidelines: Optional[list[str]] = None,
-    name: str = "guideline_adherence",
-):
-    """
-    Guideline adherence evaluates whether the agent's response follows specific constraints
-    or instructions provided in the guidelines.
-
-    You can invoke the scorer directly with a single input for testing, or pass it to
-    `mlflow.genai.evaluate` for running full evaluation on a dataset.
-
-    There are two different ways to specify judges, depending on the use case:
-
-    **1. Global Guidelines**
-
-    If you want to evaluate all the response with a single set of guidelines, you can specify
-    the guidelines in the `guidelines` parameter of this scorer.
-
-    Example (direct usage):
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.genai.scorers import guideline_adherence
-
-        # Create a global judge
-        english = guideline_adherence(
-            name="english_guidelines",
-            global_guidelines=["The response must be in English"],
-        )
-        assessment = english()(
-            inputs={"question": "What is the capital of France?"},
-            outputs="The capital of France is Paris.",
-        )
-        print(assessment)
-
-    Example (with evaluate):
-
-    In the following example, the guidelines specified in the `english` and `clarify` scorers
-    will be uniformly applied to all the examples in the dataset. The evaluation result will
-    contains two scores "english" and "clarify".
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.genai.scorers import guideline_adherence
-
-        english = guideline_adherence(
-            name="english",
-            global_guidelines=["The response must be in English"],
-        )
-        clarify = guideline_adherence(
-            name="clarify",
-            global_guidelines=["The response must be clear, coherent, and concise"],
-        )
-
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "outputs": "The capital of France is Paris.",
-            },
-            {
-                "inputs": {"question": "What is the capital of Germany?"},
-                "outputs": "The capital of Germany is Berlin.",
-            },
-        ]
-        mlflow.genai.evaluate(data=data, scorers=[english, clarify])
-
-    **2. Per-Example Guidelines**
-
-    When you have a different set of guidelines for each example, you can specify the guidelines
-    in the `guidelines` field of the `expectations` column of the input dataset. Alternatively,
-    you can annotate a trace with "guidelines" expectation and use the trace as an input data.
-
-    Example:
-
-    In this example, the guidelines specified in the `guidelines` field of the `expectations`
-    column will be applied to each example individually. The evaluation result will contain a
-    single "guideline_adherence" score.
-
-    .. code-block:: python
-
-        import mlflow
-
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "outputs": "The capital of France is Paris.",
-                "expectations": {
-                    "guidelines": ["The response must be factual and concise"],
-                },
-            },
-            {
-                "inputs": {"question": "How to learn Python?"},
-                "outputs": "You can read a book or take a course.",
-                "expectations": {
-                    "guidelines": ["The response must be helpful and encouraging"],
-                },
-            },
-        ]
-        mlflow.genai.evaluate(data=data, scorers=[guideline_adherence()])
-    """
-    return _GuidelineAdherence(name=name, global_guidelines=global_guidelines)
-
-
-class _RelevanceToQuery(_BaseBuiltInScorer):
-    name: str = "relevance_to_query"
-    required_columns: set[str] = {"inputs", "outputs"}
-
-    def __call__(self, *, inputs: Any, outputs: Any) -> Assessment:
-        """Evaluate relevance to the user's query."""
-        return super().__call__(inputs=inputs, outputs=outputs)
-
-
-@_builtin_scorer
-@experimental
-def relevance_to_query():
+class RelevanceToQuery(_BaseBuiltInScorer):
     """
     Relevance ensures that the agent's response directly addresses the user's input without
     deviating into unrelated topics.
@@ -390,6 +474,10 @@ def relevance_to_query():
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
 
+    Importing `from mlflow.genai.scorers import relevance_to_query` gives you an instance
+    of this scorer with default setting. You can override the setting by calling the
+    :py:meth:`configure` method.
+
     Example (direct usage):
 
     .. code-block:: python
@@ -397,7 +485,7 @@ def relevance_to_query():
         import mlflow
         from mlflow.genai.scorers import relevance_to_query
 
-        assessment = relevance_to_query()(
+        assessment = relevance_to_query(
             inputs={"question": "What is the capital of France?"},
             outputs="The capital of France is Paris.",
         )
@@ -416,12 +504,67 @@ def relevance_to_query():
                 "outputs": "The capital of France is Paris.",
             }
         ]
-        result = mlflow.genai.evaluate(data=data, scorers=[relevance_to_query()])
+        result = mlflow.genai.evaluate(data=data, scorers=[relevance_to_query])
     """
-    return _RelevanceToQuery()
+
+    name: str = "relevance_to_query"
+    required_columns: set[str] = {"inputs", "outputs"}
+
+    def __call__(self, *, inputs: Any, outputs: Any) -> Assessment:
+        """Evaluate relevance to the user's query."""
+        return super().__call__(inputs=inputs, outputs=outputs)
+
+    def configure(self, *, name: str = "relevance_to_query") -> "RelevanceToQuery":
+        """
+        Configure the scorer with additional parameters such as name.
+
+        Args:
+            name: The name of the scorer. Default is "relevance_to_query".
+        """
+        return RelevanceToQuery(name=name)
 
 
-class _Safety(_BaseBuiltInScorer):
+@experimental
+class Safety(_BaseBuiltInScorer):
+    """
+    Safety ensures that the agent's responses do not contain harmful, offensive, or toxic content.
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Importing `from mlflow.genai.scorers import safety` gives you an instance
+    of this scorer with default setting. You can override the setting by calling the
+    :py:meth:`configure` method.
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import safety
+
+        assessment = safety(
+            inputs={"question": "What is the capital of France?"},
+            outputs="The capital of France is Paris.",
+        )
+        print(assessment)
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import safety
+
+        data = [
+            {
+                "inputs": {"question": "What is the capital of France?"},
+                "outputs": "The capital of France is Paris.",
+            }
+        ]
+        result = mlflow.genai.evaluate(data=data, scorers=[safety])
+    """
+
     name: str = "safety"
     required_columns: set[str] = {"inputs", "outputs"}
 
@@ -429,74 +572,27 @@ class _Safety(_BaseBuiltInScorer):
         """Evaluate safety of the response."""
         return super().__call__(inputs=inputs, outputs=outputs)
 
+    def configure(self, *, name: str = "safety") -> "Safety":
+        """
+        Configure the scorer with additional parameters such as name.
 
-@_builtin_scorer
+        Args:
+            name: The name of the scorer. Default is "safety".
+        """
+        return Safety(name=name)
+
+
 @experimental
-def safety():
-    """
-    Safety ensures that the agent's responses do not contain harmful, offensive, or toxic content.
-
-    You can invoke the scorer directly with a single input for testing, or pass it to
-    `mlflow.genai.evaluate` for running full evaluation on a dataset.
-
-    Example (direct usage):
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.genai.scorers import safety
-
-        assessment = safety()(
-            inputs={"question": "What is the capital of France?"},
-            outputs="The capital of France is Paris.",
-        )
-        print(assessment)
-
-    Example (with evaluate):
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.genai.scorers import safety
-
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "outputs": "The capital of France is Paris.",
-            }
-        ]
-        result = mlflow.genai.evaluate(data=data, scorers=[safety()])
-    """
-    return _Safety()
-
-
-class _Correctness(_BaseBuiltInScorer):
-    name: str = "correctness"
-    required_columns: set[str] = {"inputs", "outputs"}
-
-    def validate_columns(self, columns: set[str]) -> None:
-        super().validate_columns(columns)
-        if (
-            "expectations/expected_response" not in columns
-            and "expectations/expected_facts" not in columns
-        ):
-            raise MissingColumnsException(
-                self.name, ["expectations/expected_response or expectations/expected_facts"]
-            )
-
-    def __call__(self, *, inputs: Any, outputs: Any, expectations: list[str]) -> Assessment:
-        """Evaluate correctness of the response against expectations."""
-        return super().__call__(inputs=inputs, outputs=outputs, expectations=expectations)
-
-
-@_builtin_scorer
-@experimental
-def correctness():
+class Correctness(_BaseBuiltInScorer):
     """
     Correctness ensures that the agent's responses are correct and accurate.
 
     You can invoke the scorer directly with a single input for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Importing `from mlflow.genai.scorers import correctness` gives you an instance
+    of this scorer with default setting. You can override the setting by calling the
+    :py:meth:`configure` method.
 
     Example (direct usage):
 
@@ -505,7 +601,7 @@ def correctness():
         import mlflow
         from mlflow.genai.scorers import correctness
 
-        assessment = correctness()(
+        assessment = correctness(
             inputs={
                 "question": "What is the difference between reduceByKey and groupByKey in Spark?"
             },
@@ -544,74 +640,59 @@ def correctness():
                 ],
             }
         ]
-        result = mlflow.genai.evaluate(data=data, scorers=[correctness()])
+        result = mlflow.genai.evaluate(data=data, scorers=[correctness])
     """
-    return _Correctness()
+
+    name: str = "correctness"
+    required_columns: set[str] = {"inputs", "outputs"}
+
+    def validate_columns(self, columns: set[str]) -> None:
+        super().validate_columns(columns)
+        if (
+            "expectations/expected_response" not in columns
+            and "expectations/expected_facts" not in columns
+        ):
+            raise MissingColumnsException(
+                self.name, ["expectations/expected_response or expectations/expected_facts"]
+            )
+
+    def __call__(self, *, inputs: Any, outputs: Any, expectations: list[str]) -> Assessment:
+        """Evaluate correctness of the response against expectations."""
+        return super().__call__(inputs=inputs, outputs=outputs, expectations=expectations)
+
+    def configure(self, *, name: str = "correctness") -> "Correctness":
+        """
+        Configure the scorer with additional parameters such as name.
+
+        Args:
+            name: The name of the scorer. Default is "correctness".
+        """
+        return Correctness(name=name)
+
+
+# === Shorthand for getting builtin scorer instances ===
+chunk_relevance = ChunkRelevance()
+context_sufficiency = ContextSufficiency()
+groundedness = Groundedness()
+guideline_adherence = GuidelineAdherence()
+relevance_to_query = RelevanceToQuery()
+safety = Safety()
+correctness = Correctness()
 
 
 # === Shorthand for all builtin RAG scorers ===
-@_builtin_scorer
-@experimental
-def rag_scorers() -> list[BuiltInScorer]:
-    """
-    Returns a list of built-in scorers for evaluating RAG models. Contains scorers
-    chunk_relevance, context_sufficiency, groundedness, and relevance_to_query.
+rag_scorers = [
+    chunk_relevance,
+    context_sufficiency,
+    groundedness,
+    relevance_to_query,
+]
 
-    Example:
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.genai.scorers import rag_scorers
-
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "outputs": "The capital of France is Paris.",
-                "retrieved_context": [
-                    {"content": "Paris is the capital city of France."},
-                ],
-            }
-        ]
-        result = mlflow.genai.evaluate(data=data, scorers=rag_scorers())
-    """
-    return [
-        chunk_relevance(),
-        context_sufficiency(),
-        groundedness(),
-        relevance_to_query(),
-    ]
-
-
-@_builtin_scorer
-@experimental
-def all_scorers() -> list[BuiltInScorer]:
-    """
-    Returns a list of all built-in scorers.
-
-    Example:
-
-    .. code-block:: python
-
-        import mlflow
-        from mlflow.genai.scorers import all_scorers
-
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "outputs": "The capital of France is Paris.",
-                "retrieved_context": [
-                    {"content": "Paris is the capital city of France."},
-                ],
-            }
-        ]
-        result = mlflow.genai.evaluate(data=data, scorers=all_scorers())
-    """
-    return rag_scorers() + [
-        guideline_adherence(),
-        safety(),
-        correctness(),
-    ]
+all_scorers = rag_scorers + [
+    guideline_adherence,
+    safety,
+    correctness,
+]
 
 
 class MissingColumnsException(MlflowException):

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -32,7 +32,7 @@ def validate_scorers(scorers: list[Any]) -> tuple[list[BuiltInScorer], list[Scor
         raise MlflowException.invalid_parameter_value(
             "The `scorers` argument must be a list of scorers with at least one scorer. "
             "If you are unsure about which scorer to use, you can specify "
-            "`scorers=mlflow.genai.scorers.all_scorers()` to jump start with all "
+            "`scorers=mlflow.genai.scorers.all_scorers` to jump start with all "
             "available built-in scorers."
         )
 
@@ -48,15 +48,6 @@ def validate_scorers(scorers: list[Any]) -> tuple[list[BuiltInScorer], list[Scor
         elif isinstance(scorer, Metric):
             legacy_metrics.append(scorer)
             custom_scorers.append(scorer)
-        elif isinstance(scorer, Callable) and getattr(scorer, "__is_mlflow_builtin_scorer", False):
-            raise MlflowException.invalid_parameter_value(
-                f"A built-in scorer {scorer.__name__} is specified, but the constructor function "
-                "is specified, not the scorer object itself. Please pass the returned scorer "
-                "object from the constructor function instead.\n"
-                "Example:\n"
-                "  - Correct:   `mlflow.genai.evaluate(scorers=[correctness()])`\n"
-                "  - Incorrect: `mlflow.genai.evaluate(scorers=[correctness])`"
-            )
         else:
             raise MlflowException.invalid_parameter_value(
                 f"Scorer {scorer} is not a valid scorer. Please use the @scorer decorator "

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -32,7 +32,7 @@ def validate_scorers(scorers: list[Any]) -> tuple[list[BuiltInScorer], list[Scor
         raise MlflowException.invalid_parameter_value(
             "The `scorers` argument must be a list of scorers with at least one scorer. "
             "If you are unsure about which scorer to use, you can specify "
-            "`scorers=mlflow.genai.scorers.all_scorers` to jump start with all "
+            "`scorers=mlflow.genai.scorers.get_all_scorers()` to jump start with all "
             "available built-in scorers."
         )
 

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -275,7 +275,7 @@ def test_evaluate_passes_model_id_to_mlflow_evaluate():
             data=data,
             predict_fn=model,
             model_id="test_model_id",
-            scorers=[safety()],
+            scorers=[safety],
         )
 
         # Verify the call was made with the right parameters
@@ -315,4 +315,4 @@ def test_trace_input_can_contain_string_input(pass_full_dataframe):
         traces = traces[["trace"]]
 
     # Harness should run without an error
-    mlflow.genai.evaluate(data=traces, scorers=[safety()])
+    mlflow.genai.evaluate(data=traces, scorers=[safety])

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -278,7 +278,7 @@ def test_input_is_required_if_trace_is_not_provided():
         with pytest.raises(MlflowException, match="inputs.*required"):
             mlflow.genai.evaluate(
                 data=pd.DataFrame({"outputs": ["Paris"]}),
-                scorers=[safety()],
+                scorers=[safety],
             )
 
         mock_evaluate.assert_not_called()
@@ -287,7 +287,7 @@ def test_input_is_required_if_trace_is_not_provided():
             data=pd.DataFrame(
                 {"inputs": [{"question": "What is the capital of France?"}], "outputs": ["Paris"]}
             ),
-            scorers=[safety()],
+            scorers=[safety],
         )
         mock_evaluate.assert_called_once()
 
@@ -302,7 +302,7 @@ def test_input_is_optional_if_trace_is_provided():
     with patch("mlflow.models.evaluate") as mock_evaluate:
         mlflow.genai.evaluate(
             data=pd.DataFrame({"trace": [trace]}),
-            scorers=[safety()],
+            scorers=[safety],
         )
 
         mock_evaluate.assert_called_once()
@@ -353,7 +353,7 @@ def test_predict_fn_receives_correct_data(data_fixture, request):
     mlflow.genai.evaluate(
         predict_fn=predict_fn,
         data=sample_data,
-        scorers=[safety()],
+        scorers=[safety],
     )
 
     received_args.pop(0)  # Remove the one-time prediction to check if a model is traced

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -4,13 +4,15 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import (
     chunk_relevance,
     context_sufficiency,
+    correctness,
+    get_all_scorers,
+    get_rag_scorers,
     groundedness,
     guideline_adherence,
-    rag_scorers,
     relevance_to_query,
     safety,
 )
-from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, all_scorers, correctness
+from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME
 
 
 def normalize_config(config):
@@ -22,7 +24,7 @@ def normalize_config(config):
 
 ALL_SCORERS = [
     guideline_adherence.configure(name="politeness", global_guidelines=["Be polite", "Be kind"]),
-    *all_scorers,
+    *get_all_scorers(),
 ]
 
 expected = {
@@ -48,16 +50,7 @@ expected = {
     [
         ALL_SCORERS,
         ALL_SCORERS + ALL_SCORERS,  # duplicate scorers
-        rag_scorers
-        + [
-            guideline_adherence.configure(
-                name="politeness", global_guidelines=["Be polite", "Be kind"]
-            ),
-            guideline_adherence,
-            correctness,
-            safety,
-        ],
-        [*rag_scorers]
+        get_rag_scorers()
         + [
             guideline_adherence.configure(
                 name="politeness", global_guidelines=["Be polite", "Be kind"]

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -23,7 +23,7 @@ def normalize_config(config):
 
 
 ALL_SCORERS = [
-    guideline_adherence.configure(name="politeness", global_guidelines=["Be polite", "Be kind"]),
+    guideline_adherence.with_config(name="politeness", global_guidelines=["Be polite", "Be kind"]),
     *get_all_scorers(),
 ]
 
@@ -52,7 +52,7 @@ expected = {
         ALL_SCORERS + ALL_SCORERS,  # duplicate scorers
         get_rag_scorers()
         + [
-            guideline_adherence.configure(
+            guideline_adherence.with_config(
                 name="politeness", global_guidelines=["Be polite", "Be kind"]
             ),
             guideline_adherence,
@@ -98,7 +98,7 @@ def test_individual_scorers(scorer, expected_metric):
 def test_global_guideline_adherence():
     """Test that the global guideline adherence scorer correctly updates the evaluation config."""
     evaluation_config = {}
-    scorer = guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"])
+    scorer = guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"])
     evaluation_config = scorer.update_evaluation_config(evaluation_config)
 
     expected_conf = {
@@ -117,14 +117,14 @@ def test_multiple_global_guideline_adherence():
     """Test passing multiple global guideline adherence scorers with different names."""
     evaluation_config = {}
 
-    guideline = guideline_adherence.configure(
+    guideline = guideline_adherence.with_config(
         global_guidelines=["Be polite", "Be kind"]
     )  # w/ default name
-    english = guideline_adherence.configure(
+    english = guideline_adherence.with_config(
         name="english",
         global_guidelines=["The response must be in English"],
     )
-    clarify = guideline_adherence.configure(
+    clarify = guideline_adherence.with_config(
         name="clarify",
         global_guidelines=["The response must be clear, coherent, and concise"],
     )
@@ -150,12 +150,12 @@ def test_multiple_global_guideline_adherence():
     "scorers",
     [
         [
-            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"]),
             guideline_adherence,
         ],
         [
             guideline_adherence,
-            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"]),
         ],
     ],
 )
@@ -201,13 +201,13 @@ def test_builtin_scorer_block_mutations():
     ids=lambda x: x.__class__.__name__,
 )
 def test_configure_builtin_scorers(scorer, updates):
-    updated_scorer = scorer.configure(**updates)
+    updated_scorer = scorer.with_config(**updates)
 
-    assert updated_scorer is not scorer  # configure() should return a new instance
+    assert updated_scorer is not scorer  # with_config() should return a new instance
     assert isinstance(updated_scorer, scorer.__class__)
     for key, value in updates.items():
         assert getattr(updated_scorer, key) == value
 
     # Positional argument should not be allowed
-    with pytest.raises(TypeError, match=rf"{scorer.__class__.__name__}.configure\(\) takes"):
-        scorer.configure("custom_name")
+    with pytest.raises(TypeError, match=rf"{scorer.__class__.__name__}.with_config\(\) takes"):
+        scorer.with_config("custom_name")

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1,5 +1,6 @@
 import pytest
 
+from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import (
     chunk_relevance,
     context_sufficiency,
@@ -20,8 +21,8 @@ def normalize_config(config):
 
 
 ALL_SCORERS = [
-    guideline_adherence(name="politeness", global_guidelines=["Be polite", "Be kind"]),
-    *all_scorers(),
+    guideline_adherence.configure(name="politeness", global_guidelines=["Be polite", "Be kind"]),
+    *all_scorers,
 ]
 
 expected = {
@@ -47,19 +48,23 @@ expected = {
     [
         ALL_SCORERS,
         ALL_SCORERS + ALL_SCORERS,  # duplicate scorers
-        rag_scorers()
+        rag_scorers
         + [
-            guideline_adherence(name="politeness", global_guidelines=["Be polite", "Be kind"]),
-            guideline_adherence(),
-            correctness(),
-            safety(),
+            guideline_adherence.configure(
+                name="politeness", global_guidelines=["Be polite", "Be kind"]
+            ),
+            guideline_adherence,
+            correctness,
+            safety,
         ],
-        [*rag_scorers()]
+        [*rag_scorers]
         + [
-            guideline_adherence(name="politeness", global_guidelines=["Be polite", "Be kind"]),
-            guideline_adherence(),
-            correctness(),
-            safety(),
+            guideline_adherence.configure(
+                name="politeness", global_guidelines=["Be polite", "Be kind"]
+            ),
+            guideline_adherence,
+            correctness,
+            safety,
         ],
     ],
 )
@@ -74,13 +79,13 @@ def test_scorers_and_rag_scorers_config(scorers):
 @pytest.mark.parametrize(
     ("scorer", "expected_metric"),
     [
-        (chunk_relevance(), "chunk_relevance"),
-        (context_sufficiency(), "context_sufficiency"),
-        (correctness(), "correctness"),
-        (groundedness(), "groundedness"),
-        (guideline_adherence(), "guideline_adherence"),
-        (relevance_to_query(), "relevance_to_query"),
-        (safety(), "safety"),
+        (chunk_relevance, "chunk_relevance"),
+        (context_sufficiency, "context_sufficiency"),
+        (correctness, "correctness"),
+        (groundedness, "groundedness"),
+        (guideline_adherence, "guideline_adherence"),
+        (relevance_to_query, "relevance_to_query"),
+        (safety, "safety"),
     ],
 )
 def test_individual_scorers(scorer, expected_metric):
@@ -100,7 +105,7 @@ def test_individual_scorers(scorer, expected_metric):
 def test_global_guideline_adherence():
     """Test that the global guideline adherence scorer correctly updates the evaluation config."""
     evaluation_config = {}
-    scorer = guideline_adherence(["Be polite", "Be kind"])
+    scorer = guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"])
     evaluation_config = scorer.update_evaluation_config(evaluation_config)
 
     expected_conf = {
@@ -119,12 +124,14 @@ def test_multiple_global_guideline_adherence():
     """Test passing multiple global guideline adherence scorers with different names."""
     evaluation_config = {}
 
-    guideline = guideline_adherence(["Be polite", "Be kind"])  # w/ default name
-    english = guideline_adherence(
+    guideline = guideline_adherence.configure(
+        global_guidelines=["Be polite", "Be kind"]
+    )  # w/ default name
+    english = guideline_adherence.configure(
         name="english",
         global_guidelines=["The response must be in English"],
     )
-    clarify = guideline_adherence(
+    clarify = guideline_adherence.configure(
         name="clarify",
         global_guidelines=["The response must be clear, coherent, and concise"],
     )
@@ -149,8 +156,14 @@ def test_multiple_global_guideline_adherence():
 @pytest.mark.parametrize(
     "scorers",
     [
-        [guideline_adherence(["Be polite", "Be kind"]), guideline_adherence()],
-        [guideline_adherence(), guideline_adherence(["Be polite", "Be kind"])],
+        [
+            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence,
+        ],
+        [
+            guideline_adherence,
+            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+        ],
     ],
 )
 def test_guideline_adherence_scorers(scorers):
@@ -170,3 +183,38 @@ def test_guideline_adherence_scorers(scorers):
     }
 
     assert normalize_config(evaluation_config) == normalize_config(expected_conf)
+
+
+def test_builtin_scorer_block_mutations():
+    """Test that the built-in scorers are immutable."""
+    with pytest.raises(MlflowException, match=r"Built-in scorer fields are immutable"):
+        chunk_relevance.name = "new_name"
+
+
+@pytest.mark.parametrize(
+    ("scorer", "updates"),
+    [
+        (chunk_relevance, {"name": "custom_name"}),
+        (context_sufficiency, {"name": "custom_name"}),
+        (groundedness, {"name": "custom_name"}),
+        (relevance_to_query, {"name": "custom_name"}),
+        (safety, {"name": "custom_name"}),
+        (correctness, {"name": "custom_name"}),
+        (
+            guideline_adherence,
+            {"name": "custom_name", "global_guidelines": ["Be polite", "Be kind"]},
+        ),
+    ],
+    ids=lambda x: x.__class__.__name__,
+)
+def test_configure_builtin_scorers(scorer, updates):
+    updated_scorer = scorer.configure(**updates)
+
+    assert updated_scorer is not scorer  # configure() should return a new instance
+    assert isinstance(updated_scorer, scorer.__class__)
+    for key, value in updates.items():
+        assert getattr(updated_scorer, key) == value
+
+    # Positional argument should not be allowed
+    with pytest.raises(TypeError, match=rf"{scorer.__class__.__name__}.configure\(\) takes"):
+        scorer.configure("custom_name")

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 import mlflow
-from mlflow.exceptions import MlflowException
 from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
 from mlflow.genai.scorers.base import BuiltInScorer, Scorer, scorer
 from mlflow.genai.scorers.builtin_scorers import (
@@ -30,9 +29,9 @@ def test_validate_scorers_valid():
 
     builtin, custom = validate_scorers(
         [
-            chunk_relevance(),
-            correctness(),
-            guideline_adherence(["Be polite", "Be kind"]),
+            chunk_relevance,
+            correctness,
+            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
             custom_scorer,
         ]
     )
@@ -63,11 +62,6 @@ def test_validate_scorers_legacy_metric():
     assert "legacy_metric_1" in mock_logger.warning.call_args[0][0]
 
 
-def test_validate_scorers_builtin_scorer_passed_as_function():
-    with pytest.raises(MlflowException, match=r"A built-in scorer chunk_relevance"):
-        validate_scorers([chunk_relevance])
-
-
 def test_validate_data(mock_logger):
     data = pd.DataFrame(
         {
@@ -81,9 +75,9 @@ def test_validate_data(mock_logger):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            chunk_relevance(),
-            groundedness(),
-            guideline_adherence(["Be polite", "Be kind"]),
+            chunk_relevance,
+            groundedness,
+            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
         ],
     )
     mock_logger.info.assert_not_called()
@@ -107,9 +101,9 @@ def test_validate_data_with_expectations(mock_logger):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            chunk_relevance(),
-            context_sufficiency(),  # requires expected_response in expectations
-            guideline_adherence(),  # requires guidelines in expectations
+            chunk_relevance,
+            context_sufficiency,  # requires expected_response in expectations
+            guideline_adherence,  # requires guidelines in expectations
         ],
     )
     mock_logger.info.assert_not_called()
@@ -126,7 +120,7 @@ def test_global_guideline_adherence_does_not_require_expectations(mock_logger):
     converted_date = _convert_to_legacy_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
-        builtin_scorers=[guideline_adherence(global_guidelines=["Be polite", "Be kind"])],
+        builtin_scorers=[guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"])],
     )
     mock_logger.info.assert_not_called()
 
@@ -151,12 +145,12 @@ def test_validate_data_with_correctness(expectations, mock_logger):
     converted_date = _convert_to_legacy_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
-        builtin_scorers=[correctness()],
+        builtin_scorers=[correctness],
     )
 
     valid_data_for_builtin_scorers(
         data=pd.DataFrame({"inputs": ["input1"], "outputs": ["output1"]}),
-        builtin_scorers=[correctness()],
+        builtin_scorers=[correctness],
     )
 
     mock_logger.info.assert_called_once()
@@ -172,9 +166,9 @@ def test_validate_data_missing_columns(mock_logger):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            chunk_relevance(),
-            groundedness(),
-            guideline_adherence(["Be polite", "Be kind"]),
+            chunk_relevance,
+            groundedness,
+            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
         ],
     )
 
@@ -198,9 +192,9 @@ def test_validate_data_with_trace(mock_logger):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            chunk_relevance(),
-            groundedness(),
-            guideline_adherence(["Be polite", "Be kind"]),
+            chunk_relevance,
+            groundedness,
+            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
         ],
     )
     mock_logger.info.assert_not_called()
@@ -216,9 +210,9 @@ def test_validate_data_with_predict_fn(mock_logger):
         predict_fn=lambda x: x,
         builtin_scorers=[
             # Requires "outputs" but predict_fn will provide it
-            guideline_adherence(["Be polite", "Be kind"]),
+            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
             # Requires "retrieved_context" but predict_fn will provide it
-            chunk_relevance(),
+            chunk_relevance,
         ],
     )
 

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -31,7 +31,7 @@ def test_validate_scorers_valid():
         [
             chunk_relevance,
             correctness,
-            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"]),
             custom_scorer,
         ]
     )
@@ -77,7 +77,7 @@ def test_validate_data(mock_logger):
         builtin_scorers=[
             chunk_relevance,
             groundedness,
-            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"]),
         ],
     )
     mock_logger.info.assert_not_called()
@@ -120,7 +120,9 @@ def test_global_guideline_adherence_does_not_require_expectations(mock_logger):
     converted_date = _convert_to_legacy_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
-        builtin_scorers=[guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"])],
+        builtin_scorers=[
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"])
+        ],
     )
     mock_logger.info.assert_not_called()
 
@@ -168,7 +170,7 @@ def test_validate_data_missing_columns(mock_logger):
         builtin_scorers=[
             chunk_relevance,
             groundedness,
-            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"]),
         ],
     )
 
@@ -194,7 +196,7 @@ def test_validate_data_with_trace(mock_logger):
         builtin_scorers=[
             chunk_relevance,
             groundedness,
-            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"]),
         ],
     )
     mock_logger.info.assert_not_called()
@@ -210,7 +212,7 @@ def test_validate_data_with_predict_fn(mock_logger):
         predict_fn=lambda x: x,
         builtin_scorers=[
             # Requires "outputs" but predict_fn will provide it
-            guideline_adherence.configure(global_guidelines=["Be polite", "Be kind"]),
+            guideline_adherence.with_config(global_guidelines=["Be polite", "Be kind"]),
             # Requires "retrieved_context" but predict_fn will provide it
             chunk_relevance,
         ],

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -254,7 +254,7 @@ def test_builtin_scorers_are_callable():
 
     # test with new scorer signature format
     with patch("databricks.agents.evals.judges.safety") as mock_safety:
-        safety()(
+        safety(
             inputs={"question": "What is the capital of France?"},
             outputs="The capital of France is Paris.",
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15824?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15824/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15824/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15824/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The current built-in scorer is defined as a function that returns a scorer instance.


```
# Definition
def correctness():
    return _Correctness()

# How to use
from mlflow.genai.scorers import correctness

mlflow.genai.evaluate(data=data, scorers=[correctness()])
```

However, this interface have a few friction points:


**1. User needs to add `()` to the imported scorer.**

This is inconsistent with the custom scorer syntax.

```
from mlflow.genai.scorers import correctness, scorer

@scorer 
def custom_scorer(inputs, outputs):
    ...

mlflow.genai.evaluate(
    data=data,
    # Custom scorer can be passed as-is, but built-in one requires "()"!
    scorers=[custom_scorer, correctness()]
)
```

(The reason why built-in one is defined as a function is to allow passing custom settings e.g. `correctness(name="custom name", aggregation=["max"])`.)

**2. Directly running built-in scorer looks ugly**

The built-in scorer needs to be directly callable without using evaluate API - so that users can debug issues easily or compute metrics in ad-hoc manner. However, this requires extra `()` compared to how it is done in 2.x judges ([ref](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/llm-judge-reference#examples-1)).

```
from mlflow.genai.scorers import correctness

assessment = correctness()(inputs=..., outputs=..., ...)
```

**Solution**

To resolve these issues, this PR updates those built-in scorers to directly return a scorer instance.

```
from mlflow.genai.scorers import correctness

# No () required!
mlflow.genai.evaluate(data=data, scorers=[correctness])
```

The only issue is how to allow customizing names, aggregations, etc. To resolve this, we add `configure` method to the scorer class.

```
mlflow.genai.evaluate(
    data=data, 
    scorers=[
        correctness.configure(name="custom name")
    ]
)

```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested all built-in scorers in staging.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
