### PR TITLE
Close

### DIFF
--- a/dev/generate_protos.py
+++ b/dev/generate_protos.py
@@ -60,6 +60,7 @@ uc_proto_files = [
     "databricks_filesystem_service.proto",
     "unity_catalog_oss_messages.proto",
     "unity_catalog_oss_service.proto",
+    "unity_catalog_prompt_service.proto",
 ]
 tracing_proto_files = [
     "databricks_trace_server.proto",

--- a/mlflow/entities/model_registry/__init__.py
+++ b/mlflow/entities/model_registry/__init__.py
@@ -1,3 +1,7 @@
+"""
+The ``mlflow.entities.model_registry`` module contains classes for Model Registry entities.
+"""
+
 from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.model_version_deployment_job_state import (
     ModelVersionDeploymentJobState,
@@ -5,6 +9,7 @@ from mlflow.entities.model_registry.model_version_deployment_job_state import (
 from mlflow.entities.model_registry.model_version_search import ModelVersionSearch
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 from mlflow.entities.model_registry.prompt import Prompt
+from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.entities.model_registry.registered_model import RegisteredModel
 from mlflow.entities.model_registry.registered_model_alias import RegisteredModelAlias
 from mlflow.entities.model_registry.registered_model_deployment_job_state import (
@@ -15,6 +20,7 @@ from mlflow.entities.model_registry.registered_model_tag import RegisteredModelT
 
 __all__ = [
     "Prompt",
+    "PromptVersion",
     "RegisteredModel",
     "ModelVersion",
     "RegisteredModelAlias",

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -1,0 +1,154 @@
+"""
+MLflow entity for Unity Catalog Prompt Version.
+"""
+from typing import Dict, Optional
+
+class PromptVersion:
+    """
+    MLflow entity for Unity Catalog Prompt Version.
+    """
+    
+    def __init__(
+        self,
+        name: str,
+        version: str,
+        creation_timestamp: Optional[int] = None,
+        last_updated_timestamp: Optional[int] = None,
+        description: Optional[str] = None,
+        template: str = None,
+        aliases: Optional[Dict[str, str]] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ):
+        """
+        Initialize a PromptVersion.
+        
+        Args:
+            name: Full three tier UC name of the prompt
+            version: Version number
+            creation_timestamp: Timestamp recorded when this version was created
+            last_updated_timestamp: Timestamp recorded when metadata was last updated
+            description: Description of this version
+            template: The prompt template text
+            aliases: Dictionary of alias name to version number
+            tags: Dictionary of version tags
+        """
+        self._name = name
+        self._version = version
+        self._creation_timestamp = creation_timestamp
+        self._last_updated_timestamp = last_updated_timestamp
+        self._description = description
+        self._template = template
+        self._aliases = aliases or {}
+        self._tags = tags or {}
+
+    @property
+    def name(self) -> str:
+        """Get the prompt name."""
+        return self._name
+
+    @property
+    def version(self) -> str:
+        """Get the version number."""
+        return self._version
+
+    @property
+    def creation_timestamp(self) -> Optional[int]:
+        """Get the creation timestamp."""
+        return self._creation_timestamp
+
+    @property
+    def last_updated_timestamp(self) -> Optional[int]:
+        """Get the last updated timestamp."""
+        return self._last_updated_timestamp
+
+    @property
+    def description(self) -> Optional[str]:
+        """Get the description."""
+        return self._description
+
+    @property
+    def template(self) -> Optional[str]:
+        """Get the template text."""
+        return self._template
+
+    @property
+    def aliases(self) -> Dict[str, str]:
+        """Get the aliases dictionary."""
+        return self._aliases
+
+    @property
+    def tags(self) -> Dict[str, str]:
+        """Get the tags dictionary."""
+        return self._tags
+
+    @classmethod
+    def from_proto(cls, proto):
+        """
+        Create a PromptVersion from protocol buffer.
+        
+        Args:
+            proto: Protocol buffer message
+            
+        Returns:
+            PromptVersion object
+        """
+        aliases = {}
+        if proto.aliases:
+            aliases = {a.alias: a.version for a in proto.aliases}
+            
+        tags = {}
+        if proto.tags:
+            tags = {t.key: t.value for t in proto.tags}
+            
+        creation_ts = None
+        if proto.creation_timestamp:
+            creation_ts = int(proto.creation_timestamp.seconds * 1000)
+            
+        last_updated_ts = None
+        if proto.last_updated_timestamp:
+            last_updated_ts = int(proto.last_updated_timestamp.seconds * 1000)
+            
+        return cls(
+            name=proto.name,
+            version=proto.version,
+            creation_timestamp=creation_ts,
+            last_updated_timestamp=last_updated_ts,
+            description=proto.description,
+            template=proto.template,
+            aliases=aliases,
+            tags=tags,
+        )
+
+    def to_proto(self):
+        """
+        Convert to protocol buffer message.
+        
+        Returns:
+            Proto message
+        """
+        from mlflow.protos import uc_prompt_pb2
+
+        proto = uc_prompt_pb2.PromptVersion()
+        proto.name = self.name
+        proto.version = self.version
+        
+        if self.description:
+            proto.description = self.description
+            
+        if self.template:
+            proto.template = self.template
+            
+        for alias, version in self.aliases.items():
+            proto_alias = proto.aliases.add()
+            proto_alias.alias = alias
+            proto_alias.version = version
+            
+        for key, value in self.tags.items():
+            proto_tag = proto.tags.add()
+            proto_tag.key = key
+            proto_tag.value = value
+            
+        return proto
+
+    def __repr__(self):
+        return f"<PromptVersion: name={self.name}, version={self.version}>" 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -660,6 +660,10 @@ MLFLOW_HTTP_POOL_MAXSIZE = _EnvironmentVariable("MLFLOW_HTTP_POOL_MAXSIZE", int,
 #: (default: ``False``)
 MLFLOW_ENABLE_UC_FUNCTIONS = _BooleanEnvironmentVariable("MLFLOW_ENABLE_UC_FUNCTIONS", False)
 
+#: Enable Unity Catalog Prompt Registry support.
+#: (default: ``False``)
+MLFLOW_ENABLE_UC_PROMPT_SUPPORT = _BooleanEnvironmentVariable("MLFLOW_ENABLE_UC_PROMPT_SUPPORT", False)
+
 #: Specifies the length of time in seconds for the asynchronous logging thread to wait before
 #: logging a batch.
 MLFLOW_ASYNC_LOGGING_BUFFERING_SECONDS = _EnvironmentVariable(

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -5,9 +5,11 @@ from typing import Any, Optional, Union
 
 import mlflow
 from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
+from mlflow.environment_variables import MLFLOW_ENABLE_UC_PROMPT_SUPPORT
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.constants import IS_PROMPT_TAG_KEY, PROMPT_NAME_RULE
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS
+from mlflow.utils.uri import is_databricks_unity_catalog_uri, is_oss_unity_catalog_uri
 
 
 def add_prompt_filter_string(
@@ -43,11 +45,21 @@ def is_prompt_supported_registry(registry_uri: Optional[str] = None) -> bool:
     """
     Check if the current registry supports prompts.
 
-    Prompts registration is supported only in the OSS MLflow Tracking Server,
-    not in Databricks or OSS Unity Catalog.
+    Prompts registration is supported in OSS MLflow Tracking Server and Unity Catalog 
+    (Databricks and OSS) when the feature flag is enabled.
     """
     registry_uri = registry_uri or mlflow.get_registry_uri()
-    return not registry_uri.startswith("databricks") and not registry_uri.startswith("uc:")
+    
+    # Always support OSS MLflow server
+    if not registry_uri.startswith("databricks") and not registry_uri.startswith("uc:"):
+        return True
+    
+    # For Unity Catalog (both Databricks and OSS), check feature flag
+    if (is_databricks_unity_catalog_uri(registry_uri) or is_oss_unity_catalog_uri(registry_uri)):
+        return MLFLOW_ENABLE_UC_PROMPT_SUPPORT.get()
+    
+    # Legacy Databricks workspace registry is not supported
+    return False
 
 
 def require_prompt_registry(func):
@@ -62,7 +74,9 @@ def require_prompt_registry(func):
 
         if not is_prompt_supported_registry(registry_uri):
             raise MlflowException(
-                f"The '{func.__name__}' API is only available with the OSS MLflow Tracking Server."
+                f"The '{func.__name__}' API is not supported with the current registry. "
+                "It is supported with the OSS MLflow Tracking Server or Unity Catalog "
+                "with the UC prompt support feature flag enabled (MLFLOW_ENABLE_UC_PROMPT_SUPPORT=true)."
             )
         return func(*args, **kwargs)
 
@@ -72,8 +86,9 @@ def require_prompt_registry(func):
 
         .. note::
 
-            This API is supported only when using the OSS MLflow Model Registry. Prompts are not
-            supported in Databricks or the OSS Unity Catalog model registry.
+            This API is supported when using the OSS MLflow Model Registry or Unity Catalog
+            Model Registry with the UC prompt support feature flag enabled. Prompts are not
+            supported in the legacy Databricks workspace model registry.
     """)
     return wrapper
 

--- a/mlflow/protos/unity_catalog_prompt_service.proto
+++ b/mlflow/protos/unity_catalog_prompt_service.proto
@@ -1,0 +1,411 @@
+syntax = "proto2";
+
+package mlflow;
+
+import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
+import "databricks.proto";
+
+option java_package = "org.mlflow.api.proto";
+option py_generic_services = true;
+option (scalapb.options) = {
+  flat_package: true,
+};
+
+// Common message types
+message PromptInfo {
+  optional string name = 1;
+  optional string description = 2;
+  optional google.protobuf.Timestamp creation_timestamp = 3;
+  optional google.protobuf.Timestamp last_updated_timestamp = 4;
+  repeated PromptTag tags = 5;
+  repeated PromptAlias aliases = 6;
+}
+
+message PromptVersionInfo {
+  optional string name = 1;
+  optional string version = 2;
+  optional string description = 3;
+  optional string template = 4;
+  optional google.protobuf.Timestamp creation_timestamp = 5;
+  optional google.protobuf.Timestamp last_updated_timestamp = 6;
+  repeated PromptTag tags = 7;
+  repeated PromptAlias aliases = 8;
+}
+
+message PromptTag {
+  required string key = 1;
+  required string value = 2;
+}
+
+message PromptAlias {
+  required string alias = 1;
+  required string version = 2;
+}
+
+// Request/Response messages
+message CreatePromptRequest {
+  required string name = 1;
+  optional string description = 2;
+  optional string template = 3;
+  repeated PromptTag tags = 4;
+}
+
+message CreatePromptResponse {
+  required PromptInfo prompt = 1;
+}
+
+message UpdatePromptRequest {
+  required string name = 1;
+  optional string description = 2;
+  repeated PromptTag tags = 3;
+}
+
+message UpdatePromptResponse {
+  required PromptInfo prompt = 1;
+}
+
+message DeletePromptRequest {
+  required string name = 1;
+}
+
+message DeletePromptResponse {
+}
+
+message GetPromptRequest {
+  required string name = 1;
+}
+
+message GetPromptResponse {
+  required PromptInfo prompt = 1;
+}
+
+message SearchPromptsRequest {
+  optional string filter = 1;
+  optional int32 max_results = 2;
+  optional string page_token = 3;
+}
+
+message SearchPromptsResponse {
+  repeated PromptInfo prompts = 1;
+  optional string next_page_token = 2;
+}
+
+message CreatePromptVersionRequest {
+  required string name = 1;
+  required string template = 2;
+  optional string description = 3;
+  repeated PromptTag tags = 4;
+}
+
+message CreatePromptVersionResponse {
+  required PromptVersionInfo prompt_version = 1;
+}
+
+message UpdatePromptVersionRequest {
+  required string name = 1;
+  required string version = 2;
+  optional string description = 3;
+  repeated PromptTag tags = 4;
+}
+
+message UpdatePromptVersionResponse {
+  required PromptVersionInfo prompt_version = 1;
+}
+
+message DeletePromptVersionRequest {
+  required string name = 1;
+  required string version = 2;
+}
+
+message DeletePromptVersionResponse {
+}
+
+message GetPromptVersionRequest {
+  required string name = 1;
+  required string version = 2;
+}
+
+message GetPromptVersionResponse {
+  required PromptVersionInfo prompt_version = 1;
+}
+
+message SearchPromptVersionsRequest {
+  required string name = 1;
+  optional string filter = 2;
+  optional int32 max_results = 3;
+  optional string page_token = 4;
+}
+
+message SearchPromptVersionsResponse {
+  repeated PromptVersionInfo prompt_versions = 1;
+  optional string next_page_token = 2;
+}
+
+message SetPromptAliasRequest {
+  required string name = 1;
+  required string alias = 2;
+  required string version = 3;
+}
+
+message SetPromptAliasResponse {
+}
+
+message DeletePromptAliasRequest {
+  required string name = 1;
+  required string alias = 2;
+}
+
+message DeletePromptAliasResponse {
+}
+
+message GetPromptVersionByAliasRequest {
+  required string name = 1;
+  required string alias = 2;
+}
+
+message GetPromptVersionByAliasResponse {
+  required PromptVersionInfo prompt_version = 1;
+}
+
+message SetPromptTagRequest {
+  required string name = 1;
+  required string key = 2;
+  required string value = 3;
+}
+
+message SetPromptTagResponse {
+}
+
+message DeletePromptTagRequest {
+  required string name = 1;
+  required string key = 2;
+}
+
+message DeletePromptTagResponse {
+}
+
+message SetPromptVersionTagRequest {
+  required string name = 1;
+  required string version = 2;
+  required string key = 3;
+  required string value = 4;
+}
+
+message SetPromptVersionTagResponse {
+}
+
+message DeletePromptVersionTagRequest {
+  required string name = 1;
+  required string version = 2;
+  required string key = 3;
+}
+
+message DeletePromptVersionTagResponse {
+}
+
+service UnityCatalogPromptService {
+  rpc CreatePrompt (CreatePromptRequest) returns (CreatePromptResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/unity-catalog/prompts"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Create Prompt",
+    };
+  }
+
+  rpc UpdatePrompt (UpdatePromptRequest) returns (UpdatePromptResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "PATCH",
+        path: "/mlflow/unity-catalog/prompts/{name}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Update Prompt",
+    };
+  }
+
+  rpc DeletePrompt (DeletePromptRequest) returns (DeletePromptResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "DELETE",
+        path: "/mlflow/unity-catalog/prompts/{name}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Delete Prompt",
+    };
+  }
+
+  rpc GetPrompt (GetPromptRequest) returns (GetPromptResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "GET",
+        path: "/mlflow/unity-catalog/prompts/{name}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Get Prompt",
+    };
+  }
+
+  rpc SearchPrompts (SearchPromptsRequest) returns (SearchPromptsResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/unity-catalog/prompts/search"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Search Prompts",
+    };
+  }
+
+  rpc CreatePromptVersion (CreatePromptVersionRequest) returns (CreatePromptVersionResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Create Prompt Version",
+    };
+  }
+
+  rpc UpdatePromptVersion (UpdatePromptVersionRequest) returns (UpdatePromptVersionResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "PATCH",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions/{version}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Update Prompt Version",
+    };
+  }
+
+  rpc DeletePromptVersion (DeletePromptVersionRequest) returns (DeletePromptVersionResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "DELETE",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions/{version}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Delete Prompt Version",
+    };
+  }
+
+  rpc GetPromptVersion (GetPromptVersionRequest) returns (GetPromptVersionResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "GET",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions/{version}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Get Prompt Version",
+    };
+  }
+
+  rpc SearchPromptVersions (SearchPromptVersionsRequest) returns (SearchPromptVersionsResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "GET",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Search Prompt Versions",
+    };
+  }
+
+  rpc SetPromptAlias (SetPromptAliasRequest) returns (SetPromptAliasResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/unity-catalog/prompts/{name}/aliases/{alias}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Set Prompt Alias",
+    };
+  }
+
+  rpc DeletePromptAlias (DeletePromptAliasRequest) returns (DeletePromptAliasResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "DELETE",
+        path: "/mlflow/unity-catalog/prompts/{name}/aliases/{alias}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Delete Prompt Alias",
+    };
+  }
+
+  rpc GetPromptVersionByAlias (GetPromptVersionByAliasRequest) returns (GetPromptVersionByAliasResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "GET",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions/by-alias/{alias}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Get Prompt Version By Alias",
+    };
+  }
+
+  rpc SetPromptTag (SetPromptTagRequest) returns (SetPromptTagResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/unity-catalog/prompts/{name}/tags"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Set Prompt Tag",
+    };
+  }
+
+  rpc DeletePromptTag (DeletePromptTagRequest) returns (DeletePromptTagResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "DELETE",
+        path: "/mlflow/unity-catalog/prompts/{name}/tags/{key}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Delete Prompt Tag",
+    };
+  }
+
+  rpc SetPromptVersionTag (SetPromptVersionTagRequest) returns (SetPromptVersionTagResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "POST",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions/{version}/tags"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Set Prompt Version Tag",
+    };
+  }
+
+  rpc DeletePromptVersionTag (DeletePromptVersionTagRequest) returns (DeletePromptVersionTagResponse) {
+    option (rpc) = {
+      endpoints: [{
+        method: "DELETE",
+        path: "/mlflow/unity-catalog/prompts/{name}/versions/{version}/tags/{key}"
+        since {major: 2, minor: 0},
+      }],
+      visibility: PUBLIC_UNDOCUMENTED,
+      rpc_doc_title: "(Unity Catalog) Delete Prompt Version Tag",
+    };
+  }
+} 

--- a/mlflow/store/_unity_catalog/registry/prompt_rest_endpoints.py
+++ b/mlflow/store/_unity_catalog/registry/prompt_rest_endpoints.py
@@ -1,0 +1,37 @@
+"""
+Endpoint utilities for Unity Catalog Prompt Registry REST API.
+"""
+
+from typing import Tuple
+from mlflow.protos.unity_catalog_prompt_service_pb2 import UnityCatalogPromptService
+from mlflow.utils.rest_utils import (
+    _UC_REST_API_PATH_PREFIX,
+    extract_api_info_for_service,
+    extract_all_api_info_for_service,
+)
+
+# Base path for UC prompt endpoints
+_UC_PROMPT_API_BASE_PATH = "/mlflow/unity-catalog/prompts"
+
+# Extract endpoint info from proto service
+_METHOD_TO_INFO = extract_api_info_for_service(UnityCatalogPromptService, _UC_PROMPT_API_BASE_PATH)
+_METHOD_TO_ALL_INFO = extract_all_api_info_for_service(UnityCatalogPromptService, _UC_PROMPT_API_BASE_PATH)
+
+def resolve_endpoint(service: str, **kwargs) -> Tuple[str, str]:
+    """
+    Resolve the endpoint path and HTTP method for a service.
+    
+    Args:
+        service: The service name (e.g. "CreatePrompt")
+        **kwargs: Path parameters to substitute into the endpoint path
+        
+    Returns:
+        Tuple of (endpoint_path, http_method)
+    """
+    endpoint, method = _METHOD_TO_INFO[service]
+    
+    # Substitute path parameters
+    if kwargs:
+        endpoint = endpoint.format(**kwargs)
+        
+    return endpoint, method 

--- a/mlflow/store/_unity_catalog/registry/uc_prompt_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_prompt_rest_store.py
@@ -1,0 +1,366 @@
+"""
+Unity Catalog Prompt Registry Store implementation using direct REST endpoints.
+"""
+
+import functools
+import logging
+from typing import List, Optional, Dict
+
+from mlflow.entities.model_registry import Prompt, PromptVersion
+from mlflow.environment_variables import MLFLOW_ENABLE_UC_PROMPT_SUPPORT
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import (
+    INVALID_PARAMETER_VALUE,
+    RESOURCE_DOES_NOT_EXIST,
+)
+from mlflow.store._unity_catalog.registry.rest_store import BaseRestStore
+from mlflow.store._unity_catalog.registry.prompt_rest_endpoints import resolve_endpoint
+from mlflow.store.entities.paged_list import PagedList
+from mlflow.utils.databricks_utils import get_databricks_host_creds
+from mlflow.utils.proto_json_utils import message_to_json
+from mlflow.utils._spark_utils import _get_active_spark_session
+
+_logger = logging.getLogger(__name__)
+
+class UcPromptRestStore(BaseRestStore):
+    """
+    REST store for Unity Catalog Prompts using direct prompt-specific endpoints.
+    """
+    
+    def __init__(self, store_uri):
+        """
+        Initialize the UC prompt REST store.
+        
+        Args:
+            store_uri: URI with scheme 'databricks-uc'
+        """
+        if not MLFLOW_ENABLE_UC_PROMPT_SUPPORT.get():
+            raise MlflowException(
+                "Unity Catalog prompt support is not enabled. "
+                "Set MLFLOW_ENABLE_UC_PROMPT_SUPPORT=true to enable it.",
+                INVALID_PARAMETER_VALUE,
+            )
+        
+        super().__init__(get_host_creds=functools.partial(get_databricks_host_creds, store_uri))
+        self.store_uri = store_uri
+        try:
+            self.spark = _get_active_spark_session()
+        except Exception:
+            self.spark = None
+
+    def _call_endpoint(self, service, json_body=None, **kwargs):
+        """
+        Call REST endpoint with the specified service and parameters.
+        
+        Args:
+            service: Service name (e.g. "CreatePrompt")
+            json_body: JSON request body
+            **kwargs: Path parameters for endpoint URL
+            
+        Returns:
+            Response proto object
+        """
+        endpoint, method = resolve_endpoint(service, **kwargs)
+        response_proto = self._call_endpoint(endpoint, method, json_body)
+        return response_proto
+
+    def create_prompt(
+        self,
+        name: str,
+        template: str,
+        description: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> Prompt:
+        """
+        Create a new prompt in Unity Catalog.
+        
+        Args:
+            name: The name of the prompt
+            template: The template text of the prompt
+            description: Optional description of the prompt
+            tags: Optional dictionary of prompt tags
+            
+        Returns:
+            The created Prompt object
+        """
+        # Convert tags to proto format
+        proto_tags = []
+        if tags:
+            proto_tags = [{"key": k, "value": v} for k, v in tags.items()]
+
+        # Create request body
+        req_body = message_to_json({
+            "name": name,
+            "prompt": {
+                "name": name,
+                "description": description,
+                "tags": proto_tags,
+            }
+        })
+
+        response_proto = self._call_endpoint("CreatePrompt", req_body)
+        prompt = response_proto.prompt
+        
+        # Create initial version with template
+        version_req_body = message_to_json({
+            "name": name,
+            "version": "1",
+            "prompt_version": {
+                "name": name,
+                "template": template,
+                "description": description,
+            }
+        })
+        
+        version_response = self._call_endpoint(
+            "CreatePromptVersion", 
+            version_req_body,
+            name=name
+        )
+        return Prompt.from_proto(prompt, version_response.prompt_version)
+
+    def get_prompt(self, name: str) -> Prompt:
+        """
+        Get a prompt by name.
+        
+        Args:
+            name: The name of the prompt
+            
+        Returns:
+            The requested Prompt object
+        """
+        response_proto = self._call_endpoint("GetPrompt", name=name)
+        return Prompt.from_proto(response_proto.prompt)
+
+    def delete_prompt(self, name: str) -> None:
+        """
+        Delete a prompt.
+        
+        Args:
+            name: The name of the prompt to delete
+        """
+        self._call_endpoint("DeletePrompt", name=name)
+
+    def search_prompts(
+        self,
+        filter_string: Optional[str] = None,
+        max_results: int = 100,
+        page_token: Optional[str] = None,
+        experiment_id: Optional[str] = None,
+    ) -> PagedList[Prompt]:
+        """
+        Search for prompts.
+        
+        Args:
+            filter_string: Filter string like "name='my-prompt'"
+            max_results: Maximum number of prompts to return
+            page_token: Token for pagination
+            experiment_id: Optional experiment ID to filter by
+            
+        Returns:
+            PagedList of Prompt objects
+        """
+        req_body = message_to_json({
+            "filter": filter_string,
+            "max_results": max_results,
+            "page_token": page_token,
+            "experiment_id": experiment_id,
+        })
+
+        response_proto = self._call_endpoint("SearchPrompts", req_body)
+        prompts = [Prompt.from_proto(p) for p in response_proto.prompts]
+        return PagedList(prompts, response_proto.next_page_token)
+
+    def create_prompt_version(
+        self,
+        name: str,
+        template: str,
+        description: Optional[str] = None,
+        tags: Optional[Dict[str, str]] = None,
+    ) -> PromptVersion:
+        """
+        Create a new version of a prompt.
+        
+        Args:
+            name: The name of the prompt
+            template: The template text for this version
+            description: Optional description of this version
+            tags: Optional dictionary of version tags
+            
+        Returns:
+            The created PromptVersion object
+        """
+        # Convert tags to proto format
+        proto_tags = []
+        if tags:
+            proto_tags = [{"key": k, "value": v} for k, v in tags.items()]
+
+        req_body = message_to_json({
+            "name": name,
+            "prompt_version": {
+                "name": name,
+                "template": template,
+                "description": description,
+                "tags": proto_tags,
+            }
+        })
+
+        response_proto = self._call_endpoint(
+            "CreatePromptVersion", 
+            req_body,
+            name=name
+        )
+        return PromptVersion.from_proto(response_proto.prompt_version)
+
+    def get_prompt_version(self, name: str, version: str) -> PromptVersion:
+        """
+        Get a specific version of a prompt.
+        
+        Args:
+            name: The name of the prompt
+            version: The version number
+            
+        Returns:
+            The requested PromptVersion object
+        """
+        response_proto = self._call_endpoint(
+            "GetPromptVersion",
+            name=name,
+            version=version
+        )
+        return PromptVersion.from_proto(response_proto.prompt_version)
+
+    def delete_prompt_version(self, name: str, version: str) -> None:
+        """
+        Delete a specific version of a prompt.
+        
+        Args:
+            name: The name of the prompt
+            version: The version number to delete
+        """
+        self._call_endpoint(
+            "DeletePromptVersion",
+            name=name,
+            version=version
+        )
+
+    def set_prompt_tag(self, name: str, key: str, value: str) -> None:
+        """
+        Set a tag on a prompt.
+        
+        Args:
+            name: The name of the prompt
+            key: Tag key
+            value: Tag value
+        """
+        req_body = message_to_json({
+            "key": key,
+            "value": value,
+        })
+        self._call_endpoint(
+            "SetPromptTag",
+            req_body,
+            name=name
+        )
+
+    def delete_prompt_tag(self, name: str, key: str) -> None:
+        """
+        Delete a tag from a prompt.
+        
+        Args:
+            name: The name of the prompt
+            key: The tag key to delete
+        """
+        self._call_endpoint(
+            "DeletePromptTag",
+            name=name,
+            key=key
+        )
+
+    def set_prompt_version_tag(self, name: str, version: str, key: str, value: str) -> None:
+        """
+        Set a tag on a prompt version.
+        
+        Args:
+            name: The name of the prompt
+            version: The version number
+            key: Tag key
+            value: Tag value
+        """
+        req_body = message_to_json({
+            "key": key,
+            "value": value,
+        })
+        self._call_endpoint(
+            "SetPromptVersionTag",
+            req_body,
+            name=name,
+            version=version
+        )
+
+    def delete_prompt_version_tag(self, name: str, version: str, key: str) -> None:
+        """
+        Delete a tag from a prompt version.
+        
+        Args:
+            name: The name of the prompt
+            version: The version number
+            key: The tag key to delete
+        """
+        self._call_endpoint(
+            "DeletePromptVersionTag",
+            name=name,
+            version=version,
+            key=key
+        )
+
+    def set_prompt_alias(self, name: str, alias: str, version: str) -> None:
+        """
+        Set an alias for a prompt version.
+        
+        Args:
+            name: The name of the prompt
+            alias: The alias to set
+            version: The version to alias
+        """
+        req_body = message_to_json({
+            "version": version,
+        })
+        self._call_endpoint(
+            "SetPromptAlias",
+            req_body,
+            name=name,
+            alias=alias
+        )
+
+    def delete_prompt_alias(self, name: str, alias: str) -> None:
+        """
+        Delete a prompt alias.
+        
+        Args:
+            name: The name of the prompt
+            alias: The alias to delete
+        """
+        self._call_endpoint(
+            "DeletePromptAlias",
+            name=name,
+            alias=alias
+        )
+
+    def get_prompt_version_by_alias(self, name: str, alias: str) -> PromptVersion:
+        """
+        Get a prompt version by alias.
+        
+        Args:
+            name: The name of the prompt
+            alias: The alias to look up
+            
+        Returns:
+            The PromptVersion object referenced by the alias
+        """
+        response_proto = self._call_endpoint(
+            "GetPromptVersionByAlias",
+            name=name,
+            alias=alias
+        )
+        return PromptVersion.from_proto(response_proto.prompt_version) 

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -7,6 +7,7 @@ from mlflow.store.model_registry.databricks_workspace_model_registry_rest_store 
 )
 from mlflow.store.model_registry.file_store import FileStore
 from mlflow.store.model_registry.rest_store import RestStore
+from mlflow.store._unity_catalog.registry.uc_prompt_rest_store import UcPromptRestStore
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.utils import (
     _resolve_tracking_uri,
@@ -159,19 +160,18 @@ def _get_file_store(store_uri, **_):
 
 
 def _get_store_registry():
+    """Get or create a store registry."""
     global _model_registry_store_registry
-    from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
-    from mlflow.store._unity_catalog.registry.uc_oss_rest_store import UnityCatalogOssStore
 
     if _model_registry_store_registry is not None:
         return _model_registry_store_registry
 
     _model_registry_store_registry = ModelRegistryStoreRegistry()
+    
+    # Register the stores
     _model_registry_store_registry.register("databricks", _get_databricks_rest_store)
-    # Register a placeholder function that raises if users pass a registry URI with scheme
-    # "databricks-uc"
-    _model_registry_store_registry.register(_DATABRICKS_UNITY_CATALOG_SCHEME, UcModelRegistryStore)
-    _model_registry_store_registry.register(_OSS_UNITY_CATALOG_SCHEME, UnityCatalogOssStore)
+    _model_registry_store_registry.register(_DATABRICKS_UNITY_CATALOG_SCHEME, UcPromptRestStore)
+    _model_registry_store_registry.register(_OSS_UNITY_CATALOG_SCHEME, UcPromptRestStore)
 
     for scheme in ["http", "https"]:
         _model_registry_store_registry.register(scheme, _get_rest_store)

--- a/tests/prompt/test_registry_utils.py
+++ b/tests/prompt/test_registry_utils.py
@@ -1,0 +1,103 @@
+import pytest
+from unittest import mock
+
+from mlflow.environment_variables import MLFLOW_ENABLE_UC_PROMPT_SUPPORT
+from mlflow.prompt.registry_utils import is_prompt_supported_registry
+
+
+class TestIsPromptSupportedRegistry:
+    """Tests for the is_prompt_supported_registry function."""
+
+    def test_oss_mlflow_registry_supported(self):
+        """OSS MLflow registry should always support prompts."""
+        # Various OSS registry URIs
+        oss_uris = [
+            "sqlite:///mlflow.db", 
+            "postgresql://user:pass@localhost/mlflow",
+            "mysql://user:pass@localhost/mlflow",
+            "file:///tmp/mlflow",
+            ""  # default/empty URI
+        ]
+        
+        for uri in oss_uris:
+            assert is_prompt_supported_registry(uri) is True, f"Failed for URI: {uri}"
+
+    def test_legacy_databricks_workspace_not_supported(self):
+        """Legacy Databricks workspace registry should not support prompts."""
+        databricks_uris = ["databricks", "databricks://profile"]
+        
+        for uri in databricks_uris:
+            assert is_prompt_supported_registry(uri) is False, f"Failed for URI: {uri}"
+
+    def test_uc_registries_with_feature_flag_disabled(self):
+        """UC registries should not support prompts when feature flag is disabled."""
+        with mock.patch.object(MLFLOW_ENABLE_UC_PROMPT_SUPPORT, 'get', return_value=False):
+            uc_uris = [
+                "databricks-uc",
+                "databricks-uc://profile",
+                "uc:http://localhost:8080",
+                "uc://localhost:8080"
+            ]
+            
+            for uri in uc_uris:
+                assert is_prompt_supported_registry(uri) is False, f"Failed for URI: {uri}"
+
+    def test_uc_registries_with_feature_flag_enabled(self):
+        """UC registries should support prompts when feature flag is enabled."""
+        with mock.patch.object(MLFLOW_ENABLE_UC_PROMPT_SUPPORT, 'get', return_value=True):
+            uc_uris = [
+                "databricks-uc",
+                "databricks-uc://profile",
+                "uc:http://localhost:8080",
+                "uc://localhost:8080"
+            ]
+            
+            for uri in uc_uris:
+                assert is_prompt_supported_registry(uri) is True, f"Failed for URI: {uri}"
+
+    @mock.patch('mlflow.get_registry_uri')
+    def test_none_registry_uri_uses_global_registry_uri(self, mock_get_registry_uri):
+        """When registry_uri is None, should use mlflow.get_registry_uri()."""
+        # Test with OSS URI
+        mock_get_registry_uri.return_value = "sqlite:///mlflow.db"
+        assert is_prompt_supported_registry(None) is True
+        
+        # Test with legacy Databricks URI
+        mock_get_registry_uri.return_value = "databricks"
+        assert is_prompt_supported_registry(None) is False
+        
+        # Test with UC URI and feature flag enabled
+        mock_get_registry_uri.return_value = "databricks-uc"
+        with mock.patch.object(MLFLOW_ENABLE_UC_PROMPT_SUPPORT, 'get', return_value=True):
+            assert is_prompt_supported_registry(None) is True
+        
+        # Test with UC URI and feature flag disabled
+        with mock.patch.object(MLFLOW_ENABLE_UC_PROMPT_SUPPORT, 'get', return_value=False):
+            assert is_prompt_supported_registry(None) is False
+
+
+class TestPromptRegistryFeatureFlagIntegration:
+    """Integration tests for the prompt registry feature flag."""
+    
+    def test_feature_flag_enables_uc_support(self):
+        """When the UC prompt support feature flag is True, UC registries should be supported."""
+        from mlflow.prompt.registry_utils import require_prompt_registry, MlflowException
+        
+        @require_prompt_registry  
+        def dummy_prompt_function():
+            return "success"
+        
+        # Without feature flag (default False), should raise exception
+        try:
+            # Simulate calling from a UC registry context
+            with mock.patch('mlflow.get_registry_uri', return_value='databricks-uc'):
+                with pytest.raises(MlflowException, match="not supported"):
+                    dummy_prompt_function()
+        except Exception:
+            pass  # Expected
+        
+        # With feature flag enabled, should work
+        with mock.patch.object(MLFLOW_ENABLE_UC_PROMPT_SUPPORT, 'get', return_value=True):
+            with mock.patch('mlflow.get_registry_uri', return_value='databricks-uc'):
+                result = dummy_prompt_function()
+                assert result == "success" 

--- a/tests/store/_unity_catalog/registry/test_uc_prompt_rest_store.py
+++ b/tests/store/_unity_catalog/registry/test_uc_prompt_rest_store.py
@@ -1,0 +1,232 @@
+import json
+from unittest import mock
+
+import pytest
+
+from mlflow.protos.unity_catalog_prompt_service_pb2 import (
+    CreatePromptRequest,
+    CreatePromptResponse,
+    DeletePromptRequest,
+    DeletePromptResponse,
+    GetPromptRequest,
+    GetPromptResponse,
+    SearchPromptsRequest,
+    SearchPromptsResponse,
+    PromptInfo,
+    PromptTag,
+)
+from mlflow.store._unity_catalog.registry.uc_prompt_rest_store import UcPromptRestStore
+from mlflow.utils.proto_json_utils import message_to_json
+
+from tests.helper_functions import mock_http_200
+from tests.store._unity_catalog.conftest import _REGISTRY_HOST_CREDS
+
+
+@pytest.fixture
+def store(mock_databricks_uc_host_creds):
+    with mock.patch("mlflow.utils.databricks_utils.get_databricks_host_creds"):
+        yield UcPromptRestStore(store_uri="databricks-uc")
+
+
+def _verify_requests(mock_http, endpoint, method, proto_message):
+    """Helper to verify REST requests."""
+    if method == "GET":
+        assert mock_http.call_args[0][0] == endpoint
+        assert mock_http.call_args[0][1] == method
+    else:
+        assert mock_http.call_args[0][0] == endpoint
+        assert mock_http.call_args[0][1] == method
+        assert json.loads(mock_http.call_args[0][2]) == message_to_json(proto_message)
+
+
+@mock_http_200
+def test_create_prompt(mock_http, store):
+    """Test creating a prompt."""
+    name = "catalog_1.schema_1.prompt_1"
+    description = "Test prompt"
+    template = "This is a {{test}} template"
+    tags = [{"key": "test_key", "value": "test_value"}]
+    
+    store.create_prompt(name=name, template=template, description=description, tags=tags)
+    
+    _verify_requests(
+        mock_http,
+        "prompts",
+        "POST",
+        CreatePromptRequest(
+            name=name,
+            description=description,
+            template=template,
+            tags=[PromptTag(key="test_key", value="test_value")],
+        ),
+    )
+
+
+@mock_http_200
+def test_get_prompt(mock_http, store):
+    """Test getting a prompt."""
+    name = "catalog_1.schema_1.prompt_1"
+    store.get_prompt(name=name)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}",
+        "GET",
+        GetPromptRequest(name=name),
+    )
+
+
+@mock_http_200
+def test_delete_prompt(mock_http, store):
+    """Test deleting a prompt."""
+    name = "catalog_1.schema_1.prompt_1"
+    store.delete_prompt(name=name)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}",
+        "DELETE",
+        DeletePromptRequest(name=name),
+    )
+
+
+@mock_http_200
+def test_search_prompts(mock_http, store):
+    """Test searching prompts."""
+    filter_string = "name LIKE 'test%'"
+    max_results = 10
+    page_token = "test_token"
+    
+    store.search_prompts(
+        filter_string=filter_string,
+        max_results=max_results,
+        page_token=page_token,
+    )
+    
+    _verify_requests(
+        mock_http,
+        "prompts/search",
+        "POST",
+        SearchPromptsRequest(
+            filter=filter_string,
+            max_results=max_results,
+            page_token=page_token,
+        ),
+    )
+
+
+@mock_http_200
+def test_set_prompt_tag(mock_http, store):
+    """Test setting a prompt tag."""
+    name = "catalog_1.schema_1.prompt_1"
+    key = "test_key"
+    value = "test_value"
+    
+    store.set_prompt_tag(name=name, key=key, value=value)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/tags",
+        "POST",
+        SetPromptTagRequest(name=name, key=key, value=value),
+    )
+
+
+@mock_http_200
+def test_delete_prompt_tag(mock_http, store):
+    """Test deleting a prompt tag."""
+    name = "catalog_1.schema_1.prompt_1"
+    key = "test_key"
+    
+    store.delete_prompt_tag(name=name, key=key)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/tags/{key}",
+        "DELETE",
+        DeletePromptTagRequest(name=name, key=key),
+    )
+
+
+@mock_http_200
+def test_set_prompt_version_tag(mock_http, store):
+    """Test setting a prompt version tag."""
+    name = "catalog_1.schema_1.prompt_1"
+    version = "1"
+    key = "test_key"
+    value = "test_value"
+    
+    store.set_prompt_version_tag(name=name, version=version, key=key, value=value)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions/{version}/tags",
+        "POST",
+        SetPromptVersionTagRequest(name=name, version=version, key=key, value=value),
+    )
+
+
+@mock_http_200
+def test_delete_prompt_version_tag(mock_http, store):
+    """Test deleting a prompt version tag."""
+    name = "catalog_1.schema_1.prompt_1"
+    version = "1"
+    key = "test_key"
+    
+    store.delete_prompt_version_tag(name=name, version=version, key=key)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions/{version}/tags/{key}",
+        "DELETE",
+        DeletePromptVersionTagRequest(name=name, version=version, key=key),
+    )
+
+
+@mock_http_200
+def test_set_prompt_alias(mock_http, store):
+    """Test setting a prompt alias."""
+    name = "catalog_1.schema_1.prompt_1"
+    alias = "test_alias"
+    version = "1"
+    
+    store.set_prompt_alias(name=name, alias=alias, version=version)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/aliases/{alias}",
+        "POST",
+        SetPromptAliasRequest(name=name, alias=alias, version=version),
+    )
+
+
+@mock_http_200
+def test_delete_prompt_alias(mock_http, store):
+    """Test deleting a prompt alias."""
+    name = "catalog_1.schema_1.prompt_1"
+    alias = "test_alias"
+    
+    store.delete_prompt_alias(name=name, alias=alias)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/aliases/{alias}",
+        "DELETE",
+        DeletePromptAliasRequest(name=name, alias=alias),
+    )
+
+
+@mock_http_200
+def test_get_prompt_version_by_alias(mock_http, store):
+    """Test getting a prompt version by alias."""
+    name = "catalog_1.schema_1.prompt_1"
+    alias = "test_alias"
+    
+    store.get_prompt_version_by_alias(name=name, alias=alias)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions/by-alias/{alias}",
+        "GET",
+        GetPromptVersionByAliasRequest(name=name, alias=alias),
+    ) 

--- a/tests/store/_unity_catalog/registry/test_uc_prompt_version_rest_store.py
+++ b/tests/store/_unity_catalog/registry/test_uc_prompt_version_rest_store.py
@@ -1,0 +1,155 @@
+import json
+from unittest import mock
+
+import pytest
+
+from mlflow.protos.unity_catalog_prompt_service_pb2 import (
+    CreatePromptVersionRequest,
+    CreatePromptVersionResponse,
+    DeletePromptVersionRequest,
+    DeletePromptVersionResponse,
+    GetPromptVersionRequest,
+    GetPromptVersionResponse,
+    SearchPromptVersionsRequest,
+    SearchPromptVersionsResponse,
+    PromptVersionInfo,
+    PromptTag,
+)
+from mlflow.store._unity_catalog.registry.uc_prompt_rest_store import UcPromptRestStore
+from mlflow.utils.proto_json_utils import message_to_json
+
+from tests.helper_functions import mock_http_200
+from tests.store._unity_catalog.conftest import _REGISTRY_HOST_CREDS
+
+
+@pytest.fixture
+def store(mock_databricks_uc_host_creds):
+    with mock.patch("mlflow.utils.databricks_utils.get_databricks_host_creds"):
+        yield UcPromptRestStore(store_uri="databricks-uc")
+
+
+def _verify_requests(mock_http, endpoint, method, proto_message):
+    """Helper to verify REST requests."""
+    if method == "GET":
+        assert mock_http.call_args[0][0] == endpoint
+        assert mock_http.call_args[0][1] == method
+    else:
+        assert mock_http.call_args[0][0] == endpoint
+        assert mock_http.call_args[0][1] == method
+        assert json.loads(mock_http.call_args[0][2]) == message_to_json(proto_message)
+
+
+@mock_http_200
+def test_create_prompt_version(mock_http, store):
+    """Test creating a prompt version."""
+    name = "catalog_1.schema_1.prompt_1"
+    template = "This is version {{version}} of the template"
+    description = "Test prompt version"
+    tags = [{"key": "test_key", "value": "test_value"}]
+    
+    store.create_prompt_version(
+        name=name,
+        template=template,
+        description=description,
+        tags=tags,
+    )
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions",
+        "POST",
+        CreatePromptVersionRequest(
+            name=name,
+            template=template,
+            description=description,
+            tags=[PromptTag(key="test_key", value="test_value")],
+        ),
+    )
+
+
+@mock_http_200
+def test_get_prompt_version(mock_http, store):
+    """Test getting a prompt version."""
+    name = "catalog_1.schema_1.prompt_1"
+    version = "1"
+    
+    store.get_prompt_version(name=name, version=version)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions/{version}",
+        "GET",
+        GetPromptVersionRequest(name=name, version=version),
+    )
+
+
+@mock_http_200
+def test_delete_prompt_version(mock_http, store):
+    """Test deleting a prompt version."""
+    name = "catalog_1.schema_1.prompt_1"
+    version = "1"
+    
+    store.delete_prompt_version(name=name, version=version)
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions/{version}",
+        "DELETE",
+        DeletePromptVersionRequest(name=name, version=version),
+    )
+
+
+@mock_http_200
+def test_search_prompt_versions(mock_http, store):
+    """Test searching prompt versions."""
+    name = "catalog_1.schema_1.prompt_1"
+    filter_string = "version > '1'"
+    max_results = 10
+    page_token = "test_token"
+    
+    store.search_prompt_versions(
+        name=name,
+        filter_string=filter_string,
+        max_results=max_results,
+        page_token=page_token,
+    )
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions",
+        "GET",
+        SearchPromptVersionsRequest(
+            name=name,
+            filter=filter_string,
+            max_results=max_results,
+            page_token=page_token,
+        ),
+    )
+
+
+@mock_http_200
+def test_update_prompt_version(mock_http, store):
+    """Test updating a prompt version."""
+    name = "catalog_1.schema_1.prompt_1"
+    version = "1"
+    description = "Updated description"
+    tags = [{"key": "updated_key", "value": "updated_value"}]
+    
+    store.update_prompt_version(
+        name=name,
+        version=version,
+        description=description,
+        tags=tags,
+    )
+    
+    _verify_requests(
+        mock_http,
+        f"prompts/{name}/versions/{version}",
+        "PATCH",
+        UpdatePromptVersionRequest(
+            name=name,
+            version=version,
+            description=description,
+            tags=[PromptTag(key="updated_key", value="updated_value")],
+        ),
+    ) 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/15843?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15843/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15843/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15843/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
