### PR TITLE
Remove pyspark dep from cross version test to avoid overriding pip constraint

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -632,7 +632,7 @@ langchain:
       # Installing both pyspark and databricks-connect causes a conflict
       pip uninstall -y databricks-connect
       # TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this pin when MLflow is ready for pyspark 4.0.0
-      pip install --no-deps --force-reinstall 'pyspark<4.0.0'
+      pip install --no-deps --force-reinstall 'pyspark<3.5.6'
     run: |
       # Some dependencies above includes 'mlflow-skinny' but not full 'mlflow', such as databricks-vectorsearch.
       # This causes installation of mlflow-skinny from stable version, while 'mlflow' points to the dev version,
@@ -675,7 +675,7 @@ langchain:
       # Installing both pyspark and databricks-connect causes a conflict
       pip uninstall -y databricks-connect
       # TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this pin when MLflow is ready for pyspark 4.0.0
-      pip install --no-deps --force-reinstall 'pyspark<4.0.0'
+      pip install --no-deps --force-reinstall 'pyspark<3.5.6'
     run: |
       pytest tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -107,7 +107,7 @@ tensorflow:
     maximum: "2.19.0"
     requirements:
       # Requirements to run tests for keras
-      ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
+      ">= 0.0.0": ["scikit-learn", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
       # TensorFlow 2.12.1 and 2.13.1 requires typing_extensions < 4.6.0, which is
       # incompatible with SQLAlchemy 2.0.25 and Pydantic v2 with error
       # `cannot import name 'TypeAliasType' from 'typing_extensions'`
@@ -535,7 +535,6 @@ openai:
     maximum: "1.78.1"
     requirements:
       ">= 0.0.0": [
-          "pyspark",
           "tiktoken",
           "aiohttp",
           "tenacity",
@@ -557,7 +556,6 @@ openai:
       ">= 1.33.0": "3.10"
     requirements:
       ">= 0.0.0": [
-          "pyspark",
           "tiktoken",
           "aiohttp",
           "tenacity",
@@ -602,7 +600,6 @@ langchain:
     maximum: "0.3.25"
     requirements:
       ">= 0.0.0": [
-          "pyspark",
           "transformers",
           "torch",
           "torchvision",
@@ -634,7 +631,8 @@ langchain:
     pre_test: |
       # Installing both pyspark and databricks-connect causes a conflict
       pip uninstall -y databricks-connect
-      pip install --no-deps --force-reinstall pyspark
+      # TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this pin when MLflow is ready for pyspark 4.0.0
+      pip install --no-deps --force-reinstall pyspark<4.0.0
     run: |
       # Some dependencies above includes 'mlflow-skinny' but not full 'mlflow', such as databricks-vectorsearch.
       # This causes installation of mlflow-skinny from stable version, while 'mlflow' points to the dev version,
@@ -654,7 +652,6 @@ langchain:
     maximum: "0.3.25"
     requirements:
       ">= 0.0.0": [
-          "pyspark",
           "openai",
           "google-search-results",
           "psutil",
@@ -677,7 +674,8 @@ langchain:
     pre_test: |
       # Installing both pyspark and databricks-connect causes a conflict
       pip uninstall -y databricks-connect
-      pip install --no-deps --force-reinstall pyspark
+      # TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this pin when MLflow is ready for pyspark 4.0.0
+      pip install --no-deps --force-reinstall pyspark<4.0.0
     run: |
       pytest tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2
@@ -903,7 +901,6 @@ sentence_transformers:
     maximum: "4.1.0"
     requirements:
       ">= 0.0.0": [
-          "pyspark",
           "torch>1.6",
           "transformers>4.25",
           "hf_transfer",
@@ -946,7 +943,7 @@ promptflow:
       # Requirements to run sparkudf predict test
       # marshmallow 3.24.0 has breaking change causes `from marshmallow.fields import _T` error
       # inside promptflow
-      ">= 0.0.0": ["pyspark", "jinja2", "marshmallow<3.24.0"]
+      ">= 0.0.0": ["jinja2", "marshmallow<3.24.0"]
       ">= 1.11.0": ["openai>=1"]
       "< 1.18": ["numpy<2"]
     run: |

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -632,7 +632,7 @@ langchain:
       # Installing both pyspark and databricks-connect causes a conflict
       pip uninstall -y databricks-connect
       # TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this pin when MLflow is ready for pyspark 4.0.0
-      pip install --no-deps --force-reinstall pyspark<4.0.0
+      pip install --no-deps --force-reinstall 'pyspark<4.0.0'
     run: |
       # Some dependencies above includes 'mlflow-skinny' but not full 'mlflow', such as databricks-vectorsearch.
       # This causes installation of mlflow-skinny from stable version, while 'mlflow' points to the dev version,
@@ -675,7 +675,7 @@ langchain:
       # Installing both pyspark and databricks-connect causes a conflict
       pip uninstall -y databricks-connect
       # TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this pin when MLflow is ready for pyspark 4.0.0
-      pip install --no-deps --force-reinstall pyspark<4.0.0
+      pip install --no-deps --force-reinstall 'pyspark<4.0.0'
     run: |
       pytest tests/langchain/test_langchain_autolog.py
       # test both pydantic v1 and v2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15894?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15894/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15894/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15894/merge
```

</p>
</details>

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
