### PR TITLE
Revert "Pin Pyspark to <3.5.6"

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,9 +10,9 @@ json_repair!=0.45.0
 # https://github.com/huggingface/transformers/issues/38269
 transformers!=4.52.2
 transformers!=4.52.1
-# TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this constraint when MLflow is ready for pyspark 4.0.0. Pyspark 3.5.6 has the same issue.
-pyspark<3.5.6
 # FLAML disables warnings globally using `warnings.simplefilter("ignore", category=...)`:
 # https://github.com/microsoft/FLAML/blob/01c3c836534a244ac8038535455a7fde367366ad/flaml/fabric/mlflow.py#L67-L68
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
+# TODO(https://github.com/mlflow/mlflow/issues/15847): Remove this constraint when MLflow is ready for pyspark 4.0.0
+pyspark<4.0.0

--- a/tests/data/test_delta_dataset_source.py
+++ b/tests/data/test_delta_dataset_source.py
@@ -17,7 +17,7 @@ def spark_session():
 
     with (
         SparkSession.builder.master("local[*]")
-        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.3.1")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .config(
             "spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog"

--- a/tests/data/test_pandas_dataset.py
+++ b/tests/data/test_pandas_dataset.py
@@ -24,7 +24,7 @@ def spark_session():
 
     with (
         SparkSession.builder.master("local[*]")
-        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.3.1")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .config(
             "spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog"

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -21,7 +21,7 @@ def spark_session(tmp_path):
 
     with (
         SparkSession.builder.master("local[*]")
-        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.3.1")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .config(
             "spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog"

--- a/tests/data/test_spark_dataset_source.py
+++ b/tests/data/test_spark_dataset_source.py
@@ -14,7 +14,7 @@ def spark_session():
 
     with (
         SparkSession.builder.master("local[*]")
-        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
+        .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.3.1")
         .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
         .config(
             "spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog"

--- a/tests/evaluate/test_default_evaluator_delta.py
+++ b/tests/evaluate/test_default_evaluator_delta.py
@@ -39,7 +39,7 @@ def spark_session_with_delta():
     with tempfile.TemporaryDirectory() as tmpdir:
         with (
             SparkSession.builder.master("local[*]")
-            .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.0.0")
+            .config("spark.jars.packages", "io.delta:delta-spark_2.12:3.3.1")
             .config("spark.sql.extensions", "io.delta.sql.DeltaSparkSessionExtension")
             .config(
                 "spark.sql.catalog.spark_catalog", "org.apache.spark.sql.delta.catalog.DeltaCatalog"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/15923?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15923/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15923/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15923/merge
```

</p>
</details>

Reverts mlflow/mlflow#15898. Spark 3.5.6 jars were missing but they have been uploaded in maven.