### PR TITLE
Prompt Registry Client: Prompt URI with Alias Handling

### DIFF
--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -59,7 +59,7 @@ def _parse_model_uri(uri, prefix: str = "models") -> ParsedModelUri:
         - (name, None, stage, None) to look for the latest version of a stage,
         - (name, None, None, None) to look for the latest of all versions.
         - (name, None, None, alias) to look for a registered model alias.
-    
+
     Args:
         uri: The URI to parse (e.g., "models:/name/version" or "prompts:/name@alias")
         prefix: The expected URI scheme prefix (default: "models", can be "prompts")

--- a/mlflow/store/artifact/utils/models.py
+++ b/mlflow/store/artifact/utils/models.py
@@ -18,13 +18,15 @@ def is_using_databricks_registry(uri):
     return is_databricks_uri(profile_uri)
 
 
-def _improper_model_uri_msg(uri):
+def _improper_model_uri_msg(uri, prefix: str = "models"):
+    entity_type = "Models" if prefix == "models" else "Prompts"
     return (
-        f"Not a proper models:/ URI: {uri}. "
-        + "Models URIs must be of the form 'models:/model_name/suffix' "
-        + "or 'models:/model_name@alias' where suffix is a model version, stage, "
-        + f"or the string {_MODELS_URI_SUFFIX_LATEST!r} and where alias is a registered model "
-        + "alias. Only one of suffix or alias can be defined at a time."
+        f"Not a proper {prefix}:/ URI: {uri}. "
+        + f"{entity_type} URIs must be of the form '{prefix}:/name/suffix' "
+        + f"or '{prefix}:/name@alias' where suffix is a version"
+        + (f", stage, or the string {_MODELS_URI_SUFFIX_LATEST!r}" if prefix == "models" else "")
+        + f" and where alias is a registered {prefix[:-1]} alias. "
+        + "Only one of suffix or alias can be defined at a time."
     )
 
 
@@ -48,46 +50,55 @@ class ParsedModelUri(NamedTuple):
     alias: Optional[str] = None
 
 
-def _parse_model_uri(uri) -> ParsedModelUri:
+def _parse_model_uri(uri, prefix: str = "models") -> ParsedModelUri:
     """
-    Returns a ParsedModelUri tuple. Since a models:/ URI can only have one of
+    Returns a ParsedModelUri tuple. Since a models:/ or prompts:/ URI can only have one of
     {version, stage, 'latest', alias}, it will return
         - (id, None, None, None) to look for a specific model by ID,
         - (name, version, None, None) to look for a specific version,
         - (name, None, stage, None) to look for the latest version of a stage,
         - (name, None, None, None) to look for the latest of all versions.
         - (name, None, None, alias) to look for a registered model alias.
+    
+    Args:
+        uri: The URI to parse (e.g., "models:/name/version" or "prompts:/name@alias")
+        prefix: The expected URI scheme prefix (default: "models", can be "prompts")
     """
     parsed = urllib.parse.urlparse(uri, allow_fragments=False)
-    if parsed.scheme != "models":
-        raise MlflowException(_improper_model_uri_msg(uri))
+    if parsed.scheme != prefix:
+        raise MlflowException(_improper_model_uri_msg(uri, prefix))
     path = parsed.path
     if not path.startswith("/") or len(path) <= 1:
-        raise MlflowException(_improper_model_uri_msg(uri))
+        raise MlflowException(_improper_model_uri_msg(uri, prefix))
 
     parts = path.lstrip("/").split("/")
     if len(parts) > 2 or parts[0].strip() == "":
-        raise MlflowException(_improper_model_uri_msg(uri))
+        raise MlflowException(_improper_model_uri_msg(uri, prefix))
 
     if len(parts) == 2:
         name, suffix = parts
         if suffix.strip() == "":
-            raise MlflowException(_improper_model_uri_msg(uri))
+            raise MlflowException(_improper_model_uri_msg(uri, prefix))
         # The URI is in the suffix format
         if suffix.isdigit():
             # The suffix is a specific version, e.g. "models:/AdsModel1/123"
             return ParsedModelUri(name=name, version=suffix)
-        elif suffix.lower() == _MODELS_URI_SUFFIX_LATEST.lower():
+        elif suffix.lower() == _MODELS_URI_SUFFIX_LATEST.lower() and prefix == "models":
             # The suffix is the 'latest' string (case insensitive), e.g. "models:/AdsModel1/latest"
+            # Only supported for models, not prompts
             return ParsedModelUri(name=name)
-        else:
+        elif prefix == "models":
             # The suffix is a specific stage (case insensitive), e.g. "models:/AdsModel1/Production"
+            # Only supported for models, not prompts
             return ParsedModelUri(name=name, stage=suffix)
+        else:
+            # For prompts, only version numbers are supported, not stages or 'latest'
+            raise MlflowException(_improper_model_uri_msg(uri, prefix))
     elif "@" in path:
         # The URI is an alias URI, e.g. "models:/AdsModel1@Champion"
         alias_parts = parts[0].rsplit("@", 1)
         if len(alias_parts) != 2 or alias_parts[1].strip() == "":
-            raise MlflowException(_improper_model_uri_msg(uri))
+            raise MlflowException(_improper_model_uri_msg(uri, prefix))
         return ParsedModelUri(name=alias_parts[0], alias=alias_parts[1])
     else:
         # The URI is of the form "models:/<model_id>"

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -925,8 +925,7 @@ class MlflowClient:
             name, alias = path.rsplit("@", 1)
             if not name or not alias:
                 raise MlflowException.invalid_parameter_value(
-                    f"Invalid prompt alias URI: {uri}. "
-                    "Expected format 'prompts:/<name>@<alias>'"
+                    f"Invalid prompt alias URI: {uri}. Expected format 'prompts:/<name>@<alias>'"
                 )
             return name, alias
         elif "/" in path:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -915,7 +915,8 @@ class MlflowClient:
 
         if parsed.scheme != "prompts":
             raise MlflowException.invalid_parameter_value(
-                f"Invalid prompt URI: {uri}. Expected schema 'prompts:/<name>/<version>' or 'prompts:/<name>@<alias>'"
+                f"Invalid prompt URI: {uri}. "
+                "Expected schema 'prompts:/<name>/<version>' or 'prompts:/<name>@<alias>'"
             )
 
         path = parsed.path.lstrip("/")
@@ -924,7 +925,8 @@ class MlflowClient:
             name, alias = path.rsplit("@", 1)
             if not name or not alias:
                 raise MlflowException.invalid_parameter_value(
-                    f"Invalid prompt alias URI: {uri}. Expected format 'prompts:/<name>@<alias>'"
+                    f"Invalid prompt alias URI: {uri}. "
+                    "Expected format 'prompts:/<name>@<alias>'"
                 )
             return name, alias
         elif "/" in path:
@@ -932,12 +934,14 @@ class MlflowClient:
             name, version = path.split("/", 1)
             if not name or not version:
                 raise MlflowException.invalid_parameter_value(
-                    f"Invalid prompt version URI: {uri}. Expected format 'prompts:/<name>/<version>'"
+                    f"Invalid prompt version URI: {uri}. "
+                    "Expected format 'prompts:/<name>/<version>'"
                 )
             return name, version
         else:
             raise MlflowException.invalid_parameter_value(
-                f"Invalid prompt URI: {uri}. Expected format 'prompts:/<name>/<version>' or 'prompts:/<name>@<alias>'"
+                f"Invalid prompt URI: {uri}. "
+                "Expected format 'prompts:/<name>/<version>' or 'prompts:/<name>@<alias>'"
             )
 
     ##### Tracing #####

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -910,29 +910,31 @@ class MlflowClient:
         Parse prompt URI into prompt name and prompt version.
         - 'prompts:/<name>/<version>' -> ('<name>', '<version>')
         - 'prompts:/<name>@<alias>' -> ('<name>', '<version>')
-        
+
         This method reuses the existing model URI parsing logic with prompts prefix.
         """
         from mlflow.store.artifact.utils.models import _parse_model_uri
-        
+
         # Use the existing model URI parsing utilities with prompts prefix
         parsed_prompt_uri = _parse_model_uri(uri, prefix="prompts")
-        
+
         if parsed_prompt_uri.model_id is not None:
             # This shouldn't happen for prompts (no model IDs), but handle gracefully
             raise MlflowException.invalid_parameter_value(
                 f"Invalid prompt URI format: {uri}"
             )
-        
+
         if parsed_prompt_uri.version is not None:
             # Direct version reference: prompts:/name/version
             return parsed_prompt_uri.name, parsed_prompt_uri.version
-        
+
         if parsed_prompt_uri.alias is not None:
             # Alias reference: prompts:/name@alias - resolve to version
-            prompt_version = self.get_prompt_version_by_alias(parsed_prompt_uri.name, parsed_prompt_uri.alias)
+            prompt_version = self.get_prompt_version_by_alias(
+                parsed_prompt_uri.name, parsed_prompt_uri.alias
+            )
             return parsed_prompt_uri.name, str(prompt_version.version)
-        
+
         # Handle stage or latest (not supported for prompts)
         raise MlflowException.invalid_parameter_value(
             f"Invalid prompt URI: {uri}. Prompts do not support stage-based references."

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -919,9 +919,7 @@ class MlflowClient:
 
         if parsed_prompt_uri.model_id is not None:
             # This shouldn't happen for prompts (no model IDs), but handle gracefully
-            raise MlflowException.invalid_parameter_value(
-                f"Invalid prompt URI format: {uri}"
-            )
+            raise MlflowException.invalid_parameter_value(f"Invalid prompt URI format: {uri}")
 
         if parsed_prompt_uri.version is not None:
             # Direct version reference: prompts:/name/version

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -73,8 +73,8 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.store.artifact.utils.models import (
-    get_model_name_and_version,
     _parse_model_uri,
+    get_model_name_and_version,
 )
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry import (

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -74,6 +74,7 @@ from mlflow.protos.databricks_pb2 import (
 )
 from mlflow.store.artifact.utils.models import (
     get_model_name_and_version,
+    _parse_model_uri,
 )
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry import (
@@ -913,10 +914,8 @@ class MlflowClient:
 
         This method reuses the existing model URI parsing logic with prompts prefix.
         """
-        from mlflow.store.artifact.utils.models import _parse_model_uri
-
-        # Use the existing model URI parsing utilities with prompts prefix
-        parsed_prompt_uri = _parse_model_uri(uri, prefix="prompts")
+        # Use the existing model URI parsing utilities with prompts scheme
+        parsed_prompt_uri = _parse_model_uri(uri, scheme="prompts")
 
         if parsed_prompt_uri.model_id is not None:
             # This shouldn't happen for prompts (no model IDs), but handle gracefully

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -135,7 +135,9 @@ def test_improper_model_uri_msg_prompts():
     from mlflow.store.artifact.utils.models import _improper_model_uri_msg
     uri = "prompts:/baduri"
     msg = _improper_model_uri_msg(uri, scheme="prompts")
-    assert "prompts:/" in msg and "Prompts URIs" in msg and "prompts:/name/suffix" in msg, f"Unexpected message: {msg}"
+    assert "prompts:/" in msg, f"Missing 'prompts:/' in message: {msg}"
+    assert "Prompts URIs" in msg, f"Missing 'Prompts URIs' in message: {msg}"
+    assert "prompts:/name/suffix" in msg, f"Missing 'prompts:/name/suffix' in message: {msg}"
 
 
 def test_get_model_name_and_version_with_version():

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -131,6 +131,13 @@ def test_parse_models_uri_invalid_input(uri):
         _parse_model_uri(uri)
 
 
+def test_improper_model_uri_msg_prompts():
+    from mlflow.store.artifact.utils.models import _improper_model_uri_msg
+    uri = "prompts:/baduri"
+    msg = _improper_model_uri_msg(uri, scheme="prompts")
+    assert "prompts:/" in msg and "Prompts URIs" in msg and "prompts:/name/suffix" in msg, f"Unexpected message: {msg}"
+
+
 def test_get_model_name_and_version_with_version():
     with mock.patch.object(
         ModelRegistryClient, "get_latest_versions", return_value=[]
@@ -199,3 +206,46 @@ def test_get_model_name_and_version_with_alias():
             "10",
         )
         mlflow_client_mock.assert_called_once_with("AdsModel1", "Champion")
+
+
+@pytest.mark.parametrize(
+    ("uri", "expected_name", "expected_version", "expected_alias"),
+    [
+        ("prompts:/Prompt1/1", "Prompt1", "1", None),
+        ("prompts:/Prompt-Name_123/42", "Prompt-Name_123", "42", None),
+        ("prompts:/Prompt1@production", "Prompt1", None, "production"),
+        ("prompts:/Prompt1@PRODUCTION", "Prompt1", None, "PRODUCTION"),
+        ("prompts:/Prompt1@prod-1", "Prompt1", None, "prod-1"),
+        ("prompts:/complex.prompt_name@alias-42", "complex.prompt_name", None, "alias-42"),
+    ],
+)
+def test_parse_prompts_uri(uri, expected_name, expected_version, expected_alias):
+    parsed = _parse_model_uri(uri, scheme="prompts")
+    assert parsed.name == expected_name
+    assert parsed.version == expected_version
+    assert parsed.alias == expected_alias
+
+
+@pytest.mark.parametrize(
+    "uri",
+    [
+        "notprompts:/Prompt1/1",  # wrong scheme
+        "prompts:/",  # no prompt name
+        "prompts:/ /1",  # empty name
+        "prompts:/Prompt1/",  # empty version
+        "prompts:/Prompt1@",  # empty alias
+        "prompts:/Prompt1/1/2",  # too many specifiers
+        "prompts:Prompt1/1",  # missing slash
+        "prompts:/Prompt1/latest",  # 'latest' not supported for prompts
+        "prompts:/Prompt1/Production",  # stage not supported for prompts
+    ],
+)
+def test_parse_prompts_uri_invalid_input(uri):
+    with pytest.raises(MlflowException, match="Not a proper prompts"):
+        _parse_model_uri(uri, scheme="prompts")
+
+
+def test_improper_model_uri_msg_invalid_scheme():
+    from mlflow.store.artifact.utils.models import _improper_model_uri_msg
+    with pytest.raises(ValueError, match="Unsupported scheme"):
+        _improper_model_uri_msg("foo:/bar", scheme="foo")

--- a/tests/store/artifact/utils/test_model_utils.py
+++ b/tests/store/artifact/utils/test_model_utils.py
@@ -133,6 +133,7 @@ def test_parse_models_uri_invalid_input(uri):
 
 def test_improper_model_uri_msg_prompts():
     from mlflow.store.artifact.utils.models import _improper_model_uri_msg
+
     uri = "prompts:/baduri"
     msg = _improper_model_uri_msg(uri, scheme="prompts")
     assert "prompts:/" in msg, f"Missing 'prompts:/' in message: {msg}"
@@ -249,5 +250,6 @@ def test_parse_prompts_uri_invalid_input(uri):
 
 def test_improper_model_uri_msg_invalid_scheme():
     from mlflow.store.artifact.utils.models import _improper_model_uri_msg
+
     with pytest.raises(ValueError, match="Unsupported scheme"):
         _improper_model_uri_msg("foo:/bar", scheme="foo")

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -184,7 +184,7 @@ def test_prompt_alias(tmp_path):
     assert mlflow.load_prompt("prompts:/p1@production").template == "Hi, {{name}}!"
 
     mlflow.delete_prompt_alias("p1", alias="production")
-    with pytest.raises(MlflowException, match=r"Prompt (.*) does not exist."):
+    with pytest.raises(MlflowException, match=r"Prompt (.*) does not exist.|Prompt alias (.*) not found."):
         mlflow.load_prompt("prompts:/p1@production")
 
 

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -184,7 +184,13 @@ def test_prompt_alias(tmp_path):
     assert mlflow.load_prompt("prompts:/p1@production").template == "Hi, {{name}}!"
 
     mlflow.delete_prompt_alias("p1", alias="production")
-    with pytest.raises(MlflowException, match=r"Prompt (.*) does not exist.|Prompt alias (.*) not found."):
+    with pytest.raises(
+        MlflowException,
+        match=(
+            r"Prompt (.*) does not exist."
+            r"|Prompt alias (.*) not found."
+        ),
+    ):
         mlflow.load_prompt("prompts:/p1@production")
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2379,7 +2379,6 @@ def test_load_prompt_with_alias_uri(tracking_uri):
     # Delete alias and verify loading fails
     client.delete_prompt_alias("alias_prompt", alias="production")
     with pytest.raises(
-        MlflowException,
-        match=r"Prompt (.*) does not exist.|Prompt alias (.*) not found."
+        MlflowException, match=r"Prompt (.*) does not exist.|Prompt alias (.*) not found."
     ):
         client.load_prompt("prompts:/alias_prompt@production")

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2355,3 +2355,31 @@ def test_log_batch_link_to_active_model(tracking_uri):
     assert logged_model.name == model.name
     assert logged_model.model_id == model.model_id
     assert {m.key: m.value for m in logged_model.metrics} == {"metric1": 1, "metric2": 2}
+
+
+def test_load_prompt_with_alias_uri(tracking_uri):
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    # Register two versions of a prompt
+    client.register_prompt(name="alias_prompt", template="Hello, world!")
+    client.register_prompt(name="alias_prompt", template="Hello, {{name}}!")
+
+    # Assign alias to version 1
+    client.set_prompt_alias("alias_prompt", alias="production", version=1)
+    prompt = client.load_prompt("prompts:/alias_prompt@production")
+    assert prompt.template == "Hello, world!"
+    assert "production" in prompt.aliases
+
+    # Reassign alias to version 2
+    client.set_prompt_alias("alias_prompt", alias="production", version=2)
+    prompt = client.load_prompt("prompts:/alias_prompt@production")
+    assert prompt.template == "Hello, {{name}}!"
+    assert "production" in prompt.aliases
+
+    # Delete alias and verify loading fails
+    client.delete_prompt_alias("alias_prompt", alias="production")
+    with pytest.raises(
+        MlflowException,
+        match=r"Prompt (.*) does not exist.|Prompt alias (.*) not found."
+    ):
+        client.load_prompt("prompts:/alias_prompt@production")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/16261?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16261/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16261/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16261/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Update Prompt URI handling and ensure that it correctly handles aliases. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
