### PR TITLE
Sync footer from mlflow-website with custom changes

### DIFF
--- a/docs/src/components/Footer/Footer.tsx
+++ b/docs/src/components/Footer/Footer.tsx
@@ -34,7 +34,7 @@ export const Footer = ({ variant }: { variant: "blue" | "red" | "colorful" }) =>
           </div>
         </div>
 
-        <div className="flex flex-col flex-wrap justify-end md:text-right md:flex-row gap-x-10 gap-y-5 w-2/5 md:w-auto md:pt-2">
+        <div className="flex flex-col flex-wrap justify-end md:text-right md:flex-row gap-x-10 lg:gap-x-20 gap-y-5 w-2/5 md:w-auto md:pt-2 max-w-fit">
           {/* these routes are on the main mlflow.org site, which is hosted in a different repo */}
           <FooterMenuItem href="https://mllfow.org">Components</FooterMenuItem>
           <FooterMenuItem href="https://mlflow.org/releases">Releases</FooterMenuItem>

--- a/docs/src/components/Footer/Footer.tsx
+++ b/docs/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { cva, type VariantProps, cx } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 
 import Logo from "@site/static/images/mlflow-logo-white.svg";
 import BlueBg from "@site/static/images/footer-blue-bg.png";
@@ -9,7 +9,7 @@ import useBaseUrl from '@docusaurus/useBaseUrl';
 import { FooterMenuItem } from "../FooterMenuItem/FooterMenuItem";
 
 const footerVariants = cva(
-  "pb-150 flex flex-col pt-37 bg-linear-to-b from-brand-black to-brand-black bg-bottom bg-no-repeat bg-cover w-full bg-(--background-color-dark) bg-size-[100%_340px]",
+  "pb-30 flex flex-col pt-30 bg-bottom bg-no-repeat bg-cover bg-size-[auto_360px] 2xl:bg-size-[100%_360px]",
 );
 
 const getBackgroundImage = (variant: "blue" | "red" | "colorful") => {
@@ -25,17 +25,23 @@ const getBackgroundImage = (variant: "blue" | "red" | "colorful") => {
 
 export const Footer = ({ variant }: { variant: "blue" | "red" | "colorful" }) => {
   return (
-    <footer className={cx(footerVariants())} style={{ backgroundImage: `url(${getBackgroundImage(variant)})` }}>
-      <div className="flex flex-row justify-between items-start md:items-center px-6 lg:px-20 gap-10 xs:gap-0 max-w-container">
-        <Logo className="h-[36px] shrink-0" />
+    <footer className={footerVariants()} style={{ backgroundImage: `linear-gradient(#0e1414 60%,#0c141400 90% 100%),url(${getBackgroundImage(variant)})` }}>
+      <div className="flex flex-row justify-between items-start px-6 lg:px-20 gap-10 xs:gap-0 max-w-container">
+        <div className="flex flex-col gap-8">
+          <Logo className="h-[36px] shrink-0" />
+          <div className="text-xs text-[rgb(255_255_255_/_80%)] text-left md:text-nowrap md:w-0">
+            © 2025 MLflow Project, a Series of LF Projects, LLC.
+          </div>
+        </div>
 
-        <div className="flex flex-col md:flex-row gap-10">
+        <div className="flex flex-col flex-wrap justify-end md:text-right md:flex-row gap-x-10 gap-y-5 w-2/5 md:w-auto md:pt-2">
           {/* these routes are on the main mlflow.org site, which is hosted in a different repo */}
-          <FooterMenuItem href="https://mllfow.org">Product</FooterMenuItem>
+          <FooterMenuItem href="https://mllfow.org">Components</FooterMenuItem>
           <FooterMenuItem href="https://mlflow.org/releases">Releases</FooterMenuItem>
           <FooterMenuItem href="https://mlflow.org/blog">Blog</FooterMenuItem>
-          <FooterMenuItem href={useBaseUrl("/")}>
-            Docs
+          <FooterMenuItem href={useBaseUrl("/")}>Docs</FooterMenuItem>
+          <FooterMenuItem href="https://mlflow.org//ambassadors">
+            Ambassador Program
           </FooterMenuItem>
         </div>
       </div>

--- a/docs/src/components/FooterMenuItem/FooterMenuItem.module.css
+++ b/docs/src/components/FooterMenuItem/FooterMenuItem.module.css
@@ -6,6 +6,7 @@
 }
 
 .link:hover {
+  color: white;
   text-decoration: none;
 }
 

--- a/docs/src/components/FooterMenuItem/FooterMenuItem.module.css
+++ b/docs/src/components/FooterMenuItem/FooterMenuItem.module.css
@@ -1,5 +1,5 @@
 .link {
-  color: white;
+  color: rgb(255 255 255 / 80%);
   font-size: 15px;
   font-weight: 500;
   text-decoration: none;
@@ -10,5 +10,5 @@
 }
 
 .link:visited {
-  color: white;
+  color: rgb(255 255 255 / 80%);
 }

--- a/docs/src/components/FooterMenuItem/FooterMenuItem.tsx
+++ b/docs/src/components/FooterMenuItem/FooterMenuItem.tsx
@@ -6,7 +6,7 @@ import { cx } from "class-variance-authority";
 
 export const FooterMenuItem = ({ className, ...props }: ComponentProps<typeof Link>) => {
   return (
-    <div className="min-w-[120px]">
+    <div>
       <Link {...props} className={cx(className, styles.link)} />
     </div>
   );


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16209?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16209/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16209/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16209/merge
```

</p>
</details>

Signed-off-by: Fatih Altinok <fatihaltinok@live.com>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Sync footer component and styles from `mlflow-website` repo so they look the same.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

| Website | Docs |
|---------|------|
| <img width="1470" alt="Screenshot 2025-06-11 at 15 49 55" src="https://github.com/user-attachments/assets/b77eb107-797c-40c8-a173-884621119000" /> | <img width="1470" alt="Screenshot 2025-06-11 at 15 50 13" src="https://github.com/user-attachments/assets/db99c4d8-5fb4-4999-8e71-4dd19bb587fd" /> |


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
