### PR TITLE
Expose categorical rating in mlflow.genai.judges

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -266,9 +266,15 @@ class Feedback(Assessment):
             overrides=overrides,
             valid=valid,
         )
-
-        self.value = value
         self.error = error
+
+    @property
+    def value(self) -> FeedbackValueType:
+        return self.feedback.value
+
+    @value.setter
+    def value(self, value: FeedbackValueType):
+        self.feedback.value = value
 
     @classmethod
     def from_proto(cls, proto):
@@ -371,9 +377,6 @@ class Expectation(Assessment):
             )
     """
 
-    # Needs to be optional because other earlier args in the Assessment is optional
-    value: Optional[Any] = None
-
     def __init__(
         self,
         name: str,
@@ -402,7 +405,13 @@ class Expectation(Assessment):
             expectation=ExpectationValue(value=value),
         )
 
-        self.value = value
+    @property
+    def value(self) -> Any:
+        return self.expectation.value
+
+    @value.setter
+    def value(self, value: Any):
+        self.expectation.value = value
 
     @classmethod
     def from_proto(cls, proto) -> "Expectation":

--- a/mlflow/genai/judges/__init__.py
+++ b/mlflow/genai/judges/__init__.py
@@ -1,4 +1,5 @@
 from mlflow.genai.judges.databricks import (
+    CategoricalRating,
     is_context_relevant,
     is_context_sufficient,
     is_correct,
@@ -8,6 +9,7 @@ from mlflow.genai.judges.databricks import (
 )
 
 __all__ = [
+    "CategoricalRating",
     "is_grounded",
     "is_safe",
     "is_correct",

--- a/mlflow/genai/judges/databricks.py
+++ b/mlflow/genai/judges/databricks.py
@@ -37,14 +37,15 @@ class CategoricalRating(StrEnum):
 def _sanitize_feedback(feedback: Feedback) -> Feedback:
     """Sanitize the feedback object from the databricks judges.
 
+    The judge returns a CategoricalRating class defined in the databricks-agents package.
+    This function converts it to our CategoricalRating definition above.
+
     Args:
         feedback: The Feedback object to convert.
 
     Returns:
         A new Feedback object with our CategoricalRating.
     """
-    feedback.feedback.value = CategoricalRating(feedback.value.value)
-    # Need to set the value attribute to ensure it is synced with the feedback.value
     feedback.value = CategoricalRating(feedback.value.value)
     return feedback
 
@@ -280,13 +281,7 @@ def is_safe(*, content: str, name: Optional[str] = None) -> Feedback:
     """
     from databricks.agents.evals.judges import safety
 
-    return _sanitize_feedback(
-        safety(
-            request="",  # Safety check doesn't need a request
-            response=content,
-            assessment_name=name,
-        )
-    )
+    return _sanitize_feedback(safety(response=content, assessment_name=name))
 
 
 @requires_databricks_agents
@@ -339,7 +334,6 @@ def meets_guidelines(
 
     return _sanitize_feedback(
         guideline_adherence(
-            request="",  # Guideline adherence doesn't need a request
             guidelines=guidelines,
             guidelines_context=context,
             assessment_name=name,

--- a/mlflow/genai/judges/databricks.py
+++ b/mlflow/genai/judges/databricks.py
@@ -2,6 +2,23 @@ from functools import wraps
 from typing import Any, Optional, Union
 
 from mlflow.entities.assessment import Feedback
+from mlflow.genai.utils.enum_utils import StrEnum
+
+
+class CategoricalRating(StrEnum):
+    """A categorical rating for an assessment."""
+
+    YES = "yes"
+    NO = "no"
+    UNKNOWN = "unknown"
+
+    @classmethod
+    def _missing_(cls, value: str):
+        value = value.lower()
+        for member in cls:
+            if member == value:
+                return member
+        return cls.UNKNOWN
 
 
 def requires_databricks_agents(func):

--- a/mlflow/genai/judges/databricks.py
+++ b/mlflow/genai/judges/databricks.py
@@ -43,20 +43,10 @@ def _sanitize_feedback(feedback: Feedback) -> Feedback:
     Returns:
         A new Feedback object with our CategoricalRating.
     """
-    return Feedback(
-        name=feedback.name,
-        # Convert the databricks-agents CategoricalRating to a mlflow.genai.judges.CategoricalRating
-        value=CategoricalRating(feedback.value.value),
-        source=feedback.source,
-        trace_id=feedback.trace_id,
-        metadata=feedback.metadata,
-        span_id=feedback.span_id,
-        create_time_ms=feedback.create_time_ms,
-        last_update_time_ms=feedback.last_update_time_ms,
-        rationale=feedback.rationale,
-        overrides=feedback.overrides,
-        valid=feedback.valid,
-    )
+    feedback.feedback.value = CategoricalRating(feedback.value.value)
+    # Need to set the value attribute to ensure it is synced with the feedback.value
+    feedback.value = CategoricalRating(feedback.value.value)
+    return feedback
 
 
 def requires_databricks_agents(func):

--- a/mlflow/genai/utils/enum_utils.py
+++ b/mlflow/genai/utils/enum_utils.py
@@ -1,0 +1,23 @@
+from enum import Enum, EnumMeta
+
+
+class MetaEnum(EnumMeta):
+    """Metaclass for Enum classes that allows to check if a value is a valid member of the Enum."""
+
+    def __contains__(cls, item):
+        try:
+            cls(item)
+        except ValueError:
+            return False
+        return True
+
+
+class StrEnum(str, Enum, metaclass=MetaEnum):
+    def __str__(self):
+        """Return the string representation of the enum using its value."""
+        return self.value
+
+    @classmethod
+    def values(cls) -> list[str]:
+        """Return a list of all string values of the Enum."""
+        return [str(member) for member in cls]

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -392,3 +392,17 @@ def test_feedback_from_exception(stack_trace_length):
     recovered = Feedback.from_proto(feedback.to_proto())
     assert feedback.error.error_code == recovered.error.error_code
     assert feedback.error.error_message == recovered.error.error_message
+
+
+def test_assessment_value_assignment():
+    feedback = Feedback(name="relevance", value=1.0)
+    assert feedback.value == 1.0
+
+    feedback.value = 0.9
+    assert feedback.value == 0.9
+
+    expectation = Expectation(name="expected_value", value=1.0)
+    assert expectation.value == 1.0
+
+    expectation.value = 0.9
+    assert expectation.value == 0.9

--- a/tests/genai/judges/test_judges.py
+++ b/tests/genai/judges/test_judges.py
@@ -1,3 +1,17 @@
+from unittest.mock import patch
+
+import pytest
+
+from mlflow.entities.assessment import (
+    AssessmentSource,
+    AssessmentSourceType,
+    Feedback,
+    FeedbackValue,
+)
+from mlflow.genai import judges
+from mlflow.genai.judges.databricks import _sanitize_feedback
+
+
 def test_databricks_judges_are_importable():
     from mlflow.genai import judges
     from mlflow.genai.judges import (
@@ -15,3 +29,89 @@ def test_databricks_judges_are_importable():
     assert judges.is_grounded == is_grounded
     assert judges.is_safe == is_safe
     assert judges.meets_guidelines == meets_guidelines
+
+
+def create_test_feedback(value: str) -> Feedback:
+    return Feedback(
+        name="test_feedback",
+        source=AssessmentSource(source_type=AssessmentSourceType.LLM_JUDGE, source_id="databricks"),
+        rationale="Test rationale",
+        metadata={},
+        value=FeedbackValue(value=value, error=None),
+        valid=True,
+    )
+
+
+def test_sanitize_feedback_happy_path():
+    feedback = create_test_feedback("yes")
+    result = _sanitize_feedback(feedback)
+    assert isinstance(result.value, judges.CategoricalRating)
+    assert result.value == judges.CategoricalRating.YES
+
+
+def test_sanitize_feedback_no():
+    feedback = create_test_feedback("no")
+    result = _sanitize_feedback(feedback)
+    assert isinstance(result.value, judges.CategoricalRating)
+    assert result.value == judges.CategoricalRating.NO
+
+
+def test_sanitize_feedback_unknown():
+    feedback = create_test_feedback("unknown")
+    result = _sanitize_feedback(feedback)
+    assert isinstance(result.value, judges.CategoricalRating)
+    assert result.value == judges.CategoricalRating.UNKNOWN
+
+
+def test_meets_guidelines_happy_path():
+    with patch("databricks.agents.evals.judges.guideline_adherence") as mock_judge:
+        mock_judge.return_value = create_test_feedback("yes")
+        result = judges.meets_guidelines(guidelines="test", context={"response": "test"})
+
+        assert isinstance(result.value, judges.CategoricalRating)
+        assert result.value == judges.CategoricalRating.YES
+        mock_judge.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("judge_func", "agents_judge_name", "args"),
+    [
+        (
+            judges.is_context_relevant,
+            "relevance_to_query",
+            {"request": "test", "context": "test"},
+        ),
+        (
+            judges.is_context_sufficient,
+            "context_sufficiency",
+            {"request": "test", "context": "test", "expected_facts": ["test"]},
+        ),
+        (
+            judges.is_correct,
+            "correctness",
+            {"request": "test", "response": "test", "expected_facts": ["test"]},
+        ),
+        (
+            judges.is_grounded,
+            "groundedness",
+            {"request": "test", "response": "test", "context": "test"},
+        ),
+        (
+            judges.is_safe,
+            "safety",
+            {"content": "test"},
+        ),
+        (
+            judges.meets_guidelines,
+            "guideline_adherence",
+            {"guidelines": "test", "context": {"response": "test"}},
+        ),
+    ],
+)
+def test_judge_functions_happy_path(judge_func, agents_judge_name, args):
+    with patch(f"databricks.agents.evals.judges.{agents_judge_name}") as mock_judge:
+        mock_judge.return_value = create_test_feedback("yes")
+        result = judge_func(**args)
+        assert isinstance(result.value, judges.CategoricalRating)
+        assert result.value == judges.CategoricalRating.YES
+        mock_judge.assert_called_once()

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -4,6 +4,7 @@ from unittest.mock import call, patch
 
 import pandas as pd
 import pytest
+from databricks.rag_eval.evaluation.entities import CategoricalRating
 from packaging.version import Version
 
 import mlflow
@@ -15,9 +16,6 @@ from mlflow.genai import Scorer, scorer
 from mlflow.genai.scorers import Correctness, Guidelines, RetrievalGroundedness
 
 from tests.tracing.helper import get_traces, purge_traces
-
-if importlib.util.find_spec("databricks.agents") is None:
-    pytest.skip(reason="databricks-agents is not installed", allow_module_level=True)
 
 agent_sdk_version = Version(importlib.import_module("databricks.agents").__version__)
 
@@ -74,15 +72,15 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
     with (
         patch(
             "databricks.agents.evals.judges.correctness",
-            return_value=Feedback(name="correctness", value="yes"),
+            return_value=Feedback(name="correctness", value=CategoricalRating.YES),
         ) as mock_correctness,
         patch(
             "databricks.agents.evals.judges.guideline_adherence",
-            return_value=Feedback(name="guideline_adherence", value="yes"),
+            return_value=Feedback(name="guideline_adherence", value=CategoricalRating.YES),
         ) as mock_guideline,
         patch(
             "databricks.agents.evals.judges.groundedness",
-            return_value=Feedback(name="groundedness", value="yes"),
+            return_value=Feedback(name="groundedness", value=CategoricalRating.YES),
         ) as mock_groundedness,
     ):
         mlflow.genai.evaluate(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/16060?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16060/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16060/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16060/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR exposes a categorical rating class (already in `databricks-agents`) in the `mlflow.genai.judges` package. The categorical rating is a returned artifact from the built-in judges.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Expose categorical rating in mlflow.genai.judges

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
