### PR TITLE
Prompt Registry Client: Remaining Prompt Store Infrastructure & Search Parsing [Part 3]

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -1216,7 +1216,7 @@ class UcModelRegistryStore(BaseRestStore):
         )
         req_body = message_to_json(
             SearchPromptsRequest(
-                unity_catalog_schema=unity_catalog_schema,
+                catalog_schema=unity_catalog_schema,
                 filter=filter_string,
                 max_results=max_results,
                 page_token=page_token,

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -5,6 +5,7 @@ import os
 import re
 import shutil
 from contextlib import contextmanager
+from dataclasses import dataclass
 from typing import Optional, Union
 
 import mlflow
@@ -167,13 +168,13 @@ _DELTA_TABLE = "delta_table"
 _MAX_LINEAGE_DATA_SOURCES = 10
 
 
+@dataclass
 class _CatalogSchemaFilter:
     """Internal class to hold parsed catalog, schema, and remaining filter."""
 
-    def __init__(self, catalog_name: str, schema_name: str, remaining_filter: Optional[str]):
-        self.catalog_name = catalog_name
-        self.schema_name = schema_name
-        self.remaining_filter = remaining_filter
+    catalog_name: str
+    schema_name: str
+    remaining_filter: Optional[str]
 
 
 def _require_arg_unspecified(arg_name, arg_value, default_values=None, message=None):

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -12,7 +12,12 @@ from mlflow.entities import Run
 from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.exceptions import MlflowException
-from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_DOES_NOT_EXIST, ErrorCode
+from mlflow.protos.databricks_pb2 import (
+    INTERNAL_ERROR,
+    INVALID_PARAMETER_VALUE,
+    RESOURCE_DOES_NOT_EXIST,
+    ErrorCode,
+)
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     MODEL_VERSION_OPERATION_READ_WRITE,
     CreateModelVersionRequest,
@@ -139,6 +144,7 @@ from mlflow.utils.mlflow_tags import (
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import (
     _REST_API_PATH_PREFIX,
+    call_endpoint,
     extract_all_api_info_for_service,
     extract_api_info_for_service,
     http_request,
@@ -1198,9 +1204,6 @@ class UcModelRegistryStore(BaseRestStore):
                 )
                 filter_string = remaining_filter
             else:
-                from mlflow.exceptions import MlflowException
-                from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-
                 raise MlflowException(
                     "For Unity Catalog prompt registries, you must specify catalog and schema "
                     "in the filter string: \"catalog = 'catalog_name' AND schema = 'schema_name'\"",
@@ -1245,9 +1248,6 @@ class UcModelRegistryStore(BaseRestStore):
         Raises:
             MlflowException: If filter format is invalid for Unity Catalog
         """
-        from mlflow.exceptions import MlflowException
-        from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
-
         if not filter_string:
             raise MlflowException(
                 "For Unity Catalog prompt registries, you must specify catalog and schema "
@@ -1484,8 +1484,6 @@ class UcModelRegistryStore(BaseRestStore):
                 endpoint = endpoint.replace(f"{{{key}}}", str(value))
 
         # Make the API call
-        from mlflow.utils.rest_utils import call_endpoint
-
         return call_endpoint(
             self.get_host_creds(),
             endpoint=endpoint,

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -81,9 +81,18 @@ def proto_to_mlflow_prompt(
     if hasattr(proto_version, "aliases") and proto_version.aliases:
         aliases = [alias.alias for alias in proto_version.aliases]
 
+    # Require version to be present - no more defaulting to 1
+    if not proto_version.version:
+        raise ValueError(
+            f"PromptVersion proto is missing version field. This indicates an issue with "
+            f"the backend response or test mock setup. Proto: name={proto_version.name}, "
+            f"template={getattr(proto_version, 'template', 'N/A')}"
+        )
+    version = int(proto_version.version)
+
     return Prompt(
         name=proto_version.name,
-        version=int(proto_version.version),
+        version=version,
         template=proto_version.template,
         commit_message=proto_version.description,
         creation_timestamp=proto_version.creation_timestamp,

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -82,9 +82,7 @@ def proto_to_mlflow_prompt(
         aliases = [alias.alias for alias in proto_version.aliases]
 
     if not proto_version.version:
-        raise ValueError(
-            f"Prompt is missing its version field."
-        )
+        raise ValueError("Prompt is missing its version field.")
     version = int(proto_version.version)
 
     return Prompt(

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -81,12 +81,9 @@ def proto_to_mlflow_prompt(
     if hasattr(proto_version, "aliases") and proto_version.aliases:
         aliases = [alias.alias for alias in proto_version.aliases]
 
-    # Require version to be present - no more defaulting to 1
     if not proto_version.version:
         raise ValueError(
-            f"PromptVersion proto is missing version field. This indicates an issue with "
-            f"the backend response or test mock setup. Proto: name={proto_version.name}, "
-            f"template={getattr(proto_version, 'template', 'N/A')}"
+            f"Prompt is missing its version field."
         )
     version = int(proto_version.version)
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -505,7 +505,7 @@ class AbstractStore:
     def search_prompts(
         self,
         filter_string: Optional[str] = None,
-        max_results: Optional[int] = 100,
+        max_results: Optional[int] = None,
         order_by: Optional[list[str]] = None,
         page_token: Optional[str] = None,
     ) -> PagedList[PromptInfo]:
@@ -524,6 +524,9 @@ class AbstractStore:
         Returns:
             A PagedList of PromptInfo objects.
         """
+        if max_results is None:
+            max_results = 100
+
         # Build filter to only include prompts (use backticks for tag key with dots)
         prompt_filter = f"tags.`{IS_PROMPT_TAG_KEY}` = 'true'"
         if filter_string:
@@ -627,7 +630,6 @@ class AbstractStore:
             version_int = int(str(version))
             mv = self.get_model_version(name, version_int)
 
-        # Verify this is actually a prompt
         if not has_prompt_tag(mv.tags):
             return None
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -6,6 +6,7 @@ from typing import Optional, Union
 from mlflow.entities.model_registry import ModelVersionTag
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
 from mlflow.entities.model_registry.prompt import Prompt
+from mlflow.entities.model_registry.registered_model import RegisteredModel
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.registry_utils import has_prompt_tag
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
@@ -511,7 +512,7 @@ class AbstractStore:
         page_token: Optional[str] = None,
         catalog_name: Optional[str] = None,
         schema_name: Optional[str] = None,
-    ) -> PagedList[PromptInfo]:
+    ) -> PagedList[RegisteredModel]:
         """
         Search for prompts in the registry.
 
@@ -527,7 +528,7 @@ class AbstractStore:
             schema_name: Schema name (for catalog-based stores).
 
         Returns:
-            A PagedList of PromptInfo objects.
+            A PagedList of RegisteredModel objects (with prompt filtering applied).
         """
         from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -543,8 +543,8 @@ class AbstractStore:
             page_token=page_token,
         )
 
-        # For backward compatibility, return RegisteredModel objects with latest_versions
-        # The traditional search_prompts() expects objects with latest_versions attribute
+        # For backward compatibility with non-Unity Catalog registries, return RegisteredModel objects
+        # with latest_versions populated. The client-level search_prompts() expects this attribute.
         for rm in registered_models:
             # Ensure the registered model has latest_versions populated
             if not hasattr(rm, "latest_versions") or rm.latest_versions is None:

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -10,7 +10,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.prompt.registry_utils import has_prompt_tag
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store._unity_catalog.registry.prompt_info import PromptInfo
-from mlflow.store.entities.paged_list import PagedList
 from mlflow.utils.annotations import developer_stable
 from mlflow.utils.logging_utils import eprint
 
@@ -462,9 +461,8 @@ class AbstractStore:
                 f"version: {mv.version} with status: {mv.status} and message: {mv.status_message}"
             )
 
-    # Prompt management methods
+    # Prompt-related methods with concrete implementations for traditional stores
 
-    @abstractmethod
     def create_prompt(
         self,
         name: str,
@@ -472,86 +470,191 @@ class AbstractStore:
         tags: Optional[dict[str, str]] = None,
     ) -> PromptInfo:
         """
-        Create a new prompt (metadata only, no initial version).
+        Create a new prompt in the registry.
+
+        Default implementation for non-Unity Catalog registries: creates a RegisteredModel
+        with special prompt tags. Unity Catalog stores override this method.
 
         Args:
             name: Name of the prompt.
-            description: Description of the prompt.
-            tags: Dictionary of tag key-value pairs.
+            description: Optional description of the prompt.
+            tags: Optional dictionary of prompt tags.
 
         Returns:
-            A :py:class:`mlflow.store._unity_catalog.registry.prompt_info.PromptInfo` object.
+            A PromptInfo object representing the created prompt.
         """
+        # Default implementation: use RegisteredModel with special tags
+        from mlflow.entities.model_registry import RegisteredModelTag
+        from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 
-    @abstractmethod
+        prompt_tags = [RegisteredModelTag(key=IS_PROMPT_TAG_KEY, value="true")]
+        if tags:
+            prompt_tags.extend([RegisteredModelTag(key=k, value=v) for k, v in tags.items()])
+
+        # Create registered model for the prompt
+        rm = self.create_registered_model(name, tags=prompt_tags, description=description)
+
+        # Return as PromptInfo
+        return PromptInfo(
+            name=rm.name,
+            description=rm.description,
+            creation_timestamp=rm.creation_timestamp,
+            tags=tags or {},
+        )
+
     def search_prompts(
         self,
         filter_string: Optional[str] = None,
-        max_results: Optional[int] = None,
+        max_results: Optional[int] = 100,
         order_by: Optional[list[str]] = None,
         page_token: Optional[str] = None,
         catalog_name: Optional[str] = None,
         schema_name: Optional[str] = None,
-    ) -> PagedList[PromptInfo]:
+    ):
         """
-        Search for prompts that satisfy the filter criteria.
+        Search for prompts in the registry.
+
+        Default implementation for non-Unity Catalog registries: searches RegisteredModels
+        with prompt tags. Unity Catalog stores override this method.
 
         Args:
-            filter_string: Filter query string.
+            filter_string: Filter query string, defaults to searching for all prompts.
             max_results: Maximum number of prompts desired.
-            order_by: List of column names with ASC|DESC annotation.
-            page_token: Token specifying the next page of results.
-            catalog_name: Unity Catalog catalog name (for UC registries).
-            schema_name: Unity Catalog schema name (for UC registries).
+            order_by: List of order-by clauses.
+            page_token: Pagination token for requesting subsequent pages.
+            catalog_name: Catalog name (Unity Catalog only).
+            schema_name: Schema name (Unity Catalog only).
 
         Returns:
-            A PagedList of prompt objects that satisfy the search expressions.
+            A PagedList of PromptInfo objects.
         """
+        from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
 
-    @abstractmethod
+        # Build filter to only include prompts (use backticks for tag key with dots)
+        prompt_filter = f"tags.`{IS_PROMPT_TAG_KEY}` = 'true'"
+        if filter_string:
+            prompt_filter = f"{prompt_filter} AND {filter_string}"
+
+        # Search registered models with prompt filter
+        registered_models = self.search_registered_models(
+            filter_string=prompt_filter,
+            max_results=max_results,
+            order_by=order_by,
+            page_token=page_token,
+        )
+
+        # For backward compatibility, return RegisteredModel objects with latest_versions
+        # The traditional search_prompts() expects objects with latest_versions attribute
+        for rm in registered_models:
+            # Ensure the registered model has latest_versions populated
+            if not hasattr(rm, "latest_versions") or rm.latest_versions is None:
+                # Get the latest versions for this prompt
+                from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
+
+                try:
+                    latest_versions = self.get_latest_versions(rm.name, stages=ALL_STAGES)
+                    rm.latest_versions = latest_versions
+                except Exception:
+                    rm.latest_versions = []
+
+        return registered_models
+
     def delete_prompt(self, name: str) -> None:
         """
-        Delete a prompt.
+        Delete a prompt from the registry.
+
+        Default implementation for non-Unity Catalog registries: deletes the underlying
+        RegisteredModel. Unity Catalog stores override this method.
 
         Args:
             name: Name of the prompt to delete.
         """
+        # Default implementation: delete the registered model
+        return self.delete_registered_model(name)
 
-    @abstractmethod
     def set_prompt_tag(self, name: str, key: str, value: str) -> None:
         """
-        Set a tag for a prompt.
+        Set a tag on a prompt.
+
+        Default implementation for non-Unity Catalog registries: sets a tag on the underlying
+        RegisteredModel. Unity Catalog stores override this method.
 
         Args:
             name: Name of the prompt.
             key: Tag key.
             value: Tag value.
         """
+        # Default implementation: set tag on registered model
+        from mlflow.entities.model_registry import RegisteredModelTag
 
-    @abstractmethod
+        tag = RegisteredModelTag(key=key, value=value)
+        return self.set_registered_model_tag(name, tag)
+
     def delete_prompt_tag(self, name: str, key: str) -> None:
         """
-        Delete a tag associated with a prompt.
+        Delete a tag from a prompt.
+
+        Default implementation for non-Unity Catalog registries: deletes a tag from the underlying
+        RegisteredModel. Unity Catalog stores override this method.
 
         Args:
             name: Name of the prompt.
-            key: Tag key.
+            key: Tag key to delete.
         """
+        # Default implementation: delete tag from registered model
+        return self.delete_registered_model_tag(name, key)
 
-    @abstractmethod
     def get_prompt(self, name: str, version: Optional[Union[str, int]] = None) -> Optional[Prompt]:
         """
-        Get prompt by name and version.
+        Get prompt by name and version or alias.
+
+        Default implementation for non-Unity Catalog registries: gets ModelVersion with prompt tags
+        and converts to Prompt. Unity Catalog stores override this method.
 
         Args:
-            name: Name of the prompt.
-            version: Version number or alias. If None, gets latest version.
+            name: Registered prompt name.
+            version: Registered prompt version or alias. If None, loads the latest version.
 
         Returns:
-            A prompt object or None if not found.
+            A single Prompt object, or None if not found.
         """
+        try:
+            # Handle latest version resolution when version is None
+            if version is None:
+                from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 
-    @abstractmethod
+                latest_versions = self.get_latest_versions(name, stages=ALL_STAGES)
+                if not latest_versions:
+                    return None
+                mv = latest_versions[0]
+            else:
+                # Try to get by version number first, then by alias
+                try:
+                    version_int = int(str(version))
+                    mv = self.get_model_version(name, version_int)
+                except (ValueError, TypeError):
+                    # If conversion fails, try as alias
+                    try:
+                        mv = self.get_model_version_by_alias(name, str(version))
+                    except Exception:
+                        return None
+
+            # Verify this is actually a prompt
+            if not has_prompt_tag(mv.tags):
+                return None
+
+            # Get prompt-level tags from registered model
+            rm = self.get_registered_model(name)
+            if isinstance(rm.tags, dict):
+                prompt_tags = rm.tags.copy()
+            else:
+                prompt_tags = {tag.key: tag.value for tag in rm.tags}
+
+            return Prompt.from_model_version(mv, prompt_tags=prompt_tags)
+
+        except Exception:
+            return None
+
     def create_prompt_version(
         self,
         name: str,
@@ -560,50 +663,118 @@ class AbstractStore:
         tags: Optional[dict[str, str]] = None,
     ) -> Prompt:
         """
-        Create a new prompt version.
+        Create a new version of an existing prompt.
+
+        Default implementation for non-Unity Catalog registries: creates a ModelVersion with
+        prompt tags. Unity Catalog stores override this method.
 
         Args:
             name: Name of the prompt.
-            template: Template content for the prompt version.
-            description: Description of the prompt version.
-            tags: Dictionary of tag key-value pairs.
+            template: The prompt template text.
+            description: Optional description of the prompt version.
+            tags: Optional dictionary of version tags.
 
         Returns:
-            A prompt version object.
+            A Prompt object representing the created version.
         """
+        from mlflow.entities.model_registry import ModelVersionTag
+        from mlflow.prompt.constants import IS_PROMPT_TAG_KEY, PROMPT_TEXT_TAG_KEY
 
-    @abstractmethod
-    def get_prompt_version(self, name: str, version: Union[str, int]) -> Prompt:
+        # Create version tags including template
+        version_tags = [
+            ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
+            ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value=template),
+        ]
+        if tags:
+            version_tags.extend([ModelVersionTag(key=k, value=v) for k, v in tags.items()])
+
+        # Create model version
+        mv = self.create_model_version(
+            name=name,
+            source="prompt-template",  # Required field for ModelVersion
+            tags=version_tags,
+            description=description,
+        )
+
+        # Get prompt-level tags from registered model
+        rm = self.get_registered_model(name)
+        if isinstance(rm.tags, dict):
+            prompt_tags = rm.tags.copy()
+        else:
+            prompt_tags = {tag.key: tag.value for tag in rm.tags}
+
+        return Prompt.from_model_version(mv, prompt_tags=prompt_tags)
+
+    def get_prompt_version(self, name: str, version: Union[str, int]) -> Optional[Prompt]:
         """
         Get a specific prompt version.
 
+        Default implementation for non-Unity Catalog registries: gets ModelVersion and converts
+        to Prompt. Unity Catalog stores override this method.
+
         Args:
             name: Name of the prompt.
-            version: Version number.
+            version: Version number or alias.
 
         Returns:
-            A prompt version object.
+            A Prompt object, or None if not found.
         """
+        return self.get_prompt(name, version)
 
-    @abstractmethod
     def delete_prompt_version(self, name: str, version: Union[str, int]) -> None:
         """
-        Delete a prompt version.
+        Delete a specific prompt version.
+
+        Default implementation for non-Unity Catalog registries: deletes the underlying
+        ModelVersion. Unity Catalog stores override this method.
 
         Args:
             name: Name of the prompt.
-            version: Version number.
+            version: Version number to delete.
         """
+        # Convert version to int if needed
+        try:
+            version_int = int(str(version))
+            return self.delete_model_version(name, version_int)
+        except (ValueError, TypeError):
+            raise MlflowException(f"Invalid version number: {version}")
 
-    @abstractmethod
-    def get_prompt_version_by_alias(self, name: str, alias: str) -> Prompt:
+    def get_prompt_version_by_alias(self, name: str, alias: str) -> Optional[Prompt]:
         """
         Get a prompt version by alias.
+
+        Default implementation: uses get_model_version_by_alias and converts to Prompt.
 
         Args:
             name: Name of the prompt.
             alias: Alias name.
 
         Returns:
-            A prompt version object.
+            A Prompt object, or None if not found.
         """
+        return self.get_prompt(name, alias)
+
+    def set_prompt_alias(self, name: str, alias: str, version: Union[str, int]) -> None:
+        """
+        Set an alias for a prompt version.
+
+        Default implementation: uses set_registered_model_alias.
+
+        Args:
+            name: Name of the prompt.
+            alias: Alias to set.
+            version: Version to alias.
+        """
+        self.set_registered_model_alias(name, alias, version)
+
+    def delete_prompt_alias(self, name: str, alias: str) -> None:
+        """
+        Delete a prompt alias.
+
+        Default implementation: uses delete_registered_model_alias.
+
+        Args:
+            name: Name of the prompt.
+            alias: Alias to delete.
+        """
+        self.delete_registered_model_alias(name, alias)

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -10,6 +10,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.prompt.registry_utils import has_prompt_tag
 from mlflow.protos.databricks_pb2 import RESOURCE_ALREADY_EXISTS, ErrorCode
 from mlflow.store._unity_catalog.registry.prompt_info import PromptInfo
+from mlflow.store.entities.paged_list import PagedList
 from mlflow.utils.annotations import developer_stable
 from mlflow.utils.logging_utils import eprint
 
@@ -510,7 +511,7 @@ class AbstractStore:
         page_token: Optional[str] = None,
         catalog_name: Optional[str] = None,
         schema_name: Optional[str] = None,
-    ):
+    ) -> PagedList[PromptInfo]:
         """
         Search for prompts in the registry.
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -618,40 +618,27 @@ class AbstractStore:
         Returns:
             A single Prompt object, or None if not found.
         """
-        try:
-            # Handle latest version resolution when version is None
-            if version is None:
-                latest_versions = self.get_latest_versions(name, stages=ALL_STAGES)
-                if not latest_versions:
-                    return None
-                mv = latest_versions[0]
-            else:
-                # Try to get by version number first, then by alias
-                try:
-                    version_int = int(str(version))
-                    mv = self.get_model_version(name, version_int)
-                except (ValueError, TypeError):
-                    # If conversion fails, try as alias
-                    try:
-                        mv = self.get_model_version_by_alias(name, str(version))
-                    except Exception:
-                        return None
-
-            # Verify this is actually a prompt
-            if not has_prompt_tag(mv.tags):
+        if version is None:
+            latest_versions = self.get_latest_versions(name, stages=ALL_STAGES)
+            if not latest_versions:
                 return None
+            mv = latest_versions[0]
+        else:
+            version_int = int(str(version))
+            mv = self.get_model_version(name, version_int)
 
-            # Get prompt-level tags from registered model
-            rm = self.get_registered_model(name)
-            if isinstance(rm.tags, dict):
-                prompt_tags = rm.tags.copy()
-            else:
-                prompt_tags = {tag.key: tag.value for tag in rm.tags}
-
-            return Prompt.from_model_version(mv, prompt_tags=prompt_tags)
-
-        except Exception:
+        # Verify this is actually a prompt
+        if not has_prompt_tag(mv.tags):
             return None
+
+        # Get prompt-level tags from registered model
+        rm = self.get_registered_model(name)
+        if isinstance(rm.tags, dict):
+            prompt_tags = rm.tags.copy()
+        else:
+            prompt_tags = {tag.key: tag.value for tag in rm.tags}
+
+        return Prompt.from_model_version(mv, prompt_tags=prompt_tags)
 
     def create_prompt_version(
         self,

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -729,10 +729,10 @@ class AbstractStore:
         """
         # Convert version to int if needed
         try:
-            version_int = int(str(version))
-            return self.delete_model_version(name, version_int)
+            version_int = int(version)
         except (ValueError, TypeError):
             raise MlflowException(f"Invalid version number: {version}")
+        return self.delete_model_version(name, version_int)
 
     def get_prompt_version_by_alias(self, name: str, alias: str) -> Optional[Prompt]:
         """

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -462,7 +462,7 @@ class AbstractStore:
                 f"version: {mv.version} with status: {mv.status} and message: {mv.status_message}"
             )
 
-    # Prompt-related methods with concrete implementations for traditional stores
+    # Prompt-related methods with concrete implementations for OSS stores
 
     def create_prompt(
         self,
@@ -473,8 +473,8 @@ class AbstractStore:
         """
         Create a new prompt in the registry.
 
-        Default implementation for non-Unity Catalog registries: creates a RegisteredModel
-        with special prompt tags. Unity Catalog stores override this method.
+        Default implementation: creates a RegisteredModel with special prompt tags.
+        Other store implementations may override this method.
 
         Args:
             name: Name of the prompt.
@@ -515,16 +515,16 @@ class AbstractStore:
         """
         Search for prompts in the registry.
 
-        Default implementation for non-Unity Catalog registries: searches RegisteredModels
-        with prompt tags. Unity Catalog stores override this method.
+        Default implementation: searches RegisteredModels with prompt tags.
+        Other store implementations may override this method.
 
         Args:
             filter_string: Filter query string, defaults to searching for all prompts.
             max_results: Maximum number of prompts desired.
             order_by: List of order-by clauses.
             page_token: Pagination token for requesting subsequent pages.
-            catalog_name: Catalog name (Unity Catalog only).
-            schema_name: Schema name (Unity Catalog only).
+            catalog_name: Catalog name (for catalog-based stores).
+            schema_name: Schema name (for catalog-based stores).
 
         Returns:
             A PagedList of PromptInfo objects.
@@ -544,8 +544,8 @@ class AbstractStore:
             page_token=page_token,
         )
 
-        # For backward compatibility with non-Unity Catalog registries, return RegisteredModel objects
-        # with latest_versions populated. The client-level search_prompts() expects this attribute.
+        # For backward compatibility with OSS registries, return RegisteredModel
+        # objects with latest_versions populated. The client-level search_prompts() expects this.
         for rm in registered_models:
             # Ensure the registered model has latest_versions populated
             if not hasattr(rm, "latest_versions") or rm.latest_versions is None:
@@ -564,8 +564,8 @@ class AbstractStore:
         """
         Delete a prompt from the registry.
 
-        Default implementation for non-Unity Catalog registries: deletes the underlying
-        RegisteredModel. Unity Catalog stores override this method.
+        Default implementation: deletes the underlying RegisteredModel.
+        Other store implementations may override this method.
 
         Args:
             name: Name of the prompt to delete.
@@ -577,8 +577,8 @@ class AbstractStore:
         """
         Set a tag on a prompt.
 
-        Default implementation for non-Unity Catalog registries: sets a tag on the underlying
-        RegisteredModel. Unity Catalog stores override this method.
+        Default implementation: sets a tag on the underlying RegisteredModel.
+        Other store implementations may override this method.
 
         Args:
             name: Name of the prompt.
@@ -595,8 +595,8 @@ class AbstractStore:
         """
         Delete a tag from a prompt.
 
-        Default implementation for non-Unity Catalog registries: deletes a tag from the underlying
-        RegisteredModel. Unity Catalog stores override this method.
+        Default implementation: deletes a tag from the underlying RegisteredModel.
+        Other store implementations may override this method.
 
         Args:
             name: Name of the prompt.
@@ -609,8 +609,8 @@ class AbstractStore:
         """
         Get prompt by name and version or alias.
 
-        Default implementation for non-Unity Catalog registries: gets ModelVersion with prompt tags
-        and converts to Prompt. Unity Catalog stores override this method.
+        Default implementation: gets ModelVersion with prompt tags and converts to Prompt.
+        Other store implementations may override this method.
 
         Args:
             name: Registered prompt name.
@@ -666,8 +666,8 @@ class AbstractStore:
         """
         Create a new version of an existing prompt.
 
-        Default implementation for non-Unity Catalog registries: creates a ModelVersion with
-        prompt tags. Unity Catalog stores override this method.
+        Default implementation: creates a ModelVersion with prompt tags.
+        Other store implementations may override this method.
 
         Args:
             name: Name of the prompt.
@@ -710,8 +710,8 @@ class AbstractStore:
         """
         Get a specific prompt version.
 
-        Default implementation for non-Unity Catalog registries: gets ModelVersion and converts
-        to Prompt. Unity Catalog stores override this method.
+        Default implementation: gets ModelVersion and converts to Prompt.
+        Other store implementations may override this method.
 
         Args:
             name: Name of the prompt.
@@ -726,8 +726,8 @@ class AbstractStore:
         """
         Delete a specific prompt version.
 
-        Default implementation for non-Unity Catalog registries: deletes the underlying
-        ModelVersion. Unity Catalog stores override this method.
+        Default implementation: deletes the underlying ModelVersion.
+        Other store implementations may override this method.
 
         Args:
             name: Name of the prompt.

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -544,8 +544,10 @@ class AbstractStore:
             page_token=page_token,
         )
 
-        # For backward compatibility with OSS registries, return RegisteredModel
-        # objects with latest_versions populated. The client-level search_prompts() expects this.
+        # Return RegisteredModel objects instead of PromptInfo objects for OSS compatibility.
+        # The ModelRegistryClient.search_prompts() method expects RegisteredModel objects with
+        # latest_versions populated so it can extract prompt templates from ModelVersion tags.
+        # Other stores may override this method to return actual PromptInfo objects.
         for rm in registered_models:
             # Ensure the registered model has latest_versions populated
             if not hasattr(rm, "latest_versions") or rm.latest_versions is None:

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -508,8 +508,6 @@ class AbstractStore:
         max_results: Optional[int] = 100,
         order_by: Optional[list[str]] = None,
         page_token: Optional[str] = None,
-        catalog_name: Optional[str] = None,
-        schema_name: Optional[str] = None,
     ) -> PagedList[PromptInfo]:
         """
         Search for prompts in the registry.
@@ -522,8 +520,6 @@ class AbstractStore:
             max_results: Maximum number of prompts desired.
             order_by: List of order-by clauses.
             page_token: Pagination token for requesting subsequent pages.
-            catalog_name: Catalog name (for catalog-based stores).
-            schema_name: Schema name (for catalog-based stores).
 
         Returns:
             A PagedList of PromptInfo objects.

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -2127,7 +2127,9 @@ def test_search_prompts_uc(mock_http, store, monkeypatch):
         "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
         return_value=PromptInfo("prompt1", "test prompt"),
     ) as proto_to_prompt:
-        store.search_prompts()
+        store.search_prompts(
+            filter_string="catalog = 'test_catalog' AND schema = 'test_schema'"
+        )
         # Should call the correct endpoint for SearchPromptsRequest
         assert any("/prompts" in c[1]["endpoint"] for c in mock_http.call_args_list)
         # The utility function should NOT be called when there are no results (empty list)
@@ -2167,13 +2169,16 @@ def test_search_prompts_with_results_uc(store, monkeypatch):
 
     with (
         mock.patch.object(store, "_call_endpoint", return_value=mock_response),
-        mock.patch(
+                mock.patch(
             "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
             side_effect=expected_prompts,
         ) as mock_converter,
     ):
         # Call search_prompts
-        result = store.search_prompts(max_results=10)
+        result = store.search_prompts(
+            max_results=10,
+            filter_string="catalog = 'test_catalog' AND schema = 'test_schema'"
+        )
 
         # Verify conversion function was called twice (once for each result)
         assert mock_converter.call_count == 2

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -2127,9 +2127,7 @@ def test_search_prompts_uc(mock_http, store, monkeypatch):
         "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
         return_value=PromptInfo("prompt1", "test prompt"),
     ) as proto_to_prompt:
-        store.search_prompts(
-            filter_string="catalog = 'test_catalog' AND schema = 'test_schema'"
-        )
+        store.search_prompts(filter_string="catalog = 'test_catalog' AND schema = 'test_schema'")
         # Should call the correct endpoint for SearchPromptsRequest
         assert any("/prompts" in c[1]["endpoint"] for c in mock_http.call_args_list)
         # The utility function should NOT be called when there are no results (empty list)
@@ -2169,15 +2167,14 @@ def test_search_prompts_with_results_uc(store, monkeypatch):
 
     with (
         mock.patch.object(store, "_call_endpoint", return_value=mock_response),
-                mock.patch(
+        mock.patch(
             "mlflow.store._unity_catalog.registry.rest_store.proto_info_to_mlflow_prompt_info",
             side_effect=expected_prompts,
         ) as mock_converter,
     ):
         # Call search_prompts
         result = store.search_prompts(
-            max_results=10,
-            filter_string="catalog = 'test_catalog' AND schema = 'test_schema'"
+            max_results=10, filter_string="catalog = 'test_catalog' AND schema = 'test_schema'"
         )
 
         # Verify conversion function was called twice (once for each result)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/16074?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16074/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16074/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16074/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Handles backwards compatibility with OSS. This is done by actually implementing the prompt related methods in the abstract store. It will be overridden by the previous PRs efforts that defined these methods in the rest store (which will handle the UC-backed implementation). 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
