### PR TITLE
Support pagination in get-history of FileStore and SqlAlchemyStore

### DIFF
--- a/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
+++ b/mlflow/java/client/src/main/java/org/mlflow/tracking/MlflowClient.java
@@ -74,7 +74,7 @@ public class MlflowClient implements Serializable, Closeable {
 
     GetMetricHistory.Response response = mapper
             .toGetMetricHistoryResponse(httpCaller.get(builder.toString()));
-    List<Metric> metrics = response.getMetricsList();
+    List<Metric> metrics = new ArrayList<>(response.getMetricsList());
     String token = response.getNextPageToken();
     while (!token.isEmpty()) {
       URIBuilder bld = builder.setParameter("page_token", token);

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1167,7 +1167,14 @@ def _get_metric_history():
     )
     response_message = GetMetricHistory.Response()
     run_id = request_message.run_id or request_message.run_uuid
-    metric_entities = _get_tracking_store().get_metric_history(run_id, request_message.metric_key)
+
+    # Extract max_results and page_token from request
+    max_results = request_message.max_results if request_message.max_results else None
+    page_token = request_message.page_token if request_message.page_token else None
+
+    metric_entities = _get_tracking_store().get_metric_history(
+        run_id, request_message.metric_key, max_results=max_results, page_token=page_token
+    )
     response_message.metrics.extend([m.to_proto() for m in metric_entities])
     response = Response(mimetype="application/json")
     response.set_data(message_to_json(response_message))

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1168,18 +1168,11 @@ def _get_metric_history():
     response_message = GetMetricHistory.Response()
     run_id = request_message.run_id or request_message.run_uuid
 
-    # Extract max_results and page_token from request
     max_results = request_message.max_results if request_message.max_results else None
-    page_token = request_message.page_token if request_message.page_token else None
-
     metric_entities = _get_tracking_store().get_metric_history(
-        run_id, request_message.metric_key, max_results=max_results, page_token=page_token
+        run_id, request_message.metric_key, max_results=max_results
     )
     response_message.metrics.extend([m.to_proto() for m in metric_entities])
-
-    # Set next_page_token if available for pagination
-    if hasattr(metric_entities, "token") and metric_entities.token:
-        response_message.next_page_token = metric_entities.token
 
     response = Response(mimetype="application/json")
     response.set_data(message_to_json(response_message))

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1168,12 +1168,11 @@ def _get_metric_history():
     response_message = GetMetricHistory.Response()
     run_id = request_message.run_id or request_message.run_uuid
 
-    max_results = request_message.max_results if request_message.max_results else None
+    max_results = request_message.max_results if request_message.max_results is not None else None
     metric_entities = _get_tracking_store().get_metric_history(
         run_id, request_message.metric_key, max_results=max_results
     )
     response_message.metrics.extend([m.to_proto() for m in metric_entities])
-
     response = Response(mimetype="application/json")
     response.set_data(message_to_json(response_message))
     return response

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1176,6 +1176,11 @@ def _get_metric_history():
         run_id, request_message.metric_key, max_results=max_results, page_token=page_token
     )
     response_message.metrics.extend([m.to_proto() for m in metric_entities])
+
+    # Set next_page_token if available for pagination
+    if hasattr(metric_entities, "token") and metric_entities.token:
+        response_message.next_page_token = metric_entities.token
+
     response = Response(mimetype="application/json")
     response.set_data(message_to_json(response_message))
     return response

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1177,9 +1177,9 @@ def _get_metric_history():
     )
     response_message.metrics.extend([m.to_proto() for m in metric_entities])
 
-    # Set next_page_token if available (PagedList has token attribute)
-    if hasattr(metric_entities, "token") and metric_entities.token:
-        response_message.next_page_token = metric_entities.token
+    # Set next_page_token if available
+    if next_page_token := metric_entities.token:
+        response_message.next_page_token = next_page_token
 
     response = Response(mimetype="application/json")
     response.set_data(message_to_json(response_message))

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -895,10 +895,18 @@ class FileStore(AbstractStore):
         parent_path, metric_files = self._get_run_files(run_info, "metric")
         if metric_key not in metric_files:
             return PagedList([], None)
+
+        # Read all metric lines first
+        all_lines = read_file_lines(parent_path, metric_key)
+
+        # Apply max_results limit if specified
+        if max_results is not None:
+            all_lines = all_lines[:max_results]
+
         return PagedList(
             [
                 FileStore._get_metric_from_line(run_id, metric_key, line, run_info.experiment_id)
-                for line in read_file_lines(parent_path, metric_key)
+                for line in all_lines
             ],
             None,
         )

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -867,8 +867,7 @@ class FileStore(AbstractStore):
         Args:
             run_id: Unique identifier for run.
             metric_key: Metric name within the run.
-            max_results: An indicator for paginated results. This functionality is not
-                implemented for FileStore and is unused in this store's implementation.
+            max_results: An indicator for paginated results.
             page_token: An indicator for paginated results. This functionality is not
                 implemented for FileStore and if the value is overridden with a value other than
                 ``None``, an MlflowException will be thrown.
@@ -896,10 +895,8 @@ class FileStore(AbstractStore):
         if metric_key not in metric_files:
             return PagedList([], None)
 
-        # Read all metric lines first
         all_lines = read_file_lines(parent_path, metric_key)
 
-        # Apply max_results limit if specified
         if max_results is not None:
             all_lines = all_lines[:max_results]
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -868,25 +868,14 @@ class FileStore(AbstractStore):
             run_id: Unique identifier for run.
             metric_key: Metric name within the run.
             max_results: An indicator for paginated results.
-            page_token: An indicator for paginated results. This functionality is not
-                implemented for FileStore and if the value is overridden with a value other than
-                ``None``, an MlflowException will be thrown.
+            page_token: Token indicating the page of metric history to fetch.
 
         Returns:
-            A List of :py:class:`mlflow.entities.Metric` entities if ``metric_key`` values
+            A :py:class:`mlflow.store.entities.paged_list.PagedList` of
+            :py:class:`mlflow.entities.Metric` entities if ``metric_key`` values
             have been logged to the ``run_id``, else an empty list.
 
         """
-        # NB: The FileStore does not currently support pagination for this API.
-        # Raise if `page_token` is specified, as the functionality to support paged queries
-        # is not implemented.
-        if page_token is not None:
-            raise MlflowException(
-                "The FileStore backend does not support pagination for the "
-                f"`get_metric_history` API. Supplied argument `page_token` '{page_token}' must "
-                "be `None`."
-            )
-
         _validate_run_id(run_id)
         _validate_metric_name(metric_key)
         run_info = self._get_run_info(run_id)
@@ -897,16 +886,20 @@ class FileStore(AbstractStore):
 
         all_lines = read_file_lines(parent_path, metric_key)
 
-        if max_results is not None:
-            all_lines = all_lines[:max_results]
+        all_metrics = [
+            FileStore._get_metric_from_line(run_id, metric_key, line, run_info.experiment_id)
+            for line in all_lines
+        ]
 
-        return PagedList(
-            [
-                FileStore._get_metric_from_line(run_id, metric_key, line, run_info.experiment_id)
-                for line in all_lines
-            ],
-            None,
-        )
+        if max_results is None:
+            # If no max_results specified, return all metrics but handle page_token if provided
+            offset = SearchUtils.parse_start_offset_from_page_token(page_token)
+            metrics = all_metrics[offset:]
+            next_page_token = None
+        else:
+            metrics, next_page_token = SearchUtils.paginate(all_metrics, page_token, max_results)
+
+        return PagedList(metrics, next_page_token)
 
     @staticmethod
     def _get_param_from_file(parent_path, param_name):

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1035,6 +1035,9 @@ class SqlAlchemyStore(AbstractStore):
 
             # Parse offset from page_token for pagination
             offset = SearchUtils.parse_start_offset_from_page_token(page_token)
+
+            # Add ORDER BY clause to satisfy MSSQL requirement for OFFSET
+            query = query.order_by(SqlMetric.timestamp, SqlMetric.step, SqlMetric.value)
             query = query.offset(offset)
 
             if max_results is not None:

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1022,33 +1022,34 @@ class SqlAlchemyStore(AbstractStore):
             run_id: Unique identifier for run.
             metric_key: Metric name within the run.
             max_results: An indicator for paginated results.
-            page_token: An indicator for paginated results. This functionality is not
-                implemented for SQLAlchemyStore and if the value is overridden with a value other
-                than ``None``, an MlflowException will be thrown.
+            page_token: Token indicating the page of metric history to fetch.
 
         Returns:
-            A List of :py:class:`mlflow.entities.Metric` entities if ``metric_key`` values
+            A :py:class:`mlflow.store.entities.paged_list.PagedList` of
+            :py:class:`mlflow.entities.Metric` entities if ``metric_key`` values
             have been logged to the ``run_id``, else an empty list.
 
         """
-        # NB: The SQLAlchemyStore does not currently support pagination for this API.
-        # Raise if `page_token` is specified, as the functionality to support paged queries
-        # is not implemented.
-        if page_token is not None:
-            raise MlflowException(
-                "The SQLAlchemyStore backend does not support pagination for the "
-                f"`get_metric_history` API. Supplied argument `page_token` '{page_token}' must be "
-                "`None`."
-            )
-
         with self.ManagedSessionMaker() as session:
             query = session.query(SqlMetric).filter_by(run_uuid=run_id, key=metric_key)
 
+            # Parse offset from page_token for pagination
+            offset = SearchUtils.parse_start_offset_from_page_token(page_token)
+            query = query.offset(offset)
+
             if max_results is not None:
-                query = query.limit(max_results)
+                query = query.limit(max_results + 1)
 
             metrics = query.all()
-            return PagedList([metric.to_mlflow_entity() for metric in metrics], None)
+
+            # Compute next token if more results are available
+            next_token = None
+            if max_results is not None and len(metrics) == max_results + 1:
+                final_offset = offset + max_results
+                next_token = SearchUtils.create_page_token(final_offset)
+                metrics = metrics[:max_results]
+
+            return PagedList([metric.to_mlflow_entity() for metric in metrics], next_token)
 
     def get_metric_history_bulk(self, run_ids, metric_key, max_results):
         """

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1021,8 +1021,7 @@ class SqlAlchemyStore(AbstractStore):
         Args:
             run_id: Unique identifier for run.
             metric_key: Metric name within the run.
-            max_results: An indicator for paginated results. This functionality is not
-                implemented for SQLAlchemyStore and is unused in this store's implementation.
+            max_results: An indicator for paginated results.
             page_token: An indicator for paginated results. This functionality is not
                 implemented for SQLAlchemyStore and if the value is overridden with a value other
                 than ``None``, an MlflowException will be thrown.
@@ -1045,7 +1044,6 @@ class SqlAlchemyStore(AbstractStore):
         with self.ManagedSessionMaker() as session:
             query = session.query(SqlMetric).filter_by(run_uuid=run_id, key=metric_key)
 
-            # Apply max_results limit if specified
             if max_results is not None:
                 query = query.limit(max_results)
 

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -1043,7 +1043,13 @@ class SqlAlchemyStore(AbstractStore):
             )
 
         with self.ManagedSessionMaker() as session:
-            metrics = session.query(SqlMetric).filter_by(run_uuid=run_id, key=metric_key).all()
+            query = session.query(SqlMetric).filter_by(run_uuid=run_id, key=metric_key)
+
+            # Apply max_results limit if specified
+            if max_results is not None:
+                query = query.limit(max_results)
+
+            metrics = query.all()
             return PagedList([metric.to_mlflow_entity() for metric in metrics], None)
 
     def get_metric_history_bulk(self, run_ids, metric_key, max_results):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1191,21 +1191,21 @@ def test_get_metric_history_with_page_token(store):
     first_page = store.get_metric_history(
         run_id, metric_key, max_results=page_size, page_token=None
     )
-    assert hasattr(first_page, "token"), "Result should be a PagedList with token attribute"
+    assert isinstance(first_page, PagedList)
     assert first_page.token is not None
     assert len(first_page) == 4
 
     second_page = store.get_metric_history(
         run_id, metric_key, max_results=page_size, page_token=first_page.token
     )
-    assert hasattr(second_page, "token"), "Result should be a PagedList with token attribute"
+    assert isinstance(first_page, PagedList)
     assert second_page.token is not None
     assert len(second_page) == 4
 
     third_page = store.get_metric_history(
         run_id, metric_key, max_results=page_size, page_token=second_page.token
     )
-    assert hasattr(third_page, "token"), "Result should be a PagedList with token attribute"
+    assert isinstance(first_page, PagedList)
     assert third_page.token is None
     assert len(third_page) == 2
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1186,28 +1186,30 @@ def test_get_metric_history_with_page_token(store):
         metric = Metric(key=metric_key, value=float(i), timestamp=1000 + i, step=i)
         store.log_metric(run_id, metric)
 
-    page_size = 3
-    all_paginated_metrics = []
-    page_token = None
-    page_count = 0
+    page_size = 4
 
-    while True:
-        result = store.get_metric_history(
-            run_id, metric_key, max_results=page_size, page_token=page_token
-        )
+    first_page = store.get_metric_history(
+        run_id, metric_key, max_results=page_size, page_token=None
+    )
+    assert hasattr(first_page, "token"), "Result should be a PagedList with token attribute"
+    assert first_page.token is not None
+    assert len(first_page) == 4
 
-        assert hasattr(result, "token"), "Result should be a PagedList with token attribute"
+    second_page = store.get_metric_history(
+        run_id, metric_key, max_results=page_size, page_token=first_page.token
+    )
+    assert hasattr(second_page, "token"), "Result should be a PagedList with token attribute"
+    assert second_page.token is not None
+    assert len(second_page) == 4
 
-        metrics = list(result)
-        all_paginated_metrics.extend(metrics)
-        page_count += 1
+    third_page = store.get_metric_history(
+        run_id, metric_key, max_results=page_size, page_token=second_page.token
+    )
+    assert hasattr(third_page, "token"), "Result should be a PagedList with token attribute"
+    assert third_page.token is None
+    assert len(third_page) == 2
 
-        page_token = result.token
-        if not page_token:
-            break
-
-        assert page_count < 10, "Too many pages, possible infinite loop"
-
+    all_paginated_metrics = list(first_page) + list(second_page) + list(third_page)
     assert len(all_paginated_metrics) == 10
 
     for i, metric in enumerate(all_paginated_metrics):

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -1209,7 +1209,7 @@ def test_get_metric_history_with_page_token(store):
     assert third_page.token is None
     assert len(third_page) == 2
 
-    all_paginated_metrics = list(first_page) + list(second_page) + list(third_page)
+    all_paginated_metrics = first_page + second_page + third_page
     assert len(all_paginated_metrics) == 10
 
     for i, metric in enumerate(all_paginated_metrics):

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -56,6 +56,7 @@ from mlflow.store.db.utils import (
     _get_latest_schema_revision,
     _get_schema_version,
 )
+from mlflow.store.entities import PagedList
 from mlflow.store.tracking import (
     SEARCH_MAX_RESULTS_DEFAULT,
     SEARCH_MAX_RESULTS_THRESHOLD,
@@ -1445,21 +1446,21 @@ def test_get_metric_history_with_page_token(store: SqlAlchemyStore):
     first_page = store.get_metric_history(
         run_id, metric_key, max_results=page_size, page_token=None
     )
-    assert hasattr(first_page, "token"), "Result should be a PagedList with token attribute"
+    assert isinstance(first_page, PagedList)
     assert first_page.token is not None
     assert len(first_page) == 4
 
     second_page = store.get_metric_history(
         run_id, metric_key, max_results=page_size, page_token=first_page.token
     )
-    assert hasattr(second_page, "token"), "Result should be a PagedList with token attribute"
+    assert isinstance(first_page, PagedList)
     assert second_page.token is not None
     assert len(second_page) == 4
 
     third_page = store.get_metric_history(
         run_id, metric_key, max_results=page_size, page_token=second_page.token
     )
-    assert hasattr(third_page, "token"), "Result should be a PagedList with token attribute"
+    assert isinstance(first_page, PagedList)
     assert third_page.token is None
     assert len(third_page) == 2
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16325?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16325/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16325/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16325/merge
```

</p>
</details>

### Related Issues/PRs

Fixes #16318

### What changes are proposed in this pull request?

Support `max_results` param and `page_token` param in get-history of FileStore and SQLStore

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support `max_results` and `page_token` parameters in get-history of FileStore and SQLStore

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
