### PR TITLE
Fix: `mlflow.spark.load_model` fails to load a model from `dbfs:/databricks/mlflow-tracking/<exp_id>/<run_id>/artifacts/model`

### DIFF
--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -945,12 +945,12 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
         spark_model_local_path = os.path.join(local_mlflow_model_path, flavor_conf["model_data"])
         return _load_spark_connect_model(model_class, spark_model_local_path)
 
-    if _should_use_mlflowdbfs(model_uri):
+    if _should_use_mlflowdbfs(model_uri) and (
+        run_id := DatabricksArtifactRepository._extract_run_id(model_uri)
+    ):
         from pyspark.ml.pipeline import PipelineModel
 
-        mlflowdbfs_path = _mlflowdbfs_path(
-            DatabricksArtifactRepository._extract_run_id(model_uri), artifact_path
-        )
+        mlflowdbfs_path = _mlflowdbfs_path(run_id, artifact_path)
         with databricks_utils.MlflowCredentialContext(
             get_databricks_profile_uri_from_artifact_uri(root_uri)
         ):

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -150,6 +150,21 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
 
         return _Run(id_=parts[3], artifact_uri=artifact_uri, call_endpoint=self._call_endpoint)
 
+    @staticmethod
+    def _extract_run_id(artifact_uri: str) -> Optional[str]:
+        """
+        Extracts the run ID from the run artifact URI.
+        """
+        artifact_path = extract_and_normalize_path(artifact_uri)
+        parts = artifact_path.split("/")
+        if len(parts) < 4:
+            return None
+
+        if parts[3] == "logged_models" or parts[3].startswith(TRACE_REQUEST_ID_PREFIX):
+            return None
+
+        return parts[3]
+
     def _call_endpoint(
         self, service, api, json_body=None, path_params=None, retry_timeout_seconds=None
     ):

--- a/tests/store/artifact/test_databricks_artifact_repo.py
+++ b/tests/store/artifact/test_databricks_artifact_repo.py
@@ -4,6 +4,7 @@ import posixpath
 import re
 import shutil
 import time
+from typing import Optional
 from unittest import mock
 from unittest.mock import ANY
 
@@ -199,7 +200,20 @@ def test_run_relative_artifact_repo_root_path(artifact_uri, expected_relative_pa
         assert repo.resource.relative_path == expected_relative_path
 
 
-def test_extract_run_id():
+@pytest.mark.parametrize(
+    ("uri", "expected"),
+    [
+        ("dbfs:/databricks/mlflow-tracking/123/456/artifact", "456"),
+        ("dbfs:/databricks/mlflow-tracking/123/logged_models/m-123", None),
+        ("dbfs:/databricks/mlflow-tracking/123/tr-123/artifacts", None),
+        ("dbfs:/databricks/mlflow-tracking/123/", None),
+    ],
+)
+def test_extract_run_id(uri: str, expected: Optional[str]):
+    assert DatabricksArtifactRepository._extract_run_id(uri) == expected
+
+
+def test_extract_resource():
     with mock.patch(
         f"{DATABRICKS_ARTIFACT_REPOSITORY_RESOURCES}._Run.get_artifact_root",
         return_value=MOCK_RUN_ROOT_URI,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16279?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16279/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16279/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16279/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix a regression in mlflow 3.0. `DatabricksArtifactRepository._extract_run_id` has been removed but `mlflow.spark` still uses it. This PR restores it.

```
AttributeError: type object 'DatabricksArtifactRepository' has no attribute '_extract_run_id'
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
File <command-1334475583821427>, line 4
      1 import mlflow
      2 from unittest import mock
----> 4 model = mlflow.spark.load_model(model_uri)
      5 # Prepare test documents, which are unlabeled (id, text) tuples.
      6 test = spark.createDataFrame([
      7     (4, "spark i j k"),
      8     (5, "l m n"),
      9     (6, "spark hadoop spark"),
     10     (7, "apache hadoop")], ["id", "text"])

File /local_disk0/.ephemeral_nfs/envs/pythonEnv-77c4ea7c-500a-4b3c-b2fc-96079522fa84/lib/python3.12/site-packages/mlflow/spark/__init__.py:952, in load_model(model_uri, dfs_tmpdir, dst_path)
    948 if _should_use_mlflowdbfs(model_uri):
    949     from pyspark.ml.pipeline import PipelineModel
    951     mlflowdbfs_path = _mlflowdbfs_path(
--> 952         DatabricksArtifactRepository._extract_run_id(model_uri), artifact_path
    953     )
    954     with databricks_utils.MlflowCredentialContext(
    955         get_databricks_profile_uri_from_artifact_uri(root_uri)
    956     ):
    957         return PipelineModel.load(mlflowdbfs_path)

AttributeError: type object 'DatabricksArtifactRepository' has no attribute '_extract_run_id'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
