### PR TITLE
Support custom request/response preview

### DIFF
--- a/docs/docs/tracing/api/how-to.mdx
+++ b/docs/docs/tracing/api/how-to.mdx
@@ -211,3 +211,46 @@ The following configurations are available for async logging:
 |`MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS`|The maximum number of worker threads to use for async trace logging.|`10`|
 |`MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE`|The maximum number of traces that can be queued for logging. Traces will be discarded if the queue is full.|`1000`|
 |`MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT`|Timeout in seconds for retrying failed trace logging. Namely, failed traces will be retried up to this timeout with backoff, after which they will be discarded.|`500`|
+
+
+## Customize Request and Response Preview in Trace UI
+
+The Traces tab in MLflow UI displays a list of traces logged in the MLflow tracking server. The `Request` and `Response` columns
+show the preview of the end input and output of the trace, so that you can quickly understand the trace.
+
+By default, the preview is truncated to a fix number of characters for each request and response. However, you can also customize the preview by setting the `request_preview` and `response_preview` parameters in the <APILink fn="mlflow.update_current_trace" /> function.
+
+Below is an example of setting a custom request preview for a trace to render large message history nicely in the UI.
+
+```python
+import mlflow
+import openai
+
+
+@mlflow.trace
+def predict(messages: list[dict]) -> str:
+    # Customize the request preview to show the first and last messages
+    custom_preview = f'{messages[0]["content"][:10]} ... {messages[-1]["content"][:10]}'
+    mlflow.update_current_trace(request_preview=custom_preview)
+
+    # Call the model
+    response = openai.chat.completions.create(
+        model="o4-mini",
+        messages=messages,
+    )
+
+    return response.choices[0].message.content
+
+
+messages = [
+    {"role": "user", "content": "Hi, how are you?"},
+    {"role": "assistant", "content": "I'm good, thank you!"},
+    {"role": "user", "content": "What's your name?"},
+    # ... (long message history)
+    {"role": "assistant", "content": "Bye!"},
+]
+predict(messages)
+
+# The request preview rendered in the UI will be:
+#     "Hi, how are you? ... Bye!"
+```

--- a/mlflow/entities/trace_info_v2.py
+++ b/mlflow/entities/trace_info_v2.py
@@ -9,7 +9,6 @@ from mlflow.entities.trace_status import TraceStatus
 from mlflow.protos.service_pb2 import TraceInfo as ProtoTraceInfo
 from mlflow.protos.service_pb2 import TraceRequestMetadata as ProtoTraceRequestMetadata
 from mlflow.protos.service_pb2 import TraceTag as ProtoTraceTag
-from mlflow.tracing.utils.truncation import truncate_request_response_preview
 
 
 def _truncate_request_metadata(d: dict[str, Any]) -> dict[str, str]:
@@ -136,8 +135,8 @@ class TraceInfoV2(_MlflowObject):
         return TraceInfo(
             trace_id=self.request_id,
             trace_location=TraceLocation.from_experiment_id(self.experiment_id),
-            request_preview=truncate_request_response_preview(request, role="user"),
-            response_preview=truncate_request_response_preview(response, role="assistant"),
+            request_preview=request,
+            response_preview=response,
             request_time=self.timestamp_ms,
             execution_duration=self.execution_time_ms,
             state=self.status.to_state(),

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -909,7 +909,7 @@ def update_current_trace(
 
     Example:
 
-        You can use this function either within a function decorated with `@mlflow.trace` or
+        You can use this function either within a function decorated with ``@mlflow.trace`` or
         within the scope of the `with mlflow.start_span` context manager. If there is no active
         trace found, this function will raise an exception.
 
@@ -922,7 +922,7 @@ def update_current_trace(
                 mlflow.update_current_trace(tags={"fruit": "apple"}, client_request_id="req-12345")
                 return x + 1
 
-        Using within the `with mlflow.start_span` context manager:
+        Using within the ``with mlflow.start_span`` context manager:
 
         .. code-block:: python
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -7,6 +7,7 @@ from typing import Generator, Optional
 from mlflow.entities import LiveSpan, Trace, TraceData, TraceInfo
 from mlflow.environment_variables import MLFLOW_TRACE_TIMEOUT_SECONDS
 from mlflow.tracing.utils.timeout import get_trace_cache_with_timeout
+from mlflow.tracing.utils.truncation import truncate_request_response_preview
 
 _logger = logging.getLogger(__name__)
 
@@ -23,8 +24,18 @@ class _Trace:
         for span in self.span_dict.values():
             # Convert LiveSpan, mutable objects, into immutable Span objects before persisting.
             trace_data.spans.append(span.to_immutable_span())
-        self.info.request_preview = trace_data.request
-        self.info.response_preview = trace_data.response
+
+        # If request/response preview is already set by users via `mlflow.update_current_trace`,
+        # we don't override it with the truncated version.
+        if self.info.request_preview is None:
+            self.info.request_preview = truncate_request_response_preview(
+                trace_data.request, role="user"
+            )
+        if self.info.response_preview is None:
+            self.info.response_preview = truncate_request_response_preview(
+                trace_data.response, role="assistant"
+            )
+
         return Trace(self.info, trace_data)
 
     def get_root_span(self) -> Optional[LiveSpan]:

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -391,22 +391,22 @@ def test_from_v2_dict():
 
 
 def test_request_response_smart_truncation():
-    # Create a trace info with chat format request/response
     @mlflow.trace
     def f(messages: list[dict[str, Any]]) -> dict[str, Any]:
         return {"choices": [{"message": {"role": "assistant", "content": "Hi!" * 10000}}]}
 
-    messages = [{"role": "user", "content": "Hello!" * 10000}]
-    result = f(messages)
+    # NB: Since MLflow OSS backend still uses v2 tracing schema, the most accurate way to
+    # check if the preview is truncated properly is to mock the upload_trace_data call.
+    with mock.patch(
+        "mlflow.tracing.export.mlflow_v2.TracingClient._upload_trace_data"
+    ) as mock_upload_trace_data:
+        f([{"role": "user", "content": "Hello!" * 10000}])
 
-    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
-    assert len(trace.info.request_preview) == 10000
-    assert trace.info.request_preview.startswith("Hello!")
-    assert len(trace.info.response_preview) == 10000
-    assert trace.info.response_preview.startswith("Hi!")
-
-    assert trace.data.spans[0].inputs == {"messages": messages}
-    assert trace.data.spans[0].outputs == result
+    trace_info = mock_upload_trace_data.call_args[0][0]
+    assert len(trace_info.request_preview) == 10000
+    assert trace_info.request_preview.startswith("Hello!")
+    assert len(trace_info.response_preview) == 10000
+    assert trace_info.response_preview.startswith("Hi!")
 
 
 def test_request_response_smart_truncation_non_chat_format():
@@ -415,14 +415,32 @@ def test_request_response_smart_truncation_non_chat_format():
     def f(question: str) -> list[str]:
         return ["a" * 5000, "b" * 5000, "c" * 5000]
 
-    question = "start" + "a" * 10000
-    result = f(question)
+    with mock.patch(
+        "mlflow.tracing.export.mlflow_v2.TracingClient._upload_trace_data"
+    ) as mock_upload_trace_data:
+        f("start" + "a" * 10000)
 
-    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
-    assert len(trace.info.request_preview) == 10000
-    assert trace.info.request_preview.startswith('{"question": "startaaa')
-    assert len(trace.info.response_preview) == 10000
-    assert trace.info.response_preview.startswith('["aaaaa')
+    trace_info = mock_upload_trace_data.call_args[0][0]
+    assert len(trace_info.request_preview) == 10000
+    assert trace_info.request_preview.startswith('{"question": "startaaa')
+    assert len(trace_info.response_preview) == 10000
+    assert trace_info.response_preview.startswith('["aaaaa')
 
-    assert trace.data.spans[0].inputs == {"question": question}
-    assert trace.data.spans[0].outputs == result
+
+def test_request_response_custom_truncation():
+    @mlflow.trace
+    def f(messages: list[dict[str, Any]]) -> dict[str, Any]:
+        mlflow.update_current_trace(
+            request_preview="custom request preview",
+            response_preview="custom response preview",
+        )
+        return {"choices": [{"message": {"role": "assistant", "content": "Hi!" * 10000}}]}
+
+    with mock.patch(
+        "mlflow.tracing.export.mlflow_v2.TracingClient._upload_trace_data"
+    ) as mock_upload_trace_data:
+        f([{"role": "user", "content": "Hello!" * 10000}])
+
+    trace_info = mock_upload_trace_data.call_args[0][0]
+    assert trace_info.request_preview == "custom request preview"
+    assert trace_info.response_preview == "custom response preview"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15919?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15919/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15919/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15919/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Add `request_preview` / `response_preview` field to `update_current_trace` API to allow users set arbitrary preview string for their traces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Ran the example in docstring:

![Screenshot 2025-05-28 at 1 35 08](https://github.com/user-attachments/assets/5600dcc9-7124-494b-82ed-da7dc3f1efe0)

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support customizing request/response preview for traces in UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
