### PR TITLE
create prompt handler Signed-off-by: Daniel Low <danlowgw@gmail.com>

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
@@ -24,10 +24,25 @@ const PromptsPage = () => {
     usePromptsListQuery({ searchFilter: debouncedSearchFilter });
 
   const { EditTagsModal, showEditPromptTagsModal } = useUpdateRegisteredPromptTags({ onSuccess: refetch });
-  const { CreatePromptModal, openModal: openCreateVersionModal } = useCreatePromptModal({
+  // Checks if existing prompts are available
+  const hasPrompts = Array.isArray(data) && data.length > 0;
+  const { CreatePromptModal: CreatePrompModal, openModal: openCreatePromptModal } = useCreatePromptModal({
     mode: CreatePromptModalMode.CreatePrompt,
     onSuccess: ({ promptName }) => navigate(Routes.getPromptDetailsPageRoute(promptName)),
   });
+  const { CreatePromptModal: CreatePromptVersionModal, openModal: openCreatePromptVersionModal } = useCreatePromptModal({
+    mode: CreatePromptModalMode.CreatePromptVersion,
+    onSuccess: ({ promptName }) => navigate(Routes.getPromptDetailsPageRoute(promptName)),
+  });
+
+  // handler for the button
+  const handleCreatePromptClick = () => {
+    if (hasPrompts) {
+      openCreatePromptVersionModal();
+    } else {
+      openCreatePromptModal();
+    }
+  };
 
   return (
     <ScrollablePageWrapper css={{ overflow: 'hidden', display: 'flex', flexDirection: 'column' }}>
@@ -35,7 +50,7 @@ const PromptsPage = () => {
       <Header
         title={<FormattedMessage defaultMessage="Prompts" description="Header title for the registered prompts page" />}
         buttons={
-          <Button componentId="mlflow.prompts.list.create" type="primary" onClick={openCreateVersionModal}>
+          <Button componentId="mlflow.prompts.list.create" type="primary" onClick={handleCreatePromptClick}>
             <FormattedMessage
               defaultMessage="Create prompt"
               description="Label for the create prompt button on the registered prompts page"
@@ -65,7 +80,8 @@ const PromptsPage = () => {
         />
       </div>
       {EditTagsModal}
-      {CreatePromptModal}
+      {CreatePrompModal}
+      {CreatePromptVersionModal}
     </ScrollablePageWrapper>
   );
 };


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/marmal88/mlflow/pull/15857?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15857/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15857/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15857/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- This is a proposal to address the issue listed in this [bug](https://github.com/mlflow/mlflow/issues/15825#issuecomment-2897568687)

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ x ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
<img width="1631" alt="Screenshot 2025-05-23 at 3 06 51 PM" src="https://github.com/user-attachments/assets/00f348e4-f56c-4d41-bffd-12652221dff0" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
