### PR TITLE
Make spark_udf support DBConnect + DBR 15.4 / DBR dedicated cluster

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2245,9 +2245,12 @@ def spark_udf(
         if dbr_runtime_version == Version("15.4"):
             if spark.conf.get("spark.databricks.pyspark.udf.isolation.enabled").lower() == "true":
                 # The connected cluster is standard (shared) mode.
-                if spark.conf.get(
-                    "spark.databricks.safespark.archive.artifact.unpack.disabled"
-                ).lower() != "false":
+                if (
+                    spark.conf.get(
+                        "spark.databricks.safespark.archive.artifact.unpack.disabled"
+                    ).lower()
+                    != "false"
+                ):
                     raise MlflowException(
                         "Using 'mlflow.pyfunc.spark_udf' in remote Databricks Connect requires "
                         "Databricks cluster setting "

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2242,7 +2242,7 @@ def spark_udf(
                 "Using 'mlflow.pyfunc.spark_udf' in Databricks Serverless or in remote "
                 "Databricks Connect requires Databricks runtime version >= 15.4."
             )
-        if dbr_runtime_version == "15.4":
+        if dbr_runtime_version == Version("15.4"):
             if spark.conf.get("spark.databricks.pyspark.udf.isolation.enabled").lower() == "true":
                 # The connected cluster is standard (shared) mode.
                 if spark.conf.get(

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2041,9 +2041,11 @@ def spark_udf(
 
     .. note::
         When using Databricks Connect to connect to a remote Databricks cluster,
-        the Databricks cluster must use runtime version >= 16, and when 'spark_udf'
+        the Databricks cluster must use runtime version >= 15.4, and when 'spark_udf'
         param 'env_manager' is set as 'virtualenv', the 'prebuilt_env_uri' param is
-        required to be specified.
+        required to be specified, if the runtime version is 15.4 and the cluster is
+        standard access mode, the cluster need to configure
+        "spark.databricks.safespark.archive.artifact.unpack.disabled" to "false".
 
     .. note::
         Please be aware that when operating in Databricks Serverless,
@@ -2232,6 +2234,26 @@ def spark_udf(
                 "Databricks Connect requires UDF sandbox image installed with MLflow "
                 "of version >= 2.18.0"
             )
+        # `udf_sandbox_info.runtime_version` format is like '<major_version>.<minor_version>'.
+        # It's safe to apply `Version`.
+        dbr_runtime_version = Version(udf_sandbox_info.runtime_version)
+        if dbr_runtime_version < Version("15.4"):
+            raise MlflowException(
+                "Using 'mlflow.pyfunc.spark_udf' in Databricks Serverless or in remote "
+                "Databricks Connect requires Databricks runtime version >= 15.4."
+            )
+        if dbr_runtime_version == "15.4":
+            if spark.conf.get("spark.databricks.pyspark.udf.isolation.enabled").lower() == "true":
+                # The connected cluster is standard (shared) mode.
+                if spark.conf.get(
+                    "spark.databricks.safespark.archive.artifact.unpack.disabled"
+                ).lower() != "false":
+                    raise MlflowException(
+                        "Using 'mlflow.pyfunc.spark_udf' in remote Databricks Connect requires "
+                        "Databricks cluster setting "
+                        "'spark.databricks.safespark.archive.artifact.unpack.disabled' to 'false' "
+                        "if Databricks runtime version is 15.4"
+                    )
 
     nfs_root_dir = get_nfs_cache_root_dir()
     should_use_nfs = nfs_root_dir is not None

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2232,13 +2232,6 @@ def spark_udf(
                 "Databricks Connect requires UDF sandbox image installed with MLflow "
                 "of version >= 2.18.0"
             )
-        # `udf_sandbox_info.runtime_version` format is like '<major_version>.<minor_version>'.
-        # It's safe to apply `Version`.
-        if Version(udf_sandbox_info.runtime_version).major < 16:
-            raise MlflowException(
-                "Using 'mlflow.pyfunc.spark_udf' in Databricks Serverless or in remote "
-                "Databricks Connect requires Databricks runtime version >= 16.0."
-            )
 
     nfs_root_dir = get_nfs_cache_root_dir()
     should_use_nfs = nfs_root_dir is not None

--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -109,7 +109,9 @@ class DBConnectArtifactCache:
         archive_file_name = self._cache[cache_key]
 
         if session_id := os.environ.get("DB_SESSION_UUID"):
-            return f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_file_name}"
+            return (
+                f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_file_name}"
+            )
 
         # If 'DB_SESSION_UUID' environment variable does not exist, it means it is running
         # in a dedicated mode Spark cluster.

--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -107,8 +107,13 @@ class DBConnectArtifactCache:
         if cache_key not in self._cache:
             raise RuntimeError(f"The artifact '{cache_key}' does not exist.")
         archive_file_name = self._cache[cache_key]
-        session_id = os.environ["DB_SESSION_UUID"]
-        return f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_file_name}"
+
+        if session_id := os.environ.get("DB_SESSION_UUID"):
+            return f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_file_name}"
+
+        # If 'DB_SESSION_UUID' environment variable does not exist, it means it is running
+        # in a dedicated mode Spark cluster.
+        return os.path.join(os.getcwd(), archive_file_name)
 
 
 def archive_directory(input_dir, archive_file_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/15938?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15938/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15938/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 15938
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Make spark_udf support DBConnect + DBR 15.4 / DBR dedicated cluster

Context: https://databricks.slack.com/archives/C022KUWGVQS/p1747738983145379?thread_ts=1741796167.131499&cid=C022KUWGVQS

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Make spark_udf support DBConnect + DBR 15.4 / DBR dedicated cluster

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [X] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
