### PR TITLE
Log eval score as metadata

### DIFF
--- a/mlflow/genai/optimize/base.py
+++ b/mlflow/genai/optimize/base.py
@@ -14,7 +14,7 @@ from mlflow.genai.optimize.types import (
     PromptOptimizationResult,
 )
 from mlflow.genai.scorers import Scorer
-from mlflow.tracking._model_registry.fluent import load_prompt, register_prompt
+from mlflow.tracking._model_registry.fluent import load_prompt
 from mlflow.utils.annotations import experimental
 
 if TYPE_CHECKING:
@@ -122,20 +122,13 @@ def optimize_prompt(
     if isinstance(prompt, str):
         prompt: Prompt = load_prompt(prompt)
 
-    optimized_prompt_template = optimzer.optimize(
+    optimized_prompt = optimzer.optimize(
         prompt=prompt,
         target_llm_params=target_llm_params,
         train_data=train_data,
         scorers=scorers,
         objective=objective,
         eval_data=eval_data,
-    )
-
-    optimized_prompt = register_prompt(
-        name=prompt.name,
-        # TODO: we should revisit the optimized template format
-        # once multi-turn messages are supported.
-        template=optimized_prompt_template,
     )
 
     return PromptOptimizationResult(prompt=optimized_prompt)

--- a/mlflow/genai/optimize/optimizers/base_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/base_optimizer.py
@@ -1,5 +1,5 @@
 import abc
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 from mlflow.entities.model_registry import Prompt
 from mlflow.genai.optimize.types import OBJECTIVE_FN, LLMParams, OptimizerConfig
@@ -22,7 +22,7 @@ class _BaseOptimizer(abc.ABC):
         scorers: list[Scorer],
         objective: Optional[OBJECTIVE_FN] = None,
         eval_data: Optional["pd.DataFrame"] = None,
-    ) -> Union[str, list[dict[str, Any]]]:
+    ) -> Prompt:
         """Optimize the given prompt using the specified configuration.
 
         Args:
@@ -34,5 +34,5 @@ class _BaseOptimizer(abc.ABC):
             eval_data: Optional evaluation dataset.
 
         Returns:
-            The optimized prompt template.
+            The optimized prompt registered in the model registry as a new version.
         """

--- a/mlflow/genai/optimize/optimizers/base_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/base_optimizer.py
@@ -34,5 +34,5 @@ class _BaseOptimizer(abc.ABC):
             eval_data: Optional evaluation dataset.
 
         Returns:
-            The optimized prompt registered in the model registry as a new version.
+            The optimized prompt registered in the prompt registry as a new version.
         """

--- a/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
@@ -101,7 +101,7 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
             input_fields=input_fields,
         )
 
-        self._log_optimization_result(optimized_program)
+        self._display_optimization_result(optimized_program)
 
         return register_prompt(
             name=prompt.name,
@@ -186,7 +186,7 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
         else:
             yield
 
-    def _log_optimization_result(self, program: "dspy.Predict"):
+    def _display_optimization_result(self, program: "dspy.Predict"):
         if hasattr(program, "score") and hasattr(program, "trial_logs"):
             initial_score = program.trial_logs[1]["full_eval_score"]
             _logger.info(

--- a/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
@@ -3,13 +3,14 @@ import io
 import logging
 import math
 import os
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Optional
 
 from mlflow.entities.model_registry import Prompt
 from mlflow.exceptions import MlflowException
 from mlflow.genai.optimize.optimizers.dspy_optimizer import _DSPyOptimizer
 from mlflow.genai.optimize.types import OBJECTIVE_FN, LLMParams
 from mlflow.genai.scorers import Scorer
+from mlflow.tracking._model_registry.fluent import register_prompt
 
 if TYPE_CHECKING:
     import dspy
@@ -28,7 +29,7 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
         scorers: list[Scorer],
         objective: Optional[OBJECTIVE_FN] = None,
         eval_data: Optional["pd.DataFrame"] = None,
-    ) -> Union[str, list[dict[str, Any]]]:
+    ) -> Prompt:
         import dspy
 
         _logger.info(
@@ -94,11 +95,21 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
                     requires_permission_to_run=False,
                 )
 
-            return self._format_optimized_prompt(
-                adapter=adapter,
-                program=optimized_program,
-                input_fields=input_fields,
-            )
+        template = self._format_optimized_prompt(
+            adapter=adapter,
+            program=optimized_program,
+            input_fields=input_fields,
+        )
+
+        self._log_optimization_result(optimized_program)
+
+        return register_prompt(
+            name=prompt.name,
+            template=template,
+            version_metadata={
+                "overall_eval_score": getattr(optimized_program, "score", None),
+            },
+        )
 
     def _get_num_trials(self, num_candidates: int) -> int:
         # MAX(2*log(num_candidates), 3/2*num_candidates)
@@ -174,3 +185,11 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
                     yield
         else:
             yield
+
+    def _log_optimization_result(self, program: "dspy.Predict"):
+        if hasattr(program, "score") and hasattr(program, "trial_logs"):
+            initial_score = program.trial_logs[1]["full_eval_score"]
+            _logger.info(
+                "Prompt optimization completed. Evaluation score changed "
+                f"from {initial_score} to {program.score}."
+            )

--- a/tests/genai/optimize/test_base.py
+++ b/tests/genai/optimize/test_base.py
@@ -41,7 +41,12 @@ def sample_scorer(inputs, outputs, expectations):
 
 def test_optimize_prompt_basic(sample_prompt, sample_data):
     with patch(
-        "mlflow.genai.optimize.base._DSPyMIPROv2Optimizer.optimize", return_value="optimized"
+        "mlflow.genai.optimize.base._DSPyMIPROv2Optimizer.optimize",
+        return_value=Prompt(
+            name=sample_prompt.name,
+            template="optimized",
+            version=2,
+        ),
     ) as mock_optimizer:
         result = optimize_prompt(
             target_llm_params=LLMParams(model_name="test/model"),

--- a/tests/genai/optimize/test_dspy_mipro_optimizer.py
+++ b/tests/genai/optimize/test_dspy_mipro_optimizer.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 import pytest
 
+from mlflow import register_prompt
 from mlflow.exceptions import MlflowException
 
 pytest.importorskip("dspy", minversion="2.6.0")
@@ -44,10 +45,9 @@ def sample_data():
 
 @pytest.fixture
 def sample_prompt():
-    return Prompt(
+    return register_prompt(
         name="test_prompt",
         template="Translate the following text to {{language}}: {{input_text}}",
-        version=1,
     )
 
 
@@ -109,70 +109,56 @@ def test_format_optimized_prompt():
     mock_format.assert_called_once()
 
 
-def test_optimize_with_teacher_llm(mock_mipro, sample_data, sample_prompt, mock_extractor):
+@pytest.mark.parametrize(
+    ("optimizer_config", "use_eval_data", "expected_teacher_settings"),
+    [
+        (
+            OptimizerConfig(
+                num_instruction_candidates=4,
+                max_few_show_examples=2,
+                num_threads=2,
+                optimizer_llm=LLMParams(model_name="test/model"),
+            ),
+            False,
+            {"lm": True},
+        ),
+        (
+            OptimizerConfig(num_instruction_candidates=4),
+            False,
+            {},
+        ),
+        (
+            OptimizerConfig(),
+            True,
+            {},
+        ),
+    ],
+)
+def test_optimize_scenarios(
+    mock_mipro,
+    sample_data,
+    sample_prompt,
+    mock_extractor,
+    capsys,
+    optimizer_config,
+    use_eval_data,
+    expected_teacher_settings,
+):
     import dspy
-
-    teacher_llm = LLMParams(model_name="test/model")
-    optimizer_config = OptimizerConfig(
-        num_instruction_candidates=4,
-        max_few_show_examples=2,
-        num_threads=2,
-        optimizer_llm=teacher_llm,
-    )
 
     optimizer = _DSPyMIPROv2Optimizer(optimizer_config)
 
     optimized_program = dspy.Predict("input_text, language -> translation")
+    optimized_program.score = 1.0
+    optimized_program.trial_logs = {
+        1: {"full_eval_score": 0.0},
+    }
     mock_mipro.return_value.compile.return_value = optimized_program
+
+    # Prepare eval_data if needed
+    eval_data = sample_data.copy() if use_eval_data else None
 
     result = optimizer.optimize(
-        prompt=sample_prompt,
-        target_llm_params=LLMParams(model_name="agent/model"),
-        train_data=sample_data,
-        scorers=[sample_scorer],
-        eval_data=None,
-    )
-
-    mock_mipro.assert_called_once()
-    kwargs = mock_mipro.call_args[1]
-    assert "teacher_settings" in kwargs
-    assert "lm" in kwargs["teacher_settings"]
-    assert isinstance(result, str)
-
-
-def test_optimize_without_teacher_llm(mock_mipro, sample_data, sample_prompt, mock_extractor):
-    import dspy
-
-    optimizer = _DSPyMIPROv2Optimizer(OptimizerConfig(num_instruction_candidates=4))
-
-    optimized_program = dspy.Predict("input_text, language -> translation")
-    mock_mipro.return_value.compile.return_value = optimized_program
-
-    result = optimizer.optimize(
-        prompt=sample_prompt,
-        target_llm_params=LLMParams(model_name="agent/model"),
-        train_data=sample_data,
-        scorers=[sample_scorer],
-        eval_data=None,
-    )
-
-    mock_mipro.assert_called_once()
-    kwargs = mock_mipro.call_args[1]
-    assert "teacher_settings" in kwargs
-    assert kwargs["teacher_settings"] == {}
-    assert isinstance(result, str)
-
-
-def test_optimize_with_eval_data(mock_mipro, sample_data, sample_prompt, mock_extractor):
-    import dspy
-
-    optimizer = _DSPyMIPROv2Optimizer(OptimizerConfig())
-    eval_data = sample_data.copy()
-
-    optimized_program = dspy.Predict("input_text, language -> translation")
-    mock_mipro.return_value.compile.return_value = optimized_program
-
-    optimizer.optimize(
         prompt=sample_prompt,
         target_llm_params=LLMParams(model_name="agent/model"),
         train_data=sample_data,
@@ -180,10 +166,36 @@ def test_optimize_with_eval_data(mock_mipro, sample_data, sample_prompt, mock_ex
         eval_data=eval_data,
     )
 
+    # Verify teacher LLM settings
+    mock_mipro.assert_called_once()
+    kwargs = mock_mipro.call_args[1]
+    assert "teacher_settings" in kwargs
+    if expected_teacher_settings:
+        assert "lm" in kwargs["teacher_settings"]
+    else:
+        assert kwargs["teacher_settings"] == {}
+
+    # Verify optimization result
+    assert isinstance(result, Prompt)
+    assert result.version == 2
+    assert result.version_metadata["overall_eval_score"] == "1.0"
+
+    # Verify eval data handling
     compile_args = mock_mipro.return_value.compile.call_args[1]
     assert "trainset" in compile_args
     assert "valset" in compile_args
-    assert compile_args["valset"] is not None
+    if eval_data is not None:
+        assert compile_args["valset"] is not None
+    else:
+        assert compile_args["valset"] is None
+
+    # Verify logging
+    captured = capsys.readouterr()
+    assert "Started optimizing prompt" in captured.err
+    assert "Please wait as this process typically takes several minutes" in captured.err
+    assert (
+        "Prompt optimization completed. Evaluation score changed from 0.0 to 1.0." in captured.err
+    )
 
 
 def test_convert_to_dspy_metric():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16046?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16046/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16046/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16046/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Log evaluation score as a version metadata and move the prompt registration into the optimizer class for more granular control

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
