### PR TITLE
Databricks Model Registry: Default URI to databricks-uc when tracking URI is databricks & registry URI is unspecified

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -16,7 +16,7 @@ from mlflow.entities import Run
 from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, RestException
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
@@ -443,7 +443,28 @@ class UcModelRegistryStore(BaseRestStore):
                 deployment_job_id=str(deployment_job_id) if deployment_job_id else None,
             )
         )
-        response_proto = self._call_endpoint(CreateRegisteredModelRequest, req_body)
+        try:
+            response_proto = self._call_endpoint(CreateRegisteredModelRequest, req_body)
+        except RestException as e:
+            if "specify all three levels" in e.message:
+                # The exception is likely due to the user trying to create a registered model
+                # in Unity Catalog without specifying a 3-level name (catalog.schema.model).
+                # The user may not be intending to use the Unity Catalog Model Registry at all,
+                # but rather the legacy Workspace Model Registry. Accordingly, we re-raise with
+                # a hint
+                legacy_hint = (
+                    "If you are trying to use the legacy Workspace Model Registry, instead of the"
+                    " recommended Unity Catalog Model Registry, set the Model Registry URI to"
+                    " 'databricks' (legacy) instead of 'databricks-uc' (recommended)."
+                )
+                new_message = e.message.rstrip(".") + f". {legacy_hint}"
+                raise MlflowException(
+                    message=new_message,
+                    error_code=e.error_code,
+                )
+            else:
+                raise
+
         if deployment_job_id:
             _print_databricks_deployment_job_url(
                 model_name=full_name,

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -151,12 +151,9 @@ def get_registry_uri() -> str:
         Current tracking uri: file:///.../mlruns
 
     """
-    registry_uri = _get_registry_uri_from_context()
-    if registry_uri is not None:
-        return registry_uri
-
-    tracking_uri = get_tracking_uri()
-    return _get_default_registry_uri_for_tracking_uri(tracking_uri)
+    return _get_registry_uri_from_context() or _get_default_registry_uri_for_tracking_uri(
+        get_tracking_uri()
+    )
 
 
 def _resolve_registry_uri(

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -116,9 +116,9 @@ def _get_default_registry_uri_for_tracking_uri(tracking_uri: Optional[str]) -> O
         The default registry URI
     """
     if tracking_uri is not None and tracking_uri.startswith("databricks"):
-        # If the tracking URI is "databricks", we impute the
-        # registry URI as databricks-uc, which is the recommended model registry solution on
-        # Databricks
+        # If the tracking URI is "databricks", we impute the registry URI as "databricks-uc"
+        # corresponding to Databricks Unity Catalog Model Registry, which is the recommended
+        # model registry offering on Databricks
         return _DATABRICKS_UNITY_CATALOG_SCHEME
 
     # For non-databricks tracking URIs, use the tracking URI as the registry URI

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -159,8 +159,10 @@ def _resolve_registry_uri(
     """
     Resolve the registry URI following the same logic as get_registry_uri().
     """
-    return _get_registry_uri_from_context() or _get_default_registry_uri_for_tracking_uri(
-        _resolve_tracking_uri(tracking_uri)
+    return (
+        registry_uri
+        or _get_registry_uri_from_context()
+        or _get_default_registry_uri_for_tracking_uri(_resolve_tracking_uri(tracking_uri))
     )
 
 

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -11,7 +11,6 @@ from mlflow.store.model_registry.rest_store import RestStore
 from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service.utils import (
     _resolve_tracking_uri,
-    get_tracking_uri,
 )
 from mlflow.utils._spark_utils import _get_active_spark_session
 from mlflow.utils.credentials import get_default_host_creds
@@ -151,9 +150,7 @@ def get_registry_uri() -> str:
         Current tracking uri: file:///.../mlruns
 
     """
-    return _get_registry_uri_from_context() or _get_default_registry_uri_for_tracking_uri(
-        get_tracking_uri()
-    )
+    return _resolve_registry_uri()
 
 
 def _resolve_registry_uri(
@@ -162,15 +159,9 @@ def _resolve_registry_uri(
     """
     Resolve the registry URI following the same logic as get_registry_uri().
     """
-    if registry_uri:
-        return registry_uri
-
-    context_uri = _get_registry_uri_from_context()
-    if context_uri is not None:
-        return context_uri
-
-    resolved_tracking_uri = _resolve_tracking_uri(tracking_uri)
-    return _get_default_registry_uri_for_tracking_uri(resolved_tracking_uri)
+    return _get_registry_uri_from_context() or _get_default_registry_uri_for_tracking_uri(
+        _resolve_tracking_uri(tracking_uri)
+    )
 
 
 def _get_sqlalchemy_store(store_uri):

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -127,7 +127,19 @@ def get_registry_uri() -> str:
         Current tracking uri: file:///.../mlruns
 
     """
-    return _get_registry_uri_from_context() or get_tracking_uri()
+    registry_uri = _get_registry_uri_from_context()
+    if registry_uri is not None:
+        return registry_uri
+
+    tracking_uri = get_tracking_uri()
+    if tracking_uri and tracking_uri.startswith("databricks"):
+        # If the registry URI is unspecified and the tracking URI is "databricks", we impute the
+        # registry URI as databricks-uc, which is the recommended model registry solution on
+        # Databricks
+        return _DATABRICKS_UNITY_CATALOG_SCHEME
+
+    # For non-databricks tracking URIs, use the tracking URI as the registry URI
+    return tracking_uri
 
 
 def _resolve_registry_uri(registry_uri=None, tracking_uri=None):

--- a/mlflow/tracking/_model_registry/utils.py
+++ b/mlflow/tracking/_model_registry/utils.py
@@ -19,7 +19,11 @@ from mlflow.utils.databricks_utils import (
     is_in_databricks_serverless_runtime,
     warn_on_deprecated_cross_workspace_registry_uri,
 )
-from mlflow.utils.uri import _DATABRICKS_UNITY_CATALOG_SCHEME, _OSS_UNITY_CATALOG_SCHEME
+from mlflow.utils.uri import (
+    _DATABRICKS_UNITY_CATALOG_SCHEME,
+    _OSS_UNITY_CATALOG_SCHEME,
+    is_databricks_uri,
+)
 
 # NOTE: in contrast to tracking, we do not support the following ways to specify
 # the model registry URI:
@@ -115,7 +119,7 @@ def _get_default_registry_uri_for_tracking_uri(tracking_uri: Optional[str]) -> O
     Returns:
         The default registry URI
     """
-    if tracking_uri is not None and tracking_uri.startswith("databricks"):
+    if tracking_uri is not None and is_databricks_uri(tracking_uri):
         # If the tracking URI is "databricks", we impute the registry URI as "databricks-uc"
         # corresponding to Databricks Unity Catalog Model Registry, which is the recommended
         # model registry offering on Databricks

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -138,6 +138,22 @@ def construct_db_uri_from_profile(profile):
         return "databricks://" + profile
 
 
+def construct_db_uc_uri_from_profile(profile):
+    """
+    Construct a databricks-uc URI from a profile.
+
+    Args:
+        profile: The profile name, optionally with key_prefix (e.g., "profile" or "scope:key")
+
+    Returns:
+        A databricks-uc URI string, or the scheme alone if no profile is provided
+    """
+    if profile:
+        return f"{_DATABRICKS_UNITY_CATALOG_SCHEME}://{profile}"
+    else:
+        return _DATABRICKS_UNITY_CATALOG_SCHEME
+
+
 # Both scope and key_prefix should not contain special chars for URIs, like '/'
 # and ':'.
 def validate_db_scope_prefix_info(scope, prefix):

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -24,7 +24,7 @@ from mlflow.entities.run_data import RunData
 from mlflow.entities.run_info import RunInfo
 from mlflow.entities.run_inputs import RunInputs
 from mlflow.entities.run_tag import RunTag
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, RestException
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature, Schema
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
@@ -186,6 +186,71 @@ def test_create_registered_model(mock_http, store):
             tags=uc_registered_model_tag_from_mlflow_tags(tags),
         ),
     )
+
+
+def test_create_registered_model_three_level_name_hint(store):
+    """Test that creating a registered model with invalid name provides legacy registry hint."""
+    # Mock the _call_endpoint method to raise a RestException with
+    # "specify all three levels" message
+    original_error_message = "Model name must specify all three levels"
+    rest_exception = RestException(
+        {"error_code": "INVALID_PARAMETER_VALUE", "message": original_error_message}
+    )
+
+    with mock.patch.object(store, "_call_endpoint", side_effect=rest_exception):
+        with pytest.raises(MlflowException, match=original_error_message) as exc_info:
+            store.create_registered_model(name="invalid_model")
+
+    # Verify the exception message includes the original error and the legacy registry hint
+    expected_hint = (
+        "If you are trying to use the legacy Workspace Model Registry, instead of the"
+        " recommended Unity Catalog Model Registry, set the Model Registry URI to"
+        " 'databricks' (legacy) instead of 'databricks-uc' (recommended)."
+    )
+    assert original_error_message in str(exc_info.value)
+    assert expected_hint in str(exc_info.value)
+
+
+def test_create_registered_model_three_level_name_hint_with_period(store):
+    """Test the hint works correctly when original error message ends with a period."""
+    original_error_message = "Model name must specify all three levels."
+    rest_exception = RestException(
+        {"error_code": "INVALID_PARAMETER_VALUE", "message": original_error_message}
+    )
+
+    with mock.patch.object(store, "_call_endpoint", side_effect=rest_exception):
+        with pytest.raises(MlflowException, match=original_error_message) as exc_info:
+            store.create_registered_model(name="invalid_model")
+
+    # Verify the period is removed before adding the hint
+    expected_hint = (
+        "If you are trying to use the legacy Workspace Model Registry, instead of the"
+        " recommended Unity Catalog Model Registry, set the Model Registry URI to"
+        " 'databricks' (legacy) instead of 'databricks-uc' (recommended)."
+    )
+    error_message = str(exc_info.value)
+    assert "Model name must specify all three levels" in error_message
+    assert expected_hint in error_message
+    # Should not have double periods
+    assert ". ." not in error_message
+
+
+def test_create_registered_model_other_rest_exceptions_not_modified(store):
+    """
+    Test that RestExceptions unrelated to bad UC model names are not modified
+    and are re-raised as-is.
+    """
+    original_error_message = "Some other error"
+    rest_exception = RestException(
+        {"error_code": "INTERNAL_ERROR", "message": original_error_message}
+    )
+
+    with mock.patch.object(store, "_call_endpoint", side_effect=rest_exception):
+        with pytest.raises(RestException, match=original_error_message) as exc_info:
+            store.create_registered_model(name="some_model")
+
+    # Verify the original RestException is re-raised without modification
+    assert str(exc_info.value) == "INTERNAL_ERROR: Some other error"
 
 
 @pytest.fixture

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -65,9 +65,9 @@ def test_default_get_registry_uri_with_databricks_tracking_uri_defaults_to_uc():
     """Test that databricks tracking URIs default to databricks-uc for registry"""
     tracking_uri = "databricks://tracking_werohoz"
     with mock.patch(
-        "mlflow.tracking._model_registry.utils.get_tracking_uri"
-    ) as get_tracking_uri_mock:
-        get_tracking_uri_mock.return_value = tracking_uri
+        "mlflow.tracking._model_registry.utils._resolve_tracking_uri"
+    ) as resolve_tracking_uri_mock:
+        resolve_tracking_uri_mock.return_value = tracking_uri
         set_registry_uri(None)
         # Should default to Unity Catalog when tracking URI starts with 'databricks'
         assert get_registry_uri() == "databricks-uc"

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -33,7 +33,7 @@ def reset_registry_uri():
 
 def test_set_get_registry_uri():
     with mock.patch(
-        "mlflow.tracking._model_registry.utils.get_tracking_uri"
+        "mlflow.tracking._model_registry.utils._resolve_tracking_uri"
     ) as get_tracking_uri_mock:
         get_tracking_uri_mock.return_value = "databricks://tracking_sldkfj"
         uri = "databricks://registry/path"
@@ -44,7 +44,7 @@ def test_set_get_registry_uri():
 
 def test_set_get_empty_registry_uri():
     with mock.patch(
-        "mlflow.tracking._model_registry.utils.get_tracking_uri"
+        "mlflow.tracking._model_registry.utils._resolve_tracking_uri"
     ) as get_tracking_uri_mock:
         get_tracking_uri_mock.return_value = None
         set_registry_uri("")
@@ -54,7 +54,7 @@ def test_set_get_empty_registry_uri():
 
 def test_default_get_registry_uri_no_tracking_uri():
     with mock.patch(
-        "mlflow.tracking._model_registry.utils.get_tracking_uri"
+        "mlflow.tracking._model_registry.utils._resolve_tracking_uri"
     ) as get_tracking_uri_mock:
         get_tracking_uri_mock.return_value = None
         set_registry_uri(None)

--- a/tests/tracking/_model_registry/test_utils.py
+++ b/tests/tracking/_model_registry/test_utils.py
@@ -85,7 +85,7 @@ def test_default_registry_uri_non_databricks_tracking_uri():
 
     for tracking_uri in non_databricks_uris:
         with mock.patch(
-            "mlflow.tracking._model_registry.utils.get_tracking_uri"
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri"
         ) as get_tracking_uri_mock:
             get_tracking_uri_mock.return_value = tracking_uri
             set_registry_uri(None)
@@ -105,7 +105,7 @@ def test_databricks_tracking_uri_variations_default_to_uc():
 
     for tracking_uri in databricks_uris:
         with mock.patch(
-            "mlflow.tracking._model_registry.utils.get_tracking_uri"
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri"
         ) as get_tracking_uri_mock:
             get_tracking_uri_mock.return_value = tracking_uri
             set_registry_uri(None)
@@ -119,7 +119,7 @@ def test_explicit_registry_uri_overrides_databricks_default():
     explicit_registry_uri = "databricks://different_workspace"
 
     with mock.patch(
-        "mlflow.tracking._model_registry.utils.get_tracking_uri"
+        "mlflow.tracking._tracking_service.utils.get_tracking_uri"
     ) as get_tracking_uri_mock:
         get_tracking_uri_mock.return_value = tracking_uri
         set_registry_uri(explicit_registry_uri)
@@ -137,7 +137,7 @@ def test_registry_uri_from_environment_overrides_databricks_default():
 
     with (
         mock.patch(
-            "mlflow.tracking._model_registry.utils.get_tracking_uri"
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri"
         ) as get_tracking_uri_mock,
         mock.patch.object(MLFLOW_REGISTRY_URI, "get", return_value=env_registry_uri),
     ):
@@ -154,7 +154,7 @@ def test_registry_uri_from_spark_session_overrides_databricks_default():
 
     with (
         mock.patch(
-            "mlflow.tracking._model_registry.utils.get_tracking_uri"
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri"
         ) as get_tracking_uri_mock,
         mock.patch(
             "mlflow.tracking._model_registry.utils._get_registry_uri_from_spark_session"
@@ -178,7 +178,7 @@ def test_edge_cases_for_databricks_uri_detection():
 
     for tracking_uri, expected_result in edge_case_uris:
         with mock.patch(
-            "mlflow.tracking._model_registry.utils.get_tracking_uri"
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri"
         ) as get_tracking_uri_mock:
             get_tracking_uri_mock.return_value = tracking_uri
             set_registry_uri(None)

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1166,7 +1166,8 @@ def test_registry_uri_from_tracking_uri_param():
         return_value=tracking_uri,
     ):
         client = MlflowClient(tracking_uri=tracking_uri)
-        assert client._registry_uri == tracking_uri
+        # For databricks tracking URIs, registry URI defaults to Unity Catalog
+        assert client._registry_uri == "databricks-uc"
 
 
 def test_registry_uri_from_implicit_tracking_uri():
@@ -1176,7 +1177,8 @@ def test_registry_uri_from_implicit_tracking_uri():
         return_value=tracking_uri,
     ):
         client = MlflowClient()
-        assert client._registry_uri == tracking_uri
+        # For databricks tracking URIs, registry URI defaults to Unity Catalog
+        assert client._registry_uri == "databricks-uc"
 
 
 def test_create_model_version_nondatabricks_source_no_runlink(mock_registry_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1166,8 +1166,8 @@ def test_registry_uri_from_tracking_uri_param():
         return_value=tracking_uri,
     ):
         client = MlflowClient(tracking_uri=tracking_uri)
-        # For databricks tracking URIs, registry URI defaults to Unity Catalog
-        assert client._registry_uri == "databricks-uc"
+        # For databricks tracking URIs, registry URI defaults to Unity Catalog with profile
+        assert client._registry_uri == "databricks-uc://tracking_vhawoierj"
 
 
 def test_registry_uri_from_implicit_tracking_uri():
@@ -1177,8 +1177,8 @@ def test_registry_uri_from_implicit_tracking_uri():
         return_value=tracking_uri,
     ):
         client = MlflowClient()
-        # For databricks tracking URIs, registry URI defaults to Unity Catalog
-        assert client._registry_uri == "databricks-uc"
+        # For databricks tracking URIs, registry URI defaults to Unity Catalog with profile
+        assert client._registry_uri == "databricks-uc://tracking_wierojasdf"
 
 
 def test_create_model_version_nondatabricks_source_no_runlink(mock_registry_store):

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -1318,7 +1318,7 @@ def test_create_model_version_with_source(mock_registry_store, mock_databricks_t
         assert model_version.model_id == model_id
         mock_registry_store.create_model_version.assert_called_once_with(
             "name",
-            "/path/to/source",
+            f"models:/{model_id}",
             "runid",
             [],
             None,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/16135?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16135/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16135/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16135/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Default URI to databricks-uc when tracking URI is databricks & registry URI is unspecified

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

When using MLflow on Databricks, Unity Catalog Model Registry is now the default destination for Model Registry operations.

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [X] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
