### PR TITLE
Prompt Version: Remove Unrelated Fields

### DIFF
--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -265,21 +265,24 @@ class PromptVersion(ModelVersion):
     def deployment_job_state(self):
         """Deployment job information - not applicable to prompts."""
         raise AttributeError(
-            "PromptVersion does not have 'deployment_job_state'. Prompts are not deployed like models."
+            "PromptVersion does not have 'deployment_job_state'. "
+            "Prompts are not deployed like models."
         )
 
     @property
     def last_updated_timestamp(self):
         """Timestamp of last update - inherited but not relevant for prompts."""
         raise AttributeError(
-            "PromptVersion does not have 'last_updated_timestamp'. Use 'creation_timestamp' instead."
+            "PromptVersion does not have 'last_updated_timestamp'. "
+            "Use 'creation_timestamp' instead."
         )
 
     @property
     def current_stage(self):
         """Model staging information - not applicable to prompts."""
         raise AttributeError(
-            "PromptVersion does not have 'current_stage'. Prompts do not use staging concepts like models."
+            "PromptVersion does not have 'current_stage'. "
+            "Prompts do not use staging concepts like models."
         )
 
     @property

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -223,3 +223,89 @@ class PromptVersion(ModelVersion):
             prompt_tags=prompt_tags,
             aliases=model_version.aliases,
         )
+
+    # Override model-specific properties that don't make sense for prompts
+    @property
+    def run_id(self):
+        """MLflow run that generated the model - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'run_id'. Prompts are not tied to specific MLflow runs. "
+            "Use 'run_ids' property for associated runs."
+        )
+
+    @property
+    def run_link(self):
+        """Link to the MLflow run - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'run_link'. Prompts are not tied to specific MLflow runs."
+        )
+
+    @property
+    def model_id(self):
+        """ID linking to logged model - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'model_id'. Prompts are separate from models."
+        )
+
+    @property
+    def params(self):
+        """Model parameters - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'params'. Prompts do not have model parameters."
+        )
+
+    @property
+    def metrics(self):
+        """Model metrics - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'metrics'. Prompts do not have model metrics."
+        )
+
+    @property
+    def deployment_job_state(self):
+        """Deployment job information - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'deployment_job_state'. Prompts are not deployed like models."
+        )
+
+    @property
+    def last_updated_timestamp(self):
+        """Timestamp of last update - inherited but not relevant for prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'last_updated_timestamp'. Use 'creation_timestamp' instead."
+        )
+
+    @property
+    def current_stage(self):
+        """Model staging information - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'current_stage'. Prompts do not use staging concepts like models."
+        )
+
+    @property
+    def source(self):
+        """Model artifact source path - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'source'. Prompts do not have artifact source paths."
+        )
+
+    @property
+    def status(self):
+        """Model deployment status - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'status'. Prompts do not have deployment status."
+        )
+
+    @property
+    def status_message(self):
+        """Model deployment status message - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'status_message'. Prompts do not have deployment status."
+        )
+
+    @property
+    def user_id(self):
+        """User who created the model - not applicable to prompts."""
+        raise AttributeError(
+            "PromptVersion does not have 'user_id'. User information is not tracked for prompts."
+        )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/16159?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16159/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16159/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16159/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Removing unnecessary fields from Prompt Entity. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
