### PR TITLE
[DOC-FIX] Fix broken models documentation link in mlflow.models.__init__

### DIFF
--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -27,7 +27,7 @@ The built-in flavors are:
 - :py:mod:`mlflow.transformers`
 - :py:mod:`mlflow.xgboost`
 
-For details, see `MLflow Models <../models.html>`_.
+For details, see `MLflow Models guide <../../ml/model/>`_.
 """
 
 from mlflow.models.dependencies_schemas import set_retriever_schema

--- a/mlflow/models/__init__.py
+++ b/mlflow/models/__init__.py
@@ -27,7 +27,7 @@ The built-in flavors are:
 - :py:mod:`mlflow.transformers`
 - :py:mod:`mlflow.xgboost`
 
-For details, see `MLflow Models guide <../../ml/model/>`_.
+For details, see `MLflow Models guide <https://mlflow.org/docs/latest/ml/model/>`_.
 """
 
 from mlflow.models.dependencies_schemas import set_retriever_schema


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mohammadsubhani/mlflow/pull/16326?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16326/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16326/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16326/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #16282

### What changes are proposed in this pull request?

This PR fixes a broken documentation link in `mlflow.models.__init__.py`. The link was pointing to `../models.html` which returns a 403 error, as reported in issue #16282. The link has been updated to point to the correct MLflow Models guide location at `../../ml/model/`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing performed:**
- Verified the module imports correctly after the change
- Built the API documentation locally and confirmed the link points to the correct location
- Tested that the relative path `../../ml/model/` resolves to the proper MLflow Models guide

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

This PR directly addresses the issue reported in [#16282](https://github.com/mlflow/mlflow/issues/16282) where the models documentation link was returning a 403 error. The fix updates the broken link to point to the correct MLflow Models guide location.