### PR TITLE
Implement smart request/response preview

### DIFF
--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -97,6 +97,7 @@ class TraceInfo(_MlflowObject):
         if self.execution_duration is not None:
             execution_duration = Duration()
             execution_duration.FromMilliseconds(self.execution_duration)
+
         return ProtoTraceInfoV3(
             trace_id=self.trace_id,
             client_request_id=self.client_request_id,

--- a/mlflow/entities/trace_info_v2.py
+++ b/mlflow/entities/trace_info_v2.py
@@ -9,6 +9,7 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.protos.service_pb2 import TraceInfo as ProtoTraceInfo
 from mlflow.protos.service_pb2 import TraceRequestMetadata as ProtoTraceRequestMetadata
 from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
+from mlflow.tracing.utils.truncation import truncate_request_response_preview
 
 
 def _truncate_request_metadata(d: dict[str, Any]) -> dict[str, str]:
@@ -141,8 +142,8 @@ class TraceInfoV2(_MlflowObject):
             trace_id=self.request_id,
             client_request_id=self.client_request_id,
             trace_location=TraceLocation.from_experiment_id(self.experiment_id),
-            request_preview=request,
-            response_preview=response,
+            request_preview=truncate_request_response_preview(request, role="user"),
+            response_preview=truncate_request_response_preview(response, role="assistant"),
             request_time=self.timestamp_ms,
             execution_duration=self.execution_time_ms,
             state=self.status.to_state(),

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -46,6 +46,8 @@ MAX_CHARS_IN_TRACE_INFO_TAGS_KEY = 250
 MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE = 4096
 TRUNCATION_SUFFIX = "..."
 
+TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH = 10000
+
 # Trace request ID must have the prefix "tr-" appended to the OpenTelemetry trace ID
 TRACE_REQUEST_ID_PREFIX = "tr-"
 

--- a/mlflow/tracing/utils/truncation.py
+++ b/mlflow/tracing/utils/truncation.py
@@ -1,0 +1,72 @@
+import json
+from typing import Any, Optional
+
+from mlflow.tracing.constant import TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH
+
+
+def truncate_request_response_preview(request_or_response: Optional[str], role: str) -> str:
+    """
+    Truncate the request preview to fit the max length.
+    """
+    if request_or_response is None:
+        return ""
+
+    if len(request_or_response) <= TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH:
+        return request_or_response
+
+    content = None
+    if messages := _try_extract_messages(request_or_response):
+        msg = _get_last_message(messages, role=role)
+        content = _get_text_content_from_message(msg)
+
+    content = content or request_or_response
+
+    if len(content) <= TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH:
+        return content
+
+    return content[: TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH - 3] + "..."
+
+
+def _try_extract_messages(obj_str: str) -> Optional[list[dict[str, Any]]]:
+    try:
+        obj = json.loads(obj_str)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(obj, dict):
+        return None
+
+    # Check if the object contains messages with OpenAI ChatCompletion format
+    if messages := obj.get("messages"):
+        return messages
+
+    # Check if the object contains a message in OpenAI ChatCompletion response format (choices)
+    if (choices := obj.get("choices")) and len(choices) > 0:
+        return [choices[0].get("message")]
+
+    return None
+
+
+def _get_last_message(messages: list[dict[str, Any]], role: str) -> Optional[dict[str, Any]]:
+    """
+    Return last message with the given role.
+    If the messages don't include a message with the given role, return the last one.
+    """
+    for message in reversed(messages):
+        if message.get("role") == role:
+            return message
+    return messages[-1]
+
+
+def _get_text_content_from_message(message: dict[str, Any]) -> str:
+    content = message.get("content")
+    if isinstance(content, list):
+        # content is a list of content parts
+        for part in content:
+            if isinstance(part, str):
+                return part
+            elif isinstance(part, dict) and part.get("type") == "text":
+                return part.get("text")
+    elif isinstance(content, str):
+        return content
+    return ""

--- a/tests/tracing/utils/test_truncation.py
+++ b/tests/tracing/utils/test_truncation.py
@@ -1,0 +1,127 @@
+import json
+from unittest.mock import patch
+
+import pytest
+
+from mlflow.tracing.utils.truncation import truncate_request_response_preview
+
+
+@pytest.fixture(autouse=True)
+def patch_max_length():
+    # Patch max length to 50 to make tests faster
+    with patch("mlflow.tracing.utils.truncation.TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH", 50):
+        yield
+
+
+@pytest.mark.parametrize(
+    ("input_str", "expected"),
+    [
+        ("short string", "short string"),
+        ("{'a': 'b'}", "{'a': 'b'}"),
+        ("start" + "a" * 50, "start" + "a" * 42 + "..."),
+        (None, ""),
+    ],
+    ids=["short string", "short json", "long string", "none"],
+)
+def test_truncate_simple_string(input_str, expected):
+    assert truncate_request_response_preview(input_str, role="user") == expected
+
+
+def test_truncate_long_non_message_json():
+    input_str = json.dumps(
+        {
+            "a": "b" + "a" * 30,
+            "b": "c" + "a" * 30,
+        }
+    )
+    result = truncate_request_response_preview(input_str, role="user")
+    assert len(result) == 50
+    assert result.startswith('{"a": "b')
+
+
+def test_truncate_request_messages():
+    input_str = json.dumps(
+        {
+            "messages": [
+                {"role": "user", "content": "First"},
+                {"role": "assistant", "content": "Second"},
+                {"role": "user", "content": "Third" + "a" * 50},
+                {"role": "assistant", "content": "Fourth"},
+            ]
+        }
+    )
+    assert truncate_request_response_preview(input_str, role="assistant") == "Fourth"
+    # Long content should be truncated
+    assert truncate_request_response_preview(input_str, role="user") == "Third" + "a" * 42 + "..."
+    # If non-existing role is provided, return the last message
+    assert truncate_request_response_preview(input_str, role="system") == "Fourth"
+
+
+def test_truncate_request_choices():
+    input_str = json.dumps(
+        {
+            "choices": [
+                {
+                    "index": 1,
+                    "message": {"role": "assistant", "content": "First" + "a" * 50},
+                    "finish_reason": "stop",
+                },
+            ],
+            "object": "chat.completions",
+        }
+    )
+    assert truncate_request_response_preview(input_str, role="assistant").startswith("First")
+
+
+def test_truncate_multi_content_messages():
+    # If text content exists, use it
+    assert (
+        truncate_request_response_preview(
+            json.dumps(
+                {"messages": [{"role": "user", "content": [{"type": "text", "text": "a" * 60}]}]}
+            ),
+            role="user",
+        )
+        == "a" * 47 + "..."
+    )
+
+    # Ignore non text content
+    assert (
+        truncate_request_response_preview(
+            json.dumps(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "text", "text": "a" * 60},
+                                {"type": "image", "image_url": "http://example.com/image.jpg"},
+                            ],
+                        },
+                    ]
+                }
+            ),
+            role="user",
+        )
+        == "a" * 47 + "..."
+    )
+
+    # If non-text content exists, truncate the full json as-is
+    assert truncate_request_response_preview(
+        json.dumps(
+            {
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "image_url": "http://example.com/image.jpg" + "a" * 50,
+                            }
+                        ],
+                    },
+                ]
+            }
+        ),
+        role="user",
+    ).startswith('{"messages":')


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15840?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15840/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15840/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15840/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `request_preview` and `response_preview` fields in TraceIn contain a truncated version of trace input and output. They are mainly used for showing preview in the trace table. Since it is a part of trace info, we need to truncate it so the size doesn't become too big.

However, one problem is that this truncation doesn't consider any structure of the value. For example, if the input is chat message format, current UI tries to render the content string (or last message) by parsing it. However, for large input, MLflow will naively truncate string and make it broken json that UI cannot parse.

To address this issue, this PR introduces a "smart truncation":
* When the input is chat message format, store the last user message content as `request_preview`.
* When the output is chat message format, store the last assistant message content as `response_preview`.
* For other format, keep doing naive truncation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
