### PR TITLE
Unflake `test_databricks_sdk_retry_backoff_calculation`

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -373,6 +373,15 @@ def _validate_backoff_factor(backoff_factor):
         )
 
 
+def _time_sleep(seconds: float) -> None:
+    """
+    This function is specifically mocked in `test_rest_utils.py` to test the backoff logic in
+    isolation. We avoid wrapping `time.sleep` globally to prevent interfering with unrelated sleep
+    calls elsewhere in the codebase or in third-party libraries.
+    """
+    time.sleep(seconds)
+
+
 def _retry_databricks_sdk_call_with_exponential_backoff(
     *,
     call_func: Callable,
@@ -442,7 +451,7 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
                 f"Retrying in {backoff_time:.2f} seconds (attempt {attempt + 1})"
             )
 
-            time.sleep(backoff_time)
+            _time_sleep(backoff_time)
             attempt += 1
 
 

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -801,7 +801,7 @@ def test_databricks_sdk_retry_backoff_calculation():
 
         raise DatabricksError(error_code="INTERNAL_ERROR", message="Mock error")
 
-    with mock.patch("time.sleep") as mock_sleep:
+    with mock.patch("mlflow.utils.rest_utils._time_sleep") as mock_sleep:
         with pytest.raises(DatabricksError, match="Mock error"):
             _retry_databricks_sdk_call_with_exponential_backoff(
                 call_func=mock_failing_call,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16234?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16234/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16234/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16234/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`test_databricks_sdk_retry_backoff_calculation` is flaky. When it fails, it has extra calls with `seconds=0.1`:

https://github.com/mlflow/mlflow/actions/runs/15605518643/job/43953991657

```
        expected_sleep_times = [0, 2, 4]
        actual_sleep_times = [call.args[0] for call in mock_sleep.call_args_list]
>       assert actual_sleep_times == expected_sleep_times
E       assert [0, 2, 4, 0.1, 0.1, 0.1, ...] == [0, 2, 4]
E         
E         Left contains 39467 more items, first extra item: 0.1
E         
E         Full diff:
E           [
E               0,
E               2,
E               4,
E         +     0.1,
E         +     0.1,
E         +     0.1,
E         +     0.1,
E         +     0.1,
E         +     0.1,
E         +     0.1,
E         +     0.1,
```

The culprit is the optuna integration which leaves a zombie process that periodically calls `time.sleep`:

https://github.com/mlflow/mlflow/pull/16229#issuecomment-2968670341

```
----------------------------- Captured stderr call -----------------------------
2025/06/12 14:23:53 WARNING mlflow.utils.rest_utils: Max retries (3) exceeded: Mock error
--------------------------- Captured stderr teardown ---------------------------
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/threading.py", line 937, in _bootstrap
    self._bootstrap_inner()
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/threading.py", line 980, in _bootstrap_inner
    self.run()
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/threading.py", line 917, in run
    self._target(*self._args, **self._kwargs)
  File "/home/runner/work/mlflow/mlflow/mlflow/optuna/storage.py", line 155, in _periodic_flush_worker
    time.sleep(min(0.1, self._batch_flush_interval / 10))  # Sleep in small increments
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/unittest/mock.py", line 1092, in __call__
    return self._mock_call(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/unittest/mock.py", line 1096, in _mock_call
    return self._execute_mock_call(*args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.9.18/x64/lib/python3.9/unittest/mock.py", line 1157, in _execute_mock_call
    result = effect(*args, **kwargs)
  File "/home/runner/work/mlflow/mlflow/tests/utils/test_rest_utils.py", line 808, in sleep
    traceback.print_stack()
=============================== warnings summary ===============================
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
