### PR TITLE
Fix the prompt optimizer failure with older dspy

### DIFF
--- a/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
@@ -189,15 +189,19 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
         score = getattr(program, "score", None)
         if not score:
             return
-        # In DSPy < 2.6.17, tiral_logs does not contain initial score correctly.
-        initial_score = getattr(program, "trial_logs", {}).get(1, {}).get("full_eval_score")
+        # In DSPy < 2.6.17, tiral_logs contains initial score in key=-1.
+        trial_logs = getattr(program, "trial_logs", {})
+        if 1 in trial_logs:
+            initial_score = trial_logs[1].get("full_eval_score")
+        elif -1 in trial_logs:
+            initial_score = trial_logs[-1].get("full_eval_score")
+        else:
+            initial_score = None
         if initial_score is not None:
             _logger.info(
                 "Prompt optimization completed. Evaluation score changed "
                 f"from {initial_score} to {program.score}."
             )
-        else:
-            _logger.info(f"Prompt optimization completed. Final evaluation score: {program.score}.")
 
     def _log_optimization_result(self, final_score: Optional[float], optimized_prompt: Prompt):
         if not active_run():

--- a/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
@@ -187,9 +187,9 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
 
     def _display_optimization_result(self, program: "dspy.Predict"):
         score = getattr(program, "score", None)
-        if not score:
+        if score is None:
             return
-        # In DSPy < 2.6.17, tiral_logs contains initial score in key=-1.
+        # In DSPy < 2.6.17, trial_logs contains initial score in key=-1.
         trial_logs = getattr(program, "trial_logs", {})
         if 1 in trial_logs:
             initial_score = trial_logs[1].get("full_eval_score")

--- a/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
@@ -186,12 +186,18 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
             yield
 
     def _display_optimization_result(self, program: "dspy.Predict"):
-        if hasattr(program, "score") and hasattr(program, "trial_logs"):
-            initial_score = program.trial_logs[1]["full_eval_score"]
+        score = getattr(program, "score", None)
+        if not score:
+            return
+        # In DSPy < 2.6.17, tiral_logs does not contain initial score correctly.
+        initial_score = getattr(program, "trial_logs", {}).get(1, {}).get("full_eval_score")
+        if initial_score is not None:
             _logger.info(
                 "Prompt optimization completed. Evaluation score changed "
                 f"from {initial_score} to {program.score}."
             )
+        else:
+            _logger.info(f"Prompt optimization completed. Final evaluation score: {program.score}.")
 
     def _log_optimization_result(self, final_score: Optional[float], optimized_prompt: Prompt):
         if not active_run():

--- a/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/dspy_mipro_optimizer.py
@@ -198,10 +198,16 @@ class _DSPyMIPROv2Optimizer(_DSPyOptimizer):
         else:
             initial_score = None
         if initial_score is not None:
-            _logger.info(
-                "Prompt optimization completed. Evaluation score changed "
-                f"from {initial_score} to {program.score}."
-            )
+            if initial_score == score:
+                _logger.info(
+                    f"Prompt optimization completed. Evaluation score did not change. Score {score}"
+                )
+                return
+            else:
+                _logger.info(
+                    "Prompt optimization completed. Evaluation score changed "
+                    f"from {initial_score} to {score}."
+                )
 
     def _log_optimization_result(self, final_score: Optional[float], optimized_prompt: Prompt):
         if not active_run():

--- a/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
@@ -89,7 +89,7 @@ def test_get_minibatch_size(train_size, eval_size, expected_batch_size):
 
 
 @pytest.mark.parametrize(
-    ("optimizer_config", "use_eval_data", "expected_teacher_settings", "include_trial_logs"),
+    ("optimizer_config", "use_eval_data", "expected_teacher_settings", "trial_logs"),
     [
         (
             OptimizerConfig(
@@ -100,25 +100,25 @@ def test_get_minibatch_size(train_size, eval_size, expected_batch_size):
             ),
             False,
             {"lm": True},
-            True,
+            {1: {"full_eval_score": 0.0}},
         ),
         (
             OptimizerConfig(num_instruction_candidates=4),
             False,
             {},
-            True,
+            {1: {"full_eval_score": 0.0}},
         ),
         (
             OptimizerConfig(),
             True,
             {},
-            True,
+            {1: {"full_eval_score": 0.0}},
         ),
         (
             OptimizerConfig(),
             True,
             {},
-            False,
+            {-1: {"full_eval_score": 0.0}},
         ),
     ],
 )
@@ -131,7 +131,7 @@ def test_optimize_scenarios(
     optimizer_config,
     use_eval_data,
     expected_teacher_settings,
-    include_trial_logs,
+    trial_logs,
 ):
     import dspy
 
@@ -139,10 +139,7 @@ def test_optimize_scenarios(
 
     optimized_program = dspy.Predict("input_text, language -> translation")
     optimized_program.score = 1.0
-    if include_trial_logs:
-        optimized_program.trial_logs = {
-            1: {"full_eval_score": 0.0},
-        }
+    optimized_program.trial_logs = trial_logs
     mock_mipro.return_value.compile.return_value = optimized_program
 
     # Prepare eval_data if needed
@@ -183,13 +180,9 @@ def test_optimize_scenarios(
     captured = capsys.readouterr()
     assert "Started optimizing prompt" in captured.err
     assert "Please wait as this process typically takes several minutes" in captured.err
-    if include_trial_logs:
-        assert (
-            "Prompt optimization completed. Evaluation score changed from 0.0 to 1.0."
-            in captured.err
-        )
-    else:
-        assert "Prompt optimization completed. Final evaluation score: 1.0" in captured.err
+    assert (
+        "Prompt optimization completed. Evaluation score changed from 0.0 to 1.0." in captured.err
+    )
 
 
 def test_convert_to_dspy_metric():

--- a/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
@@ -120,6 +120,12 @@ def test_get_minibatch_size(train_size, eval_size, expected_batch_size):
             {},
             {-1: {"full_eval_score": 0.0}},
         ),
+        (
+            OptimizerConfig(),
+            True,
+            {},
+            {1: {"full_eval_score": 1.0}},
+        ),
     ],
 )
 def test_optimize_scenarios(
@@ -139,6 +145,9 @@ def test_optimize_scenarios(
 
     optimized_program = dspy.Predict("input_text, language -> translation")
     optimized_program.score = 1.0
+    initial_score = trial_logs.get(1, {}).get("full_eval_score") or trial_logs.get(-1, {}).get(
+        "full_eval_score"
+    )
     optimized_program.trial_logs = trial_logs
     mock_mipro.return_value.compile.return_value = optimized_program
 
@@ -180,9 +189,16 @@ def test_optimize_scenarios(
     captured = capsys.readouterr()
     assert "Started optimizing prompt" in captured.err
     assert "Please wait as this process typically takes several minutes" in captured.err
-    assert (
-        "Prompt optimization completed. Evaluation score changed from 0.0 to 1.0." in captured.err
-    )
+    if initial_score == 1.0 == optimized_program.score:
+        assert (
+            "Prompt optimization completed. Evaluation score did not change. Score 1.0"
+            in captured.err
+        )
+    else:
+        assert (
+            "Prompt optimization completed. Evaluation score changed from 0.0 to 1.0."
+            in captured.err
+        )
 
 
 def test_convert_to_dspy_metric():

--- a/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_dspy_mipro_optimizer.py
@@ -89,7 +89,7 @@ def test_get_minibatch_size(train_size, eval_size, expected_batch_size):
 
 
 @pytest.mark.parametrize(
-    ("optimizer_config", "use_eval_data", "expected_teacher_settings"),
+    ("optimizer_config", "use_eval_data", "expected_teacher_settings", "include_trial_logs"),
     [
         (
             OptimizerConfig(
@@ -100,16 +100,25 @@ def test_get_minibatch_size(train_size, eval_size, expected_batch_size):
             ),
             False,
             {"lm": True},
+            True,
         ),
         (
             OptimizerConfig(num_instruction_candidates=4),
             False,
             {},
+            True,
         ),
         (
             OptimizerConfig(),
             True,
             {},
+            True,
+        ),
+        (
+            OptimizerConfig(),
+            True,
+            {},
+            False,
         ),
     ],
 )
@@ -122,6 +131,7 @@ def test_optimize_scenarios(
     optimizer_config,
     use_eval_data,
     expected_teacher_settings,
+    include_trial_logs,
 ):
     import dspy
 
@@ -129,9 +139,10 @@ def test_optimize_scenarios(
 
     optimized_program = dspy.Predict("input_text, language -> translation")
     optimized_program.score = 1.0
-    optimized_program.trial_logs = {
-        1: {"full_eval_score": 0.0},
-    }
+    if include_trial_logs:
+        optimized_program.trial_logs = {
+            1: {"full_eval_score": 0.0},
+        }
     mock_mipro.return_value.compile.return_value = optimized_program
 
     # Prepare eval_data if needed
@@ -172,9 +183,13 @@ def test_optimize_scenarios(
     captured = capsys.readouterr()
     assert "Started optimizing prompt" in captured.err
     assert "Please wait as this process typically takes several minutes" in captured.err
-    assert (
-        "Prompt optimization completed. Evaluation score changed from 0.0 to 1.0." in captured.err
-    )
+    if include_trial_logs:
+        assert (
+            "Prompt optimization completed. Evaluation score changed from 0.0 to 1.0."
+            in captured.err
+        )
+    else:
+        assert "Prompt optimization completed. Final evaluation score: 1.0" in captured.err
 
 
 def test_convert_to_dspy_metric():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16106?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16106/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16106/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16106/merge
```

</p>
</details>

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

In DSPy, trial logs contains initial value in key=-1, which causes a failure in older dspy version
https://github.com/stanfordnlp/dspy/pull/8029/files

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
