### PR TITLE
Support setting tags on traces waiting for async export

### DIFF
--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -48,6 +48,12 @@ def log_assessment(trace_id: str, assessment: Assessment) -> Assessment:
         Feedback can come from different sources, such as human judges, heuristic scorers,
         or LLM-as-a-Judge.
 
+    .. note::
+
+        Please be careful when using this API while async trace logging is enabled. When
+        this API is called right after the trace is ended, it might block until the trace
+        is exported to the tracking server.
+
     The following code annotates a trace with a feedback provided by LLM-as-a-Judge.
 
     .. code-block:: python
@@ -153,6 +159,12 @@ def log_expectation(
         This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
 
     Logs an expectation (e.g. ground truth label) to a Trace. This API only takes keyword arguments.
+
+    .. note::
+
+        Please be careful when using this API while async trace logging is enabled. When
+        this API is called right after the trace is ended, it might block until the trace
+        is exported to the tracking server.
 
     Args:
         trace_id: The ID of the trace.
@@ -264,6 +276,12 @@ def log_feedback(
         This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
 
     Logs feedback to a Trace. This API only takes keyword arguments.
+
+    .. note::
+
+        Please be careful when using this API while async trace logging is enabled. When
+        this API is called right after the trace is ended, it might block until the trace
+        is exported to the tracking server.
 
     Args:
         trace_id: The ID of the trace.

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -70,11 +70,11 @@ def _retry_if_trace_is_pending_export(func):
             try:
                 return func(self, trace_id, *args, **kwargs)
             except RestException as e:
-                if e.error_code == RESOURCE_DOES_NOT_EXIST or (
+                if e.error_code == "RESOURCE_DOES_NOT_EXIST" or (
                     # Databricks backend returns INVALID_PARAMETER_VALUE for non-existent traces.
                     # TODO: Remove this workaround once the backend is fixed to return correct
                     # error code.
-                    e.error_code == INVALID_PARAMETER_VALUE
+                    e.error_code == "INVALID_PARAMETER_VALUE"
                     and e.message.endswith(f"Traces with ids ({trace_id}) do not exist")
                 ):
                     time.sleep(interval)

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -84,13 +84,6 @@ def _retry_if_trace_is_pending_export(func):
             error_code=RESOURCE_DOES_NOT_EXIST,
         ) from error
 
-    # Add a note in API doc to say the API might block until the trace is exported
-    wrapper.__doc__ = f"{wrapper.__doc__}\n\n" + (
-        ".. note::\n\n"
-        "    Please be careful when using this API while async trace logging is enabled. The API "
-        "might block until the trace is exported to the tracking server.\n"
-    )
-
     return wrapper
 
 
@@ -251,7 +244,6 @@ class TracingClient:
             ) from None  # Ensure the original spammy exception is not included in the traceback
         return Trace(trace_info, trace_data)
 
-    @_retry_if_trace_is_pending_export
     def get_online_trace_details(
         self,
         trace_id: str,
@@ -518,7 +510,6 @@ class TracingClient:
         else:
             self.store.delete_trace_tag(trace_id, key)
 
-    @_retry_if_trace_is_pending_export
     def get_assessment(self, trace_id: str, assessment_id: str) -> Assessment:
         """
         Get an assessment entity from the backend store.
@@ -568,7 +559,6 @@ class TracingClient:
 
         return self.store.create_assessment(assessment)
 
-    @_retry_if_trace_is_pending_export
     def update_assessment(
         self,
         trace_id: str,
@@ -599,7 +589,6 @@ class TracingClient:
             metadata=assessment.metadata,
         )
 
-    @_retry_if_trace_is_pending_export
     def delete_assessment(self, trace_id: str, assessment_id: str):
         """
         Delete an assessment associated with a trace.

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -57,12 +57,13 @@ def _retry_if_trace_is_pending_export(func):
     and waiting to be flushed to the backend store. In that case, we need to wait
     for the trace to be flushed to the backend store before calling backend API.
     """
-    # If async logging is not enabled, we shouldn't retry.
-    if not should_enable_async_logging():
-        return func
 
     @wraps(func)
     def wrapper(self, trace_id, *args, **kwargs):
+        # If async logging is not enabled, we shouldn't retry.
+        if not should_enable_async_logging():
+            return func
+
         interval = 1
         error = None
         for _ in range(_PENDING_TRACE_MAX_RETRY_COUNT):

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -84,6 +84,13 @@ def _retry_if_trace_is_pending_export(func):
             error_code=RESOURCE_DOES_NOT_EXIST,
         ) from error
 
+    # Add a note in API doc to say the API might block until the trace is exported
+    wrapper.__doc__ = f"{wrapper.__doc__}\n\n" + (
+        ".. note::\n\n"
+        "    Please be careful when using this API while async trace logging is enabled. The API "
+        "might block until the trace is exported to the tracking server.\n"
+    )
+
     return wrapper
 
 

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -69,7 +69,9 @@ class AsyncTraceExportQueue:
         if cls._instance is None:
             return True
 
-        return cls._instance._queue.empty()
+        # If the item is not in the queue but is being processed by a worker,
+        # it should be considered as not empty
+        return cls._instance._queue.empty() and not cls._instance._active_tasks
 
     def put(self, task: Task):
         """Put a new task to the queue for processing."""

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -11,9 +11,27 @@ from typing import Callable, Sequence
 from mlflow.environment_variables import (
     MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE,
     MLFLOW_ASYNC_TRACE_LOGGING_MAX_WORKERS,
+    MLFLOW_ENABLE_ASYNC_TRACE_LOGGING,
 )
+from mlflow.utils.databricks_utils import is_in_databricks_notebook
 
 _logger = logging.getLogger(__name__)
+
+
+def should_enable_async_logging():
+    if is_in_databricks_notebook():
+        # NB: We don't turn on async logging in Databricks notebook by default
+        # until we are confident that the async logging is working on the
+        # offline workload on Databricks, to derisk the inclusion to the
+        # standard image. When it is enabled explicitly via the env var, we
+        # will respect that.
+        return (
+            MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
+            if MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.is_set()
+            else False
+        )
+
+    return MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
 
 
 @dataclass

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -595,6 +595,11 @@ def get_trace(trace_id: str) -> Optional[Trace]:
     it fetches the trace from the tracking store. If the trace is not found in the tracking store,
     it returns None.
 
+    .. note::
+        Please be careful when using this API while async trace logging is enabled. When
+        this API is called right after the trace is ended, it might block until the trace
+        is exported to the tracking server.
+
     Args:
         trace_id: The ID of the trace.
 
@@ -1123,6 +1128,11 @@ def set_trace_tag(trace_id: str, key: str, value: str):
     backend. Below is an example of setting a tag on an active trace. You can replace the
     ``trace_id`` parameter to set a tag on an already ended trace.
 
+    .. note::
+        Please be careful when using this API while async trace logging is enabled. When
+        this API is called right after the trace is ended, it might block until the trace
+        is exported to the tracking server.
+
     .. code-block:: python
         :test:
 
@@ -1149,6 +1159,11 @@ def delete_trace_tag(trace_id: str, key: str) -> None:
     The trace can be an active one or the one that has already ended and recorded in the
     backend. Below is an example of deleting a tag on an active trace. You can replace the
     ``trace_id`` parameter to delete a tag on an already ended trace.
+
+    .. note::
+        Please be careful when using this API while async trace logging is enabled. When
+        this API is called right after the trace is ended, it might block until the trace
+        is exported to the tracking server.
 
     .. code-block:: python
         :test:

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -109,7 +109,7 @@ def test_export(is_async, monkeypatch):
     assert mlflow.get_last_active_trace_id() is not None
 
 
-@mock.patch("mlflow.tracing.export.mlflow_v3.is_in_databricks_notebook", return_value=True)
+@mock.patch("mlflow.tracing.export.async_export_queue.is_in_databricks_notebook", return_value=True)
 def test_async_logging_disabled_in_databricks_notebook(mock_is_in_db_notebook, monkeypatch):
     exporter = MlflowV3SpanExporter()
     assert not exporter._is_async_enabled

--- a/tests/tracing/test_client.py
+++ b/tests/tracing/test_client.py
@@ -1,4 +1,5 @@
 import time
+from unittest import mock
 
 import pytest
 
@@ -50,10 +51,13 @@ def test_set_trace_tag_on_pending_trace(monkeypatch):
         time.sleep(5)
         original(*args, **kwargs)
 
-    monkeypatch.setattr(TracingClient, "_upload_ended_trace_info", _slow_upload_ended_trace_info)
-
-    with mlflow.start_span() as span:
-        pass
+    with mock.patch.object(
+        TracingClient,
+        "_upload_ended_trace_info",
+        side_effect=_slow_upload_ended_trace_info,
+    ):
+        with mlflow.start_span() as span:
+            pass
 
     # Trace is still pending export, not uploaded to the backend yet
     assert get_traces() == []

--- a/tests/tracing/test_client.py
+++ b/tests/tracing/test_client.py
@@ -1,0 +1,123 @@
+import time
+
+import pytest
+
+import mlflow
+from mlflow.exceptions import MlflowException, RestException
+from mlflow.tracing.client import TracingClient, _retry_if_trace_is_pending_export
+from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue
+
+from tests.tracing.helper import get_traces
+
+
+def test_set_and_delete_trace_tag_on_logged_trace():
+    client = TracingClient()
+
+    with mlflow.start_span() as span:
+        pass
+
+    client.set_trace_tag(span.trace_id, "foo", "bar")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.tags["foo"] == "bar"
+
+    client.delete_trace_tag(span.trace_id, "foo")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert "foo" not in trace.info.tags
+
+
+def test_set_and_delete_trace_tag_on_active_trace():
+    client = TracingClient()
+
+    with mlflow.start_span() as span:
+        trace_id = span.trace_id
+        client.set_trace_tag(trace_id, "foo", "bar")
+        client.set_trace_tag(trace_id, "baz", "qux")
+        client.delete_trace_tag(trace_id, "baz")
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.tags["foo"] == "bar"
+    assert "baz" not in trace.info.tags
+
+
+def test_set_trace_tag_on_pending_trace(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", "true")
+
+    original = TracingClient._upload_ended_trace_info
+
+    def _slow_upload_ended_trace_info(*args, **kwargs):
+        time.sleep(5)
+        original(*args, **kwargs)
+
+    monkeypatch.setattr(TracingClient, "_upload_ended_trace_info", _slow_upload_ended_trace_info)
+
+    with mlflow.start_span() as span:
+        pass
+
+    # Trace is still pending export, not uploaded to the backend yet
+    assert get_traces() == []
+
+    client = TracingClient()
+    client.set_trace_tag(span.trace_id, "foo", "bar")
+
+    # Force the trace to be uploaded to the backend
+    mlflow.flush_trace_async_logging()
+    assert len(get_traces()) == 1
+    trace = get_traces()[0]
+    assert trace.info.tags["foo"] == "bar"
+
+
+def test_retry_decorator_should_retry_when_queue_is_not_empty(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", "true")
+    monkeypatch.setattr(AsyncTraceExportQueue, "is_empty", lambda: False)
+    monkeypatch.setattr(mlflow.tracing.client, "_PENDING_TRACE_MAX_RETRY_COUNT", 2)
+
+    calls = []
+
+    @_retry_if_trace_is_pending_export
+    def dummy_method(self, trace_id, key, value):
+        calls.append((trace_id, key, value))
+        raise RestException({"error_code": "INVALID_PARAMETER_VALUE", "message": "Not found"})
+
+    with pytest.raises(MlflowException, match=r"Failed to call dummy_method API."):
+        dummy_method(None, "trace_id", "key", "value")
+
+    assert len(calls) == 2
+    assert all(call == ("trace_id", "key", "value") for call in calls)
+
+
+def test_retry_decorator_should_not_retry_when_queue_is_empty(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", "false")
+    monkeypatch.setattr(AsyncTraceExportQueue, "is_empty", lambda: True)
+
+    calls = []
+
+    @_retry_if_trace_is_pending_export
+    def dummy_method(self, trace_id, key, value):
+        calls.append((trace_id, key, value))
+        raise RestException({"error_code": "INVALID_PARAMETER_VALUE", "message": "Not found"})
+
+    with pytest.raises(RestException, match=r"INVALID_PARAMETER_VALUE"):
+        dummy_method(None, "trace_id", "key", "value")
+
+    assert len(calls) == 1
+    assert calls[0] == ("trace_id", "key", "value")
+
+
+def test_retry_decorator_should_not_retry_other_exceptions(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ENABLE_ASYNC_LOGGING", "false")
+    monkeypatch.setattr(AsyncTraceExportQueue, "is_empty", lambda: False)
+
+    calls = []
+
+    @_retry_if_trace_is_pending_export
+    def dummy_method(self, trace_id, key, value):
+        calls.append((trace_id, key, value))
+        raise ValueError("test")
+
+    with pytest.raises(ValueError, match="test"):
+        dummy_method(None, "trace_id", "key", "value")
+
+    assert len(calls) == 1
+    assert calls[0] == ("trace_id", "key", "value")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16042?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16042/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16042/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16042/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `set_trace_tag(trace_id, key, value)` API works as follows:
1. If the trace with the given ID is still in-progress i.e. not exported to backend, MLflow looks for a in-memory trace stored in `InMemoryTraceManager` and set tag on it.
2. If the trace is already exported, call the backend SetTraceTag API.

These two cover pretty much all cases *before we add async logging*. When async logging is enabled, there is a third case

3. The trace is finished, but waiting for export inside async logging queue.

In this case, the trace is not in either InMemoryTraceManager or backend, resulting in NotFound error. This happens when users code is like this

```
import mlflow

mlflow.openai.autolog()

openai.OpenAI().chat.completions.create(...)

trace_id = mlflow.get_last_active_trace_id()
mlflow.set_trace_tag(trace_id, "key", "value") # At this moment, trace is ended but may not be exported to backend yet.
```

However, mutating a trace object in async queue is not trivial. We need to iterate on the queue and also make sure the worker doesn't export it during the mutation. Making it overly complex has a risk of introducing new edge cases.

Therefore, this PR resolves it by a simple retry strategy. We first try (1) and (2) as usual. Then if (2) fails and async queue is not empty, we suspect the trace is pending export, hence retry (2) after some interval.

**Note**: Another way to workaround the problem is to call `mlflow.flush_async_trace_logging()` before setting the tag. However, it can be significantly costly than retrying for single trace, because it blocks until all pending traces to be exported.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests (TBD)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix trace-not-found error in `mlflow.set_trace_tag` API when async logging is enabled.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
