### PR TITLE
Fix: Clarify mlflow.log_artifacts only supports directories

### DIFF
--- a/docs/docs/classic-ml/tracking/tracking-api/index.mdx
+++ b/docs/docs/classic-ml/tracking/tracking-api/index.mdx
@@ -131,8 +131,8 @@ Ideal for custom training loops, advanced experimentation, or when you need prec
 
 | Function | Purpose | Example |
 |----------|---------|---------|
-| <APILink fn="mlflow.log_artifact" /> | Log single file/directory | `mlflow.log_artifact("model.pkl")` |
-| <APILink fn="mlflow.log_artifacts" /> | Log entire directory | `mlflow.log_artifacts("./plots/")` |
+| <APILink fn="mlflow.log_artifact" /> | Log a single file or directory | `mlflow.log_artifact("model.pkl")` |
+| <APILink fn="mlflow.log_artifacts" /> | Log all files in a directory (**not for single files**) | `mlflow.log_artifacts("./plots/")` |
 | <APILink fn="mlflow.get_artifact_uri" /> | Get artifact storage location | `uri = mlflow.get_artifact_uri()` |
 
 ### Model Management (New in MLflow 3)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #16241

### What changes are proposed in this pull request?

Clarified the `mlflow.log_artifacts` function in the documentation table to reflect that it only supports **logging directories**, and **does not accept single file paths**. This prevents misunderstanding based on ambiguous examples or assumptions.

### How is this PR tested?

- [x] Manual tests — verified the change in `tracking-api/index.mdx` renders as expected.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] API references

### Release Notes

#### Is this a user-facing change?

- [x] Yes. This change updates the documentation to clarify the proper usage of `mlflow.log_artifacts`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<!-- Leave others unchecked -->

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
