### PR TITLE
Use the right Java version when building docker image in `tests/spark/test_spark_model_export.py::test_model_deployment`

### DIFF
--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -60,10 +60,10 @@ PYSPARK_VERSION = Version(pyspark.__version__)
 def spark_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     additional_pip_deps = ["/opt/mlflow", f"pyspark=={PYSPARK_VERSION}", "pytest"]
-    if PYSPARK_VERSION <= Version("3.3.2"):
+    if PYSPARK_VERSION <= Version("3.4"):
         additional_pip_deps.extend(
             [
-                # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
+                # Versions of PySpark < 3.4 are incompatible with pandas >= 2
                 "pandas<2",
                 # pandas<2.0 is incompatible with numpy>=2.0
                 "numpy<2.0",

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -60,7 +60,7 @@ PYSPARK_VERSION = Version(pyspark.__version__)
 def spark_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
     additional_pip_deps = ["/opt/mlflow", f"pyspark=={PYSPARK_VERSION}", "pytest"]
-    if PYSPARK_VERSION <= Version("3.4"):
+    if PYSPARK_VERSION < Version("3.4"):
         additional_pip_deps.extend(
             [
                 # Versions of PySpark < 3.4 are incompatible with pandas >= 2

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -53,12 +53,14 @@ from tests.store.artifact.constants import MODELS_ARTIFACT_REPOSITORY
 
 _logger = logging.getLogger(__name__)
 
+PYSPARK_VERSION = Version(pyspark.__version__)
+
 
 @pytest.fixture
 def spark_custom_env(tmp_path):
     conda_env = os.path.join(tmp_path, "conda_env.yml")
-    additional_pip_deps = ["/opt/mlflow", "pyspark", "pytest"]
-    if Version(pyspark.__version__) <= Version("3.3.2"):
+    additional_pip_deps = ["/opt/mlflow", f"pyspark=={PYSPARK_VERSION}", "pytest"]
+    if PYSPARK_VERSION <= Version("3.3.2"):
         additional_pip_deps.extend(
             [
                 # Versions of PySpark <= 3.3.2 are incompatible with pandas >= 2
@@ -337,7 +339,12 @@ def test_transformer_model_export(spark_model_transformer, model_path, spark_cus
     assert spark_model_transformer.predictions == preds2
 
 
-def test_model_deployment(spark_model_iris, model_path, spark_custom_env):
+def test_model_deployment(spark_model_iris, model_path, spark_custom_env, monkeypatch):
+    monkeypatch.setenv(
+        "MLFLOW_DOCKER_OPENJDK_VERSION",
+        "17" if PYSPARK_VERSION > Version("3.4.1") else "11",
+    )
+
     mlflow.spark.save_model(
         spark_model_iris.model,
         path=model_path,


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow/mlflow/actions/runs/15381339950/job/43272611088?pr=15966:

```
  File "/opt/mlflow/mlflow/pyfunc/scoring_server/app.py", line 6, in <module>
    scoring_server.load_model_with_mlflow_config(os.environ[scoring_server._SERVER_MODEL_PATH])
  File "/opt/mlflow/mlflow/pyfunc/scoring_server/__init__.py", line 102, in load_model_with_mlflow_config
    return load_model(model_uri, **extra_kwargs)
  File "/opt/mlflow/mlflow/tracing/provider.py", line 435, in wrapper
    is_func_called, result = True, f(*args, **kwargs)
  File "/opt/mlflow/mlflow/pyfunc/__init__.py", line 1168, in load_model
    model_impl = importlib.import_module(conf[MAIN])._load_pyfunc(data_path)
  File "/opt/mlflow/mlflow/spark/__init__.py", line 940, in _load_pyfunc
    spark = _create_local_spark_session_for_loading_spark_model()
  File "/opt/mlflow/mlflow/utils/_spark_utils.py", line 104, in _create_local_spark_session_for_loading_spark_model
    .getOrCreate()
  File "/root/.mlflow/envs/mlflow-c8a62d2fe965a0f3c619884676f297aa789f148c/lib/python3.10/site-packages/pyspark/sql/session.py", line 556, in getOrCreate
    sc = SparkContext.getOrCreate(sparkConf)
  File "/root/.mlflow/envs/mlflow-c8a62d2fe965a0f3c619884676f297aa789f148c/lib/python3.10/site-packages/pyspark/core/context.py", line 523, in getOrCreate
    SparkContext(conf=conf or SparkConf())
  File "/root/.mlflow/envs/mlflow-c8a62d2fe965a0f3c619884676f297aa789f148c/lib/python3.10/site-packages/pyspark/core/context.py", line 205, in __init__
    SparkContext._ensure_initialized(self, gateway=gateway, conf=conf)
  File "/root/.mlflow/envs/mlflow-c8a62d2fe965a0f3c619884676f297aa789f148c/lib/python3.10/site-packages/pyspark/core/context.py", line 444, in _ensure_initialized
    SparkContext._gateway = gateway or launch_gateway(conf)
  File "/root/.mlflow/envs/mlflow-c8a62d2fe965a0f3c619884676f297aa789f148c/lib/python3.10/site-packages/pyspark/java_gateway.py", line 111, in launch_gateway
    raise PySparkRuntimeError(
pyspark.errors.exceptions.base.PySparkRuntimeError: [JAVA_GATEWAY_EXITED] Java gateway process exited before sending its port number.
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
