### PR TITLE
Specify attribute.run_id when search_traces filters by run_id

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -290,6 +290,8 @@ class TracingClient:
                 else None
             )
 
+        is_databricks = is_databricks_uri(self.tracking_uri)
+
         if run_id:
             run = self.store.get_run(run_id)
             if run.info.experiment_id not in experiment_ids:
@@ -301,7 +303,11 @@ class TracingClient:
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 
-            additional_filter = f"attribute.run_id = '{run_id}'"
+            additional_filter = (
+                f"attribute.run_id = '{run_id}'"
+                if is_databricks
+                else f"metadata.{TraceMetadataKey.SOURCE_RUN} = '{run_id}'"
+            )
             if filter_string:
                 if TraceMetadataKey.SOURCE_RUN in filter_string:
                     raise MlflowException(
@@ -313,8 +319,6 @@ class TracingClient:
                 filter_string += f" AND {additional_filter}"
             else:
                 filter_string = additional_filter
-
-        is_databricks = is_databricks_uri(self.tracking_uri)
 
         def download_trace_extra_fields(
             trace_info: Union[TraceInfoV2, TraceInfo],

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -301,7 +301,7 @@ class TracingClient:
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 
-            additional_filter = f"metadata.{TraceMetadataKey.SOURCE_RUN} = '{run_id}'"
+            additional_filter = f"attribute.run_id = '{run_id}'"
             if filter_string:
                 if TraceMetadataKey.SOURCE_RUN in filter_string:
                     raise MlflowException(

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -2088,3 +2088,44 @@ def test_set_delete_trace_tag():
     mlflow.delete_trace_tag(request_id=trace_id, key="key3")
     trace = mlflow.get_trace(request_id=trace_id)
     assert "key3" not in trace.info.tags
+
+
+@pytest.mark.parametrize("is_databricks", [True, False])
+def test_search_traces_with_run_id_validates_store_filter_string(is_databricks):
+    # Mock the store
+    mock_store = mock.MagicMock()
+    mock_store.search_traces.return_value = ([], None)  # Return empty results
+    mock_store.get_run.return_value = mock.MagicMock()
+    mock_store.get_run.return_value.info.experiment_id = "test_exp_id"
+
+    test_run_id = "test_run_123"
+
+    with (
+        mock.patch("mlflow.tracing.client._get_store", return_value=mock_store),
+        mock.patch(
+            "mlflow.tracing.client.is_databricks_uri", return_value=is_databricks
+        ),
+        mock.patch(
+            "mlflow.tracking.fluent._get_experiment_id", return_value="test_exp_id"
+        ),
+    ):
+        # Call search_traces with run_id but no experiment_ids
+        mlflow.search_traces(run_id=test_run_id)
+
+        # Verify the store was called with the correct filter string
+        if is_databricks:
+            expected_filter_string = f"attribute.run_id = '{test_run_id}'"
+        else:
+            expected_filter_string = (
+                f"metadata.{TraceMetadataKey.SOURCE_RUN} = '{test_run_id}'"
+            )
+
+        mock_store.search_traces.assert_called()
+
+        # Get the actual arguments passed to the store
+        call_args = mock_store.search_traces.call_args
+        actual_filter_string = call_args[1]["filter_string"]  # using keyword arguments
+
+        assert (
+            actual_filter_string == expected_filter_string
+        ), f"Expected filter string '{expected_filter_string}', but got '{actual_filter_string}'"

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -2102,12 +2102,8 @@ def test_search_traces_with_run_id_validates_store_filter_string(is_databricks):
 
     with (
         mock.patch("mlflow.tracing.client._get_store", return_value=mock_store),
-        mock.patch(
-            "mlflow.tracing.client.is_databricks_uri", return_value=is_databricks
-        ),
-        mock.patch(
-            "mlflow.tracking.fluent._get_experiment_id", return_value="test_exp_id"
-        ),
+        mock.patch("mlflow.tracing.client.is_databricks_uri", return_value=is_databricks),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="test_exp_id"),
     ):
         # Call search_traces with run_id but no experiment_ids
         mlflow.search_traces(run_id=test_run_id)
@@ -2116,9 +2112,7 @@ def test_search_traces_with_run_id_validates_store_filter_string(is_databricks):
         if is_databricks:
             expected_filter_string = f"attribute.run_id = '{test_run_id}'"
         else:
-            expected_filter_string = (
-                f"metadata.{TraceMetadataKey.SOURCE_RUN} = '{test_run_id}'"
-            )
+            expected_filter_string = f"metadata.{TraceMetadataKey.SOURCE_RUN} = '{test_run_id}'"
 
         mock_store.search_traces.assert_called()
 
@@ -2126,6 +2120,6 @@ def test_search_traces_with_run_id_validates_store_filter_string(is_databricks):
         call_args = mock_store.search_traces.call_args
         actual_filter_string = call_args[1]["filter_string"]  # using keyword arguments
 
-        assert (
-            actual_filter_string == expected_filter_string
-        ), f"Expected filter string '{expected_filter_string}', but got '{actual_filter_string}'"
+        assert actual_filter_string == expected_filter_string, (
+            f"Expected filter string '{expected_filter_string}', but got '{actual_filter_string}'"
+        )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/16295?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16295/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16295/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16295/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Use `attribute.run_id` instead of `metadata.mlflow.sourceRun` when searching traces based on a run_id.
`metadata.mlflow.sourceRun` searches only through trace metadata for run_id, while `attribute.run_id` searches through trace metadata and traces that were explicitly linked to a run (aka a labeling session) via the LinkTraceToRun endpoint.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
