### PR TITLE
Add Databricks App resource

### DIFF
--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -20,6 +20,7 @@ class ResourceType(Enum):
     FUNCTION = "function"
     GENIE_SPACE = "genie_space"
     TABLE = "table"
+    APP = "app"
 
 
 class Resource(ABC):
@@ -233,6 +234,27 @@ class DatabricksTable(DatabricksResource):
         super().__init__(table_name, on_behalf_of_user)
 
 
+class DatabricksApp(DatabricksResource):
+    """
+    Defines a Databricks Unity Catalog (UC) Table, which establishes table dependencies
+    for Model Serving. This table will be referenced in Agent Model Serving endpoints,
+    where an agent queries a SQL table via either Genie or UC Functions.
+
+     Args:
+         table_name (str): The name of the table used by the model
+         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resource is accessed with the permissions of the creator
+    """
+
+    @property
+    def type(self) -> ResourceType:
+        return ResourceType.APP
+
+    def __init__(self, app_name: str, on_behalf_of_user: Optional[bool] = None):
+        super().__init__(app_name, on_behalf_of_user)
+
+
 def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
     resource_classes = {
         "databricks": {
@@ -243,6 +265,7 @@ def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
             ResourceType.FUNCTION.value: DatabricksFunction,
             ResourceType.GENIE_SPACE.value: DatabricksGenieSpace,
             ResourceType.TABLE.value: DatabricksTable,
+            ResourceType.APP.value: DatabricksApp,
         }
     }
     resource = resource_classes.get(target_uri)

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -2,6 +2,7 @@ import pytest
 
 from mlflow.models.resources import (
     DEFAULT_API_VERSION,
+    DatabricksApp,
     DatabricksFunction,
     DatabricksGenieSpace,
     DatabricksServingEndpoint,
@@ -126,6 +127,21 @@ def test_table(on_behalf_of_user):
     }
 
 
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_app(on_behalf_of_user):
+    app = DatabricksApp(app_name="id1", on_behalf_of_user=on_behalf_of_user)
+    expected = (
+        {"app": [{"name": "id1"}]}
+        if on_behalf_of_user is None
+        else {"app": [{"name": "id1", "on_behalf_of_user": on_behalf_of_user}]}
+    )
+    assert app.to_dict() == expected
+    assert _ResourceBuilder.from_resources([app]) == {
+        "api_version": DEFAULT_API_VERSION,
+        "databricks": expected,
+    }
+
+
 def test_resources():
     resources = [
         DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
@@ -135,6 +151,7 @@ def test_resources():
         DatabricksFunction(function_name="rag.studio.test_function_1"),
         DatabricksFunction(function_name="rag.studio.test_function_2"),
         DatabricksUCConnection(connection_name="slack_connection"),
+        DatabricksApp(app_name="test_databricks_app"),
     ]
     expected = {
         "api_version": DEFAULT_API_VERSION,
@@ -150,6 +167,7 @@ def test_resources():
                 {"name": "rag.studio.test_function_2"},
             ],
             "uc_connection": [{"name": "slack_connection"}],
+            "app": [{"name": "test_databricks_app"}],
         },
     }
 
@@ -211,6 +229,8 @@ def test_resources_from_yaml(tmp_path):
                 - name: rag.studio.test_function_2
                 uc_connection:
                 - name: slack_connection
+                app:
+                - name: test_databricks_app
             """
         )
 
@@ -228,6 +248,7 @@ def test_resources_from_yaml(tmp_path):
                 {"name": "rag.studio.test_function_2"},
             ],
             "uc_connection": [{"name": "slack_connection"}],
+            "app": [{"name": "test_databricks_app"}],
         },
     }
 

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -38,6 +38,7 @@ from mlflow.models.auth_policy import AuthPolicy, SystemAuthPolicy, UserAuthPoli
 from mlflow.models.dependencies_schemas import DependenciesSchemasType
 from mlflow.models.model import _DATABRICKS_FS_LOADER_MODULE
 from mlflow.models.resources import (
+    DatabricksApp,
     DatabricksFunction,
     DatabricksGenieSpace,
     DatabricksServingEndpoint,
@@ -1545,6 +1546,7 @@ def test_model_save_load_with_resources(tmp_path):
             "genie_space": [{"name": "genie_space_id_1"}, {"name": "genie_space_id_2"}],
             "uc_connection": [{"name": "test_connection_1"}, {"name": "test_connection_2"}],
             "table": [{"name": "rag.studio.table_a"}, {"name": "rag.studio.table_b"}],
+            "app": [{"name": "test_databricks_app"}],
         },
     }
     mlflow.pyfunc.save_model(
@@ -1565,6 +1567,7 @@ def test_model_save_load_with_resources(tmp_path):
             DatabricksUCConnection(connection_name="test_connection_2"),
             DatabricksTable(table_name="rag.studio.table_a"),
             DatabricksTable(table_name="rag.studio.table_b"),
+            DatabricksApp(app_name="test_databricks_app"),
         ],
     )
 
@@ -1597,6 +1600,8 @@ def test_model_save_load_with_resources(tmp_path):
                 table:
                 - name: rag.studio.table_a
                 - name: rag.studio.table_b
+                app:
+                - name: test_databricks_app
             """
         )
 
@@ -1639,6 +1644,7 @@ def test_model_save_load_with_invokers_resources(tmp_path):
                 {"name": "rag.studio.table_a", "on_behalf_of_user": True},
                 {"name": "rag.studio.table_b"},
             ],
+            "app": [{"name": "test_databricks_app"}],
         },
     }
     mlflow.pyfunc.save_model(
@@ -1663,6 +1669,7 @@ def test_model_save_load_with_invokers_resources(tmp_path):
             DatabricksUCConnection(connection_name="test_connection_2"),
             DatabricksTable(table_name="rag.studio.table_a", on_behalf_of_user=True),
             DatabricksTable(table_name="rag.studio.table_b"),
+            DatabricksApp(app_name="test_databricks_app"),
         ],
     )
 
@@ -1700,6 +1707,8 @@ def test_model_save_load_with_invokers_resources(tmp_path):
                 - name: rag.studio.table_a
                   on_behalf_of_user: True
                 - name: rag.studio.table_b
+                app:
+                - name: test_databricks_app
             """
         )
 
@@ -1849,6 +1858,7 @@ def test_model_log_with_resources(tmp_path):
             ],
             "uc_connection": [{"name": "test_connection_1"}, {"name": "test_connection_2"}],
             "table": [{"name": "rag.studio.table_a"}, {"name": "rag.studio.table_b"}],
+            "app": [{"name": "test_databricks_app"}],
         },
     }
     with mlflow.start_run() as run:
@@ -1869,6 +1879,7 @@ def test_model_log_with_resources(tmp_path):
                 DatabricksUCConnection(connection_name="test_connection_2"),
                 DatabricksTable(table_name="rag.studio.table_a"),
                 DatabricksTable(table_name="rag.studio.table_b"),
+                DatabricksApp(app_name="test_databricks_app"),
             ],
         )
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
@@ -1902,6 +1913,8 @@ def test_model_log_with_resources(tmp_path):
                 table:
                 - name: "rag.studio.table_a"
                 - name: "rag.studio.table_b"
+                app:
+                - name: test_databricks_app
             """
         )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/aravind-segu/mlflow/pull/15867?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15867/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15867/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15867/merge
```

</p>
</details>

### What changes are proposed in this pull request?

- This PR adds a Databricks App resource type. This will be used in order to auto authenticate to MCP Servers hosted on Databricks Apps from Databricks Agent Frameworks

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests
    - Notebook Link: https://e2-spog.staging.cloud.databricks.com/editor/notebooks/2462810993433329?o=6051921418418893#command/5868577598411975
    - Registered Model Yaml File:
<img width="522" alt="image" src="https://github.com/user-attachments/assets/a58d9198-d365-4b23-a3a6-80fd49400723" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add Databricks App Resource to automatically authenticate to Databricks Apps from Databricks Agent Frameworks

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
