### PR TITLE
Add run_id to Assessments to support table storage

### DIFF
--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -52,6 +52,7 @@ class Assessment(_MlflowObject):
     #   assessment to a trace in the backend eventually.
     #   https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/custom-metrics#-metric-decorator
     trace_id: Optional[str] = None
+    run_id: Optional[str] = None
     rationale: Optional[str] = None
     metadata: Optional[dict[str, str]] = None
     span_id: Optional[str] = None
@@ -104,6 +105,9 @@ class Assessment(_MlflowObject):
                 "`source` must be an instance of `AssessmentSource`. "
                 f"Got {type(self.source)} instead."
             )
+        # Extract and set run_id from metadata but don't modify the proto representation
+        if self.run_id is None and self.metadata and "run_id" in self.metadata:
+            self.run_id = self.metadata["run_id"]
 
     def to_proto(self):
         assessment = ProtoAssessment()

--- a/mlflow/entities/assessment.py
+++ b/mlflow/entities/assessment.py
@@ -76,6 +76,8 @@ class Assessment(_MlflowObject):
     valid: Optional[bool] = None
 
     def __post_init__(self):
+        from mlflow.tracing.constant import AssessmentMetadataKey
+
         if (self.expectation is not None) + (self.feedback is not None) != 1:
             raise MlflowException.invalid_parameter_value(
                 "Exactly one of `expectation` or `feedback` should be specified.",
@@ -106,8 +108,12 @@ class Assessment(_MlflowObject):
                 f"Got {type(self.source)} instead."
             )
         # Extract and set run_id from metadata but don't modify the proto representation
-        if self.run_id is None and self.metadata and "run_id" in self.metadata:
-            self.run_id = self.metadata["run_id"]
+        if (
+            self.run_id is None
+            and self.metadata
+            and AssessmentMetadataKey.SOURCE_RUN_ID in self.metadata
+        ):
+            self.run_id = self.metadata[AssessmentMetadataKey.SOURCE_RUN_ID]
 
     def to_proto(self):
         assessment = ProtoAssessment()

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -426,7 +426,6 @@ def test_run_id_handling(metadata, explicit_run_id, expected_run_id):
     assert feedback.run_id == expected_run_id
     assert not hasattr(feedback.to_proto(), "run_id")
 
-    # Only test proto roundtrip for metadata-extracted run_id
     if expected_run_id and not explicit_run_id:
         recovered = Feedback.from_proto(feedback.to_proto())
         assert recovered.run_id == expected_run_id


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/16322?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16322/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16322/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16322/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds run_id as a top-level attr for Assessments (instead of it residing as a reserved metadata entry exclusively) to allow for a more concrete mapping to a table entry for the SQL backend. 

Intentionally did not modify the proto handlers to ensure compatibility with existing Databricks rest store implementation and handling. Added tests to confirm the behavior for compatibility. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
