### PR TITLE
Support adding assessments to in-progress traces

### DIFF
--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -169,6 +169,7 @@ from mlflow.tracing.assessment import (
 from mlflow.tracing.fluent import (
     add_trace,
     delete_trace_tag,
+    get_active_trace_id,
     get_current_active_span,
     get_last_active_trace_id,
     get_trace,
@@ -203,6 +204,7 @@ __all__ = [
     "add_trace",
     "delete_trace_tag",
     "flush_trace_async_logging",
+    "get_active_trace_id",
     "get_current_active_span",
     "get_last_active_trace_id",
     "get_trace",

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -491,7 +491,7 @@ class TracingClient:
                 if trace is None:
                     _logger.debug(
                         f"Trace {trace_id} is active but not found in the in-memory buffer. "
-                        "Something is wrong with the trace managing. Skipping assessment logging."
+                        "Something is wrong with trace handling. Skipping assessment logging."
                     )
                 trace.info.assessments.append(assessment)
             return assessment

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -4,9 +4,11 @@ from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
 from typing import Optional, Union
 
+import mlflow
 from mlflow.entities.assessment import (
     Assessment,
 )
+from mlflow.entities.span import NO_OP_SPAN_TRACE_ID
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
@@ -475,6 +477,25 @@ class TracingClient:
             )
 
         assessment.trace_id = trace_id
+
+        if trace_id is None or trace_id == NO_OP_SPAN_TRACE_ID:
+            _logger.debug(
+                "Skipping assessment logging for NO_OP_SPAN_TRACE_ID. This is expected when "
+                "tracing is disabled."
+            )
+            return assessment
+
+        # If the trace is the active trace, add the assessment to it in-memory
+        if trace_id == mlflow.get_active_trace_id():
+            with InMemoryTraceManager.get_instance().get_trace(trace_id) as trace:
+                if trace is None:
+                    _logger.debug(
+                        f"Trace {trace_id} is active but not found in the in-memory buffer. "
+                        "Something is wrong with the trace managing. Skipping assessment logging."
+                    )
+                trace.info.assessments.append(assessment)
+            return assessment
+
         return self.store.create_assessment(assessment)
 
     def update_assessment(

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -835,9 +835,40 @@ def get_current_active_span() -> Optional[LiveSpan]:
     return trace_manager.get_span_from_id(request_id, encode_span_id(otel_span.context.span_id))
 
 
+def get_active_trace_id() -> Optional[str]:
+    """
+    Get the active trace ID in the current process.
+
+    This function is thread-safe.
+
+    Example:
+
+    .. code-block:: python
+        :test:
+
+        import mlflow
+
+
+        @mlflow.trace
+        def f():
+            trace_id = mlflow.get_active_trace_id()
+            print(trace_id)
+
+
+        f()
+
+    Returns:
+        The ID of the current active trace if exists, otherwise None.
+    """
+    active_span = get_current_active_span()
+    if active_span:
+        return active_span.trace_id
+    return None
+
+
 def get_last_active_trace_id(thread_local: bool = False) -> Optional[str]:
     """
-    Get the last active trace in the same process if exists.
+    Get the **LAST** active trace in the same process if exists.
 
     .. warning::
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, field
 from typing import Generator, Optional
 
 from mlflow.entities import LiveSpan, Trace, TraceData, TraceInfo
+from mlflow.entities.assessment import Assessment
 from mlflow.environment_variables import MLFLOW_TRACE_TIMEOUT_SECONDS
 from mlflow.tracing.utils.timeout import get_trace_cache_with_timeout
 
@@ -162,6 +163,14 @@ class InMemoryTraceManager:
                 # We need to check here again in case this method runs in parallel
                 if new_timeout != getattr(self._traces, "timeout", None):
                     self._traces = get_trace_cache_with_timeout()
+
+    def add_or_update_assessment(self, trace_id: str, assessment: Assessment):
+        """
+        Add or update an assessment for the given trace ID.
+        """
+        with self.get_trace(trace_id) as trace:
+            if trace:
+                trace.info.assessments.append(assessment)
 
     @classmethod
     def reset(cls):

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from typing import Generator, Optional
 
 from mlflow.entities import LiveSpan, Trace, TraceData, TraceInfo
-from mlflow.entities.assessment import Assessment
 from mlflow.environment_variables import MLFLOW_TRACE_TIMEOUT_SECONDS
 from mlflow.tracing.utils.timeout import get_trace_cache_with_timeout
 
@@ -163,14 +162,6 @@ class InMemoryTraceManager:
                 # We need to check here again in case this method runs in parallel
                 if new_timeout != getattr(self._traces, "timeout", None):
                     self._traces = get_trace_cache_with_timeout()
-
-    def add_or_update_assessment(self, trace_id: str, assessment: Assessment):
-        """
-        Add or update an assessment for the given trace ID.
-        """
-        with self.get_trace(trace_id) as trace:
-            if trace:
-                trace.info.assessments.append(assessment)
 
     @classmethod
     def reset(cls):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15922?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15922/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15922/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15922/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Currently, `log_assessment`/`log_expectation` API can log assessments only for a trace that is already completed. There is a request to log assessments for in-progress traces. One use case is doing a guardrail:

```
@mlflow.trace(span_type="LLM")
def predict(messages: list[dict]) -> dict:
    # Do some prefiction
    output = ...
    # Compute guardrail score on the fly
    is_safe = some_llm_judge.is_safe(output)
    # Log the guardrail result
    mlflow.log_feedback((trace_id, name="safety", value=is_safe, rationale="...")

    if is_safe:
        return output
    else:
        # Do some guardrail handling.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
