### PR TITLE
Introduce public MLFLOW_ACTIVE_MODEL_ID env var for easy linking of traces to logged models in prod deployments

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -774,11 +774,15 @@ MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", int, 500
 )
 
+#: The default active LoggedModel ID. Traces created while this variable is set (unless overridden,
+#: e.g., by the `set_active_model()` API) will be associated with this LoggedModel ID.
+#: (default: ``None``)
+MLFLOW_ACTIVE_MODEL_ID = _EnvironmentVariable("MLFLOW_ACTIVE_MODEL_ID", str, None)
 
-#: Default active LoggedModel ID.
-#: This should only by used by MLflow internally, users should always use
-#: `set_active_model` to set the active LoggedModel, and should not set
-#: this environment variable directly.
+#: Legacy environment variable for setting the default active LoggedModel ID.
+#: This should only by used by MLflow internally. Users should use the
+#: public `MLFLOW_ACTIVE_MODEL_ID` environment variable or the `set_active_model`
+#: API to set the active LoggedModel, and should not set this environment variable directly.
 #: (default: ``None``)
 _MLFLOW_ACTIVE_MODEL_ID = _EnvironmentVariable("_MLFLOW_ACTIVE_MODEL_ID", str, None)
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3308,25 +3308,25 @@ def _get_active_model_id_from_env() -> Optional[str]:
 
     This utility function reads the active model ID from environment variables with the following
     precedence order:
-    1. _MLFLOW_ACTIVE_MODEL_ID (legacy internal variable) - takes precedence if set
-    2. MLFLOW_ACTIVE_MODEL_ID (public variable) - used as fallback
+    1. MLFLOW_ACTIVE_MODEL_ID (public variable) - takes precedence if set
+    2. _MLFLOW_ACTIVE_MODEL_ID (legacy internal variable) - used as fallback
 
     Historical Context:
     The _MLFLOW_ACTIVE_MODEL_ID environment variable was originally created for internal MLflow
-    use only. With the introduction of MLFLOW_ACTIVE_MODEL_ID as the public API, we maintain
-    backward compatibility by preferentially reading from the legacy variable when both are set.
-    This ensures existing internal MLflow code and systems continue to work as expected.
+    use only. With the introduction of MLFLOW_ACTIVE_MODEL_ID as the public API, we prioritize
+    the public variable to encourage migration to the public interface while maintaining
+    backward compatibility by falling back to the legacy variable when only it is set.
 
     Returns:
         The active model ID if found in environment variables, otherwise None.
     """
-    # Check legacy internal variable first for backward compatibility
-    legacy_model_id = _MLFLOW_ACTIVE_MODEL_ID.get()
-    if legacy_model_id is not None:
-        return legacy_model_id
+    # Check public variable first to prioritize the public API
+    public_model_id = MLFLOW_ACTIVE_MODEL_ID.get()
+    if public_model_id is not None:
+        return public_model_id
 
-    # Fallback to public environment variable
-    return MLFLOW_ACTIVE_MODEL_ID.get()
+    # Fallback to legacy internal variable for backward compatibility
+    return _MLFLOW_ACTIVE_MODEL_ID.get()
 
 
 _ACTIVE_MODEL_CONTEXT = ThreadLocalVariable(default_factory=lambda: ActiveModelContext())

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -3480,8 +3480,9 @@ def get_active_model_id() -> Optional[str]:
     """
     Get the active model ID. If no active model is set with ``set_active_model()``, the
     default active model is set using model ID from the environment variable
-    ``_MLFLOW_ACTIVE_MODEL_ID``. If neither is set, return None.
-    Note that this function only get the active model ID from the current thread.
+    ``MLFLOW_ACTIVE_MODEL_ID`` or the legacy environment variable ``_MLFLOW_ACTIVE_MODEL_ID``.
+    If neither is set, return None. Note that this function only get the active model ID from the
+    current thread.
 
     Returns:
         The active model ID if set, otherwise None.
@@ -3517,7 +3518,10 @@ def _get_active_model_id_global() -> Optional[str]:
 def clear_active_model() -> None:
     """
     Clear the active model. This will clear the active model previously set by
-    :py:func:`mlflow.set_active_model` from current thread. To temporarily switch
+    :py:func:`mlflow.set_active_model` or via the ``MLFLOW_ACTIVE_MODEL_ID`` environment variable
+    or the ``_MLFLOW_ACTIVE_MODEL_ID`` legacy environment variable.
+
+    from current thread. To temporarily switch
     the active model, use ``with mlflow.set_active_model(...)`` instead.
 
     .. code-block:: python
@@ -3540,11 +3544,11 @@ def clear_active_model() -> None:
             assert mlflow.get_active_model_id() == active_model.model_id
         assert mlflow.get_active_model_id() is None
     """
-    # reset the environment variable as well to avoid it being used when creating
+    # reset the environment variables as well to avoid them being used when creating
     # ActiveModelContext
-    # no lock here because this environment variable is not expected to be set outside
-    # of databricks serving environment
+    MLFLOW_ACTIVE_MODEL_ID.unset()
     _MLFLOW_ACTIVE_MODEL_ID.unset()
+
     # set_by_user is False because this API clears the state of active model
     # and MLflow might still set the active model in cases like `load_model`
     _ACTIVE_MODEL_CONTEXT.set(ActiveModelContext(set_by_user=False))

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -59,7 +59,6 @@ from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracking.fluent import (
     _ACTIVE_MODEL_CONTEXT,
     ActiveModelContext,
-    _get_active_model_id_from_env,
     _get_active_model_id_global,
     _get_experiment_id,
     _get_experiment_id_from_env,
@@ -2109,37 +2108,6 @@ def test_set_active_model_env_var_precedence(monkeypatch):
     monkeypatch.delenv(_MLFLOW_ACTIVE_MODEL_ID.name)
     _ACTIVE_MODEL_CONTEXT.set(ActiveModelContext())
     assert mlflow.get_active_model_id() is None
-
-
-def test_get_active_model_id_from_env_utility():
-    """Test the _get_active_model_id_from_env utility function directly."""
-    # Test with no environment variables set
-    with (
-        mock.patch.object(_MLFLOW_ACTIVE_MODEL_ID, "get", return_value=None),
-        mock.patch.object(MLFLOW_ACTIVE_MODEL_ID, "get", return_value=None),
-    ):
-        assert _get_active_model_id_from_env() is None
-
-    # Test with only public variable set
-    with (
-        mock.patch.object(_MLFLOW_ACTIVE_MODEL_ID, "get", return_value=None),
-        mock.patch.object(MLFLOW_ACTIVE_MODEL_ID, "get", return_value="public-id"),
-    ):
-        assert _get_active_model_id_from_env() == "public-id"
-
-    # Test with only legacy variable set
-    with (
-        mock.patch.object(_MLFLOW_ACTIVE_MODEL_ID, "get", return_value="legacy-id"),
-        mock.patch.object(MLFLOW_ACTIVE_MODEL_ID, "get", return_value=None),
-    ):
-        assert _get_active_model_id_from_env() == "legacy-id"
-
-    # Test with both variables set - public should take precedence
-    with (
-        mock.patch.object(_MLFLOW_ACTIVE_MODEL_ID, "get", return_value="legacy-id"),
-        mock.patch.object(MLFLOW_ACTIVE_MODEL_ID, "get", return_value="public-id"),
-    ):
-        assert _get_active_model_id_from_env() == "public-id"
 
 
 def test_set_active_model_link_traces():

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2110,7 +2110,7 @@ def test_set_active_model_env_var_precedence(monkeypatch):
     assert mlflow.get_active_model_id() is None
 
 
-def test_clear_active_model_disregards_env_vars(monkeypatch):
+def test_clear_active_model_clears_env_vars(monkeypatch):
     """Test that clear_active_model() properly clears environment variables."""
     # Set both environment variables
     monkeypatch.setenv(_MLFLOW_ACTIVE_MODEL_ID.name, "legacy-model-id")


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Introduce public MLFLOW_ACTIVE_MODEL_ID env var for easy linking of traces to logged models in prod deployments.

When deploying to production, developers may not want to edit their agent code directly in order to hardcode a call to `set_active_model()`. `MLFLOW_ACTIVE_MODEL_ID` env var is a more natural fit, e.g. for docker container deployments.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
