### PR TITLE
Avoid pandas 2.3.0

### DIFF
--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -35,7 +35,7 @@ dependencies = [
   "gunicorn<24; platform_system != 'Windows'",
   "matplotlib<4",
   "numpy<3",
-  "pandas<3",
+  "pandas<3,!=2.3.0",
   "pyarrow<21,>=4.0.0",
   "scikit-learn<2",
   "scipy<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "opentelemetry-api<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<26",
-  "pandas<3",
+  "pandas<3,!=2.3.0",
   "protobuf<7,>=3.12.0",
   "pyarrow<21,>=4.0.0",
   "pydantic<3,>=1.10.8",

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -7,7 +7,7 @@ docker<8,>=4.0.0
 Flask<4
 numpy<3
 scipy<2
-pandas<3
+pandas<3,!=2.3.0
 sqlalchemy<3,>=1.4.0
 gunicorn<24; platform_system != 'Windows'
 waitress<4; platform_system == 'Windows'

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -30,6 +30,8 @@ scipy:
 pandas:
   pip_release: pandas
   max_major_version: 2
+  # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is resolved
+  unsupported: ["2.3.0"]
 
 sqlalchemy:
   pip_release: sqlalchemy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,10 @@ def remote_backend_for_tracing_sdk_test():
                 "run",
                 "--with",
                 "mlflow",
+                # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is
+                # resolved
+                "--with",
+                "pandas!=2.3.0",
                 "--python",
                 # Get current python version
                 f"{sys.version_info.major}.{sys.version_info.minor}",

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -22,8 +22,11 @@ from tests.pyfunc.docker.conftest import RESOURCE_DIR, get_released_mlflow_versi
 
 
 def assert_dockerfiles_equal(actual_dockerfile_path: Path, expected_dockerfile_path: Path):
-    actual_dockerfile = actual_dockerfile_path.read_text().replace(
-        VERSION, get_released_mlflow_version()
+    actual_dockerfile = (
+        actual_dockerfile_path.read_text()
+        .replace(VERSION, get_released_mlflow_version())
+        # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is resolved
+        .replace("  pandas!=2.3.0", "")
     )
     expected_dockerfile = (
         expected_dockerfile_path.read_text()
@@ -47,6 +50,8 @@ def save_model(tmp_path):
         pip_requirements=[
             f"mlflow=={get_released_mlflow_version()}",
             f"scikit-learn=={sklearn.__version__}",
+            # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is resolved
+            "pandas!=2.3.0",
         ],  # Skip requirements inference for speed up
     )
     return model_path
@@ -93,7 +98,12 @@ def test_build_image(tmp_path, params):
         # Replace mlflow dev version in Dockerfile with the latest released one
         dockerfile = Path(context_dir) / "Dockerfile"
         content = dockerfile.read_text()
-        content = content.replace(VERSION, get_released_mlflow_version())
+        content = content.replace(
+            f"pip install mlflow=={VERSION}",
+            # TODO: Remove ` pandas!=2.3.0` once https://github.com/pandas-dev/pandas/issues/61564
+            # is resolved
+            f"pip install mlflow=={get_released_mlflow_version()} pandas!=2.3.0",
+        )
         dockerfile.write_text(content)
 
         shutil.copytree(context_dir, dst_dir)

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -26,7 +26,7 @@ def assert_dockerfiles_equal(actual_dockerfile_path: Path, expected_dockerfile_p
         actual_dockerfile_path.read_text()
         .replace(VERSION, get_released_mlflow_version())
         # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is resolved
-        .replace("  pandas!=2.3.0", "")
+        .replace(" pandas!=2.3.0", "")
     )
     expected_dockerfile = (
         expected_dockerfile_path.read_text()


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

A temporary workaround for https://github.com/pandas-dev/pandas/issues/61564.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
