### PR TITLE
Add new area labels for tracing, evaluation, and prompt engineering

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_template.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report_template.yaml
@@ -194,6 +194,8 @@ body:
           required: false
         - label: "`area/docs`: MLflow documentation pages"
           required: false
+        - label: "`area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows"
+          required: false
         - label: "`area/examples`: Example code"
           required: false
         - label: "`area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry"
@@ -202,9 +204,13 @@ body:
           required: false
         - label: "`area/projects`: MLproject format, project running backends"
           required: false
+        - label: "`area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management"
+          required: false
         - label: "`area/scoring`: MLflow Model server, model deployment tools, Spark UDFs"
           required: false
         - label: "`area/server-infra`: MLflow Tracking server backend"
+          required: false
+        - label: "`area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality"
           required: false
         - label: "`area/tracking`: Tracking Service, tracking client APIs, autologging"
           required: false

--- a/.github/ISSUE_TEMPLATE/feature_request_template.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request_template.yaml
@@ -66,6 +66,8 @@ body:
           required: false
         - label: "`area/docs`: MLflow documentation pages"
           required: false
+        - label: "`area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows"
+          required: false
         - label: "`area/examples`: Example code"
           required: false
         - label: "`area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry"
@@ -74,9 +76,13 @@ body:
           required: false
         - label: "`area/projects`: MLproject format, project running backends"
           required: false
+        - label: "`area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management"
+          required: false
         - label: "`area/scoring`: MLflow Model server, model deployment tools, Spark UDFs"
           required: false
         - label: "`area/server-infra`: MLflow Tracking server backend"
+          required: false
+        - label: "`area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality"
           required: false
         - label: "`area/tracking`: Tracking Service, tracking client APIs, autologging"
           required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -40,12 +40,15 @@ Components
 - [ ] `area/build`: Build and test infrastructure for MLflow
 - [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
 - [ ] `area/docs`: MLflow documentation pages
+- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
 - [ ] `area/examples`: Example code
 - [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
 - [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
 - [ ] `area/projects`: MLproject format, project running backends
+- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
 - [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
 - [ ] `area/server-infra`: MLflow Tracking server backend
+- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
 - [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
 
 Interface

--- a/ISSUE_TRIAGE.rst
+++ b/ISSUE_TRIAGE.rst
@@ -70,13 +70,16 @@ Components
 - ``area/artifacts``: Artifact stores and artifact logging
 - ``area/build``: Build and test infrastructure for MLflow
 - ``area/docs``: MLflow documentation pages
+- ``area/evaluation``: MLflow model evaluation features, evaluation metrics, and evaluation workflows
 - ``area/examples``: Example code
 - ``area/gateway``: AI Gateway service, Gateway client APIs, third-party Gateway integrations
 - ``area/model-registry``: Model Registry service, APIs, and the fluent client calls for Model Registry
 - ``area/models``: MLmodel format, model serialization/deserialization, flavors
 - ``area/projects``: MLproject format, project execution backends
+- ``area/prompt``: MLflow prompt engineering features, prompt templates, and prompt management
 - ``area/scoring``: MLflow Model server, model deployment tools, Spark UDFs
 - ``area/server-infra``: MLflow Tracking server backend
+- ``area/tracing``: MLflow Tracing features, tracing APIs, and LLM tracing functionality
 - ``area/tracking``: Tracking Service, tracking client APIs, autologging
 
 Interface Surface


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16266?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16266/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16266/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16266/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Added three new area categories to issue and PR templates:
- area/evaluation: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- area/prompt: MLflow prompt engineering features, prompt templates, and prompt management
- area/tracing: MLflow Tracing features, tracing APIs, and LLM tracing functionality

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
