### PR TITLE
Show helpful error message for invalid scorer types

### DIFF
--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -71,14 +71,9 @@ def validate_scorers(scorers: list[Any]) -> list[Scorer]:
             else:
                 hint = ""
 
-            # Truncate the item string to 30 characters not to overwhelm the error message
-            scorer_str = str(scorer)[:30] + "..." if len(str(scorer)) > 30 else str(scorer)
-
             raise MlflowException.invalid_parameter_value(
                 f"The `scorers` argument must be a list of scorers. The specified "
-                "list contains an item that is not a scorer.\n"
-                f" - Type of the invalid item: {type(scorer)}\n"
-                f" - Invalid item: {scorer_str}"
+                f"list contains an invalid item with type: {type(scorer).__name__}.\n"
                 f"{hint}"
             )
 

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -53,13 +53,13 @@ def validate_scorers(scorers: list[Any]) -> list[Scorer]:
                 # Common mistake 1: scorers=[get_all_scorers()]
                 if len(scorers) == 1:
                     hint = (
-                        "\n\nHint: Use `scorers=get_all_scorers()` to pass all "
+                        "\nHint: Use `scorers=get_all_scorers()` to pass all "
                         "builtin scorers at once."
                     )
                 # Common mistake 2: scorers=[get_all_scorers(), scorer1, scorer2]
                 elif len(scorer) > 1:
                     hint = (
-                        "\n\nHint: Use `scorers=[*get_all_scorers(), scorer1, scorer2]` to pass "
+                        "\nHint: Use `scorers=[*get_all_scorers(), scorer1, scorer2]` to pass "
                         "all builtin scorers at once along with your custom scorers."
                     )
             # Common mistake 3: scorers=[RetrievalRelevance, Correctness]
@@ -73,7 +73,7 @@ def validate_scorers(scorers: list[Any]) -> list[Scorer]:
 
             raise MlflowException.invalid_parameter_value(
                 f"The `scorers` argument must be a list of scorers. The specified "
-                f"list contains an invalid item with type: {type(scorer).__name__}.\n"
+                f"list contains an invalid item with type: {type(scorer).__name__}."
                 f"{hint}"
             )
 

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -65,7 +65,7 @@ def validate_scorers(scorers: list[Any]) -> list[Scorer]:
             # Common mistake 3: scorers=[RetrievalRelevance, Correctness]
             elif isinstance(scorer, type) and issubclass(scorer, BuiltInScorer):
                 hint = (
-                    "\nHint: You looks like passing a scorer class instead of an instance. "
+                    "\nHint: It looks like you passed a scorer class instead of an instance. "
                     f"Correct way to pass scorers is `scorers=[{scorer.__name__}()]`."
                 )
             else:
@@ -86,38 +86,6 @@ def validate_scorers(scorers: list[Any]) -> list[Scorer]:
         )
 
     return valid_scorers
-
-
-def _get_helpful_error_message(scorer: Any) -> str:
-    if isinstance(scorer, list) and (scorer == get_all_scorers()):
-        # Common mistake 1: scorers=[get_all_scorers()]
-        if len(scorer) == 1:
-            hint = "\n\nHint: Use `scorers=get_all_scorers()` to pass all builtin scorers at once."
-        # Common mistake 2: scorers=[get_all_scorers(), scorer1, scorer2]
-        elif len(scorer) > 1:
-            hint = (
-                "\n\nHint: Use `scorers=[*get_all_scorers(), scorer1, scorer2]` to pass "
-                "all builtin scorers at once along with your custom scorers."
-            )
-    # Common mistake 3: scorers=[RetrievalRelevance, Correctness]
-    elif isinstance(scorer, type) and issubclass(scorer, BuiltInScorer):
-        hint = (
-            "\n\nHint: You looks like passing a scorer class instead of an instance. "
-            f"Correct way to pass scorers is `scorers=[{type(scorer).__name__}()]`."
-        )
-    else:
-        hint = ""
-
-    # Truncate the item string to 30 characters not to overwhelm the error message
-    scorer_str = str(scorer)[:30] + "..." if len(str(scorer)) > 30 else str(scorer)
-
-    raise MlflowException.invalid_parameter_value(
-        f"The `scorers` argument must be a list of scorers. The specified "
-        "list contains an item that is not a scorer.\n"
-        f" - Type of the invalid item: {type(scorer)}\n"
-        f" - Invalid item: {scorer_str}"
-        f"{hint}"
-    )
 
 
 def valid_data_for_builtin_scorers(

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pytest
 
 import mlflow
+from mlflow.exceptions import MlflowException
 from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
 from mlflow.genai.scorers.base import Scorer, scorer
 from mlflow.genai.scorers.builtin_scorers import (
@@ -13,6 +14,7 @@ from mlflow.genai.scorers.builtin_scorers import (
     RetrievalGroundedness,
     RetrievalRelevance,
     RetrievalSufficiency,
+    get_all_scorers,
 )
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
 
@@ -58,6 +60,32 @@ def test_validate_scorers_legacy_metric():
     assert len(scorers) == 2
     mock_logger.warning.assert_called_once()
     assert "legacy_metric_1" in mock_logger.warning.call_args[0][0]
+
+
+def test_validate_scorers_invalid_all_scorers():
+    with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
+        validate_scorers([1, 2, 3])
+    assert " - Type of the invalid item: <class 'int'>" in str(e.value)
+
+    # Special case 1: List of list of all scorers
+    with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
+        validate_scorers([get_all_scorers()])
+
+    assert " - Type of the invalid item: <class 'list'>" in str(e.value)
+    assert "Hint: Use `scorers=get_all_scorers()` to pass all" in str(e.value)
+
+    # Special case 2: List of list of all scorers + custom scorers
+    with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
+        validate_scorers([get_all_scorers(), RetrievalRelevance(), Correctness()])
+
+    assert " - Type of the invalid item: <class 'list'>" in str(e.value)
+    assert "Hint: Use `scorers=[*get_all_scorers(), scorer1, scorer2]` to pass all" in str(e.value)
+
+    # Special case 3: List of classes (not instances)
+    with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
+        validate_scorers([RetrievalRelevance])
+
+    assert "Correct way to pass scorers is `scorers=[RetrievalRelevance()]`." in str(e.value)
 
 
 def test_validate_data(mock_logger, sample_rag_trace):

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -65,20 +65,20 @@ def test_validate_scorers_legacy_metric():
 def test_validate_scorers_invalid_all_scorers():
     with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
         validate_scorers([1, 2, 3])
-    assert " - Type of the invalid item: <class 'int'>" in str(e.value)
+    assert "an invalid item with type: int" in str(e.value)
 
     # Special case 1: List of list of all scorers
     with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
         validate_scorers([get_all_scorers()])
 
-    assert " - Type of the invalid item: <class 'list'>" in str(e.value)
+    assert "an invalid item with type: list" in str(e.value)
     assert "Hint: Use `scorers=get_all_scorers()` to pass all" in str(e.value)
 
     # Special case 2: List of list of all scorers + custom scorers
     with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
         validate_scorers([get_all_scorers(), RetrievalRelevance(), Correctness()])
 
-    assert " - Type of the invalid item: <class 'list'>" in str(e.value)
+    assert "an invalid item with type: list" in str(e.value)
     assert "Hint: Use `scorers=[*get_all_scorers(), scorer1, scorer2]` to pass all" in str(e.value)
 
     # Special case 3: List of classes (not instances)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16048?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16048/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16048/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16048/merge
```

</p>
</details>

### What changes are proposed in this pull request?

We've seen a few typical mistakes when passing scorers to `mlflow.genai.evaluate` during preview. Improving error message for those cases.

* Case 1: Wrapping `get_all_scorers()` in a list.
    * Incorrect: `mlflow.genai.evaluate(scorers=[get_all_scorers()])`
    * Correct: `mlflow.genai.evaluate(scorers=get_all_scorers())`
* Case 2: Wrapping `get_all_scorers()` in a list, with custom scorers
    * Incorrect: `mlflow.genai.evaluate(scorers=[get_all_scorers(), custom1, custom2])`
    * Correct: `mlflow.genai.evaluate(scorers=[*get_all_scorers(), custom1, custom2])`
* Case 3: Passing classes instead of instances
    * Incorrect: `mlflow.genai.evaluate(scorers=[Correctness, Safety])`
    * Correct: `mlflow.genai.evaluate(scorers=[Correctness(), Safety())`

<img width="1155" alt="Screenshot 2025-06-04 at 12 39 49" src="https://github.com/user-attachments/assets/0f852157-e3d1-471e-8f66-c7d0d28b91f5" />
<img width="1082" alt="Screenshot 2025-06-04 at 11 59 24" src="https://github.com/user-attachments/assets/cbe57565-6140-441c-99ee-8dc759a30ef7" />
<img width="1082" alt="Screenshot 2025-06-04 at 11 58 44" src="https://github.com/user-attachments/assets/a01082c1-b49a-435b-9b8c-d8e4cb6fc09d" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
