### PR TITLE
Introduce Resolver class for improved AST name resolution in clint

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -502,10 +502,10 @@ class Linter(ast.NodeVisitor):
         self._invalid_abstract_method(node)
         self._pytest_mark_repeat(node)
         self.stack.append(node)
+        self._no_rst(node)
+        for deco in node.decorator_list:
+            self.visit_decorator(deco)
         with self.resolver.scope():
-            self._no_rst(node)
-            for deco in node.decorator_list:
-                self.visit_decorator(deco)
             self.generic_visit(node)
         self.stack.pop()
 

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -407,8 +407,8 @@ class Linter(ast.NodeVisitor):
         return [v for v in linter.violations if v.rule.name in config.example_rules]
 
     def visit_decorator(self, node: ast.expr) -> None:
-        if rules.NonLiteralExperimentalVersion.check(node, self.resolver):
-            self._check(Location.from_node(node), rules.NonLiteralExperimentalVersion())
+        if rules.InvalidExperimentalDecorator.check(node, self.resolver):
+            self._check(Location.from_node(node), rules.InvalidExperimentalDecorator())
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
         self.stack.append(node)

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -417,7 +417,8 @@ class Linter(ast.NodeVisitor):
         self._mlflow_class_name(node)
         for deco in node.decorator_list:
             self.visit_decorator(deco)
-        self.generic_visit(node)
+        with self.resolver.scope():
+            self.generic_visit(node)
         self.stack.pop()
 
     def _syntax_error_example(

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -14,6 +14,7 @@ from typing import Any, Iterator, Union
 from clint import rules
 from clint.builtin import BUILTIN_MODULES
 from clint.config import Config
+from clint.resolver import Resolver
 
 PARAM_REGEX = re.compile(r"\s+:param\s+\w+:", re.MULTILINE)
 RETURN_REGEX = re.compile(r"\s+:returns?:", re.MULTILINE)
@@ -302,6 +303,7 @@ class Linter(ast.NodeVisitor):
         self.imported_modules: set[str] = set()
         self.lazy_modules: dict[str, Location] = {}
         self.offset = offset or Location(0, 0)
+        self.resolver = Resolver()
 
     def _check(self, loc: Location, rule: rules.Rule) -> None:
         if (lines := self.ignore.get(rule.name)) and loc.lineno in lines:
@@ -405,7 +407,7 @@ class Linter(ast.NodeVisitor):
         return [v for v in linter.violations if v.rule.name in config.example_rules]
 
     def visit_decorator(self, node: ast.expr) -> None:
-        if rules.NonLiteralExperimentalVersion._check(node):
+        if rules.NonLiteralExperimentalVersion.check(node, self.resolver):
             self._check(Location.from_node(node), rules.NonLiteralExperimentalVersion())
 
     def visit_ClassDef(self, node: ast.ClassDef) -> None:
@@ -466,7 +468,7 @@ class Linter(ast.NodeVisitor):
         if not self.path.name.startswith("test_"):
             return
 
-        if rules.PytestMarkRepeat.check(node):
+        if rules.PytestMarkRepeat.check(node, self.resolver):
             self._check(Location.from_node(node), rules.PytestMarkRepeat())
 
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -488,7 +490,8 @@ class Linter(ast.NodeVisitor):
         self._no_rst(node)
         for deco in node.decorator_list:
             self.visit_decorator(deco)
-        self.generic_visit(node)
+        with self.resolver.scope():
+            self.generic_visit(node)
         self.stack.pop()
 
     def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
@@ -499,13 +502,15 @@ class Linter(ast.NodeVisitor):
         self._invalid_abstract_method(node)
         self._pytest_mark_repeat(node)
         self.stack.append(node)
-        self._no_rst(node)
-        for deco in node.decorator_list:
-            self.visit_decorator(deco)
-        self.generic_visit(node)
+        with self.resolver.scope():
+            self._no_rst(node)
+            for deco in node.decorator_list:
+                self.visit_decorator(deco)
+            self.generic_visit(node)
         self.stack.pop()
 
     def visit_Import(self, node: ast.Import) -> None:
+        self.resolver.add_import(node)
         for alias in node.names:
             root_module = alias.name.split(".", 1)[0]
             if self._is_in_function() and root_module in BUILTIN_MODULES:
@@ -529,6 +534,8 @@ class Linter(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_ImportFrom(self, node: ast.ImportFrom) -> None:
+        self.resolver.add_import_from(node)
+
         root_module = node.module and node.module.split(".", 1)[0]
         if self._is_in_function() and root_module in BUILTIN_MODULES:
             self._check(Location.from_node(node), rules.LazyBuiltinImport())
@@ -632,13 +639,15 @@ class Linter(ast.NodeVisitor):
         if self._log_model_with_artifact_path(node):
             self._check(Location.from_node(node), rules.LogModelArtifactPath())
 
-        if rules.UseSysExecutable.check(node):
+        if rules.UseSysExecutable.check(node, self.resolver):
             self._check(Location.from_node(node), rules.UseSysExecutable())
 
-        if self.path.parts[0] != "tests" and _is_set_active_model(node.func):
+        if self.path.parts[0] != "tests" and rules.ForbiddenSetActiveModelUsage.check(
+            node, self.resolver
+        ):
             self._check(Location.from_node(node), rules.ForbiddenSetActiveModelUsage())
 
-        if self.path.parts[0] != "tests" and rules.UnnamedThread.check(node):
+        if self.path.parts[0] != "tests" and rules.UnnamedThread.check(node, self.resolver):
             self._check(Location.from_node(node), rules.UnnamedThread())
 
         self.generic_visit(node)

--- a/dev/clint/src/clint/resolver.py
+++ b/dev/clint/src/clint/resolver.py
@@ -50,7 +50,7 @@ class Resolver:
         Resolve a node to its fully qualified name parts.
 
         Args:
-            node: Can be ast.Call, ast.Name, or ast.Attribute
+            node: AST node to resolve, typically a Call, Name, or Attribute.
 
         Returns:
             List of name parts (e.g., ["threading", "Thread"]) or None if unresolvable

--- a/dev/clint/src/clint/resolver.py
+++ b/dev/clint/src/clint/resolver.py
@@ -1,0 +1,86 @@
+import ast
+from contextlib import contextmanager
+from typing import Optional
+
+
+class Resolver:
+    def __init__(self):
+        self.name_map: dict[str, list[str]] = {}
+        self._scope_stack: list[dict[str, list[str]]] = []
+
+    def clear(self) -> None:
+        """Clear all name mappings. Useful when starting to process a new file."""
+        self.name_map.clear()
+        self._scope_stack.clear()
+
+    def enter_scope(self) -> None:
+        """Enter a new scope by taking a snapshot of current mappings."""
+        self._scope_stack.append(self.name_map.copy())
+
+    def exit_scope(self) -> None:
+        """Exit current scope by restoring the previous snapshot."""
+        if self._scope_stack:
+            self.name_map = self._scope_stack.pop()
+
+    @contextmanager
+    def scope(self):
+        """Context manager for automatic scope management."""
+        self.enter_scope()
+        try:
+            yield
+        finally:
+            self.exit_scope()
+
+    def add_import(self, node: ast.Import) -> None:
+        for alias in node.names:
+            name = alias.asname if alias.asname else alias.name
+            self.name_map[name] = alias.name.split(".")
+
+    def add_import_from(self, node: ast.ImportFrom) -> None:
+        if node.module is None:
+            return
+
+        for alias in node.names:
+            name = alias.asname if alias.asname else alias.name
+            module_parts = node.module.split(".")
+            self.name_map[name] = module_parts + [alias.name]
+
+    def resolve(self, node: ast.expr) -> Optional[list[str]]:
+        """
+        Resolve a node to its fully qualified name parts.
+
+        Args:
+            node: Can be ast.Call, ast.Name, or ast.Attribute
+
+        Returns:
+            List of name parts (e.g., ["threading", "Thread"]) or None if unresolvable
+        """
+        if isinstance(node, ast.Call):
+            parts = self._extract_call_parts(node.func)
+        elif isinstance(node, ast.Name):
+            parts = [node.id]
+        elif isinstance(node, ast.Attribute):
+            parts = self._extract_call_parts(node)
+        else:
+            return None
+
+        return self._resolve_parts(parts) if parts else None
+
+    def _extract_call_parts(self, node: ast.AST) -> list[str]:
+        if isinstance(node, ast.Name):
+            return [node.id]
+        elif isinstance(node, ast.Attribute) and (
+            base_parts := self._extract_call_parts(node.value)
+        ):
+            return base_parts + [node.attr]
+        return []
+
+    def _resolve_parts(self, parts: list[str]) -> Optional[list[str]]:
+        if not parts:
+            return None
+
+        # Check if the first part is in our name mapping
+        if resolved_base := self.name_map.get(parts[0]):
+            return resolved_base + parts[1:]
+
+        return None

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -415,7 +415,7 @@ class UnnamedThread(Rule):
         return "MLF0024"
 
     def _message(self) -> str:
-        return "`threading.Thread()` calls should include a `name` parameter for easier debugging"
+        return "`threading.Thread()` calls should include a `name` parameter for easier debugging."
 
     @staticmethod
     def check(node: ast.Call, resolver: Resolver) -> bool:

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -429,7 +429,7 @@ class UnnamedThread(Rule):
         )
 
 
-class NonLiteralExperimentalVersion(Rule):
+class InvalidExperimentalDecorator(Rule):
     def _id(self) -> str:
         return "MLF0025"
 

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -435,8 +435,8 @@ class InvalidExperimentalDecorator(Rule):
 
     def _message(self) -> str:
         return (
-            "The `version` argument of `@experimental` must be a string literal that is a valid "
-            "semantic version (e.g., '3.0.0')."
+            "Invalid usage of `@experimental` decorator. It must be used with a `version` "
+            "argument that is a valid semantic version string."
         )
 
     @staticmethod

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -415,7 +415,10 @@ class UnnamedThread(Rule):
         return "MLF0024"
 
     def _message(self) -> str:
-        return "`threading.Thread()` calls should include a `name` parameter for easier debugging."
+        return (
+            "`threading.Thread()` must be called with a `name` argument to improve debugging "
+            "and traceability of thread-related issues."
+        )
 
     @staticmethod
     def check(node: ast.Call, resolver: Resolver) -> bool:

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -452,6 +452,9 @@ class NonLiteralExperimentalVersion(Rule):
         if resolved != ["mlflow", "utils", "annotations", "experimental"]:
             return False
 
+        if not isinstance(node, ast.Call):
+            return True
+
         version = next((k.value for k in node.keywords if k.arg == "version"), None)
         if version is None:
             # No `version` argument, invalid usage

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -358,7 +358,7 @@ class ForbiddenSetActiveModelUsage(Rule):
         )
 
     @staticmethod
-    def check(node: ast.Call, resolver: "Resolver") -> bool:
+    def check(node: ast.Call, resolver: Resolver) -> bool:
         """Check if this is a call to set_active_model function."""
         return (
             (resolved := resolver.resolve(node))

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -515,6 +515,8 @@ def test_pyfunc_cli_predict_command_without_conda_env_activation_succeeds(
     output_json_path = os.path.join(tmp_path, "output.json")
     process = Popen(
         [
+            sys.executable,
+            "-m",
             "mlflow",
             "models",
             "predict",
@@ -566,6 +568,8 @@ def test_pyfunc_cli_predict_command_with_conda_env_activation_succeeds(
     output_json_path = os.path.join(tmp_path, "output.json")
     process = Popen(
         [
+            sys.executable,
+            "-m",
             "mlflow",
             "models",
             "predict",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16256?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16256/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16256/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16256/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

#### Summary

Adds a new `Resolver` class to improve name resolution in the clint linter by tracking imports and resolving qualified names, making rule checking more accurate.

#### Changes

- **New `Resolver` class**: Tracks imports and resolves AST nodes to fully qualified names
- **Enhanced rules**: Updated `UseSysExecutable`, `PytestMarkRepeat`, `UnnamedThread`, and `NonLiteralExperimentalVersion` to use resolver
- **Linter integration**: Added resolver instance and scope management for function definitions

Reduces false positives and improves accuracy of lint rule detection.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
