### PR TITLE
Port trace parsing logic from harness

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -129,7 +129,10 @@ class Trace(_MlflowObject):
             return value
 
     def search_spans(
-        self, span_type: Optional[SpanType] = None, name: Optional[Union[str, re.Pattern]] = None
+        self,
+        span_type: Optional[SpanType] = None,
+        name: Optional[Union[str, re.Pattern]] = None,
+        span_id: Optional[str] = None,
     ) -> list[Span]:
         """
         Search for spans that match the given criteria within the trace.
@@ -137,6 +140,7 @@ class Trace(_MlflowObject):
         Args:
             span_type: The type of the span to search for.
             name: The name of the span to search for. This can be a string or a regular expression.
+            span_id: The ID of the span to search for.
 
         Returns:
             A list of spans that match the given criteria.
@@ -224,7 +228,17 @@ class Trace(_MlflowObject):
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 
-        return [span for span in self.data.spans if _match_name(span) and _match_type(span)]
+        def _match_id(span: Span) -> bool:
+            if span_id is None:
+                return True
+            else:
+                return span.span_id == span_id
+
+        return [
+            span
+            for span in self.data.spans
+            if _match_name(span) and _match_type(span) and _match_id(span)
+        ]
 
     @staticmethod
     def pandas_dataframe_columns() -> list[str]:

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -1,10 +1,14 @@
+import json
 import logging
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 from opentelemetry.trace import NoOpTracer
 
 import mlflow
+from mlflow.entities.span import Span, SpanType
+from mlflow.entities.trace import Trace
 from mlflow.genai.utils.data_validation import check_model_prediction
+from mlflow.tracing.utils import TraceJSONEncoder
 
 _logger = logging.getLogger(__name__)
 
@@ -54,3 +58,96 @@ class NoOpTracerPatcher:
 
     def __exit__(self, exc_type, exc_value, traceback):
         NoOpTracer.start_span = self.original
+
+
+def parse_inputs_to_str(inputs: Any) -> str:
+    """Parse the inputs to a request string compatible with the judges API"""
+    if isinstance(inputs, str):
+        return inputs
+
+    # If it is a single key dictionary, return the value
+    if isinstance(inputs, dict) and len(inputs) == 1:
+        if len(inputs) == 1:
+            return inputs[list(inputs.keys())[0]]
+
+    # Otherwise, encode the inputs to a JSON string
+    return json.dumps(inputs, default=TraceJSONEncoder)
+
+
+def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> Optional[dict[str, list]]:
+    """
+    Extract the retrieval context from the trace.
+    Only consider the last retrieval span in the trace if there are multiple retrieval spans.
+    If the trace does not have a retrieval span, return None.
+    ⚠️ Warning: Please make sure to not throw exception. If fails, return None.
+    """
+    if trace is None or trace.data is None:
+        return None
+
+    # Only consider the top-level retrieval spans
+    top_level_retrieval_spans = _get_top_level_retrieval_spans(trace)
+    if len(top_level_retrieval_spans) == 0:
+        return None
+
+    retrieved = {}  # span_id -> list of documents
+
+    for retrieval_span in top_level_retrieval_spans:
+        try:
+            contexts = [_parse_chunk(chunk) for chunk in retrieval_span.outputs or []]
+            retrieved[retrieval_span.span_id] = [c for c in contexts if c is not None]
+        except Exception as e:
+            _logger.debug(
+                f"Fail to get retrieval context from span: {retrieval_span}. Error: {e!r}"
+            )
+
+    return retrieved
+
+
+def _get_top_level_retrieval_spans(trace: Trace) -> list[Span]:
+    """
+    Get the top-level retrieval spans in the trace.
+    Top-level retrieval spans are retrieval spans that are not children of other retrieval spans.
+    For example, given the following spans:
+    - Span A (Chain)
+      - Span B (Retriever)
+        - Span C (Retriever)
+      - Span D (Retriever)
+        - Span E (LLM)
+          - Span F (Retriever)
+    Span B and Span D are top-level retrieval spans.
+    Span C and Span F are NOT top-level because they are children of other retrieval spans.
+    """
+    retrieval_spans = {
+        span.span_id: span for span in trace.search_spans(span_type=SpanType.RETRIEVER)
+    }
+
+    top_level_retrieval_spans = []
+
+    for span in retrieval_spans.values():
+        # Check if this span is a child of another retrieval span
+        parent_id = span.parent_id
+        while parent_id:
+            if parent_id in retrieval_spans:
+                # This span is a child of another retrieval span
+                break
+            parents = trace.search_spans(span_id=parent_id)
+            if len(parents) != 1:
+                # Malformed trace
+                break
+
+            parent_id = parents[0].parent_id
+        else:
+            # If the loop completes without breaking, this is a top-level span
+            top_level_retrieval_spans.append(span)
+
+    return top_level_retrieval_spans
+
+
+def _parse_chunk(chunk: Any) -> Optional[dict[str, Any]]:
+    if not isinstance(chunk, dict):
+        return None
+
+    doc = {"content": chunk.get("page_content")}
+    if doc_uri := chunk.get("metadata", {}).get("doc_uri"):
+        doc["doc_uri"] = doc_uri
+    return doc

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -67,8 +67,7 @@ def parse_inputs_to_str(inputs: Any) -> str:
 
     # If it is a single key dictionary, return the value
     if isinstance(inputs, dict) and len(inputs) == 1:
-        if len(inputs) == 1:
-            return inputs[list(inputs.keys())[0]]
+        return inputs[list(inputs.keys())[0]]
 
     # Otherwise, encode the inputs to a JSON string
     return json.dumps(inputs, default=TraceJSONEncoder)
@@ -133,6 +132,7 @@ def _get_top_level_retrieval_spans(trace: Trace) -> list[Span]:
             parents = trace.search_spans(span_id=parent_id)
             if len(parents) != 1:
                 # Malformed trace
+                _logger.debug(f"Malformed trace: span {span} has multiple parents: {parents}")
                 break
 
             parent_id = parents[0].parent_id

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -1,13 +1,20 @@
+import json
+from typing import Any
 from unittest import mock
 
 import httpx
 import openai
 import pytest
+from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 
 import mlflow
-from mlflow.genai.utils.trace_utils import convert_predict_fn
+from mlflow.entities.span import Span, SpanType
+from mlflow.entities.trace import Trace
+from mlflow.entities.trace_data import TraceData
+from mlflow.genai.utils.trace_utils import convert_predict_fn, extract_retrieval_context_from_trace
+from mlflow.tracing.utils import build_otel_context
 
-from tests.tracing.helper import get_traces, purge_traces
+from tests.tracing.helper import create_test_trace_info, get_traces, purge_traces
 
 
 def httpx_send_patch(request, *args, **kwargs):
@@ -99,3 +106,226 @@ def test_convert_predict_fn(predict_fn_generator, with_tracing):
 
     # Trace should be generated
     assert len(get_traces()) == 1
+
+
+def create_span(
+    span_id: int,
+    parent_id: int,
+    span_type: str,
+    inputs: dict[str, Any],
+    outputs: dict[str, Any],
+) -> Span:
+    otel_span = OTelReadableSpan(
+        name="test",
+        context=build_otel_context(123, span_id),
+        parent=build_otel_context(123, parent_id) if parent_id else None,
+        start_time=100,
+        end_time=200,
+        attributes={
+            "mlflow.spanInputs": json.dumps(inputs),
+            "mlflow.spanOutputs": json.dumps(outputs),
+            "mlflow.spanType": json.dumps(span_type),
+        },
+    )
+    return Span(otel_span)
+
+
+@pytest.mark.parametrize(
+    ("spans", "expected_retrieval_context"),
+    [
+        # multiple retrieval steps - only take the last top-level one
+        (
+            [
+                create_span(
+                    span_id=1,
+                    parent_id=None,  # root span
+                    inputs="question",
+                    outputs={"generations": [[{"text": "some text"}]]},
+                    span_type=SpanType.LLM,
+                ),
+                create_span(
+                    span_id=2,
+                    parent_id=1,
+                    inputs="What is the capital of France?",
+                    outputs=[
+                        {
+                            "page_content": "document content 3",
+                            "metadata": {
+                                "doc_uri": "uri3",
+                                "chunk_id": "3",
+                            },
+                            "type": "Document",
+                        },
+                    ],
+                    span_type=SpanType.RETRIEVER,
+                ),
+                create_span(
+                    span_id=3,
+                    parent_id=1,
+                    inputs="What is the capital of France?",
+                    outputs=[
+                        {
+                            "page_content": "document content 1",
+                            "metadata": {
+                                "doc_uri": "uri1",
+                                "chunk_id": "1",
+                            },
+                            "type": "Document",
+                        },
+                        {
+                            "page_content": "document content 2",
+                            "metadata": {
+                                "doc_uri": "uri2",
+                                "chunk_id": "2",
+                            },
+                            "type": "Document",
+                        },
+                    ],
+                    span_type=SpanType.RETRIEVER,
+                ),
+                create_span(
+                    span_id=4,
+                    parent_id=3,
+                    inputs="This should be ignored because it's not a top-level retrieval span",
+                    outputs=[
+                        {
+                            "page_content": "document content 4",
+                            "metadata": {
+                                "doc_uri": "uri4",
+                                "chunk_id": "4",
+                            },
+                            "type": "Document",
+                        },
+                    ],
+                    span_type=SpanType.RETRIEVER,
+                ),
+            ],
+            {
+                "0000000000000002": [
+                    {
+                        "doc_uri": "uri3",
+                        "content": "document content 3",
+                    },
+                ],
+                "0000000000000003": [
+                    {
+                        "doc_uri": "uri1",
+                        "content": "document content 1",
+                    },
+                    {
+                        "doc_uri": "uri2",
+                        "content": "document content 2",
+                    },
+                ],
+            },
+        ),
+        # one retrieval step
+        (
+            [
+                create_span(
+                    span_id=1,
+                    parent_id=None,
+                    inputs="What is the capital of France?",
+                    outputs=[
+                        {
+                            "page_content": "document content 1",
+                            "metadata": {
+                                "doc_uri": "uri1",
+                                "chunk_id": "1",
+                            },
+                            "type": "Document",
+                        },
+                        # missing doc_uri
+                        {
+                            "page_content": "document content 2",
+                            "metadata": {
+                                "chunk_id": "2",
+                            },
+                            "type": "Document",
+                        },
+                        # missing content
+                        {
+                            "metadata": {
+                                "doc_uri": "uri3",
+                                "chunk_id": "3",
+                            },
+                            "type": "Document",
+                        },
+                        # missing metadata
+                        {
+                            "page_content": "document content 4",
+                            "type": "Document",
+                        },
+                    ],
+                    span_type=SpanType.RETRIEVER,
+                ),
+            ],
+            {
+                "0000000000000001": [
+                    {
+                        "doc_uri": "uri1",
+                        "content": "document content 1",
+                    },
+                    {
+                        "content": "document content 2",
+                    },
+                    {
+                        "content": None,
+                        "doc_uri": "uri3",
+                    },
+                    {
+                        "content": "document content 4",
+                    },
+                ],
+            },
+        ),
+        # one retrieval step - empty retrieval span outputs
+        (
+            [
+                create_span(
+                    span_id=1,
+                    parent_id=None,
+                    inputs="What is the capital of France?",
+                    outputs=[],
+                    span_type=SpanType.RETRIEVER,
+                ),
+            ],
+            {"0000000000000001": []},
+        ),
+        # one retrieval step - wrong format retrieval span outputs
+        (
+            [
+                create_span(
+                    span_id=1,
+                    parent_id=None,
+                    inputs="What is the capital of France?",
+                    outputs=["wrong output", "should be ignored"],
+                    span_type=SpanType.RETRIEVER,
+                ),
+            ],
+            {"0000000000000001": []},
+        ),
+        # no retrieval steps
+        (
+            [
+                create_span(
+                    span_id=1,
+                    parent_id=None,
+                    inputs="What is the capital of France?",
+                    outputs=[{"text": "some text"}],
+                    span_type=SpanType.LLM,
+                ),
+            ],
+            None,
+        ),
+        # None trace
+        (
+            None,
+            None,
+        ),
+    ],
+)
+def test_get_retrieval_context_from_trace(spans, expected_retrieval_context):
+    """Test traces.extract_retrieval_context_from_trace."""
+    trace = Trace(info=create_test_trace_info(trace_id="tr-123"), data=TraceData(spans=spans))
+    assert extract_retrieval_context_from_trace(trace) == expected_retrieval_context


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15902?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15902/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15902/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15902/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Porting retrieval context extraction logic from agent eval SDK to MLflow. This is a prep for incoming changes of scorer update. The logic extracts retrieved documents from a single trace, by looking for retriever span.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
