### PR TITLE
Suppress all logs from dspy by default

### DIFF
--- a/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
@@ -84,7 +84,7 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
 
         adapter = dspy.JSONAdapter()
         with dspy.context(lm=lm, adapter=adapter):
-            with self._redirect_logs():
+            with self._maybe_suppress_stdout_stderr():
                 optimized_program = optimizer.compile(
                     program,
                     trainset=train_data,
@@ -155,7 +155,7 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
             return extractor(prompt=template).instruction
 
     @contextlib.contextmanager
-    def _redirect_logs(self):
+    def _maybe_suppress_stdout_stderr(self):
         """Context manager for redirecting stdout/stderr based on verbose setting.
         If verbose is False, redirects output to devnull or StringIO.
         If verbose is True, doesn't redirect output.

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -60,6 +60,7 @@ class OptimizerConfig:
         optimizer_llm: Optional LLM parameters for the teacher model. If not provided,
             the target LLM will be used as the teacher.
         algorithm: The optimization algorithm to use. Default: "DSPy/MIPROv2"
+        verbose: Whether to show detailed optimization progress. Default: False
     """
 
     num_instruction_candidates: int = 8
@@ -67,3 +68,4 @@ class OptimizerConfig:
     num_threads: int = field(default_factory=lambda: (multiprocessing.cpu_count() or 1) * 2 + 1)
     optimizer_llm: Optional[LLMParams] = None
     algorithm: str = "DSPy/MIPROv2"
+    verbose: bool = False

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -60,7 +60,7 @@ class OptimizerConfig:
         optimizer_llm: Optional LLM parameters for the teacher model. If not provided,
             the target LLM will be used as the teacher.
         algorithm: The optimization algorithm to use. Default: "DSPy/MIPROv2"
-        verbose: Whether to show detailed optimization progress. Default: False
+        verbose: Whether to show optimizer logs during optimization. Default: False
     """
 
     num_instruction_candidates: int = 8

--- a/tests/genai/optimize/test_dspy_mipro_optimizer.py
+++ b/tests/genai/optimize/test_dspy_mipro_optimizer.py
@@ -276,8 +276,8 @@ def test_extract_instructions():
 @pytest.mark.parametrize(
     "verbose",
     [
-        False,  # Should suppress output
-        True,  # Should show output
+        False,
+        True,
     ],
 )
 def test_optimize_with_verbose(

--- a/tests/genai/optimize/test_dspy_mipro_optimizer.py
+++ b/tests/genai/optimize/test_dspy_mipro_optimizer.py
@@ -1,3 +1,4 @@
+import sys
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
@@ -286,7 +287,9 @@ def test_optimize_with_verbose(
     import dspy
 
     mock_mipro.return_value.compile.side_effect = lambda *args, **kwargs: (
-        print("DSPy optimization progress") or dspy.Predict("input_text, language -> translation")  # noqa: T201
+        print("DSPy optimization progress")  # noqa: T201
+        or print("DSPy debug info", file=sys.stderr)  # noqa: T201
+        or dspy.Predict("input_text, language -> translation")
     )
 
     optimizer = _DSPyMIPROv2Optimizer(OptimizerConfig(verbose=verbose))
@@ -301,7 +304,9 @@ def test_optimize_with_verbose(
     captured = capsys.readouterr()
     if verbose:
         assert "DSPy optimization progress" in captured.out
+        assert "DSPy debug info" in captured.err
     else:
         assert "DSPy optimization progress" not in captured.out
+        assert "DSPy debug info" not in captured.err
 
     mock_mipro.assert_called_once()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/15971?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15971/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15971/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15971/merge
```

</p>
</details>

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

This PR introduces `verbose` option to optimizer config and suppress all DSPy logs by default.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
