### PR TITLE
Scheduled Scorers

### DIFF
--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -29,11 +29,11 @@ from mlflow.genai.optimize import optimize_prompt
 from mlflow.genai.scheduled_scorers import (
     ScorerScheduleConfig,
     add_scheduled_scorer,
-    update_scheduled_scorer,
     delete_scheduled_scorer,
     get_scheduled_scorer,
     list_scheduled_scorers,
     set_scheduled_scorers,
+    update_scheduled_scorer,
 )
 
 __all__ = [

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -27,7 +27,7 @@ from mlflow.genai.datasets import (
 )
 from mlflow.genai.optimize import optimize_prompt
 from mlflow.genai.scheduled_scorers import (
-    ScheduledScorer,
+    ScorerScheduleConfig,
     add_scheduled_scorer,
     update_scheduled_scorer,
     delete_scheduled_scorer,
@@ -47,7 +47,7 @@ __all__ = [
     "delete_dataset",
     "get_dataset",
     "optimize_prompt",
-    "ScheduledScorer",
+    "ScorerScheduleConfig",
     "add_scheduled_scorer",
     "update_scheduled_scorer",
     "delete_scheduled_scorer",

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -26,6 +26,15 @@ from mlflow.genai.datasets import (
     get_dataset,
 )
 from mlflow.genai.optimize import optimize_prompt
+from mlflow.genai.scheduled_scorers import (
+    ScheduledScorer,
+    add_scheduled_scorer,
+    update_scheduled_scorer,
+    delete_scheduled_scorer,
+    get_scheduled_scorer,
+    list_scheduled_scorers,
+    set_scheduled_scorers,
+)
 
 __all__ = [
     "evaluate",
@@ -38,6 +47,13 @@ __all__ = [
     "delete_dataset",
     "get_dataset",
     "optimize_prompt",
+    "ScheduledScorer",
+    "add_scheduled_scorer",
+    "update_scheduled_scorer",
+    "delete_scheduled_scorer",
+    "get_scheduled_scorer",
+    "list_scheduled_scorers",
+    "set_scheduled_scorers",
     # Labeling exports (only included when databricks-agents is installed)
     *(
         [

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import Optional
+
 from mlflow.genai.scorers.base import Scorer
 from mlflow.utils.annotations import experimental
 
@@ -10,7 +11,7 @@ _ERROR_MSG = (
 
 
 @experimental
-@dataclass(kw_only=True)
+@dataclass()
 class ScorerScheduleConfig:
     """
     A scheduled scorer configuration for automated monitoring of generative AI applications.
@@ -29,8 +30,9 @@ class ScorerScheduleConfig:
         scorer: The scorer function to run on sampled traces. Must be either a built-in
             scorer (e.g., Safety, Correctness) or a function decorated with @scorer.
             Subclasses of Scorer are not supported.
-        scheduled_scorer_name: The name for this scheduled scorer configuration within the experiment.
-            This name must be unique among all scheduled scorers in the same experiment.
+        scheduled_scorer_name: The name for this scheduled scorer configuration
+            within the experiment. This name must be unique among all scheduled scorers
+            in the same experiment.
             We recommend using the scorer's name (e.g., scorer.name) for consistency.
         sample_rate: The fraction of traces to evaluate, between 0.0 and 1.0. For example,
             0.1 means 10% of traces will be randomly selected for evaluation.
@@ -71,6 +73,9 @@ class ScorerScheduleConfig:
         manually triggered. The Assessments appear in the Traces tab of the MLflow
         experiment. Only traces logged directly to the experiment are monitored; traces
         logged to individual runs within the experiment are not evaluated.
+
+    .. warning::
+        This API is in Beta and may change or be removed in a future release without warning.
     """
 
     scorer: Scorer
@@ -81,7 +86,7 @@ class ScorerScheduleConfig:
 
 # Scheduled Scorer CRUD operations
 @experimental
-def add_scheduled_scorer(
+def add_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
     scorer: Scorer,
@@ -145,6 +150,9 @@ def add_scheduled_scorer(
         There may be a delay between when traces are logged and when they are evaluated.
         Only traces logged directly to the experiment are monitored; traces logged to
         individual runs within the experiment are not evaluated.
+
+    .. warning::
+        This API is in Beta and may change or be removed in a future release without warning.
     """
     try:
         from databricks.agents.scorers import add_scheduled_scorer
@@ -156,7 +164,7 @@ def add_scheduled_scorer(
 
 
 @experimental
-def update_scheduled_scorer(
+def update_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
     scorer: Optional[Scorer] = None,
@@ -204,6 +212,9 @@ def update_scheduled_scorer(
                 sample_rate=0.8,  # Increased from 0.5 to 0.8
                 filter_string="trace.status = 'OK'",
             )
+
+    .. warning::
+        This API is in Beta and may change or be removed in a future release without warning.
     """
     try:
         from databricks.agents.scorers import update_scheduled_scorer
@@ -215,7 +226,7 @@ def update_scheduled_scorer(
 
 
 @experimental
-def delete_scheduled_scorer(
+def delete_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
     experiment_id: Optional[str] = None,
@@ -253,6 +264,9 @@ def delete_scheduled_scorer(
     Note:
         Deletion is immediate and cannot be undone. If you need the same scorer
         configuration later, you will need to add it again using add_scheduled_scorer.
+
+    .. warning::
+        This API is in Beta and may change or be removed in a future release without warning.
     """
     try:
         from databricks.agents.scorers import delete_scheduled_scorer
@@ -262,7 +276,7 @@ def delete_scheduled_scorer(
 
 
 @experimental
-def get_scheduled_scorer(
+def get_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
     experiment_id: Optional[str] = None,
@@ -294,6 +308,9 @@ def get_scheduled_scorer(
             print(f"Sample rate: {scorer_config.sample_rate}")
             print(f"Filter: {scorer_config.filter_string}")
             print(f"Scorer: {scorer_config.scorer.name}")
+
+    .. warning::
+        This API is in Beta and may change or be removed in a future release without warning.
     """
     try:
         from databricks.agents.scorers import get_scheduled_scorer
@@ -303,7 +320,7 @@ def get_scheduled_scorer(
 
 
 @experimental
-def list_scheduled_scorers(
+def list_scheduled_scorers(  # clint: disable=missing-docstring-param  # noqa: D417
     *, experiment_id: Optional[str] = None, **kwargs
 ) -> list[ScorerScheduleConfig]:
     """
@@ -337,6 +354,9 @@ def list_scheduled_scorers(
             mlflow.set_experiment("my_genai_app_monitoring")
             current_scorers = list_scheduled_scorers()
             print(f"Found {len(current_scorers)} scheduled scorers")
+
+    .. warning::
+        This API is in Beta and may change or be removed in a future release without warning.
     """
     try:
         from databricks.agents.scorers import list_scheduled_scorers
@@ -346,7 +366,7 @@ def list_scheduled_scorers(
 
 
 @experimental
-def set_scheduled_scorers(
+def set_scheduled_scorers(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorers: list[ScorerScheduleConfig],
     experiment_id: Optional[str] = None,
@@ -402,6 +422,9 @@ def set_scheduled_scorers(
 
     Note:
         Existing Assessments will remain in the Traces tab of the MLflow experiment.
+
+    .. warning::
+        This API is in Beta and may change or be removed in a future release without warning.
     """
     try:
         from databricks.agents.scorers import set_scheduled_scorers

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -17,7 +17,7 @@ class ScorerScheduleConfig:
     A scheduled scorer configuration for automated monitoring of generative AI applications.
 
     Scheduled scorers are used to automatically evaluate traces logged to MLflow experiments
-    by production applications. They are part of Databricks' Lakehouse Monitoring for GenAI,
+    by production applications. They are part of [Databricks Lakehouse Monitoring for GenAI](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/monitoring),
     which helps track quality metrics like groundedness, safety, and guideline adherence
     alongside operational metrics like volume, latency, and cost.
 
@@ -98,8 +98,8 @@ def add_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D41
     """
     Add a scheduled scorer to automatically monitor traces in an MLflow experiment.
 
-    This function configures a scorer to run automatically on traces logged to the specified
-    experiment. The scorer will evaluate a sample of traces based on the sampling rate
+    This function configures a scorer function to run automatically on traces logged to the
+    specified experiment. The scorer will evaluate a sample of traces based on the sampling rate
     and any filter criteria. Assessments are displayed in the Traces tab of the MLflow experiment.
 
     Args:
@@ -208,9 +208,7 @@ def update_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: 
             # Update an existing safety scorer to increase sampling rate
             updated_scorer = update_scheduled_scorer(
                 scheduled_scorer_name="safety_monitor",
-                scorer=Safety(),
                 sample_rate=0.8,  # Increased from 0.5 to 0.8
-                filter_string="trace.status = 'OK'",
             )
 
     .. warning::

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -1,0 +1,391 @@
+from typing import Any, Optional, Union
+from mlflow.genai.scorers.base import Scorer
+from mlflow.utils.annotations import experimental
+
+_ERROR_MSG = (
+    "The `databricks-agents` package is required to use `mlflow.genai.scheduled_scorers`. "
+    "Please install it with `pip install databricks-agents`."
+)
+
+
+@experimental
+class ScheduledScorer:
+    """
+    A scheduled scorer configuration for automated monitoring of generative AI applications.
+
+    Scheduled scorers are used to automatically evaluate traces logged to MLflow experiments
+    by production applications. They are part of Databricks' Lakehouse Monitoring for GenAI,
+    which helps track quality metrics like groundedness, safety, and guideline adherence
+    alongside operational metrics like volume, latency, and cost.
+
+    When configured, scheduled scorers run automatically in the background to evaluate
+    a sample of traces based on the specified sampling rate and filter criteria. The
+    evaluation results are displayed in the Traces tab of the MLflow experiment and can be used to
+    identify quality issues in production.
+
+    Args:
+        scorer_fn: The scorer function to run on sampled traces. Must be either a built-in
+            scorer (e.g., Safety, Correctness) or a function decorated with @scorer.
+            Subclasses of Scorer are not supported.
+        scorer_name: A unique name for this scheduled scorer configuration.
+        sample_rate: The fraction of traces to evaluate, between 0.0 and 1.0. For example,
+            0.1 means 10% of traces will be randomly selected for evaluation.
+        filter_string: An optional MLflow search_traces compatible filter string to apply
+            before sampling traces. Only traces matching this filter will be considered
+            for evaluation. Uses the same syntax as mlflow.search_traces().
+
+    Example:
+        .. code-block:: python
+
+            from mlflow.genai.scorers import Safety, scorer
+            from mlflow.genai.scheduled_scorers import ScheduledScorer
+
+            # Using a built-in scorer
+            safety_config = ScheduledScorer(
+                scorer_fn=Safety(),
+                scorer_name="production_safety",
+                sample_rate=0.2,  # Evaluate 20% of traces
+                filter_string="trace.status = 'OK'",
+            )
+
+
+            # Using a custom scorer
+            @scorer
+            def response_length(outputs):
+                return len(str(outputs)) > 100
+
+
+            length_config = ScheduledScorer(
+                scorer_fn=response_length,
+                scorer_name="adequate_length",
+                sample_rate=0.1,  # Evaluate 10% of traces
+                filter_string="trace.status = 'OK'",
+            )
+
+    Note:
+        Scheduled scorers are executed automatically by Databricks and do not need to be
+        manually triggered. The evaluation results appear in the MLflow experiment's
+        monitoring dashboard.
+    """
+
+    def __init__(
+        self,
+        *,
+        scorer_fn: Scorer,
+        scorer_name: str,
+        sample_rate: float,
+        filter_string: Optional[str] = None,
+    ):
+        self.scorer_fn = scorer_fn
+        self.scorer_name = scorer_name
+        self.sample_rate = sample_rate
+        self.filter_string = filter_string
+
+
+# Scheduled Scorer CRUD operations
+@experimental
+def add_scheduled_scorer(
+    *,
+    experiment_id: Optional[str] = None,
+    scorer_name: str,
+    scorer_fn: Scorer,
+    sample_rate: float,
+    filter_string: Optional[str] = None,
+) -> ScheduledScorer:
+    """
+    Add a scheduled scorer to automatically monitor traces in an MLflow experiment.
+
+    This function configures a scorer to run automatically on traces logged to the specified
+    experiment. The scorer will evaluate a sample of traces based on the sampling rate
+    and any filter criteria. Results are displayed in the experiment's monitoring dashboard.
+
+    Args:
+        experiment_id: The ID of the MLflow experiment to monitor. If None, uses the
+            currently active experiment.
+        scorer_name: A unique name for this scheduled scorer within the experiment.
+            We recommend using the scorer's name (e.g., scorer_fn.name) for consistency.
+        scorer_fn: The scorer function to execute on sampled traces. Must be either a
+            built-in scorer or a function decorated with @scorer. Subclasses of Scorer
+            are not supported.
+        sample_rate: The fraction of traces to evaluate, between 0.0 and 1.0. For example,
+            0.3 means 30% of traces will be randomly selected for evaluation.
+        filter_string: An optional MLflow search_traces compatible filter string. Only
+            traces matching this filter will be considered for evaluation. If None,
+            all traces in the experiment are eligible for sampling.
+
+    Returns:
+        A ScheduledScorer object representing the configured scheduled scorer.
+
+    Example:
+        .. code-block:: python
+
+            import mlflow
+            from mlflow.genai.scorers import Safety, Correctness
+            from mlflow.genai.scheduled_scorers import add_scheduled_scorer
+
+            # Set up your experiment
+            experiment = mlflow.set_experiment("my_genai_app_monitoring")
+
+            # Add a safety scorer to monitor 50% of traces
+            safety_scorer = add_scheduled_scorer(
+                scorer_name="safety_monitor",
+                scorer_fn=Safety(),
+                sample_rate=0.5,
+                filter_string="trace.status = 'OK'",
+            )
+
+            # Add a correctness scorer with different sampling
+            correctness_scorer = add_scheduled_scorer(
+                experiment_id=experiment.experiment_id,  # Explicitly specify experiment
+                scorer_name="correctness_monitor",
+                scorer_fn=Correctness(),
+                sample_rate=0.2,  # More expensive, so lower sample rate
+            )
+
+    Note:
+        Once added, the scheduled scorer will begin evaluating new traces automatically.
+        There may be a delay between when traces are logged and when they are evaluated.
+    """
+    try:
+        from databricks.agents.scorers import add_scheduled_scorer
+    except ImportError as e:
+        raise ImportError(_ERROR_MSG) from e
+    return add_scheduled_scorer(experiment_id, scorer_name, scorer_fn, sample_rate, filter_string)
+
+
+@experimental
+def update_scheduled_scorer(
+    *,
+    experiment_id: Optional[str] = None,
+    scorer_name: str,
+    scorer_fn: Scorer,
+    sample_rate: float,
+    filter_string: Optional[str] = None,
+) -> ScheduledScorer:
+    """
+    Update an existing scheduled scorer configuration.
+
+    This function modifies the configuration of an existing scheduled scorer, allowing you
+    to change the scorer function, sampling rate, or filter criteria. The scorer will
+    continue to run automatically with the new configuration.
+
+    Args:
+        experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
+            If None, uses the currently active experiment.
+        scorer_name: The name of the existing scheduled scorer to update. Must match
+            the name used when the scorer was originally added. We recommend using the
+            scorer's name (e.g., scorer_fn.name) for consistency.
+        scorer_fn: The new scorer function to execute on sampled traces. Must be either
+            a built-in scorer or a function decorated with @scorer.
+        sample_rate: The new fraction of traces to evaluate, between 0.0 and 1.0.
+        filter_string: The new MLflow search_traces compatible filter string. If None,
+            all traces in the experiment are eligible for sampling.
+
+    Returns:
+        A ScheduledScorer object representing the updated scheduled scorer configuration.
+
+    Example:
+        .. code-block:: python
+
+            from mlflow.genai.scorers import Safety
+            from mlflow.genai.scheduled_scorers import update_scheduled_scorer
+
+            # Update an existing safety scorer to increase sampling rate
+            updated_scorer = update_scheduled_scorer(
+                scorer_name="safety_monitor",
+                scorer_fn=Safety(),
+                sample_rate=0.8,  # Increased from 0.5 to 0.8
+                filter_string="trace.status = 'OK'",
+            )
+    """
+    try:
+        from databricks.agents.scorers import update_scheduled_scorer
+    except ImportError as e:
+        raise ImportError(_ERROR_MSG) from e
+    return update_scheduled_scorer(
+        experiment_id, scorer_name, scorer_fn, sample_rate, filter_string
+    )
+
+
+@experimental
+def delete_scheduled_scorer(*, experiment_id: Optional[str] = None, scorer_name: str) -> None:
+    """
+    Delete a scheduled scorer from an MLflow experiment.
+
+    This function removes a scheduled scorer configuration, stopping automatic evaluation
+    of traces. Existing evaluation results will remain in the monitoring dashboard, but
+    no new evaluations will be performed.
+
+    Args:
+        experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
+            If None, uses the currently active experiment.
+        scorer_name: The name of the scheduled scorer to delete. Must match the name
+            used when the scorer was originally added.
+
+    Example:
+        .. code-block:: python
+
+            from mlflow.genai.scheduled_scorers import delete_scheduled_scorer
+
+            # Remove a scheduled scorer that's no longer needed
+            delete_scheduled_scorer(scorer_name="safety_monitor")
+
+            # To delete all scheduled scorers at once, use set_scheduled_scorers
+            # with an empty list instead:
+            from mlflow.genai.scheduled_scorers import set_scheduled_scorers
+
+            set_scheduled_scorers(
+                scheduled_scorers=[]  # Empty list removes all scorers
+            )
+
+    Note:
+        Deletion is immediate and cannot be undone. If you need the same scorer
+        configuration later, you will need to add it again using add_scheduled_scorer.
+    """
+    try:
+        from databricks.agents.scorers import delete_scheduled_scorer
+    except ImportError as e:
+        raise ImportError(_ERROR_MSG) from e
+    return delete_scheduled_scorer(experiment_id, scorer_name)
+
+
+@experimental
+def get_scheduled_scorer(
+    *, experiment_id: Optional[str] = None, scorer_name: str
+) -> ScheduledScorer:
+    """
+    Retrieve the configuration of a specific scheduled scorer.
+
+    This function returns the current configuration of a scheduled scorer, including
+    its scorer function, sampling rate, and filter criteria.
+
+    Args:
+        experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
+            If None, uses the currently active experiment.
+        scorer_name: The name of the scheduled scorer to retrieve.
+
+    Returns:
+        A ScheduledScorer object containing the current configuration of the specified
+        scheduled scorer.
+
+    Example:
+        .. code-block:: python
+
+            from mlflow.genai.scheduled_scorers import get_scheduled_scorer
+
+            # Get the current configuration of a scheduled scorer
+            scorer_config = get_scheduled_scorer(scorer_name="safety_monitor")
+
+            print(f"Sample rate: {scorer_config.sample_rate}")
+            print(f"Filter: {scorer_config.filter_string}")
+            print(f"Scorer: {scorer_config.scorer_fn.name}")
+    """
+    try:
+        from databricks.agents.scorers import get_scheduled_scorer
+    except ImportError as e:
+        raise ImportError(_ERROR_MSG) from e
+    return get_scheduled_scorer(experiment_id, scorer_name)
+
+
+@experimental
+def list_scheduled_scorers(*, experiment_id: Optional[str] = None) -> list[ScheduledScorer]:
+    """
+    List all scheduled scorers for an experiment.
+
+    This function returns all scheduled scorers configured for the specified experiment,
+    or for the current active experiment if no experiment ID is provided.
+
+    Args:
+        experiment_id: The ID of the MLflow experiment to list scheduled scorers for.
+            If None, uses the currently active experiment.
+
+    Returns:
+        A list of ScheduledScorer objects representing all scheduled scorers configured
+        for the specified experiment.
+
+    Example:
+        .. code-block:: python
+
+            import mlflow
+            from mlflow.genai.scheduled_scorers import list_scheduled_scorers
+
+            # List scorers for a specific experiment
+            scorers = list_scheduled_scorers(experiment_id="12345")
+            for scorer in scorers:
+                print(f"Scorer: {scorer.scorer_name}")
+                print(f"Sample rate: {scorer.sample_rate}")
+                print(f"Filter: {scorer.filter_string}")
+
+            # List scorers for the current active experiment
+            mlflow.set_experiment("my_genai_app_monitoring")
+            current_scorers = list_scheduled_scorers()
+            print(f"Found {len(current_scorers)} scheduled scorers")
+    """
+    try:
+        from databricks.agents.scorers import list_scheduled_scorers
+    except ImportError as e:
+        raise ImportError(_ERROR_MSG) from e
+    return list_scheduled_scorers(experiment_id)
+
+
+@experimental
+def set_scheduled_scorers(
+    *, experiment_id: Optional[str] = None, scheduled_scorers: list[ScheduledScorer]
+) -> None:
+    """
+    Replace all scheduled scorers for an experiment with the provided list.
+
+    This function removes all existing scheduled scorers for the specified experiment
+    and replaces them with the new list. This is useful for batch configuration updates
+    or when you want to ensure only specific scorers are active.
+
+    Args:
+        experiment_id: The ID of the MLflow experiment to configure. If None, uses the
+            currently active experiment.
+        scheduled_scorers: A list of ScheduledScorer objects to set as the complete
+            set of scheduled scorers for the experiment. Any existing scheduled scorers
+            not in this list will be removed.
+
+    Example:
+        .. code-block:: python
+
+            from mlflow.genai.scorers import Safety, Correctness, RelevanceToQuery
+            from mlflow.genai.scheduled_scorers import ScheduledScorer, set_scheduled_scorers
+
+            # Define a complete monitoring configuration
+            monitoring_config = [
+                ScheduledScorer(
+                    scorer_fn=Safety(),
+                    scorer_name="safety_check",
+                    sample_rate=1.0,  # Check all traces for safety
+                ),
+                ScheduledScorer(
+                    scorer_fn=Correctness(),
+                    scorer_name="correctness_check",
+                    sample_rate=0.2,  # Sample 20% for correctness (more expensive)
+                    filter_string="trace.status = 'OK'",
+                ),
+                ScheduledScorer(
+                    scorer_fn=RelevanceToQuery(),
+                    scorer_name="relevance_check",
+                    sample_rate=0.5,  # Sample 50% for relevance
+                ),
+            ]
+
+            # Apply this configuration, replacing any existing scorers
+            set_scheduled_scorers(scheduled_scorers=monitoring_config)
+
+    Warning:
+        This function will remove all existing scheduled scorers for the experiment
+        that are not included in the provided list. Use add_scheduled_scorer() if you
+        want to add scorers without affecting existing ones.
+
+    Note:
+        Changes may take a few minutes to take effect in the monitoring system.
+        Existing evaluation results will remain in the monitoring dashboard.
+    """
+    try:
+        from databricks.agents.scorers import set_scheduled_scorers
+    except ImportError as e:
+        raise ImportError(_ERROR_MSG) from e
+    return set_scheduled_scorers(experiment_id, scheduled_scorers)

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -20,7 +20,7 @@ class ScheduledScorer:
 
     When configured, scheduled scorers run automatically in the background to evaluate
     a sample of traces based on the specified sampling rate and filter criteria. The
-    evaluation results are displayed in the Traces tab of the MLflow experiment and can be used to
+    Assessments are displayed in the Traces tab of the MLflow experiment and can be used to
     identify quality issues in production.
 
     Args:
@@ -64,8 +64,9 @@ class ScheduledScorer:
 
     Note:
         Scheduled scorers are executed automatically by Databricks and do not need to be
-        manually triggered. The evaluation results appear in the MLflow experiment's
-        monitoring dashboard.
+        manually triggered. The Assessments appear in the Traces tab of the MLflow
+        experiment. Only traces logged directly to the experiment are monitored; traces
+        logged to individual runs within the experiment are not evaluated.
     """
 
     def __init__(
@@ -97,7 +98,7 @@ def add_scheduled_scorer(
 
     This function configures a scorer to run automatically on traces logged to the specified
     experiment. The scorer will evaluate a sample of traces based on the sampling rate
-    and any filter criteria. Results are displayed in the experiment's monitoring dashboard.
+    and any filter criteria. Assessments are displayed in the Traces tab of the MLflow experiment.
 
     Args:
         experiment_id: The ID of the MLflow experiment to monitor. If None, uses the
@@ -145,6 +146,8 @@ def add_scheduled_scorer(
     Note:
         Once added, the scheduled scorer will begin evaluating new traces automatically.
         There may be a delay between when traces are logged and when they are evaluated.
+        Only traces logged directly to the experiment are monitored; traces logged to
+        individual runs within the experiment are not evaluated.
     """
     try:
         from databricks.agents.scorers import add_scheduled_scorer
@@ -213,8 +216,8 @@ def delete_scheduled_scorer(*, experiment_id: Optional[str] = None, scorer_name:
     Delete a scheduled scorer from an MLflow experiment.
 
     This function removes a scheduled scorer configuration, stopping automatic evaluation
-    of traces. Existing evaluation results will remain in the monitoring dashboard, but
-    no new evaluations will be performed.
+    of traces. Existing Assessments will remain in the Traces tab of the MLflow
+    experiment, but no new evaluations will be performed.
 
     Args:
         experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
@@ -381,8 +384,7 @@ def set_scheduled_scorers(
         want to add scorers without affecting existing ones.
 
     Note:
-        Changes may take a few minutes to take effect in the monitoring system.
-        Existing evaluation results will remain in the monitoring dashboard.
+        Existing Assessments will remain in the Traces tab of the MLflow experiment.
     """
     try:
         from databricks.agents.scorers import set_scheduled_scorers

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -87,11 +87,11 @@ class ScheduledScorer:
 @experimental
 def add_scheduled_scorer(
     *,
-    experiment_id: Optional[str] = None,
     scorer_name: str,
     scorer_fn: Scorer,
     sample_rate: float,
     filter_string: Optional[str] = None,
+    experiment_id: Optional[str] = None,
 ) -> ScheduledScorer:
     """
     Add a scheduled scorer to automatically monitor traces in an MLflow experiment.
@@ -101,8 +101,6 @@ def add_scheduled_scorer(
     and any filter criteria. Assessments are displayed in the Traces tab of the MLflow experiment.
 
     Args:
-        experiment_id: The ID of the MLflow experiment to monitor. If None, uses the
-            currently active experiment.
         scorer_name: A unique name for this scheduled scorer within the experiment.
             We recommend using the scorer's name (e.g., scorer_fn.name) for consistency.
         scorer_fn: The scorer function to execute on sampled traces. Must be either a
@@ -113,6 +111,8 @@ def add_scheduled_scorer(
         filter_string: An optional MLflow search_traces compatible filter string. Only
             traces matching this filter will be considered for evaluation. If None,
             all traces in the experiment are eligible for sampling.
+        experiment_id: The ID of the MLflow experiment to monitor. If None, uses the
+            currently active experiment.
 
     Returns:
         A ScheduledScorer object representing the configured scheduled scorer.
@@ -137,10 +137,10 @@ def add_scheduled_scorer(
 
             # Add a correctness scorer with different sampling
             correctness_scorer = add_scheduled_scorer(
-                experiment_id=experiment.experiment_id,  # Explicitly specify experiment
                 scorer_name="correctness_monitor",
                 scorer_fn=Correctness(),
                 sample_rate=0.2,  # More expensive, so lower sample rate
+                experiment_id=experiment.experiment_id,  # Explicitly specify experiment
             )
 
     Note:
@@ -159,11 +159,11 @@ def add_scheduled_scorer(
 @experimental
 def update_scheduled_scorer(
     *,
-    experiment_id: Optional[str] = None,
     scorer_name: str,
     scorer_fn: Scorer,
     sample_rate: float,
     filter_string: Optional[str] = None,
+    experiment_id: Optional[str] = None,
 ) -> ScheduledScorer:
     """
     Update an existing scheduled scorer configuration.
@@ -173,8 +173,6 @@ def update_scheduled_scorer(
     continue to run automatically with the new configuration.
 
     Args:
-        experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
-            If None, uses the currently active experiment.
         scorer_name: The name of the existing scheduled scorer to update. Must match
             the name used when the scorer was originally added. We recommend using the
             scorer's name (e.g., scorer_fn.name) for consistency.
@@ -183,6 +181,8 @@ def update_scheduled_scorer(
         sample_rate: The new fraction of traces to evaluate, between 0.0 and 1.0.
         filter_string: The new MLflow search_traces compatible filter string. If None,
             all traces in the experiment are eligible for sampling.
+        experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
+            If None, uses the currently active experiment.
 
     Returns:
         A ScheduledScorer object representing the updated scheduled scorer configuration.
@@ -211,7 +211,11 @@ def update_scheduled_scorer(
 
 
 @experimental
-def delete_scheduled_scorer(*, experiment_id: Optional[str] = None, scorer_name: str) -> None:
+def delete_scheduled_scorer(
+    *,
+    scorer_name: str,
+    experiment_id: Optional[str] = None,
+) -> None:
     """
     Delete a scheduled scorer from an MLflow experiment.
 
@@ -220,10 +224,10 @@ def delete_scheduled_scorer(*, experiment_id: Optional[str] = None, scorer_name:
     experiment, but no new evaluations will be performed.
 
     Args:
-        experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
-            If None, uses the currently active experiment.
         scorer_name: The name of the scheduled scorer to delete. Must match the name
             used when the scorer was originally added.
+        experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
+            If None, uses the currently active experiment.
 
     Example:
         .. code-block:: python
@@ -254,7 +258,9 @@ def delete_scheduled_scorer(*, experiment_id: Optional[str] = None, scorer_name:
 
 @experimental
 def get_scheduled_scorer(
-    *, experiment_id: Optional[str] = None, scorer_name: str
+    *,
+    scorer_name: str,
+    experiment_id: Optional[str] = None,
 ) -> ScheduledScorer:
     """
     Retrieve the configuration of a specific scheduled scorer.
@@ -263,9 +269,9 @@ def get_scheduled_scorer(
     its scorer function, sampling rate, and filter criteria.
 
     Args:
+        scorer_name: The name of the scheduled scorer to retrieve.
         experiment_id: The ID of the MLflow experiment containing the scheduled scorer.
             If None, uses the currently active experiment.
-        scorer_name: The name of the scheduled scorer to retrieve.
 
     Returns:
         A ScheduledScorer object containing the current configuration of the specified
@@ -333,7 +339,9 @@ def list_scheduled_scorers(*, experiment_id: Optional[str] = None) -> list[Sched
 
 @experimental
 def set_scheduled_scorers(
-    *, experiment_id: Optional[str] = None, scheduled_scorers: list[ScheduledScorer]
+    *,
+    scheduled_scorers: list[ScheduledScorer],
+    experiment_id: Optional[str] = None,
 ) -> None:
     """
     Replace all scheduled scorers for an experiment with the provided list.
@@ -343,11 +351,11 @@ def set_scheduled_scorers(
     or when you want to ensure only specific scorers are active.
 
     Args:
-        experiment_id: The ID of the MLflow experiment to configure. If None, uses the
-            currently active experiment.
         scheduled_scorers: A list of ScheduledScorer objects to set as the complete
             set of scheduled scorers for the experiment. Any existing scheduled scorers
             not in this list will be removed.
+        experiment_id: The ID of the MLflow experiment to configure. If None, uses the
+            currently active experiment.
 
     Example:
         .. code-block:: python

--- a/tests/genai/test_scheduled_scorers.py
+++ b/tests/genai/test_scheduled_scorers.py
@@ -1,0 +1,88 @@
+import pytest
+
+from mlflow.genai.scheduled_scorers import (
+    ScheduledScorer,
+    add_scheduled_scorer,
+    delete_scheduled_scorer,
+    get_scheduled_scorer,
+    list_scheduled_scorers,
+    set_scheduled_scorers,
+    update_scheduled_scorer,
+)
+from mlflow.genai.scorers.base import Scorer
+
+
+class MockScorer(Scorer):
+    """Mock scorer for testing purposes."""
+
+    name: str = "mock_scorer"
+
+    def __call__(self, *, outputs=None, **kwargs):
+        return {"score": 1.0}
+
+
+def test_scheduled_scorer_class_instantiation():
+    """Test that ScheduledScorer class can be instantiated without import errors."""
+    mock_scorer = MockScorer()
+    scheduled_scorer = ScheduledScorer(
+        scorer_fn=mock_scorer,
+        scorer_name="test_scorer",
+        sample_rate=0.5,
+        filter_string="test_filter",
+    )
+
+    assert scheduled_scorer.scorer_fn == mock_scorer
+    assert scheduled_scorer.scorer_name == "test_scorer"
+    assert scheduled_scorer.sample_rate == 0.5
+    assert scheduled_scorer.filter_string == "test_filter"
+
+
+def test_add_scheduled_scorer_raises_when_agents_not_installed():
+    mock_scorer = MockScorer()
+
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        add_scheduled_scorer(
+            experiment_id="test_experiment",
+            scorer_name="test_scorer",
+            scorer_fn=mock_scorer,
+            sample_rate=0.5,
+            filter_string="test_filter",
+        )
+
+
+def test_update_scheduled_scorer_raises_when_agents_not_installed():
+    mock_scorer = MockScorer()
+
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        update_scheduled_scorer(
+            experiment_id="test_experiment",
+            scorer_name="test_scorer",
+            scorer_fn=mock_scorer,
+            sample_rate=0.5,
+            filter_string="test_filter",
+        )
+
+
+def test_delete_scheduled_scorer_raises_when_agents_not_installed():
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        delete_scheduled_scorer(experiment_id="test_experiment", scorer_name="test_scorer")
+
+
+def test_get_scheduled_scorer_raises_when_agents_not_installed():
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        get_scheduled_scorer(experiment_id="test_experiment", scorer_name="test_scorer")
+
+
+def test_list_scheduled_scorers_raises_when_agents_not_installed():
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        list_scheduled_scorers(experiment_id="test_experiment")
+
+
+def test_set_scheduled_scorers_raises_when_agents_not_installed():
+    mock_scorer = MockScorer()
+    scheduled_scorer = ScheduledScorer(
+        scorer_fn=mock_scorer, scorer_name="test_scorer", sample_rate=0.5
+    )
+
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        set_scheduled_scorers(experiment_id="test_experiment", scheduled_scorers=[scheduled_scorer])

--- a/tests/genai/test_scheduled_scorers.py
+++ b/tests/genai/test_scheduled_scorers.py
@@ -1,7 +1,7 @@
 import pytest
 
 from mlflow.genai.scheduled_scorers import (
-    ScheduledScorer,
+    ScorerScheduleConfig,
     add_scheduled_scorer,
     delete_scheduled_scorer,
     get_scheduled_scorer,
@@ -24,15 +24,15 @@ class MockScorer(Scorer):
 def test_scheduled_scorer_class_instantiation():
     """Test that ScheduledScorer class can be instantiated without import errors."""
     mock_scorer = MockScorer()
-    scheduled_scorer = ScheduledScorer(
-        scorer_fn=mock_scorer,
-        scorer_name="test_scorer",
+    scheduled_scorer = ScorerScheduleConfig(
+        scorer=mock_scorer,
+        scheduled_scorer_name="test_scorer",
         sample_rate=0.5,
         filter_string="test_filter",
     )
 
-    assert scheduled_scorer.scorer_fn == mock_scorer
-    assert scheduled_scorer.scorer_name == "test_scorer"
+    assert scheduled_scorer.scorer == mock_scorer
+    assert scheduled_scorer.scheduled_scorer_name == "test_scorer"
     assert scheduled_scorer.sample_rate == 0.5
     assert scheduled_scorer.filter_string == "test_filter"
 
@@ -43,8 +43,8 @@ def test_add_scheduled_scorer_raises_when_agents_not_installed():
     with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
         add_scheduled_scorer(
             experiment_id="test_experiment",
-            scorer_name="test_scorer",
-            scorer_fn=mock_scorer,
+            scheduled_scorer_name="test_scorer",
+            scorer=mock_scorer,
             sample_rate=0.5,
             filter_string="test_filter",
         )
@@ -56,8 +56,8 @@ def test_update_scheduled_scorer_raises_when_agents_not_installed():
     with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
         update_scheduled_scorer(
             experiment_id="test_experiment",
-            scorer_name="test_scorer",
-            scorer_fn=mock_scorer,
+            scheduled_scorer_name="test_scorer",
+            scorer=mock_scorer,
             sample_rate=0.5,
             filter_string="test_filter",
         )
@@ -65,12 +65,14 @@ def test_update_scheduled_scorer_raises_when_agents_not_installed():
 
 def test_delete_scheduled_scorer_raises_when_agents_not_installed():
     with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        delete_scheduled_scorer(experiment_id="test_experiment", scorer_name="test_scorer")
+        delete_scheduled_scorer(
+            experiment_id="test_experiment", scheduled_scorer_name="test_scorer"
+        )
 
 
 def test_get_scheduled_scorer_raises_when_agents_not_installed():
     with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        get_scheduled_scorer(experiment_id="test_experiment", scorer_name="test_scorer")
+        get_scheduled_scorer(experiment_id="test_experiment", scheduled_scorer_name="test_scorer")
 
 
 def test_list_scheduled_scorers_raises_when_agents_not_installed():
@@ -80,8 +82,8 @@ def test_list_scheduled_scorers_raises_when_agents_not_installed():
 
 def test_set_scheduled_scorers_raises_when_agents_not_installed():
     mock_scorer = MockScorer()
-    scheduled_scorer = ScheduledScorer(
-        scorer_fn=mock_scorer, scorer_name="test_scorer", sample_rate=0.5
+    scheduled_scorer = ScorerScheduleConfig(
+        scorer=mock_scorer, scheduled_scorer_name="test_scorer", sample_rate=0.5
     )
 
     with pytest.raises(ImportError, match="The `databricks-agents` package is required"):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AveshCSingh/mlflow/pull/16072?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16072/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16072/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16072/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This PR introduces a ScheduledScorer API to monitor agents with Scorers. The implementation delegates to `databricks.agents`. 

Imports are run within try/import/except blocks that issue an error if the user does not have a version of `databricks-agents` installed which supports scheduled scorers.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

Instructions and Examples will be provided in a follow-up PR.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
