### PR TITLE
Add support for multiple messages via chat/completions for AI Gateway with a mlflow-model-serving provider 

### DIFF
--- a/tests/gateway/providers/test_mlflow.py
+++ b/tests/gateway/providers/test_mlflow.py
@@ -288,7 +288,7 @@ async def test_chat():
         mock_client.post.assert_called_once_with(
             "http://127.0.0.1:4000/invocations",
             json={
-                "inputs": ["Is this a test?"],
+                "inputs": ["[USER]\nIs this a test?\n\n"],
                 "params": {"temperature": 0.0, "n": 1},
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
@@ -296,23 +296,58 @@ async def test_chat():
 
 
 @pytest.mark.asyncio
-async def test_chat_exception_raised_for_multiple_elements_in_query():
-    resp = {"predictions": "It is a test"}
+async def test_chat_for_multiple_elements_in_query():
+    resp = {
+        "predictions": ["Hello, it is a test"],
+        "headers": {"Content-Type": "application/json"},
+    }
     config = chat_config()
     mock_client = mock_http_client(MockAsyncResponse(resp))
 
-    with mock.patch("aiohttp.ClientSession", return_value=mock_client):
+    with (
+        mock.patch("time.time", return_value=1700242674),
+        mock.patch("aiohttp.ClientSession", return_value=mock_client) as mock_build_client,
+    ):
         provider = MlflowModelServingProvider(RouteConfig(**config))
         payload = {
             "messages": [
+                {"role": "user", "content": "Hi!"},
                 {"role": "user", "content": "Is this a test?"},
-                {"role": "user", "content": "This is a second message."},
             ]
         }
-
-        with pytest.raises(AIGatewayException, match=r".*") as e:
-            await provider.chat(chat.RequestPayload(**payload))
-        assert "MLflow chat models are only capable of processing" in e.value.detail
+        response = await provider.chat(chat.RequestPayload(**payload))
+        assert jsonable_encoder(response) == {
+            "id": None,
+            "created": 1700242674,
+            "object": "chat.completion",
+            "model": "chat-bot-9000",
+            "choices": [
+                {
+                    "message": {
+                        "role": "assistant",
+                        "content": "Hello, it is a test",
+                        "tool_calls": None,
+                        "refusal": None,
+                    },
+                    "finish_reason": None,
+                    "index": 0,
+                }
+            ],
+            "usage": {
+                "prompt_tokens": None,
+                "completion_tokens": None,
+                "total_tokens": None,
+            },
+        }
+        mock_build_client.assert_called_once()
+        mock_client.post.assert_called_once_with(
+            "http://127.0.0.1:4000/invocations",
+            json={
+                "inputs": ["[USER]\nHi!\n\n[USER]\nIs this a test?\n\n"],
+                "params": {"temperature": 0.0, "n": 1},
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
 
 
 def test_route_construction_fails_with_invalid_config():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jmho/mlflow/pull/15912?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15912/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15912/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15912/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Currently, if one is using an `mlflow-model-serving` provider proxied with an ai gateway for the `chat/completions` endpoint, a developer is only allowed to send a chat completions request with one message in the `messages` field at a time. This behavior breaks compatibility with the OpenAI API spec and as a result, adds a pretty significant limitation for the `ml-flow-model-serving` provider that is not apparent in any of the other providers.

This PR adds support for multiple messages to be sent to an AI Gateway through the `chat/completions` endpoint given an `mlflow-model-serving` provider. This is done using a serialization step in the `chat` endpoint. An example of this is as follows:

Requests that are sent to the AI Gateway that look like:
```
ChatCompletionsRequest(
   messages = [
      {"role": "User", "content": "Hello"},
      {"role": "User", "content": "World"},
   ],
   ...
) 
```

Would be converted and sent to `invocations/` as follows:
```
InvocationRequest(
      "inputs": ["[USER]\nHello\n\n[USER]\nWorld\n\n"],
      "params": [...],
)
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
- [ ] Examples
- [ ] API references
- [ ] Instructions

*(Technically the limitation with AI gateway and the `mlflow-model-serving` provider above is not mentioned in the docs as far as I'm aware, so if this behavior is accepted the docs need not change. Otherwise, an additional blurb should be added noting this limitation)*

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add support for multiple messages to be sent to the `chat/completions` endpoint for AI Gateway with a `mlflow-model-serving` provider.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
