### PR TITLE
Add client_request_id param to update_current_trace

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -951,7 +951,7 @@ def update_current_trace(
     with InMemoryTraceManager.get_instance().get_trace(request_id) as trace:
         trace.info.tags.update(tags or {})
         if client_request_id is not None:
-            trace.info.client_request_id = client_request_id
+            trace.info.client_request_id = str(client_request_id)
 
 
 @request_id_backward_compatible

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -914,10 +914,10 @@ def update_current_trace(
             mlflow.update_current_trace(tags={"fruit": "apple"}, client_request_id="req-12345")
 
     Args:
-        tags: A dictionary of tags to set on the trace.
+        tags: A dictionary of tags to set on the trace. If None, no tags are updated.
         client_request_id: Client supplied request ID to associate with the trace. This is
             useful for linking the trace back to a specific request in your application or
-            external system.
+            external system. If None, the client request ID is not updated.
 
     """
     active_span = get_current_active_span()

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -888,9 +888,10 @@ def _set_last_active_trace_id(trace_id: str):
 
 def update_current_trace(
     tags: Optional[dict[str, str]] = None,
+    client_request_id: Optional[str] = None,
 ):
     """
-    Update the current active trace with the given tags.
+    Update the current active trace with the given tags and client request ID.
 
     You can use this function either within a function decorated with `@mlflow.trace` or within the
     scope of the `with mlflow.start_span` context manager. If there is no active trace found, this
@@ -902,7 +903,7 @@ def update_current_trace(
 
         @mlflow.trace
         def my_func(x):
-            mlflow.update_current_trace(tags={"fruit": "apple"})
+            mlflow.update_current_trace(tags={"fruit": "apple"}, client_request_id="req-12345")
             return x + 1
 
     Using within the `with mlflow.start_span` context manager:
@@ -910,7 +911,13 @@ def update_current_trace(
     .. code-block:: python
 
         with mlflow.start_span("span"):
-            mlflow.update_current_trace(tags={"fruit": "apple"})
+            mlflow.update_current_trace(tags={"fruit": "apple"}, client_request_id="req-12345")
+
+    Args:
+        tags: A dictionary of tags to set on the trace.
+        client_request_id: Client supplied request ID to associate with the trace. This is
+            useful for linking the trace back to a specific request in your application or
+            external system.
 
     """
     active_span = get_current_active_span()
@@ -937,12 +944,14 @@ def update_current_trace(
                 f"Non-string items: {non_string_items}"
             )
 
-    # Update tags for the trace stored in-memory rather than directly updating the
-    # backend store. The in-memory trace will be exported when it is ended. By doing
-    # this, we can avoid unnecessary server requests for each tag update.
+    # Update tags and client request ID for the trace stored in-memory rather than directly
+    # updating the backend store. The in-memory trace will be exported when it is ended.
+    # By doing this, we can avoid unnecessary server requests for each tag update.
     request_id = active_span.request_id
     with InMemoryTraceManager.get_instance().get_trace(request_id) as trace:
         trace.info.tags.update(tags or {})
+        if client_request_id is not None:
+            trace.info.client_request_id = client_request_id
 
 
 @request_id_backward_compatible


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add client_request_id param to update_current_trace

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
