### PR TITLE
Use consistent retry policy for Databricks SDK REST API calls and non-Databricks-SDK REST API calls

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -127,7 +127,6 @@ def http_request(
             else MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT.get()
         )
 
-        # Define the SDK call as a function for retry logic
         def make_sdk_call():
             # Databricks SDK `APIClient.do` API is for making request using
             # HTTP
@@ -166,7 +165,6 @@ def http_request(
                 max_retries=max_retries,
             )
         except DatabricksError as e:
-            # Convert to requests.Response for consistency
             response = requests.Response()
             response.url = url
             response.status_code = ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -120,13 +120,6 @@ def http_request(
             retry_timeout_seconds=retry_timeout_seconds,
         )
 
-        # Set default retry timeout if not specified
-        effective_retry_timeout = (
-            retry_timeout_seconds
-            if retry_timeout_seconds is not None
-            else MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT.get()
-        )
-
         def make_sdk_call():
             # Databricks SDK `APIClient.do` API is for making request using
             # HTTP
@@ -159,7 +152,11 @@ def http_request(
             return _retry_databricks_sdk_call_with_exponential_backoff(
                 call_func=make_sdk_call,
                 retry_codes=retry_codes,
-                retry_timeout_seconds=effective_retry_timeout,
+                retry_timeout_seconds=(
+                    retry_timeout_seconds
+                    if retry_timeout_seconds is not None
+                    else MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT.get()
+                ),
                 backoff_factor=backoff_factor,
                 backoff_jitter=backoff_jitter,
                 max_retries=max_retries,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -1,6 +1,8 @@
 import base64
 import json
 import logging
+import random
+import time
 import warnings
 from functools import lru_cache
 
@@ -51,6 +53,76 @@ _DATABRICKS_SDK_RETRY_AFTER_SECS_DEPRECATION_WARNING = (
 )
 
 
+def _retry_databricks_sdk_call_with_exponential_backoff(
+    call_func, retry_codes, retry_timeout_seconds, backoff_factor, backoff_jitter, max_retries
+):
+    """
+    Retry a Databricks SDK call with exponential backoff until timeout or max retries reached.
+
+    Args:
+        call_func: Function to call that may raise DatabricksError
+        retry_codes: Set of HTTP status codes that should trigger retries
+        retry_timeout_seconds: Maximum time to spend retrying in seconds
+        backoff_factor: Factor for exponential backoff
+        backoff_jitter: Random jitter to add to backoff
+        max_retries: Maximum number of retry attempts
+
+    Returns:
+        The result of call_func() on success
+
+    Raises:
+        DatabricksError: If all retries are exhausted or non-retryable error occurs
+    """
+    from databricks.sdk.errors import DatabricksError
+
+    start_time = time.time()
+    attempt = 0
+
+    while True:
+        try:
+            return call_func()
+        except DatabricksError as e:
+            # Get HTTP status code from the error
+            status_code = ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)
+
+            # Check if this is a retryable error
+            if status_code not in retry_codes:
+                raise e
+
+            # Check if we've exceeded max retries
+            if attempt >= max_retries:
+                _logger.warning(f"Max retries ({max_retries}) exceeded: {e}")
+                raise e
+
+            # Check if we've exceeded the timeout
+            elapsed_time = time.time() - start_time
+            if elapsed_time >= retry_timeout_seconds:
+                _logger.warning(f"Retry timeout ({retry_timeout_seconds}s) exceeded: {e}")
+                raise e
+
+            # Calculate backoff time with exponential backoff and jitter
+            # Use the same formula as urllib3.util.retry.Retry.get_backoff_time()
+            if attempt <= 0:
+                backoff_time = 0  # No backoff on first retry attempt
+            else:
+                backoff_time = backoff_factor * (2**attempt)
+                if backoff_jitter > 0:
+                    backoff_time += random.random() * backoff_jitter
+
+            # Check if sleeping would exceed timeout
+            if elapsed_time + backoff_time >= retry_timeout_seconds:
+                _logger.warning(f"Retry timeout ({retry_timeout_seconds}s) exceeded: {e}")
+                raise e
+
+            _logger.debug(
+                f"Databricks SDK call failed with retryable error (status {status_code}): {e}. "
+                f"Retrying in {backoff_time:.2f} seconds (attempt {attempt + 1})"
+            )
+
+            time.sleep(backoff_time)
+            attempt += 1
+
+
 def http_request(
     host_creds,
     endpoint,
@@ -98,6 +170,15 @@ def http_request(
     cleaned_hostname = strip_suffix(host_creds.host, "/")
     url = f"{cleaned_hostname}{endpoint}"
 
+    # Set defaults for retry parameters from environment variables if not specified
+    max_retries = MLFLOW_HTTP_REQUEST_MAX_RETRIES.get() if max_retries is None else max_retries
+    backoff_factor = (
+        MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR.get() if backoff_factor is None else backoff_factor
+    )
+    backoff_jitter = (
+        MLFLOW_HTTP_REQUEST_BACKOFF_JITTER.get() if backoff_jitter is None else backoff_jitter
+    )
+
     if host_creds.use_databricks_sdk:
         from databricks.sdk.errors import DatabricksError
 
@@ -108,7 +189,16 @@ def http_request(
             host_creds.databricks_auth_profile,
             retry_timeout_seconds=retry_timeout_seconds,
         )
-        try:
+
+        # Set default retry timeout if not specified
+        effective_retry_timeout = (
+            retry_timeout_seconds
+            if retry_timeout_seconds is not None
+            else MLFLOW_DATABRICKS_ENDPOINT_HTTP_RETRY_TIMEOUT.get()
+        )
+
+        # Define the SDK call as a function for retry logic
+        def make_sdk_call():
             # Databricks SDK `APIClient.do` API is for making request using
             # HTTP
             # https://github.com/databricks/databricks-sdk-py/blob/a714146d9c155dd1e3567475be78623f72028ee0/databricks/sdk/core.py#L134
@@ -128,7 +218,18 @@ def http_request(
                     data=kwargs.get("data"),
                 )
                 return raw_response["contents"]._response
+
+        try:
+            return _retry_databricks_sdk_call_with_exponential_backoff(
+                call_func=make_sdk_call,
+                retry_codes=retry_codes,
+                retry_timeout_seconds=effective_retry_timeout,
+                backoff_factor=backoff_factor,
+                backoff_jitter=backoff_jitter,
+                max_retries=max_retries,
+            )
         except DatabricksError as e:
+            # Convert to requests.Response for consistency
             response = requests.Response()
             response.url = url
             response.status_code = ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)
@@ -140,22 +241,14 @@ def http_request(
                     "message": str(e),
                 }
             ).encode("UTF-8")
-
             return response
 
-    max_retries = MLFLOW_HTTP_REQUEST_MAX_RETRIES.get() if max_retries is None else max_retries
-    backoff_factor = (
-        MLFLOW_HTTP_REQUEST_BACKOFF_FACTOR.get() if backoff_factor is None else backoff_factor
-    )
     _validate_max_retries(max_retries)
     _validate_backoff_factor(backoff_factor)
     respect_retry_after_header = (
         MLFLOW_HTTP_RESPECT_RETRY_AFTER_HEADER.get()
         if respect_retry_after_header is None
         else respect_retry_after_header
-    )
-    backoff_jitter = (
-        MLFLOW_HTTP_REQUEST_BACKOFF_JITTER.get() if backoff_jitter is None else backoff_jitter
     )
 
     timeout = MLFLOW_HTTP_REQUEST_TIMEOUT.get() if timeout is None else timeout

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import logging
+import random
 import time
 import warnings
 from functools import lru_cache
@@ -387,14 +388,9 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
         DatabricksError: If all retries are exhausted or non-retryable error occurs
     """
     from databricks.sdk.errors import DatabricksError
-    from urllib3.exceptions import MaxRetryError
-    from urllib3.util.retry import Retry
 
     start_time = time.time()
     attempt = 0
-    retry_obj = Retry(
-        total=max_retries, backoff_factor=backoff_factor, backoff_jitter=backoff_jitter
-    )
 
     while attempt <= max_retries:
         try:
@@ -407,14 +403,21 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
             if status_code not in retry_codes:
                 raise e
 
-            # Get backoff time from urllib3 Retry object and increment it for next iteration
-            backoff_time = retry_obj.get_backoff_time()
-            try:
-                retry_obj = retry_obj.increment()
-            except MaxRetryError:
-                # MaxRetryError means we've exceeded max retries
+            # Check if we've exceeded max retries
+            if attempt >= max_retries:
                 _logger.warning(f"Max retries ({max_retries}) exceeded: {e}")
                 raise e
+
+            # Calculate backoff time with exponential backoff and jitter
+            # NB: Ideally, we'd use urllib3.Retry to compute the jitter, check whether we've
+            # exceed max retries, etc. However, urllib3 version 1.x (which MLflow maintains
+            # compatibility with) doesn't support retries with jitter
+            if attempt <= 0:
+                backoff_time = 0  # No backoff on first retry attempt
+            else:
+                backoff_time = backoff_factor * (2**attempt)
+                if backoff_jitter > 0:
+                    backoff_time += random.random() * backoff_jitter
 
             # Check if we've exceeded or would exceed timeout
             elapsed_time = time.time() - start_time

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -410,8 +410,8 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
 
             # Calculate backoff time with exponential backoff and jitter
             # NB: Ideally, we'd use urllib3.Retry to compute the jitter, check whether we've
-            # exceed max retries, etc. However, urllib3 version 1.x (which MLflow maintains
-            # compatibility with) doesn't support retries with jitter
+            # exceed max retries, etc. However, urllib3.Retry in urllib3 version 1.x, which MLflow
+            # maintains compatibility with, doesn't support retries with jitter
             if attempt <= 0:
                 backoff_time = 0  # No backoff on first retry attempt
             else:

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -813,12 +813,11 @@ def test_databricks_sdk_retry_backoff_calculation():
         except Exception:
             pass  # Expected to fail
 
-    # Verify sleep was called with correct intervals using urllib3 Retry behavior
-    # urllib3 Retry.get_backoff_time() uses consecutive_errors_len - 1 formula
-    # attempt 0 (1st retry): 0 seconds (no consecutive errors yet)
-    # attempt 1 (2nd retry): 0 seconds (consecutive_errors_len = 1, so 1-1 = 0)
-    # attempt 2 (3rd retry): 2.0 seconds (consecutive_errors_len = 2, so 1 * 2^(2-1) = 2)
-    expected_sleep_times = [0, 0, 2.0]
+    # Verify sleep was called with correct intervals
+    # attempt 0 (1st retry): 0 seconds (immediate)
+    # attempt 1 (2nd retry): 1 * (2^1) = 2 seconds
+    # attempt 2 (3rd retry): 1 * (2^2) = 4 seconds
+    expected_sleep_times = [0, 2, 4]
     actual_sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
     assert actual_sleep_times == expected_sleep_times
     assert call_count == 4  # Initial + 3 retries

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -813,11 +813,12 @@ def test_databricks_sdk_retry_backoff_calculation():
         except Exception:
             pass  # Expected to fail
 
-    # Verify sleep was called with correct intervals
-    # attempt 0 (1st retry): 0 seconds (immediate)
-    # attempt 1 (2nd retry): 1 * (2^1) = 2 seconds
-    # attempt 2 (3rd retry): 1 * (2^2) = 4 seconds
-    expected_sleep_times = [0, 2, 4]
+    # Verify sleep was called with correct intervals using urllib3 Retry behavior
+    # urllib3 Retry.get_backoff_time() uses consecutive_errors_len - 1 formula
+    # attempt 0 (1st retry): 0 seconds (no consecutive errors yet)
+    # attempt 1 (2nd retry): 0 seconds (consecutive_errors_len = 1, so 1-1 = 0)
+    # attempt 2 (3rd retry): 2.0 seconds (consecutive_errors_len = 2, so 1 * 2^(2-1) = 2)
+    expected_sleep_times = [0, 0, 2.0]
     actual_sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
     assert actual_sleep_times == expected_sleep_times
     assert call_count == 4  # Initial + 3 retries

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -1,4 +1,5 @@
 import re
+import time
 import warnings
 from unittest import mock
 
@@ -646,3 +647,177 @@ def test_suppress_databricks_retry_after_secs_warnings():
             _DATABRICKS_SDK_RETRY_AFTER_SECS_DEPRECATION_WARNING in str(w.message)
             for w in recorded_warnings
         )
+
+
+def test_databricks_sdk_retry_on_transient_errors():
+    """Test that Databricks SDK retries on transient HTTP errors."""
+    host_creds = MlflowHostCreds("http://example.com", use_databricks_sdk=True)
+
+    call_count = 0
+
+    def mock_do_failing_then_success(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:  # Fail first 2 attempts
+            from databricks.sdk.errors import DatabricksError
+
+            from mlflow.protos.databricks_pb2 import ErrorCode
+
+            raise DatabricksError(
+                error_code=ErrorCode.Name(ErrorCode.INTERNAL_ERROR), message="Transient error"
+            )
+        # Success on 3rd attempt
+        response_mock = mock.MagicMock()
+        response_mock._response = mock.MagicMock()
+        return {"contents": response_mock}
+
+    with mock.patch("mlflow.utils.rest_utils.get_workspace_client") as mock_get_workspace_client:
+        mock_workspace_client = mock.MagicMock()
+        mock_workspace_client.api_client.do = mock_do_failing_then_success
+        mock_get_workspace_client.return_value = mock_workspace_client
+
+        # Use smaller retry timeout to make test run faster
+        response = http_request(
+            host_creds,
+            "/endpoint",
+            "GET",
+            retry_timeout_seconds=10,
+            backoff_factor=0.1,  # Very small backoff for faster test
+        )
+
+        assert call_count == 3  # Should retry 2 times, succeed on 3rd
+        assert response is not None
+
+
+def test_databricks_sdk_retry_max_retries_exceeded():
+    """Test that Databricks SDK stops retrying when max_retries is exceeded."""
+    host_creds = MlflowHostCreds("http://example.com", use_databricks_sdk=True)
+
+    call_count = 0
+
+    def mock_do_always_fail(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        from databricks.sdk.errors import DatabricksError
+
+        raise DatabricksError(error_code="INTERNAL_ERROR", message="Always fails")
+
+    with (
+        mock.patch("mlflow.utils.rest_utils.get_workspace_client") as mock_get_workspace_client,
+        mock.patch("mlflow.utils.rest_utils._logger") as mock_logger,
+    ):
+        mock_workspace_client = mock.MagicMock()
+        mock_workspace_client.api_client.do = mock_do_always_fail
+        mock_get_workspace_client.return_value = mock_workspace_client
+
+        response = http_request(host_creds, "/endpoint", "GET", max_retries=3)
+
+        assert call_count == 4  # Initial call + 3 retries
+        assert response.status_code == 500  # Should return error response
+
+        # Check that max retries warning was logged
+        mock_logger.warning.assert_called()
+        warning_call = mock_logger.warning.call_args[0][0]
+        assert "Max retries (3) exceeded" in warning_call
+
+
+def test_databricks_sdk_retry_timeout_exceeded():
+    """Test that Databricks SDK stops retrying when timeout is exceeded."""
+    host_creds = MlflowHostCreds("http://example.com", use_databricks_sdk=True)
+
+    call_count = 0
+
+    def mock_do_always_fail(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+        time.sleep(0.1)  # Small delay to ensure timeout
+        from databricks.sdk.errors import DatabricksError
+
+        raise DatabricksError(error_code="INTERNAL_ERROR", message="Always fails")
+
+    with (
+        mock.patch("mlflow.utils.rest_utils.get_workspace_client") as mock_get_workspace_client,
+        mock.patch("mlflow.utils.rest_utils._logger") as mock_logger,
+    ):
+        mock_workspace_client = mock.MagicMock()
+        mock_workspace_client.api_client.do = mock_do_always_fail
+        mock_get_workspace_client.return_value = mock_workspace_client
+
+        response = http_request(
+            host_creds,
+            "/endpoint",
+            "GET",
+            retry_timeout_seconds=0.2,  # Very short timeout
+            max_retries=10,  # High retry limit that shouldn't be reached
+        )
+
+        assert call_count >= 1  # At least initial call
+        assert response.status_code == 500  # Should return error response
+
+        # Check that timeout warning was logged
+        mock_logger.warning.assert_called()
+        warning_call = mock_logger.warning.call_args[0][0]
+        assert "Retry timeout (0.2s) exceeded" in warning_call
+
+
+def test_databricks_sdk_retry_non_retryable_error():
+    """Test that Databricks SDK doesn't retry on non-retryable errors."""
+    host_creds = MlflowHostCreds("http://example.com", use_databricks_sdk=True)
+
+    call_count = 0
+
+    def mock_do_non_retryable_error(*args, **kwargs):
+        nonlocal call_count
+        call_count += 1
+        from databricks.sdk.errors import DatabricksError
+
+        # Use an error code that maps to 400 (non-retryable)
+        raise DatabricksError(error_code="INVALID_PARAMETER_VALUE", message="Bad request")
+
+    with mock.patch("mlflow.utils.rest_utils.get_workspace_client") as mock_get_workspace_client:
+        mock_workspace_client = mock.MagicMock()
+        mock_workspace_client.api_client.do = mock_do_non_retryable_error
+        mock_get_workspace_client.return_value = mock_workspace_client
+
+        response = http_request(host_creds, "/endpoint", "GET", max_retries=5)
+
+        assert call_count == 1  # Should not retry on non-retryable error
+        assert response.status_code == 400  # Should return 400 for INVALID_PARAMETER_VALUE
+
+
+def test_databricks_sdk_retry_backoff_calculation():
+    """Test that Databricks SDK uses correct exponential backoff timing."""
+    from mlflow.utils.request_utils import _TRANSIENT_FAILURE_RESPONSE_CODES
+    from mlflow.utils.rest_utils import _retry_databricks_sdk_call_with_exponential_backoff
+
+    call_count = 0
+
+    def mock_failing_call():
+        nonlocal call_count
+        call_count += 1
+        from databricks.sdk.errors import DatabricksError
+
+        raise DatabricksError(error_code="INTERNAL_ERROR", message="Mock error")
+
+    with mock.patch("time.sleep") as mock_sleep:
+        try:
+            _retry_databricks_sdk_call_with_exponential_backoff(
+                call_func=mock_failing_call,
+                retry_codes=_TRANSIENT_FAILURE_RESPONSE_CODES,
+                retry_timeout_seconds=10,
+                backoff_factor=1,  # Use 1 for predictable calculation
+                backoff_jitter=0,  # No jitter for predictable calculation
+                max_retries=3,
+            )
+        except Exception:
+            pass  # Expected to fail
+
+    # Verify sleep was called with correct intervals
+    # attempt 0 (1st retry): 0 seconds (immediate)
+    # attempt 1 (2nd retry): 1 * (2^1) = 2 seconds
+    # attempt 2 (3rd retry): 1 * (2^2) = 4 seconds
+    expected_sleep_times = [0, 2, 4]
+    actual_sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
+    assert actual_sleep_times == expected_sleep_times
+    assert call_count == 4  # Initial + 3 retries


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/16128?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16128/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16128/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16128/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Use consistent retry policy for Databricks SDK REST API calls and non-Databricks-SDK REST API calls.

Currently, for API calls that use databricks SDK, the calls don't retry on server-level 500 errors and fail immediately.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
