### PR TITLE
Add validation to SerializedScorer + additional unit tests

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -42,6 +42,23 @@ class SerializedScorer:
     call_signature: Optional[str] = None
     original_func_name: Optional[str] = None
 
+    def validate(self):
+        """Validate that either builtin scorer fields or decorator scorer fields are present."""
+        has_builtin_fields = self.builtin_scorer_class is not None
+        has_decorator_fields = self.call_source is not None
+
+        if not has_builtin_fields and not has_decorator_fields:
+            raise ValueError(
+                "SerializedScorer must have either builtin scorer fields "
+                "(builtin_scorer_class) or decorator scorer fields (call_source) present"
+            )
+
+        if has_builtin_fields and has_decorator_fields:
+            raise ValueError(
+                "SerializedScorer cannot have both builtin scorer fields and "
+                "decorator scorer fields present simultaneously"
+            )
+
 
 @experimental
 class Scorer(BaseModel):
@@ -77,6 +94,8 @@ class Scorer(BaseModel):
                 f"Please use the @scorer decorator instead."
             )
 
+        # Validate before serialization
+        serialized.validate()
         return asdict(serialized)
 
     def _extract_source_code_info(self) -> dict:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -42,7 +42,7 @@ class SerializedScorer:
     call_signature: Optional[str] = None
     original_func_name: Optional[str] = None
 
-    def validate(self):
+    def __post_init__(self):
         """Validate that either builtin scorer fields or decorator scorer fields are present."""
         has_builtin_fields = self.builtin_scorer_class is not None
         has_decorator_fields = self.call_source is not None
@@ -67,21 +67,20 @@ class Scorer(BaseModel):
 
     def model_dump(self, **kwargs) -> dict:
         """Override model_dump to include source code."""
-        # Create serialized scorer with core fields
-        serialized = SerializedScorer(
-            name=self.name,
-            aggregations=self.aggregations,
-            mlflow_version=mlflow.__version__,
-            serialization_version=_SERIALIZATION_VERSION,
-        )
-
         # Check if this is a decorator scorer
         if hasattr(self, "_original_func") and self._original_func:
             # Decorator scorer - extract and store source code
             source_info = self._extract_source_code_info()
-            serialized.call_source = source_info.get("call_source")
-            serialized.call_signature = source_info.get("call_signature")
-            serialized.original_func_name = source_info.get("original_func_name")
+            # Create serialized scorer with all fields at once
+            serialized = SerializedScorer(
+                name=self.name,
+                aggregations=self.aggregations,
+                mlflow_version=mlflow.__version__,
+                serialization_version=_SERIALIZATION_VERSION,
+                call_source=source_info.get("call_source"),
+                call_signature=source_info.get("call_signature"),
+                original_func_name=source_info.get("original_func_name"),
+            )
         else:
             # BuiltInScorer overrides `model_dump`, so this is neither a builtin scorer nor a
             # decorator scorer
@@ -94,8 +93,6 @@ class Scorer(BaseModel):
                 f"Please use the @scorer decorator instead."
             )
 
-        # Validate before serialization
-        serialized.validate()
         return asdict(serialized)
 
     def _extract_source_code_info(self) -> dict:

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -44,6 +44,8 @@ class BuiltInScorer(Scorer):
             builtin_scorer_pydantic_data=pydantic_model_data,
         )
 
+        # Validate before serialization
+        serialized.validate()
         return asdict(serialized)
 
     @classmethod

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -44,8 +44,6 @@ class BuiltInScorer(Scorer):
             builtin_scorer_pydantic_data=pydantic_model_data,
         )
 
-        # Validate before serialization
-        serialized.validate()
         return asdict(serialized)
 
     @classmethod


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AveshCSingh/mlflow/pull/16124?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16124/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16124/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16124/merge
```

</p>
</details>

### Related Issues/PRs

This PR is a follow-up to https://github.com/mlflow/mlflow/pull/16026

### What changes are proposed in this pull request?

This PR:
1. Adds a unit test to ensure that the deserialized function can run without global context
2. Adds validation to SerializedScorer

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
