### PR TITLE
Anthropic token count

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
@@ -200,6 +200,67 @@ for city, answer in zip(cities, answers):
     print(f"{city}: {answer}")
 ```
 
+## Token usage
+
+MLflow >= 3.1.0 supports token usage tracking for Anthropic. The token usage for each LLM call will be logged in the `mlflow.chat.tokenUsage` attribute. The total token usage throughout the trace will be
+available in the `token_usage` field of the trace info object.
+
+```python
+import json
+import mlflow
+
+mlflow.anthropic.autolog()
+
+client = anthropic.Anthropic()
+message = client.messages.create(
+    model="claude-3-5-sonnet-20241022",
+    max_tokens=1024,
+    messages=[{"role": "user", "content": "Hello"}],
+)
+
+# Get the trace object just created
+last_trace_id = mlflow.get_last_active_trace_id()
+trace = mlflow.get_trace(trace_id=last_trace_id)
+
+# Print the token usage
+total_usage = trace.info.token_usage
+print("== Total token usage: ==")
+print(f"  Input tokens: {total_usage['input_tokens']}")
+print(f"  Output tokens: {total_usage['output_tokens']}")
+print(f"  Total tokens: {total_usage['total_tokens']}")
+
+# Print the token usage for each LLM call
+print("\n== Detailed usage for each LLM call: ==")
+for span in trace.data.spans:
+    if usage := span.get_attribute("mlflow.chat.tokenUsage"):
+        print(f"{span.name}:")
+        print(f"  Input tokens: {usage['input_tokens']}")
+        print(f"  Output tokens: {usage['output_tokens']}")
+        print(f"  Total tokens: {usage['total_tokens']}")
+```
+
+```bash
+== Total token usage: ==
+  Input tokens: 8
+  Output tokens: 12
+  Total tokens: 20
+
+== Detailed usage for each LLM call: ==
+Messages.create:
+  Input tokens: 8
+  Output tokens: 12
+  Total tokens: 20
+```
+
+
+### Supported APIs:
+
+Token usage tracking is supported for the following Anthropic APIs:
+
+|Chat Completion|Function Calling|Streaming|Async|Image|Batch|
+|:--:|:--:|:--:|:--:|:--:|:--:|
+|✅|✅|-|✅ (*1)|-|-|
+
 ## Disable auto-tracing
 
 Auto tracing for Anthropic can be disabled globally by calling `mlflow.anthropic.autolog(disable=True)` or `mlflow.autolog(disable=True)`.

--- a/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
@@ -202,7 +202,7 @@ for city, answer in zip(cities, answers):
 
 ## Token usage
 
-MLflow >= 3.1.0 supports token usage tracking for Anthropic. The token usage for each LLM call will be logged in the `mlflow.chat.tokenUsage` attribute. The total token usage throughout the trace will be
+MLflow >= 3.2.0 supports token usage tracking for Anthropic. The token usage for each LLM call will be logged in the `mlflow.chat.tokenUsage` attribute. The total token usage throughout the trace will be
 available in the `token_usage` field of the trace info object.
 
 ```python
@@ -260,6 +260,12 @@ Token usage tracking is supported for the following Anthropic APIs:
 |Chat Completion|Function Calling|Streaming|Async|Image|Batch|
 |:--:|:--:|:--:|:--:|:--:|:--:|
 |✅|✅|-|✅ (*1)|-|-|
+
+<div style={{ fontSize: '0.9em', marginTop: '10px' }}>
+
+  (*1) Async support was added in MLflow 2.21.0.
+
+</div>
 
 ## Disable auto-tracing
 

--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -120,10 +120,9 @@ def _parse_usage(output: Any) -> Optional[dict[str, int]]:
         usage = getattr(output, "usage", None)
         if usage:
             return {
-                TokenUsageKey.INPUT_TOKENS: getattr(usage, "input_tokens", None),
-                TokenUsageKey.OUTPUT_TOKENS: getattr(usage, "output_tokens", None),
-                TokenUsageKey.TOTAL_TOKENS: getattr(usage, "output_tokens", 0)
-                + getattr(usage, "input_tokens", 0),
+                TokenUsageKey.INPUT_TOKENS: usage.input_tokens,
+                TokenUsageKey.OUTPUT_TOKENS: usage.output_tokens,
+                TokenUsageKey.TOTAL_TOKENS: usage.input_tokens + usage.output_tokens,
             }
     except Exception as e:
         _logger.debug(f"Failed to parse token usage from output: {e}")

--- a/tests/anthropic/test_anthropic_autolog.py
+++ b/tests/anthropic/test_anthropic_autolog.py
@@ -208,6 +208,18 @@ def test_messages_autolog(is_async):
         },
     ]
 
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }
+
+    assert traces[0].info.token_usage == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }
+
     mlflow.anthropic.autolog(disable=True)
     _call_anthropic(DUMMY_CREATE_MESSAGE_REQUEST, DUMMY_CREATE_MESSAGE_RESPONSE, is_async)
 

--- a/tests/anthropic/test_anthropic_autolog.py
+++ b/tests/anthropic/test_anthropic_autolog.py
@@ -294,6 +294,18 @@ def test_messages_autolog_multi_modal(is_async):
         },
     ]
 
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }
+
+    assert traces[0].info.token_usage == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }
+
 
 def test_messages_autolog_tool_calling(is_async):
     mlflow.anthropic.autolog()
@@ -404,6 +416,18 @@ def test_messages_autolog_tool_calling(is_async):
         },
     ]
 
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }
+
+    assert traces[0].info.token_usage == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }
+
 
 @pytest.mark.skipif(not _is_thinking_supported, reason="Thinking block is not supported")
 def test_messages_autolog_with_thinking(is_async):
@@ -448,3 +472,15 @@ def test_messages_autolog_with_thinking(is_async):
             ],
         },
     ]
+
+    assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }
+
+    assert traces[0].info.token_usage == {
+        "input_tokens": 10,
+        "output_tokens": 18,
+        "total_tokens": 28,
+    }


### PR DESCRIPTION
### Related Issues/PRs

FR: #16233 

### What changes are proposed in this pull request?

Support logging token counts in trace for Anthropic LLM calls.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support logging token counts in trace for Anthropic LLM calls.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
