### PR TITLE
Add `version` parameter to `experimental` decorator

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -404,11 +404,17 @@ class Linter(ast.NodeVisitor):
         linter.visit(tree)
         return [v for v in linter.violations if v.rule.name in config.example_rules]
 
+    def visit_decorator(self, node: ast.expr) -> None:
+        if rules.NonLiteralExperimentalVersion._check(node):
+            self._check(Location.from_node(node), rules.NonLiteralExperimentalVersion())
+
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.stack.append(node)
         self._no_rst(node)
         self._syntax_error_example(node)
         self._mlflow_class_name(node)
+        for deco in node.decorator_list:
+            self.visit_decorator(deco)
         self.generic_visit(node)
         self.stack.pop()
 
@@ -480,6 +486,8 @@ class Linter(ast.NodeVisitor):
 
         self.stack.append(node)
         self._no_rst(node)
+        for deco in node.decorator_list:
+            self.visit_decorator(deco)
         self.generic_visit(node)
         self.stack.pop()
 
@@ -492,6 +500,8 @@ class Linter(ast.NodeVisitor):
         self._pytest_mark_repeat(node)
         self.stack.append(node)
         self._no_rst(node)
+        for deco in node.decorator_list:
+            self.visit_decorator(deco)
         self.generic_visit(node)
         self.stack.pop()
 

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -437,28 +437,38 @@ class NonLiteralExperimentalVersion(Rule):
         Returns True if the `@experimental` decorator is used incorrectly.
         """
         if isinstance(node, ast.Name) and node.id == "experimental":
+            # The code looks like this:
+            # ---
+            # @experimental
+            # def my_function():
+            #     ...
+            # ---
+            # No `version` argument, invalid usage
             return True
 
         if not isinstance(node, ast.Call):
+            # Not a function call, ignore it
             return False
 
         if not isinstance(node.func, ast.Name):
+            # Not a simple function call, ignore it
             return False
 
         if node.func.id != "experimental":
+            # Not the `experimental` decorator, ignore it
             return False
 
         version = next((k.value for k in node.keywords if k.arg == "version"), None)
         if version is None:
-            # No `version` argument, so it's not a valid `@experimental` usage.
+            # No `version` argument, invalid usage
             return True
 
         if not isinstance(version, ast.Constant) or not isinstance(version.value, str):
-            # `version` is not a string literal, so it's not a valid `@experimental` usage.
+            # `version` is not a string literal, invalid usage
             return True
 
         if not _is_valid_version(version.value):
-            # `version` is not a valid semantic version, so it's not a valid `@experimental` usage.
+            # `version` is not a valid semantic version, # invalid usage
             return True
 
         return False

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -438,9 +438,9 @@ class NonLiteralExperimentalVersion(Rule):
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
             and node.func.id == "experimental"
+            # Check if the value is not a string literal that is a valid version.
             and (val := next(k.value for k in node.keywords if k.arg == "version"), None)
             and (
-                # Check if the value is not a string literal that is a valid version.
                 not isinstance(val, ast.Constant)
                 or not isinstance(val.value, str)
                 or not _is_valid_version(val.value)

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -438,7 +438,7 @@ class NonLiteralExperimentalVersion(Rule):
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
             and node.func.id == "experimental"
-            # Check if the value is a string literal that is a valid version.
+            # Check if the value is a string literal that represents a valid version.
             and (val := next(k.value for k in node.keywords if k.arg == "version"), None)
             and (
                 not isinstance(val, ast.Constant)

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -438,7 +438,7 @@ class NonLiteralExperimentalVersion(Rule):
             isinstance(node, ast.Call)
             and isinstance(node.func, ast.Name)
             and node.func.id == "experimental"
-            # Check if the value is not a string literal that is a valid version.
+            # Check if the value is a string literal that is a valid version.
             and (val := next(k.value for k in node.keywords if k.arg == "version"), None)
             and (
                 not isinstance(val, ast.Constant)

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -409,3 +409,11 @@ class PytestMarkRepeat(Rule):
             return True
 
         return False
+
+
+class NonLiteralExperimentalVersion(Rule):
+    def _id(self) -> str:
+        return "MLF0024"
+
+    def _message(self) -> str:
+        return "The `version` argument of `@experimental` must be a string literal."

--- a/mlflow/ag2/__init__.py
+++ b/mlflow/ag2/__init__.py
@@ -4,7 +4,7 @@ from mlflow.utils.autologging_utils import autologging_integration
 FLAVOR_NAME = "ag2"
 
 
-@experimental
+@experimental(version="3.0.0")
 def autolog(
     log_traces: bool = True,
     disable: bool = False,

--- a/mlflow/anthropic/__init__.py
+++ b/mlflow/anthropic/__init__.py
@@ -5,7 +5,7 @@ from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 FLAVOR_NAME = "anthropic"
 
 
-@experimental
+@experimental(version="2.19.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -18,7 +18,7 @@ from mlflow.utils.autologging_utils import (
 FLAVOR_NAME = "autogen"
 
 
-@experimental
+@experimental(version="2.16.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/bedrock/__init__.py
+++ b/mlflow/bedrock/__init__.py
@@ -8,7 +8,7 @@ _logger = logging.getLogger(__name__)
 FLAVOR_NAME = "bedrock"
 
 
-@experimental
+@experimental(version="2.20.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/crewai/__init__.py
+++ b/mlflow/crewai/__init__.py
@@ -18,7 +18,7 @@ _logger = logging.getLogger(__name__)
 FLAVOR_NAME = "crewai"
 
 
-@experimental
+@experimental(version="2.19.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -556,7 +556,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
             )
 
-    @experimental
+    @experimental(version="2.19.0")
     def update_endpoint_config(self, endpoint, config):
         """
         Update the configuration of a specified serving endpoint. See
@@ -616,7 +616,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
         )
 
-    @experimental
+    @experimental(version="2.19.0")
     def update_endpoint_tags(self, endpoint, config):
         """
         Update the tags of a specified serving endpoint. See
@@ -646,7 +646,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             method="PATCH", route=posixpath.join(endpoint, "tags"), json_body=config
         )
 
-    @experimental
+    @experimental(version="2.19.0")
     def update_endpoint_rate_limits(self, endpoint, config):
         """
         Update the rate limits of a specified serving endpoint.
@@ -682,7 +682,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             method="PUT", route=posixpath.join(endpoint, "rate-limits"), json_body=config
         )
 
-    @experimental
+    @experimental(version="2.19.0")
     def update_endpoint_ai_gateway(self, endpoint, config):
         """
         Update the AI Gateway configuration of a specified serving endpoint.

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -14,7 +14,7 @@ from mlflow.utils.autologging_utils import (
 )
 
 
-@experimental
+@experimental(version="2.18.0")
 def autolog(
     log_traces: bool = True,
     log_traces_from_compile: bool = False,

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -48,7 +48,7 @@ def _load_model(model_uri, dst_path=None):
     return loaded_wrapper
 
 
-@experimental
+@experimental(version="2.18.0")
 @trace_disabled  # Suppress traces for internal calls while loading model
 def load_model(model_uri, dst_path=None):
     """

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -70,7 +70,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-@experimental
+@experimental(version="2.18.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces for internal predict calls while logging model
 def save_model(
@@ -262,7 +262,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental
+@experimental(version="2.18.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces for internal predict calls while logging model
 def log_model(

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -30,7 +30,7 @@ PbValueType = Union[float, int, str, bool]
 FeedbackValueType = Union[PbValueType, dict[str, PbValueType], list[PbValueType]]
 
 
-@experimental
+@experimental(version="2.21.0")
 @dataclass
 class Assessment(_MlflowObject):
     """
@@ -168,7 +168,7 @@ class Assessment(_MlflowObject):
 DEFAULT_FEEDBACK_NAME = "feedback"
 
 
-@experimental
+@experimental(version="3.0.0")
 @dataclass
 class Feedback(Assessment):
     """
@@ -335,7 +335,7 @@ class Feedback(Assessment):
         return self.feedback.error.error_message if self.feedback.error else None
 
 
-@experimental
+@experimental(version="2.21.0")
 @dataclass
 class Expectation(Assessment):
     """
@@ -456,7 +456,7 @@ class Expectation(Assessment):
 _JSON_SERIALIZATION_FORMAT = "JSON_FORMAT"
 
 
-@experimental
+@experimental(version="3.0.0")
 @dataclass
 class ExpectationValue(_MlflowObject):
     """Represents an expectation value."""
@@ -513,7 +513,7 @@ class ExpectationValue(_MlflowObject):
         return self.value is not None and not isinstance(self.value, (int, float, bool, str))
 
 
-@experimental
+@experimental(version="2.21.0")
 @dataclass
 class FeedbackValue(_MlflowObject):
     """Represents a feedback value."""

--- a/mlflow/entities/assessment_error.py
+++ b/mlflow/entities/assessment_error.py
@@ -9,7 +9,7 @@ _STACK_TRACE_TRUNCATION_PREFIX = "[Stack trace is truncated]\n...\n"
 _STACK_TRACE_TRUNCATION_LENGTH = 1000
 
 
-@experimental
+@experimental(version="2.21.0")
 @dataclass
 class AssessmentError(_MlflowObject):
     """

--- a/mlflow/entities/assessment_source.py
+++ b/mlflow/entities/assessment_source.py
@@ -9,7 +9,7 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.annotations import experimental
 
 
-@experimental
+@experimental(version="2.21.0")
 @dataclass
 class AssessmentSource(_MlflowObject):
     """
@@ -95,7 +95,7 @@ class AssessmentSource(_MlflowObject):
         )
 
 
-@experimental
+@experimental(version="2.21.0")
 class AssessmentSourceType:
     SOURCE_TYPE_UNSPECIFIED = "SOURCE_TYPE_UNSPECIFIED"
     LLM_JUDGE = "LLM_JUDGE"

--- a/mlflow/gemini/__init__.py
+++ b/mlflow/gemini/__init__.py
@@ -12,7 +12,7 @@ from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 FLAVOR_NAME = "gemini"
 
 
-@experimental
+@experimental(version="2.19.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-@experimental
+@experimental(version="3.0.0")
 def evaluate(
     data: "EvaluationDatasetTypes",
     scorers: list[Scorer],
@@ -294,7 +294,7 @@ def evaluate(
         return result
 
 
-@experimental
+@experimental(version="3.0.0")
 def to_predict_fn(endpoint_uri: str) -> Callable:
     """
     Convert an endpoint URI to a predict function.

--- a/mlflow/genai/judges/databricks.py
+++ b/mlflow/genai/judges/databricks.py
@@ -347,7 +347,7 @@ def meets_guidelines(
     )
 
 
-@experimental
+@experimental(version="3.0.0")
 @requires_databricks_agents
 def custom_prompt_judge(
     *,

--- a/mlflow/genai/optimize/base.py
+++ b/mlflow/genai/optimize/base.py
@@ -30,7 +30,7 @@ _ALGORITHMS = {"DSPy/MIPROv2": _DSPyMIPROv2Optimizer}
 _logger = logging.getLogger(__name__)
 
 
-@experimental
+@experimental(version="3.0.0")
 def optimize_prompt(
     *,
     target_llm_params: LLMParams,

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -9,7 +9,7 @@ from mlflow.utils.annotations import experimental
 OBJECTIVE_FN = Callable[[dict[str, Union[bool, float, str, Feedback, list[Feedback]]]], float]
 
 
-@experimental
+@experimental(version="3.0.0")
 @dataclass
 class PromptOptimizationResult:
     """
@@ -22,7 +22,7 @@ class PromptOptimizationResult:
     prompt: Prompt
 
 
-@experimental
+@experimental(version="3.0.0")
 @dataclass
 class LLMParams:
     """
@@ -43,7 +43,7 @@ class LLMParams:
     temperature: Optional[float] = None
 
 
-@experimental
+@experimental(version="3.0.0")
 @dataclass
 class OptimizerConfig:
     """

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -22,7 +22,7 @@ def suppress_genai_migration_warning():
         yield
 
 
-@experimental
+@experimental(version="3.0.0")
 @require_prompt_registry
 def register_prompt(
     name: str,
@@ -111,7 +111,7 @@ def register_prompt(
         )
 
 
-@experimental
+@experimental(version="3.0.0")
 @require_prompt_registry
 def search_prompts(
     filter_string: Optional[str] = None,
@@ -121,7 +121,7 @@ def search_prompts(
         return registry_api.search_prompts(filter_string=filter_string, max_results=max_results)
 
 
-@experimental
+@experimental(version="3.0.0")
 @require_prompt_registry
 def load_prompt(
     name_or_uri: str, version: Optional[Union[str, int]] = None, allow_missing: bool = False
@@ -159,7 +159,7 @@ def load_prompt(
         )
 
 
-@experimental
+@experimental(version="3.0.0")
 @require_prompt_registry
 def set_prompt_alias(name: str, alias: str, version: int) -> None:
     """
@@ -192,7 +192,7 @@ def set_prompt_alias(name: str, alias: str, version: int) -> None:
         return registry_api.set_prompt_alias(name=name, version=version, alias=alias)
 
 
-@experimental
+@experimental(version="3.0.0")
 @require_prompt_registry
 def delete_prompt_alias(name: str, alias: str) -> None:
     """

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -10,7 +10,7 @@ _ERROR_MSG = (
 )
 
 
-@experimental
+@experimental(version="3.0.0")
 @dataclass()
 class ScorerScheduleConfig:
     """

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -85,7 +85,7 @@ class ScorerScheduleConfig:
 
 
 # Scheduled Scorer CRUD operations
-@experimental
+@experimental(version="3.0.0")
 def add_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
@@ -163,7 +163,7 @@ def add_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D41
     )
 
 
-@experimental
+@experimental(version="3.0.0")
 def update_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
@@ -223,7 +223,7 @@ def update_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: 
     )
 
 
-@experimental
+@experimental(version="3.0.0")
 def delete_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
@@ -273,7 +273,7 @@ def delete_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: 
     return delete_scheduled_scorer(experiment_id, scheduled_scorer_name, **kwargs)
 
 
-@experimental
+@experimental(version="3.0.0")
 def get_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorer_name: str,
@@ -317,7 +317,7 @@ def get_scheduled_scorer(  # clint: disable=missing-docstring-param  # noqa: D41
     return get_scheduled_scorer(experiment_id, scheduled_scorer_name, **kwargs)
 
 
-@experimental
+@experimental(version="3.0.0")
 def list_scheduled_scorers(  # clint: disable=missing-docstring-param  # noqa: D417
     *, experiment_id: Optional[str] = None, **kwargs
 ) -> list[ScorerScheduleConfig]:
@@ -363,7 +363,7 @@ def list_scheduled_scorers(  # clint: disable=missing-docstring-param  # noqa: D
     return list_scheduled_scorers(experiment_id, **kwargs)
 
 
-@experimental
+@experimental(version="3.0.0")
 def set_scheduled_scorers(  # clint: disable=missing-docstring-param  # noqa: D417
     *,
     scheduled_scorers: list[ScorerScheduleConfig],

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -317,7 +317,7 @@ class Scorer(BaseModel):
         raise NotImplementedError("Implementation of __call__ is required for Scorer class")
 
 
-@experimental
+@experimental(version="3.0.0")
 def scorer(
     func=None,
     *,

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -43,7 +43,7 @@ class SerializedScorer:
     original_func_name: Optional[str] = None
 
 
-@experimental
+@experimental(version="3.0.0")
 class Scorer(BaseModel):
     name: str
     aggregations: Optional[list] = None

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -722,7 +722,7 @@ class Correctness(BuiltInScorer):
 
 
 # === Shorthand for getting preset of builtin scorers ===
-@experimental
+@experimental(version="3.0.0")
 def get_all_scorers() -> list[BuiltInScorer]:
     """
     Returns a list of all built-in scorers.

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -85,7 +85,7 @@ class BuiltInScorer(Scorer):
 
 
 # === Builtin Scorers ===
-@experimental
+@experimental(version="3.0.0")
 class RetrievalRelevance(BuiltInScorer):
     """
     Retrieval relevance measures whether each chunk is relevant to the input request.
@@ -174,7 +174,7 @@ class RetrievalRelevance(BuiltInScorer):
         return [span_level_feedback] + chunk_feedbacks
 
 
-@experimental
+@experimental(version="3.0.0")
 class RetrievalSufficiency(BuiltInScorer):
     """
     Retrieval sufficiency evaluates whether the retrieved documents provide all necessary
@@ -263,7 +263,7 @@ class RetrievalSufficiency(BuiltInScorer):
         return feedbacks
 
 
-@experimental
+@experimental(version="3.0.0")
 class RetrievalGroundedness(BuiltInScorer):
     """
     RetrievalGroundedness assesses whether the agent's response is aligned with the information
@@ -322,7 +322,7 @@ class RetrievalGroundedness(BuiltInScorer):
         return feedbacks
 
 
-@experimental
+@experimental(version="3.0.0")
 class Guidelines(BuiltInScorer):
     """
     Guideline adherence evaluates whether the agent's response follows specific constraints
@@ -416,7 +416,7 @@ class Guidelines(BuiltInScorer):
         )
 
 
-@experimental
+@experimental(version="3.0.0")
 class ExpectationsGuidelines(BuiltInScorer):
     """
     This scorer evaluates whether the agent's response follows specific constraints
@@ -504,7 +504,7 @@ class ExpectationsGuidelines(BuiltInScorer):
         )
 
 
-@experimental
+@experimental(version="3.0.0")
 class RelevanceToQuery(BuiltInScorer):
     """
     Relevance ensures that the agent's response directly addresses the user's input without
@@ -562,7 +562,7 @@ class RelevanceToQuery(BuiltInScorer):
         return judges.is_context_relevant(request=request, context=outputs, name=self.name)
 
 
-@experimental
+@experimental(version="3.0.0")
 class Safety(BuiltInScorer):
     """
     Safety ensures that the agent's responses do not contain harmful, offensive, or toxic content.
@@ -613,7 +613,7 @@ class Safety(BuiltInScorer):
         return judges.is_safe(content=parse_output_to_str(outputs), name=self.name)
 
 
-@experimental
+@experimental(version="3.0.0")
 class Correctness(BuiltInScorer):
     """
     Correctness ensures that the agent's responses are correct and accurate.

--- a/mlflow/groq/__init__.py
+++ b/mlflow/groq/__init__.py
@@ -9,7 +9,7 @@ from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 FLAVOR_NAME = "groq"
 
 
-@experimental
+@experimental(version="2.20.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/langchain/autolog.py
+++ b/mlflow/langchain/autolog.py
@@ -9,7 +9,7 @@ from mlflow.utils.autologging_utils.safety import safe_patch
 logger = logging.getLogger(__name__)
 
 
-@experimental
+@experimental(version="3.0.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     disable=False,

--- a/mlflow/langchain/autolog.py
+++ b/mlflow/langchain/autolog.py
@@ -9,7 +9,7 @@ from mlflow.utils.autologging_utils.safety import safe_patch
 logger = logging.getLogger(__name__)
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.10.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     disable=False,

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -69,7 +69,7 @@ def _add_agent_messages(left: Union[dict, list[dict]], right: Union[dict, list[d
     return merged
 
 
-@experimental
+@experimental(version="2.21.0")
 class ChatAgentState(TypedDict):
     """
     Helper class that enables building a LangGraph agent that produces ChatAgent-compatible
@@ -288,7 +288,7 @@ def parse_message(
     return chat_agent_msg.model_dump_compat(exclude_none=True)
 
 
-@experimental
+@experimental(version="2.21.0")
 class ChatAgentToolNode(ToolNode):
     """
     Helper class to make ToolNodes be compatible with

--- a/mlflow/langchain/model.py
+++ b/mlflow/langchain/model.py
@@ -126,7 +126,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-@experimental
+@experimental(version="3.0.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces for internal predict calls while saving model
@@ -414,7 +414,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental
+@experimental(version="3.0.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces for internal predict calls while logging model
@@ -710,7 +710,7 @@ class _LangChainModelWrapper:
                 context.update(**schema)
             return context
 
-    @experimental
+    @experimental(version="3.0.0")
     def _predict_with_callbacks(
         self,
         data: Union[pd.DataFrame, list[Union[str, dict[str, Any]]], Any],
@@ -890,7 +890,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
     return model
 
 
-@experimental
+@experimental(version="3.0.0")
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):

--- a/mlflow/langchain/model.py
+++ b/mlflow/langchain/model.py
@@ -126,7 +126,7 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces for internal predict calls while saving model
@@ -414,7 +414,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces for internal predict calls while logging model
@@ -710,7 +710,7 @@ class _LangChainModelWrapper:
                 context.update(**schema)
             return context
 
-    @experimental(version="3.0.0")
+    @experimental(version="2.10.0")
     def _predict_with_callbacks(
         self,
         data: Union[pd.DataFrame, list[Union[str, dict[str, Any]]], Any],
@@ -890,7 +890,7 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
     return model
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):

--- a/mlflow/langchain/output_parsers.py
+++ b/mlflow/langchain/output_parsers.py
@@ -103,7 +103,7 @@ class StringResponseOutputParser(BaseTransformOutputParser[dict[str, Any]]):
         return asdict(StringResponse(content=text))
 
 
-@experimental
+@experimental(version="2.21.0")
 class ChatAgentOutputParser(BaseTransformOutputParser[str]):
     """
     OutputParser that wraps the string output into a dictionary representation of a

--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -17,7 +17,7 @@ FLAVOR_NAME = "litellm"
 _logger = logging.getLogger(__name__)
 
 
-@experimental
+@experimental(version="2.19.0")
 def autolog(
     log_traces: bool = True,
     disable: bool = False,

--- a/mlflow/llama_index/autolog.py
+++ b/mlflow/llama_index/autolog.py
@@ -3,7 +3,7 @@ from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.15.0")
 def autolog(
     log_traces: bool = True,
     disable: bool = False,

--- a/mlflow/llama_index/autolog.py
+++ b/mlflow/llama_index/autolog.py
@@ -3,7 +3,7 @@ from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration
 
 
-@experimental
+@experimental(version="3.0.0")
 def autolog(
     log_traces: bool = True,
     disable: bool = False,

--- a/mlflow/llama_index/model.py
+++ b/mlflow/llama_index/model.py
@@ -118,7 +118,7 @@ def _supported_classes():
     return supported
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.15.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def save_model(
@@ -312,7 +312,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.15.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def log_model(
@@ -528,7 +528,7 @@ def _load_llama_model(path, flavor_conf):
         return load_index_from_storage(storage_context)
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.15.0")
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """

--- a/mlflow/llama_index/model.py
+++ b/mlflow/llama_index/model.py
@@ -118,7 +118,7 @@ def _supported_classes():
     return supported
 
 
-@experimental
+@experimental(version="3.0.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def save_model(
@@ -312,7 +312,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental
+@experimental(version="3.0.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def log_model(
@@ -528,7 +528,7 @@ def _load_llama_model(path, flavor_conf):
         return load_index_from_storage(storage_context)
 
 
-@experimental
+@experimental(version="3.0.0")
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -423,7 +423,7 @@ def f1_score() -> EvaluationMetric:
     return make_metric(eval_fn=_f1_score_eval_fn, greater_is_better=True, name="f1_score")
 
 
-@experimental
+@experimental(version="2.18.0")
 def bleu() -> EvaluationMetric:
     """
     This function will create a metric for evaluating `bleu`_.

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -193,7 +193,7 @@ def _get_aggregate_results(scores, aggregations):
     )
 
 
-@experimental
+@experimental(version="2.13.0")
 def make_genai_metric_from_prompt(
     name: str,
     judge_prompt: Optional[str] = None,

--- a/mlflow/mistral/__init__.py
+++ b/mlflow/mistral/__init__.py
@@ -5,7 +5,7 @@ from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 FLAVOR_NAME = "mistral"
 
 
-@experimental
+@experimental(version="2.21.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/models/auth_policy.py
+++ b/mlflow/models/auth_policy.py
@@ -4,7 +4,7 @@ from mlflow.models.resources import Resource, _ResourceBuilder
 from mlflow.utils.annotations import experimental
 
 
-@experimental
+@experimental(version="2.21.0")
 class UserAuthPolicy:
     """
     A minimal list of scopes that the user should have access to

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -22,7 +22,7 @@ class DependenciesSchemasType(Enum):
     RETRIEVERS = "retrievers"
 
 
-@experimental
+@experimental(version="2.13.0")
 def set_retriever_schema(
     *,
     primary_key: str,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -617,7 +617,7 @@ class Model:
     def model_size_bytes(self, value: Optional[int]) -> None:
         self._model_size_bytes = value
 
-    @experimental
+    @experimental(version="2.13.0")
     @property
     def resources(self) -> dict[str, dict[ResourceType, list[dict]]]:
         """
@@ -629,7 +629,7 @@ class Model:
         """
         return self._resources
 
-    @experimental
+    @experimental(version="2.13.0")
     @resources.setter
     def resources(self, value: Optional[Union[str, list[Resource]]]) -> None:
         if isinstance(value, (Path, str)):
@@ -640,7 +640,7 @@ class Model:
             serialized_resource = value
         self._resources = serialized_resource
 
-    @experimental
+    @experimental(version="2.21.0")
     @property
     def auth_policy(self) -> dict[str, dict]:
         """
@@ -652,7 +652,7 @@ class Model:
         """
         return self._auth_policy
 
-    @experimental
+    @experimental(version="2.21.0")
     @auth_policy.setter
     def auth_policy(self, value: Optional[Union[dict, AuthPolicy]]) -> None:
         self._auth_policy = value.to_dict() if isinstance(value, AuthPolicy) else value
@@ -1583,7 +1583,7 @@ def _validate_llama_index_model(model):
     return _validate_and_prepare_llama_index_model_or_path(model, None)
 
 
-@experimental
+@experimental(version="2.13.0")
 def set_model(model) -> None:
     """
     When logging model as code, this function can be used to set the model object

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -98,7 +98,7 @@ _CONTENT_TYPE_CSV = "csv"
 _CONTENT_TYPE_JSON = "json"
 
 
-@experimental
+@experimental(version="2.18.0")
 def predict(
     model_uri,
     input_data=None,

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -468,7 +468,7 @@ def _split_input_data_and_params(input_example):
     return input_example, None
 
 
-@experimental
+@experimental(version="2.16.0")
 def convert_input_example_to_serving_input(input_example) -> Optional[str]:
     """
     Helper function to convert a model's input example to a serving input example that
@@ -1978,7 +1978,7 @@ def _flatten_nested_params(
 
 # NB: this function should always be kept in sync with the serving
 # process in scoring_server invocations.
-@experimental
+@experimental(version="2.16.0")
 def validate_serving_input(model_uri: str, serving_input: Union[str, dict[str, Any]]):
     """
     Helper function to validate the model can be served and provided input is valid

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -33,7 +33,7 @@ from mlflow.utils.autologging_utils.safety import safe_patch
 _logger = logging.getLogger(__name__)
 
 
-@experimental
+@experimental(version="3.0.0")
 def autolog(
     disable=False,
     exclusive=False,

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -33,7 +33,7 @@ from mlflow.utils.autologging_utils.safety import safe_patch
 _logger = logging.getLogger(__name__)
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.14.0")
 def autolog(
     disable=False,
     exclusive=False,

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -62,7 +62,7 @@ _PYFUNC_SUPPORTED_TASKS = ("chat.completions", "embeddings", "completions")
 _logger = logging.getLogger(__name__)
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 def get_default_pip_requirements():
     """
     Returns:
@@ -73,7 +73,7 @@ def get_default_pip_requirements():
     return list(map(_get_pinned_requirement, ["openai", "tiktoken", "tenacity"]))
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 def get_default_conda_env():
     """
     Returns:
@@ -211,7 +211,7 @@ def _get_input_schema(task, content):
         return Schema([ColSpec(type="string")])
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def save_model(
     model,
@@ -410,7 +410,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def log_model(
     model,
@@ -794,7 +794,7 @@ def _load_pyfunc(path):
     return _OpenAIWrapper(_load_model(path))
 
 
-@experimental(version="3.0.0")
+@experimental(version="2.3.0")
 def load_model(model_uri, dst_path=None):
     """
     Load an OpenAI model from a local file or a run.

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -62,7 +62,7 @@ _PYFUNC_SUPPORTED_TASKS = ("chat.completions", "embeddings", "completions")
 _logger = logging.getLogger(__name__)
 
 
-@experimental
+@experimental(version="3.0.0")
 def get_default_pip_requirements():
     """
     Returns:
@@ -73,7 +73,7 @@ def get_default_pip_requirements():
     return list(map(_get_pinned_requirement, ["openai", "tiktoken", "tenacity"]))
 
 
-@experimental
+@experimental(version="3.0.0")
 def get_default_conda_env():
     """
     Returns:
@@ -211,7 +211,7 @@ def _get_input_schema(task, content):
         return Schema([ColSpec(type="string")])
 
 
-@experimental
+@experimental(version="3.0.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def save_model(
     model,
@@ -410,7 +410,7 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental
+@experimental(version="3.0.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def log_model(
     model,
@@ -794,7 +794,7 @@ def _load_pyfunc(path):
     return _OpenAIWrapper(_load_model(path))
 
 
-@experimental
+@experimental(version="3.0.0")
 def load_model(model_uri, dst_path=None):
     """
     Load an OpenAI model from a local file or a run.

--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -12,7 +12,7 @@ FLAVOR_NAME = "pydantic_ai"
 _logger = logging.getLogger(__name__)
 
 
-@experimental
+@experimental(version="3.0.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False):
     """

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -1048,7 +1048,7 @@ class PyFuncModel:
             info["flavor"] = self._model_meta.flavors[FLAVOR_NAME]["loader_module"]
         return yaml.safe_dump({"mlflow.pyfunc.loaded_model": info}, default_flow_style=False)
 
-    @experimental
+    @experimental(version="2.16.0")
     def get_raw_model(self):
         """
         Get the underlying raw model if the model wrapper implemented `get_raw_model` function.

--- a/mlflow/pyfunc/loaders/chat_agent.py
+++ b/mlflow/pyfunc/loaders/chat_agent.py
@@ -23,7 +23,7 @@ def _load_pyfunc(model_path: str, model_config: Optional[dict[str, Any]] = None)
     return _ChatAgentPyfuncWrapper(chat_agent)
 
 
-@experimental
+@experimental(version="2.20.0")
 class _ChatAgentPyfuncWrapper:
     """
     Wrapper class that converts dict inputs to pydantic objects accepted by :class:`~ChatAgent`.

--- a/mlflow/pyfunc/loaders/responses_agent.py
+++ b/mlflow/pyfunc/loaders/responses_agent.py
@@ -28,7 +28,7 @@ def _load_pyfunc(model_path: str, model_config: Optional[dict[str, Any]] = None)
     return _ResponsesAgentPyfuncWrapper(responses_agent)
 
 
-@experimental
+@experimental(version="3.0.0")
 class _ResponsesAgentPyfuncWrapper:
     """
     Wrapper class that converts dict inputs to pydantic objects accepted by

--- a/mlflow/pyfunc/model.py
+++ b/mlflow/pyfunc/model.py
@@ -831,7 +831,7 @@ if IS_PYDANTIC_V2_OR_NEWER:
         ResponsesAgentStreamEvent,
     )
 
-    @experimental
+    @experimental(version="3.0.0")
     class ResponsesAgent(PythonModel, metaclass=ABCMeta):
         """
         A base class for creating ResponsesAgent models. It can be used as a wrapper around any

--- a/mlflow/pyfunc/utils/input_converter.py
+++ b/mlflow/pyfunc/utils/input_converter.py
@@ -18,7 +18,7 @@ def _is_optional_dataclass(field_type) -> bool:
     return False
 
 
-@experimental
+@experimental(version="2.18.0")
 def _hydrate_dataclass(dataclass_type, data):
     """Recursively create an instance of the dataclass_type from data."""
     if not (is_dataclass(dataclass_type) or _is_optional_dataclass(dataclass_type)):

--- a/mlflow/smolagents/__init__.py
+++ b/mlflow/smolagents/__init__.py
@@ -15,7 +15,7 @@ _logger = logging.getLogger(__name__)
 FLAVOR_NAME = "smolagents"
 
 
-@experimental
+@experimental(version="3.0.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
@@ -71,7 +71,7 @@ def _require_arg_unspecified(arg_name, arg_value, default_values=None, message=N
         _raise_unsupported_arg(arg_name, message)
 
 
-@experimental
+@experimental(version="2.17.0")
 class UnityCatalogOssStore(BaseRestStore):
     """
     Client for an Open Source Unity Catalog Server accessed via REST API calls.

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -14,7 +14,7 @@ from mlflow.tracing.client import TracingClient
 from mlflow.utils.annotations import experimental
 
 
-@experimental
+@experimental(version="3.0.0")
 def get_assessment(trace_id: str, assessment_id: str) -> Assessment:
     """
     .. important::
@@ -33,7 +33,7 @@ def get_assessment(trace_id: str, assessment_id: str) -> Assessment:
     return TracingClient().get_assessment(trace_id, assessment_id)
 
 
-@experimental
+@experimental(version="2.21.0")
 def log_assessment(trace_id: str, assessment: Assessment) -> Assessment:
     """
     .. important::
@@ -137,7 +137,7 @@ def log_assessment(trace_id: str, assessment: Assessment) -> Assessment:
     TracingClient().log_assessment(trace_id, assessment)
 
 
-@experimental
+@experimental(version="3.0.0")
 def log_expectation(
     *,
     trace_id: str,
@@ -178,7 +178,7 @@ def log_expectation(
     return TracingClient().log_assessment(trace_id, assessment)
 
 
-@experimental
+@experimental(version="2.21.0")
 def update_assessment(
     trace_id: str,
     assessment_id: str,
@@ -230,7 +230,7 @@ def update_assessment(
     )
 
 
-@experimental
+@experimental(version="2.21.0")
 def delete_assessment(trace_id: str, assessment_id: str):
     """
     .. important::
@@ -246,7 +246,7 @@ def delete_assessment(trace_id: str, assessment_id: str):
     return TracingClient().delete_assessment(trace_id=trace_id, assessment_id=assessment_id)
 
 
-@experimental
+@experimental(version="2.21.0")
 def log_feedback(
     *,
     trace_id: str,
@@ -303,7 +303,7 @@ def log_feedback(
     return TracingClient().log_assessment(trace_id, assessment)
 
 
-@experimental
+@experimental(version="3.0.0")
 def override_feedback(
     *,
     trace_id: str,

--- a/mlflow/tracing/destination.py
+++ b/mlflow/tracing/destination.py
@@ -5,7 +5,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 
 
-@experimental
+@experimental(version="2.21.0")
 @dataclass
 class TraceDestination:
     """A configuration object for specifying the destination of trace data."""
@@ -16,7 +16,7 @@ class TraceDestination:
         raise NotImplementedError
 
 
-@experimental
+@experimental(version="2.21.0")
 @dataclass
 class MlflowExperiment(TraceDestination):
     """
@@ -40,7 +40,7 @@ class MlflowExperiment(TraceDestination):
         return "experiment"
 
 
-@experimental
+@experimental(version="2.22.0")
 @dataclass
 class Databricks(TraceDestination):
     """

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1167,7 +1167,7 @@ def delete_trace_tag(trace_id: str, key: str) -> None:
     TracingClient().delete_trace_tag(trace_id, key)
 
 
-@experimental
+@experimental(version="2.17.0")
 def add_trace(trace: Union[Trace, dict[str, Any]], target: Optional[LiveSpan] = None):
     """
     Add a completed trace object into another trace.
@@ -1284,7 +1284,7 @@ def add_trace(trace: Union[Trace, dict[str, Any]], target: Optional[LiveSpan] = 
         )
 
 
-@experimental
+@experimental(version="2.21.0")
 def log_trace(
     name: str = "Task",
     request: Optional[Any] = None,

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -153,7 +153,7 @@ def detach_span_from_context(token: contextvars.Token):
     context_api.detach(token)
 
 
-@experimental
+@experimental(version="2.21.0")
 def set_destination(destination: TraceDestination):
     """
     Set a custom span destination to which MLflow will export the traces.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -435,7 +435,7 @@ class MlflowClient:
 
     ##### Prompt Registry #####
 
-    @experimental
+    @experimental(version="2.21.0")
     @require_prompt_registry
     @translate_prompt_exception
     def register_prompt(
@@ -641,7 +641,7 @@ class MlflowClient:
             page_token=page_token,
         )
 
-    @experimental
+    @experimental(version="2.21.0")
     @require_prompt_registry
     @translate_prompt_exception
     def load_prompt(
@@ -695,7 +695,7 @@ class MlflowClient:
                 return None
             raise
 
-    @experimental
+    @experimental(version="2.21.0")
     @require_prompt_registry
     @translate_prompt_exception
     def link_prompt_version_to_run(self, run_id: str, prompt: Union[str, PromptVersion]) -> None:
@@ -774,7 +774,7 @@ class MlflowClient:
         )
 
     # TODO: Use model_id in MLflow 3.0
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def detach_prompt_from_run(self, run_id: str, prompt_uri: str) -> None:
@@ -808,7 +808,7 @@ class MlflowClient:
             )
 
     # TODO: Use model_id in MLflow 3.0
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def list_logged_prompts(self, run_id: str) -> list[PromptVersion]:
@@ -831,7 +831,7 @@ class MlflowClient:
         # with a Run is expected to be small.
         return [model_version_to_prompt_version(mv) for mv in mvs]
 
-    @experimental
+    @experimental(version="2.22.0")
     @require_prompt_registry
     @translate_prompt_exception
     def set_prompt_alias(self, name: str, alias: str, version: int) -> None:
@@ -846,7 +846,7 @@ class MlflowClient:
         self._validate_prompt(name, version)
         self._get_registry_client().set_prompt_alias(name, alias, version)
 
-    @experimental
+    @experimental(version="2.22.0")
     @require_prompt_registry
     @translate_prompt_exception
     def delete_prompt_alias(self, name: str, alias: str) -> None:
@@ -859,7 +859,7 @@ class MlflowClient:
         """
         self._get_registry_client().delete_prompt_alias(name, alias)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def set_prompt_version_tag(
@@ -876,7 +876,7 @@ class MlflowClient:
         """
         self._get_registry_client().set_prompt_version_tag(name, version, key, value)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def delete_prompt_version_tag(self, name: str, version: Union[str, int], key: str) -> None:
@@ -1212,7 +1212,7 @@ class MlflowClient:
         if root_span:
             root_span.end(outputs, attributes, status, end_time_ns)
 
-    @experimental
+    @experimental(version="2.20.0")
     def _log_trace(self, trace: Trace) -> str:
         """
         Log the complete Trace object to the backend store.
@@ -5326,7 +5326,7 @@ class MlflowClient:
         if has_prompt_tag(rm._tags):
             raise _model_not_found(name)
 
-    @experimental
+    @experimental(version="3.0.0")
     def create_logged_model(
         self,
         experiment_id: str,
@@ -5357,7 +5357,7 @@ class MlflowClient:
             experiment_id, name, source_run_id, tags, params, model_type
         )
 
-    @experimental
+    @experimental(version="3.0.0")
     def log_model_params(self, model_id: str, params: dict[str, str]) -> None:
         """
         Log parameters for a logged model.
@@ -5386,7 +5386,7 @@ class MlflowClient:
             ) from e
         return self._tracking_client.log_model_params(model_id, params)
 
-    @experimental
+    @experimental(version="3.0.0")
     def finalize_logged_model(
         self, model_id: str, status: Union[Literal["READY", "FAILED"], LoggedModelStatus]
     ) -> LoggedModel:
@@ -5405,7 +5405,7 @@ class MlflowClient:
             model_id, LoggedModelStatus(status) if isinstance(status, str) else status
         )
 
-    @experimental
+    @experimental(version="3.0.0")
     def get_logged_model(self, model_id: str) -> LoggedModel:
         """
         Fetch the logged model with the specified ID.
@@ -5419,7 +5419,7 @@ class MlflowClient:
         _validate_model_id_specified(model_id)
         return self._tracking_client.get_logged_model(model_id)
 
-    @experimental
+    @experimental(version="3.0.0")
     def delete_logged_model(self, model_id: str) -> None:
         """
         Delete the logged model with the specified ID.
@@ -5430,7 +5430,7 @@ class MlflowClient:
         _validate_model_id_specified(model_id)
         return self._tracking_client.delete_logged_model(model_id)
 
-    @experimental
+    @experimental(version="3.0.0")
     def set_logged_model_tags(self, model_id: str, tags: dict[str, Any]) -> None:
         """
         Set tags on the specified logged model.
@@ -5459,7 +5459,7 @@ class MlflowClient:
             ) from e
         self._tracking_client.set_logged_model_tags(model_id, tags)
 
-    @experimental
+    @experimental(version="3.0.0")
     def delete_logged_model_tag(self, model_id: str, key: str) -> None:
         """
         Delete a tag from the specified logged model.
@@ -5498,7 +5498,7 @@ class MlflowClient:
         """
         return self._tracking_client.log_model_artifacts(model_id, local_dir)
 
-    @experimental
+    @experimental(version="3.0.0")
     def search_logged_models(
         self,
         experiment_ids: list[str],
@@ -5570,7 +5570,7 @@ class MlflowClient:
             experiment_ids, filter_string, datasets, max_results, order_by, page_token
         )
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def create_prompt(
@@ -5609,7 +5609,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.create_prompt(name, description, tags)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def create_prompt_version(
@@ -5651,7 +5651,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.create_prompt_version(name, template, description, tags)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def get_prompt(self, name: str) -> Optional[Prompt]:
@@ -5679,7 +5679,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.get_prompt(name)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def get_prompt_version(self, name: str, version: Union[str, int]) -> Optional[PromptVersion]:
@@ -5709,7 +5709,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.get_prompt_version(name, version)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def delete_prompt_version(self, name: str, version: str) -> None:
@@ -5735,7 +5735,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.delete_prompt_version(name, version)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def set_prompt_tag(self, name: str, key: str, value: str) -> None:
@@ -5762,7 +5762,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.set_prompt_tag(name, key, value)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def delete_prompt_tag(self, name: str, key: str) -> None:
@@ -5788,7 +5788,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.delete_prompt_tag(name, key)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def get_prompt_version_by_alias(self, name: str, alias: str) -> PromptVersion:
@@ -5817,7 +5817,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.get_prompt_version_by_alias(name, alias)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def search_prompt_versions(
@@ -5850,7 +5850,7 @@ class MlflowClient:
         registry_client = self._get_registry_client()
         return registry_client.search_prompt_versions(name, max_results, page_token)
 
-    @experimental
+    @experimental(version="3.0.0")
     @require_prompt_registry
     @translate_prompt_exception
     def delete_prompt(self, name: str) -> None:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2101,7 +2101,7 @@ def delete_experiment(experiment_id: str) -> None:
     MlflowClient().delete_experiment(experiment_id)
 
 
-@experimental
+@experimental(version="3.0.0")
 def initialize_logged_model(
     name: Optional[str] = None,
     source_run_id: Optional[str] = None,
@@ -2264,7 +2264,7 @@ def _create_logged_model(
     )
 
 
-@experimental
+@experimental(version="3.0.0")
 def log_model_params(params: dict[str, str], model_id: Optional[str] = None) -> None:
     """
     Log params to the specified logged model.
@@ -2296,7 +2296,7 @@ def log_model_params(params: dict[str, str], model_id: Optional[str] = None) -> 
     MlflowClient().log_model_params(model_id, params)
 
 
-@experimental
+@experimental(version="3.0.0")
 def finalize_logged_model(
     model_id: str, status: Union[Literal["READY", "FAILED"], LoggedModelStatus]
 ) -> LoggedModel:
@@ -2329,7 +2329,7 @@ def finalize_logged_model(
     return MlflowClient().finalize_logged_model(model_id, status)
 
 
-@experimental
+@experimental(version="3.0.0")
 def get_logged_model(model_id: str) -> LoggedModel:
     """
     Get a logged model by ID.
@@ -2361,7 +2361,7 @@ def get_logged_model(model_id: str) -> LoggedModel:
     return MlflowClient().get_logged_model(model_id)
 
 
-@experimental
+@experimental(version="3.0.0")
 def last_logged_model() -> Optional[LoggedModel]:
     """
     Fetches the most recent logged model in the current session.
@@ -2413,7 +2413,7 @@ def search_logged_models(
 ) -> list[LoggedModel]: ...
 
 
-@experimental
+@experimental(version="3.0.0")
 def search_logged_models(
     experiment_ids: Optional[list[str]] = None,
     filter_string: Optional[str] = None,
@@ -2557,7 +2557,7 @@ def search_logged_models(
         )
 
 
-@experimental
+@experimental(version="3.0.0")
 def log_outputs(models: Optional[list[LoggedModelOutput]] = None):
     """
     Log outputs, such as models, to the active run. If there is no active run, a new run will be

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -671,7 +671,7 @@ class Map(BaseType):
         raise MlflowException(f"Map type {self!r} and {other!r} are incompatible")
 
 
-@experimental
+@experimental(version="2.19.0")
 class AnyType(BaseType):
     def __init__(self):
         """

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -1385,7 +1385,7 @@ def _get_dataclass_annotations(cls) -> dict[str, Any]:
     return annotations
 
 
-@experimental
+@experimental(version="2.13.0")
 def convert_dataclass_to_schema(dataclass):
     """
     Converts a given dataclass into a Schema object. The dataclass must include type hints

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -32,7 +32,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def experimental(*, version: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def experimental(*, version: Optional[str] = None) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator / decorator creator for marking APIs experimental in the docstring.
 
     Args:

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -32,7 +32,7 @@ P = ParamSpec("P")
 R = TypeVar("R")
 
 
-def experimental(*, version: Optional[str] = None) -> Callable[[Callable[P, R]], Callable[P, R]]:
+def experimental(version: Optional[str] = None) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator / decorator creator for marking APIs experimental in the docstring.
 
     Args:

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -41,8 +41,7 @@ def experimental(version: Optional[str] = None) -> Callable[[Callable[P, R]], Ca
             as stable or not when releasing a new version of MLflow.
 
     Returns:
-        Decorated API (if a ``api_or_type`` is an API) or a function that decorates
-        the specified API type (if ``api_or_type`` is a typestring).
+        A decorator that adds a note to the docstring of the decorated API,
     """
 
     def decorator(f: Callable[P, R]) -> Callable[P, R]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -281,7 +281,8 @@ exclude = [
 ]
 typing-extensions-allowlist = [
   # Docs: https://typing-extensions.readthedocs.io/en/latest/
-  "typing_extensions.Self", # Added in 4.0.0
+  "typing_extensions.Self",      # Added in 4.0.0
+  "typing_extensions.ParamSpec", # Added in 3.10.0
 ]
 # Rules that are only enabled for code examples.
 example-rules = ["lazy-builtin-import", "log-model-artifact-path"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16219?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16219/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16219/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16219/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

To make it easier to remove `experimental` decorators, this PR adds a `version` parameter. This parameter allows us to compute the age of the decorator and remove it if it exceeds a certain threshold.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
