### PR TITLE
FInalize built-in judge/scorers interface

### DIFF
--- a/docs/api_reference/source/python_api/mlflow.genai.rst
+++ b/docs/api_reference/source/python_api/mlflow.genai.rst
@@ -16,3 +16,8 @@ mlflow.genai
     :members:
     :undoc-members:
     :show-inheritance:
+
+.. automodule:: mlflow.genai.judges
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/mlflow/genai/judges/__init__.py
+++ b/mlflow/genai/judges/__init__.py
@@ -3,7 +3,6 @@ from mlflow.genai.judges.databricks import (
     is_context_sufficient,
     is_correct,
     is_grounded,
-    is_relevant_to_query,
     is_safe,
     meets_guidelines,
 )

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -196,7 +196,9 @@ class RetrievalSufficiency(BuiltInScorer):
                 self.name, ["expectations/expected_response or expectations/expected_facts"]
             )
 
-    def __call__(self, *, trace: Trace, expectations: Optional[dict[str, Any]] = None) -> Feedback:
+    def __call__(
+        self, *, trace: Trace, expectations: Optional[dict[str, Any]] = None
+    ) -> list[Feedback]:
         """
         Evaluate context sufficiency based on retrieved documents.
 
@@ -285,7 +287,7 @@ class RetrievalGroundedness(BuiltInScorer):
     name: str = "retrieval_groundedness"
     required_columns: set[str] = {"inputs", "trace"}
 
-    def __call__(self, *, trace: Trace) -> Feedback:
+    def __call__(self, *, trace: Trace) -> list[Feedback]:
         """
         Evaluate groundedness of response against retrieved context.
 

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -6,6 +6,7 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai import judges
+from mlflow.genai.judges.databricks import requires_databricks_agents
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.utils.trace_utils import (
     extract_retrieval_context_from_trace,
@@ -111,6 +112,7 @@ class RetrievalRelevance(BuiltInScorer):
             feedbacks.extend(self._compute_span_relevance(span_id, request, context))
         return feedbacks
 
+    @requires_databricks_agents
     def _compute_span_relevance(
         self, span_id: str, request: str, chunks: dict[str, str]
     ) -> list[Feedback]:

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -10,6 +10,7 @@ from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.utils.trace_utils import (
     extract_retrieval_context_from_trace,
     parse_inputs_to_str,
+    parse_output_to_str,
 )
 from mlflow.protos.databricks_pb2 import BAD_REQUEST
 from mlflow.utils.annotations import experimental
@@ -293,7 +294,7 @@ class RetrievalGroundedness(BuiltInScorer):
             indicating the groundedness of the response.
         """
         request = parse_inputs_to_str(trace.data.spans[0].inputs)
-        response = trace.data.spans[0].outputs
+        response = parse_output_to_str(trace.data.spans[0].outputs)
         span_id_to_context = extract_retrieval_context_from_trace(trace)
         feedbacks = []
         for span_id, context in span_id_to_context.items():
@@ -618,7 +619,7 @@ class Safety(BuiltInScorer):
             An :py:class:`mlflow.entities.assessment.Feedback~` object with a boolean value
             indicating the safety of the response.
         """
-        return judges.is_safe(content=outputs, name=self.name)
+        return judges.is_safe(content=parse_output_to_str(outputs), name=self.name)
 
     def with_config(self, *, name: str = "safety") -> "Safety":
         """
@@ -722,6 +723,7 @@ class Correctness(BuiltInScorer):
             indicating the correctness of the response.
         """
         request = parse_inputs_to_str(inputs)
+        response = parse_output_to_str(outputs)
         expected_facts = expectations.get("expected_facts")
         expected_response = expectations.get("expected_response")
 
@@ -733,7 +735,7 @@ class Correctness(BuiltInScorer):
 
         return judges.is_correct(
             request=request,
-            response=outputs,
+            response=response,
             expected_response=expected_response,
             expected_facts=expected_facts,
             name=self.name,

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -63,15 +63,11 @@ class NoOpTracerPatcher:
 
 def parse_inputs_to_str(inputs: Any) -> str:
     """Parse the inputs to a request string compatible with the judges API"""
-    if isinstance(inputs, str):
-        return inputs
-
-    # If it is a single key dictionary, return the value
+    # If it is a single key dictionary, extract the value
     if isinstance(inputs, dict) and len(inputs) == 1:
-        return list(inputs.values())[0]
+        inputs = list(inputs.values())[0]
 
-    # Otherwise, encode the inputs to a JSON string
-    return json.dumps(inputs, default=TraceJSONEncoder)
+    return inputs if isinstance(inputs, str) else json.dumps(inputs, default=TraceJSONEncoder)
 
 
 def parse_output_to_str(output: Any) -> str:

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -5,6 +5,7 @@ from typing import Any, Callable, Optional
 from opentelemetry.trace import NoOpTracer
 
 import mlflow
+from mlflow.entities.assessment import Feedback
 from mlflow.entities.span import Span, SpanType
 from mlflow.entities.trace import Trace
 from mlflow.genai.utils.data_validation import check_model_prediction
@@ -73,7 +74,7 @@ def parse_inputs_to_str(inputs: Any) -> str:
     return json.dumps(inputs, default=TraceJSONEncoder)
 
 
-def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> Optional[dict[str, list]]:
+def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> dict[str, list]:
     """
     Extract the retrieval context from the trace.
     Only consider the last retrieval span in the trace if there are multiple retrieval spans.
@@ -81,12 +82,12 @@ def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> Optional[dic
     ⚠️ Warning: Please make sure to not throw exception. If fails, return None.
     """
     if trace is None or trace.data is None:
-        return None
+        return {}
 
     # Only consider the top-level retrieval spans
     top_level_retrieval_spans = _get_top_level_retrieval_spans(trace)
     if len(top_level_retrieval_spans) == 0:
-        return None
+        return {}
 
     retrieved = {}  # span_id -> list of documents
 
@@ -152,3 +153,25 @@ def _parse_chunk(chunk: Any) -> Optional[dict[str, Any]]:
     if doc_uri := chunk.get("metadata", {}).get("doc_uri"):
         doc["doc_uri"] = doc_uri
     return doc
+
+
+def aggregate_per_span_feedbacks(
+    feedbacks: list[Feedback], aggregate_fn: Callable
+) -> Optional[Feedback]:
+    """Aggregate a list of feedbacks into a single feedback using the aggregate_fn."""
+    # Ignore errored feedbacks
+    values = [feedback.value for feedback in feedbacks if feedback.value is not None]
+
+    if len(values) == 0:
+        return None
+
+    feedback_name = feedbacks[0].name  # All feedbacks must have the same name
+    aggregated_value = aggregate_fn(values)
+
+    return Feedback(
+        name=feedback_name,
+        value=aggregated_value,
+        source=feedbacks[0].source,
+        trace_id=feedbacks[0].trace_id,
+        rationale=f"Aggregation of multiple per-span `{feedback_name}` feedbacks.",
+    )

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Optional
 from opentelemetry.trace import NoOpTracer
 
 import mlflow
-from mlflow.entities.assessment import Feedback
 from mlflow.entities.span import Span, SpanType
 from mlflow.entities.trace import Trace
 from mlflow.genai.utils.data_validation import check_model_prediction
@@ -154,25 +153,3 @@ def _parse_chunk(chunk: Any) -> Optional[dict[str, Any]]:
     if doc_uri := chunk.get("metadata", {}).get("doc_uri"):
         doc["doc_uri"] = doc_uri
     return doc
-
-
-def aggregate_per_span_feedbacks(
-    feedbacks: list[Feedback], aggregate_fn: Callable
-) -> Optional[Feedback]:
-    """Aggregate a list of feedbacks into a single feedback using the aggregate_fn."""
-    # Ignore errored feedbacks
-    values = [feedback.value for feedback in feedbacks if feedback.value is not None]
-
-    if len(values) == 0:
-        return None
-
-    feedback_name = feedbacks[0].name  # All feedbacks must have the same name
-    aggregated_value = aggregate_fn(values)
-
-    return Feedback(
-        name=feedback_name,
-        value=aggregated_value,
-        source=feedbacks[0].source,
-        trace_id=feedbacks[0].trace_id,
-        rationale=f"Aggregation of multiple per-span `{feedback_name}` feedbacks.",
-    )

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -74,6 +74,11 @@ def parse_inputs_to_str(inputs: Any) -> str:
     return json.dumps(inputs, default=TraceJSONEncoder)
 
 
+def parse_output_to_str(output: Any) -> str:
+    """Parse the output to a string compatible with the judges API"""
+    return output if isinstance(output, str) else json.dumps(output, default=TraceJSONEncoder)
+
+
 def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> dict[str, list]:
     """
     Extract the retrieval context from the trace.

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -31,11 +31,13 @@ def spoof_tracking_uri_check():
 def sample_rag_trace():
     @mlflow.trace(span_type=SpanType.AGENT)
     def _predict(question):
-        _retrieve(question)
+        # Two retrievers calls
+        _retrieve_1(question)
+        _retrieve_2(question)
         return "answer"
 
     @mlflow.trace(span_type=SpanType.RETRIEVER)
-    def _retrieve(question):
+    def _retrieve_1(question):
         return [
             Document(
                 page_content="content_1",
@@ -45,8 +47,11 @@ def sample_rag_trace():
                 page_content="content_2",
                 metadata={"doc_uri": "url_2"},
             ),
-            Document(page_content="content_3"),
         ]
+
+    @mlflow.trace(span_type=SpanType.RETRIEVER)
+    def _retrieve_2(question):
+        return [Document(page_content="content_3")]
 
     _predict("query")
 

--- a/tests/genai/judges/test_judges.py
+++ b/tests/genai/judges/test_judges.py
@@ -5,7 +5,6 @@ def test_databricks_judges_are_importable():
         is_context_sufficient,
         is_correct,
         is_grounded,
-        is_relevant_to_query,
         is_safe,
         meets_guidelines,
     )
@@ -14,6 +13,5 @@ def test_databricks_judges_are_importable():
     assert judges.is_context_sufficient == is_context_sufficient
     assert judges.is_correct == is_correct
     assert judges.is_grounded == is_grounded
-    assert judges.is_relevant_to_query == is_relevant_to_query
     assert judges.is_safe == is_safe
     assert judges.meets_guidelines == meets_guidelines

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -189,6 +189,7 @@ def test_retrieval_sufficiency(sample_rag_trace):
                     {"content": "content_1", "doc_uri": "url_1"},
                     {"content": "content_2", "doc_uri": "url_2"},
                 ],
+                # Expectations stored in the trace is exploded
                 expected_response="expected answer",
                 expected_facts=["fact1", "fact2"],
                 assessment_name="retrieval_sufficiency",
@@ -210,6 +211,37 @@ def test_retrieval_sufficiency(sample_rag_trace):
     ]
     actual_span_ids = [f.span_id for f in result]
     assert set(actual_span_ids) == set(expected_span_ids)
+
+
+def test_retrieval_sufficiency_with_custom_expectations(sample_rag_trace):
+    with patch("databricks.agents.evals.judges.context_sufficiency") as mock_context_sufficiency:
+        retrieval_sufficiency(
+            trace=sample_rag_trace,
+            expectations={"expected_facts": ["fact3"]},
+        )
+
+    mock_context_sufficiency.assert_has_calls(
+        [
+            call(
+                request="query",
+                retrieved_context=[
+                    {"content": "content_1", "doc_uri": "url_1"},
+                    {"content": "content_2", "doc_uri": "url_2"},
+                ],
+                # Expectations stored in the trace is exploded
+                expected_response="expected answer",
+                expected_facts=["fact3"],
+                assessment_name="retrieval_sufficiency",
+            ),
+            call(
+                request="query",
+                retrieved_context=[{"content": "content_3"}],
+                expected_response="expected answer",
+                expected_facts=["fact3"],
+                assessment_name="retrieval_sufficiency",
+            ),
+        ],
+    )
 
 
 def test_guideline_adherence():

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -266,11 +266,21 @@ def test_relevance_to_query():
 
 
 def test_safety():
+    # String output
     with patch("databricks.agents.evals.judges.safety") as mock_safety:
         safety(outputs="answer")
 
     mock_safety.assert_called_once_with(
         response="answer",
+        assessment_name="safety",
+    )
+
+    # Non-string output
+    with patch("databricks.agents.evals.judges.safety") as mock_safety:
+        safety(outputs={"answer": "yes", "reason": "This is a test"})
+
+    mock_safety.assert_called_once_with(
+        response='{"answer": "yes", "reason": "This is a test"}',
         assessment_name="safety",
     )
 

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -4,7 +4,7 @@ import pytest
 
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_error import AssessmentError
-from mlflow.entities.assessment_source import AssessmentSource
+from mlflow.entities.span import SpanType
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import (
     correctness,
@@ -53,60 +53,66 @@ def test_configure_builtin_scorers(scorer, updates):
 
 
 def test_retrieval_groundedness(sample_rag_trace):
-    with patch("databricks.agents.evals.judges.groundedness") as mock_groundedness:
-        retrieval_groundedness(trace=sample_rag_trace)
+    with patch(
+        "databricks.agents.evals.judges.groundedness",
+        side_effect=lambda *args, **kwargs: Feedback(name="retrieval_groundedness", value="yes"),
+    ) as mock_groundedness:
+        result = retrieval_groundedness(trace=sample_rag_trace)
 
-    mock_groundedness.assert_called_once_with(
-        request="query",
-        response="answer",
-        retrieved_context=[
-            {"content": "content_1", "doc_uri": "url_1"},
-            {"content": "content_2", "doc_uri": "url_2"},
-            {"content": "content_3"},
+    mock_groundedness.assert_has_calls(
+        [
+            call(
+                request="query",
+                response="answer",
+                retrieved_context=[
+                    {"content": "content_1", "doc_uri": "url_1"},
+                    {"content": "content_2", "doc_uri": "url_2"},
+                ],
+                assessment_name="retrieval_groundedness",
+            ),
+            call(
+                request="query",
+                response="answer",
+                retrieved_context=[{"content": "content_3"}],
+                assessment_name="retrieval_groundedness",
+            ),
         ],
-        assessment_name="retrieval_groundedness",
     )
+    assert len(result) == 2
+    assert all(isinstance(f, Feedback) for f in result)
+    expected_span_ids = [
+        s.span_id for s in sample_rag_trace.search_spans(span_type=SpanType.RETRIEVER)
+    ]
+    actual_span_ids = [f.span_id for f in result]
+    assert set(actual_span_ids) == set(expected_span_ids)
 
 
-@pytest.mark.parametrize(
-    ("chunk_relevance_values", "expected"),
-    [
-        (["yes", "yes", "yes"], 1.0),
-        (["yes", "yes", "no"], 0.666),
-        (["no", "no", "no"], 0.0),
-        (["yes", "no", None], 0.5),
-    ],
-)
-def test_retrieval_relevance(sample_rag_trace, chunk_relevance_values, expected):
-    def mock_chunk_relevance(request, retrieved_context, assessment_name):
-        value = chunk_relevance_values.pop(0)
-        error = AssessmentError(error_code="test") if value is None else None
-        return [
-            Feedback(
-                name=assessment_name,
-                value=value,
-                error=error,
-                source=AssessmentSource(source_type="LLM_JUDGE", source_id="test"),
-                trace_id="tr-123",
-                span_id="span-123",
-            )
-        ]
+def test_retrieval_relevance(sample_rag_trace):
+    mock_responses = [
+        # First retriever span has 2 chunks
+        [
+            Feedback(name="retrieval_relevance", value="yes", metadata={"chunk_index": 0}),
+            Feedback(name="retrieval_relevance", value="no", metadata={"chunk_index": 1}),
+        ],
+        # Second retriever span has 1 chunk
+        [
+            Feedback(name="retrieval_relevance", value="yes", metadata={"chunk_index": 0}),
+        ],
+    ]
 
     with patch(
-        "databricks.agents.evals.judges.chunk_relevance", side_effect=mock_chunk_relevance
+        "databricks.agents.evals.judges.chunk_relevance", side_effect=mock_responses
     ) as mock_chunk_relevance:
-        feedback = retrieval_relevance(trace=sample_rag_trace)
+        results = retrieval_relevance(trace=sample_rag_trace)
 
     mock_chunk_relevance.assert_has_calls(
         [
             call(
                 request="query",
-                retrieved_context=[{"content": "content_1", "doc_uri": "url_1"}],
-                assessment_name="retrieval_relevance",
-            ),
-            call(
-                request="query",
-                retrieved_context=[{"content": "content_2", "doc_uri": "url_2"}],
+                retrieved_context=[
+                    {"content": "content_1", "doc_uri": "url_1"},
+                    {"content": "content_2", "doc_uri": "url_2"},
+                ],
                 assessment_name="retrieval_relevance",
             ),
             call(
@@ -117,43 +123,106 @@ def test_retrieval_relevance(sample_rag_trace, chunk_relevance_values, expected)
         ],
     )
 
-    assert feedback.name == "retrieval_relevance"
-    assert abs(feedback.value - expected) < 0.01
-    assert feedback.source == AssessmentSource(source_type="LLM_JUDGE", source_id="test")
-    assert feedback.trace_id == "tr-123"
-    assert feedback.span_id == "span-123"
+    assert len(results) == 5  # 2 span-level feedbacks + 3 chunk-level feedbacks
+    assert all(isinstance(f, Feedback) for f in results)
+    assert all(f.name == "retrieval_relevance" for f in results)
+
+    retriever_span_ids = [
+        s.span_id for s in sample_rag_trace.search_spans(span_type=SpanType.RETRIEVER)
+    ]
+
+    # First feedbacks is a span-level feedback for the first retriever span
+    assert results[0].value == 0.5
+    assert results[0].span_id == retriever_span_ids[0]
+
+    # Second and third feedbacks are chunk-level feedbacks for the first retriever span
+    assert results[1].value == "yes"
+    assert results[1].span_id == retriever_span_ids[0]
+    assert results[2].value == "no"
+    assert results[2].span_id == retriever_span_ids[0]
+
+    # Fourth result is a span-level feedback for the second retriever span
+    assert results[3].value == 1.0
+    assert results[3].span_id == retriever_span_ids[1]
+
+    # Fifth result is a chunk-level feedback for the second retriever span
+    assert results[4].value == "yes"
+    assert results[4].span_id == retriever_span_ids[1]
+
+
+def test_retrieval_relevance_handle_error_feedback(sample_rag_trace):
+    mock_responses = [
+        # Error feedback
+        [
+            Feedback(name="retrieval_relevance", value="yes"),
+            Feedback(name="retrieval_relevance", error=AssessmentError(error_code="test")),
+        ],
+        # Empty feedback - skip span
+        [],
+    ]
+
+    with patch(
+        "databricks.agents.evals.judges.chunk_relevance", side_effect=mock_responses
+    ) as mock_chunk_relevance:
+        results = retrieval_relevance(trace=sample_rag_trace)
+
+    assert mock_chunk_relevance.call_count == 2
+    assert len(results) == 3
+    assert results[0].value == 0.5  # Error feedback is handled as 0.0 relevance
+    assert results[1].value == "yes"
+    assert results[2].value is None
+    assert results[2].error.error_code == "test"
 
 
 def test_retrieval_sufficiency(sample_rag_trace):
-    with patch("databricks.agents.evals.judges.context_sufficiency") as mock_context_sufficiency:
-        retrieval_sufficiency(trace=sample_rag_trace)
+    with patch(
+        "databricks.agents.evals.judges.context_sufficiency",
+        side_effect=lambda *args, **kwargs: Feedback(name="retrieval_sufficiency", value="yes"),
+    ) as mock_context_sufficiency:
+        result = retrieval_sufficiency(trace=sample_rag_trace)
 
-    mock_context_sufficiency.assert_called_once_with(
-        request="query",
-        retrieved_context=[
-            {"content": "content_1", "doc_uri": "url_1"},
-            {"content": "content_2", "doc_uri": "url_2"},
-            {"content": "content_3"},
+    mock_context_sufficiency.assert_has_calls(
+        [
+            call(
+                request="query",
+                retrieved_context=[
+                    {"content": "content_1", "doc_uri": "url_1"},
+                    {"content": "content_2", "doc_uri": "url_2"},
+                ],
+                expected_response="expected answer",
+                expected_facts=["fact1", "fact2"],
+                assessment_name="retrieval_sufficiency",
+            ),
+            call(
+                request="query",
+                retrieved_context=[{"content": "content_3"}],
+                expected_response="expected answer",
+                expected_facts=["fact1", "fact2"],
+                assessment_name="retrieval_sufficiency",
+            ),
         ],
-        expected_response="expected answer",
-        expected_facts=["fact1", "fact2"],
-        assessment_name="retrieval_sufficiency",
     )
+
+    assert len(result) == 2
+    assert all(isinstance(f, Feedback) for f in result)
+    expected_span_ids = [
+        s.span_id for s in sample_rag_trace.search_spans(span_type=SpanType.RETRIEVER)
+    ]
+    actual_span_ids = [f.span_id for f in result]
+    assert set(actual_span_ids) == set(expected_span_ids)
 
 
 def test_guideline_adherence():
     # 1. Called with per-row guidelines
     with patch("databricks.agents.evals.judges.guideline_adherence") as mock_guideline_adherence:
         guideline_adherence(
-            inputs={"question": "query"},
             outputs="answer",
             expectations={"guidelines": ["guideline1", "guideline2"]},
         )
 
     mock_guideline_adherence.assert_called_once_with(
-        request="query",
-        response="answer",
         guidelines=["guideline1", "guideline2"],
+        guidelines_context={"response": "answer"},
         assessment_name="guideline_adherence",
     )
 
@@ -164,42 +233,43 @@ def test_guideline_adherence():
     )
 
     with patch("databricks.agents.evals.judges.guideline_adherence") as mock_guideline_adherence:
-        is_english(
-            inputs={"question": "query"},
-            outputs="answer",
-        )
+        is_english(outputs="answer")
 
     mock_guideline_adherence.assert_called_once_with(
-        request="query",
-        response="answer",
         guidelines=["The response should be in English."],
+        guidelines_context={"response": "answer"},
         assessment_name="is_english",
     )
 
 
 def test_relevance_to_query():
-    with patch("databricks.agents.evals.judges.relevance_to_query") as mock_relevance_to_query:
-        relevance_to_query(
+    with patch(
+        "databricks.agents.evals.judges.chunk_relevance",
+        return_value=[
+            Feedback(name="relevance_to_query", value="yes", metadata={"chunk_index": 0})
+        ],
+    ) as mock_chunk_relevance:
+        result = relevance_to_query(
             inputs={"question": "query"},
             outputs="answer",
         )
 
-    mock_relevance_to_query.assert_called_once_with(
+    mock_chunk_relevance.assert_called_once_with(
         request="query",
-        response="answer",
+        retrieved_context=["answer"],
         assessment_name="relevance_to_query",
     )
+
+    assert result.name == "relevance_to_query"
+    assert result.value == "yes"
+    assert result.metadata == {}  # chunk id should not be included in the metadata
 
 
 def test_safety():
     with patch("databricks.agents.evals.judges.safety") as mock_safety:
-        safety(
-            inputs={"question": "query"},
-            outputs="answer",
-        )
+        safety(outputs="answer")
 
     mock_safety.assert_called_once_with(
-        request="query",
         response="answer",
         assessment_name="safety",
     )

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -316,12 +316,12 @@ def create_span(
                     span_type=SpanType.LLM,
                 ),
             ],
-            None,
+            {},
         ),
         # None trace
         (
             None,
-            None,
+            {},
         ),
     ],
 )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/15950?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15950/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15950/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15950/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Tweak built-in judge/scorers interface to match with the request from eval team.

This PR is built on top of https://github.com/mlflow/mlflow/pull/15906. See the last commit for the actual change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
