### PR TITLE
Add filestore get and create assessment APIs

### DIFF
--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -429,8 +429,7 @@ class AbstractStore:
         Args:
             trace_id: The ID of the trace.
             assessment_id: The assessment identifier that denotes a unique assessment entry
-                for a given trace, comprised of a unique key that is a concatenation of
-                (assessment_name.source.span_id).
+                for a given trace.
 
         Returns:
             The Assessment object for the given trace and assessment ids.
@@ -439,14 +438,13 @@ class AbstractStore:
 
     def create_assessment(self, assessment: Assessment) -> Assessment:
         """
-        Logs an Assessment for a given trace using the compound unique key of
-        (assessment_name.source.span_id) and stores it as a trace tag.
+        Logs an Assessment for a given trace or a span within a trace.
 
         Args:
             assessment: An :py:class:`Assessment <mlflow.entities.Assessment>` object that
                 contains the key value mappings of assessment criteria comprised of either
                 expectations or user/system/scorer-provided feedback (label data) on the quality
-                of the trace response.
+                of the trace response or for a span within a trace.
 
         Returns:
             The Assessment object for the logging operation.

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -3,6 +3,7 @@ from abc import ABCMeta, abstractmethod
 from typing import Any, Optional
 
 from mlflow.entities import (
+    Assessment,
     DatasetInput,
     LoggedModel,
     LoggedModelInput,
@@ -418,6 +419,78 @@ class AbstractStore:
         Args:
             request_id: The ID of the trace.
             key: The string key of the tag.
+        """
+        raise NotImplementedError
+
+    def get_assessment(self, trace_id: str, assessment_id: str) -> Assessment:
+        """
+        Retrieve an assessment from a given trace.
+
+        Args:
+            trace_id: The ID of the trace.
+            assessment_id: The assessment identifier that denotes a unique assessment entry
+                for a given trace, comprised of a unique key that is a concatenation of
+                (assessment_name.source.span_id).
+
+        Returns:
+            The Assessment object for the given trace and assessment ids.
+        """
+        raise NotImplementedError
+
+    def create_assessment(self, trace_id: str, assessment: Assessment) -> Assessment:
+        """
+        Logs an Assessment for a given trace using the compound unique key of
+        (assessment_name.source.span_id) and stores it as a trace tag.
+
+        Args:
+            trace_id: The ID of the trace.
+            assessment: An :py:class:`Assessment <mlflow.entities.Assessment>` object that
+                contains the key value mappings of assessment criteria comprised of either
+                expectations or user/system/scorer-provided feedback (label data) on the quality
+                of the trace response.
+
+        Returns:
+            The Assessment object for the logging operation.
+        """
+        raise NotImplementedError
+
+    def update_assessment(
+        self,
+        trace_id: str,
+        assessment_id: str,
+        name: Optional[str] = None,
+        expectation: Optional[str] = None,
+        feedback: Optional[str] = None,
+        rationale: Optional[str] = None,
+        metadata: Optional[dict[str, str]] = None,
+    ) -> Assessment:
+        """
+        Updates the given Assessment's mutable values to overwrite updated values
+        for the given trace and Assessment data.
+
+        Args:
+            trace_id: The ID of the trace.
+            assessment_id: The ID of the assessment upon which overrides will be applied to
+                mutable attributes.
+            name: An Optional override to the name of the assessment.
+            expectation: An Optional override of the expectation for the assessment.
+            feedback: An Optional override to the feedback for a given assessment.
+            rationale: An Optional string defining the reasoning behind the override of
+                the assessment.
+            metadata: An Optional mapping of additional customizable metadata for the assessment.
+
+        Returns:
+            The Assessment object representing the updated state of an assessment for a given trace.
+        """
+        raise NotImplementedError
+
+    def delete_assessment(self, trace_id: str, assessment_id):
+        """
+        Delete an assessment for a given trace.
+
+        Args:
+            trace_id: The ID of the trace.
+            assessment_id: The ID of the assessment to be deleted.
         """
         raise NotImplementedError
 

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -437,13 +437,12 @@ class AbstractStore:
         """
         raise NotImplementedError
 
-    def create_assessment(self, trace_id: str, assessment: Assessment) -> Assessment:
+    def create_assessment(self, assessment: Assessment) -> Assessment:
         """
         Logs an Assessment for a given trace using the compound unique key of
         (assessment_name.source.span_id) and stores it as a trace tag.
 
         Args:
-            trace_id: The ID of the trace.
             assessment: An :py:class:`Assessment <mlflow.entities.Assessment>` object that
                 contains the key value mappings of assessment criteria comprised of either
                 expectations or user/system/scorer-provided feedback (label data) on the quality

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -59,10 +59,8 @@ from mlflow.store.tracking import (
     SEARCH_TRACES_DEFAULT_MAX_RESULTS,
 )
 from mlflow.store.tracking.abstract_store import AbstractStore
-from mlflow.tracing.constant import ASSESSMENT_TAG_KEY_PREFIX
 from mlflow.tracing.utils import (
     generate_assessment_id,
-    generate_assessment_key,
     generate_request_id_v2,
 )
 from mlflow.utils import get_results_from_paginated_fn
@@ -187,6 +185,7 @@ class FileStore(AbstractStore):
     TRACES_FOLDER_NAME = "traces"
     TRACE_TAGS_FOLDER_NAME = "tags"
     TRACE_REQUEST_METADATA_FOLDER_NAME = "request_metadata"
+    ASSESSMENTS_FOLDER_NAME = "assessments"
     MODELS_FOLDER_NAME = "models"
     RESERVED_EXPERIMENT_FOLDERS = [
         EXPERIMENT_TAGS_FOLDER_NAME,
@@ -1829,12 +1828,49 @@ class FileStore(AbstractStore):
             )
         os.remove(tag_path)
 
+    def _get_assessments_dir(self, request_id: str) -> str:
+        trace_dir = self._find_trace_dir(request_id, assert_exists=True)
+        return os.path.join(trace_dir, FileStore.ASSESSMENTS_FOLDER_NAME)
+
+    def _get_assessment_path(self, request_id: str, assessment_id: str) -> str:
+        assessments_dir = self._get_assessments_dir(request_id)
+        return os.path.join(assessments_dir, f"{assessment_id}.yaml")
+
+    def _save_assessment(self, assessment: Assessment) -> None:
+        assessment_path = self._get_assessment_path(assessment.trace_id, assessment.assessment_id)
+        make_containing_dirs(assessment_path)
+
+        assessment_dict = assessment.to_dictionary()
+        write_yaml(
+            root=os.path.dirname(assessment_path),
+            file_name=os.path.basename(assessment_path),
+            data=assessment_dict,
+            overwrite=True,
+        )
+
+    def _load_assessment(self, trace_id: str, assessment_id: str) -> Assessment:
+        assessment_path = self._get_assessment_path(trace_id, assessment_id)
+
+        if not exists(assessment_path):
+            raise MlflowException(
+                f"Assessment with ID '{assessment_id}' not found for trace '{trace_id}'",
+                RESOURCE_DOES_NOT_EXIST,
+            )
+
+        try:
+            assessment_dict = FileStore._read_yaml(
+                root=os.path.dirname(assessment_path), file_name=os.path.basename(assessment_path)
+            )
+            return Assessment.from_dictionary(assessment_dict)
+        except Exception as e:
+            raise MlflowException(
+                f"Failed to load assessment with ID '{assessment_id}' for trace '{trace_id}': {e}",
+                INTERNAL_ERROR,
+            ) from e
+
     def get_assessment(self, trace_id: str, assessment_id: str) -> Assessment:
         """
         Retrieves a specific assessment associated with a trace from the file store.
-
-        Searches through the trace's tags to find the assessment with the specified ID
-        and deserializes it from JSON storage.
 
         Args:
             trace_id: The unique identifier of the trace containing the assessment.
@@ -1848,46 +1884,21 @@ class FileStore(AbstractStore):
                 specified assessment_id exists for the trace, or if the stored
                 assessment data cannot be deserialized.
         """
-        trace_dir = self._find_trace_dir(trace_id, assert_exists=True)
 
-        trace_tags = self._get_dict_from_trace_sub_folder(
-            trace_dir, FileStore.TRACE_TAGS_FOLDER_NAME
-        )
-
-        assessment_tag_value = None
-        for tag_key, tag_value in trace_tags.items():
-            if tag_key.startswith(ASSESSMENT_TAG_KEY_PREFIX) and tag_key.endswith(
-                f".{assessment_id}"
-            ):
-                assessment_tag_value = tag_value
-                break
-
-        if assessment_tag_value is None:
-            raise MlflowException.invalid_parameter_value(
-                f"Assessment with ID '{assessment_id}' not found for trace '{trace_id}'"
-            )
-
-        try:
-            assessment_dict = json.loads(assessment_tag_value)
-            return Assessment.from_dictionary(assessment_dict)
-        except (json.JSONDecodeError, KeyError, ValueError) as e:
-            raise MlflowException.invalid_parameter_value(
-                f"Failed to deserialize assessment data for ID '{assessment_id}'"
-            ) from e
+        return self._load_assessment(trace_id, assessment_id)
 
     def create_assessment(self, assessment: Assessment) -> Assessment:
         """
-        Logs a defined assessment on a trace as a tag.
+        Creates a new assessment record associated with a specific trace.
 
-        This method creates a new assessment record associated with a specific trace by:
-        1. Validating the trace exists
-        2. Generating a unique assessment ID
-        3. Setting creation and update timestamps
-        4. Storing the assessment as a JSON-serialized trace tag
-        5. Returning the updated assessment object with backend-generated metadata
+        This method creates a new assessment record by:
+        1. Generating a unique assessment ID
+        2. Setting creation and update timestamps
+        3. Storing the assessment as a YAML file in the assessments subdirectory
+        4. Returning the updated assessment object with backend-generated metadata
 
         Args:
-            assessment: The assessment object to log. Can be either an Expectation or
+            assessment: The assessment object to create. Can be either an Expectation or
                 Feedback instance. The assessment will be modified in-place to include
                 the generated assessment_id and timestamps.
 
@@ -1895,12 +1906,8 @@ class FileStore(AbstractStore):
             Assessment: The input assessment object updated with backend-generated metadata.
 
         Raises:
-            MlflowException: If the trace doesn't exist, assessment serialization fails,
-                or there's an error setting the trace tag.
+            MlflowException: If the trace doesn't exist or there's an error saving the assessment.
         """
-        trace_id = assessment.trace_id
-        self.get_trace_info(trace_id)
-
         assessment_id = generate_assessment_id()
         creation_timestamp = int(time.time() * 1000)
 
@@ -1909,17 +1916,7 @@ class FileStore(AbstractStore):
         assessment.last_update_time_ms = creation_timestamp
         assessment.valid = True
 
-        assessment_key = generate_assessment_key(assessment.name, assessment_id)
-        _validate_tag_name(assessment_key)
-
-        try:
-            assessment_value = json.dumps(assessment.to_dictionary())
-        except Exception as e:
-            raise MlflowException.invalid_parameter_value(
-                "Failed to serialize assessment to JSON."
-            ) from e
-
-        self.set_trace_tag(request_id=trace_id, key=assessment_key, value=assessment_value)
+        self._save_assessment(assessment)
 
         return assessment
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1881,7 +1881,7 @@ class FileStore(AbstractStore):
 
         This method creates a new assessment record associated with a specific trace by:
         1. Validating the trace exists
-        2. Generating a unique assessment ID  
+        2. Generating a unique assessment ID
         3. Setting creation and update timestamps
         4. Storing the assessment as a JSON-serialized trace tag
         5. Returning the updated assessment object with backend-generated metadata
@@ -1901,7 +1901,7 @@ class FileStore(AbstractStore):
                 or there's an error setting the trace tag.
         """
         self.get_trace_info(trace_id)
-        
+
         assessment_id = generate_assessment_id()
         creation_timestamp = int(time.time() * 1000)
 
@@ -1917,11 +1917,11 @@ class FileStore(AbstractStore):
             assessment_value = json.dumps(assessment.to_dictionary())
         except Exception as e:
             raise MlflowException.invalid_parameter_value(
-                f"Failed to serialize assessment to JSON."
+                "Failed to serialize assessment to JSON."
             ) from e
 
         self.set_trace_tag(request_id=trace_id, key=assessment_key, value=assessment_value)
-        
+
         return assessment
 
     def _delete_traces(

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1828,12 +1828,12 @@ class FileStore(AbstractStore):
             )
         os.remove(tag_path)
 
-    def _get_assessments_dir(self, request_id: str) -> str:
-        trace_dir = self._find_trace_dir(request_id, assert_exists=True)
+    def _get_assessments_dir(self, trace_id: str) -> str:
+        trace_dir = self._find_trace_dir(trace_id, assert_exists=True)
         return os.path.join(trace_dir, FileStore.ASSESSMENTS_FOLDER_NAME)
 
-    def _get_assessment_path(self, request_id: str, assessment_id: str) -> str:
-        assessments_dir = self._get_assessments_dir(request_id)
+    def _get_assessment_path(self, trace_id: str, assessment_id: str) -> str:
+        assessments_dir = self._get_assessments_dir(trace_id)
         return os.path.join(assessments_dir, f"{assessment_id}.yaml")
 
     def _save_assessment(self, assessment: Assessment) -> None:

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1875,7 +1875,7 @@ class FileStore(AbstractStore):
                 f"Failed to deserialize assessment data for ID '{assessment_id}'"
             ) from e
 
-    def create_assessment(self, trace_id: str, assessment: Assessment) -> Assessment:
+    def create_assessment(self, assessment: Assessment) -> Assessment:
         """
         Logs a defined assessment on a trace as a tag.
 
@@ -1887,8 +1887,6 @@ class FileStore(AbstractStore):
         5. Returning the updated assessment object with backend-generated metadata
 
         Args:
-            trace_id: The unique identifier of the trace to associate the assessment with.
-                Must be a valid trace ID that exists in the tracking store.
             assessment: The assessment object to log. Can be either an Expectation or
                 Feedback instance. The assessment will be modified in-place to include
                 the generated assessment_id and timestamps.
@@ -1900,15 +1898,16 @@ class FileStore(AbstractStore):
             MlflowException: If the trace doesn't exist, assessment serialization fails,
                 or there's an error setting the trace tag.
         """
+        trace_id = assessment.trace_id
         self.get_trace_info(trace_id)
 
         assessment_id = generate_assessment_id()
         creation_timestamp = int(time.time() * 1000)
 
         assessment.assessment_id = assessment_id
-        assessment.trace_id = trace_id
         assessment.create_time_ms = creation_timestamp
         assessment.last_update_time_ms = creation_timestamp
+        assessment.valid = True
 
         assessment_key = generate_assessment_key(assessment.name, assessment_id)
         _validate_tag_name(assessment_key)

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -89,3 +89,7 @@ STREAM_CHUNK_EVENT_VALUE_KEY = "mlflow.chunk.value"
 DATABRICKS_OPTIONS_KEY = "databricks_options"
 RETURN_TRACE_OPTION_KEY = "return_trace"
 DATABRICKS_OUTPUT_KEY = "databricks_output"
+
+# Assessment constants
+ASSESSMENT_ID_PREFIX = "a-"
+ASSESSMENT_TAG_KEY_PREFIX = "mlflow.assessment."

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -92,4 +92,3 @@ DATABRICKS_OUTPUT_KEY = "databricks_output"
 
 # Assessment constants
 ASSESSMENT_ID_PREFIX = "a-"
-ASSESSMENT_TAG_KEY_PREFIX = "mlflow.assessment."

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -18,7 +18,6 @@ from packaging.version import Version
 from mlflow.exceptions import BAD_REQUEST, MlflowTracingException
 from mlflow.tracing.constant import (
     ASSESSMENT_ID_PREFIX,
-    ASSESSMENT_TAG_KEY_PREFIX,
     TRACE_REQUEST_ID_PREFIX,
     SpanAttributeKey,
     TokenUsageKey,
@@ -571,4 +570,4 @@ def generate_assessment_key(name: str, assessment_id: str) -> str:
         A constructed unique key for a given assessment for disambiguating
         assessments that are attached to traces.
     """
-    return f"{ASSESSMENT_TAG_KEY_PREFIX}.{name}.{assessment_id}"
+    return f"{name}.{assessment_id}"

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -555,19 +555,3 @@ def generate_assessment_id() -> str:
     """
     id = uuid.uuid4().hex
     return f"{ASSESSMENT_ID_PREFIX}{id}"
-
-
-def generate_assessment_key(name: str, assessment_id: str) -> str:
-    """
-    Generates a hybrid assessment key for use in storing within trace tags.
-
-    Args:
-        name: The name of the assessment.
-        assessment_id: The backend generated assessment ID created when
-            logging an assessment.
-
-    Returns:
-        A constructed unique key for a given assessment for disambiguating
-        assessments that are attached to traces.
-    """
-    return f"{name}.{assessment_id}"

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -17,6 +17,8 @@ from packaging.version import Version
 
 from mlflow.exceptions import BAD_REQUEST, MlflowTracingException
 from mlflow.tracing.constant import (
+    ASSESSMENT_ID_PREFIX,
+    ASSESSMENT_TAG_KEY_PREFIX,
     TRACE_REQUEST_ID_PREFIX,
     SpanAttributeKey,
     TokenUsageKey,
@@ -543,3 +545,30 @@ def update_trace_state_from_span_conditionally(trace, root_span):
     # and we should preserve it
     if trace.info.state == TraceState.IN_PROGRESS:
         trace.info.state = TraceState.from_otel_status(root_span.status)
+
+
+def generate_assessment_id() -> str:
+    """
+    Generates an assessment ID of the form 'a-<uuid4>' in hex string format.
+
+    Returns:
+        A unique identifier for an assessment that will be logged to a trace tag.
+    """
+    id = uuid.uuid4().hex
+    return f"{ASSESSMENT_ID_PREFIX}{id}"
+
+
+def generate_assessment_key(name: str, assessment_id: str) -> str:
+    """
+    Generates a hybrid assessment key for use in storing within trace tags.
+
+    Args:
+        name: The name of the assessment.
+        assessment_id: The backend generated assessment ID created when
+            logging an assessment.
+
+    Returns:
+        A constructed unique key for a given assessment for disambiguating
+        assessments that are attached to traces.
+    """
+    return f"{ASSESSMENT_TAG_KEY_PREFIX}.{name}.{assessment_id}"

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3462,20 +3462,3 @@ def test_get_assessment_errors(store):
         rf"'{trace_info.request_id}'",
     ):
         store.get_assessment(trace_info.request_id, "fake_assessment")
-
-
-def test_create_assessment_serialization_error(store):
-    """Test create_assessment with serialization failure"""
-    exp_id = store.create_experiment("test_serialization")
-    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
-
-    feedback = Feedback(
-        trace_id=trace_info.request_id,
-        name="test",
-        value="test_value",
-        source=AssessmentSource(source_type=AssessmentSourceType.CODE),
-    )
-
-    with mock.patch.object(feedback, "to_dictionary", side_effect=Exception("Serialization error")):
-        with pytest.raises(MlflowException, match=r"Failed to serialize assessment to JSON"):
-            store.create_assessment(feedback)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -3387,6 +3387,7 @@ def test_create_and_get_assessment(store):
     trace_info = store.start_trace(exp_id, timestamp_ms, {}, {})
 
     feedback = Feedback(
+        trace_id=trace_info.request_id,
         name="correctness",
         value=True,
         rationale="The response is correct and well-formatted",
@@ -3397,7 +3398,7 @@ def test_create_and_get_assessment(store):
         span_id="span-123",
     )
 
-    created_feedback = store.create_assessment(trace_info.request_id, feedback)
+    created_feedback = store.create_assessment(feedback)
     assert created_feedback.assessment_id is not None
     assert created_feedback.assessment_id.startswith("a-")
     assert created_feedback.trace_id == trace_info.request_id
@@ -3407,8 +3408,10 @@ def test_create_and_get_assessment(store):
     assert created_feedback.rationale == "The response is correct and well-formatted"
     assert created_feedback.metadata == {"project": "test-project", "version": "1.0"}
     assert created_feedback.span_id == "span-123"
+    assert created_feedback.valid
 
     expectation = Expectation(
+        trace_id=trace_info.request_id,
         name="expected_response",
         value="The capital of France is Paris.",
         source=AssessmentSource(
@@ -3418,12 +3421,13 @@ def test_create_and_get_assessment(store):
         span_id="span-456",
     )
 
-    created_expectation = store.create_assessment(trace_info.request_id, expectation)
+    created_expectation = store.create_assessment(expectation)
     assert created_expectation.assessment_id != created_feedback.assessment_id
     assert created_expectation.trace_id == trace_info.request_id
     assert created_expectation.expectation.value == "The capital of France is Paris."
     assert created_expectation.metadata == {"context": "geography-qa", "difficulty": "easy"}
     assert created_expectation.span_id == "span-456"
+    assert created_expectation.valid
 
     retrieved_feedback = store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
     assert retrieved_feedback.name == "correctness"
@@ -3432,6 +3436,7 @@ def test_create_and_get_assessment(store):
     assert retrieved_feedback.metadata == {"project": "test-project", "version": "1.0"}
     assert retrieved_feedback.span_id == "span-123"
     assert retrieved_feedback.trace_id == trace_info.request_id
+    assert retrieved_feedback.valid
 
     retrieved_expectation = store.get_assessment(
         trace_info.request_id, created_expectation.assessment_id
@@ -3440,6 +3445,7 @@ def test_create_and_get_assessment(store):
     assert retrieved_expectation.metadata == {"context": "geography-qa", "difficulty": "easy"}
     assert retrieved_expectation.span_id == "span-456"
     assert retrieved_expectation.trace_id == trace_info.request_id
+    assert retrieved_expectation.valid is None
 
 
 def test_get_assessment_errors(store):
@@ -3464,6 +3470,7 @@ def test_create_assessment_serialization_error(store):
     trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
 
     feedback = Feedback(
+        trace_id=trace_info.request_id,
         name="test",
         value="test_value",
         source=AssessmentSource(source_type=AssessmentSourceType.CODE),
@@ -3471,4 +3478,4 @@ def test_create_assessment_serialization_error(store):
 
     with mock.patch.object(feedback, "to_dictionary", side_effect=Exception("Serialization error")):
         with pytest.raises(MlflowException, match=r"Failed to serialize assessment to JSON"):
-            store.create_assessment(trace_info.request_id, feedback)
+            store.create_assessment(feedback)

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -16,6 +16,10 @@ import pytest
 
 import mlflow
 from mlflow.entities import (
+    Feedback, 
+    Expectation,
+    AssessmentSource,
+    AssessmentSourceType,
     Dataset,
     DatasetInput,
     ExperimentTag,
@@ -3374,3 +3378,95 @@ def test_traces_not_listed_as_runs(tmp_path):
         with mock.patch("mlflow.store.tracking.file_store.logging.debug") as mock_debug:
             client.search_runs([run.info.experiment_id], "", ViewType.ALL, max_results=1)
             mock_debug.assert_not_called()
+
+def test_create_and_get_assessment(store):
+    """Test creating and retrieving assessments with both feedback and expectations"""
+    exp_id = store.create_experiment("test_assessments")
+    timestamp_ms = get_current_time_millis()
+    trace_info = store.start_trace(exp_id, timestamp_ms, {}, {})
+    
+    feedback = Feedback(
+        name="correctness",
+        value=True,
+        rationale="The response is correct and well-formatted",
+        source=AssessmentSource(
+            source_type=AssessmentSourceType.HUMAN,
+            source_id="evaluator@company.com"
+        ),
+        metadata={"project": "test-project", "version": "1.0"},
+        span_id="span-123"
+    )
+    
+    created_feedback = store.create_assessment(trace_info.request_id, feedback)
+    assert created_feedback.assessment_id is not None
+    assert created_feedback.assessment_id.startswith("a-")
+    assert created_feedback.trace_id == trace_info.request_id
+    assert created_feedback.create_time_ms is not None
+    assert created_feedback.name == "correctness"
+    assert created_feedback.feedback.value is True
+    assert created_feedback.rationale == "The response is correct and well-formatted"
+    assert created_feedback.metadata == {"project": "test-project", "version": "1.0"}
+    assert created_feedback.span_id == "span-123"
+    
+    expectation = Expectation(
+        name="expected_response",
+        value="The capital of France is Paris.",
+        source=AssessmentSource(
+            source_type=AssessmentSourceType.HUMAN,
+            source_id="annotator@company.com"
+        ),
+        metadata={"context": "geography-qa", "difficulty": "easy"},
+        span_id="span-456"
+    )
+    
+    created_expectation = store.create_assessment(trace_info.request_id, expectation)
+    assert created_expectation.assessment_id != created_feedback.assessment_id
+    assert created_expectation.trace_id == trace_info.request_id
+    assert created_expectation.expectation.value == "The capital of France is Paris."
+    assert created_expectation.metadata == {"context": "geography-qa", "difficulty": "easy"}
+    assert created_expectation.span_id == "span-456"
+    
+    retrieved_feedback = store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
+    assert retrieved_feedback.name == "correctness"
+    assert retrieved_feedback.feedback.value is True
+    assert retrieved_feedback.rationale == "The response is correct and well-formatted"
+    assert retrieved_feedback.metadata == {"project": "test-project", "version": "1.0"}
+    assert retrieved_feedback.span_id == "span-123"
+    assert retrieved_feedback.trace_id == trace_info.request_id
+    
+    retrieved_expectation = store.get_assessment(trace_info.request_id, created_expectation.assessment_id)
+    assert retrieved_expectation.expectation.value == "The capital of France is Paris."
+    assert retrieved_expectation.metadata == {"context": "geography-qa", "difficulty": "easy"}
+    assert retrieved_expectation.span_id == "span-456"
+    assert retrieved_expectation.trace_id == trace_info.request_id
+
+
+def test_get_assessment_errors(store):
+    """Test error cases for get_assessment"""
+    with pytest.raises(MlflowException, match=r"Trace with request ID 'fake_trace' not found"):
+        store.get_assessment("fake_trace", "fake_assessment")
+    
+    exp_id = store.create_experiment("test_errors")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+    
+    with pytest.raises(
+        MlflowException, 
+        match=rf"Assessment with ID 'fake_assessment' not found for trace '{trace_info.request_id}'"
+    ):
+        store.get_assessment(trace_info.request_id, "fake_assessment")
+
+
+def test_create_assessment_serialization_error(store):
+    """Test create_assessment with serialization failure"""
+    exp_id = store.create_experiment("test_serialization")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+    
+    feedback = Feedback(
+        name="test",
+        value="test_value",
+        source=AssessmentSource(source_type=AssessmentSourceType.CODE)
+    )
+    
+    with mock.patch.object(feedback, 'to_dictionary', side_effect=Exception("Serialization error")):
+        with pytest.raises(MlflowException, match=r"Failed to serialize assessment to JSON"):
+            store.create_assessment(trace_info.request_id, feedback)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/16297?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16297/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16297/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16297/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds the filestore backend implementation for get_assessment and create_assessment client APIs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
