### PR TITLE
Add support arbitrary plain text file

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -47,6 +47,7 @@
     "d3-selection": "^1.3.0",
     "dateformat": "3.0.3",
     "diff": "5.1.0",
+    "dompurify": "3.2.6",
     "file-saver": "1.3.8",
     "font-awesome": "4.7.0",
     "graphql": "^15.5.0",

--- a/mlflow/server/js/src/common/utils/FileUtils.ts
+++ b/mlflow/server/js/src/common/utils/FileUtils.ts
@@ -50,6 +50,24 @@ export const TEXT_EXTENSIONS = new Set([
   MLPROJECT_FILE_NAME.toLowerCase(),
   MLMODEL_FILE_NAME.toLowerCase(),
   'jsonnet',
+  // Common code extensions
+  'c',
+  'cpp',
+  'h',
+  'hpp',
+  'java',
+  'sh',
+  'bash',
+  'r',
+  'scala',
+  'sql',
+  'go',
+  'rb',
+  'php',
+  'swift',
+  'rust',
+  'kt',
+  'kts',
 ]);
 export const HTML_EXTENSIONS = new Set(['html']);
 export const MAP_EXTENSIONS = new Set(['geojson']);
@@ -58,3 +76,41 @@ export const DATA_EXTENSIONS = new Set(['csv', 'tsv']);
 // Audio extensions supported by wavesurfer.js
 // Source https://github.com/katspaugh/wavesurfer.js/discussions/2703#discussioncomment-5259526
 export const AUDIO_EXTENSIONS = new Set(['m4a', 'mp3', 'mp4', 'wav', 'aac', 'wma', 'flac', 'opus', 'ogg']);
+
+export const isTextFile = (path: string, content?: string, size?: number): boolean => {
+  const ext = getExtension(path).toLowerCase();
+
+  if (TEXT_EXTENSIONS.has(ext)) {
+    return true;
+  }
+
+  if (content) {
+    // Check for null bytes which typically indicate binary data
+    if (content.indexOf('\0') >= 0) {
+      return false;
+    }
+
+    // If the content has reasonable line breaks and printable characters, it's likely text
+    const hasReasonableLines = content.split('\n').length > 1;
+    const isPrintable = /^[\x20-\x7E\t\n\r\s]*$/.test(content.slice(0, 1000));
+
+    return hasReasonableLines && isPrintable;
+  }
+
+  // If content is not available, make a conservative guess based on non-classified extensions
+  // Avoid files that are likely binary but don't have known extensions
+  const knownBinaryExts = new Set([
+    ...Array.from(IMAGE_EXTENSIONS),
+    ...Array.from(AUDIO_EXTENSIONS),
+    ...Array.from(PDF_EXTENSIONS),
+    'exe', 'dll', 'so', 'dylib', 'bin', 'dat', 'db', 'sqlite', 'zip', 'tar', 'gz', 'rar', '7z'
+  ]);
+
+  if (knownBinaryExts.has(ext)) {
+    return false;
+  }
+
+  // Default to text for small files with unknown extensions
+  const MAX_DEFAULT_TEXT_SIZE = 1024 * 1024; // 1MB
+  return !size || size < MAX_DEFAULT_TEXT_SIZE;
+};

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactPage.tsx
@@ -15,6 +15,7 @@ import {
   PDF_EXTENSIONS,
   DATA_EXTENSIONS,
   AUDIO_EXTENSIONS,
+  isTextFile,
 } from '../../../common/utils/FileUtils';
 import { getLoggedModelPathsFromTags, getLoggedTablesFromTags } from '../../../common/utils/TagUtils';
 import { ONE_MB } from '../../constants';
@@ -96,8 +97,6 @@ class ShowArtifactPage extends Component<ShowArtifactPageProps> {
           return <ShowArtifactImageView {...commonArtifactProps} />;
         } else if (DATA_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <LazyShowArtifactTableView {...commonArtifactProps} />;
-        } else if (TEXT_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
-          return <ShowArtifactTextView {...commonArtifactProps} size={this.props.size} />;
         } else if (MAP_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <LazyShowArtifactMapView {...commonArtifactProps} />;
         } else if (HTML_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
@@ -106,6 +105,9 @@ class ShowArtifactPage extends Component<ShowArtifactPageProps> {
           return <LazyShowArtifactPdfView {...commonArtifactProps} />;
         } else if (AUDIO_EXTENSIONS.has(normalizedExtension.toLowerCase())) {
           return <LazyShowArtifactAudioView {...commonArtifactProps} />;
+        } else if (TEXT_EXTENSIONS.has(normalizedExtension.toLowerCase()) || isTextFile(this.props.path, undefined, this.props.size)) {
+          // Fall back to text view for files that appear to be text based on extension or size
+          return <ShowArtifactTextView {...commonArtifactProps} size={this.props.size} />;
         }
       }
     }
@@ -131,7 +133,7 @@ const getSelectFileView = () => {
         }
         description={
           <FormattedMessage
-            defaultMessage="Supported formats: image, text, html, pdf, audio, geojson files"
+            defaultMessage="Supported formats: image, text, html, pdf, audio, geojson files and arbitrary plain text"
             description="Text to explain users which formats are supported to display the artifacts"
           />
         }

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
@@ -9,6 +9,7 @@ import { ArtifactViewSkeleton } from './ArtifactViewSkeleton';
 import { ArtifactViewErrorState } from './ArtifactViewErrorState';
 import { LoggedModelArtifactViewerProps } from './ArtifactViewComponents.types';
 import { fetchArtifactUnified } from './utils/fetchArtifactUnified';
+import DOMPurify from 'dompurify';
 
 const LARGE_ARTIFACT_SIZE = 100 * 1024;
 
@@ -99,13 +100,19 @@ class ShowArtifactTextView extends Component<Props, State> {
     this.props
       .getArtifact?.({ isLoggedModelsMode, loggedModelId, path, runUuid, experimentId }, getArtifactContent)
       .then((text: string) => {
-        this.setState({ text: text, loading: false });
+        const sanitizedText = sanitizeTextContent(text);
+        this.setState({ text: sanitizedText, loading: false });
       })
       .catch((error: Error) => {
         this.setState({ error: error, loading: false });
       });
     this.setState({ path: this.props.path });
   }
+}
+
+export function sanitizeTextContent(text: string): string {
+  if (!text) return '';
+  return DOMPurify.sanitize(text, { RETURN_DOM_TEXT: true });
 }
 
 export function prettifyArtifactText(language: string, rawText: string) {

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactTextView.tsx
@@ -112,7 +112,7 @@ class ShowArtifactTextView extends Component<Props, State> {
 
 export function sanitizeTextContent(text: string): string {
   if (!text) return '';
-  return DOMPurify.sanitize(text, { RETURN_DOM_TEXT: true });
+  return DOMPurify.sanitize(text);
 }
 
 export function prettifyArtifactText(language: string, rawText: string) {

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -5181,6 +5181,7 @@ __metadata:
     d3-selection: "npm:^1.3.0"
     dateformat: "npm:3.0.3"
     diff: "npm:5.1.0"
+    dompurify: "npm:3.2.6"
     enzyme: "npm:^3.11.0"
     eslint: "npm:^8.25.0"
     eslint-config-prettier: "npm:^8.5.0"
@@ -9455,7 +9456,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/trusted-types@npm:^2.0.2":
+"@types/trusted-types@npm:^2.0.2, @types/trusted-types@npm:^2.0.7":
   version: 2.0.7
   resolution: "@types/trusted-types@npm:2.0.7"
   checksum: 10c0/4c4855f10de7c6c135e0d32ce462419d8abbbc33713b31d294596c0cc34ae1fa6112a2f9da729c8f7a20707782b0d69da3b1f8df6645b0366d08825ca1522e0c
@@ -15537,6 +15538,18 @@ __metadata:
   dependencies:
     domelementtype: "npm:^2.2.0"
   checksum: 10c0/fd4e6f1c986402e7a703b671c4f7bdb1dcf278d613ca02a38374eae9d1bba9b3b4d5983519ad902e43c5bd1281456d11f226694e7bb4cfc00dde6f1d5f3aa13e
+  languageName: node
+  linkType: hard
+
+"dompurify@npm:3.2.6":
+  version: 3.2.6
+  resolution: "dompurify@npm:3.2.6"
+  dependencies:
+    "@types/trusted-types": "npm:^2.0.7"
+  dependenciesMeta:
+    "@types/trusted-types":
+      optional: true
+  checksum: 10c0/c8f8e5b0879a0d93c84a2e5e78649a47d0c057ed0f7850ca3d573d2cca64b84fb1ff85bd4b20980ade69c4e5b80ae73011340f1c2ff375c7ef98bb8268e1d13a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/SkafteNicki/mlflow/pull/16239?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16239/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16239/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16239/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #5931

### What changes are proposed in this pull request?

Allow the UI to render arbitrary text files and not just the files from a predefined list of file extensions. The PR both consist of extending the current list of predefined list of file extensions but also include heuristic for determining if a file can be show. Files falling into the latter category is sanitized to make them HTML safe. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

I have tried spinning up the dev server with different files to check if they renders correctly. As an example here is a screenshot of a shell script being rendered even though its extension is not predefined list

![image](https://github.com/user-attachments/assets/690fff3f-e3c7-49ed-9883-dd1d0f427d1d)

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Allow the UI to render arbitrary text files.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
