### PR TITLE
Prompt & Prompt Version Entity: Correctly Display Alias

### DIFF
--- a/mlflow/entities/model_registry/prompt.py
+++ b/mlflow/entities/model_registry/prompt.py
@@ -22,6 +22,7 @@ class Prompt:
         description: Optional[str] = None,
         creation_timestamp: Optional[int] = None,
         tags: Optional[dict[str, str]] = None,
+        aliases: Optional[dict[str, str]] = None,
     ):
         """
         Construct a Prompt entity.
@@ -31,11 +32,13 @@ class Prompt:
             description: Description of the prompt.
             creation_timestamp: Timestamp when the prompt was created.
             tags: Prompt-level metadata as key-value pairs.
+            aliases: Dict of aliases for this prompt, mapping alias name to version. Optional.
         """
         self._name = name
         self._description = description
         self._creation_timestamp = creation_timestamp
         self._tags = tags or {}
+        self._aliases = aliases or {}
 
     @property
     def name(self) -> str:
@@ -57,6 +60,11 @@ class Prompt:
         """Prompt-level metadata as key-value pairs."""
         return self._tags.copy()
 
+    @property
+    def aliases(self) -> dict[str, str]:
+        """Dict of aliases for this prompt, mapping alias name to version."""
+        return self._aliases.copy()
+
     def __eq__(self, other) -> bool:
         if not isinstance(other, Prompt):
             return False
@@ -65,9 +73,11 @@ class Prompt:
             and self.description == other.description
             and self.creation_timestamp == other.creation_timestamp
             and self.tags == other.tags
+            and self.aliases == other.aliases
         )
 
     def __repr__(self) -> str:
         return (
-            f"<PromptInfo: name='{self.name}', description='{self.description}', tags={self.tags}>"
+            f"<PromptInfo: name='{self.name}', description='{self.description}', "
+            f"tags={self.tags}, aliases={self.aliases}>"
         )

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -1743,13 +1743,13 @@ class UcModelRegistryStore(BaseRestStore):
     def _add_aliases_to_prompt_version(self, prompt_version: PromptVersion) -> PromptVersion:
         """
         Fetch prompt-level aliases and attach all aliases that point to this version.
-        
+
         Uses the get_prompt method which returns a Prompt entity with aliases as a dict
         {alias: version}, then filters to find aliases pointing to this version.
-        
+
         Args:
             prompt_version: The PromptVersion object to enhance with aliases
-            
+
         Returns:
             PromptVersion with all relevant aliases attached
         """
@@ -1758,13 +1758,14 @@ class UcModelRegistryStore(BaseRestStore):
             prompt_info = self.get_prompt(prompt_version.name)
             if not prompt_info or not prompt_info.aliases:
                 return prompt_version
-            
+
             # Find all aliases that point to this version
             version_aliases = [
-                alias for alias, version in prompt_info.aliases.items()
+                alias
+                for alias, version in prompt_info.aliases.items()
                 if str(version) == str(prompt_version.version)
             ]
-            
+
             # Create new PromptVersion with all aliases for this version
             if version_aliases:
                 return PromptVersion(
@@ -1779,5 +1780,5 @@ class UcModelRegistryStore(BaseRestStore):
         except Exception:
             # Return original version if anything goes wrong
             pass
-        
+
         return prompt_version

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -60,13 +60,13 @@ def proto_info_to_mlflow_prompt_info(
     if hasattr(proto_info, "aliases") and proto_info.aliases:
         aliases = {alias.alias: alias.version for alias in proto_info.aliases}
 
-    prompt = Prompt(
+    return Prompt(
         name=proto_info.name,
         description=proto_info.description,
         tags=tags,
         aliases=aliases,
     )
-    return prompt
+
 
 def proto_to_mlflow_prompt(
     proto_version,  # PromptVersion type from protobuf
@@ -90,7 +90,7 @@ def proto_to_mlflow_prompt(
         raise ValueError("Prompt is missing its version field.")
     version = int(proto_version.version)
 
-    prompt_version = PromptVersion(
+    return PromptVersion(
         name=proto_version.name,
         version=version,
         template=proto_version.template,
@@ -99,7 +99,6 @@ def proto_to_mlflow_prompt(
         tags=version_tags,
         aliases=aliases,
     )
-    return prompt_version
 
 
 def mlflow_prompt_to_proto(prompt: PromptVersion) -> ProtoPromptVersion:
@@ -118,7 +117,7 @@ def mlflow_prompt_to_proto(prompt: PromptVersion) -> ProtoPromptVersion:
         proto_version.tags.extend(mlflow_tags_to_proto_version_tags(prompt.tags))
 
     # Add aliases
-    if hasattr(prompt, 'aliases') and prompt.aliases:
+    if hasattr(prompt, "aliases") and prompt.aliases:
         for alias in prompt.aliases:
             alias_proto = ProtoPromptAlias()
             alias_proto.alias = alias


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/rohitarun-db/mlflow/pull/16285?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16285/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16285/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16285/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The prompt and prompt version entities that are returned from the client will now include the correct alias dicts/lists.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
