### PR TITLE
Support smart truncation for Responses API

### DIFF
--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -7,7 +7,7 @@ from typing import Generator, Optional
 from mlflow.entities import LiveSpan, Trace, TraceData, TraceInfo
 from mlflow.environment_variables import MLFLOW_TRACE_TIMEOUT_SECONDS
 from mlflow.tracing.utils.timeout import get_trace_cache_with_timeout
-from mlflow.tracing.utils.truncation import truncate_request_response_preview
+from mlflow.tracing.utils.truncation import set_request_response_preview
 
 _logger = logging.getLogger(__name__)
 
@@ -25,17 +25,7 @@ class _Trace:
             # Convert LiveSpan, mutable objects, into immutable Span objects before persisting.
             trace_data.spans.append(span.to_immutable_span())
 
-        # If request/response preview is already set by users via `mlflow.update_current_trace`,
-        # we don't override it with the truncated version.
-        if self.info.request_preview is None:
-            self.info.request_preview = truncate_request_response_preview(
-                trace_data.request, role="user"
-            )
-        if self.info.response_preview is None:
-            self.info.response_preview = truncate_request_response_preview(
-                trace_data.response, role="assistant"
-            )
-
+        set_request_response_preview(self.info, trace_data)
         return Trace(self.info, trace_data)
 
     def get_root_span(self) -> Optional[LiveSpan]:

--- a/mlflow/tracing/utils/truncation.py
+++ b/mlflow/tracing/utils/truncation.py
@@ -1,10 +1,24 @@
 import json
 from typing import Any, Optional
 
+from mlflow.entities.trace_data import TraceData
+from mlflow.entities.trace_info import TraceInfo
 from mlflow.tracing.constant import TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH
 
 
-def truncate_request_response_preview(request_or_response: Optional[str], role: str) -> str:
+def set_request_response_preview(trace_info: TraceInfo, trace_data: TraceData) -> None:
+    """
+    Set the request and response previews for the trace info.
+    """
+    # If request/response preview is already set by users via `mlflow.update_current_trace`,
+    # we don't override it with the truncated version.
+    if trace_info.request_preview is None:
+        trace_info.request_preview = _get_truncated_preview(trace_data.request, role="user")
+    if trace_info.response_preview is None:
+        trace_info.response_preview = _get_truncated_preview(trace_data.response, role="assistant")
+
+
+def _get_truncated_preview(request_or_response: Optional[str], role: str) -> str:
     """
     Truncate the request preview to fit the max length.
     """
@@ -15,7 +29,14 @@ def truncate_request_response_preview(request_or_response: Optional[str], role: 
         return request_or_response
 
     content = None
-    if messages := _try_extract_messages(request_or_response):
+
+    # Parse JSON serialized request/response
+    try:
+        obj = json.loads(request_or_response)
+    except json.JSONDecodeError:
+        obj = None
+
+    if messages := _try_extract_messages(obj):
         msg = _get_last_message(messages, role=role)
         content = _get_text_content_from_message(msg)
 
@@ -27,24 +48,37 @@ def truncate_request_response_preview(request_or_response: Optional[str], role: 
     return content[: TRACE_REQUEST_RESPONSE_PREVIEW_MAX_LENGTH - 3] + "..."
 
 
-def _try_extract_messages(obj_str: str) -> Optional[list[dict[str, Any]]]:
-    try:
-        obj = json.loads(obj_str)
-    except json.JSONDecodeError:
-        return None
-
+def _try_extract_messages(obj: dict[str, Any]) -> Optional[list[dict[str, Any]]]:
     if not isinstance(obj, dict):
         return None
 
     # Check if the object contains messages with OpenAI ChatCompletion format
     if messages := obj.get("messages"):
-        return messages
+        return [item for item in messages if _is_message(item)]
 
     # Check if the object contains a message in OpenAI ChatCompletion response format (choices)
     if (choices := obj.get("choices")) and len(choices) > 0:
         return [choices[0].get("message")]
 
+    # Check if the object contains a message in OpenAI Responses API request format
+    if (input := obj.get("input")) and isinstance(input, list):
+        return [item for item in input if _is_message(item)]
+
+    # Check if the object contains a message in OpenAI Responses API response format
+    if (output := obj.get("output")) and isinstance(output, list):
+        return [item for item in output if _is_message(item)]
+
+    # Handle ResponsesAgent input, which contains OpenAI Responses request in 'request' key
+    if "request" in obj:
+        return _try_extract_messages(obj["request"])
+
     return None
+
+
+def _is_message(item: Any) -> bool:
+    if not isinstance(item, dict):
+        return False
+    return "role" in item and "content" in item
 
 
 def _get_last_message(messages: list[dict[str, Any]], role: str) -> Optional[dict[str, Any]]:
@@ -65,7 +99,7 @@ def _get_text_content_from_message(message: dict[str, Any]) -> str:
         for part in content:
             if isinstance(part, str):
                 return part
-            elif isinstance(part, dict) and part.get("type") == "text":
+            elif isinstance(part, dict) and part.get("type") in ["text", "output_text"]:
                 return part.get("text")
     elif isinstance(content, str):
         return content


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16012?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16012/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16012/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16012/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Expand https://github.com/mlflow/mlflow/pull/15840 to OpenAI Responses API and Responses Agent

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
