### PR TITLE
Add autolog option for genai.optimize_prompt

### DIFF
--- a/docs/docs/prompts/optimize-prompt.mdx
+++ b/docs/docs/prompts/optimize-prompt.mdx
@@ -174,6 +174,7 @@ You can customize the optimization process using `OptimizerConfig`, which includ
 - **max_few_show_examples**: The maximum number of examples to show in few-shot demonstrations. Default: 6
 - **optimizer_llm**: The LLM to use for optimization. Default: None (uses target LLM)
 - **verbose**: Whether to show optimizer logs during optimization. Default: False
+- **autolog**: Whether to automatically create a MLflow run and log the optimization parameters, metrics and datasets. Default: True
 
 See <APILink fn="mlflow.genai.OptimizerConfig" /> for more details.
 

--- a/docs/docs/prompts/optimize-prompt.mdx
+++ b/docs/docs/prompts/optimize-prompt.mdx
@@ -174,7 +174,7 @@ You can customize the optimization process using `OptimizerConfig`, which includ
 - **max_few_show_examples**: The maximum number of examples to show in few-shot demonstrations. Default: 6
 - **optimizer_llm**: The LLM to use for optimization. Default: None (uses target LLM)
 - **verbose**: Whether to show optimizer logs during optimization. Default: False
-- **autolog**: Whether to automatically create a MLflow run and log the optimization parameters, metrics and datasets. Default: True
+- **autolog**: Whether to automatically create a MLflow run and log the optimization parameters, metrics and datasets. Default: False
 
 See <APILink fn="mlflow.genai.OptimizerConfig" /> for more details.
 

--- a/docs/docs/prompts/optimize-prompt.mdx
+++ b/docs/docs/prompts/optimize-prompt.mdx
@@ -174,7 +174,7 @@ You can customize the optimization process using `OptimizerConfig`, which includ
 - **max_few_show_examples**: The maximum number of examples to show in few-shot demonstrations. Default: 6
 - **optimizer_llm**: The LLM to use for optimization. Default: None (uses target LLM)
 - **verbose**: Whether to show optimizer logs during optimization. Default: False
-- **autolog**: Whether to automatically create a MLflow run and log the optimization parameters, metrics and datasets. Default: False
+- **autolog**: Whether to log the optimization parameters, datasets and metrics. If set to True, a MLflow run is automatically created to store them. Default: False
 
 See <APILink fn="mlflow.genai.OptimizerConfig" /> for more details.
 

--- a/mlflow/genai/optimize/base.py
+++ b/mlflow/genai/optimize/base.py
@@ -1,4 +1,7 @@
 import inspect
+import logging
+from contextlib import contextmanager
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Optional, Union
 
 from mlflow.entities.model_registry import Prompt
@@ -15,12 +18,16 @@ from mlflow.genai.optimize.types import (
 )
 from mlflow.genai.scorers import Scorer
 from mlflow.tracking._model_registry.fluent import load_prompt
+from mlflow.tracking.fluent import log_param, log_params, log_table, start_run
 from mlflow.utils.annotations import experimental
 
 if TYPE_CHECKING:
+    import pandas as pd
     from genai.evaluation.utils import EvaluationDatasetTypes
 
 _ALGORITHMS = {"DSPy/MIPROv2": _DSPyMIPROv2Optimizer}
+
+_logger = logging.getLogger(__name__)
 
 
 @experimental
@@ -122,14 +129,15 @@ def optimize_prompt(
     if isinstance(prompt, str):
         prompt: Prompt = load_prompt(prompt)
 
-    optimized_prompt = optimzer.optimize(
-        prompt=prompt,
-        target_llm_params=target_llm_params,
-        train_data=train_data,
-        scorers=scorers,
-        objective=objective,
-        eval_data=eval_data,
-    )
+    with _maybe_start_autolog(optimizer_config, train_data, eval_data, prompt, target_llm_params):
+        optimized_prompt = optimzer.optimize(
+            prompt=prompt,
+            target_llm_params=target_llm_params,
+            train_data=train_data,
+            scorers=scorers,
+            objective=objective,
+            eval_data=eval_data,
+        )
 
     return PromptOptimizationResult(prompt=optimized_prompt)
 
@@ -158,3 +166,28 @@ def _validate_scorers(scorers: list[Scorer]) -> None:
                 f"Trace input is found in Scorer {scorer}. "
                 "Scorers for optimization can only take inputs, outputs or expectations."
             )
+
+
+@contextmanager
+def _maybe_start_autolog(
+    optimizer_config: OptimizerConfig,
+    train_data: "pd.DataFrame",
+    eval_data: Optional["pd.DataFrame"],
+    prompt: Prompt,
+    target_llm_params: LLMParams,
+):
+    if optimizer_config.autolog:
+        with start_run() as run:
+            _logger.info(
+                f"Run {run.info.run_id} is created for autologging prompt optimization."
+                "Watch the run to view the optimization progress."
+            )
+            log_table(train_data, "train_data.json")
+            if eval_data is not None:
+                log_table(eval_data, "eval_data.json")
+            log_param("prompt_uri", prompt.uri)
+            log_params({f"target_llm_params.{k}": v for k, v in asdict(target_llm_params).items()})
+            log_params({f"optimizer_config.{k}": v for k, v in asdict(optimizer_config).items()})
+            yield
+    else:
+        yield

--- a/mlflow/genai/optimize/base.py
+++ b/mlflow/genai/optimize/base.py
@@ -18,7 +18,7 @@ from mlflow.genai.optimize.types import (
 )
 from mlflow.genai.scorers import Scorer
 from mlflow.tracking._model_registry.fluent import load_prompt
-from mlflow.tracking.fluent import log_param, log_params, log_table, start_run
+from mlflow.tracking.fluent import log_params, log_table, start_run
 from mlflow.utils.annotations import experimental
 
 if TYPE_CHECKING:
@@ -185,9 +185,12 @@ def _maybe_start_autolog(
             log_table(train_data, "train_data.json")
             if eval_data is not None:
                 log_table(eval_data, "eval_data.json")
-            log_param("prompt_uri", prompt.uri)
-            log_params({f"target_llm_params.{k}": v for k, v in asdict(target_llm_params).items()})
-            log_params({f"optimizer_config.{k}": v for k, v in asdict(optimizer_config).items()})
+            params = {
+                "prompt_uri": prompt.uri,
+                **{f"target_llm_params.{k}": v for k, v in asdict(target_llm_params).items()},
+                **{f"optimizer_config.{k}": v for k, v in asdict(optimizer_config).items()},
+            }
+            log_params(params)
             yield
     else:
         yield

--- a/mlflow/genai/optimize/base.py
+++ b/mlflow/genai/optimize/base.py
@@ -179,8 +179,8 @@ def _maybe_start_autolog(
     if optimizer_config.autolog:
         with start_run() as run:
             _logger.info(
-                f"Run {run.info.run_id} is created for autologging prompt optimization."
-                "Watch the run to view the optimization progress."
+                f"Run `{run.info.run_id}` is created for autologging prompt optimization. "
+                "Watch the run to track the optimization progress."
             )
             log_table(train_data, "train_data.json")
             if eval_data is not None:

--- a/mlflow/genai/optimize/optimizers/utils/dspy_mipro_callback.py
+++ b/mlflow/genai/optimize/optimizers/utils/dspy_mipro_callback.py
@@ -23,10 +23,7 @@ class _DSPyMIPROv2Callback(BaseCallback):
         self._best_score = None
 
     def on_evaluate_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
-        key = "eval"
-        if callback_metadata := inputs.get("callback_metadata"):
-            if "metric_key" in callback_metadata:
-                key = callback_metadata["metric_key"]
+        key = inputs.get("callback_metadata", {}).get("metric_key", "eval")
         step = self._evaluation_counter[key]
         self._evaluation_counter[key] += 1
         self._call_id_to_values[call_id] = (key, step, inputs.get("program"))

--- a/mlflow/genai/optimize/optimizers/utils/dspy_mipro_callback.py
+++ b/mlflow/genai/optimize/optimizers/utils/dspy_mipro_callback.py
@@ -1,0 +1,79 @@
+from collections import defaultdict
+from typing import Any, Optional, TYPE_CHECKING
+
+from dspy import Prediction
+from dspy.utils.callback import BaseCallback
+
+import mlflow
+from mlflow.genai.optimize.optimizers.utils.dspy_mipro_utils import format_optimized_prompt
+
+_FULL_EVAL_NAME = "eval_full"
+
+if TYPE_CHECKING:
+    import dspy
+
+class _DSPyMIPROv2Callback(BaseCallback):
+    def __init__(self, prompt_name: str, input_fields: dict[str, type]):
+        self.prompt_name = prompt_name
+        self.input_fields = input_fields
+        # call_id: (key, step, program)
+        self._call_id_to_values: dict[str, tuple[str, int, "dspy.Predict"]] = {}
+        self._evaluation_counter = defaultdict(int)
+        self._best_score = None
+
+
+    def on_evaluate_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
+        key = "eval"
+        if callback_metadata := inputs.get("callback_metadata"):
+            if "metric_key" in callback_metadata:
+                key = callback_metadata["metric_key"]
+        step = self._evaluation_counter[key]
+        self._evaluation_counter[key] += 1
+        self._call_id_to_values[call_id] = (key, step, inputs.get("program"))
+
+    def on_evaluate_end(
+        self,
+        call_id: str,
+        outputs: Any,
+        exception: Optional[Exception] = None,
+    ):
+        if exception:
+            return
+        
+        if call_id not in self._call_id_to_values:
+            return
+        key, step, program = self._call_id_to_values.pop(call_id)
+
+        # Only log the full evaluation result
+        if key != _FULL_EVAL_NAME:
+            return
+        
+        if isinstance(outputs, float):
+            score = outputs
+        elif isinstance(outputs, tuple):
+            score = outputs[0]
+        elif isinstance(outputs, Prediction):
+            score = float(outputs)
+        else:
+            return
+        
+        if self._best_score is None:
+            # This is the first evaluation with initial prompt,
+            # we don't register this prompt
+            self._best_score = score
+        elif score > self._best_score:
+            # When best score is updated, register the new prompt
+            self._best_score = score
+            template = format_optimized_prompt(program, self.input_fields)
+            mlflow.register_prompt(
+                name=self.prompt_name,
+                template=template,
+                version_metadata={"overall_eval_score": score, key: step},
+            )
+
+        if mlflow.active_run() is not None:
+            mlflow.log_metric(
+                key,
+                score,
+                step=step,
+            )

--- a/mlflow/genai/optimize/optimizers/utils/dspy_mipro_callback.py
+++ b/mlflow/genai/optimize/optimizers/utils/dspy_mipro_callback.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from typing import Any, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Optional
 
 from dspy import Prediction
 from dspy.utils.callback import BaseCallback
@@ -12,6 +12,7 @@ _FULL_EVAL_NAME = "eval_full"
 if TYPE_CHECKING:
     import dspy
 
+
 class _DSPyMIPROv2Callback(BaseCallback):
     def __init__(self, prompt_name: str, input_fields: dict[str, type]):
         self.prompt_name = prompt_name
@@ -20,7 +21,6 @@ class _DSPyMIPROv2Callback(BaseCallback):
         self._call_id_to_values: dict[str, tuple[str, int, "dspy.Predict"]] = {}
         self._evaluation_counter = defaultdict(int)
         self._best_score = None
-
 
     def on_evaluate_start(self, call_id: str, instance: Any, inputs: dict[str, Any]):
         key = "eval"
@@ -39,7 +39,7 @@ class _DSPyMIPROv2Callback(BaseCallback):
     ):
         if exception:
             return
-        
+
         if call_id not in self._call_id_to_values:
             return
         key, step, program = self._call_id_to_values.pop(call_id)
@@ -47,7 +47,7 @@ class _DSPyMIPROv2Callback(BaseCallback):
         # Only log the full evaluation result
         if key != _FULL_EVAL_NAME:
             return
-        
+
         if isinstance(outputs, float):
             score = outputs
         elif isinstance(outputs, tuple):
@@ -56,7 +56,7 @@ class _DSPyMIPROv2Callback(BaseCallback):
             score = float(outputs)
         else:
             return
-        
+
         if self._best_score is None:
             # This is the first evaluation with initial prompt,
             # we don't register this prompt

--- a/mlflow/genai/optimize/optimizers/utils/dspy_mipro_utils.py
+++ b/mlflow/genai/optimize/optimizers/utils/dspy_mipro_utils.py
@@ -3,10 +3,10 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     import dspy
 
-def format_optimized_prompt(
-    program: "dspy.Predict", input_fields: dict[str, type]
-) -> str:
+
+def format_optimized_prompt(program: "dspy.Predict", input_fields: dict[str, type]) -> str:
     import dspy
+
     messages = dspy.settings.adapter.format(
         signature=program.signature,
         demos=program.demos,
@@ -14,8 +14,5 @@ def format_optimized_prompt(
     )
 
     return "\n\n".join(
-        [
-            f"<{message['role']}>\n{message['content']}\n</{message['role']}>"
-            for message in messages
-        ]
+        [f"<{message['role']}>\n{message['content']}\n</{message['role']}>" for message in messages]
     )

--- a/mlflow/genai/optimize/optimizers/utils/dspy_mipro_utils.py
+++ b/mlflow/genai/optimize/optimizers/utils/dspy_mipro_utils.py
@@ -1,0 +1,21 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import dspy
+
+def format_optimized_prompt(
+    program: "dspy.Predict", input_fields: dict[str, type]
+) -> str:
+    import dspy
+    messages = dspy.settings.adapter.format(
+        signature=program.signature,
+        demos=program.demos,
+        inputs={key: "{{" + key + "}}" for key in input_fields.keys()},
+    )
+
+    return "\n\n".join(
+        [
+            f"<{message['role']}>\n{message['content']}\n</{message['role']}>"
+            for message in messages
+        ]
+    )

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -61,6 +61,8 @@ class OptimizerConfig:
             the target LLM will be used as the teacher.
         algorithm: The optimization algorithm to use. Default: "DSPy/MIPROv2"
         verbose: Whether to show optimizer logs during optimization. Default: False
+        autolog: Whether to create a MLflow run automatically and log the optimization
+            parameters, datasets and metrics. Default: False
     """
 
     num_instruction_candidates: int = 6
@@ -69,3 +71,4 @@ class OptimizerConfig:
     optimizer_llm: Optional[LLMParams] = None
     algorithm: str = "DSPy/MIPROv2"
     verbose: bool = False
+    autolog: bool = False

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -61,8 +61,9 @@ class OptimizerConfig:
             the target LLM will be used as the teacher.
         algorithm: The optimization algorithm to use. Default: "DSPy/MIPROv2"
         verbose: Whether to show optimizer logs during optimization. Default: False
-        autolog: Whether to create a MLflow run automatically and log the optimization
-            parameters, datasets and metrics. Default: False
+        autolog: Whether to log the optimization parameters, datasets and metrics.
+            If set to True, a MLflow run is automatically created to store them.
+            Default: False
     """
 
     num_instruction_candidates: int = 6

--- a/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
@@ -11,9 +11,9 @@ pytest.importorskip("dspy", minversion="2.6.0")
 
 from mlflow.entities.model_registry import Prompt
 from mlflow.genai.optimize.optimizers import _DSPyMIPROv2Optimizer
+from mlflow.genai.optimize.optimizers.utils.dspy_mipro_callback import _DSPyMIPROv2Callback
 from mlflow.genai.optimize.types import LLMParams, OptimizerConfig
 from mlflow.genai.scorers import scorer
-from mlflow.genai.optimize.optimizers.utils.dspy_mipro_callback import _DSPyMIPROv2Callback
 
 
 @pytest.fixture
@@ -300,6 +300,7 @@ def test_optimize_with_verbose(
         assert "DSPy debug info" not in captured.err
 
     mock_mipro.assert_called_once()
+
 
 @pytest.mark.parametrize(
     "autolog",

--- a/tests/genai/optimize/optimizers/utils/test_dspy_mipro_callback.py
+++ b/tests/genai/optimize/optimizers/utils/test_dspy_mipro_callback.py
@@ -1,16 +1,18 @@
 import pytest
-from unittest.mock import patch, MagicMock
 from dspy import Predict
 
-pytest.importorskip("dspy", minversion="2.6.12", reason="evaluate callback is available since 2.6.12")
+pytest.importorskip(
+    "dspy", minversion="2.6.12", reason="evaluate callback is available since 2.6.12"
+)
+
+import dspy
+from dspy import Evaluate, Example
+from dspy.evaluate.metrics import answer_exact_match
+from dspy.utils.dummies import DummyLM
 
 import mlflow
 from mlflow.genai.optimize.optimizers.utils.dspy_mipro_callback import _DSPyMIPROv2Callback
 
-import dspy
-from dspy.utils.dummies import DummyLM
-from dspy import Evaluate, Example
-from dspy.evaluate.metrics import answer_exact_match
 
 @pytest.fixture
 def callback():
@@ -26,7 +28,7 @@ def test_callback_with_evals(callback):
             eval(program, devset=valset, callback_metadata={"metric_key": "eval_full"})
             eval(program, devset=valset[:1], callback_metadata={"metric_key": "eval_full"})
             return program
-    
+
     lm = DummyLM(
         {
             "What is 1 + 1?": {"answer": "2"},

--- a/tests/genai/optimize/optimizers/utils/test_dspy_mipro_callback.py
+++ b/tests/genai/optimize/optimizers/utils/test_dspy_mipro_callback.py
@@ -1,0 +1,59 @@
+import pytest
+from unittest.mock import patch, MagicMock
+from dspy import Predict
+
+pytest.importorskip("dspy", minversion="2.6.12", reason="evaluate callback is available since 2.6.12")
+
+import mlflow
+from mlflow.genai.optimize.optimizers.utils.dspy_mipro_callback import _DSPyMIPROv2Callback
+
+import dspy
+from dspy.utils.dummies import DummyLM
+from dspy import Evaluate, Example
+from dspy.evaluate.metrics import answer_exact_match
+
+@pytest.fixture
+def callback():
+    return _DSPyMIPROv2Callback(
+        prompt_name="test_prompt",
+        input_fields={"question": str, "context": str},
+    )
+
+
+def test_callback_with_evals(callback):
+    class EvalOptimizer(dspy.teleprompt.Teleprompter):
+        def compile(self, program, eval, trainset, valset):
+            eval(program, devset=valset, callback_metadata={"metric_key": "eval_full"})
+            eval(program, devset=valset[:1], callback_metadata={"metric_key": "eval_full"})
+            return program
+    
+    lm = DummyLM(
+        {
+            "What is 1 + 1?": {"answer": "2"},
+            "What is 2 + 2?": {"answer": "1000"},
+        }
+    )
+
+    dataset = [
+        Example(question="What is 1 + 1?", answer="2").with_inputs("question"),
+        Example(question="What is 2 + 2?", answer="4").with_inputs("question"),
+    ]
+    program = Predict("question -> answer")
+    evaluator = Evaluate(devset=dataset, metric=answer_exact_match)
+    optimizer = EvalOptimizer()
+
+    with dspy.context(
+        lm=lm,
+        callbacks=[callback],
+        adapter=dspy.ChatAdapter(),
+    ):
+        with mlflow.start_run():
+            optimizer.compile(program, evaluator, trainset=dataset, valset=dataset)
+
+    # root run
+    run = mlflow.last_active_run()
+    assert run.data.metrics == {
+        "eval_full": 100.0,
+    }
+    prompt = mlflow.load_prompt("prompts:/test_prompt/1")
+    assert prompt.version_metadata["overall_eval_score"] == "100.0"

--- a/tests/genai/optimize/optimizers/utils/test_dspy_mipro_utils.py
+++ b/tests/genai/optimize/optimizers/utils/test_dspy_mipro_utils.py
@@ -1,9 +1,11 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 pytest.importorskip("dspy", minversion="2.6.0")
 
 from mlflow.genai.optimize.optimizers.utils.dspy_mipro_utils import format_optimized_prompt
+
 
 def test_format_optimized_prompt():
     import dspy

--- a/tests/genai/optimize/optimizers/utils/test_dspy_mipro_utils.py
+++ b/tests/genai/optimize/optimizers/utils/test_dspy_mipro_utils.py
@@ -1,0 +1,28 @@
+import pytest
+from unittest.mock import patch
+
+pytest.importorskip("dspy", minversion="2.6.0")
+
+from mlflow.genai.optimize.optimizers.utils.dspy_mipro_utils import format_optimized_prompt
+
+def test_format_optimized_prompt():
+    import dspy
+
+    mock_program = dspy.Predict("input_text, language -> translation")
+    input_fields = {"input_text": str, "language": str}
+
+    with dspy.context(adapter=dspy.JSONAdapter()):
+        with patch("dspy.JSONAdapter.format") as mock_format:
+            mock_format.return_value = [
+                {"role": "system", "content": "You are a translator"},
+                {"role": "user", "content": "Input Text: {{input_text}}, Language: {{language}}"},
+            ]
+            result = format_optimized_prompt(mock_program, input_fields)
+
+    expected = (
+        "<system>\nYou are a translator\n</system>\n\n"
+        "<user>\nInput Text: {{input_text}}, Language: {{language}}\n</user>"
+    )
+
+    assert result == expected
+    mock_format.assert_called_once()

--- a/tests/genai/optimize/test_base.py
+++ b/tests/genai/optimize/test_base.py
@@ -125,19 +125,18 @@ def test_optimize_autolog(sample_prompt, sample_data):
     run = mlflow.last_active_run()
     client = MlflowClient()
     assert run is not None
-    assert run.data.params == {
+    expected_params = {
         "optimizer_config.algorithm": "DSPy/MIPROv2",
         "optimizer_config.autolog": "True",
         "optimizer_config.max_few_show_examples": "6",
         "optimizer_config.num_instruction_candidates": "6",
-        "optimizer_config.num_threads": "33",
         "optimizer_config.optimizer_llm": "None",
         "optimizer_config.verbose": "False",
         "prompt_uri": "prompts:/test_translation_prompt/1",
-        "target_llm_params.base_uri": "None",
         "target_llm_params.model_name": "test/model",
-        "target_llm_params.temperature": "None",
     }
+    for key, expected_value in expected_params.items():
+        assert run.data.params[key] == expected_value
     artifacts = [x.path for x in client.list_artifacts(run.info.run_id)]
     assert "train_data.json" in artifacts
     assert "eval_data.json" in artifacts

--- a/tests/genai/optimize/test_base.py
+++ b/tests/genai/optimize/test_base.py
@@ -5,11 +5,13 @@ import pytest
 
 pytest.importorskip("dspy", minversion="2.6.0")
 
+import mlflow
 from mlflow.entities.model_registry import Prompt
 from mlflow.exceptions import MlflowException
 from mlflow.genai.optimize import optimize_prompt
 from mlflow.genai.optimize.types import LLMParams, OptimizerConfig
 from mlflow.genai.scorers import scorer
+from mlflow.tracking import MlflowClient
 from mlflow.tracking._model_registry.fluent import register_prompt
 
 
@@ -100,3 +102,42 @@ def test_optimize_prompt_with_trace_scorer(sample_prompt, sample_data):
             train_data=sample_data,
             scorers=[trace_scorer],
         )
+
+
+def test_optimize_autolog(sample_prompt, sample_data):
+    with patch(
+        "mlflow.genai.optimize.base._DSPyMIPROv2Optimizer.optimize",
+        return_value=Prompt(
+            name=sample_prompt.name,
+            template="optimized",
+            version=2,
+        ),
+    ):
+        optimize_prompt(
+            target_llm_params=LLMParams(model_name="test/model"),
+            prompt=f"prompts:/{sample_prompt.name}/{sample_prompt.version}",
+            train_data=sample_data,
+            eval_data=sample_data,
+            scorers=[sample_scorer],
+            optimizer_config=OptimizerConfig(autolog=True),
+        )
+
+    run = mlflow.last_active_run()
+    client = MlflowClient()
+    assert run is not None
+    assert run.data.params == {
+        "optimizer_config.algorithm": "DSPy/MIPROv2",
+        "optimizer_config.autolog": "True",
+        "optimizer_config.max_few_show_examples": "6",
+        "optimizer_config.num_instruction_candidates": "6",
+        "optimizer_config.num_threads": "33",
+        "optimizer_config.optimizer_llm": "None",
+        "optimizer_config.verbose": "False",
+        "prompt_uri": "prompts:/test_translation_prompt/1",
+        "target_llm_params.base_uri": "None",
+        "target_llm_params.model_name": "test/model",
+        "target_llm_params.temperature": "None",
+    }
+    artifacts = [x.path for x in client.list_artifacts(run.info.run_id)]
+    assert "train_data.json" in artifacts
+    assert "eval_data.json" in artifacts


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR introduces an autolog option to `mlflow.genai.optimize_prompt`, which enables users to log the following information to an MLflow run
- train dataset
- eval dataset
- optimizer params
- llm params
- eval metrics

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add autolog option for `mlflow.genai.optimize_prompt`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
