### PR TITLE
Rename default of is_context_relevant to relevance_to_context

### DIFF
--- a/mlflow/genai/judges/databricks.py
+++ b/mlflow/genai/judges/databricks.py
@@ -4,6 +4,9 @@ from typing import Any, Optional, Union
 from mlflow.entities.assessment import Feedback
 from mlflow.genai.utils.enum_utils import StrEnum
 
+# NB: User-facing name for the is_context_relevant assessment.
+_IS_CONTEXT_RELEVANT_ASSESSMENT_NAME = "relevance_to_context"
+
 
 class CategoricalRating(StrEnum):
     """
@@ -113,7 +116,9 @@ def is_context_relevant(*, request: str, context: Any, name: Optional[str] = Non
         relevance_to_query(
             request=request,
             response=str(context),
-            assessment_name=name,
+            # NB: User-facing name for the is_context_relevant assessment. This is required since
+            #     the existing databricks judge is called `relevance_to_query`
+            assessment_name=name or _IS_CONTEXT_RELEVANT_ASSESSMENT_NAME,
         )
     )
 

--- a/tests/genai/judges/test_judges.py
+++ b/tests/genai/judges/test_judges.py
@@ -115,3 +115,20 @@ def test_judge_functions_happy_path(judge_func, agents_judge_name, args):
         assert isinstance(result.value, judges.CategoricalRating)
         assert result.value == judges.CategoricalRating.YES
         mock_judge.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("name", "expected_name"),
+    [
+        (None, "relevance_to_context"),
+        ("test", "test"),
+    ],
+)
+def test_judge_functions_called_with_correct_name(name, expected_name):
+    with patch("databricks.agents.evals.judges.relevance_to_query") as mock_judge:
+        judges.is_context_relevant(request="test", context="test", name=name)
+        mock_judge.assert_called_once_with(
+            request="test",
+            response="test",
+            assessment_name=expected_name,
+        )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/16102?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16102/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16102/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16102/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Rename default of is_context_relevant to relevance_to_context

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
