### PR TITLE
Log datasets to child runs created by cross validation in sklearn autolog

### DIFF
--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1642,7 +1642,7 @@ def _autolog(  # noqa: D417
                     run_id=mlflow.active_run().info.run_id,
                     metrics={"best_cv_score": estimator.best_score_},
                     dataset=dataset,
-                    model_id=best_estimator_model_id,
+                    model_id=model_id,
                 )
 
             if hasattr(estimator, "best_params_"):

--- a/mlflow/sklearn/__init__.py
+++ b/mlflow/sklearn/__init__.py
@@ -1642,7 +1642,7 @@ def _autolog(  # noqa: D417
                     run_id=mlflow.active_run().info.run_id,
                     metrics={"best_cv_score": estimator.best_score_},
                     dataset=dataset,
-                    model_id=model_id,
+                    model_id=best_estimator_model_id,
                 )
 
             if hasattr(estimator, "best_params_"):

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -852,7 +852,11 @@ def _create_child_runs_for_parameter_search(  # noqa: D417
         # Log how many child runs will be created vs omitted.
         _log_child_runs_info(max_tuning_runs, len(cv_results_df))
 
-    datasets = [DatasetInput(dataset, tags=[InputTag(key=MLFLOW_DATASET_CONTEXT, value="train")])]
+    datasets = [
+        DatasetInput(
+            dataset._to_mlflow_entity(), tags=[InputTag(key=MLFLOW_DATASET_CONTEXT, value="train")]
+        )
+    ]
     for _, result_row in cv_results_best_n_df.iterrows():
         tags_to_log = dict(child_tags) if child_tags else {}
         tags_to_log.update({MLFLOW_PARENT_RUN_ID: parent_run.info.run_id})

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -13,6 +13,9 @@ import numpy as np
 from packaging.version import Version
 
 from mlflow import MlflowClient
+from mlflow.entities.dataset_input import DatasetInput
+from mlflow.entities.input_tag import InputTag
+from mlflow.tracking.fluent import MLFLOW_DATASET_CONTEXT
 from mlflow.utils.arguments_utils import _get_arg_names
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.mlflow_tags import MLFLOW_PARENT_RUN_ID
@@ -849,6 +852,7 @@ def _create_child_runs_for_parameter_search(  # noqa: D417
         # Log how many child runs will be created vs omitted.
         _log_child_runs_info(max_tuning_runs, len(cv_results_df))
 
+    datasets = [DatasetInput(dataset, tags=[InputTag(key=MLFLOW_DATASET_CONTEXT, value="train")])]
     for _, result_row in cv_results_best_n_df.iterrows():
         tags_to_log = dict(child_tags) if child_tags else {}
         tags_to_log.update({MLFLOW_PARENT_RUN_ID: parent_run.info.run_id})
@@ -892,7 +896,7 @@ def _create_child_runs_for_parameter_search(  # noqa: D417
             dataset=dataset,
             model_id=model_id,
         )
-
+        autologging_client.log_inputs(run_id=pending_child_run_id, datasets=datasets)
         autologging_client.set_terminated(run_id=pending_child_run_id, end_time=child_run_end_time)
 
 

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -848,6 +848,11 @@ def test_parameter_search_estimators_produce_expected_outputs(
         assert len(child_runs) == max_tuning_runs
         assert len(child_runs) + num_rest == num_total_results
 
+    # Check that each child run has a dataset input
+    for cr in child_runs:
+        cr = client.get_run(cr.info.run_id)
+        assert len(cr.inputs.dataset_inputs) == 1
+
     # Verify that the best max_tuning_runs of parameter search results
     # have a corresponding MLflow run with the expected data
     best_child_metrics = None

--- a/tests/sklearn/test_sklearn_autolog.py
+++ b/tests/sklearn/test_sklearn_autolog.py
@@ -850,7 +850,6 @@ def test_parameter_search_estimators_produce_expected_outputs(
 
     # Check that each child run has a dataset input
     for cr in child_runs:
-        cr = client.get_run(cr.info.run_id)
         assert len(cr.inputs.dataset_inputs) == 1
 
     # Verify that the best max_tuning_runs of parameter search results


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This is a fix for the issue where clicking the dataset linked to the best estimator does nothing on MLflow UI (see the video below)

https://github.com/user-attachments/assets/ee8f0c4d-6281-44ca-8286-44f1f2db78e9

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/77042c2d-a3e0-4b3f-bfc8-d64548764b40

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
