### PR TITLE
Fix: guideline adherence parsing logic + take request

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -358,7 +358,10 @@ class GuidelineAdherence(BuiltInScorer):
             name="english_guidelines",
             global_guidelines=["The response must be in English"],
         )
-        feedback = english(outputs="The capital of France is Paris.")
+        feedback = english(
+            inputs={"question": "What is the capital of France?"},
+            outputs="The capital of France is Paris.",
+        )
         print(feedback)
 
     Example (with evaluate):

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -442,6 +442,7 @@ class GuidelineAdherence(BuiltInScorer):
     def __call__(
         self,
         *,
+        inputs: dict[str, Any],
         outputs: Any,
         expectations: Optional[dict[str, Any]] = None,
     ) -> Assessment:
@@ -449,6 +450,7 @@ class GuidelineAdherence(BuiltInScorer):
         Evaluate adherence to specified guidelines.
 
         Args:
+            inputs: A dictionary of input data, e.g. {"question": "What is the capital of France?"}.
             outputs: The response from the model, e.g. "The capital of France is Paris."
             expectations: A dictionary of expectations for the response. This must contain either
                 `guidelines` key, which is used to evaluate the response against the guidelines
@@ -468,7 +470,10 @@ class GuidelineAdherence(BuiltInScorer):
 
         return judges.meets_guidelines(
             guidelines=guidelines,
-            context={"response": outputs},
+            context={
+                "request": parse_inputs_to_str(inputs),
+                "response": parse_output_to_str(outputs),
+            },
             name=self.name,
         )
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -1,4 +1,3 @@
-import json
 import logging
 from typing import Any, Callable, Optional
 
@@ -8,7 +7,6 @@ import mlflow
 from mlflow.entities.span import Span, SpanType
 from mlflow.entities.trace import Trace
 from mlflow.genai.utils.data_validation import check_model_prediction
-from mlflow.tracing.utils import TraceJSONEncoder
 
 _logger = logging.getLogger(__name__)
 
@@ -62,16 +60,16 @@ class NoOpTracerPatcher:
 
 def parse_inputs_to_str(inputs: Any) -> str:
     """Parse the inputs to a request string compatible with the judges API"""
-    # If it is a single key dictionary, extract the value
-    if isinstance(inputs, dict) and len(inputs) == 1:
-        inputs = list(inputs.values())[0]
+    from databricks.rag_eval.utils import input_output_utils
 
-    return inputs if isinstance(inputs, str) else json.dumps(inputs, default=TraceJSONEncoder)
+    return input_output_utils.request_to_string(inputs)
 
 
 def parse_output_to_str(output: Any) -> str:
     """Parse the output to a string compatible with the judges API"""
-    return output if isinstance(output, str) else json.dumps(output, default=TraceJSONEncoder)
+    from databricks.rag_eval.utils import input_output_utils
+
+    return input_output_utils.response_to_string(output)
 
 
 def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> dict[str, list]:

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -62,7 +62,7 @@ def test_retrieval_groundedness(sample_rag_trace):
     mock_groundedness.assert_has_calls(
         [
             call(
-                request="query",
+                request="{'question': 'query'}",
                 response="answer",
                 retrieved_context=[
                     {"content": "content_1", "doc_uri": "url_1"},
@@ -71,7 +71,7 @@ def test_retrieval_groundedness(sample_rag_trace):
                 assessment_name="retrieval_groundedness",
             ),
             call(
-                request="query",
+                request="{'question': 'query'}",
                 response="answer",
                 retrieved_context=[{"content": "content_3"}],
                 assessment_name="retrieval_groundedness",
@@ -108,7 +108,7 @@ def test_retrieval_relevance(sample_rag_trace):
     mock_chunk_relevance.assert_has_calls(
         [
             call(
-                request="query",
+                request="{'question': 'query'}",
                 retrieved_context=[
                     {"content": "content_1", "doc_uri": "url_1"},
                     {"content": "content_2", "doc_uri": "url_2"},
@@ -116,7 +116,7 @@ def test_retrieval_relevance(sample_rag_trace):
                 assessment_name="retrieval_relevance",
             ),
             call(
-                request="query",
+                request="{'question': 'query'}",
                 retrieved_context=[{"content": "content_3"}],
                 assessment_name="retrieval_relevance",
             ),
@@ -184,7 +184,7 @@ def test_retrieval_sufficiency(sample_rag_trace):
     mock_context_sufficiency.assert_has_calls(
         [
             call(
-                request="query",
+                request="{'question': 'query'}",
                 retrieved_context=[
                     {"content": "content_1", "doc_uri": "url_1"},
                     {"content": "content_2", "doc_uri": "url_2"},
@@ -195,7 +195,7 @@ def test_retrieval_sufficiency(sample_rag_trace):
                 assessment_name="retrieval_sufficiency",
             ),
             call(
-                request="query",
+                request="{'question': 'query'}",
                 retrieved_context=[{"content": "content_3"}],
                 expected_response="expected answer",
                 expected_facts=["fact1", "fact2"],
@@ -223,7 +223,7 @@ def test_retrieval_sufficiency_with_custom_expectations(sample_rag_trace):
     mock_context_sufficiency.assert_has_calls(
         [
             call(
-                request="query",
+                request="{'question': 'query'}",
                 retrieved_context=[
                     {"content": "content_1", "doc_uri": "url_1"},
                     {"content": "content_2", "doc_uri": "url_2"},
@@ -234,7 +234,7 @@ def test_retrieval_sufficiency_with_custom_expectations(sample_rag_trace):
                 assessment_name="retrieval_sufficiency",
             ),
             call(
-                request="query",
+                request="{'question': 'query'}",
                 retrieved_context=[{"content": "content_3"}],
                 expected_response="expected answer",
                 expected_facts=["fact3"],
@@ -248,13 +248,14 @@ def test_guideline_adherence():
     # 1. Called with per-row guidelines
     with patch("databricks.agents.evals.judges.guideline_adherence") as mock_guideline_adherence:
         guideline_adherence(
+            inputs={"question": "query"},
             outputs="answer",
             expectations={"guidelines": ["guideline1", "guideline2"]},
         )
 
     mock_guideline_adherence.assert_called_once_with(
         guidelines=["guideline1", "guideline2"],
-        guidelines_context={"response": "answer"},
+        guidelines_context={"request": "{'question': 'query'}", "response": "answer"},
         assessment_name="guideline_adherence",
     )
 
@@ -265,11 +266,14 @@ def test_guideline_adherence():
     )
 
     with patch("databricks.agents.evals.judges.guideline_adherence") as mock_guideline_adherence:
-        is_english(outputs="answer")
+        is_english(
+            inputs={"question": "query"},
+            outputs="answer",
+        )
 
     mock_guideline_adherence.assert_called_once_with(
         guidelines=["The response should be in English."],
-        guidelines_context={"response": "answer"},
+        guidelines_context={"request": "{'question': 'query'}", "response": "answer"},
         assessment_name="is_english",
     )
 
@@ -287,7 +291,7 @@ def test_relevance_to_query():
         )
 
     mock_chunk_relevance.assert_called_once_with(
-        request="query",
+        request="{'question': 'query'}",
         retrieved_context=["answer"],
         assessment_name="relevance_to_query",
     )
@@ -312,7 +316,7 @@ def test_safety():
         safety(outputs={"answer": "yes", "reason": "This is a test"})
 
     mock_safety.assert_called_once_with(
-        response='{"answer": "yes", "reason": "This is a test"}',
+        response="{'answer': 'yes', 'reason': 'This is a test'}",
         assessment_name="safety",
     )
 
@@ -326,7 +330,7 @@ def test_correctness():
         )
 
     mock_correctness.assert_called_once_with(
-        request="query",
+        request="{'question': 'query'}",
         response="answer",
         expected_facts=["fact1", "fact2"],
         expected_response=None,

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -97,7 +97,7 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
     assert mock_groundedness.call_count == 2  # Called per retriever span
 
     mock_correctness.assert_called_once_with(
-        request="query",
+        request="{'question': 'query'}",
         response="answer",
         expected_facts=["fact1", "fact2"],
         expected_response="expected answer",
@@ -105,13 +105,13 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
     )
     mock_guideline.assert_called_once_with(
         guidelines=["write in english"],
-        guidelines_context={"response": "answer"},
+        guidelines_context={"request": "{'question': 'query'}", "response": "answer"},
         assessment_name="english",
     )
     mock_groundedness.assert_has_calls(
         [
             call(
-                request="query",
+                request="{'question': 'query'}",
                 response="answer",
                 retrieved_context=[
                     {"content": "content_1", "doc_uri": "url_1"},
@@ -120,7 +120,7 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
                 assessment_name="retrieval_groundedness",
             ),
             call(
-                request="query",
+                request="{'question': 'query'}",
                 response="answer",
                 retrieved_context=[
                     {"content": "content_3"},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/15980?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15980/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15980/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15980/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR addresses feedback that the guidelines judge should use a parsed request/response in the context, via the existing parsing in `databricks-agents`. It has the side effect of replacing all other parsing with what is in `databricks-agents`. The implications are as follows:

- If the input/output has a single key, we no longer only take the value (i.e., we use the entire dict). This is beneficial because the key can store information about the value
- Otherwise, the new parsing is a superset with support for chatcompletions.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Guideline adherence takes request and parses known formats before sending inputs to judge.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
