### PR TITLE
Paginate list_endpoints when querying AWS Sagemaker. 

### DIFF
--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -2739,7 +2739,21 @@ class SageMakerDeploymentClient(BaseDeploymentClient):
         sage_client = boto3.client(
             "sagemaker", region_name=self.region_name, **assume_role_credentials
         )
-        return sage_client.list_endpoints()["Endpoints"]
+
+        # Create a reusable Paginator
+        endpoint_paginator = sage_client.get_paginator("list_endpoints")
+
+        # Create a PageIterator from the Paginator with MAX_RESULTS_PER_PAGE results
+        # per page to minimize iterations
+        MAX_RESULTS_PER_PAGE = 100
+        endpoint_page_iterator = endpoint_paginator.paginate(MaxResults=MAX_RESULTS_PER_PAGE)
+
+        # Iterate through the pages and collect the Endpoints
+        endpoints = []
+        for page in endpoint_page_iterator:
+            endpoints.extend(page["Endpoints"])
+
+        return endpoints
 
     def get_deployment(self, name, endpoint=None):
         """


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dennis-johnson-dev/mlflow/pull/15866?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15866/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15866/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15866/merge
```

</p>
</details>

### Related Issues/PRs

Fixes #15842

### What changes are proposed in this pull request?

This change adds pagination to `mlflow.SageMakerDeploymentClient.list_deployments` so it retrieves all available deployments within AWS. Currently, it only pulls the first page of results which are limited to 10 endpoints by default.

I see in the [boto3 docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sagemaker/client/list_endpoints.html) that `list_endpoints` accepts a `MaxResults` parameter which [has a](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ListEndpoints.html#sagemaker-ListEndpoints-request-MaxResults) max of 100. I used this value to minimize the number of iterations needed to gather all available endpoints.

Here are the docs for the paginator I used that boto3 provides - https://boto3.amazonaws.com/v1/documentation/api/latest/guide/paginators.html

#### Testing

It looks like there are some existing unit tests that cover this functionality
- [`test_list_deployments_returns_all_endpoints`](https://github.com/dennis-johnson-dev/mlflow/blob/15842_paginate_sagemaker_list_endpoints/tests/sagemaker/test_sagemaker_deployment_client.py#L1574)
- [`test_list_deployments_with_assumed_role_arn`](https://github.com/dennis-johnson-dev/mlflow/blob/15842_paginate_sagemaker_list_endpoints/tests/sagemaker/test_sagemaker_deployment_client.py#L1596)

I updated the unit tests to utilize pagination and asserted the sagemaker mock accept the appropriate arguments.

I did verify the AWS api calls separately and ensured that the pagination works as expected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Add pagination to `SageMakerDeploymentClient.list_deployments()` to retrieve all available endpoints. This addresses an issue with `list_deployments` that would cause the result to be truncated to 10 endpoints.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
