### PR TITLE
Prohibit passing extra kwargs to scorers

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -183,10 +183,6 @@ def evaluate(
 
                 - expectations (optional): Column containing a dictionary of ground truths.
 
-            The input dataframe can contain extra columns that will be directly passed to
-            the scorers. For example, you can pass a dataframe with `retrieved_context`
-            column to use a scorer that takes `retrieved_context` as a parameter.
-
             For list of dictionaries, each dict should follow the above schema.
 
         scorers: A list of Scorer objects that produces evaluation scores from

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -151,14 +151,10 @@ def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
         response: Optional[Any],
         expected_response: Optional[Any],
         trace: Optional[Trace],
-        retrieved_context: Optional[list[dict[str, str]]],
         guidelines: Optional[Union[list[str], dict[str, list[str]]]],
         expected_facts: Optional[list[str]],
         expected_retrieved_context: Optional[list[dict[str, str]]],
         custom_expected: Optional[dict[str, Any]],
-        custom_inputs: Optional[dict[str, Any]],
-        custom_outputs: Optional[dict[str, Any]],
-        tool_calls: Optional[list[Any]],
         **kwargs,
     ) -> Union[int, float, bool, str, Assessment, list[Assessment]]:
         # Condense all expectations into a single dict
@@ -176,21 +172,11 @@ def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
         if custom_expected is not None:
             expectations.update(custom_expected)
 
-        # TODO: scorer.aggregations require a refactor on the agents side
         merged = {
             "inputs": request,
             "outputs": response,
             "expectations": expectations,
             "trace": trace,
-            "guidelines": guidelines,
-            "retrieved_context": retrieved_context,
-            "expected_facts": expected_facts,
-            "expected_retrieved_context": expected_retrieved_context,
-            "custom_expected": custom_expected,
-            "custom_inputs": custom_inputs,
-            "custom_outputs": custom_outputs,
-            "tool_calls": tool_calls,
-            **kwargs,
         }
         return scorer.run(**merged)
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -15,7 +15,7 @@ class Scorer(BaseModel):
     name: str
     aggregations: Optional[list] = None
 
-    def run(self, *, inputs=None, outputs=None, expectations=None, trace=None, **kwargs):
+    def run(self, *, inputs=None, outputs=None, expectations=None, trace=None):
         from mlflow.evaluation import Assessment as LegacyAssessment
 
         merged = {
@@ -23,7 +23,6 @@ class Scorer(BaseModel):
             "outputs": outputs,
             "expectations": expectations,
             "trace": trace,
-            **kwargs,
         }
         # Filter to only the parameters the function actually expects
         sig = inspect.signature(self.__call__)
@@ -74,19 +73,7 @@ class Scorer(BaseModel):
         outputs: Any = None,
         expectations: Optional[dict[str, Any]] = None,
         trace: Optional[Trace] = None,
-        **kwargs,
     ) -> Union[int, float, bool, str, Feedback, list[Feedback]]:
-        # TODO: make sure scorer's signature is simply equal to whatever keys are
-        # in the eval dataset once we migrate from the agent eval harness
-        # Currently, the evaluation harness only passes the following reserved
-        # extra keyword arguments. This will be fully flexible once we migrate off
-        # the agent eval harness.
-        # - retrieved_context (optional): Retrieved context, can be from your
-        #   input eval dataset or from trace
-        # - custom_expected (optional): Custom expected results from input eval dataset
-        # - custom_inputs (optional): Custom inputs from your input eval dataset
-        # - custom_outputs (optional): Custom outputs from the agent's response
-        # - tool_calls (optional): Tool calls from the agent's response.
         """
         Implement the custom scorer's logic here.
 
@@ -140,10 +127,6 @@ class Scorer(BaseModel):
             * - ``trace``
               - A trace object corresponding to the prediction for the row.
               - Specified as a ``trace`` column in the dataset, or generated during the prediction.
-
-            * - ``**kwargs``
-              - Additional keyword arguments passed to the scorer.
-              - Must be specified as extra columns in the input dataset.
 
         Example:
 
@@ -245,10 +228,6 @@ def scorer(
         * - ``trace``
           - A trace object corresponding to the prediction for the row.
           - Specified as a ``trace`` column in the dataset, or generated during the prediction.
-
-        * - ``**kwargs``
-          - Additional keyword arguments passed to the scorer.
-          - Must be specified as extra columns in the input dataset.
 
     The scorer function should return one of the following:
 

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -2,17 +2,6 @@ from unittest import mock
 
 import pytest
 
-from mlflow.entities import TraceInfoV2
-
-
-# TODO: Remove this fixture once `databricks-agents` releases a new version that's compatible with
-# trace v3
-@pytest.fixture(scope="module", autouse=True)
-def mock_trace_info():
-    # Monkey patch TraceInfo (V3) to use TraceInfoV2
-    with mock.patch("mlflow.entities.TraceInfo", wraps=TraceInfoV2):
-        yield
-
 
 @pytest.fixture(autouse=True)
 def mock_init_auth():

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -49,23 +49,11 @@ def sample_dict_data_multiple():
             "inputs": {"question": "What is Spark?"},
             "outputs": "actual response for first question",
             "expectations": {"expected_response": "expected response for first question"},
-            # Additional columns required by the judges
-            "retrieved_context": [
-                {
-                    "content": "doc content 1",
-                    "doc_uri": "doc_uri_2_1",
-                },
-                {
-                    "content": "doc content 2.",
-                    "doc_uri": "doc_uri_6_extra",
-                },
-            ],
         },
         {
             "inputs": {"question": "How can you minimize data shuffling in Spark?"},
             "outputs": "actual response for second question",
             "expectations": {"expected_response": "expected response for second question"},
-            "retrieved_context": [],
         },
         # Some records might not have expectations
         {

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -106,31 +106,6 @@ def test_scorer_is_called_with_correct_arguments(sample_data):
         )
 
 
-def test_scorer_receives_extra_arguments():
-    received_args = []
-
-    @scorer
-    def dummy_scorer(inputs, outputs, retrieved_context) -> float:
-        received_args.append((inputs, outputs, retrieved_context))
-        return 0
-
-    mlflow.genai.evaluate(
-        data=[
-            {
-                "inputs": {"question": "What is Spark?"},
-                "outputs": "actual response for first question",
-                "retrieved_context": [{"doc_uri": "document_1", "content": "test"}],
-            },
-        ],
-        scorers=[dummy_scorer],
-    )
-
-    inputs, outputs, retrieved_context = received_args[0]
-    assert inputs == {"question": "What is Spark?"}
-    assert outputs == "actual response for first question"
-    assert retrieved_context == [{"doc_uri": "document_1", "content": "test"}]
-
-
 def test_trace_passed_correctly():
     @mlflow.trace
     def predict_fn(question):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15901?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15901/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15901/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15901/merge
```

</p>
</details>

### What changes are proposed in this pull request?

After some discussion, we decided not to allow passing extra kwargs to scorers. Scorer will only receive `inputs`, `outputs`, `expectations`, and `trace`. If any extra info is required for scoring, it needs to be passed as a part of these arguments, for example, retrieved context should be included in the trace.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
