### PR TITLE
Add script to automatically remove old `@experimental` decorators

### DIFF
--- a/dev/remove_experimental_decorators.py
+++ b/dev/remove_experimental_decorators.py
@@ -136,6 +136,9 @@ def main() -> None:
     parser.add_argument(
         "--dry-run", action="store_true", help="Show what would be removed without making changes"
     )
+    parser.add_argument(
+        "files", nargs="*", help="Python files to process (defaults to all tracked Python files)"
+    )
 
     args = parser.parse_args()
     release_dates = get_mlflow_release_dates()
@@ -143,7 +146,8 @@ def main() -> None:
     now = datetime.now(timezone.utc)
     cutoff_date = now - timedelta(days=6 * 30)  # Approximate 6 months
     print(f"Cutoff date: {cutoff_date.strftime('%Y-%m-%d %H:%M:%S UTC')}")
-    python_files: list[Path] = get_tracked_python_files()
+
+    python_files = [Path(f) for f in args.files] if args.files else get_tracked_python_files()
     for file_path in python_files:
         if not file_path.exists():
             continue

--- a/dev/remove_experimental_decorators.py
+++ b/dev/remove_experimental_decorators.py
@@ -1,0 +1,166 @@
+"""
+Script to automatically remove @experimental decorators from functions
+that have been experimental for more than 6 months.
+"""
+
+import argparse
+import ast
+import json
+import subprocess
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Optional
+from urllib.request import urlopen
+
+
+@dataclass
+class ExperimentalDecorator:
+    version: str
+    line_number: int
+    end_line_number: int
+    column: int
+    age_days: int
+    content: str
+
+
+def get_tracked_python_files() -> list[Path]:
+    """Get all tracked Python files in the repository."""
+    result = subprocess.check_output(["git", "ls-files", "*.py"], text=True)
+    return [Path(f) for f in result.strip().split("\n") if f]
+
+
+def get_mlflow_release_dates() -> dict[str, datetime]:
+    """Fetch MLflow release dates from PyPI API."""
+    with urlopen("https://pypi.org/pypi/mlflow/json") as response:
+        data = json.loads(response.read().decode())
+
+    release_dates: dict[str, datetime] = {}
+    for version, releases in data["releases"].items():
+        if releases:  # Some versions might have empty release lists
+            # Get the earliest release date for this version
+            upload_times: list[str] = [r["upload_time"] for r in releases if "upload_time" in r]
+            if upload_times:
+                earliest_time = min(upload_times)
+                # Parse ISO format datetime and convert to UTC
+                release_date = datetime.fromisoformat(earliest_time.replace("Z", "+00:00"))
+                if release_date.tzinfo is None:
+                    release_date = release_date.replace(tzinfo=timezone.utc)
+                release_dates[version] = release_date
+
+    return release_dates
+
+
+def find_experimental_decorators(
+    file_path: Path, release_dates: dict[str, datetime], now: datetime
+) -> list[ExperimentalDecorator]:
+    """
+    Find all @experimental decorators in a Python file using AST and return their information
+    with computed age.
+    """
+    content = file_path.read_text()
+    tree = ast.parse(content)
+    decorators: list[ExperimentalDecorator] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            for decorator in node.decorator_list:
+                if isinstance(decorator, ast.Call):
+                    if isinstance(decorator.func, ast.Name) and decorator.func.id == "experimental":
+                        # Extract version from decorator arguments
+                        version = _extract_version_from_ast_decorator(decorator)
+                        if version and version in release_dates:
+                            release_date = release_dates[version]
+                            age_days = (now - release_date).days
+
+                            decorator_info = ExperimentalDecorator(
+                                version=version,
+                                line_number=decorator.lineno,
+                                end_line_number=decorator.end_lineno or decorator.lineno,
+                                column=decorator.col_offset + 1,  # 1-indexed
+                                age_days=age_days,
+                                content=ast.unparse(decorator),
+                            )
+                            decorators.append(decorator_info)
+
+    return decorators
+
+
+def _extract_version_from_ast_decorator(decorator: ast.Call) -> Optional[str]:
+    """Extract version string from AST decorator node."""
+    for keyword in decorator.keywords:
+        if keyword.arg == "version" and isinstance(keyword.value, ast.Constant):
+            return str(keyword.value.value)
+    return None
+
+
+def remove_decorators_from_file(
+    file_path: Path,
+    decorators_to_remove: list[ExperimentalDecorator],
+    dry_run: bool,
+) -> list[ExperimentalDecorator]:
+    if not decorators_to_remove:
+        return []
+
+    lines = file_path.read_text().splitlines(keepends=True)
+    # Create a set of line numbers to remove for quick lookup (handle ranges)
+    lines_to_remove: set[int] = set()
+    for decorator in decorators_to_remove:
+        for line_num in range(decorator.line_number, decorator.end_line_number + 1):
+            lines_to_remove.add(line_num)
+
+    new_lines: list[str] = []
+
+    for line_num, line in enumerate(lines, 1):
+        if line_num not in lines_to_remove:
+            new_lines.append(line)
+
+    if not dry_run:
+        file_path.write_text("".join(new_lines))
+
+    return decorators_to_remove
+
+
+def main() -> None:
+    """Main entry point."""
+    parser = argparse.ArgumentParser(
+        description="Remove @experimental decorators older than 6 months"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show what would be removed without making changes"
+    )
+
+    args = parser.parse_args()
+    release_dates = get_mlflow_release_dates()
+    # Calculate cutoff date (6 months ago from now)
+    now = datetime.now(timezone.utc)
+    cutoff_date = now - timedelta(days=6 * 30)  # Approximate 6 months
+    print(f"Cutoff date: {cutoff_date.strftime('%Y-%m-%d %H:%M:%S UTC')}")
+    python_files: list[Path] = get_tracked_python_files()
+    for file_path in python_files:
+        if not file_path.exists():
+            continue
+
+        # First, find all experimental decorators in the file with computed ages
+        decorators = find_experimental_decorators(file_path, release_dates, now)
+        if not decorators:
+            continue
+
+        # Filter to only decorators that should be removed (older than 6 months)
+        old_decorators = [d for d in decorators if d.age_days > 6 * 30]  # 6 months approx
+        if not old_decorators:
+            continue
+
+        # Remove old decorators
+        removed = remove_decorators_from_file(file_path, old_decorators, args.dry_run)
+        if removed:
+            for decorator in removed:
+                action = "Would remove" if args.dry_run else "Removed"
+                print(
+                    f"{file_path}:{decorator.line_number}:{decorator.column}: "
+                    f"{action} {decorator.content} (age: {decorator.age_days} days)"
+                )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dev/test_remove_experimental_decorators.py
+++ b/tests/dev/test_remove_experimental_decorators.py
@@ -1,0 +1,73 @@
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = "dev/remove_experimental_decorators.py"
+
+
+def test_script_with_specific_file(tmp_path: Path) -> None:
+    test_file = tmp_path / "test.py"
+    test_file.write_text("""
+@experimental(version="1.0.0")
+def func():
+    pass
+""")
+
+    output = subprocess.check_output(
+        [sys.executable, SCRIPT_PATH, "--dry-run", test_file], text=True
+    )
+
+    assert "Would remove" in output
+    assert "experimental(version='1.0.0')" in output
+    assert (
+        test_file.read_text()
+        == """
+@experimental(version="1.0.0")
+def func():
+    pass
+"""
+    )
+
+
+def test_script_without_files() -> None:
+    subprocess.check_call([sys.executable, SCRIPT_PATH, "--dry-run"])
+
+
+def test_script_removes_decorator_without_dry_run(tmp_path: Path) -> None:
+    test_file = tmp_path / "test.py"
+    test_file.write_text("""
+@experimental(version="1.0.0")
+def func():
+    pass
+""")
+
+    subprocess.check_call([sys.executable, SCRIPT_PATH, test_file])
+    content = test_file.read_text()
+    assert (
+        content
+        == """
+def func():
+    pass
+"""
+    )
+
+
+def test_script_with_multiline_decorator(tmp_path: Path) -> None:
+    test_file = tmp_path / "test.py"
+    test_file.write_text("""
+@experimental(
+    version="1.0.0",
+)
+def func():
+    pass
+""")
+
+    output = subprocess.check_output([sys.executable, SCRIPT_PATH, test_file], text=True)
+    assert "Removed" in output
+    assert (
+        test_file.read_text()
+        == """
+def func():
+    pass
+"""
+    )

--- a/tests/dev/test_remove_experimental_decorators.py
+++ b/tests/dev/test_remove_experimental_decorators.py
@@ -71,3 +71,39 @@ def func():
     pass
 """
     )
+
+
+def test_script_with_multiple_decorators(tmp_path: Path) -> None:
+    test_file = tmp_path / "test.py"
+    test_file.write_text("""
+@experimental(version="1.0.0")
+def func1():
+    pass
+
+@experimental(version="1.1.0")
+class MyClass:
+    @experimental(version="1.2.0")
+    def method(self):
+        pass
+
+def regular_func():
+    pass
+""")
+
+    output = subprocess.check_output([sys.executable, SCRIPT_PATH, test_file], text=True)
+    assert output.count("Removed") == 3  # Should remove all 3 decorators
+    content = test_file.read_text()
+    assert (
+        content
+        == """
+def func1():
+    pass
+
+class MyClass:
+    def method(self):
+        pass
+
+def regular_func():
+    pass
+"""
+    )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16237?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16237/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16237/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16237/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

#16219 added `version` to `@experimental` decorators, which allows us to compute their age. This PR adds a script to automatically remove old `@experimental` decorators. This script will be run in the release pipeline.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```
% python dev/remove_experimental_decorators.py
Cutoff date: 2024-12-15 04:00:52 UTC
mlflow/anthropic/__init__.py:8:2: Removed experimental(version='2.19.0') (age: 183 days)
mlflow/autogen/__init__.py:21:2: Removed experimental(version='2.16.0') (age: 286 days)
mlflow/crewai/__init__.py:21:2: Removed experimental(version='2.19.0') (age: 183 days)
mlflow/deployments/databricks/__init__.py:559:6: Removed experimental(version='2.19.0') (age: 183 days)
mlflow/deployments/databricks/__init__.py:619:6: Removed experimental(version='2.19.0') (age: 183 days)
mlflow/deployments/databricks/__init__.py:649:6: Removed experimental(version='2.19.0') (age: 183 days)
mlflow/deployments/databricks/__init__.py:685:6: Removed experimental(version='2.19.0') (age: 183 days)
mlflow/dspy/autolog.py:17:2: Removed experimental(version='2.18.0') (age: 206 days)
mlflow/dspy/load.py:51:2: Removed experimental(version='2.18.0') (age: 206 days)
mlflow/dspy/save.py:73:2: Removed experimental(version='2.18.0') (age: 206 days)
...
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
