### PR TITLE
address lack of categorical dtype #3849 #12910

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -351,3 +351,6 @@ filterwarnings = [
   "error::pytest.PytestCollectionWarning",
 ]
 timeout = 1200
+markers = [
+    "categorical: marks tests as related to categorical data type support",
+]

--- a/tests/models/test_model_signatures_and_types.py
+++ b/tests/models/test_model_signatures_and_types.py
@@ -1,0 +1,164 @@
+import pandas as pd
+import numpy as np
+import pytest
+
+from mlflow.models import infer_signature
+from mlflow.models.utils import _enforce_schema
+from mlflow.types.schema import DataType, ColSpec, Schema
+from mlflow.exceptions import MlflowException
+
+
+@pytest.mark.categorical
+def test_datatype_from_type_with_categorical():
+    """
+    Tests that DataType.from_type correctly maps pandas CategoricalDtype to DataType.category.
+    """
+    assert DataType.from_type(pd.CategoricalDtype()) == DataType.category
+    assert DataType.category.to_pandas() == pd.CategoricalDtype
+    assert DataType.category.to_numpy() == np.dtype("object")
+    assert DataType.category.to_python() == str
+
+
+@pytest.mark.categorical
+def test_infer_signature_with_categorical_column():
+    """
+    Tests that infer_signature correctly infers DataType.category for pandas categorical columns.
+    """
+    df = pd.DataFrame({
+        "col_str": ["A", "B", "C"],
+        "col_cat": pd.Series(["X", "Y", "X"], dtype="category"),
+        "col_int": [1, 2, 3]
+    })
+
+    signature = infer_signature(df)
+    assert signature is not None
+    assert len(signature.inputs.inputs) == 3
+
+    # Check col_str
+    assert signature.inputs.inputs[0].name == "col_str"
+    assert signature.inputs.inputs[0].type == DataType.string
+
+    # Check col_cat
+    assert signature.inputs.inputs[1].name == "col_cat"
+    assert signature.inputs.inputs[1].type == DataType.category
+
+    # Check col_int
+    assert signature.inputs.inputs[2].name == "col_int"
+    assert signature.inputs.inputs[2].type == DataType.long
+
+
+@pytest.mark.categorical
+def test_enforce_schema_with_categorical_column_conversion():
+    """
+    Tests that _enforce_schema correctly converts a string column to a categorical column
+    when the schema expects DataType.category.
+    """
+    # Schema expecting a categorical column
+    schema = Schema([
+        ColSpec(type=DataType.string, name="col_str"),
+        ColSpec(type=DataType.category, name="col_cat"),
+        ColSpec(type=DataType.long, name="col_int")
+    ])
+
+    # Input DataFrame with a string column that should be converted to categorical
+    input_df = pd.DataFrame({
+        "col_str": ["hello", "world"],
+        "col_cat": ["apple", "banana"],  # This will be converted to category
+        "col_int": [10, 20]
+    })
+
+    enforced_df = _enforce_schema(input_df, schema)
+
+    assert isinstance(enforced_df, pd.DataFrame)
+    assert enforced_df["col_str"].dtype == object # string type in pandas is object
+    assert isinstance(enforced_df["col_cat"].dtype, pd.CategoricalDtype)
+    assert enforced_df["col_int"].dtype == np.int64
+
+
+@pytest.mark.categorical
+def test_enforce_schema_with_already_categorical_column():
+    """
+    Tests that _enforce_schema handles an already categorical column correctly.
+    """
+    schema = Schema([
+        ColSpec(type=DataType.category, name="col_cat")
+    ])
+
+    input_df = pd.DataFrame({
+        "col_cat": pd.Series(["red", "green", "blue"], dtype="category")
+    })
+
+    enforced_df = _enforce_schema(input_df, schema)
+
+    assert isinstance(enforced_df, pd.DataFrame)
+    assert isinstance(enforced_df["col_cat"].dtype, pd.CategoricalDtype)
+    pd.testing.assert_series_equal(input_df["col_cat"], enforced_df["col_cat"])
+
+
+@pytest.mark.categorical
+def test_enforce_schema_categorical_with_unseen_categories():
+    """
+    Tests _enforce_schema behavior when input has unseen categories.
+    Since DataType.category doesn't store categories, pandas' default `astype('category')`
+    behavior (which infers new categories from the data) is expected.
+    """
+    schema = Schema([
+        ColSpec(type=DataType.category, name="col_cat")
+    ])
+
+    # Create an initial categorical series to simulate original data
+    original_categories = pd.CategoricalDtype(categories=["A", "B"])
+    input_df = pd.DataFrame({
+        "col_cat": pd.Series(["A", "C"], dtype=object) # 'C' is unseen
+    })
+
+    # When converting to 'category' without specifying categories, pandas will infer them
+    # from the input data.
+    enforced_df = _enforce_schema(input_df, schema)
+
+    assert isinstance(enforced_df, pd.DataFrame)
+    assert isinstance(enforced_df["col_cat"].dtype, pd.CategoricalDtype)
+    # The categories in the enforced DataFrame should now include 'C'
+    assert "A" in enforced_df["col_cat"].cat.categories
+    assert "C" in enforced_df["col_cat"].cat.categories
+    assert "B" not in enforced_df["col_cat"].cat.categories # 'B' was not in input_df
+
+
+@pytest.mark.categorical
+def test_enforce_schema_categorical_with_nan_values():
+    """
+    Tests _enforce_schema with categorical columns containing NaN values.
+    """
+    schema = Schema([
+        ColSpec(type=DataType.category, name="col_cat")
+    ])
+
+    input_df = pd.DataFrame({
+        "col_cat": pd.Series(["X", np.nan, "Y"], dtype="category")
+    })
+
+    enforced_df = _enforce_schema(input_df, schema)
+
+    assert isinstance(enforced_df, pd.DataFrame)
+    assert isinstance(enforced_df["col_cat"].dtype, pd.CategoricalDtype)
+    assert enforced_df["col_cat"].isnull().any()
+    assert enforced_df["col_cat"].cat.categories.tolist() == ["X", "Y"]
+
+
+@pytest.mark.categorical
+def test_enforce_schema_categorical_type_mismatch_error():
+    """
+    Tests that _enforce_schema raises an error for incompatible type conversion to categorical.
+    """
+    schema = Schema([
+        ColSpec(type=DataType.category, name="col_cat")
+    ])
+
+    # Attempt to convert a numeric column to categorical, which is not a safe conversion
+    input_df = pd.DataFrame({
+        "col_cat": [1, 2, 3]
+    })
+
+    with pytest.raises(MlflowException, match="Incompatible input types for column col_cat"):
+        _enforce_schema(input_df, schema)
+

--- a/tests/xgboost/test_xgboost_categorical.py
+++ b/tests/xgboost/test_xgboost_categorical.py
@@ -1,0 +1,248 @@
+import pytest
+import pandas as pd
+import numpy as np
+import xgboost as xgb
+import mlflow
+from mlflow.models import infer_signature
+from mlflow.pyfunc import PyFuncModel
+from mlflow.types.schema import DataType, ColSpec, Schema
+from mlflow.exceptions import MlflowException
+import os
+
+
+@pytest.fixture(scope="module")
+def xgb_model_with_categorical():
+    """Fixture for a simple XGBoost model trained with a categorical feature."""
+    # Create a DataFrame with a categorical column
+    data = {
+        "feature1": [10, 20, 30, 40, 50],
+        "categorical_feature": pd.Series(["A", "B", "A", "C", "B"], dtype="category"),
+        "target": [0, 1, 0, 1, 0]
+    }
+    df = pd.DataFrame(data)
+
+    X = df[["feature1", "categorical_feature"]]
+    y = df["target"]
+
+    # Convert categorical to codes for XGBoost if not using native categorical support
+    # For simplicity, we'll use one-hot encoding or label encoding if XGBoost version
+    # doesn't natively support pandas categorical.
+    # However, with recent XGBoost versions, it can handle pandas categorical directly
+    # if `enable_categorical=True` is set in DMatrix or model parameters.
+    # For testing schema enforcement, we just need the DataFrame to have the dtype.
+
+    # Simple XGBoost model (Booster API)
+    dtrain = xgb.DMatrix(X, label=y, enable_categorical=True)
+    params = {"objective": "binary:logistic", "eval_metric": "logloss", "enable_categorical": True}
+    model = xgb.train(params, dtrain, num_boost_round=5)
+    return model, X, y
+
+
+@pytest.fixture(scope="module")
+def xgb_sklearn_model_with_categorical():
+    """Fixture for an XGBoost scikit-learn model trained with a categorical feature."""
+    data = {
+        "feature1": [10, 20, 30, 40, 50],
+        "categorical_feature": pd.Series(["A", "B", "A", "C", "B"], dtype="category"),
+        "target": [0, 1, 0, 1, 0]
+    }
+    df = pd.DataFrame(data)
+
+    X = df[["feature1", "categorical_feature"]]
+    y = df["target"]
+
+    # XGBClassifier (scikit-learn API)
+    model = xgb.XGBClassifier(objective="binary:logistic", enable_categorical=True, random_state=42)
+    model.fit(X, y)
+    return model, X, y
+
+
+@pytest.mark.categorical
+def test_log_and_load_xgboost_model_with_categorical_feature(tmp_path, xgb_model_with_categorical):
+    """
+    Tests logging and loading an XGBoost model with a categorical feature,
+    and verifies schema inference and pyfunc prediction.
+    """
+    model, X, y = xgb_model_with_categorical
+    model_path = os.path.join(tmp_path, "xgb_cat_model")
+
+    # Log the model
+    with mlflow.start_run() as run:
+        # Pass enable_categorical=True when creating DMatrix for prediction during signature inference
+        mlflow.xgboost.log_model(
+            xgb_model=model,
+            artifact_path="model",
+            input_example=X.head(2),
+            signature=infer_signature(X, model.predict(xgb.DMatrix(X, enable_categorical=True))),
+        )
+        model_uri = f"runs:/{run.info.run_id}/model"
+
+    # Load the model as pyfunc
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_uri)
+    assert isinstance(loaded_pyfunc_model, PyFuncModel)
+
+    # Verify the signature
+    signature = loaded_pyfunc_model.metadata.signature
+    assert signature is not None
+    assert len(signature.inputs.inputs) == 2
+    assert signature.inputs.inputs[0].name == "feature1"
+    assert signature.inputs.inputs[0].type == DataType.long
+    assert signature.inputs.inputs[1].name == "categorical_feature"
+    assert signature.inputs.inputs[1].type == DataType.category
+
+    # Prepare inference data
+    inference_data = pd.DataFrame({
+        "feature1": [15, 25],
+        "categorical_feature": pd.Series(["A", "C"], dtype="category")
+    })
+
+    # Perform prediction
+    predictions = loaded_pyfunc_model.predict(inference_data)
+    assert predictions is not None
+    assert len(predictions) == 2
+
+
+@pytest.mark.categorical
+def test_log_and_load_xgboost_sklearn_model_with_categorical_feature(tmp_path, xgb_sklearn_model_with_categorical):
+    """
+    Tests logging and loading an XGBoost scikit-learn model with a categorical feature,
+    and verifies schema inference and pyfunc prediction.
+    """
+    model, X, y = xgb_sklearn_model_with_categorical
+    model_path = os.path.join(tmp_path, "xgb_sklearn_cat_model")
+
+    # Log the model
+    with mlflow.start_run() as run:
+        mlflow.xgboost.log_model(
+            xgb_model=model,
+            artifact_path="model",
+            input_example=X.head(2),
+            signature=infer_signature(X, model.predict(X)),
+        )
+        model_uri = f"runs:/{run.info.run_id}/model"
+
+    # Load the model as pyfunc
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_uri)
+    assert isinstance(loaded_pyfunc_model, PyFuncModel)
+
+    # Verify the signature
+    signature = loaded_pyfunc_model.metadata.signature
+    assert signature is not None
+    assert len(signature.inputs.inputs) == 2
+    assert signature.inputs.inputs[0].name == "feature1"
+    assert signature.inputs.inputs[0].type == DataType.long
+    assert signature.inputs.inputs[1].name == "categorical_feature"
+    assert signature.inputs.inputs[1].type == DataType.category
+
+    # Prepare inference data
+    inference_data = pd.DataFrame({
+        "feature1": [15, 25],
+        "categorical_feature": pd.Series(["A", "C"], dtype="category")
+    })
+
+    # Perform prediction
+    predictions = loaded_pyfunc_model.predict(inference_data)
+    assert predictions is not None
+    assert len(predictions) == 2
+
+
+@pytest.mark.categorical
+def test_pyfunc_predict_with_unseen_categories(tmp_path, xgb_model_with_categorical):
+    """
+    Tests pyfunc prediction with unseen categories in the input data.
+    Expects pandas' default behavior (adding new categories to the CategoricalDtype).
+    """
+    model, X, y = xgb_model_with_categorical
+    model_path = os.path.join(tmp_path, "xgb_unseen_cat_model")
+
+    with mlflow.start_run() as run:
+        mlflow.xgboost.log_model(
+            xgb_model=model,
+            artifact_path="model",
+            input_example=X.head(2),
+            signature=infer_signature(X, model.predict(xgb.DMatrix(X, enable_categorical=True))),
+        )
+        model_uri = f"runs:/{run.info.run_id}/model"
+
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_uri)
+
+    # Inference data with an unseen category 'D'
+    inference_data = pd.DataFrame({
+        "feature1": [100],
+        "categorical_feature": pd.Series(["D"], dtype=object) # Use object dtype to simulate raw input
+    })
+
+    predictions = loaded_pyfunc_model.predict(inference_data)
+    assert predictions is not None
+    assert len(predictions) == 1
+
+    # Verify that the categorical column in the enforced input (internal to pyfunc)
+    # now contains 'D' in its categories. This is pandas' default behavior.
+    # To inspect this, we'd need to mock or inspect internal calls, but for now,
+    # successful prediction implies the conversion happened.
+    # A more robust test would involve a custom pyfunc model that logs the dtype of its input.
+
+
+@pytest.mark.categorical
+def test_pyfunc_predict_with_categorical_nan_values(tmp_path, xgb_model_with_categorical):
+    """
+    Tests pyfunc prediction with NaN values in a categorical column.
+    """
+    model, X, y = xgb_model_with_categorical
+    model_path = os.path.join(tmp_path, "xgb_nan_cat_model")
+
+    # Add NaN to the original categorical feature for logging
+    X_with_nan = X.copy()
+    X_with_nan.loc[0, "categorical_feature"] = np.nan
+    X_with_nan["categorical_feature"] = X_with_nan["categorical_feature"].astype("category")
+
+    with mlflow.start_run() as run:
+        mlflow.xgboost.log_model(
+            xgb_model=model,
+            artifact_path="model",
+            input_example=X_with_nan.head(2),
+            signature=infer_signature(X_with_nan, model.predict(xgb.DMatrix(X_with_nan, enable_categorical=True))),
+        )
+        model_uri = f"runs:/{run.info.run_id}/model"
+
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_uri)
+
+    # Inference data with NaN
+    inference_data = pd.DataFrame({
+        "feature1": [150],
+        "categorical_feature": pd.Series([np.nan], dtype="category")
+    })
+
+    predictions = loaded_pyfunc_model.predict(inference_data)
+    assert predictions is not None
+    assert len(predictions) == 1
+
+
+@pytest.mark.categorical
+def test_pyfunc_predict_with_mixed_data_types(tmp_path, xgb_model_with_categorical):
+    """
+    Tests pyfunc prediction with mixed numerical and categorical data types.
+    """
+    model, X, y = xgb_model_with_categorical
+    model_path = os.path.join(tmp_path, "xgb_mixed_model")
+
+    with mlflow.start_run() as run:
+        mlflow.xgboost.log_model(
+            xgb_model=model,
+            artifact_path="model",
+            input_example=X.head(2),
+            signature=infer_signature(X, model.predict(xgb.DMatrix(X, enable_categorical=True))),
+        )
+        model_uri = f"runs:/{run.info.run_id}/model"
+
+    loaded_pyfunc_model = mlflow.pyfunc.load_model(model_uri)
+
+    inference_data = pd.DataFrame({
+        "feature1": [55, 65],
+        "categorical_feature": pd.Series(["A", "B"], dtype="category")
+    })
+
+    predictions = loaded_pyfunc_model.predict(inference_data)
+    assert predictions is not None
+    assert len(predictions) == 2
+


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mattharrison/mlflow/pull/16194?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16194/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16194/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16194/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
< Resolve > #3849 #12910

### What changes are proposed in this pull request?

This change adds categorical types in XGBoost

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ X ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users can know use XGBoost models with categorical features

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. 

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.


</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
