### PR TITLE
Avoid generating traces from scorers during evaluation

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 from mlflow.entities import Assessment, Feedback
 from mlflow.entities.assessment import DEFAULT_FEEDBACK_NAME
 from mlflow.entities.trace import Trace
+from mlflow.tracing.provider import trace_disabled
 from mlflow.utils.annotations import experimental
 
 
@@ -15,6 +16,10 @@ class Scorer(BaseModel):
     name: str
     aggregations: Optional[list] = None
 
+    # NB: Disable tracing during the scorer call to avoid generating extra traces
+    #   during the evaluation. This should be added to `run` instead of `__call__`
+    #   so that users can still see traces when directly calling the scorer function.
+    @trace_disabled
     def run(self, *, inputs=None, outputs=None, expectations=None, trace=None):
         from mlflow.evaluation import Assessment as LegacyAssessment
 

--- a/tests/genai/test_scorer.py
+++ b/tests/genai/test_scorer.py
@@ -13,6 +13,8 @@ from mlflow.entities.assessment_error import AssessmentError
 from mlflow.evaluation import Assessment as LegacyAssessment
 from mlflow.genai import Scorer, scorer
 
+from tests.tracing.helper import get_traces, purge_traces
+
 if importlib.util.find_spec("databricks.agents") is None:
     pytest.skip(reason="databricks-agents is not installed", allow_module_level=True)
 
@@ -238,3 +240,33 @@ def test_custom_scorer_does_not_overwrite_feedback_name_when_returning_list():
     )
     assert feedbacks[0].name == "big_question"
     assert feedbacks[1].name == "small_question"
+
+
+def test_custom_scorer_does_not_generate_traces_during_evaluation():
+    @scorer
+    def my_scorer(inputs, outputs):
+        with mlflow.start_span(name="scorer_trace") as span:
+            # Tracing is disabled during evaluation but this should not NPE
+            span.set_inputs(inputs)
+            span.set_outputs(outputs)
+        return 1
+
+    result = mlflow.genai.evaluate(
+        data=[{"inputs": {"question": "Hello"}, "outputs": "Hi!"}],
+        scorers=[my_scorer],
+    )
+    assert result.metrics["metric/my_scorer/average"] == 1
+    # One trace is generated for evaluation result, but no traces are generated for the scorer
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].data.spans[0].name != "scorer_trace"
+    purge_traces()
+
+    # When invoked directly, the scorer should generate traces
+    score = my_scorer(inputs={"question": "Hello"}, outputs="Hi!")
+    assert score == 1
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].data.spans[0].name == "scorer_trace"
+    assert traces[0].data.spans[0].inputs == {"question": "Hello"}
+    assert traces[0].data.spans[0].outputs == "Hi!"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16004?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16004/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16004/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16004/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Sometimes custom scorer includes a logic that generates traces - e.g. the scorer calls OpenAI endpoint and autologging is enabled. Those traces should not be logged to the evaluation Run, otherwise they are mixed with traces from model prediction and mess up the result.

**Note**: While we *need* to suppress scorer trace here, there was a feature request to show traces inside scorer execution, so that users can track LLM judge costs and usage. Currently there is no correct place to store those traces, but we should think about how to provide this observability.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
