### PR TITLE
Do not log SHAP explainer in `mlflow.evalaute`

### DIFF
--- a/docs/docs/mlflow-3/breaking-changes.mdx
+++ b/docs/docs/mlflow-3/breaking-changes.mdx
@@ -84,6 +84,7 @@ MLflow 3.0 introduces several breaking changes as part of our commitment to impr
 #### Parameter Removals
 
 **What's changing:** Several parameters have been removed from model logging and saving APIs:
+
 - `example_no_conversion` parameter from model logging APIs ([#15322](https://github.com/mlflow/mlflow/pull/15322))
 - `code_path` parameter from model logging and model saving APIs ([#15368](https://github.com/mlflow/mlflow/pull/15368))
 - `requirements_file` parameter from `pytorch` flavor model logging and saving APIs ([#15369](https://github.com/mlflow/mlflow/pull/15369))
@@ -92,6 +93,7 @@ MLflow 3.0 introduces several breaking changes as part of our commitment to impr
 **Why:** These parameters were deprecated in earlier releases and have now been fully removed to simplify the API.
 
 **How to migrate:** Update your model logging and saving calls to remove these parameters. Use the recommended alternatives:
+
 - For `code_path`, use the code directory structure MLflow expects by default
 - For `requirements_file`, specify dependencies with the `pip_requirements` or `extra_pip_requirements` arguments when logging your torch models
 - For `inference_config` in transformers models, set your configuration before logging the model
@@ -137,6 +139,22 @@ MLflow 3.0 introduces several breaking changes as part of our commitment to impr
 **Why:** To standardize how timeouts are configured across different storage backends.
 
 **How to migrate:** Update your code to handle GCS timeouts using the standard approach for your GCS client library.
+
+### `mlflow.evaluate` no longer logs an explainer as a model by default.
+
+**What's changing:** `mlflow.evaluate` no longer logs an explainer as a model by default.
+
+**How to migrate:** Use the `log_explainer` config to log the explainer as a model.
+
+```python
+mlflow.evaluate(
+    ...,
+    evaluator_config={
+        "log_model_explainability": True,
+        "log_explainer": True,
+    },
+)
+```
 
 ## Summary
 

--- a/docs/docs/mlflow-3/breaking-changes.mdx
+++ b/docs/docs/mlflow-3/breaking-changes.mdx
@@ -144,7 +144,7 @@ MLflow 3.0 introduces several breaking changes as part of our commitment to impr
 
 **What's changing:** `mlflow.evaluate` no longer logs an explainer as a model by default.
 
-**How to migrate:** Use the `log_explainer` config to log the explainer as a model.
+**How to migrate:** Set the `log_explainer` config to `True` in the `evaluator_config` parameter to log the explainer as a model.
 
 ```python
 mlflow.evaluate(

--- a/docs/docs/model/index.mdx
+++ b/docs/docs/model/index.mdx
@@ -2324,6 +2324,9 @@ with mlflow.start_run() as run:
         targets="label",
         model_type="classifier",
         evaluators=["default"],
+        # Uncomment the following line to log the SHAP explainer used to compute the feature
+        # importance as a model
+        # evaluator_config={"log_explainer": True},
     )
 ```
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -825,7 +825,3 @@ MLFLOW_LOGGING_LEVEL = _EnvironmentVariable("MLFLOW_LOGGING_LEVEL", str, None)
 MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT = _BooleanEnvironmentVariable(
     "MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT", False
 )
-
-#: If True, MLflow logs a SHAP explainer as a model during `mlflow.evaluate`.
-#: (default: ``False``)
-MLFLOW_LOG_SHAP_EXPLAINER = _BooleanEnvironmentVariable("MLFLOW_LOG_SHAP_EXPLAINER", False)

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -825,3 +825,7 @@ MLFLOW_LOGGING_LEVEL = _EnvironmentVariable("MLFLOW_LOGGING_LEVEL", str, None)
 MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT = _BooleanEnvironmentVariable(
     "MLFLOW_SUPPRESS_PRINTING_URL_TO_STDOUT", False
 )
+
+#: If True, MLflow logs a SHAP explainer as a model during `mlflow.evaluate`.
+#: (default: ``False``)
+MLFLOW_LOG_SHAP_EXPLAINER = _BooleanEnvironmentVariable("MLFLOW_LOG_SHAP_EXPLAINER", False)

--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -1261,6 +1261,8 @@ def evaluate(  # noqa: D417
      - The available ``evaluator_config`` options for the default evaluator include:
         - **log_model_explainability**: A boolean value specifying whether or not to log model
           explainability insights, default value is True.
+        - **log_explainer**: If True, log the explainer used to compute model explainability
+            insights as a model. Default value is False.
         - **explainability_algorithm**: A string to specify the SHAP Explainer algorithm for model
           explainability. Supported algorithm includes: 'exact', 'permutation', 'partition',
           'kernel'.

--- a/mlflow/models/evaluation/evaluators/shap.py
+++ b/mlflow/models/evaluation/evaluators/shap.py
@@ -46,7 +46,7 @@ class ShapEvaluator(BuiltInEvaluator):
     @classmethod
     def can_evaluate(cls, *, model_type, evaluator_config, **kwargs):
         return model_type in (_ModelType.CLASSIFIER, _ModelType.REGRESSOR) and evaluator_config.get(
-            "log_model_explainability", False
+            "log_model_explainability", True
         )
 
     def _evaluate(

--- a/mlflow/models/evaluation/evaluators/shap.py
+++ b/mlflow/models/evaluation/evaluators/shap.py
@@ -8,7 +8,6 @@ from sklearn.pipeline import Pipeline as sk_Pipeline
 
 import mlflow
 from mlflow import MlflowException
-from mlflow.environment_variables import MLFLOW_LOG_SHAP_EXPLAINER
 from mlflow.models.evaluation.base import EvaluationMetric, EvaluationResult, _ModelType
 from mlflow.models.evaluation.default_evaluator import (
     BuiltInEvaluator,
@@ -220,7 +219,7 @@ class ShapEvaluator(BuiltInEvaluator):
             _logger.debug("", exc_info=True)
             return
 
-        if MLFLOW_LOG_SHAP_EXPLAINER.get():
+        if self.evaluator_config.get("log_explainer", False):
             try:
                 mlflow.shap.log_explainer(explainer, name="explainer")
             except Exception as e:

--- a/tests/evaluate/test_default_evaluator.py
+++ b/tests/evaluate/test_default_evaluator.py
@@ -629,7 +629,10 @@ def test_pipeline_model_kernel_explainer_on_categorical_features(pipeline_model_
             model_type="classifier",
             targets=target_col,
             evaluators="default",
-            evaluator_config={"explainability_algorithm": "kernel"},
+            evaluator_config={
+                "explainability_algorithm": "kernel",
+                "log_explainer": True,
+            },
         )
     run_id = run.info.run_id
     run_data = get_run_data(run_id)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15827?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15827/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15827/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15827/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Do not log SHAP explainer in `mlflow.evalaute`. https://github.com/shap/shap/issues/2122 is related.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
