### PR TITLE
Move prompt registry APIs under `mlflow.genai.prompt` namespace

### DIFF
--- a/docs/api_reference/source/python_api/mlflow.rst
+++ b/docs/api_reference/source/python_api/mlflow.rst
@@ -30,6 +30,11 @@ mlflow
         set_logged_model_tags,
         log_model_params,
         clear_active_model
+        load_prompt,
+        register_prompt,
+        search_prompts,
+        set_prompt_alias,
+        delete_prompt_alias,
 
 .. _mlflow-tracing-fluent-python-apis:
 

--- a/docs/api_reference/source/python_api/mlflow.rst
+++ b/docs/api_reference/source/python_api/mlflow.rst
@@ -29,7 +29,7 @@ mlflow
         set_active_model,
         set_logged_model_tags,
         log_model_params,
-        clear_active_model
+        clear_active_model,
         load_prompt,
         register_prompt,
         search_prompts,

--- a/docs/docs/prompts/index.mdx
+++ b/docs/docs/prompts/index.mdx
@@ -70,7 +70,7 @@ import TabItem from "@theme/TabItem";
           # Optional: Provide a commit message to describe the changes
           commit_message="Initial commit",
           # Optional: Specify any additional metadata about the prompt version
-          version_metadata={
+          tags={
               "author": "author@example.com",
           },
           # Optional: Set tags applies to the prompt (across versions)
@@ -133,7 +133,7 @@ This creates a new prompt with the specified template text and metadata. The pro
           name="summarization-prompt",  # Specify the existing prompt name
           template=new_template,
           commit_message="Improvement",
-          version_metadata={
+          tags={
               "author": "author@example.com",
           },
       )

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -247,6 +247,8 @@ if not IS_TRACING_SDK_ONLY:
     from mlflow.models.evaluation.validation import validate_evaluation_results
     from mlflow.projects import run
     from mlflow.tracking._model_registry.fluent import (
+        # TODO: Prompt Registry APIs are moved to the `mlflow.genai` namespace and direct
+        # imports from mlflow will be deprecated in the future.
         delete_prompt_alias,
         load_prompt,
         register_model,
@@ -385,8 +387,11 @@ if not IS_TRACING_SDK_ONLY:
         "validate_evaluation_results",
         "Image",
         # Prompt Registry APIs
+        # TODO: Prompt Registry APIs are moved to the `mlflow.genai` namespace and direct
+        # imports from mlflow will be deprecated in the future.
         "load_prompt",
         "register_prompt",
+        "search_prompts",
         "set_prompt_alias",
         "delete_prompt_alias",
         "set_logged_model_tags",

--- a/mlflow/genai/__init__.py
+++ b/mlflow/genai/__init__.py
@@ -19,6 +19,13 @@ from mlflow.genai.labeling import (
     get_review_app,
 )
 from mlflow.genai.optimize import optimize_prompt
+from mlflow.genai.prompts import (
+    delete_prompt_alias,
+    load_prompt,
+    register_prompt,
+    search_prompts,
+    set_prompt_alias,
+)
 from mlflow.genai.scheduled_scorers import (
     ScorerScheduleConfig,
     add_scheduled_scorer,
@@ -40,6 +47,11 @@ __all__ = [
     "create_dataset",
     "delete_dataset",
     "get_dataset",
+    "load_prompt",
+    "register_prompt",
+    "search_prompts",
+    "delete_prompt_alias",
+    "set_prompt_alias",
     "optimize_prompt",
     "ScorerScheduleConfig",
     "add_scheduled_scorer",

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -1,0 +1,215 @@
+import warnings
+from contextlib import contextmanager
+from typing import Optional, Union
+
+import mlflow.tracking._model_registry.fluent as registry_api
+from mlflow.entities.model_registry.prompt import Prompt
+from mlflow.entities.model_registry.prompt_version import PromptVersion
+from mlflow.prompt.registry_utils import require_prompt_registry
+from mlflow.store.entities.paged_list import PagedList
+from mlflow.utils.annotations import experimental
+
+
+@contextmanager
+def suppress_genai_migration_warning():
+    """Suppress the deprecation warning when the api is called from `mlflow.genai` namespace."""
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            action="ignore",
+            category=FutureWarning,
+            message="The `mlflow.*` API is moved to the `mlflow.genai` namespace.*",
+        )
+        yield
+
+
+@experimental
+@require_prompt_registry
+def register_prompt(
+    name: str,
+    template: str,
+    commit_message: Optional[str] = None,
+    version_metadata: Optional[dict[str, str]] = None,
+    tags: Optional[dict[str, str]] = None,
+) -> PromptVersion:
+    """
+    Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
+
+    A :py:class:`Prompt <mlflow.entities.Prompt>` is a pair of name and
+    template text at minimum. With MLflow Prompt Registry, you can create, manage, and
+    version control prompts with the MLflow's robust model tracking framework.
+
+    If there is no registered prompt with the given name, a new prompt will be created.
+    Otherwise, a new version of the existing prompt will be created.
+
+
+    Args:
+        name: The name of the prompt.
+        template: The template text of the prompt. It can contain variables enclosed in
+            double curly braces, e.g. {variable}, which will be replaced with actual values
+            by the `format` method.
+
+            .. note::
+
+                If you want to use the prompt with a framework that uses single curly braces
+                e.g. LangChain, you can use the `to_single_brace_format` method to convert the
+                loaded prompt to a format that uses single curly braces.
+
+                .. code-block:: python
+
+                    prompt = client.load_prompt("my_prompt")
+                    langchain_format = prompt.to_single_brace_format()
+
+        commit_message: A message describing the changes made to the prompt, similar to a
+            Git commit message. Optional.
+        version_metadata: A dictionary of metadata associated with the **prompt version**.
+            This is useful for storing version-specific information, such as the author of
+            the changes. Optional.
+        tags: A dictionary of tags associated with the entire prompt. This is different from
+            the `version_metadata` as it is not tied to a specific version of the prompt,
+            but to the prompt as a whole. For example, you can use tags to add an application
+            name for which the prompt is created. Since the application uses the prompt in
+            multiple versions, it makes sense to use tags instead of version-specific metadata.
+            Optional.
+
+    Returns:
+        A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+
+        # Register a new prompt
+        mlflow.genai.register_prompt(
+            name="my_prompt",
+            template="Respond to the user's message as a {{style}} AI.",
+            version_metadata={"author": "Alice"},
+        )
+
+        # Load the prompt from the registry
+        prompt = mlflow.genai.load_prompt("my_prompt")
+
+        # Use the prompt in your application
+        import openai
+
+        openai_client = openai.OpenAI()
+        openai_client.chat.completion.create(
+            model="gpt-4o-mini",
+            messages=[
+                {"role": "system", "content": prompt.format(style="friendly")},
+                {"role": "user", "content": "Hello, how are you?"},
+            ],
+        )
+
+        # Update the prompt with a new version
+        prompt = mlflow.genai.register_prompt(
+            name="my_prompt",
+            template="Respond to the user's message as a {{style}} AI. {{greeting}}",
+            commit_message="Add a greeting to the prompt.",
+            version_metadata={"author": "Bob"},
+        )
+    """
+    with suppress_genai_migration_warning():
+        return registry_api.register_prompt(
+            name=name,
+            template=template,
+            commit_message=commit_message,
+            tags=tags,
+            version_metadata=version_metadata,
+        )
+
+
+@experimental
+@require_prompt_registry
+def search_prompts(
+    filter_string: Optional[str] = None,
+    max_results: Optional[int] = None,
+) -> PagedList[Prompt]:
+    with suppress_genai_migration_warning():
+        return registry_api.search_prompts(filter_string=filter_string, max_results=max_results)
+
+
+@experimental
+@require_prompt_registry
+def load_prompt(
+    name_or_uri: str, version: Optional[Union[str, int]] = None, allow_missing: bool = False
+) -> PromptVersion:
+    """
+    Load a :py:class:`Prompt <mlflow.entities.Prompt>` from the MLflow Prompt Registry.
+
+    The prompt can be specified by name and version, or by URI.
+
+    Args:
+        name_or_uri: The name of the prompt, or the URI in the format "prompts:/name/version".
+        version: The version of the prompt (required when using name, not allowed when using URI).
+        allow_missing: If True, return None instead of raising Exception if the specified prompt
+            is not found.
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+
+        # Load a specific version of the prompt
+        prompt = mlflow.genai.load_prompt("my_prompt", version=1)
+
+        # Load a specific version of the prompt by URI
+        prompt = mlflow.genai.load_prompt(uri="prompts:/my_prompt/1")
+
+        # Load a prompt version with an alias "production"
+        prompt = mlflow.genai.load_prompt("prompts:/my_prompt@production")
+
+    """
+    with suppress_genai_migration_warning():
+        return registry_api.load_prompt(
+            name_or_uri=name_or_uri, version=version, allow_missing=allow_missing
+        )
+
+
+@experimental
+@require_prompt_registry
+def set_prompt_alias(name: str, alias: str, version: int) -> None:
+    """
+    Set an alias for a :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
+
+    Args:
+        name: The name of the prompt.
+        alias: The alias to set for the prompt.
+        version: The version of the prompt.
+
+    Example:
+
+    .. code-block:: python
+
+        import mlflow
+
+        # Set an alias for the prompt
+        mlflow.genai.set_prompt_alias(name="my_prompt", version=1, alias="production")
+
+        # Load the prompt by alias (use "@" to specify the alias)
+        prompt = mlflow.genai.load_prompt("prompts:/my_prompt@production")
+
+        # Switch the alias to a new version of the prompt
+        mlflow.genai.set_prompt_alias(name="my_prompt", version=2, alias="production")
+
+        # Delete the alias
+        mlflow.genai.delete_prompt_alias(name="my_prompt", alias="production")
+    """
+    with suppress_genai_migration_warning():
+        return registry_api.set_prompt_alias(name=name, version=version, alias=alias)
+
+
+@experimental
+@require_prompt_registry
+def delete_prompt_alias(name: str, alias: str) -> None:
+    """
+    Delete an alias for a :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
+
+    Args:
+        name: The name of the prompt.
+        alias: The alias to delete for the prompt.
+    """
+    with suppress_genai_migration_warning():
+        return registry_api.delete_prompt_alias(name=name, alias=alias)

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -28,7 +28,6 @@ def register_prompt(
     name: str,
     template: str,
     commit_message: Optional[str] = None,
-    version_metadata: Optional[dict[str, str]] = None,
     tags: Optional[dict[str, str]] = None,
 ) -> PromptVersion:
     """
@@ -61,15 +60,9 @@ def register_prompt(
 
         commit_message: A message describing the changes made to the prompt, similar to a
             Git commit message. Optional.
-        version_metadata: A dictionary of metadata associated with the **prompt version**.
+        tags: A dictionary of tags associated with the **prompt version**.
             This is useful for storing version-specific information, such as the author of
             the changes. Optional.
-        tags: A dictionary of tags associated with the entire prompt. This is different from
-            the `version_metadata` as it is not tied to a specific version of the prompt,
-            but to the prompt as a whole. For example, you can use tags to add an application
-            name for which the prompt is created. Since the application uses the prompt in
-            multiple versions, it makes sense to use tags instead of version-specific metadata.
-            Optional.
 
     Returns:
         A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
@@ -84,11 +77,10 @@ def register_prompt(
         mlflow.genai.register_prompt(
             name="my_prompt",
             template="Respond to the user's message as a {{style}} AI.",
-            version_metadata={"author": "Alice"},
         )
 
         # Load the prompt from the registry
-        prompt = mlflow.genai.load_prompt("my_prompt")
+        prompt = mlflow.load_prompt("my_prompt")
 
         # Use the prompt in your application
         import openai
@@ -107,7 +99,7 @@ def register_prompt(
             name="my_prompt",
             template="Respond to the user's message as a {{style}} AI. {{greeting}}",
             commit_message="Add a greeting to the prompt.",
-            version_metadata={"author": "Bob"},
+            tags={"author": "Bob"},
         )
     """
     with suppress_genai_migration_warning():
@@ -116,7 +108,6 @@ def register_prompt(
             template=template,
             commit_message=commit_message,
             tags=tags,
-            version_metadata=version_metadata,
         )
 
 

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -32,7 +32,6 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import active_run, get_active_model_id
 from mlflow.utils import get_results_from_paginated_fn, mlflow_tags
-from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
     _construct_databricks_uc_registered_model_url,
     get_workspace_id,
@@ -525,7 +524,6 @@ def set_model_version_tag(
     )
 
 
-@experimental
 @require_prompt_registry
 def register_prompt(
     name: str,
@@ -616,7 +614,7 @@ def register_prompt(
     warnings.warn(
         PROMPT_API_MIGRATION_MSG.format(func_name="register_prompt"),
         category=FutureWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
 
     return MlflowClient().register_prompt(
@@ -636,7 +634,7 @@ def search_prompts(
     warnings.warn(
         PROMPT_API_MIGRATION_MSG.format(func_name="search_prompts"),
         category=FutureWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
 
     def pagination_wrapper_func(number_to_get, next_page_token):
@@ -651,7 +649,6 @@ def search_prompts(
     )
 
 
-@experimental
 @require_prompt_registry
 def load_prompt(
     name_or_uri: str,
@@ -694,7 +691,7 @@ def load_prompt(
     warnings.warn(
         PROMPT_API_MIGRATION_MSG.format(func_name="load_prompt"),
         category=FutureWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
 
     client = MlflowClient()
@@ -752,7 +749,6 @@ def load_prompt(
     return prompt
 
 
-@experimental
 @require_prompt_registry
 def set_prompt_alias(name: str, alias: str, version: int) -> None:
     """
@@ -784,13 +780,12 @@ def set_prompt_alias(name: str, alias: str, version: int) -> None:
     warnings.warn(
         PROMPT_API_MIGRATION_MSG.format(func_name="set_prompt_alias"),
         category=FutureWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
 
     MlflowClient().set_prompt_alias(name=name, version=version, alias=alias)
 
 
-@experimental
 @require_prompt_registry
 def delete_prompt_alias(name: str, alias: str) -> None:
     """
@@ -803,7 +798,7 @@ def delete_prompt_alias(name: str, alias: str) -> None:
     warnings.warn(
         PROMPT_API_MIGRATION_MSG.format(func_name="delete_prompt_alias"),
         category=FutureWarning,
-        stacklevel=2,
+        stacklevel=3,
     )
 
     MlflowClient().delete_prompt_alias(name=name, alias=alias)

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -613,7 +613,11 @@ def register_prompt(
             version_metadata={"author": "Bob"},
         )
     """
-    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="register_prompt"), FutureWarning)
+    warnings.warn(
+        PROMPT_API_MIGRATION_MSG.format(func_name="register_prompt"),
+        category=FutureWarning,
+        stacklevel=2,
+    )
 
     return MlflowClient().register_prompt(
         name=name,
@@ -629,7 +633,11 @@ def search_prompts(
     filter_string: Optional[str] = None,
     max_results: Optional[int] = None,
 ) -> PagedList[Prompt]:
-    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="search_prompts"), FutureWarning)
+    warnings.warn(
+        PROMPT_API_MIGRATION_MSG.format(func_name="search_prompts"),
+        category=FutureWarning,
+        stacklevel=2,
+    )
 
     def pagination_wrapper_func(number_to_get, next_page_token):
         return MlflowClient().search_prompts(
@@ -683,7 +691,11 @@ def load_prompt(
         prompt = mlflow.load_prompt("prompts:/my_prompt@production")
 
     """
-    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="load_prompt"), FutureWarning)
+    warnings.warn(
+        PROMPT_API_MIGRATION_MSG.format(func_name="load_prompt"),
+        category=FutureWarning,
+        stacklevel=2,
+    )
 
     client = MlflowClient()
 
@@ -769,7 +781,11 @@ def set_prompt_alias(name: str, alias: str, version: int) -> None:
         # Delete the alias
         mlflow.delete_prompt_alias(name="my_prompt", alias="production")
     """
-    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="set_prompt_alias"), FutureWarning)
+    warnings.warn(
+        PROMPT_API_MIGRATION_MSG.format(func_name="set_prompt_alias"),
+        category=FutureWarning,
+        stacklevel=2,
+    )
 
     MlflowClient().set_prompt_alias(name=name, version=version, alias=alias)
 
@@ -784,6 +800,10 @@ def delete_prompt_alias(name: str, alias: str) -> None:
         name: The name of the prompt.
         alias: The alias to delete for the prompt.
     """
-    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="delete_prompt_alias"), FutureWarning)
+    warnings.warn(
+        PROMPT_API_MIGRATION_MSG.format(func_name="delete_prompt_alias"),
+        category=FutureWarning,
+        stacklevel=2,
+    )
 
     MlflowClient().delete_prompt_alias(name=name, alias=alias)

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -2,6 +2,7 @@ import json
 import logging
 import threading
 import uuid
+import warnings
 from typing import Any, Optional, Union
 
 import mlflow
@@ -10,7 +11,10 @@ from mlflow.entities.model_registry import ModelVersion, Prompt, PromptVersion, 
 from mlflow.entities.run import Run
 from mlflow.environment_variables import MLFLOW_PRINT_MODEL_URLS_ON_CREATION
 from mlflow.exceptions import MlflowException
-from mlflow.prompt.registry_utils import parse_prompt_name_or_uri, require_prompt_registry
+from mlflow.prompt.registry_utils import (
+    parse_prompt_name_or_uri,
+    require_prompt_registry,
+)
 from mlflow.protos.databricks_pb2 import (
     ALREADY_EXISTS,
     NOT_FOUND,
@@ -40,6 +44,13 @@ from mlflow.utils.logging_utils import eprint
 from mlflow.utils.uri import is_databricks_unity_catalog_uri
 
 _logger = logging.getLogger(__name__)
+
+
+PROMPT_API_MIGRATION_MSG = (
+    "The `mlflow.{func_name}` API is moved to the `mlflow.genai` namespace. Please use "
+    "`mlflow.genai.{func_name}` instead. The original API will be removed in the "
+    "future release."
+)
 
 
 def register_model(
@@ -602,6 +613,8 @@ def register_prompt(
             version_metadata={"author": "Bob"},
         )
     """
+    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="register_prompt"), FutureWarning)
+
     return MlflowClient().register_prompt(
         name=name,
         template=template,
@@ -616,6 +629,8 @@ def search_prompts(
     filter_string: Optional[str] = None,
     max_results: Optional[int] = None,
 ) -> PagedList[Prompt]:
+    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="search_prompts"), FutureWarning)
+
     def pagination_wrapper_func(number_to_get, next_page_token):
         return MlflowClient().search_prompts(
             filter_string=filter_string, max_results=number_to_get, page_token=next_page_token
@@ -668,6 +683,8 @@ def load_prompt(
         prompt = mlflow.load_prompt("prompts:/my_prompt@production")
 
     """
+    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="load_prompt"), FutureWarning)
+
     client = MlflowClient()
 
     # Use utility to handle URI vs name+version parsing
@@ -752,6 +769,7 @@ def set_prompt_alias(name: str, alias: str, version: int) -> None:
         # Delete the alias
         mlflow.delete_prompt_alias(name="my_prompt", alias="production")
     """
+    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="set_prompt_alias"), FutureWarning)
 
     MlflowClient().set_prompt_alias(name=name, version=version, alias=alias)
 
@@ -766,4 +784,6 @@ def delete_prompt_alias(name: str, alias: str) -> None:
         name: The name of the prompt.
         alias: The alias to delete for the prompt.
     """
+    warnings.warn(PROMPT_API_MIGRATION_MSG.format(func_name="delete_prompt_alias"), FutureWarning)
+
     MlflowClient().delete_prompt_alias(name=name, alias=alias)

--- a/tests/genai/prompts/test_prompts.py
+++ b/tests/genai/prompts/test_prompts.py
@@ -1,0 +1,40 @@
+import warnings
+from contextlib import contextmanager
+
+import pytest
+
+import mlflow
+
+
+@contextmanager
+def no_future_warning():
+    with warnings.catch_warnings():
+        # Translate future warning into an exception
+        warnings.simplefilter("error", FutureWarning)
+        yield
+
+
+def test_suppress_prompt_api_migration_warning():
+    with no_future_warning():
+        mlflow.genai.register_prompt("test_prompt", "test_template")
+        mlflow.genai.search_prompts()
+        mlflow.genai.load_prompt("prompts:/test_prompt/1")
+        mlflow.genai.set_prompt_alias("test_prompt", "test_alias", 1)
+        mlflow.genai.delete_prompt_alias("test_prompt", "test_alias")
+
+
+def test_prompt_api_migration_warning():
+    with pytest.warns(FutureWarning, match="The `mlflow.register_prompt` API is"):
+        mlflow.register_prompt("test_prompt", "test_template")
+
+    with pytest.warns(FutureWarning, match="The `mlflow.search_prompts` API is"):
+        mlflow.search_prompts()
+
+    with pytest.warns(FutureWarning, match="The `mlflow.load_prompt` API is"):
+        mlflow.load_prompt("prompts:/test_prompt/1")
+
+    with pytest.warns(FutureWarning, match="The `mlflow.set_prompt_alias` API is"):
+        mlflow.set_prompt_alias("test_prompt", "test_alias", 1)
+
+    with pytest.warns(FutureWarning, match="The `mlflow.delete_prompt_alias` API is"):
+        mlflow.delete_prompt_alias("test_prompt", "test_alias")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16174?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16174/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16174/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16174/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Title

Doc update follows once the MLflow 3 doc PR is landed soon

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1052" alt="Screenshot 2025-06-10 at 17 12 34" src="https://github.com/user-attachments/assets/eea0b64f-a5ad-4434-89b4-b2c4095c2f71" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow Prompt Registry API is moved under `mlflow.genai` namaspace, e.g. `mlflow.load_prompt` -> `mlflow.genai.load_prompt`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
