### PR TITLE
Allow `autoformat` workflow to be run on PRs filed by Copilot

### DIFF
--- a/.github/actions/validate-author/index.js
+++ b/.github/actions/validate-author/index.js
@@ -1,5 +1,10 @@
-function isAllowed(author_association) {
-  return ["owner", "member", "collaborator"].includes(author_association.toLowerCase());
+function isAllowed(pullRequest) {
+  const { author_association, user } = pullRequest;
+  return (
+    ["owner", "member", "collaborator"].includes(author_association.toLowerCase()) ||
+    // Allow Copilot to run this workflow
+    (user.login.toLowerCase() === "copilot" && user.type.toLowerCase() === "bot")
+  );
 }
 
 module.exports = async ({ context, github, core }) => {
@@ -13,6 +18,7 @@ module.exports = async ({ context, github, core }) => {
       repo: context.repo.repo,
       pull_number: context.issue.number,
     });
+
     if (!isAllowed(pullRequest.author_association)) {
       core.setFailed(
         `This workflow is not allowed to run on PRs from ${pullRequest.author_association}.`

--- a/.github/actions/validate-author/index.js
+++ b/.github/actions/validate-author/index.js
@@ -1,15 +1,20 @@
-function isAllowed(pullRequest) {
-  const { author_association, user } = pullRequest;
+function isAllowed({ author_association, user }) {
   return (
     ["owner", "member", "collaborator"].includes(author_association.toLowerCase()) ||
     // Allow Copilot to run this workflow
-    (user.login.toLowerCase() === "copilot" && user.type.toLowerCase() === "bot")
+    (user && user.login.toLowerCase() === "copilot" && user.type.toLowerCase() === "bot")
   );
 }
 
 module.exports = async ({ context, github, core }) => {
   if (context.eventName === "issue_comment") {
-    if (!isAllowed(context.payload.comment.author_association)) {
+    const { comment } = context.payload;
+    if (
+      !isAllowed({
+        author_association: comment.author_association,
+        user: comment.user,
+      })
+    ) {
       core.setFailed(`${comment.author_association} is not allowed to use this workflow.`);
     }
 
@@ -18,7 +23,12 @@ module.exports = async ({ context, github, core }) => {
       repo: context.repo.repo,
       pull_number: context.issue.number,
     });
-    if (!isAllowed(pullRequest.author_association)) {
+    if (
+      !isAllowed({
+        author_association: pullRequest.author_association,
+        user: pullRequest.user,
+      })
+    ) {
       core.setFailed(
         `This workflow is not allowed to run on PRs from ${pullRequest.author_association}.`
       );

--- a/.github/actions/validate-author/index.js
+++ b/.github/actions/validate-author/index.js
@@ -18,7 +18,6 @@ module.exports = async ({ context, github, core }) => {
       repo: context.repo.repo,
       pull_number: context.issue.number,
     });
-
     if (!isAllowed(pullRequest.author_association)) {
       core.setFailed(
         `This workflow is not allowed to run on PRs from ${pullRequest.author_association}.`


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15845?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15845/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15845/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15845/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Allow `autoformat` workflow to be run on PRs filed by Copilot (example: #15839).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
