### PR TITLE
Get labeling session takes run id

### DIFF
--- a/mlflow/genai/labeling/__init__.py
+++ b/mlflow/genai/labeling/__init__.py
@@ -63,34 +63,26 @@ def get_labeling_sessions() -> list[LabelingSession]:
     return get_review_app().get_labeling_sessions()
 
 
-def get_labeling_session(
-    name: Optional[str] = None, run_id: Optional[str] = None
-) -> LabelingSession:
+def get_labeling_session(run_id: str) -> LabelingSession:
     """Get a labeling session from the review app.
 
     Args:
-        name: The name of the labeling session to get.
         run_id: The mlflow run ID of the labeling session to get.
 
     Returns:
         LabelingSession: The labeling session.
     """
-    if name is None and run_id is None:
-        raise ValueError("Either `name` or `run_id` must be provided")
-    if name is not None and run_id is not None:
-        raise ValueError("Only one of `name` or `run_id` must be provided")
-
     labeling_sessions = get_labeling_sessions()
     labeling_session = next(
         (
             labeling_session
             for labeling_session in labeling_sessions
-            if labeling_session.mlflow_run_id == run_id or labeling_session.name == name
+            if labeling_session.mlflow_run_id == run_id
         ),
         None,
     )
     if labeling_session is None:
-        raise ValueError(f"Labeling session with name `{name}` not found")
+        raise ValueError(f"Labeling session with run_id `{run_id}` not found")
     return labeling_session
 
 

--- a/mlflow/genai/labeling/__init__.py
+++ b/mlflow/genai/labeling/__init__.py
@@ -63,21 +63,29 @@ def get_labeling_sessions() -> list[LabelingSession]:
     return get_review_app().get_labeling_sessions()
 
 
-def get_labeling_session(name: str) -> LabelingSession:
+def get_labeling_session(
+    name: Optional[str] = None, run_id: Optional[str] = None
+) -> LabelingSession:
     """Get a labeling session from the review app.
 
     Args:
         name: The name of the labeling session to get.
+        run_id: The mlflow run ID of the labeling session to get.
 
     Returns:
         LabelingSession: The labeling session.
     """
+    if name is None and run_id is None:
+        raise ValueError("Either `name` or `run_id` must be provided")
+    if name is not None and run_id is not None:
+        raise ValueError("Only one of `name` or `run_id` must be provided")
+
     labeling_sessions = get_labeling_sessions()
     labeling_session = next(
         (
             labeling_session
             for labeling_session in labeling_sessions
-            if labeling_session.name == name
+            if labeling_session.mlflow_run_id == run_id or labeling_session.name == name
         ),
         None,
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/16062?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16062/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16062/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16062/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR allows `mlflow.genai.labeling.get_labeling_session` to take a`run_id`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Updates mlflow.genai.labeling.get_labeling_session to take a mlflow run id.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
