### PR TITLE
Revert "Avoid pandas 2.3.0"

### DIFF
--- a/.github/actions/py-cache-key/action.yml
+++ b/.github/actions/py-cache-key/action.yml
@@ -22,5 +22,5 @@ runs:
         # Refresh cache daily
         DATE=$(date -u "+%Y%m%d")
         # Change this value to force a cache refresh
-        N=1
+        N=0
         echo "value=$RUNNER_IMAGE-$PYTHON_VERSION-$DATE-$REQUIREMENTS_HASH-$N" >> $GITHUB_OUTPUT

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -35,7 +35,7 @@ dependencies = [
   "gunicorn<24; platform_system != 'Windows'",
   "matplotlib<4",
   "numpy<3",
-  "pandas<3,!=2.3.0",
+  "pandas<3",
   "pyarrow<21,>=4.0.0",
   "scikit-learn<2",
   "scipy<2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
   "opentelemetry-api<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<26",
-  "pandas<3,!=2.3.0",
+  "pandas<3",
   "protobuf<7,>=3.12.0",
   "pyarrow<21,>=4.0.0",
   "pydantic<3,>=1.10.8",

--- a/requirements/core-requirements.txt
+++ b/requirements/core-requirements.txt
@@ -7,7 +7,7 @@ docker<8,>=4.0.0
 Flask<4
 numpy<3
 scipy<2
-pandas<3,!=2.3.0
+pandas<3
 sqlalchemy<3,>=1.4.0
 gunicorn<24; platform_system != 'Windows'
 waitress<4; platform_system == 'Windows'

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -30,8 +30,6 @@ scipy:
 pandas:
   pip_release: pandas
   max_major_version: 2
-  # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is resolved
-  unsupported: ["2.3.0"]
 
 sqlalchemy:
   pip_release: sqlalchemy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,10 +50,6 @@ def remote_backend_for_tracing_sdk_test():
                 "run",
                 "--with",
                 "mlflow",
-                # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is
-                # resolved
-                "--with",
-                "pandas!=2.3.0",
                 "--python",
                 # Get current python version
                 f"{sys.version_info.major}.{sys.version_info.minor}",

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -22,11 +22,8 @@ from tests.pyfunc.docker.conftest import RESOURCE_DIR, get_released_mlflow_versi
 
 
 def assert_dockerfiles_equal(actual_dockerfile_path: Path, expected_dockerfile_path: Path):
-    actual_dockerfile = (
-        actual_dockerfile_path.read_text()
-        .replace(VERSION, get_released_mlflow_version())
-        # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is resolved
-        .replace(" pandas!=2.3.0", "")
+    actual_dockerfile = actual_dockerfile_path.read_text().replace(
+        VERSION, get_released_mlflow_version()
     )
     expected_dockerfile = (
         expected_dockerfile_path.read_text()
@@ -50,8 +47,6 @@ def save_model(tmp_path):
         pip_requirements=[
             f"mlflow=={get_released_mlflow_version()}",
             f"scikit-learn=={sklearn.__version__}",
-            # TODO: Remove this once https://github.com/pandas-dev/pandas/issues/61564 is resolved
-            "pandas!=2.3.0",
         ],  # Skip requirements inference for speed up
     )
     return model_path
@@ -98,12 +93,7 @@ def test_build_image(tmp_path, params):
         # Replace mlflow dev version in Dockerfile with the latest released one
         dockerfile = Path(context_dir) / "Dockerfile"
         content = dockerfile.read_text()
-        content = content.replace(
-            f"pip install mlflow=={VERSION}",
-            # TODO: Remove ` pandas!=2.3.0` once https://github.com/pandas-dev/pandas/issues/61564
-            # is resolved
-            f"pip install mlflow=={get_released_mlflow_version()} pandas!=2.3.0",
-        )
+        content = content.replace(VERSION, get_released_mlflow_version())
         dockerfile.write_text(content)
 
         shutil.copytree(context_dir, dst_dir)

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.metadata
 import json
 import os
 import subprocess
@@ -2223,12 +2224,13 @@ def test_model_pip_requirements_pin_numpy_when_pandas_included():
         model_info = mlflow.pyfunc.log_model(
             name="model", python_model=TestModel(), input_example="abc"
         )
+
         _assert_pip_requirements(
             model_info.model_uri,
             [
                 expected_mlflow_version,
-                f"cloudpickle=={cloudpickle.__version__}",
-                f"pandas=={pandas.__version__}",
+                f"cloudpickle=={importlib.metadata.version('cloudpickle')}",
+                f"pandas=={importlib.metadata.version('pandas')}",
             ],
             strict=True,
         )

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -234,14 +234,10 @@ def test_strip_local_version_label():
 
 
 def test_get_installed_version(tmp_path, monkeypatch):
-    import numpy as np
-    import pandas as pd
-    import sklearn
-
     assert _get_installed_version("mlflow") == mlflow.__version__
-    assert _get_installed_version("numpy") == np.__version__
-    assert _get_installed_version("pandas") == pd.__version__
-    assert _get_installed_version("scikit-learn", module="sklearn") == sklearn.__version__
+    assert _get_installed_version("numpy") == version("numpy")
+    assert _get_installed_version("pandas") == version("pandas")
+    assert _get_installed_version("scikit-learn", module="sklearn") == version("scikit-learn")
 
     not_found_package = tmp_path.joinpath("not_found.py")
     not_found_package.write_text("__version__ = '1.2.3'")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16101?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16101/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16101/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16101/merge
```

</p>
</details>

Reverts mlflow/mlflow#16086

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

### TODO

Rerun CI once 3.9 wheels are live on pypi:

https://github.com/pandas-dev/pandas/issues/61563#issuecomment-2946600916