### PR TITLE
Fix llama-index cross version tests by setting `include_usage=True`

### DIFF
--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -91,7 +91,7 @@ def test_trace_llm_complete_stream():
     model_name = "gpt-3.5-turbo"
     llm = OpenAI(model=model_name)
 
-    response_gen = llm.stream_complete("Hello")
+    response_gen = llm.stream_complete("Hello", stream_options={"include_usage": True})
     # No trace should be created until the generator is consumed
     assert len(get_traces()) == 0
     assert inspect.isgenerator(response_gen)
@@ -107,7 +107,10 @@ def test_trace_llm_complete_stream():
     assert len(spans) == 1
     assert spans[0].name == "OpenAI.stream_complete"
     assert spans[0].span_type == SpanType.LLM
-    assert spans[0].inputs == {"args": ["Hello"]}
+    assert spans[0].inputs == {
+        "args": ["Hello"],
+        "kwargs": {"stream_options": {"include_usage": True}},
+    }
     assert spans[0].outputs["text"] == "Hello world"
 
     attr = spans[0].attributes
@@ -300,7 +303,7 @@ def test_trace_llm_chat_stream():
     llm = OpenAI()
     message = ChatMessage(role="system", content="Hello")
 
-    response_gen = llm.stream_chat([message])
+    response_gen = llm.stream_chat([message], stream_options={"include_usage": True})
     # No trace should be created until the generator is consumed
     assert len(get_traces()) == 0
     assert inspect.isgenerator(response_gen)
@@ -321,7 +324,8 @@ def test_trace_llm_chat_stream():
 
     content_json = _get_llm_input_content_json("Hello")
     assert spans[0].inputs == {
-        "messages": [{"role": "system", **content_json, "additional_kwargs": {}}]
+        "messages": [{"role": "system", **content_json, "additional_kwargs": {}}],
+        "kwargs": {"stream_options": {"include_usage": True}},
     }
     # `additional_kwargs` was broken until 0.1.30 release of llama-index-llms-openai
     expected_kwargs = (


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16077?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16077/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16077/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16077/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow/dev/actions/runs/15443335819/job/43491351532#step:12:477, which is blocking #16047.

```
E       AssertionError: assert {'additional_...istant'}, ...} == {'additional_...istant'}, ...}
E         
E         Omitting 4 identical items, use -vv to show
E         Differing items:
E         {'additional_kwargs': {}} != {'additional_kwargs': {'completion_tokens': 12, 'prompt_tokens': 9, 'total_tokens': 21}}
E         
E         Full diff:
E           {
E         -     'additional_kwargs': {
E         +     'additional_kwargs': {},
E         ?                           ++
E         -         'completion_tokens': 12,
E         -         'prompt_tokens': 9,
E         -         'total_tokens': 21,
E         -     },
E               'delta': ' world',
E               'logprobs': None,
```

#15870 changed the mock OpenAI server behavior. It only returns the usage info with `include_usage=True`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
