### PR TITLE
fix cross version test for transformers

### DIFF
--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1062,7 +1062,7 @@ def test_text2text_generation_pipeline_with_model_config_and_params(
         "repetition_penalty": 1.15,
         "do_sample": True,
     }
-    parameters = {"top_k": 3, "max_length": 30}
+    parameters = {"top_k": 3, "max_new_tokens": 30}
     generated_output = mlflow.transformers.generate_signature_output(
         text2text_generation_pipeline, data
     )
@@ -1087,7 +1087,7 @@ def test_text2text_generation_pipeline_with_model_config_and_params(
     res2 = pyfunc_loaded.predict(data, applied_params)
     assert res == res2
 
-    assert res != pyfunc_loaded.predict(data, {"max_length": 3})
+    assert res != pyfunc_loaded.predict(data, {"max_new_tokens": 3})
 
     # Extra params are ignored
     assert res == pyfunc_loaded.predict(data, {"extra_param": "extra_value"})
@@ -1156,7 +1156,7 @@ def test_text2text_generation_pipeline_with_inferred_schema(text2text_generation
         model_info = mlflow.transformers.log_model(text2text_generation_pipeline, name="my_model")
     pyfunc_loaded = mlflow.pyfunc.load_model(model_info.model_uri)
 
-    assert pyfunc_loaded.predict("muppet board nails hammer").startswith("A hammer")
+    assert pyfunc_loaded.predict("muppet board nails hammer")[0].startswith("A hammer")
 
 
 @pytest.mark.parametrize(
@@ -2553,6 +2553,14 @@ def test_whisper_model_serve_and_score(whisper_pipeline):
         assert "Failed to process the input audio data. Either" in response["message"]
 
 
+# https://github.com/huggingface/transformers/commit/9c500015c556f9ddf6e7a7449d3f46b2e3ff8ea5
+# caused a regression in beam search.
+# https://github.com/huggingface/transformers/commit/a6b51e7341d702127a4a45f37439640840b5abf0
+# fixed the regression but has not been released yet as of May 30, 2025.
+@pytest.mark.skipif(
+    Version("4.52.0") <= Version(transformers.__version__) < Version("4.53.0"),
+    reason="Transformers 4.52 has a bug for beam search in whiper implementation",
+)
 @pytest.mark.skipif(
     Version(transformers.__version__) < Version("4.29.0"), reason="Feature does not exist"
 )

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -1087,7 +1087,7 @@ def test_text2text_generation_pipeline_with_model_config_and_params(
     res2 = pyfunc_loaded.predict(data, applied_params)
     assert res == res2
 
-    assert res != pyfunc_loaded.predict(data, {"max_length": 10})
+    assert res != pyfunc_loaded.predict(data, {"max_length": 3})
 
     # Extra params are ignored
     assert res == pyfunc_loaded.predict(data, {"extra_param": "extra_value"})
@@ -1156,9 +1156,7 @@ def test_text2text_generation_pipeline_with_inferred_schema(text2text_generation
         model_info = mlflow.transformers.log_model(text2text_generation_pipeline, name="my_model")
     pyfunc_loaded = mlflow.pyfunc.load_model(model_info.model_uri)
 
-    assert pyfunc_loaded.predict("muppet board nails hammer") == [
-        "A hammer with a muppet and nails on a board."
-    ]
+    assert pyfunc_loaded.predict("muppet board nails hammer").startswith("A hammer")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15940?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15940/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15940/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15940/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Fix https://github.com/mlflow-automation/mlflow/actions/runs/15296977296/job/43028321501#step:12:653

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
