### PR TITLE
Link prompts to models when loaded via fluent API

### DIFF
--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import threading
+import uuid
 from typing import Any, Optional, Union
 
 import mlflow
@@ -709,7 +710,9 @@ def load_prompt(
                     )
 
             # Start linking in background - don't wait for completion
-            link_thread = threading.Thread(target=_link_prompt_async)
+            link_thread = threading.Thread(
+                target=_link_prompt_async, name=f"link_prompt_thread-{uuid.uuid4().hex[:8]}"
+            )
             link_thread.start()
 
     return prompt

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -1,5 +1,7 @@
+import json
 import os
 import subprocess
+import time
 from pathlib import Path
 from unittest import mock
 
@@ -117,9 +119,6 @@ def test_register_model_with_tags():
 
 
 def test_crud_prompts(tmp_path):
-    registry_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
-    mlflow.set_registry_uri(registry_uri)
-
     mlflow.register_prompt(
         name="prompt_1",
         template="Hi, {title} {name}! How are you today?",
@@ -153,9 +152,6 @@ def test_crud_prompts(tmp_path):
 
 
 def test_prompt_alias(tmp_path):
-    registry_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
-    mlflow.set_registry_uri(registry_uri)
-
     mlflow.register_prompt(name="p1", template="Hi, there!")
     mlflow.register_prompt(name="p1", template="Hi, {{name}}!")
 
@@ -174,9 +170,6 @@ def test_prompt_alias(tmp_path):
 
 
 def test_prompt_associate_with_run(tmp_path):
-    registry_uri = "sqlite:///{}".format(tmp_path.joinpath("test.db"))
-    mlflow.set_registry_uri(registry_uri)
-
     mlflow.register_prompt(name="prompt_1", template="Hi, {title} {name}! How are you today?")
 
     # mlflow.load_prompt() call during the run should associate the prompt with the run
@@ -436,3 +429,207 @@ def test_register_model_with_env_pack_staging_failure(tmp_path, mock_dbr_version
             "The model was registered successfully and is available for serving, but may take "
             "longer to deploy."
         )
+
+
+def test_load_prompt_with_link_to_model_disabled():
+    """Test load_prompt with link_to_model=False does not attempt linking."""
+
+    # Register a prompt
+    mlflow.register_prompt(name="test_prompt", template="Hello, {{name}}!")
+
+    # Create a logged model and set it as active
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=lambda x: x,
+            name="model",
+            pip_requirements=["mlflow"],
+        )
+        mlflow.set_active_model(model_info.model_id)
+
+        # Load prompt with link_to_model=False - should not link despite active model
+        prompt = mlflow.load_prompt("test_prompt", version=1, link_to_model=False)
+
+        # Verify prompt was loaded correctly
+        assert prompt.name == "test_prompt"
+        assert prompt.version == 1
+        assert prompt.template == "Hello, {{name}}!"
+
+        # Give any potential background linking thread time to complete (it shouldn't run)
+        time.sleep(5)
+
+        # Verify the model does NOT have any linked prompts tag
+        client = mlflow.MlflowClient()
+        model = client.get_logged_model(model_info.model_id)
+        linked_prompts_tag = model.tags.get("mlflow.linkedPrompts")
+        assert linked_prompts_tag is None, (
+            "Model should not have linkedPrompts tag when link_to_model=False"
+        )
+
+
+def test_load_prompt_with_explicit_model_id():
+    """Test load_prompt with explicit model_id parameter."""
+
+    # Register a prompt
+    mlflow.register_prompt(name="test_prompt", template="Hello, {{name}}!")
+
+    # Create a logged model to link to
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=lambda x: x,
+            name="model",
+            pip_requirements=["mlflow"],
+        )
+
+    # Load prompt with explicit model_id - should link successfully
+    prompt = mlflow.load_prompt(
+        "test_prompt", version=1, link_to_model=True, model_id=model_info.model_id
+    )
+
+    # Verify prompt was loaded correctly
+    assert prompt.name == "test_prompt"
+    assert prompt.version == 1
+    assert prompt.template == "Hello, {{name}}!"
+
+    # Give background linking thread time to complete
+    time.sleep(5)
+
+    # Verify the model has the linked prompt in its tags
+    client = mlflow.MlflowClient()
+    model = client.get_logged_model(model_info.model_id)
+    linked_prompts_tag = model.tags.get("mlflow.linkedPrompts")
+    assert linked_prompts_tag is not None
+
+    # Parse the JSON tag value
+    linked_prompts = json.loads(linked_prompts_tag)
+    assert len(linked_prompts) == 1
+    assert linked_prompts[0]["name"] == "test_prompt"
+    assert linked_prompts[0]["version"] == "1"
+
+
+def test_load_prompt_with_active_model_integration():
+    """Test load_prompt with active model integration using get_active_model_id."""
+
+    # Register a prompt
+    mlflow.register_prompt(name="test_prompt", template="Hello, {{name}}!")
+
+    # Test loading prompt with active model context
+    with mlflow.start_run():
+        model_info = mlflow.pyfunc.log_model(
+            python_model=lambda x: x,
+            name="model",
+            pip_requirements=["mlflow"],
+        )
+
+        mlflow.set_active_model(model_info.model_id)
+        # Load prompt with link_to_model=True - should use active model
+        prompt = mlflow.load_prompt("test_prompt", version=1, link_to_model=True)
+
+        # Verify prompt was loaded correctly
+        assert prompt.name == "test_prompt"
+        assert prompt.version == 1
+        assert prompt.template == "Hello, {{name}}!"
+
+        # Give background linking thread time to complete
+        time.sleep(5)
+
+        # Verify the model has the linked prompt in its tags
+        client = mlflow.MlflowClient()
+        model = client.get_logged_model(model_info.model_id)
+        linked_prompts_tag = model.tags.get("mlflow.linkedPrompts")
+        assert linked_prompts_tag is not None
+
+        # Parse the JSON tag value
+        linked_prompts = json.loads(linked_prompts_tag)
+        assert len(linked_prompts) == 1
+        assert linked_prompts[0]["name"] == "test_prompt"
+        assert linked_prompts[0]["version"] == "1"
+
+
+def test_load_prompt_with_no_active_model():
+    """Test load_prompt when no active model is available."""
+
+    # Register a prompt
+    mlflow.register_prompt(name="test_prompt", template="Hello, {{name}}!")
+
+    # Mock no active model available
+    with mock.patch(
+        "mlflow.tracking._model_registry.fluent.get_active_model_id", return_value=None
+    ):
+        # Load prompt with link_to_model=True but no active model - should still work
+        prompt = mlflow.load_prompt("test_prompt", version=1, link_to_model=True)
+
+        # Verify prompt was loaded correctly (linking just gets skipped)
+        assert prompt.name == "test_prompt"
+        assert prompt.version == 1
+        assert prompt.template == "Hello, {{name}}!"
+
+
+def test_load_prompt_linking_error_handling():
+    """Test load_prompt error handling when linking fails."""
+
+    # Register a prompt
+    mlflow.register_prompt(name="test_prompt", template="Hello, {{name}}!")
+
+    # Test with invalid model ID - should still load prompt successfully
+    with mock.patch(
+        "mlflow.tracking._model_registry.fluent.get_active_model_id",
+        return_value="invalid_model_id",
+    ):
+        # Load prompt - should succeed despite linking failure (happens in background)
+        prompt = mlflow.load_prompt("test_prompt", version=1, link_to_model=True)
+
+        # Verify prompt was loaded successfully despite linking failure
+        assert prompt.name == "test_prompt"
+        assert prompt.version == 1
+        assert prompt.template == "Hello, {{name}}!"
+
+
+def test_load_prompt_explicit_model_id_overrides_active_model():
+    """Test that explicit model_id parameter overrides active model ID."""
+
+    # Register a prompt
+    mlflow.register_prompt(name="test_prompt", template="Hello, {{name}}!")
+
+    # Create models to test override behavior
+    with mlflow.start_run():
+        active_model = mlflow.pyfunc.log_model(
+            python_model=lambda x: x,
+            name="active_model",
+            pip_requirements=["mlflow"],
+        )
+        explicit_model = mlflow.pyfunc.log_model(
+            python_model=lambda x: x,
+            name="explicit_model",
+            pip_requirements=["mlflow"],
+        )
+
+    # Set active model context but provide explicit model_id - explicit should win
+    mlflow.set_active_model(active_model.model_id)
+    prompt = mlflow.load_prompt(
+        "test_prompt", version=1, link_to_model=True, model_id=explicit_model.model_id
+    )
+
+    # Verify prompt was loaded correctly (explicit model_id should be used)
+    assert prompt.name == "test_prompt"
+    assert prompt.version == 1
+    assert prompt.template == "Hello, {{name}}!"
+
+    # Give background linking thread time to complete
+    time.sleep(5)
+
+    # Verify the EXPLICIT model (not active model) has the linked prompt in its tags
+    client = mlflow.MlflowClient()
+    explicit_model_data = client.get_logged_model(explicit_model.model_id)
+    linked_prompts_tag = explicit_model_data.tags.get("mlflow.linkedPrompts")
+    assert linked_prompts_tag is not None
+
+    # Parse the JSON tag value
+    linked_prompts = json.loads(linked_prompts_tag)
+    assert len(linked_prompts) == 1
+    assert linked_prompts[0]["name"] == "test_prompt"
+    assert linked_prompts[0]["version"] == "1"
+
+    # Verify the active model does NOT have the linked prompt
+    active_model_data = client.get_logged_model(active_model.model_id)
+    active_linked_prompts_tag = active_model_data.tags.get("mlflow.linkedPrompts")
+    assert active_linked_prompts_tag is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/16166?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16166/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16166/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16166/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Link prompts to models when loaded via fluent API

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
