### PR TITLE
Adjust dataframe format from mlflow.search_traces()

### DIFF
--- a/docs/docs/tracing/api/search.mdx
+++ b/docs/docs/tracing/api/search.mdx
@@ -199,10 +199,10 @@ When using `return_type="pandas"` (default), MLflow returns the retrieved traces
     - **state**: State of the trace, can be one of [`OK`, `ERROR`, `IN_PROGRESS`, `STATE_UNSPECIFIED`].
     - **request_time**: The start time of the trace in milliseconds
     - **execution_duration**: The duration of the trace in milliseconds
-    - **request**: The input to the traced logic
-    - **response**: The output of the traced logic
+    - **inputs**: The input to the traced logic.
+    - **outputs**: The output of the traced logic.
+    - **expectations**: A dictionary of expectation keys and values associated with the trace.
     - **trace_metadata**: Key-value pairs associated with the trace
-    - **spans**: List of spans in the trace
     - **tags**: List of assessments associated with the trace.
   </TabItem>
   <TabItem value="2.x" label="MLflow 2.x">

--- a/examples/mlflow-3/langchain_example.py
+++ b/examples/mlflow-3/langchain_example.py
@@ -44,7 +44,7 @@ with mlflow.start_span(model_id=model_id) as span:
     span.set_outputs(outputs)
 
 # Fetch the traces by model ID
-print(mlflow.search_traces(model_id=model_id)[["request", "response"]])
+print(mlflow.search_traces(model_id=model_id)[["inputs", "outputs"]])
 
 import pandas as pd
 

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -115,8 +115,10 @@ class Trace(_MlflowObject):
         for assessment in self.info.assessments or []:
             # Only include Expectation type assessments, filter out Feedback
             if isinstance(assessment, Expectation):
-                expectations[assessment.name] = assessment.expectation.value
+                expectations[assessment.name] = assessment.value
 
+        inputs = self._deserialize_json_attr(self.data.request)
+        outputs = self._deserialize_json_attr(self.data.response)
         return {
             "trace_id": self.info.trace_id,
             "trace": self,
@@ -124,12 +126,16 @@ class Trace(_MlflowObject):
             "state": self.info.state,
             "request_time": self.info.request_time,
             "execution_duration": self.info.execution_duration,
-            "inputs": self._deserialize_json_attr(self.data.request),
-            "outputs": self._deserialize_json_attr(self.data.response),
+            "inputs": inputs,
+            "outputs": outputs,
             "expectations": expectations,
             "trace_metadata": self.info.trace_metadata,
             "tags": self.info.tags,
             "assessments": self.info.assessments,
+            # Keeping these fields for backward compatibility.
+            # TODO: Remove these fields in the future release.
+            "request": inputs,
+            "response": outputs,
         }
 
     def _deserialize_json_attr(self, value: str):
@@ -312,6 +318,10 @@ class Trace(_MlflowObject):
             "trace_metadata",
             "tags",
             "assessments",
+            # Keeping these fields for backward compatibility.
+            # TODO: Remove these fields in the future release.
+            "request",
+            "response",
         ]
 
     def to_proto(self):

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -91,15 +91,17 @@ def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame
         expectations, which is same as the schema that mlflow.genai.evaluate() expects.
         Therefore, we can simply pass through expectations column.
     """
-    column_mapping = {
-        "inputs": "request",
-        "outputs": "response",
-    }
+    col_mapping = {"inputs": "request", "outputs": "response"}
 
     df = _convert_eval_set_to_df(data)
 
+    # If both old and new column names exist, remove the old column
+    for old, new in col_mapping.items():
+        if old in df.columns and new in df.columns:
+            df.drop(columns=[old], inplace=True)
+
     return (
-        df.rename(columns=column_mapping)
+        df.rename(columns=col_mapping)
         .pipe(_extract_request_from_trace)
         .pipe(_extract_expectations_from_trace)
     )

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -30,7 +30,6 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.provider import is_tracing_enabled, safe_set_span_in_context
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
-    SPANS_COLUMN_NAME,
     TraceJSONEncoder,
     capture_function_input_args,
     encode_span_id,
@@ -822,7 +821,6 @@ def search_traces(
             results = extract_span_inputs_outputs(
                 traces=results,
                 fields=extract_fields,
-                col_name=SPANS_COLUMN_NAME,
             )
 
     return results

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -27,7 +27,6 @@ from mlflow.version import IS_TRACING_SDK_ONLY
 
 _logger = logging.getLogger(__name__)
 
-SPANS_COLUMN_NAME = "spans"
 
 if TYPE_CHECKING:
     from mlflow.entities import LiveSpan, Trace

--- a/mlflow/tracing/utils/search.py
+++ b/mlflow/tracing/utils/search.py
@@ -3,16 +3,12 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, Union
 
+from mlflow.entities import Span, Trace
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 
-SPANS_COLUMN_NAME = "spans"
-
 if TYPE_CHECKING:
     import pandas
-
-    import mlflow.entities
-    from mlflow.entities import Trace
 
 
 def traces_to_df(traces: list[Trace]) -> "pandas.DataFrame":
@@ -29,9 +25,8 @@ def traces_to_df(traces: list[Trace]) -> "pandas.DataFrame":
 
 
 def extract_span_inputs_outputs(
-    traces: Union[list["mlflow.entities.Trace"], "pandas.DataFrame"],
+    traces: Union[list[Trace], "pandas.DataFrame"],
     fields: list[str],
-    col_name: Optional[str] = None,
 ) -> "pandas.DataFrame":
     """
     Extracts the specified input and output fields from the spans contained in the specified traces.
@@ -40,8 +35,6 @@ def extract_span_inputs_outputs(
         traces: A list of :py:class:`mlflow.entities.Trace` or a pandas DataFrame containing traces.
         fields: A list of field strings of the form 'span_name.[inputs|outputs]' or
             'span_name.[inputs|outputs].field_name'.
-        col_name: The name of the column in the traces DataFrame containing the spans. If `traces`
-            is a list of MLflow Traces, this argument should not be provided.
     """
     try:
         import pandas as pd
@@ -56,18 +49,10 @@ def extract_span_inputs_outputs(
     parsed_fields = _parse_fields(fields)
 
     if isinstance(traces, list):
-        if col_name is not None:
-            raise MlflowException(
-                message=(
-                    "If `traces` is a list of MLflow Traces, `col_name` should not be provided."
-                ),
-                error_code=INVALID_PARAMETER_VALUE,
-            )
         traces = traces_to_df(traces)
-        col_name = SPANS_COLUMN_NAME
 
     if isinstance(traces, pd.DataFrame):
-        return _extract_from_traces_pandas_df(df=traces, col_name=col_name, fields=parsed_fields)
+        return _extract_from_traces_pandas_df(df=traces, fields=parsed_fields)
 
     raise MlflowException(
         message=(
@@ -217,33 +202,16 @@ def _parse_fields(fields: list[str]) -> list[_ParsedField]:
 
 
 def _extract_from_traces_pandas_df(
-    df: "pandas.DataFrame", col_name: str, fields: list[_ParsedField]
+    df: "pandas.DataFrame", fields: list[_ParsedField]
 ) -> "pandas.DataFrame":
     """
-    Extracts the specified fields from the spans contained in the specified column of the
-    specified traces DataFrame.
+    Extracts the specified fields from the spans in the traces DataFrame.
     """
-
-    from mlflow.entities import Span
-
-    if col_name not in df.columns:
-        raise MlflowException(
-            message=(
-                f"Column '{col_name}' not found in traces DataFrame."
-                f" Available columns: {df.columns}"
-            ),
-            error_code=INVALID_PARAMETER_VALUE,
-        )
-
     new_columns: dict[str, list[Any]] = defaultdict(list)
     for _, row in df.iterrows():
-        spans_dict: dict[str, list[Span]] = defaultdict(list)
-        for span in _extract_spans_from_row(row[col_name]):
-            spans_dict[span.name].append(span)
-
+        spans_dict = {span.name: span for span in row["trace"].data.spans}
         for field in fields:
-            matching_spans = spans_dict.get(field.span_name, [])
-            matching_value = _find_matching_value(field, matching_spans)
+            matching_value = _find_matching_value(field, spans_dict.get(field.span_name))
             new_columns[str(field)].append(matching_value)
 
     df_with_new_fields = df.copy()
@@ -253,40 +221,19 @@ def _extract_from_traces_pandas_df(
     return df_with_new_fields
 
 
-def _find_matching_value(field: _ParsedField, spans: list["mlflow.entities.Span"]) -> Optional[Any]:
+def _find_matching_value(field: _ParsedField, span: Optional[Span]) -> Optional[Any]:
     """
     Find the value of the field in the list of spans. If the field is not found, return None.
     """
-    for span in spans:
-        span_inputs_or_outputs = getattr(span, field.field_type)
-        if (
-            isinstance(span_inputs_or_outputs, dict)
-            and field.field_name is not None
-            and field.field_name in span_inputs_or_outputs
-        ):
-            return span_inputs_or_outputs.get(field.field_name)
-        elif field.field_name is None:
-            return span_inputs_or_outputs
+    if span is None:
+        return None
 
-
-def _extract_spans_from_row(
-    row_content: Optional[list[dict[str, Any]]],
-) -> list["mlflow.entities.Span"]:
-    """
-    Parses and extracts MLflow Spans from the row content of a traces pandas DataFrame.
-    """
-    from mlflow.entities import Span
-
-    if row_content is None:
-        return []
-
-    try:
-        return [Span.from_dict(span_dict) for span_dict in row_content]
-    except Exception as e:
-        raise MlflowException(
-            message=(
-                f"Failed to extract spans from traces DataFrame row content: {row_content}."
-                f" Error: {e}"
-            ),
-            error_code=INVALID_PARAMETER_VALUE,
-        ) from e
+    span_inputs_or_outputs = getattr(span, field.field_type)
+    if (
+        isinstance(span_inputs_or_outputs, dict)
+        and field.field_name is not None
+        and field.field_name in span_inputs_or_outputs
+    ):
+        return span_inputs_or_outputs.get(field.field_name)
+    elif field.field_name is None:
+        return span_inputs_or_outputs

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -16,6 +16,7 @@ from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info_v2 import TraceInfoV2
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
+from mlflow.version import IS_TRACING_SDK_ONLY
 
 
 # TODO: This test mocks out the tracking client and only test if the fluent API implementation
@@ -382,6 +383,9 @@ def test_assessment_apis_only_available_in_databricks():
 
 @pytest.mark.parametrize("return_type", ["list", "pandas"])
 def test_search_traces_with_assessments(store, tracking_uri, return_type):
+    if IS_TRACING_SDK_ONLY and return_type == "pandas":
+        pytest.skip("Pandas is not available when testing tracing SDK")
+
     # Create a trace info with an assessment
     assessments = [
         Feedback(trace_id="test", name="feedback", value=1),

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -966,11 +966,11 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         "state",
         "request_time",
         "execution_duration",
-        "request",
-        "response",
+        "inputs",
+        "outputs",
+        "expectations",
         "trace_metadata",
         "tags",
-        "spans",
         "assessments",
     ]
     for idx, trace in enumerate(expected_traces):
@@ -980,10 +980,9 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         assert df.iloc[idx].state == trace.info.state
         assert df.iloc[idx].request_time == trace.info.request_time
         assert df.iloc[idx].execution_duration == trace.info.execution_duration
-        assert df.iloc[idx].request == json.loads(trace.data.request)
-        assert df.iloc[idx].response == json.loads(trace.data.response)
+        assert df.iloc[idx].inputs == json.loads(trace.data.request)
+        assert df.iloc[idx].outputs == json.loads(trace.data.response)
         assert df.iloc[idx].trace_metadata == trace.info.trace_metadata
-        assert df.iloc[idx].spans == [s.to_dict() for s in trace.data.spans]
         assert df.iloc[idx].tags == trace.info.tags
         assert df.iloc[idx].assessments == trace.info.assessments
 
@@ -1011,7 +1010,7 @@ def test_search_traces_handles_missing_response_tags_and_metadata(mock_client):
     )
 
     df = mlflow.search_traces()
-    assert df["response"].isnull().all()
+    assert df["outputs"].isnull().all()
     assert df["tags"].tolist() == [{}]
     assert df["trace_metadata"].tolist() == [{}]
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -972,6 +972,8 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         "trace_metadata",
         "tags",
         "assessments",
+        "request",
+        "response",
     ]
     for idx, trace in enumerate(expected_traces):
         assert df.iloc[idx].trace_id == trace.info.trace_id
@@ -985,6 +987,8 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
         assert df.iloc[idx].trace_metadata == trace.info.trace_metadata
         assert df.iloc[idx].tags == trace.info.tags
         assert df.iloc[idx].assessments == trace.info.assessments
+        assert df.iloc[idx].request == json.loads(trace.data.request)
+        assert df.iloc[idx].response == json.loads(trace.data.response)
 
 
 @skip_when_testing_trace_sdk


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16118?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16118/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16118/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16118/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Adjust the return format of `mlflow.search_traces()` to be compatible with evaluation input, given the early user feedback.

* `request` -> `inputs`
* `response` -> `outputs`
* Adding `expectations` column that stores key-value map of expectation assessments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
