### PR TITLE
Fix footer image CSS processing

### DIFF
--- a/docs/src/components/Footer/Footer.tsx
+++ b/docs/src/components/Footer/Footer.tsx
@@ -1,26 +1,31 @@
 import { cva, type VariantProps, cx } from "class-variance-authority";
 
 import Logo from "@site/static/images/mlflow-logo-white.svg";
+import BlueBg from "@site/static/images/footer-blue-bg.png";
+import RedBg from "@site/static/images/footer-red-bg.png";
+import ColorfulBg from "@site/static/images/footer-colorful-bg.png";
 import useBaseUrl from '@docusaurus/useBaseUrl';
 
 import { FooterMenuItem } from "../FooterMenuItem/FooterMenuItem";
 
 const footerVariants = cva(
-  "pb-150 flex flex-col pt-37 bg-linear-to-b from-brand-black to-brand-black bg-bottom bg-no-repeat bg-cover w-full bg-(--background-color-dark)",
-  {
-    variants: {
-      variant: {
-        blue: ` bg-[url('/images/footer-blue-bg.png')] bg-size-[100%_340px]`,
-        red: `bg-[url('/images/footer-red-bg.png')] bg-size-[100%_340px]`,
-        colorful: `bg-[url('/images/footer-colorful-bg.png')] bg-size-[100%_340px]`,
-      },
-    },
-  },
+  "pb-150 flex flex-col pt-37 bg-linear-to-b from-brand-black to-brand-black bg-bottom bg-no-repeat bg-cover w-full bg-(--background-color-dark) bg-size-[100%_340px]",
 );
 
-export const Footer = ({ variant }: VariantProps<typeof footerVariants>) => {
+const getBackgroundImage = (variant: "blue" | "red" | "colorful") => {
+  switch (variant) {
+    case "blue":
+      return BlueBg;
+    case "red":
+      return RedBg;
+    case "colorful":
+      return ColorfulBg;
+  }
+};
+
+export const Footer = ({ variant }: { variant: "blue" | "red" | "colorful" }) => {
   return (
-    <footer className={cx(footerVariants({ variant }))}>
+    <footer className={cx(footerVariants())} style={{ backgroundImage: `url(${getBackgroundImage(variant)})` }}>
       <div className="flex flex-row justify-between items-start md:items-center px-6 lg:px-20 gap-10 xs:gap-0 max-w-container">
         <Logo className="h-[36px] shrink-0" />
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/16198?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16198/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16198/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16198/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Still unsure of the exact cause, but it looks like using `url(...)` as a tailwind className causes issues with docusaurus (generated CSS is not guaranteed to have the correct path). 

It appears to be partially a caching issue but also probably there is some CSS postprocessing problems happening due to interactions between tailwind and docusaurus. To avoid these entirely, i move the CSS for loading the background image into a static `style` definition.

This avoids putting the URL in a generated CSS file, instead having it declared inline on the element.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Validated that the CSS file no longer contains code for the background image, and that the definition is in `style` instead:

<img width="1728" alt="Screenshot 2025-06-11 at 3 31 12 PM" src="https://github.com/user-attachments/assets/7eae6a9e-f044-4f9c-88a2-4a30002a5f22" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
