### PR TITLE
Update `__call__` method of built-in scorers to parse traces.

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -454,16 +454,15 @@ class GuidelineAdherence(_BaseBuiltInScorer):
         from databricks.agents.evals import judges
 
         request = parse_inputs_to_str(inputs)
-        response = outputs
         guidelines = (expectations or {}).get("guidelines", self.global_guidelines)
         if not guidelines:
             raise MlflowException(
                 "Guidelines must be specified either in the `expectations` parameter or "
-                "by the :py:meth:`with_config` method of the scorer."
+                "by the `with_config` method of the scorer."
             )
 
         return judges.guideline_adherence(
-            request=request, response=response, guidelines=guidelines, assessment_name=self.name
+            request=request, response=outputs, guidelines=guidelines, assessment_name=self.name
         )
 
     def with_config(
@@ -557,9 +556,8 @@ class RelevanceToQuery(_BaseBuiltInScorer):
         from databricks.agents.evals import judges
 
         request = parse_inputs_to_str(inputs)
-        response = outputs
         return judges.relevance_to_query(
-            request=request, response=response, assessment_name=self.name
+            request=request, response=outputs, assessment_name=self.name
         )
 
     def with_config(self, *, name: str = "relevance_to_query") -> "RelevanceToQuery":
@@ -630,8 +628,7 @@ class Safety(_BaseBuiltInScorer):
         from databricks.agents.evals import judges
 
         request = parse_inputs_to_str(inputs)
-        response = outputs
-        return judges.safety(request=request, response=response, assessment_name=self.name)
+        return judges.safety(request=request, response=outputs, assessment_name=self.name)
 
     def with_config(self, *, name: str = "safety") -> "Safety":
         """
@@ -737,7 +734,6 @@ class Correctness(_BaseBuiltInScorer):
         from databricks.agents.evals import judges
 
         request = parse_inputs_to_str(inputs)
-        response = outputs
         expected_facts = expectations.get("expected_facts")
         expected_response = expectations.get("expected_response")
 
@@ -749,7 +745,7 @@ class Correctness(_BaseBuiltInScorer):
 
         return judges.correctness(
             request=request,
-            response=response,
+            response=outputs,
             expected_response=expected_response,
             expected_facts=expected_facts,
             assessment_name=self.name,

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1,10 +1,13 @@
 from abc import abstractmethod
 from copy import deepcopy
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from mlflow.entities import Assessment
+from mlflow.entities.assessment import Feedback
+from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import BuiltInScorer
+from mlflow.genai.utils.trace_utils import extract_retrieval_context_from_trace, parse_inputs_to_str
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.utils.annotations import experimental
 
@@ -28,30 +31,6 @@ class _BaseBuiltInScorer(BuiltInScorer):
             "get a new instance with the custom field values.",
             error_code=BAD_REQUEST,
         )
-
-    def __call__(self, **kwargs):
-        try:
-            from databricks.agents.evals import judges
-        except ImportError:
-            raise ImportError(
-                "databricks-agents is not installed. Please install it with "
-                "`pip install databricks-agents`"
-            )
-
-        if self.name and self.name in set(dir(judges)):
-            import pandas as pd
-
-            from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
-
-            converted_kwargs = _convert_to_legacy_eval_set(pd.DataFrame([kwargs])).iloc[0].to_dict()
-            return getattr(judges, self.name)(**converted_kwargs)
-        elif self.name:
-            raise ValueError(
-                f"The scorer '{self.name}' doesn't currently have a usable implementation in the "
-                "databricks-agents package."
-            )
-        else:
-            raise ValueError("This scorer isn't recognized since it doesn't have a name.")
 
     @abstractmethod
     def with_config(self, **kwargs) -> "_BaseBuiltInScorer":
@@ -94,14 +73,9 @@ class ChunkRelevance(_BaseBuiltInScorer):
         import mlflow
         from mlflow.genai.scorers import chunk_relevance
 
-        assessment = chunk_relevance(
-            inputs={"question": "What is the capital of France?"},
-            retrieved_context=[
-                {"content": "Paris is the capital city of France."},
-                {"content": "The chicken crossed the road."},
-            ],
-        )
-        print(assessment)
+        trace = mlflow.get_trace("<your-trace-id>")
+        feedback = chunk_relevance(trace)
+        print(feedback)
 
     Example (with evaluate):
 
@@ -109,44 +83,36 @@ class ChunkRelevance(_BaseBuiltInScorer):
 
         import mlflow
 
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "retrieved_context": [
-                    {"content": "Paris is the capital city of France."},
-                    {"content": "The chicken crossed the road."},
-                ],
-            }
-        ]
+        data = mlflow.search_traces(...)
         result = mlflow.genai.evaluate(data=data, scorers=[chunk_relevance])
     """
 
     name: str = "chunk_relevance"
-    required_columns: set[str] = {"inputs", "retrieved_context"}
+    required_columns: set[str] = {"inputs", "trace"}
 
-    def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> list[Assessment]:
+    def __call__(self, *, trace: Trace) -> list[Feedback]:
         """
         Evaluate chunk relevance for each context chunk.
 
         Args:
-            inputs: The input data.
-            retrieved_context: The retrieved context.
+            trace: The trace of the model's execution. Must contains at least one span with
+                type `RETRIEVER`. MLflow will extract the retrieved context from that span.
+                If multiple spans are found, MLflow will use the **last** one.
 
         Returns:
             A list of assessments evaluating the relevance of each context chunk.
-
-        Example:
-
-        .. code-block:: python
-
-            from mlflow.genai.scorers import chunk_relevance
-
-            assessments = chunk_relevance(
-                inputs={"question": "What is the capital of France?"},
-                retrieved_context=[{"content": "Paris is the capital city of France."}],
-            )
         """
-        return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
+        from databricks.agents.evals import judges
+
+        request = parse_inputs_to_str(trace.data.spans[0].inputs)
+        span_id_to_context = extract_retrieval_context_from_trace(trace)
+        # NB: Only pass contexts from the last retriever span for now. This is the same
+        # behavior as the current judge implementation. TODO: Update this to the new
+        # behavior requested by eval team that consider all retriever spans.
+        retrieved_context = list(span_id_to_context.values())[-1]
+        return judges.chunk_relevance(
+            request=request, retrieved_context=retrieved_context, assessment_name=self.name
+        )
 
     def with_config(self, *, name: str = "chunk_relevance") -> "ChunkRelevance":
         """
@@ -177,11 +143,9 @@ class ContextSufficiency(_BaseBuiltInScorer):
         import mlflow
         from mlflow.genai.scorers import context_sufficiency
 
-        assessment = context_sufficiency(
-            inputs={"question": "What is the capital of France?"},
-            retrieved_context=[{"content": "Paris is the capital city of France."}],
-        )
-        print(assessment)
+        trace = mlflow.get_trace("<your-trace-id>")
+        feedback = context_sufficiency(trace)
+        print(feedback)
 
     Example (with evaluate):
 
@@ -189,21 +153,59 @@ class ContextSufficiency(_BaseBuiltInScorer):
 
         import mlflow
 
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "retrieved_context": [{"content": "Paris is the capital city of France."}],
-            }
-        ]
+        data = mlflow.search_traces(...)
         result = mlflow.genai.evaluate(data=data, scorers=[context_sufficiency])
     """
 
     name: str = "context_sufficiency"
-    required_columns: set[str] = {"inputs", "retrieved_context", "expectations/expected_response"}
+    required_columns: set[str] = {"inputs", "trace"}
 
-    def __call__(self, *, inputs: Any, retrieved_context: list[dict[str, Any]]) -> Assessment:
-        """Evaluate context sufficiency based on retrieved documents."""
-        return super().__call__(inputs=inputs, retrieved_context=retrieved_context)
+    def validate_columns(self, columns: set[str]) -> None:
+        super().validate_columns(columns)
+        if (
+            "expectations/expected_response" not in columns
+            and "expectations/expected_facts" not in columns
+        ):
+            raise MissingColumnsException(
+                self.name, ["expectations/expected_response or expectations/expected_facts"]
+            )
+
+    def __call__(self, *, trace: Trace) -> Feedback:
+        """
+        Evaluate context sufficiency based on retrieved documents.
+
+        Args:
+            trace: The trace of the model's execution. Must contains at least one span with
+                type `RETRIEVER`. MLflow will extract the retrieved context from that span.
+                If multiple spans are found, MLflow will use the **last** one.
+                Optionally, you can annotate the trace with `expected_facts` or `expected_response`
+                label(s) by calling :py:func:`mlflow.log_expectation` API. The annotated label(s)
+                will be considered when computing the sufficiency of retrieved context.
+        """
+        from databricks.agents.evals import judges
+
+        request = parse_inputs_to_str(trace.data.spans[0].inputs)
+        span_id_to_context = extract_retrieval_context_from_trace(trace)
+        # NB: Only pass contexts from the last retriever span for now. This is the same
+        # behavior as the current judge implementation. TODO: Update this to the new
+        # behavior requested by eval team that consider all retriever spans.
+        retrieved_context = list(span_id_to_context.values())[-1]
+
+        expected_facts = None
+        expected_response = None
+        for assessment in trace.info.assessments:
+            if assessment.name == "expected_facts":
+                expected_facts = assessment.value
+            if assessment.name == "expected_response":
+                expected_response = assessment.value
+
+        return judges.context_sufficiency(
+            request=request,
+            retrieved_context=retrieved_context,
+            expected_response=expected_response,
+            expected_facts=expected_facts,
+            assessment_name=self.name,
+        )
 
     def with_config(self, *, name: str = "context_sufficiency") -> "ContextSufficiency":
         """
@@ -234,12 +236,9 @@ class Groundedness(_BaseBuiltInScorer):
         import mlflow
         from mlflow.genai.scorers import groundedness
 
-        assessment = groundedness(
-            inputs={"question": "What is the capital of France?"},
-            outputs="The capital of France is Paris.",
-            retrieved_context=[{"content": "Paris is the capital city of France."}],
-        )
-        print(assessment)
+        trace = mlflow.get_trace("<your-trace-id>")
+        feedback = groundedness(trace)
+        print(feedback)
 
     Example (with evaluate):
 
@@ -247,24 +246,41 @@ class Groundedness(_BaseBuiltInScorer):
 
         import mlflow
 
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "outputs": "The capital of France is Paris.",
-                "retrieved_context": [{"content": "Paris is the capital city of France."}],
-            }
-        ]
+        data = mlflow.search_traces(...)
         result = mlflow.genai.evaluate(data=data, scorers=[groundedness])
     """
 
     name: str = "groundedness"
-    required_columns: set[str] = {"inputs", "outputs", "retrieved_context"}
+    required_columns: set[str] = {"inputs", "trace"}
 
-    def __call__(
-        self, *, inputs: Any, outputs: Any, retrieved_context: list[dict[str, Any]]
-    ) -> Assessment:
-        """Evaluate groundedness of response against context."""
-        return super().__call__(inputs=inputs, outputs=outputs, retrieved_context=retrieved_context)
+    def __call__(self, *, trace: Trace) -> Feedback:
+        """
+        Evaluate groundedness of response against retrieved context.
+
+        Args:
+            trace: The trace of the model's execution. Must contains at least one span with
+                type `RETRIEVER`. MLflow will extract the retrieved context from that span.
+                If multiple spans are found, MLflow will use the **last** one.
+
+        Returns:
+            An :py:class:`mlflow.entities.assessment.Feedback~` object with a boolean value
+            indicating the groundedness of the response.
+        """
+        from databricks.agents.evals import judges
+
+        request = parse_inputs_to_str(trace.data.spans[0].inputs)
+        response = trace.data.spans[0].outputs
+        span_id_to_context = extract_retrieval_context_from_trace(trace)
+        # NB: Only pass contexts from the last retriever span for now. This is the same
+        # behavior as the current judge implementation. TODO: Update this to the new
+        # behavior requested by eval team that consider all retriever spans.
+        retrieved_context = list(span_id_to_context.values())[-1]
+        return judges.groundedness(
+            request=request,
+            response=response,
+            retrieved_context=retrieved_context,
+            assessment_name=self.name,
+        )
 
     def with_config(self, *, name: str = "groundedness") -> "Groundedness":
         """
@@ -310,11 +326,11 @@ class GuidelineAdherence(_BaseBuiltInScorer):
             name="english_guidelines",
             global_guidelines=["The response must be in English"],
         )
-        assessment = english(
+        feedback = english(
             inputs={"question": "What is the capital of France?"},
             outputs="The capital of France is Paris.",
         )
-        print(assessment)
+        print(feedback)
 
     Example (with evaluate):
 
@@ -385,7 +401,7 @@ class GuidelineAdherence(_BaseBuiltInScorer):
     """
 
     name: str = "guideline_adherence"
-    global_guidelines: Optional[list[str]] = None
+    global_guidelines: Optional[Union[str, list[str]]] = None
     required_columns: set[str] = {"inputs", "outputs"}
 
     def update_evaluation_config(self, evaluation_config) -> dict:
@@ -416,17 +432,38 @@ class GuidelineAdherence(_BaseBuiltInScorer):
     def __call__(
         self,
         *,
-        inputs: Any,
+        inputs: dict[str, Any],
         outputs: Any,
-        guidelines: dict[str, list[str]],
-        guidelines_context: dict[str, Any],
+        expectations: Optional[dict[str, Any]] = None,
     ) -> Assessment:
-        """Evaluate adherence to specified guidelines."""
-        return super().__call__(
-            inputs=inputs,
-            outputs=outputs,
-            guidelines=guidelines,
-            guidelines_context=guidelines_context,
+        """
+        Evaluate adherence to specified guidelines.
+
+        Args:
+            inputs: A dictionary of input data, e.g. {"question": "What is the capital of France?"}.
+            outputs: The response from the model, e.g. "The capital of France is Paris."
+            expectations: A dictionary of expectations for the response. This must contain either
+                `guidelines` key, which is used to evaluate the response against the guidelines
+                specified in the `guidelines` field of the `expectations` column of the dataset.
+                E.g., {"guidelines": ["The response must be factual and concise"]}
+
+        Returns:
+            An :py:class:`mlflow.entities.assessment.Assessment~` object with a boolean value
+            indicating the adherence to the specified guidelines.
+        """
+        from databricks.agents.evals import judges
+
+        request = parse_inputs_to_str(inputs)
+        response = outputs
+        guidelines = (expectations or {}).get("guidelines", self.global_guidelines)
+        if not guidelines:
+            raise MlflowException(
+                "Guidelines must be specified either in the `expectations` parameter or "
+                "by the :py:meth:`with_config` method of the scorer."
+            )
+
+        return judges.guideline_adherence(
+            request=request, response=response, guidelines=guidelines, assessment_name=self.name
         )
 
     def with_config(
@@ -505,9 +542,25 @@ class RelevanceToQuery(_BaseBuiltInScorer):
     name: str = "relevance_to_query"
     required_columns: set[str] = {"inputs", "outputs"}
 
-    def __call__(self, *, inputs: Any, outputs: Any) -> Assessment:
-        """Evaluate relevance to the user's query."""
-        return super().__call__(inputs=inputs, outputs=outputs)
+    def __call__(self, *, inputs: dict[str, Any], outputs: Any) -> Feedback:
+        """
+        Evaluate relevance to the user's query.
+
+        Args:
+            inputs: A dictionary of input data, e.g. {"question": "What is the capital of France?"}.
+            outputs: The response from the model, e.g. "The capital of France is Paris."
+
+        Returns:
+            An :py:class:`mlflow.entities.assessment.Feedback~` object with a boolean value
+            indicating the relevance of the response to the query.
+        """
+        from databricks.agents.evals import judges
+
+        request = parse_inputs_to_str(inputs)
+        response = outputs
+        return judges.relevance_to_query(
+            request=request, response=response, assessment_name=self.name
+        )
 
     def with_config(self, *, name: str = "relevance_to_query") -> "RelevanceToQuery":
         """
@@ -562,9 +615,23 @@ class Safety(_BaseBuiltInScorer):
     name: str = "safety"
     required_columns: set[str] = {"inputs", "outputs"}
 
-    def __call__(self, *, inputs: Any, outputs: Any) -> Assessment:
-        """Evaluate safety of the response."""
-        return super().__call__(inputs=inputs, outputs=outputs)
+    def __call__(self, *, inputs: dict[str, Any], outputs: Any) -> Feedback:
+        """
+        Evaluate safety of the response.
+
+        Args:
+            inputs: A dictionary of input data, e.g. {"question": "What is the capital of France?"}.
+            outputs: The response from the model, e.g. "The capital of France is Paris."
+
+        Returns:
+            An :py:class:`mlflow.entities.assessment.Feedback~` object with a boolean value
+            indicating the safety of the response.
+        """
+        from databricks.agents.evals import judges
+
+        request = parse_inputs_to_str(inputs)
+        response = outputs
+        return judges.safety(request=request, response=response, assessment_name=self.name)
 
     def with_config(self, *, name: str = "safety") -> "Safety":
         """
@@ -649,9 +716,44 @@ class Correctness(_BaseBuiltInScorer):
                 self.name, ["expectations/expected_response or expectations/expected_facts"]
             )
 
-    def __call__(self, *, inputs: Any, outputs: Any, expectations: list[str]) -> Assessment:
-        """Evaluate correctness of the response against expectations."""
-        return super().__call__(inputs=inputs, outputs=outputs, expectations=expectations)
+    def __call__(
+        self, *, inputs: dict[str, Any], outputs: Any, expectations: dict[str, Any]
+    ) -> Feedback:
+        """
+        Evaluate correctness of the response against expectations.
+
+        Args:
+            inputs: A dictionary of input data, e.g. {"question": "What is the capital of France?"}.
+            outputs: The response from the model, e.g. "The capital of France is Paris."
+            expectations: A dictionary of expectations for the response. This must contain either
+                `expected_response` or `expected_facts` key, which is used to evaluate the response
+                against the expected response or facts respectively.
+                E.g., {"expected_facts": ["Paris", "France", "Capital"]}
+
+        Returns:
+            An :py:class:`mlflow.entities.assessment.Feedback~` object with a boolean value
+            indicating the correctness of the response.
+        """
+        from databricks.agents.evals import judges
+
+        request = parse_inputs_to_str(inputs)
+        response = outputs
+        expected_facts = expectations.get("expected_facts")
+        expected_response = expectations.get("expected_response")
+
+        if expected_response is None and expected_facts is None:
+            raise MlflowException(
+                "Correctness scorer requires either `expected_response` or `expected_facts` "
+                "in the `expectations` dictionary."
+            )
+
+        return judges.correctness(
+            request=request,
+            response=response,
+            expected_response=expected_response,
+            expected_facts=expected_facts,
+            assessment_name=self.name,
+        )
 
     def with_config(self, *, name: str = "correctness") -> "Correctness":
         """
@@ -664,9 +766,9 @@ class Correctness(_BaseBuiltInScorer):
 
 
 # === Shorthand for getting builtin scorer instances ===
+groundedness = Groundedness()
 chunk_relevance = ChunkRelevance()
 context_sufficiency = ContextSufficiency()
-groundedness = Groundedness()
 guideline_adherence = GuidelineAdherence()
 relevance_to_query = RelevanceToQuery()
 safety = Safety()
@@ -687,15 +789,7 @@ def get_rag_scorers() -> list[BuiltInScorer]:
         import mlflow
         from mlflow.genai.scorers import get_rag_scorers
 
-        data = [
-            {
-                "inputs": {"question": "What is the capital of France?"},
-                "outputs": "The capital of France is Paris.",
-                "retrieved_context": [
-                    {"content": "Paris is the capital city of France."},
-                ],
-            }
-        ]
+        data = mlflow.search_traces(...)
         result = mlflow.genai.evaluate(data=data, scorers=get_rag_scorers())
     """
     return [
@@ -722,8 +816,8 @@ def get_all_scorers() -> list[BuiltInScorer]:
             {
                 "inputs": {"question": "What is the capital of France?"},
                 "outputs": "The capital of France is Paris.",
-                "retrieved_context": [
-                    {"content": "Paris is the capital city of France."},
+                "expectations": [
+                    {"expected_response": "Paris is the capital city of France."},
                 ],
             }
         ]

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -99,7 +99,7 @@ def valid_data_for_builtin_scorers(
         # Inputs and outputs are inferred from the trace.
         input_columns |= {"inputs", "outputs"}
 
-    if predict_fn is not None or "trace" in input_columns:
+    if predict_fn is not None:
         input_columns |= {"trace"}
 
     # Explode keys in the "expectations" column for easier processing.

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -100,12 +100,7 @@ def valid_data_for_builtin_scorers(
         input_columns |= {"inputs", "outputs"}
 
     if predict_fn is not None or "trace" in input_columns:
-        # NB: The retrieved_context is only inferred when a trace contains a retriever span,
-        #     however, it is not impractical to check all traces and see if any of them
-        #     contains a retriever span (it is valid case that some trace misses a retriever
-        #     span). Therefore, we don't rigorously check the retrieved_context presence for
-        #     traces and let scorers handle the missing retrieved_context gracefully.
-        input_columns |= {"retrieved_context"}
+        input_columns |= {"trace"}
 
     # Explode keys in the "expectations" column for easier processing.
     if "expectations" in input_columns:

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -2,6 +2,11 @@ from unittest import mock
 
 import pytest
 
+import mlflow
+from mlflow.entities.assessment import Expectation
+from mlflow.entities.document import Document
+from mlflow.entities.span import SpanType
+
 
 @pytest.fixture(autouse=True)
 def mock_init_auth():
@@ -20,3 +25,38 @@ def spoof_tracking_uri_check():
     # we spoof the check by patching the is_databricks_uri() function.
     with mock.patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True):
         yield
+
+
+@pytest.fixture
+def sample_rag_trace():
+    @mlflow.trace(span_type=SpanType.AGENT)
+    def _predict(question):
+        _retrieve(question)
+        return "answer"
+
+    @mlflow.trace(span_type=SpanType.RETRIEVER)
+    def _retrieve(question):
+        return [
+            Document(
+                page_content="content_1",
+                metadata={"doc_uri": "url_1"},
+            ),
+            Document(
+                page_content="content_2",
+                metadata={"doc_uri": "url_2"},
+            ),
+            Document(page_content="content_3"),
+        ]
+
+    _predict("query")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    # Add expectations. Directly append to the trace info because OSS backend doesn't
+    # support assessment logging yet.
+    trace.info.assessments = [
+        Expectation(name="expected_response", value="expected answer"),
+        Expectation(name="expected_facts", value=["fact1", "fact2"]),
+        Expectation(name="guidelines", value=["write in english"]),
+    ]
+    return trace

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -62,12 +62,12 @@ def test_validate_scorers_legacy_metric():
     assert "legacy_metric_1" in mock_logger.warning.call_args[0][0]
 
 
-def test_validate_data(mock_logger):
+def test_validate_data(mock_logger, sample_rag_trace):
     data = pd.DataFrame(
         {
             "inputs": [{"question": "input1"}, {"question": "input2"}],
             "outputs": ["output1", "output2"],
-            "retrieved_context": [{"context": "context1"}, {"context": "context2"}],
+            "trace": [sample_rag_trace, sample_rag_trace],
         }
     )
 
@@ -83,13 +83,13 @@ def test_validate_data(mock_logger):
     mock_logger.info.assert_not_called()
 
 
-def test_validate_data_with_expectations(mock_logger):
+def test_validate_data_with_expectations(mock_logger, sample_rag_trace):
     """Test that expectations are unwrapped and validated properly"""
     data = pd.DataFrame(
         {
             "inputs": [{"question": "input1"}, {"question": "input2"}],
             "outputs": ["output1", "output2"],
-            "retrieved_context": ["context1", "context2"],
+            "trace": [sample_rag_trace, sample_rag_trace],
             "expectations": [
                 {"expected_response": "response1", "guidelines": ["Be polite", "Be kind"]},
                 {"expected_response": "response2", "guidelines": ["Be nice", "Be strong"]},
@@ -176,8 +176,8 @@ def test_validate_data_missing_columns(mock_logger):
 
     mock_logger.info.assert_called_once()
     msg = mock_logger.info.call_args[0][0]
-    assert " - `outputs` column is required by [groundedness, guideline_adherence]." in msg
-    assert " - `retrieved_context` column is required by [chunk_relevance, groundedness]." in msg
+    assert " - `outputs` column is required by [guideline_adherence]." in msg
+    assert " - `trace` column is required by [chunk_relevance, groundedness]." in msg
 
 
 def test_validate_data_with_trace(mock_logger):

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -202,22 +202,6 @@ def test_scorer_returns_feedback_with_error(sample_data):
     assert all("metric/dummy_scorer" not in metric for metric in results.metrics.keys())
 
 
-def test_builtin_scorers_are_callable():
-    from mlflow.genai.scorers import safety
-
-    # test with new scorer signature format
-    with patch("databricks.agents.evals.judges.safety") as mock_safety:
-        safety(
-            inputs={"question": "What is the capital of France?"},
-            outputs="The capital of France is Paris.",
-        )
-
-        mock_safety.assert_called_once_with(
-            request={"question": "What is the capital of France?"},
-            response="The capital of France is Paris.",
-        )
-
-
 @pytest.mark.parametrize(
     ("scorer_return", "expected_feedback_name"),
     [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15905?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15905/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15905/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15905/merge
```

</p>
</details>

### Related Issues/PRs

This PR depends on https://github.com/mlflow/mlflow/pull/15901 and https://github.com/mlflow/mlflow/pull/15902

### What changes are proposed in this pull request?

Each built-in scorer should implement `__call__` method so that users can invoke them directly for debugging. Currently, the `__call__` logic assumes users would pass in kwargs like `retrieved_context`, which is no longer supported after https://github.com/mlflow/mlflow/pull/15901.

```
# No longer supported
groundedess(inputs=..., outputs=..., retrieved_context=...)

# New supported way
groundedess(trace=...)
```

The `__call__` method invokes Databricks judges, which has signature like `groundedness(request, response, retrieved_context, expected_facts).` Therefore, buildin scorers need to parse inputs, outputs, expectations, trace. This PR updates the `__call__` method to do that.

Also, current implementation assumes the scorer name is always equal to the judge, which is not the case soon.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
