### PR TITLE
Allow multi inputs module in DSPy

### DIFF
--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -87,7 +87,18 @@ class DspyModelWrapper(PythonModel):
                     yield output
 
     def _get_model_input(self, inputs: Any) -> Union[str, dict[str, Any]]:
-        """Convert the PythonModel input into the DSPy program input"""
+        """Convert the PythonModel input into the DSPy program input
+
+        Examples of expected conversions:
+        - str -> str
+        - dict -> dict
+        - np.ndarray with one element -> single element
+        - pd.DataFrame with one row and string column -> single row dict
+        - pd.DataFrame with one row and non-string column -> single element
+        - list -> raises an exception
+        - np.ndarray with more than one element -> raises an exception
+        - pd.DataFrame with more than one row -> raises an exception
+        """
         import numpy as np
         import pandas as pd
 

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -107,7 +107,7 @@ class DspyModelWrapper(PythonModel):
             if all(isinstance(col, str) for col in inputs.columns):
                 inputs = inputs.to_dict(orient="records")[0]
             else:
-                inputs = inputs.values
+                inputs = inputs.values[0]
         if isinstance(inputs, np.ndarray):
             if len(inputs) != 1:
                 raise MlflowException(

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -15,6 +15,10 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.pyfunc import PythonModel
 from mlflow.types.schema import DataType, Schema
 
+_INVALID_SIZE_MESSAGE = (
+    "Dspy model doesn't support batch inference or empty input. Please provide a single input."
+)
+
 
 class DspyModelWrapper(PythonModel):
     """MLflow PyFunc wrapper class for Dspy models.
@@ -97,8 +101,7 @@ class DspyModelWrapper(PythonModel):
         if isinstance(inputs, pd.DataFrame):
             if len(inputs) != 1:
                 raise MlflowException(
-                    "Dspy model doesn't support batch inference or empty input. "
-                    "Please provide a single input.",
+                    _INVALID_SIZE_MESSAGE,
                     INVALID_PARAMETER_VALUE,
                 )
             if all(isinstance(col, str) for col in inputs.columns):
@@ -108,8 +111,7 @@ class DspyModelWrapper(PythonModel):
         if isinstance(inputs, np.ndarray):
             if len(inputs) != 1:
                 raise MlflowException(
-                    "Dspy model doesn't support batch inference or empty input. "
-                    "Please provide a single input.",
+                    _INVALID_SIZE_MESSAGE,
                     INVALID_PARAMETER_VALUE,
                 )
             inputs = inputs[0]

--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -112,7 +112,7 @@ class DspyModelWrapper(PythonModel):
                     "Please provide a single input.",
                     INVALID_PARAMETER_VALUE,
                 )
-            inputs = inputs.flatten()[0]
+            inputs = inputs[0]
 
         return inputs
 

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -22,7 +22,7 @@ from tests.helper_functions import (
 
 _DSPY_VERSION = Version(importlib.metadata.version("dspy"))
 
-_DSPY_UNDER_2_6 = _DSPY_VERSION < Version("2.6.0rc1")
+_DSPY_UNDER_2_6 = _DSPY_VERSION < Version("2.6.0")
 
 _DSPY_2_6_23_OR_OLDER = _DSPY_VERSION <= Version("2.6.23")
 skip_if_2_6_23_or_older = pytest.mark.skipif(
@@ -265,6 +265,24 @@ def test_serving_logged_model(dummy_model):
 
     assert _REASONING_KEYWORD in json_response["predictions"]
     assert "answer" in json_response["predictions"]
+
+
+def test_log_model_multi_inputs(dummy_model):
+    dspy_model = dspy.ChainOfThought("question, hint -> answer")
+
+    dspy.settings.configure(lm=dummy_model)
+
+    input_example = {"inputs": "What is 2 + 2?", "hint": "Hint: 2 + 2 = ?"}
+
+    with mlflow.start_run():
+        model_info = mlflow.dspy.log_model(
+            dspy_model,
+            name="model",
+            input_example=input_example,
+        )
+
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    assert loaded_model.predict(input_example) == {"answer": "6", _REASONING_KEYWORD: "reason"}
 
 
 def test_save_chat_model_with_string_output(dummy_model):

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -132,6 +132,7 @@ def test_dspy_save_preserves_object_state():
             self.generate_answer = dspy.ChainOfThought(GenerateAnswer)
 
         def forward(self, question):
+            assert question == "What is 2 + 2?"
             context = self.retrieve(question).passages
             prediction = self.generate_answer(context=context, question=question)
             return dspy.Prediction(context=context, answer=prediction.answer)
@@ -231,6 +232,7 @@ def test_serving_logged_model(dummy_model):
             self.prog = dspy.ChainOfThought("question -> answer")
 
         def forward(self, question):
+            assert question == "What is 2 + 2?"
             return self.prog(question=question)
 
     dspy_model = CoT()
@@ -247,7 +249,7 @@ def test_serving_logged_model(dummy_model):
             dspy_model,
             name=artifact_path,
             signature=signature,
-            input_example=input_examples,
+            input_example=["What is 2 + 2?"],
         )
         model_uri = model_info.model_uri
     dspy.settings.configure(lm=None)
@@ -274,6 +276,8 @@ def test_log_model_multi_inputs(dummy_model):
             self.prog = dspy.ChainOfThought("question, hint -> answer")
 
         def forward(self, question, hint):
+            assert question == "What is 2 + 2?"
+            assert hint == "Hint: 2 + 2 = ?"
             return self.prog(question=question, hint=hint)
 
     dspy_model = MultiInputCoT()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15859?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15859/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15859/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15859/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

It is common for DSPy models to receive multiple arguments, but MLflow DSPy flavor does not allow models to receive multiple arguments. Therefore, the following code does not currently work.

```
import mlflow
import dspy

mlflow.set_experiment("DSPy")

lm = dspy.LM("openai/gpt-4o-mini")
dspy.settings.configure(lm=lm)

dspy_program = dspy.ChainOfThought("question, context -> answer")

with mlflow.start_run():
    model_info = mlflow.dspy.log_model(
        dspy_program,
        "dspy_program",
        input_example={
            "question": "What is LLM agent?",
            "context": "LLM agents are a type of AI agent that use LLMs to make decisions.",
        },
    )
```
This PR remove the limitation by converting a Dataframe into a dict.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
