### PR TITLE
Fix: Add precision suffix to retrieval relevance

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -135,7 +135,7 @@ class RetrievalRelevance(BuiltInScorer):
         average = sum(f.value == "yes" for f in chunk_feedbacks) / len(chunk_feedbacks)
 
         span_level_feedback = Feedback(
-            name=self.name,
+            name=self.name + "/precision",
             value=average,
             source=chunk_feedbacks[0].source,
             span_id=span_id,

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -135,6 +135,8 @@ class RetrievalRelevance(BuiltInScorer):
         average = sum(f.value == "yes" for f in chunk_feedbacks) / len(chunk_feedbacks)
 
         span_level_feedback = Feedback(
+            # NB: Adding a special suffix for span-level aggregation so that UI can distinguish
+            # it from the chunk-level score and render it on span correctly.
             name=self.name + "/precision",
             value=average,
             source=chunk_feedbacks[0].source,

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -125,7 +125,6 @@ def test_retrieval_relevance(sample_rag_trace):
 
     assert len(results) == 5  # 2 span-level feedbacks + 3 chunk-level feedbacks
     assert all(isinstance(f, Feedback) for f in results)
-    assert all(f.name == "retrieval_relevance" for f in results)
 
     retriever_span_ids = [
         s.span_id for s in sample_rag_trace.search_spans(span_type=SpanType.RETRIEVER)
@@ -133,20 +132,25 @@ def test_retrieval_relevance(sample_rag_trace):
 
     # First feedbacks is a span-level feedback for the first retriever span
     assert results[0].value == 0.5
+    assert results[0].name == "retrieval_relevance/precision"
     assert results[0].span_id == retriever_span_ids[0]
 
     # Second and third feedbacks are chunk-level feedbacks for the first retriever span
     assert results[1].value == "yes"
+    assert results[1].name == "retrieval_relevance"
     assert results[1].span_id == retriever_span_ids[0]
     assert results[2].value == "no"
+    assert results[2].name == "retrieval_relevance"
     assert results[2].span_id == retriever_span_ids[0]
 
     # Fourth result is a span-level feedback for the second retriever span
     assert results[3].value == 1.0
+    assert results[3].name == "retrieval_relevance/precision"
     assert results[3].span_id == retriever_span_ids[1]
 
     # Fifth result is a chunk-level feedback for the second retriever span
     assert results[4].value == "yes"
+    assert results[4].name == "retrieval_relevance"
     assert results[4].span_id == retriever_span_ids[1]
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/15983?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15983/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/15983/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/15983/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled, to fix the issue where all retrieval assessments bunch into the same column.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Add precision suffix to aggregate retrieval relevance assessment.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
