### PR TITLE
Add 'metadata' field to update_current_Trace

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -957,8 +957,8 @@ def update_current_trace(
         tags: A dictionary of tags to update the trace with Tags are designed for mutable values,
             that can be updated after the trace is created via MLflow UI or API.
         metadata: A dictionary of metadata to update the trace with. Metadata cannot be updated
-            once the trace is logged, and suitable for recording immutable values like git
-            commit hash of the source system.
+            once the trace is logged. It is suitable for recording immutable values like the
+            git hash of the application version that produced the trace.
         client_request_id: Client supplied request ID to associate with the trace. This is
             useful for linking the trace back to a specific request in your application or
             external system. If None, the client request ID is not updated.
@@ -1050,7 +1050,7 @@ def update_current_trace(
         )
         return
 
-    def _warn_non_string_values(d: dict[str, Any], field_name: str) -> dict[str, str]:
+    def _warn_non_string_values(d: dict[str, Any], field_name: str):
         non_string_items = {k: v for k, v in d.items() if not isinstance(v, str)}
         if non_string_items:
             _logger.warning(

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -945,6 +945,7 @@ def _set_last_active_trace_id(trace_id: str):
 
 def update_current_trace(
     tags: Optional[dict[str, str]] = None,
+    metadata: Optional[dict[str, str]] = None,
     client_request_id: Optional[str] = None,
     request_preview: Optional[str] = None,
     response_preview: Optional[str] = None,
@@ -953,7 +954,11 @@ def update_current_trace(
     Update the current active trace with the given options.
 
     Args:
-        tags: A dictionary of tags to update the trace with.
+        tags: A dictionary of tags to update the trace with Tags are designed for mutable values,
+            that can be updated after the trace is created via MLflow UI or API.
+        metadata: A dictionary of metadata to update the trace with. Metadata cannot be updated
+            once the trace is logged, and suitable for recording immutable values like git
+            commit hash of the source system.
         client_request_id: Client supplied request ID to associate with the trace. This is
             useful for linking the trace back to a specific request in your application or
             external system. If None, the client request ID is not updated.
@@ -985,6 +990,20 @@ def update_current_trace(
 
             with mlflow.start_span("span"):
                 mlflow.update_current_trace(tags={"fruit": "apple"}, client_request_id="req-12345")
+
+        Updating source information of the trace. These keys are reserved ones and MLflow populate
+        them from environment information by default. You can override them if needed. Please refer
+        to the MLflow Tracing documentation for the full list of reserved metadata keys.
+
+        .. code-block:: python
+
+            mlflow.update_current_trace(
+                metadata={
+                    "mlflow.source.name": "inference.py",
+                    "mlflow.source.git.commit": "1234567890",
+                    "mlflow.source.git.repoURL": "https://github.com/mlflow/mlflow",
+                },
+            )
 
         Updating request preview:
 
@@ -1031,20 +1050,17 @@ def update_current_trace(
         )
         return
 
-    if isinstance(tags, dict):
-        non_string_items = {k: v for k, v in tags.items() if not isinstance(v, str)}
+    def _warn_non_string_values(d: dict[str, Any], field_name: str) -> dict[str, str]:
+        non_string_items = {k: v for k, v in d.items() if not isinstance(v, str)}
         if non_string_items:
-            none_values_present = any(v is None for v in non_string_items.values())
-            null_tag_advice = (
-                "Consider dropping None values from the tag dict prior to updating the trace."
-                if none_values_present
-                else ""
-            )
             _logger.warning(
-                "Found non-string values in tags. Please note that non-string tag values will "
-                f"automatically be stringified when the trace is logged. {null_tag_advice}\n\n"
-                f"Non-string items: {non_string_items}"
+                f"Found non-string values in {field_name}. Non-string values in {field_name} will "
+                f"automatically be stringified when the trace is logged. Non-string items: "
+                f"{non_string_items}"
             )
+
+    _warn_non_string_values(tags or {}, "tags")
+    _warn_non_string_values(metadata or {}, "metadata")
 
     # Update tags and client request ID for the trace stored in-memory rather than directly
     # updating the backend store. The in-memory trace will be exported when it is ended.
@@ -1069,6 +1085,7 @@ def update_current_trace(
             trace.info.response_preview = response_preview
 
         trace.info.tags.update(tags or {})
+        trace.info.trace_metadata.update(metadata or {})
         if client_request_id is not None:
             trace.info.client_request_id = str(client_request_id)
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1456,6 +1456,44 @@ def test_update_current_trace_client_request_id_stringification():
                     assert isinstance(trace.info.client_request_id, str)
 
 
+def test_update_current_trace_with_metadata():
+    """Test that update_current_trace correctly handles metadata parameter."""
+
+    @mlflow.trace
+    def f():
+        mlflow.update_current_trace(
+            mlflow.update_current_trace(
+                metadata={
+                    "mlflow.source.name": "inference.py",
+                    "mlflow.source.git.commit": "1234567890",
+                    "mlflow.source.git.repoURL": "https://github.com/mlflow/mlflow",
+                    "non-string-metadata": 123,
+                },
+            )
+        )
+
+    f()
+
+    expected_metadata = {
+        "mlflow.source.name": "inference.py",
+        "mlflow.source.git.commit": "1234567890",
+        "mlflow.source.git.repoURL": "https://github.com/mlflow/mlflow",
+        "non-string-metadata": "123",  # Should be stringified
+    }
+
+    # Validate in-memory trace
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    for k, v in expected_metadata.items():
+        assert trace.info.trace_metadata[k] == v
+
+    # Validate backend trace
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == "OK"
+    for k, v in expected_metadata.items():
+        assert traces[0].info.trace_metadata[k] == v
+
+
 @skip_when_testing_trace_sdk
 def test_update_current_trace_should_not_raise_during_model_logging():
     """

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1462,14 +1462,12 @@ def test_update_current_trace_with_metadata():
     @mlflow.trace
     def f():
         mlflow.update_current_trace(
-            mlflow.update_current_trace(
-                metadata={
-                    "mlflow.source.name": "inference.py",
-                    "mlflow.source.git.commit": "1234567890",
-                    "mlflow.source.git.repoURL": "https://github.com/mlflow/mlflow",
-                    "non-string-metadata": 123,
-                },
-            )
+            metadata={
+                "mlflow.source.name": "inference.py",
+                "mlflow.source.git.commit": "1234567890",
+                "mlflow.source.git.repoURL": "https://github.com/mlflow/mlflow",
+                "non-string-metadata": 123,
+            },
         )
 
     f()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16055?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16055/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16055/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16055/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Allow users to specify trace metadata for in-progress trace. They are immutable once trace is logged, but should be editable during generation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
