### PR TITLE
Fix catboost cross-version tests

### DIFF
--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -69,7 +69,11 @@ def iter_models():
     yield ModelWithData(model=model, inference_dataframe=X)
 
 
-@pytest.fixture(params=iter_models(), ids=["CatBoost", "CatBoostClassifier", "CatBoostRegressor"])
+@pytest.fixture(
+    scope="module",
+    params=iter_models(),
+    ids=["CatBoost", "CatBoostClassifier", "CatBoostRegressor"],
+)
 def cb_model(request):
     return request.param
 

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -57,19 +57,21 @@ def read_yaml(path):
 MODEL_PARAMS = {"allow_writing_files": False, "iterations": 10}
 
 
-@pytest.fixture(
-    scope="module",
-    params=[
-        cb.CatBoost(MODEL_PARAMS),
-        cb.CatBoostClassifier(**MODEL_PARAMS),
-        cb.CatBoostRegressor(**MODEL_PARAMS),
-    ],
-    ids=["CatBoost", "CatBoostClassifier", "CatBoostRegressor"],
-)
-def cb_model(request):
-    model = request.param
+def iter_models():
     X, y = get_iris()
-    return ModelWithData(model=model.fit(X, y), inference_dataframe=X)
+    model = cb.CatBoost(MODEL_PARAMS).fit(X, y)
+    yield ModelWithData(model=model, inference_dataframe=X)
+
+    model = cb.CatBoostClassifier(**MODEL_PARAMS).fit(X, y)
+    yield ModelWithData(model=model, inference_dataframe=X)
+
+    model = cb.CatBoostRegressor(**MODEL_PARAMS).fit(X, y)
+    yield ModelWithData(model=model, inference_dataframe=X)
+
+
+@pytest.fixture(params=iter_models(), ids=["CatBoost", "CatBoostClassifier", "CatBoostRegressor"])
+def cb_model(request):
+    return request.param
 
 
 @pytest.fixture


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16065?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16065/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16065/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16065/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

#16025 pinned pytest to `8.4.0`. This change broke cross-version tests. Not sure why. This PR fixes them. This error is blocking https://github.com/mlflow/mlflow/pull/16047.

https://github.com/mlflow/mlflow/actions/runs/15434237187/job/43437488050?pr=16047

```
/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/catboost/core.py:1779: CatBoostError
_____________ ERROR at setup of test_log_model[CatBoostClassifier] _____________

self = <catboost.core.CatBoostClassifier object at 0x7fdb03762020>
other = <catboost.core.CatBoost object at 0x7fdb03762ec0>

    def __eq__(self, other):
>       return self._is_comparable_to(other) and self._object == other._object

other      = <catboost.core.CatBoost object at 0x7fdb03762ec0>
self       = <catboost.core.CatBoostClassifier object at 0x7fdb03762020>

/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/site-packages/catboost/core.py:[176](https://github.com/mlflow/mlflow/actions/runs/15434237187/job/43437488050?pr=16047#step:12:177)1: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <catboost.core.CatBoostClassifier object at 0x7fdb03762020>
rhs = <catboost.core.CatBoost object at 0x7fdb03762ec0>

    def _is_comparable_to(self, rhs):
        if not isinstance(rhs, _CatBoostBase):
            return False
        for side, estimator in [('left', self), ('right', rhs)]:
            if not estimator.is_fitted():
                message = 'The {} argument is not fitted, only fitted models' \
                          ' could be compared.'
>               raise CatBoostError(message.format(side))
E               _catboost.CatBoostError: The left argument is not fitted, only fitted models could be compared.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
