### PR TITLE
Add support for chat-style prompts with structured output with prompt object

### DIFF
--- a/dev/run-python-skinny-tests.sh
+++ b/dev/run-python-skinny-tests.sh
@@ -36,7 +36,8 @@ pytest \
   tests/utils/test_requirements_utils.py::test_infer_requirements_excludes_mlflow \
   tests/utils/test_search_utils.py \
   tests/store/tracking/test_file_store.py \
-  tests/utils/test_doctor.py
+  tests/utils/test_doctor.py \
+  --import-mode=importlib
 
 python -m pip install pandas
 pytest tests/test_skinny_client_autolog_without_scipy.py

--- a/docs/docs/genai/data-model/prompts.mdx
+++ b/docs/docs/genai/data-model/prompts.mdx
@@ -154,12 +154,7 @@ chat_template = [
 </TabItem>
 </Tabs>
 
-### Tags and Response Formats
-
-Use `tags` for storing version-specific information and `response_format` for structured output specifications.
-
-<Tabs>
-<TabItem value="tags" label="Tags" default>
+### Tags
 
 Tags store version-specific metadata and prompt type information:
 
@@ -179,8 +174,7 @@ prompt = mlflow.genai.register_prompt(
 )
 ```
 
-</TabItem>
-<TabItem value="response-format" label="Response Format">
+### Response Formats
 
 Response formats define expected output structures for structured generation:
 
@@ -216,9 +210,6 @@ prompt = mlflow.genai.register_prompt(
     },
 )
 ```
-
-</TabItem>
-</Tabs>
 
 ## Prompt Lifecycle Management
 
@@ -504,6 +495,14 @@ Creating and managing prompts involves several key steps:
 ```python
 # Complete workflow example
 import mlflow
+from pydantic import BaseModel
+
+
+class SupportResponse(BaseModel):
+    response: str
+    confidence: float
+    suggested_actions: list[str]
+
 
 # 1. Register initial text prompt
 text_prompt = mlflow.genai.register_prompt(

--- a/docs/docs/genai/data-model/prompts.mdx
+++ b/docs/docs/genai/data-model/prompts.mdx
@@ -111,10 +111,15 @@ graph TB
 
 ### Template Structure
 
-Prompt templates support sophisticated variable interpolation:
+Prompt templates support sophisticated variable interpolation and multiple formats:
+
+<Tabs>
+<TabItem value="text" label="Text Templates" default>
+
+Text templates use string-based content with variable interpolation:
 
 ```python
-# Example template with variables
+# Example text template with variables
 template = """
 You are an expert {{ role }}. Analyze the following {{ content_type }} and provide {{ num_points }} key insights.
 
@@ -129,9 +134,34 @@ Requirements:
 # Variables automatically extracted: role, content_type, num_points, content, focus_area, tone, max_length
 ```
 
-### Tags
+</TabItem>
+<TabItem value="chat" label="Chat Templates">
 
-Use `tags` for storing version-specific information, such as the author of the changes.
+Chat templates use structured message arrays for conversational AI:
+
+```python
+# Example chat template with multiple messages
+chat_template = [
+    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
+    {"role": "user", "content": "{{ question }}"},
+    {"role": "assistant", "content": "I'll help you with that."},
+    {"role": "user", "content": "Can you provide more details about {{ topic }}?"},
+]
+
+# Variables automatically extracted: style, question, topic
+```
+
+</TabItem>
+</Tabs>
+
+### Tags and Response Formats
+
+Use `tags` for storing version-specific information and `response_format` for structured output specifications.
+
+<Tabs>
+<TabItem value="tags" label="Tags" default>
+
+Tags store version-specific metadata and prompt type information:
 
 ```python
 # Register prompt with comprehensive tags
@@ -148,6 +178,47 @@ prompt = mlflow.genai.register_prompt(
     },
 )
 ```
+
+</TabItem>
+<TabItem value="response-format" label="Response Format">
+
+Response formats define expected output structures for structured generation:
+
+```python
+from pydantic import BaseModel
+
+
+class AnalysisResponse(BaseModel):
+    summary: str
+    key_points: list[str]
+    confidence_score: float
+
+
+# Register prompt with response format
+prompt = mlflow.genai.register_prompt(
+    name="content-analyzer",
+    template=template,
+    response_format=AnalysisResponse,
+    commit_message="Added structured response format",
+)
+
+# Or use dictionary format
+prompt = mlflow.genai.register_prompt(
+    name="qa-prompt",
+    template="Answer: {{ question }}",
+    response_format={
+        "type": "object",
+        "properties": {
+            "answer": {"type": "string"},
+            "confidence": {"type": "number"},
+            "sources": {"type": "array", "items": {"type": "string"}},
+        },
+    },
+)
+```
+
+</TabItem>
+</Tabs>
 
 ## Prompt Lifecycle Management
 
@@ -230,31 +301,64 @@ graph TB
 
 ### Loading and Formatting
 
-Prompts are loaded and used through systematic patterns:
+Prompts are loaded and used through systematic patterns with support for different template types:
 
 <Tabs>
-  <TabItem value="specific" label="Specific Version" default>
-    ```python
-    # Load specific version
-    prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
+<TabItem value="text-prompts" label="Text Prompts" default>
 
-    # Format with variables
-    formatted_text = prompt.format(
-        num_sentences=3, content="Your content here...", tone="professional"
-    )
-    ```
+Text prompts use string-based templates with variable interpolation:
 
-  </TabItem>
-  <TabItem value="alias" label="Alias Reference">
-    ```python
-    # Load via alias for deployment flexibility
-    prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt@production")
+```python
+# Load specific version
+prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
-    # Same formatting interface
-    formatted_text = prompt.format(
-        num_sentences=3, content="Your content here...", tone="professional"
-    )
-    ```
+# Check prompt properties
+print(f"Is text prompt: {prompt.is_text_prompt}")
+print(f"Response format: {prompt.response_format}")
+
+# Format with variables
+formatted_text = prompt.format(
+    num_sentences=3, content="Your content here...", tone="professional"
+)
+```
+
+</TabItem>
+<TabItem value="chat-prompts" label="Chat Prompts">
+
+Chat prompts use structured message arrays for conversational AI:
+
+```python
+# Load specific version of chat prompt
+chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
+
+# Check prompt properties
+print(f"Is text prompt: {chat_prompt.is_text_prompt}")
+print(f"Response format: {chat_prompt.response_format}")
+
+# Format with variables
+formatted_messages = chat_prompt.format(
+    style="friendly",
+    domain="machine learning",
+    question="What is MLflow?",
+    specific_aspect="its tracking capabilities",
+)
+```
+
+</TabItem>
+<TabItem value="alias-loading" label="Alias Loading">
+
+Load prompts via aliases for deployment flexibility:
+
+```python
+# Load via alias for deployment flexibility
+prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt@production")
+
+# Same formatting interface works for both types
+if prompt.is_text_prompt:
+    formatted = prompt.format(num_sentences=3, content="Your content here...")
+else:
+    formatted = prompt.format(style="professional", question="Your question here...")
+```
 
   </TabItem>
   <TabItem value="search" label="Discovery and Search">
@@ -274,24 +378,51 @@ Prompts are loaded and used through systematic patterns:
 Prompts integrate seamlessly with popular GenAI frameworks:
 
 ```python
-# Integration with LangChain
 from langchain.prompts import PromptTemplate
+from langchain_core.prompts import ChatPromptTemplate
 
-# Load from MLflow and convert format
-mlflow_prompt = mlflow.genai.load_prompt("prompts:/qa-prompt/1")
-langchain_prompt = PromptTemplate.from_template(mlflow_prompt.to_single_brace_format())
+# Load text prompt from MLflow and convert format
+text_prompt = mlflow.genai.load_prompt("prompts:/qa-prompt/1")
+langchain_text_prompt = PromptTemplate.from_template(
+    text_prompt.to_single_brace_format()
+)
 
-# Integration with OpenAI
+# Load chat prompt from MLflow
+chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/1")
+formatted_messages = chat_prompt.format(style="friendly", question="What is MLflow?")
+langchain_chat_prompt = ChatPromptTemplate.from_messages(formatted_messages)
+```
+
+</TabItem>
+<TabItem value="openai" label="OpenAI">
+
+OpenAI integration works with both prompt types:
+
+```python
 import openai
 
 client = openai.OpenAI()
-response = client.chat.completions.create(
+
+# Use text prompt
+text_prompt = mlflow.genai.load_prompt("prompts:/qa-prompt/1")
+text_response = client.chat.completions.create(
     messages=[
-        {"role": "user", "content": mlflow_prompt.format(question="What is MLflow?")}
+        {"role": "user", "content": text_prompt.format(question="What is MLflow?")}
     ],
     model="gpt-4",
 )
+
+# Use chat prompt directly
+chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/1")
+formatted_messages = chat_prompt.format(style="friendly", question="What is MLflow?")
+chat_response = client.chat.completions.create(
+    messages=formatted_messages,
+    model="gpt-4",
+)
 ```
+
+</TabItem>
+</Tabs>
 
 ## Prompt Comparison and Evolution
 
@@ -374,23 +505,45 @@ Creating and managing prompts involves several key steps:
 # Complete workflow example
 import mlflow
 
-# 1. Register initial prompt
-prompt = mlflow.genai.register_prompt(
+# 1. Register initial text prompt
+text_prompt = mlflow.genai.register_prompt(
     name="customer-support",
     template="You are a helpful {{ role }}. Please {{ action }} for: {{ query }}",
+    response_format=SupportResponse,
     commit_message="Initial customer support template",
     tags={"domain": "support", "language": "en"},
 )
 
-# 2. Create production alias
-mlflow.set_prompt_alias("customer-support", "production", 1)
+# 2. Register chat prompt
+chat_prompt = mlflow.genai.register_prompt(
+    name="assistant-chat",
+    template=[
+        {"role": "system", "content": "You are a {{ style }} assistant."},
+        {"role": "user", "content": "{{ question }}"},
+    ],
+    response_format={"type": "object", "properties": {"response": {"type": "string"}}},
+    commit_message="Initial chat assistant template",
+    tags={"domain": "assistant", "language": "en"},
+)
 
-# 3. Load and use in application
-production_prompt = mlflow.genai.load_prompt("prompts:/customer-support@production")
-formatted = production_prompt.format(
+# 3. Create production aliases
+mlflow.set_prompt_alias("customer-support", "production", 1)
+mlflow.set_prompt_alias("assistant-chat", "production", 1)
+
+# 4. Load and use in application
+production_text_prompt = mlflow.genai.load_prompt(
+    "prompts:/customer-support@production"
+)
+formatted_text = production_text_prompt.format(
     role="customer service agent",
     action="provide assistance",
     query="How do I reset my password?",
+)
+
+production_chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-chat@production")
+formatted_messages = production_chat_prompt.format(
+    style="friendly",
+    question="What is MLflow?",
 )
 ```
 

--- a/docs/docs/genai/data-model/prompts.mdx
+++ b/docs/docs/genai/data-model/prompts.mdx
@@ -111,12 +111,7 @@ graph TB
 
 ### Template Structure
 
-Prompt templates support sophisticated variable interpolation and multiple formats:
-
-<Tabs>
-<TabItem value="text" label="Text Templates" default>
-
-Text templates use string-based content with variable interpolation:
+Prompt templates support sophisticated variable interpolation:
 
 ```python
 # Example text template with variables
@@ -132,31 +127,26 @@ Requirements:
 """
 
 # Variables automatically extracted: role, content_type, num_points, content, focus_area, tone, max_length
-```
 
-</TabItem>
-<TabItem value="chat" label="Chat Templates">
 
-Chat templates use structured message arrays for conversational AI:
-
-```python
 # Example chat template with multiple messages
 chat_template = [
-    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
-    {"role": "user", "content": "{{ question }}"},
-    {"role": "assistant", "content": "I'll help you with that."},
-    {"role": "user", "content": "Can you provide more details about {{ topic }}?"},
+    {
+        "role": "system",
+        "content": "You are an expert {{ role }}. Analyze the following {{ content_type }} and provide {{ num_points }} key insights.",
+    },
+    {
+        "role": "user",
+        "content": " Content: {{ content }}\n\nRequirements:\n- Focus on {{ focus_area }}\n- Use {{ tone }} tone\n- Limit response to {{ max_length }} words",
+    },
 ]
 
-# Variables automatically extracted: style, question, topic
+# Variables automatically extracted: role, content_type, num_points, content, focus_area, tone, max_length
 ```
-
-</TabItem>
-</Tabs>
 
 ### Tags
 
-Tags store version-specific metadata and prompt type information:
+Use `tags` for storing version-specific information, such as the author of the changes.
 
 ```python
 # Register prompt with comprehensive tags
@@ -292,64 +282,31 @@ graph TB
 
 ### Loading and Formatting
 
-Prompts are loaded and used through systematic patterns with support for different template types:
+Prompts are loaded and used through systematic patterns:
 
 <Tabs>
-<TabItem value="text-prompts" label="Text Prompts" default>
+  <TabItem value="specific" label="Specific Version" default>
+    ```python
+    # Load specific version
+    prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
-Text prompts use string-based templates with variable interpolation:
+    # Format with variables
+    formatted_text = prompt.format(
+        num_sentences=3, content="Your content here...", tone="professional"
+    )
+    ```
 
-```python
-# Load specific version
-prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
+  </TabItem>
+  <TabItem value="alias" label="Alias Reference">
+    ```python
+    # Load via alias for deployment flexibility
+    prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt@production")
 
-# Check prompt properties
-print(f"Is text prompt: {prompt.is_text_prompt}")
-print(f"Response format: {prompt.response_format}")
-
-# Format with variables
-formatted_text = prompt.format(
-    num_sentences=3, content="Your content here...", tone="professional"
-)
-```
-
-</TabItem>
-<TabItem value="chat-prompts" label="Chat Prompts">
-
-Chat prompts use structured message arrays for conversational AI:
-
-```python
-# Load specific version of chat prompt
-chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
-
-# Check prompt properties
-print(f"Is text prompt: {chat_prompt.is_text_prompt}")
-print(f"Response format: {chat_prompt.response_format}")
-
-# Format with variables
-formatted_messages = chat_prompt.format(
-    style="friendly",
-    domain="machine learning",
-    question="What is MLflow?",
-    specific_aspect="its tracking capabilities",
-)
-```
-
-</TabItem>
-<TabItem value="alias-loading" label="Alias Loading">
-
-Load prompts via aliases for deployment flexibility:
-
-```python
-# Load via alias for deployment flexibility
-prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt@production")
-
-# Same formatting interface works for both types
-if prompt.is_text_prompt:
-    formatted = prompt.format(num_sentences=3, content="Your content here...")
-else:
-    formatted = prompt.format(style="professional", question="Your question here...")
-```
+    # Same formatting interface
+    formatted_text = prompt.format(
+        num_sentences=3, content="Your content here...", tone="professional"
+    )
+    ```
 
   </TabItem>
   <TabItem value="search" label="Discovery and Search">
@@ -369,51 +326,24 @@ else:
 Prompts integrate seamlessly with popular GenAI frameworks:
 
 ```python
+# Integration with LangChain
 from langchain.prompts import PromptTemplate
-from langchain_core.prompts import ChatPromptTemplate
 
-# Load text prompt from MLflow and convert format
-text_prompt = mlflow.genai.load_prompt("prompts:/qa-prompt/1")
-langchain_text_prompt = PromptTemplate.from_template(
-    text_prompt.to_single_brace_format()
-)
+# Load from MLflow and convert format
+mlflow_prompt = mlflow.genai.load_prompt("prompts:/qa-prompt/1")
+langchain_prompt = PromptTemplate.from_template(mlflow_prompt.to_single_brace_format())
 
-# Load chat prompt from MLflow
-chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/1")
-formatted_messages = chat_prompt.format(style="friendly", question="What is MLflow?")
-langchain_chat_prompt = ChatPromptTemplate.from_messages(formatted_messages)
-```
-
-</TabItem>
-<TabItem value="openai" label="OpenAI">
-
-OpenAI integration works with both prompt types:
-
-```python
+# Integration with OpenAI
 import openai
 
 client = openai.OpenAI()
-
-# Use text prompt
-text_prompt = mlflow.genai.load_prompt("prompts:/qa-prompt/1")
-text_response = client.chat.completions.create(
+response = client.chat.completions.create(
     messages=[
-        {"role": "user", "content": text_prompt.format(question="What is MLflow?")}
+        {"role": "user", "content": mlflow_prompt.format(question="What is MLflow?")}
     ],
     model="gpt-4",
 )
-
-# Use chat prompt directly
-chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/1")
-formatted_messages = chat_prompt.format(style="friendly", question="What is MLflow?")
-chat_response = client.chat.completions.create(
-    messages=formatted_messages,
-    model="gpt-4",
-)
 ```
-
-</TabItem>
-</Tabs>
 
 ## Prompt Comparison and Evolution
 
@@ -513,36 +443,15 @@ text_prompt = mlflow.genai.register_prompt(
     tags={"domain": "support", "language": "en"},
 )
 
-# 2. Register chat prompt
-chat_prompt = mlflow.genai.register_prompt(
-    name="assistant-chat",
-    template=[
-        {"role": "system", "content": "You are a {{ style }} assistant."},
-        {"role": "user", "content": "{{ question }}"},
-    ],
-    response_format={"type": "object", "properties": {"response": {"type": "string"}}},
-    commit_message="Initial chat assistant template",
-    tags={"domain": "assistant", "language": "en"},
-)
-
-# 3. Create production aliases
+# 2. Create production alias
 mlflow.set_prompt_alias("customer-support", "production", 1)
-mlflow.set_prompt_alias("assistant-chat", "production", 1)
 
-# 4. Load and use in application
-production_text_prompt = mlflow.genai.load_prompt(
-    "prompts:/customer-support@production"
-)
-formatted_text = production_text_prompt.format(
+# 3. Load and use in application
+production_prompt = mlflow.genai.load_prompt("prompts:/customer-support@production")
+formatted = production_prompt.format(
     role="customer service agent",
     action="provide assistance",
     query="How do I reset my password?",
-)
-
-production_chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-chat@production")
-formatted_messages = production_chat_prompt.format(
-    style="friendly",
-    question="What is MLflow?",
 )
 ```
 

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
@@ -39,31 +39,61 @@ You can initiate a new prompt in the MLflow Prompt Registry in two primary ways:
       initial_template = """\
       Summarize content you are provided with in {{ num_sentences }} sentences.
 
-      Sentences: {{ sentences }}
-      """
+```python
+import mlflow
+from pydantic import BaseModel
 
-      # Register a new prompt
-      prompt = mlflow.genai.register_prompt(
-          name="summarization-prompt",
-          template=initial_template,
-          # Optional: Provide a commit message to describe the changes
-          commit_message="Initial commit",
-          # Optional: Set tags applies to the prompt (across versions)
-          tags={
-              "author": "author@example.com",
-              "task": "summarization",
-              "language": "en",
-          },
-      )
+# Text prompt with response format
+text_template = """\
+Summarize content you are provided with in {{ num_sentences }} sentences.
 
       # The prompt object contains information about the registered prompt
       print(f"Created prompt '{prompt.name}' (version {prompt.version})")
       ```
     </div>
 
-  </TabItem>
-</Tabs>
-</TabsWrapper>
+
+# Define response format for structured output
+class SummaryResponse(BaseModel):
+    summary: str
+    key_points: list[str]
+    word_count: int
+
+
+# Register a text prompt
+text_prompt = mlflow.genai.register_prompt(
+    name="summarization-prompt",
+    template=text_template,
+    response_format=SummaryResponse,
+    # Optional: Provide a commit message to describe the changes
+    commit_message="Initial commit",
+    # Optional: Set tags applies to the prompt (across versions)
+    tags={
+        "author": "author@example.com",
+        "task": "summarization",
+        "language": "en",
+    },
+)
+
+# Chat prompt example
+chat_template = [
+    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
+    {"role": "user", "content": "{{ question }}"},
+]
+
+# Register a chat prompt
+chat_prompt = mlflow.genai.register_prompt(
+    name="assistant-prompt",
+    template=chat_template,
+    response_format={"type": "string", "description": "A helpful response"},
+    commit_message="Initial chat prompt",
+    tags={"type": "chat", "style": "friendly"},
+)
+
+# The prompt object contains information about the registered prompt
+print(f"Created text prompt '{text_prompt.name}' (version {text_prompt.version})")
+print(f"Created chat prompt '{chat_prompt.name}' (version {chat_prompt.version})")
+```
 
 ## Editing an Existing Prompt (Creating New Versions)
 
@@ -93,14 +123,13 @@ Once a prompt version is created, its template and initial metadata are **immuta
       new_template = """\
       You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
-      Sentences: {{ sentences }}
+```python
+import mlflow
+from pydantic import BaseModel
 
-      Your summary should:
-      - Contain exactly {{ num_sentences }} sentences
-      - Include only the most important information
-      - Be written in a neutral, objective tone
-      - Maintain the same level of formality as the original text
-      """
+# Update text prompt with enhanced response format
+new_text_template = """\
+You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
       # Register a new version of an existing prompt
       updated_prompt = mlflow.genai.register_prompt(
@@ -114,9 +143,61 @@ Once a prompt version is created, its template and initial metadata are **immuta
       ```
     </div>
 
-  </TabItem>
-</Tabs>
-</TabsWrapper>
+Your summary should:
+- Contain exactly {{ num_sentences }} sentences
+- Include only the most important information
+- Be written in a neutral, objective tone
+- Maintain the same level of formality as the original text
+"""
+
+
+# Enhanced response format
+class EnhancedSummaryResponse(BaseModel):
+    summary: str
+    key_points: list[str]
+    word_count: int
+    confidence_score: float
+    reading_level: str
+
+
+# Register a new version of an existing text prompt
+updated_text_prompt = mlflow.genai.register_prompt(
+    name="summarization-prompt",  # Specify the existing prompt name
+    template=new_text_template,
+    response_format=EnhancedSummaryResponse,
+    commit_message="Enhanced with confidence scoring and reading level",
+    tags={
+        "author": "author@example.com",
+        "enhanced": "true",
+    },
+)
+
+# Update chat prompt with additional messages
+new_chat_template = [
+    {
+        "role": "system",
+        "content": "You are a helpful {{ style }} assistant with expertise in {{ domain }}.",
+    },
+    {"role": "user", "content": "{{ question }}"},
+    {
+        "role": "assistant",
+        "content": "I'll help you with that. Let me provide a detailed response.",
+    },
+    {"role": "user", "content": "Please elaborate on {{ specific_aspect }}."},
+]
+
+# Register a new version of an existing chat prompt
+updated_chat_prompt = mlflow.genai.register_prompt(
+    name="assistant-prompt",
+    template=new_chat_template,
+    response_format={
+        "type": "object",
+        "properties": {"answer": {"type": "string"}, "sources": {"type": "array"}},
+    },
+    commit_message="Added multi-turn conversation support",
+    tags={"type": "chat", "style": "friendly", "multi_turn": "true"},
+)
+```
 
 ## Understanding Immutability
 

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
@@ -41,9 +41,8 @@ You can initiate a new prompt in the MLflow Prompt Registry in two primary ways:
 
 ```python
 import mlflow
-from pydantic import BaseModel
 
-# Text prompt with response format
+# Text prompt template
 text_template = """\
 Summarize content you are provided with in {{ num_sentences }} sentences.
 
@@ -52,19 +51,10 @@ Summarize content you are provided with in {{ num_sentences }} sentences.
       ```
     </div>
 
-
-# Define response format for structured output
-class SummaryResponse(BaseModel):
-    summary: str
-    key_points: list[str]
-    word_count: int
-
-
 # Register a text prompt
 text_prompt = mlflow.genai.register_prompt(
     name="summarization-prompt",
     template=text_template,
-    response_format=SummaryResponse,
     # Optional: Provide a commit message to describe the changes
     commit_message="Initial commit",
     # Optional: Set tags applies to the prompt (across versions)
@@ -75,7 +65,7 @@ text_prompt = mlflow.genai.register_prompt(
     },
 )
 
-# Chat prompt example
+# Chat prompt template
 chat_template = [
     {"role": "system", "content": "You are a helpful {{ style }} assistant."},
     {"role": "user", "content": "{{ question }}"},
@@ -85,7 +75,6 @@ chat_template = [
 chat_prompt = mlflow.genai.register_prompt(
     name="assistant-prompt",
     template=chat_template,
-    response_format={"type": "string", "description": "A helpful response"},
     commit_message="Initial chat prompt",
     tags={"type": "chat", "style": "friendly"},
 )
@@ -125,9 +114,8 @@ Once a prompt version is created, its template and initial metadata are **immuta
 
 ```python
 import mlflow
-from pydantic import BaseModel
 
-# Update text prompt with enhanced response format
+# Update text prompt template
 new_text_template = """\
 You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
@@ -150,22 +138,11 @@ Your summary should:
 - Maintain the same level of formality as the original text
 """
 
-
-# Enhanced response format
-class EnhancedSummaryResponse(BaseModel):
-    summary: str
-    key_points: list[str]
-    word_count: int
-    confidence_score: float
-    reading_level: str
-
-
 # Register a new version of an existing text prompt
 updated_text_prompt = mlflow.genai.register_prompt(
     name="summarization-prompt",  # Specify the existing prompt name
     template=new_text_template,
-    response_format=EnhancedSummaryResponse,
-    commit_message="Enhanced with confidence scoring and reading level",
+    commit_message="Enhanced with better instructions and formatting",
     tags={
         "author": "author@example.com",
         "enhanced": "true",
@@ -190,10 +167,6 @@ new_chat_template = [
 updated_chat_prompt = mlflow.genai.register_prompt(
     name="assistant-prompt",
     template=new_chat_template,
-    response_format={
-        "type": "object",
-        "properties": {"answer": {"type": "string"}, "sources": {"type": "array"}},
-    },
     commit_message="Added multi-turn conversation support",
     tags={"type": "chat", "style": "friendly", "multi_turn": "true"},
 )

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
@@ -42,8 +42,8 @@ You can initiate a new prompt in the MLflow Prompt Registry in two primary ways:
 ```python
 import mlflow
 
-# Text prompt template
-text_template = """\
+# Use double curly braces for variables in the template
+initial_template = """\
 Summarize content you are provided with in {{ num_sentences }} sentences.
 
       # The prompt object contains information about the registered prompt
@@ -51,10 +51,10 @@ Summarize content you are provided with in {{ num_sentences }} sentences.
       ```
     </div>
 
-# Register a text prompt
-text_prompt = mlflow.genai.register_prompt(
+# Register a new prompt
+prompt = mlflow.genai.register_prompt(
     name="summarization-prompt",
-    template=text_template,
+    template=initial_template,
     # Optional: Provide a commit message to describe the changes
     commit_message="Initial commit",
     # Optional: Set tags applies to the prompt (across versions)
@@ -65,23 +65,8 @@ text_prompt = mlflow.genai.register_prompt(
     },
 )
 
-# Chat prompt template
-chat_template = [
-    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
-    {"role": "user", "content": "{{ question }}"},
-]
-
-# Register a chat prompt
-chat_prompt = mlflow.genai.register_prompt(
-    name="assistant-prompt",
-    template=chat_template,
-    commit_message="Initial chat prompt",
-    tags={"type": "chat", "style": "friendly"},
-)
-
 # The prompt object contains information about the registered prompt
-print(f"Created text prompt '{text_prompt.name}' (version {text_prompt.version})")
-print(f"Created chat prompt '{chat_prompt.name}' (version {chat_prompt.version})")
+print(f"Created prompt '{prompt.name}' (version {prompt.version})")
 ```
 
 ## Editing an Existing Prompt (Creating New Versions)
@@ -115,8 +100,7 @@ Once a prompt version is created, its template and initial metadata are **immuta
 ```python
 import mlflow
 
-# Update text prompt template
-new_text_template = """\
+new_template = """\
 You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
       # Register a new version of an existing prompt
@@ -138,37 +122,14 @@ Your summary should:
 - Maintain the same level of formality as the original text
 """
 
-# Register a new version of an existing text prompt
-updated_text_prompt = mlflow.genai.register_prompt(
+# Register a new version of an existing prompt
+updated_prompt = mlflow.genai.register_prompt(
     name="summarization-prompt",  # Specify the existing prompt name
-    template=new_text_template,
-    commit_message="Enhanced with better instructions and formatting",
+    template=new_template,
+    commit_message="Improvement",
     tags={
         "author": "author@example.com",
-        "enhanced": "true",
     },
-)
-
-# Update chat prompt with additional messages
-new_chat_template = [
-    {
-        "role": "system",
-        "content": "You are a helpful {{ style }} assistant with expertise in {{ domain }}.",
-    },
-    {"role": "user", "content": "{{ question }}"},
-    {
-        "role": "assistant",
-        "content": "I'll help you with that. Let me provide a detailed response.",
-    },
-    {"role": "user", "content": "Please elaborate on {{ specific_aspect }}."},
-]
-
-# Register a new version of an existing chat prompt
-updated_chat_prompt = mlflow.genai.register_prompt(
-    name="assistant-prompt",
-    template=new_chat_template,
-    commit_message="Added multi-turn conversation support",
-    tags={"type": "chat", "style": "friendly", "multi_turn": "true"},
 )
 ```
 

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts.mdx
@@ -39,35 +39,50 @@ You can initiate a new prompt in the MLflow Prompt Registry in two primary ways:
       initial_template = """\
       Summarize content you are provided with in {{ num_sentences }} sentences.
 
-```python
-import mlflow
+      Sentences: {{ sentences }}
+      """
 
-# Use double curly braces for variables in the template
-initial_template = """\
-Summarize content you are provided with in {{ num_sentences }} sentences.
+      # Chat Style template
+      initial_template = [
+          {
+              "role": "system",
+              "content": "Summarize content you are provided with in {{ num_sentences }} sentences.",
+          },
+          {"role": "user", "content": "Sentences: {{ sentences }}"},
+      ]
+
+      # Optional Response Format
+      from pydantic import BaseModel, Field
+
+
+      class ResponseFormat:
+          summary: str = Field(..., description="Summary of the content")
+
+
+      # Register a new prompt
+      prompt = mlflow.genai.register_prompt(
+          name="summarization-prompt",
+          template=initial_template,
+          # Optional: Provide Response Format to get structured output
+          response_format=ResponseFormat,
+          # Optional: Provide a commit message to describe the changes
+          commit_message="Initial commit",
+          # Optional: Set tags applies to the prompt (across versions)
+          tags={
+              "author": "author@example.com",
+              "task": "summarization",
+              "language": "en",
+          },
+      )
 
       # The prompt object contains information about the registered prompt
       print(f"Created prompt '{prompt.name}' (version {prompt.version})")
       ```
     </div>
 
-# Register a new prompt
-prompt = mlflow.genai.register_prompt(
-    name="summarization-prompt",
-    template=initial_template,
-    # Optional: Provide a commit message to describe the changes
-    commit_message="Initial commit",
-    # Optional: Set tags applies to the prompt (across versions)
-    tags={
-        "author": "author@example.com",
-        "task": "summarization",
-        "language": "en",
-    },
-)
-
-# The prompt object contains information about the registered prompt
-print(f"Created prompt '{prompt.name}' (version {prompt.version})")
-```
+  </TabItem>
+</Tabs>
+</TabsWrapper>
 
 ## Editing an Existing Prompt (Creating New Versions)
 
@@ -97,11 +112,14 @@ Once a prompt version is created, its template and initial metadata are **immuta
       new_template = """\
       You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
-```python
-import mlflow
+      Sentences: {{ sentences }}
 
-new_template = """\
-You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
+      Your summary should:
+      - Contain exactly {{ num_sentences }} sentences
+      - Include only the most important information
+      - Be written in a neutral, objective tone
+      - Maintain the same level of formality as the original text
+      """
 
       # Register a new version of an existing prompt
       updated_prompt = mlflow.genai.register_prompt(
@@ -115,23 +133,9 @@ You are an expert summarizer. Condense the following content into exactly {{ num
       ```
     </div>
 
-Your summary should:
-- Contain exactly {{ num_sentences }} sentences
-- Include only the most important information
-- Be written in a neutral, objective tone
-- Maintain the same level of formality as the original text
-"""
-
-# Register a new version of an existing prompt
-updated_prompt = mlflow.genai.register_prompt(
-    name="summarization-prompt",  # Specify the existing prompt name
-    template=new_template,
-    commit_message="Improvement",
-    tags={
-        "author": "author@example.com",
-    },
-)
-```
+  </TabItem>
+</Tabs>
+</TabsWrapper>
 
 ## Understanding Immutability
 

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/index.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/index.mdx
@@ -69,28 +69,18 @@ import { Package, GitBranch, Tag, LineChart, Users } from "lucide-react";
 
       ```python
       import mlflow
-      from pydantic import BaseModel
 
-      # Text prompt with response format
-      text_template = """\
+      # Use double curly braces for variables in the template
+      initial_template = """\
       Summarize content you are provided with in {{ num_sentences }} sentences.
 
       Sentences: {{ sentences }}
       """
 
-
-      # Define response format for structured output
-      class SummaryResponse(BaseModel):
-          summary: str
-          key_points: list[str]
-          word_count: int
-
-
-      # Register a text prompt
+      # Register a new prompt
       prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",
-          template=text_template,
-          response_format=SummaryResponse,
+          template=initial_template,
           # Optional: Provide a commit message to describe the changes
           commit_message="Initial commit",
           # Optional: Set tags applies to the prompt (across versions)
@@ -99,21 +89,6 @@ import { Package, GitBranch, Tag, LineChart, Users } from "lucide-react";
               "task": "summarization",
               "language": "en",
           },
-      )
-
-      # Chat prompt example
-      chat_template = [
-          {"role": "system", "content": "You are a helpful {{ style }} assistant."},
-          {"role": "user", "content": "{{ question }}"},
-      ]
-
-      # Register a chat prompt
-      chat_prompt = mlflow.genai.register_prompt(
-          name="assistant-prompt",
-          template=chat_template,
-          response_format={"type": "string", "description": "A helpful response"},
-          commit_message="Initial chat prompt",
-          tags={"type": "chat", "style": "friendly"},
       )
 
       # The prompt object contains information about the registered prompt
@@ -153,10 +128,8 @@ This creates a new prompt with the specified template text and metadata. The pro
 
       ```python
       import mlflow
-      from pydantic import BaseModel
 
-      # Update text prompt with enhanced response format
-      new_text_template = """\
+      new_template = """\
       You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
       Sentences: {{ sentences }}
@@ -168,52 +141,14 @@ This creates a new prompt with the specified template text and metadata. The pro
       - Maintain the same level of formality as the original text
       """
 
-
-      # Enhanced response format
-      class EnhancedSummaryResponse(BaseModel):
-          summary: str
-          key_points: list[str]
-          word_count: int
-          confidence_score: float
-          reading_level: str
-
-
-      # Register a new version of an existing text prompt
+      # Register a new version of an existing prompt
       updated_prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",  # Specify the existing prompt name
-          template=new_text_template,
-          response_format=EnhancedSummaryResponse,
-          commit_message="Enhanced with confidence scoring and reading level",
+          template=new_template,
+          commit_message="Improvement",
           tags={
               "author": "author@example.com",
-              "enhanced": "true",
           },
-      )
-
-      # Update chat prompt with additional messages
-      new_chat_template = [
-          {
-              "role": "system",
-              "content": "You are a helpful {{ style }} assistant with expertise in {{ domain }}.",
-          },
-          {"role": "user", "content": "{{ question }}"},
-          {
-              "role": "assistant",
-              "content": "I'll help you with that. Let me provide a detailed response.",
-          },
-          {"role": "user", "content": "Please elaborate on {{ specific_aspect }}."},
-      ]
-
-      # Register a new version of an existing chat prompt
-      updated_chat_prompt = mlflow.genai.register_prompt(
-          name="assistant-prompt",
-          template=new_chat_template,
-          response_format={
-              "type": "object",
-              "properties": {"answer": {"type": "string"}, "sources": {"type": "array"}},
-          },
-          commit_message="Added multi-turn conversation support",
-          tags={"type": "chat", "style": "friendly", "multi_turn": "true"},
       )
       ```
     </div>
@@ -249,10 +184,6 @@ MLflow Projects, MLflow Models, and MLflow Registry.
 # Load the prompt
 prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
-# Check prompt properties
-print(f"Is text prompt: {prompt.is_text_prompt}")
-print(f"Response format: {prompt.response_format}")
-
 # Use the prompt with an LLM
 client = openai.OpenAI()
 response = client.chat.completions.create(
@@ -262,35 +193,6 @@ response = client.chat.completions.create(
             "content": prompt.format(num_sentences=1, sentences=target_text),
         }
     ],
-    model="gpt-4o-mini",
-)
-
-print(response.choices[0].message.content)
-```
-
-For chat prompts, you can load and use them similarly:
-
-```python
-import mlflow
-import openai
-
-# Load the chat prompt
-chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
-
-# Check prompt properties
-print(f"Is text prompt: {chat_prompt.is_text_prompt}")
-print(f"Response format: {chat_prompt.response_format}")
-
-# Format the chat prompt
-formatted_messages = chat_prompt.format(
-    style="friendly",
-    question="What is MLflow?",
-)
-
-# Use the formatted messages directly with an LLM
-client = openai.OpenAI()
-response = client.chat.completions.create(
-    messages=formatted_messages,
     model="gpt-4o-mini",
 )
 
@@ -329,9 +231,9 @@ print(f"Total prompts across pages: {len(all_prompts)}")
 
 ## Prompt Object
 
-The `PromptVersion` object is the core entity in MLflow Prompt Registry. It represents a versioned template that can contain variables for dynamic content. MLflow now supports two types of prompts: **text prompts** and **chat prompts**.
+The `Prompt` object is the core entity in MLflow Prompt Registry. It represents a versioned template text that can contain variables for dynamic content.
 
-Key attributes of a PromptVersion object:
+Key attributes of a Prompt object:
 
 - `Name`: A unique identifier for the prompt.
 - `Template`: The content of the prompt, which can be either:

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/index.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/index.mdx
@@ -69,18 +69,28 @@ import { Package, GitBranch, Tag, LineChart, Users } from "lucide-react";
 
       ```python
       import mlflow
+      from pydantic import BaseModel
 
-      # Use double curly braces for variables in the template
-      initial_template = """\
+      # Text prompt with response format
+      text_template = """\
       Summarize content you are provided with in {{ num_sentences }} sentences.
 
       Sentences: {{ sentences }}
       """
 
-      # Register a new prompt
+
+      # Define response format for structured output
+      class SummaryResponse(BaseModel):
+          summary: str
+          key_points: list[str]
+          word_count: int
+
+
+      # Register a text prompt
       prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",
-          template=initial_template,
+          template=text_template,
+          response_format=SummaryResponse,
           # Optional: Provide a commit message to describe the changes
           commit_message="Initial commit",
           # Optional: Set tags applies to the prompt (across versions)
@@ -89,6 +99,21 @@ import { Package, GitBranch, Tag, LineChart, Users } from "lucide-react";
               "task": "summarization",
               "language": "en",
           },
+      )
+
+      # Chat prompt example
+      chat_template = [
+          {"role": "system", "content": "You are a helpful {{ style }} assistant."},
+          {"role": "user", "content": "{{ question }}"},
+      ]
+
+      # Register a chat prompt
+      chat_prompt = mlflow.genai.register_prompt(
+          name="assistant-prompt",
+          template=chat_template,
+          response_format={"type": "string", "description": "A helpful response"},
+          commit_message="Initial chat prompt",
+          tags={"type": "chat", "style": "friendly"},
       )
 
       # The prompt object contains information about the registered prompt
@@ -128,8 +153,10 @@ This creates a new prompt with the specified template text and metadata. The pro
 
       ```python
       import mlflow
+      from pydantic import BaseModel
 
-      new_template = """\
+      # Update text prompt with enhanced response format
+      new_text_template = """\
       You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
       Sentences: {{ sentences }}
@@ -141,14 +168,52 @@ This creates a new prompt with the specified template text and metadata. The pro
       - Maintain the same level of formality as the original text
       """
 
-      # Register a new version of an existing prompt
+
+      # Enhanced response format
+      class EnhancedSummaryResponse(BaseModel):
+          summary: str
+          key_points: list[str]
+          word_count: int
+          confidence_score: float
+          reading_level: str
+
+
+      # Register a new version of an existing text prompt
       updated_prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",  # Specify the existing prompt name
-          template=new_template,
-          commit_message="Improvement",
+          template=new_text_template,
+          response_format=EnhancedSummaryResponse,
+          commit_message="Enhanced with confidence scoring and reading level",
           tags={
               "author": "author@example.com",
+              "enhanced": "true",
           },
+      )
+
+      # Update chat prompt with additional messages
+      new_chat_template = [
+          {
+              "role": "system",
+              "content": "You are a helpful {{ style }} assistant with expertise in {{ domain }}.",
+          },
+          {"role": "user", "content": "{{ question }}"},
+          {
+              "role": "assistant",
+              "content": "I'll help you with that. Let me provide a detailed response.",
+          },
+          {"role": "user", "content": "Please elaborate on {{ specific_aspect }}."},
+      ]
+
+      # Register a new version of an existing chat prompt
+      updated_chat_prompt = mlflow.genai.register_prompt(
+          name="assistant-prompt",
+          template=new_chat_template,
+          response_format={
+              "type": "object",
+              "properties": {"answer": {"type": "string"}, "sources": {"type": "array"}},
+          },
+          commit_message="Added multi-turn conversation support",
+          tags={"type": "chat", "style": "friendly", "multi_turn": "true"},
       )
       ```
     </div>
@@ -184,6 +249,10 @@ MLflow Projects, MLflow Models, and MLflow Registry.
 # Load the prompt
 prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
+# Check prompt properties
+print(f"Is text prompt: {prompt.is_text_prompt}")
+print(f"Response format: {prompt.response_format}")
+
 # Use the prompt with an LLM
 client = openai.OpenAI()
 response = client.chat.completions.create(
@@ -193,6 +262,35 @@ response = client.chat.completions.create(
             "content": prompt.format(num_sentences=1, sentences=target_text),
         }
     ],
+    model="gpt-4o-mini",
+)
+
+print(response.choices[0].message.content)
+```
+
+For chat prompts, you can load and use them similarly:
+
+```python
+import mlflow
+import openai
+
+# Load the chat prompt
+chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
+
+# Check prompt properties
+print(f"Is text prompt: {chat_prompt.is_text_prompt}")
+print(f"Response format: {chat_prompt.response_format}")
+
+# Format the chat prompt
+formatted_messages = chat_prompt.format(
+    style="friendly",
+    question="What is MLflow?",
+)
+
+# Use the formatted messages directly with an LLM
+client = openai.OpenAI()
+response = client.chat.completions.create(
+    messages=formatted_messages,
     model="gpt-4o-mini",
 )
 
@@ -231,17 +329,64 @@ print(f"Total prompts across pages: {len(all_prompts)}")
 
 ## Prompt Object
 
-The `Prompt` object is the core entity in MLflow Prompt Registry. It represents a versioned template text that can contain variables for dynamic content.
+The `PromptVersion` object is the core entity in MLflow Prompt Registry. It represents a versioned template that can contain variables for dynamic content. MLflow now supports two types of prompts: **text prompts** and **chat prompts**.
 
-Key attributes of a Prompt object:
+Key attributes of a PromptVersion object:
 
 - `Name`: A unique identifier for the prompt.
-- `Template`: The text of the prompt, which can include variables in `{{variable}}` format.
+- `Template`: The content of the prompt, which can be either:
+  - A string containing text with variables in `{{variable}}` format (text prompts)
+  - A list of dictionaries representing chat messages with 'role' and 'content' keys (chat prompts)
 - `Version`: A sequential number representing the revision of the prompt.
 - `Commit Message`: A description of the changes made in the prompt version, similar to Git commit messages.
 - `Tags`: Optional key-value pairs assigned at the prompt version
   for categorization and filtering. For example, you may add tags for project name, language, etc, which apply to all versions of the prompt.
 - `Alias`: An mutable named reference to the prompt. For example, you can create an alias named `production` to refer to the version used in your production system. See [Aliases](/genai/data-model/prompts#alias-management) for more details.
+- `is_text_prompt`: A boolean property indicating whether the prompt is a text prompt (True) or chat prompt (False).
+- `response_format`: An optional property containing the expected response structure specification, which can be used to validate or structure outputs from LLM calls.
+
+### Prompt Types
+
+#### Text Prompts
+Text prompts use a simple string template with variables enclosed in double curly braces:
+
+```python
+text_template = "Hello {{ name }}, how are you today?"
+```
+
+#### Chat Prompts
+Chat prompts use a list of message dictionaries, each with 'role' and 'content' keys:
+
+```python
+chat_template = [
+    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
+    {"role": "user", "content": "{{ question }}"},
+]
+```
+
+### Response Format
+The `response_format` property allows you to specify the expected structure of responses from LLM calls. This can be either a Pydantic model class or a dictionary defining the schema:
+
+```python
+from pydantic import BaseModel
+
+
+class SummaryResponse(BaseModel):
+    summary: str
+    key_points: list[str]
+    word_count: int
+
+
+# Or as a dictionary
+response_format_dict = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "key_points": {"type": "array", "items": {"type": "string"}},
+        "word_count": {"type": "integer"},
+    },
+}
+```
 
 ## FAQ
 

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/index.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/index.mdx
@@ -250,6 +250,7 @@ Key attributes of a Prompt object:
 ### Prompt Types
 
 #### Text Prompts
+
 Text prompts use a simple string template with variables enclosed in double curly braces:
 
 ```python
@@ -257,6 +258,7 @@ text_template = "Hello {{ name }}, how are you today?"
 ```
 
 #### Chat Prompts
+
 Chat prompts use a list of message dictionaries, each with 'role' and 'content' keys:
 
 ```python
@@ -267,6 +269,7 @@ chat_template = [
 ```
 
 ### Response Format
+
 The `response_format` property allows you to specify the expected structure of responses from LLM calls. This can be either a Pydantic model class or a dictionary defining the schema:
 
 ```python

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/structured-output.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/structured-output.mdx
@@ -1,0 +1,234 @@
+---
+title: Structured Output
+description: Learn how to define structured output schemas for your prompts to ensure consistent and validated responses from language models.
+---
+
+# Structured Output
+
+MLflow Prompt Registry supports defining structured output schemas for your prompts, ensuring that language model responses follow a consistent format and can be validated. This feature is particularly useful for applications that need to parse and process model outputs programmatically.
+
+## Overview
+
+Structured output allows you to:
+
+- **Define expected response formats** using Pydantic models or JSON schemas
+- **Validate model responses** against your defined schema
+- **Ensure consistency** across different model calls
+- **Improve integration** with downstream applications
+- **Enable type safety** in your GenAI applications
+
+:::note
+**Important**: The `response_format` parameter is used for **tracking and documentation purposes** rather than direct runtime enforcement. MLflow stores this information as metadata to help you understand the expected output structure of your prompts, but it does not automatically validate or enforce the format during model execution. You are responsible for implementing the actual validation and enforcement in your application code.
+:::
+
+## Basic Usage
+
+### Using Pydantic Models
+
+The most common way to define structured output is using Pydantic models:
+
+```python
+import mlflow
+from pydantic import BaseModel
+from typing import List
+
+
+class SummaryResponse(BaseModel):
+    summary: str
+    key_points: List[str]
+    word_count: int
+
+
+# Register prompt with structured output
+prompt = mlflow.genai.register_prompt(
+    name="summarization-prompt",
+    template="Summarize the following text in {{ num_sentences }} sentences: {{ text }}",
+    response_format=SummaryResponse,
+    commit_message="Added structured output for summarization",
+    tags={"task": "summarization", "structured": "true"},
+)
+```
+
+### Using JSON Schema
+
+You can also define response formats using JSON schema dictionaries:
+
+```python
+import mlflow
+
+# Define response format as JSON schema
+response_schema = {
+    "type": "object",
+    "properties": {
+        "answer": {"type": "string", "description": "The main answer"},
+        "confidence": {"type": "number", "description": "Confidence score (0-1)"},
+        "sources": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "List of source references",
+        },
+    },
+    "required": ["answer", "confidence"],
+}
+
+# Register prompt with JSON schema
+prompt = mlflow.genai.register_prompt(
+    name="qa-prompt",
+    template="Answer the following question: {{ question }}",
+    response_format=response_schema,
+    commit_message="Added structured output for Q&A",
+    tags={"task": "qa", "structured": "true"},
+)
+```
+
+## Advanced Examples
+
+### Complex Response Formats
+
+For more complex applications, you can define nested structures:
+
+```python
+import mlflow
+from pydantic import BaseModel
+from typing import List, Optional
+from datetime import datetime
+
+
+class AnalysisResult(BaseModel):
+    sentiment: str
+    confidence: float
+    entities: List[str]
+    summary: str
+
+
+class DocumentAnalysis(BaseModel):
+    document_id: str
+    analysis: AnalysisResult
+    processed_at: datetime
+    metadata: Optional[dict] = None
+
+
+# Register prompt with complex structured output
+prompt = mlflow.genai.register_prompt(
+    name="document-analyzer",
+    template="Analyze the following document: {{ document_text }}",
+    response_format=DocumentAnalysis,
+    commit_message="Added comprehensive document analysis output",
+    tags={"task": "analysis", "complex": "true"},
+)
+```
+
+### Chat Prompts with Structured Output
+
+Chat prompts can also use structured output formats:
+
+```python
+import mlflow
+from pydantic import BaseModel
+
+
+class ChatResponse(BaseModel):
+    response: str
+    tone: str
+    suggestions: List[str]
+
+
+# Chat prompt with structured output
+chat_template = [
+    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
+    {"role": "user", "content": "{{ question }}"},
+]
+
+prompt = mlflow.genai.register_prompt(
+    name="assistant-chat",
+    template=chat_template,
+    response_format=ChatResponse,
+    commit_message="Added structured output for chat responses",
+    tags={"type": "chat", "structured": "true"},
+)
+```
+
+## Loading and Using Structured Prompts
+
+When you load a prompt with structured output, you can access the response format for tracking and documentation purposes:
+
+```python
+# Load the prompt
+prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/1")
+
+# Check if it has structured output (for tracking purposes)
+if prompt.response_format:
+    print(f"Response format: {prompt.response_format}")
+
+# Format the prompt
+formatted_text = prompt.format(num_sentences=3, text="Your content here...")
+
+# Use with a language model that supports structured output
+# Note: You need to implement validation against your defined schema
+```
+
+## Integration with Language Models
+
+### OpenAI Integration
+
+```python
+import openai
+
+client = openai.OpenAI()
+
+# Load prompt with structured output
+prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/1")
+
+# Use with OpenAI's response_format parameter
+response = client.chat.completions.create(
+    model="gpt-4.1",
+    messages=[
+        {"role": "user", "content": prompt.format(num_sentences=3, text="Your text")}
+    ],
+    response_format=prompt.response_format,  # OpenAI's structured output
+)
+
+# Get structured output
+import json
+
+result = json.loads(response.choices[0].message.content)
+```
+
+### LangChain Integration
+
+```python
+from langchain.prompts import PromptTemplate
+from langchain_openai import ChatOpenAI
+from pydantic import BaseModel
+
+# Load prompt with structured output
+prompt = mlflow.genai.load_prompt("prompts:/qa-prompt/1")
+
+# Create LangChain prompt template
+langchain_prompt = PromptTemplate.from_template(prompt.template)
+
+# Use with LangChain's structured output
+llm = ChatOpenAI(model="gpt-4")
+chain = langchain_prompt | llm.with_structured_output(prompt.response_format)
+
+# Execute the chain
+result = chain.invoke({"question": "What is MLflow?"})
+# result will be a validated Pydantic model instance
+```
+
+
+## Key Takeaways
+
+- **Structured output** is used for **tracking and documentation purposes** to define expected response formats
+- **Pydantic models** provide type safety and validation schemas for your response formats
+- **JSON schemas** offer flexibility for complex nested structures
+- **Integration** with popular frameworks like OpenAI and LangChain is straightforward
+- **Manual validation** is required in your application code - MLflow does not enforce the format at runtime
+
+## Next Steps
+
+- **[Create and Edit Prompts](/genai/prompt-version-mgmt/prompt-registry/create-and-edit-prompts)** to learn the basics of prompt management
+- **[Use Prompts in Apps](/genai/prompt-version-mgmt/prompt-registry/use-prompts-in-apps)** to see how to integrate prompts into your applications
+- **[Evaluate Prompts](/genai/prompt-version-mgmt/prompt-registry/evaluate-prompts)** to learn how to assess prompt performance
+
+Structured output is a powerful feature that can significantly improve the reliability and maintainability of your GenAI applications by ensuring consistent data formats and enabling better integration with downstream systems.

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/structured-output.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/structured-output.mdx
@@ -216,7 +216,6 @@ result = chain.invoke({"question": "What is MLflow?"})
 # result will be a validated Pydantic model instance
 ```
 
-
 ## Key Takeaways
 
 - **Structured output** is used for **tracking and documentation purposes** to define expected response formats

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/use-prompts-in-apps.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/use-prompts-in-apps.mdx
@@ -35,52 +35,30 @@ Once you have loaded a prompt object (which is a `PromptVersion` instance), you 
 ```python
 import mlflow
 
-# Load text prompt
-prompt = mlflow.genai.load_prompt("prompts:/ai_assistant_prompt/1")
+# define a prompt template
+prompt_template = """\
+You are an expert AI assistant. Answer the user's question with clarity, accuracy, and conciseness.
 
-# Check prompt properties
-print(f"Is text prompt: {prompt.is_text_prompt}")
-print(f"Response format: {prompt.response_format}")
+## Question:
+{{question}}
 
-# Format with variables
+## Guidelines:
+- Keep responses factual and to the point.
+- If relevant, provide examples or step-by-step instructions.
+- If the question is ambiguous, clarify before answering.
+
+Respond below:
+"""
+prompt = mlflow.genai.register_prompt(
+    name="ai_assistant_prompt",
+    template=prompt_template,
+    commit_message="Initial version of AI assistant",
+)
+
 question = "What is MLflow?"
-formatted_text = prompt.format(question=question)
-
-# Use with LLM
 response = (
     client.chat.completions.create(
-        messages=[{"role": "user", "content": formatted_text}],
-        model="gpt-4o-mini",
-        temperature=0.1,
-        max_tokens=2000,
-    )
-    .choices[0]
-    .message.content
-)
-```
-
-For chat prompts, you can format them similarly:
-
-```python
-import mlflow
-
-# Load chat prompt
-chat_prompt = mlflow.genai.load_prompt("prompts:/assistant_prompt/1")
-
-# Check prompt properties
-print(f"Is text prompt: {chat_prompt.is_text_prompt}")
-print(f"Response format: {chat_prompt.response_format}")
-
-# Format with variables
-formatted_messages = chat_prompt.format(
-    style="friendly",
-    question="What is MLflow?",
-)
-
-# Use directly with LLM
-response = (
-    client.chat.completions.create(
-        messages=formatted_messages,
+        messages=[{"role": "user", "content": prompt.format(question=question)}],
         model="gpt-4o-mini",
         temperature=0.1,
         max_tokens=2000,
@@ -92,21 +70,27 @@ response = (
 
 ## Using Prompts with Other Frameworks (LangChain, LlamaIndex)
 
-MLflow prompts use the `{{variable}}` double-brace syntax for templating. Some other popular frameworks, like LangChain and LlamaIndex, often expect a single-brace syntax (e.g., `{variable}`). To facilitate seamless integration, the MLflow `PromptVersion` object provides the `prompt.to_single_brace_format()` method. This method returns the prompt template string converted to a single-brace format, ready to be used by these frameworks.
+MLflow prompts use the `{{variable}}` double-brace syntax for templating. Some other popular frameworks, like LangChain and LlamaIndex, often expect a single-brace syntax (e.g., `{variable}`). To facilitate seamless integration, the MLflow `Prompt` object provides the `prompt.to_single_brace_format()` method. This method returns the prompt template string converted to a single-brace format, ready to be used by these frameworks.
 
 ```python
 import mlflow
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
-# Load registered text prompt
+# Load registered prompt
 prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
-# Convert to single brace format for LangChain
-langchain_template = prompt.to_single_brace_format()
-
 # Create LangChain prompt object
-langchain_prompt = ChatPromptTemplate.from_template(langchain_template)
+langchain_prompt = ChatPromptTemplate.from_messages(
+    [
+        (
+            # IMPORTANT: Convert prompt template from double to single curly braces format
+            "system",
+            prompt.to_single_brace_format(),
+        ),
+        ("placeholder", "{messages}"),
+    ]
+)
 
 # Define the LangChain chain
 llm = ChatOpenAI()
@@ -114,34 +98,6 @@ chain = langchain_prompt | llm
 
 # Invoke the chain
 response = chain.invoke({"num_sentences": 1, "sentences": "This is a test sentence."})
-print(response)
-```
-
-For chat prompts, you can integrate them with frameworks like this:
-
-```python
-import mlflow
-from langchain_core.prompts import ChatPromptTemplate
-from langchain_openai import ChatOpenAI
-
-# Load registered chat prompt
-chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
-
-# Format the messages
-formatted_messages = chat_prompt.format(
-    style="friendly",
-    question="What is MLflow?",
-)
-
-# Create LangChain prompt object directly from messages
-langchain_prompt = ChatPromptTemplate.from_messages(formatted_messages)
-
-# Define the LangChain chain
-llm = ChatOpenAI()
-chain = langchain_prompt | llm
-
-# Invoke the chain
-response = chain.invoke({})
 print(response)
 ```
 

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/use-prompts-in-apps.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/use-prompts-in-apps.mdx
@@ -30,7 +30,7 @@ mlflow.genai.load_prompt(name_or_uri=f"prompts:/{prompt_name}@staging")
 
 ## Formatting Prompts with Variables
 
-Once you have loaded a prompt object (which is a `PromptVersion` instance), you can populate its template variables using the `prompt.format()` method. This method takes keyword arguments where the keys match the variable names in your prompt template (without the `{{ }}` braces).
+Once you have loaded a prompt object (which is a `Prompt` instance), you can populate its template variables using the `prompt.format()` method. This method takes keyword arguments where the keys match the variable names in your prompt template (without the `{{ }}` braces).
 
 ```python
 import mlflow

--- a/docs/docs/genai/prompt-version-mgmt/prompt-registry/use-prompts-in-apps.mdx
+++ b/docs/docs/genai/prompt-version-mgmt/prompt-registry/use-prompts-in-apps.mdx
@@ -30,35 +30,57 @@ mlflow.genai.load_prompt(name_or_uri=f"prompts:/{prompt_name}@staging")
 
 ## Formatting Prompts with Variables
 
-Once you have loaded a prompt object (which is a `Prompt` instance), you can populate its template variables using the `prompt.format()` method. This method takes keyword arguments where the keys match the variable names in your prompt template (without the `{{ }}` braces).
+Once you have loaded a prompt object (which is a `PromptVersion` instance), you can populate its template variables using the `prompt.format()` method. This method takes keyword arguments where the keys match the variable names in your prompt template (without the `{{ }}` braces).
 
 ```python
 import mlflow
 
-# define a prompt template
-prompt_template = """\
-You are an expert AI assistant. Answer the user's question with clarity, accuracy, and conciseness.
+# Load text prompt
+prompt = mlflow.genai.load_prompt("prompts:/ai_assistant_prompt/1")
 
-## Question:
-{{question}}
+# Check prompt properties
+print(f"Is text prompt: {prompt.is_text_prompt}")
+print(f"Response format: {prompt.response_format}")
 
-## Guidelines:
-- Keep responses factual and to the point.
-- If relevant, provide examples or step-by-step instructions.
-- If the question is ambiguous, clarify before answering.
-
-Respond below:
-"""
-prompt = mlflow.genai.register_prompt(
-    name="ai_assistant_prompt",
-    template=prompt_template,
-    commit_message="Initial version of AI assistant",
-)
-
+# Format with variables
 question = "What is MLflow?"
+formatted_text = prompt.format(question=question)
+
+# Use with LLM
 response = (
     client.chat.completions.create(
-        messages=[{"role": "user", "content": prompt.format(question=question)}],
+        messages=[{"role": "user", "content": formatted_text}],
+        model="gpt-4o-mini",
+        temperature=0.1,
+        max_tokens=2000,
+    )
+    .choices[0]
+    .message.content
+)
+```
+
+For chat prompts, you can format them similarly:
+
+```python
+import mlflow
+
+# Load chat prompt
+chat_prompt = mlflow.genai.load_prompt("prompts:/assistant_prompt/1")
+
+# Check prompt properties
+print(f"Is text prompt: {chat_prompt.is_text_prompt}")
+print(f"Response format: {chat_prompt.response_format}")
+
+# Format with variables
+formatted_messages = chat_prompt.format(
+    style="friendly",
+    question="What is MLflow?",
+)
+
+# Use directly with LLM
+response = (
+    client.chat.completions.create(
+        messages=formatted_messages,
         model="gpt-4o-mini",
         temperature=0.1,
         max_tokens=2000,
@@ -70,27 +92,21 @@ response = (
 
 ## Using Prompts with Other Frameworks (LangChain, LlamaIndex)
 
-MLflow prompts use the `{{variable}}` double-brace syntax for templating. Some other popular frameworks, like LangChain and LlamaIndex, often expect a single-brace syntax (e.g., `{variable}`). To facilitate seamless integration, the MLflow `Prompt` object provides the `prompt.to_single_brace_format()` method. This method returns the prompt template string converted to a single-brace format, ready to be used by these frameworks.
+MLflow prompts use the `{{variable}}` double-brace syntax for templating. Some other popular frameworks, like LangChain and LlamaIndex, often expect a single-brace syntax (e.g., `{variable}`). To facilitate seamless integration, the MLflow `PromptVersion` object provides the `prompt.to_single_brace_format()` method. This method returns the prompt template string converted to a single-brace format, ready to be used by these frameworks.
 
 ```python
 import mlflow
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
-# Load registered prompt
+# Load registered text prompt
 prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
+# Convert to single brace format for LangChain
+langchain_template = prompt.to_single_brace_format()
+
 # Create LangChain prompt object
-langchain_prompt = ChatPromptTemplate.from_messages(
-    [
-        (
-            # IMPORTANT: Convert prompt template from double to single curly braces format
-            "system",
-            prompt.to_single_brace_format(),
-        ),
-        ("placeholder", "{messages}"),
-    ]
-)
+langchain_prompt = ChatPromptTemplate.from_template(langchain_template)
 
 # Define the LangChain chain
 llm = ChatOpenAI()
@@ -98,6 +114,34 @@ chain = langchain_prompt | llm
 
 # Invoke the chain
 response = chain.invoke({"num_sentences": 1, "sentences": "This is a test sentence."})
+print(response)
+```
+
+For chat prompts, you can integrate them with frameworks like this:
+
+```python
+import mlflow
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+
+# Load registered chat prompt
+chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
+
+# Format the messages
+formatted_messages = chat_prompt.format(
+    style="friendly",
+    question="What is MLflow?",
+)
+
+# Create LangChain prompt object directly from messages
+langchain_prompt = ChatPromptTemplate.from_messages(formatted_messages)
+
+# Define the LangChain chain
+llm = ChatOpenAI()
+chain = langchain_prompt | llm
+
+# Invoke the chain
+response = chain.invoke({})
 print(response)
 ```
 

--- a/docs/docs/prompts/index.mdx
+++ b/docs/docs/prompts/index.mdx
@@ -56,33 +56,56 @@ import TabItem from "@theme/TabItem";
 
       ```python
       import mlflow
+      from pydantic import BaseModel
 
-      # Use double curly braces for variables in the template
-      initial_template = """\
+      # Text prompt with response format
+      text_template = """\
       Summarize content you are provided with in {{ num_sentences }} sentences.
 
       Sentences: {{ sentences }}
       """
 
-      # Register a new prompt
-      prompt = mlflow.genai.register_prompt(
+
+      # Define response format for structured output
+      class SummaryResponse(BaseModel):
+          summary: str
+          key_points: list[str]
+          word_count: int
+
+
+      # Register a text prompt
+      text_prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",
-          template=initial_template,
+          template=text_template,
+          response_format=SummaryResponse,
           # Optional: Provide a commit message to describe the changes
           commit_message="Initial commit",
           # Optional: Specify any additional metadata about the prompt version
           tags={
               "author": "author@example.com",
-          },
-          # Optional: Set tags applies to the prompt (across versions)
-          tags={
               "task": "summarization",
               "language": "en",
           },
       )
 
+      # Chat prompt example
+      chat_template = [
+          {"role": "system", "content": "You are a helpful {{ style }} assistant."},
+          {"role": "user", "content": "{{ question }}"},
+      ]
+
+      # Register a chat prompt
+      chat_prompt = mlflow.genai.register_prompt(
+          name="assistant-prompt",
+          template=chat_template,
+          response_format={"type": "string", "description": "A helpful response"},
+          commit_message="Initial chat prompt",
+          tags={"type": "chat", "style": "friendly"},
+      )
+
       # The prompt object contains information about the registered prompt
-      print(f"Created prompt '{prompt.name}' (version {prompt.version})")
+      print(f"Created text prompt '{text_prompt.name}' (version {text_prompt.version})")
+      print(f"Created chat prompt '{chat_prompt.name}' (version {chat_prompt.version})")
       ```
     </div>
 
@@ -118,8 +141,10 @@ This creates a new prompt with the specified template text and metadata. The pro
 
       ```python
       import mlflow
+      from pydantic import BaseModel
 
-      new_template = """\
+      # Update text prompt with enhanced response format
+      new_text_template = """\
       You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
       Sentences: {{ sentences }}
@@ -131,14 +156,52 @@ This creates a new prompt with the specified template text and metadata. The pro
       - Maintain the same level of formality as the original text
       """
 
-      # Register a new version of an existing prompt
-      updated_prompt = mlflow.genai.register_prompt(
+
+      # Enhanced response format
+      class EnhancedSummaryResponse(BaseModel):
+          summary: str
+          key_points: list[str]
+          word_count: int
+          confidence_score: float
+          reading_level: str
+
+
+      # Register a new version of an existing text prompt
+      updated_text_prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",  # Specify the existing prompt name
-          template=new_template,
-          commit_message="Improvement",
+          template=new_text_template,
+          response_format=EnhancedSummaryResponse,
+          commit_message="Enhanced with confidence scoring and reading level",
           tags={
               "author": "author@example.com",
+              "enhanced": "true",
           },
+      )
+
+      # Update chat prompt with additional messages
+      new_chat_template = [
+          {
+              "role": "system",
+              "content": "You are a helpful {{ style }} assistant with expertise in {{ domain }}.",
+          },
+          {"role": "user", "content": "{{ question }}"},
+          {
+              "role": "assistant",
+              "content": "I'll help you with that. Let me provide a detailed response.",
+          },
+          {"role": "user", "content": "Please elaborate on {{ specific_aspect }}."},
+      ]
+
+      # Register a new version of an existing chat prompt
+      updated_chat_prompt = mlflow.genai.register_prompt(
+          name="assistant-prompt",
+          template=new_chat_template,
+          response_format={
+              "type": "object",
+              "properties": {"answer": {"type": "string"}, "sources": {"type": "array"}},
+          },
+          commit_message="Added multi-turn conversation support",
+          tags={"type": "chat", "style": "friendly", "multi_turn": "true"},
       )
       ```
     </div>
@@ -173,6 +236,10 @@ MLflow Projects, MLflow Models, and MLflow Registry.
 # Load the prompt
 prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
+# Check prompt properties
+print(f"Is text prompt: {prompt.is_text_prompt}")
+print(f"Response format: {prompt.response_format}")
+
 # Use the prompt with an LLM
 client = openai.OpenAI()
 response = client.chat.completions.create(
@@ -182,6 +249,35 @@ response = client.chat.completions.create(
             "content": prompt.format(num_sentences=1, sentences=target_text),
         }
     ],
+    model="gpt-4o-mini",
+)
+
+print(response.choices[0].message.content)
+```
+
+For chat prompts, you can load and use them similarly:
+
+```python
+import mlflow
+import openai
+
+# Load the chat prompt
+chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
+
+# Check prompt properties
+print(f"Is text prompt: {chat_prompt.is_text_prompt}")
+print(f"Response format: {chat_prompt.response_format}")
+
+# Format the chat prompt
+formatted_messages = chat_prompt.format(
+    style="friendly",
+    question="What is MLflow?",
+)
+
+# Use the formatted messages directly with an LLM
+client = openai.OpenAI()
+response = client.chat.completions.create(
+    messages=formatted_messages,
     model="gpt-4o-mini",
 )
 
@@ -229,18 +325,65 @@ print(f"Total prompts across pages: {len(all_prompts)}")
 
 ## Prompt Object
 
-The `Prompt` object is the core entity in MLflow Prompt Registry. It represents a versioned template text that can contain variables for dynamic content.
+The `PromptVersion` object is the core entity in MLflow Prompt Registry. It represents a versioned template that can contain variables for dynamic content. MLflow now supports two types of prompts: **text prompts** and **chat prompts**.
 
-Key attributes of a Prompt object:
+Key attributes of a PromptVersion object:
 
 - `Name`: A unique identifier for the prompt.
-- `Template`: The text of the prompt, which can include variables in `{{variable}}` format.
+- `Template`: The content of the prompt, which can be either:
+  - A string containing text with variables in `{{variable}}` format (text prompts)
+  - A list of dictionaries representing chat messages with 'role' and 'content' keys (chat prompts)
 - `Version`: A sequential number representing the revision of the prompt.
 - `Commit Message`: A description of the changes made in the prompt version, similar to Git commit messages.
 - `Version Metadata`: Optional key-value pairs for adding metadata to the prompt version. For example, you may use this for tracking the author of the prompt version.
 - `Tags`: Optional key-value pairs assigned at the prompt level (across versions)
   for categorization and filtering. For example, you may add tags for project name, language, etc, which apply to all versions of the prompt.
 - `Alias`: An mutable named reference to the prompt. For example, you can create an alias named `production` to refer to the version used in your production system. See [Aliases](/prompts/cm#aliases) for more details.
+- `is_text_prompt`: A boolean property indicating whether the prompt is a text prompt (True) or chat prompt (False).
+- `response_format`: An optional property containing the expected response structure specification, which can be used to validate or structure outputs from LLM calls.
+
+### Prompt Types
+
+#### Text Prompts
+Text prompts use a simple string template with variables enclosed in double curly braces:
+
+```python
+text_template = "Hello {{ name }}, how are you today?"
+```
+
+#### Chat Prompts
+Chat prompts use a list of message dictionaries, each with 'role' and 'content' keys:
+
+```python
+chat_template = [
+    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
+    {"role": "user", "content": "{{ question }}"},
+]
+```
+
+### Response Format
+The `response_format` property allows you to specify the expected structure of responses from LLM calls. This can be either a Pydantic model class or a dictionary defining the schema:
+
+```python
+from pydantic import BaseModel
+
+
+class SummaryResponse(BaseModel):
+    summary: str
+    key_points: list[str]
+    word_count: int
+
+
+# Or as a dictionary
+response_format_dict = {
+    "type": "object",
+    "properties": {
+        "summary": {"type": "string"},
+        "key_points": {"type": "array", "items": {"type": "string"}},
+        "word_count": {"type": "integer"},
+    },
+}
+```
 
 ## FAQ
 

--- a/docs/docs/prompts/index.mdx
+++ b/docs/docs/prompts/index.mdx
@@ -58,8 +58,8 @@ import TabItem from "@theme/TabItem";
       import mlflow
       from pydantic import BaseModel
 
-      # Text prompt with response format
-      text_template = """\
+      # Use double curly braces for variables in the template
+      initial_template = """\
       Summarize content you are provided with in {{ num_sentences }} sentences.
 
       Sentences: {{ sentences }}
@@ -76,36 +76,24 @@ import TabItem from "@theme/TabItem";
       # Register a text prompt
       text_prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",
-          template=text_template,
+          template=initial_template,
+          # Optional: Provide response format
           response_format=SummaryResponse,
           # Optional: Provide a commit message to describe the changes
           commit_message="Initial commit",
           # Optional: Specify any additional metadata about the prompt version
           tags={
               "author": "author@example.com",
+          },
+          # Optional: Set tags applies to the prompt (across versions)
+          tags={
               "task": "summarization",
               "language": "en",
           },
       )
 
-      # Chat prompt example
-      chat_template = [
-          {"role": "system", "content": "You are a helpful {{ style }} assistant."},
-          {"role": "user", "content": "{{ question }}"},
-      ]
-
-      # Register a chat prompt
-      chat_prompt = mlflow.genai.register_prompt(
-          name="assistant-prompt",
-          template=chat_template,
-          response_format={"type": "string", "description": "A helpful response"},
-          commit_message="Initial chat prompt",
-          tags={"type": "chat", "style": "friendly"},
-      )
-
       # The prompt object contains information about the registered prompt
-      print(f"Created text prompt '{text_prompt.name}' (version {text_prompt.version})")
-      print(f"Created chat prompt '{chat_prompt.name}' (version {chat_prompt.version})")
+      print(f"Created prompt '{prompt.name}' (version {prompt.version})")
       ```
     </div>
 
@@ -143,8 +131,7 @@ This creates a new prompt with the specified template text and metadata. The pro
       import mlflow
       from pydantic import BaseModel
 
-      # Update text prompt with enhanced response format
-      new_text_template = """\
+      new_template = """\
       You are an expert summarizer. Condense the following content into exactly {{ num_sentences }} clear and informative sentences that capture the key points.
 
       Sentences: {{ sentences }}
@@ -166,42 +153,15 @@ This creates a new prompt with the specified template text and metadata. The pro
           reading_level: str
 
 
-      # Register a new version of an existing text prompt
+      # Register a new version of an existing prompt
       updated_text_prompt = mlflow.genai.register_prompt(
           name="summarization-prompt",  # Specify the existing prompt name
-          template=new_text_template,
+          template=new_template,
           response_format=EnhancedSummaryResponse,
-          commit_message="Enhanced with confidence scoring and reading level",
+          commit_message="Improvement",
           tags={
               "author": "author@example.com",
-              "enhanced": "true",
           },
-      )
-
-      # Update chat prompt with additional messages
-      new_chat_template = [
-          {
-              "role": "system",
-              "content": "You are a helpful {{ style }} assistant with expertise in {{ domain }}.",
-          },
-          {"role": "user", "content": "{{ question }}"},
-          {
-              "role": "assistant",
-              "content": "I'll help you with that. Let me provide a detailed response.",
-          },
-          {"role": "user", "content": "Please elaborate on {{ specific_aspect }}."},
-      ]
-
-      # Register a new version of an existing chat prompt
-      updated_chat_prompt = mlflow.genai.register_prompt(
-          name="assistant-prompt",
-          template=new_chat_template,
-          response_format={
-              "type": "object",
-              "properties": {"answer": {"type": "string"}, "sources": {"type": "array"}},
-          },
-          commit_message="Added multi-turn conversation support",
-          tags={"type": "chat", "style": "friendly", "multi_turn": "true"},
       )
       ```
     </div>
@@ -236,10 +196,6 @@ MLflow Projects, MLflow Models, and MLflow Registry.
 # Load the prompt
 prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt/2")
 
-# Check prompt properties
-print(f"Is text prompt: {prompt.is_text_prompt}")
-print(f"Response format: {prompt.response_format}")
-
 # Use the prompt with an LLM
 client = openai.OpenAI()
 response = client.chat.completions.create(
@@ -249,35 +205,6 @@ response = client.chat.completions.create(
             "content": prompt.format(num_sentences=1, sentences=target_text),
         }
     ],
-    model="gpt-4o-mini",
-)
-
-print(response.choices[0].message.content)
-```
-
-For chat prompts, you can load and use them similarly:
-
-```python
-import mlflow
-import openai
-
-# Load the chat prompt
-chat_prompt = mlflow.genai.load_prompt("prompts:/assistant-prompt/2")
-
-# Check prompt properties
-print(f"Is text prompt: {chat_prompt.is_text_prompt}")
-print(f"Response format: {chat_prompt.response_format}")
-
-# Format the chat prompt
-formatted_messages = chat_prompt.format(
-    style="friendly",
-    question="What is MLflow?",
-)
-
-# Use the formatted messages directly with an LLM
-client = openai.OpenAI()
-response = client.chat.completions.create(
-    messages=formatted_messages,
     model="gpt-4o-mini",
 )
 
@@ -325,9 +252,9 @@ print(f"Total prompts across pages: {len(all_prompts)}")
 
 ## Prompt Object
 
-The `PromptVersion` object is the core entity in MLflow Prompt Registry. It represents a versioned template that can contain variables for dynamic content. MLflow now supports two types of prompts: **text prompts** and **chat prompts**.
+The `Prompt` object is the core entity in MLflow Prompt Registry. It represents a versioned template text that can contain variables for dynamic content.
 
-Key attributes of a PromptVersion object:
+Key attributes of a Prompt object:
 
 - `Name`: A unique identifier for the prompt.
 - `Template`: The content of the prompt, which can be either:
@@ -339,51 +266,6 @@ Key attributes of a PromptVersion object:
 - `Tags`: Optional key-value pairs assigned at the prompt level (across versions)
   for categorization and filtering. For example, you may add tags for project name, language, etc, which apply to all versions of the prompt.
 - `Alias`: An mutable named reference to the prompt. For example, you can create an alias named `production` to refer to the version used in your production system. See [Aliases](/prompts/cm#aliases) for more details.
-- `is_text_prompt`: A boolean property indicating whether the prompt is a text prompt (True) or chat prompt (False).
-- `response_format`: An optional property containing the expected response structure specification, which can be used to validate or structure outputs from LLM calls.
-
-### Prompt Types
-
-#### Text Prompts
-Text prompts use a simple string template with variables enclosed in double curly braces:
-
-```python
-text_template = "Hello {{ name }}, how are you today?"
-```
-
-#### Chat Prompts
-Chat prompts use a list of message dictionaries, each with 'role' and 'content' keys:
-
-```python
-chat_template = [
-    {"role": "system", "content": "You are a helpful {{ style }} assistant."},
-    {"role": "user", "content": "{{ question }}"},
-]
-```
-
-### Response Format
-The `response_format` property allows you to specify the expected structure of responses from LLM calls. This can be either a Pydantic model class or a dictionary defining the schema:
-
-```python
-from pydantic import BaseModel
-
-
-class SummaryResponse(BaseModel):
-    summary: str
-    key_points: list[str]
-    word_count: int
-
-
-# Or as a dictionary
-response_format_dict = {
-    "type": "object",
-    "properties": {
-        "summary": {"type": "string"},
-        "key_points": {"type": "array", "items": {"type": "string"}},
-        "word_count": {"type": "integer"},
-    },
-}
-```
 
 ## FAQ
 

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import re
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import BaseModel, ValidationError
 
@@ -19,7 +19,9 @@ from mlflow.prompt.constants import (
     PROMPT_TYPE_TEXT,
     RESPONSE_FORMAT_TAG_KEY,
 )
-from mlflow.types.chat import ChatMessage, ContentType
+
+if TYPE_CHECKING:
+    from mlflow.types.chat import ContentType
 
 # Alias type
 PromptVersionTag = ModelVersionTag
@@ -67,7 +69,7 @@ class PromptVersion(_ModelRegistryEntity):
         self,
         name: str,
         version: int,
-        template: Union[str, list[dict[str, ContentType]]],
+        template: Union[str, list[dict[str, "ContentType"]]],
         response_format: BaseModel | dict[str, Any] | None = None,
         commit_message: Optional[str] = None,
         creation_timestamp: Optional[int] = None,
@@ -76,6 +78,8 @@ class PromptVersion(_ModelRegistryEntity):
         last_updated_timestamp: Optional[int] = None,
         user_id: Optional[str] = None,
     ):
+        from mlflow.types.chat import ChatMessage
+
         super().__init__()
 
         # Core PromptVersion attributes

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -70,13 +70,13 @@ class PromptVersion(_ModelRegistryEntity):
         name: str,
         version: int,
         template: Union[str, list[dict[str, "ContentType"]]],
-        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         commit_message: Optional[str] = None,
         creation_timestamp: Optional[int] = None,
         tags: Optional[dict[str, str]] = None,
         aliases: Optional[list[str]] = None,
         last_updated_timestamp: Optional[int] = None,
         user_id: Optional[str] = None,
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     ):
         from mlflow.types.chat import ChatMessage
 

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import json
 import re
-from typing import Optional, Union
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel, ValidationError
 
 from mlflow.entities.model_registry._model_registry_entity import _ModelRegistryEntity
 from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
@@ -11,14 +14,24 @@ from mlflow.prompt.constants import (
     PROMPT_TEMPLATE_VARIABLE_PATTERN,
     PROMPT_TEXT_DISPLAY_LIMIT,
     PROMPT_TEXT_TAG_KEY,
+    PROMPT_TYPE_CHAT,
+    PROMPT_TYPE_TAG_KEY,
+    PROMPT_TYPE_TEXT,
+    RESPONSE_FORMAT_TAG_KEY,
 )
+from mlflow.types.chat import ChatMessage, ContentType
 
 # Alias type
 PromptVersionTag = ModelVersionTag
 
 
 def _is_reserved_tag(key: str) -> bool:
-    return key in {IS_PROMPT_TAG_KEY, PROMPT_TEXT_TAG_KEY}
+    return key in {
+        IS_PROMPT_TAG_KEY,
+        PROMPT_TEXT_TAG_KEY,
+        PROMPT_TYPE_TAG_KEY,
+        RESPONSE_FORMAT_TAG_KEY,
+    }
 
 
 class PromptVersion(_ModelRegistryEntity):
@@ -28,10 +41,15 @@ class PromptVersion(_ModelRegistryEntity):
     Args:
         name: The name of the prompt.
         version: The version number of the prompt.
-        template: The template text of the prompt. It can contain variables enclosed in
-            double curly braces, e.g. {{variable}}, which will be replaced with actual values
-            by the `format` method. MLflow use the same variable naming rules same as Jinja2
-            https://jinja.palletsprojects.com/en/stable/api/#notes-on-identifiers
+        template: The template content of the prompt. Can be either:
+            - A string containing text with variables enclosed in double curly braces,
+              e.g. {{variable}}, which will be replaced with actual values by the `format` method.
+              MLflow uses the same variable naming rules as Jinja2:
+              https://jinja.palletsprojects.com/en/stable/api/#notes-on-identifiers
+            - A list of dictionaries representing chat messages, where each message has
+              'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+        response_format: Optional Pydantic class or dictionary defining the expected response
+            structure. This can be used to specify the schema for structured outputs.
         commit_message: The commit message for the prompt version. Optional.
         creation_timestamp: Timestamp of the prompt creation. Optional.
         tags: A dictionary of tags associated with the **prompt version**.
@@ -46,7 +64,8 @@ class PromptVersion(_ModelRegistryEntity):
         self,
         name: str,
         version: int,
-        template: str,
+        template: Union[str, list[dict[str, ContentType]]],
+        response_format: BaseModel | dict[str, Any] | None = None,
         commit_message: Optional[str] = None,
         creation_timestamp: Optional[int] = None,
         tags: Optional[dict[str, str]] = None,
@@ -61,46 +80,126 @@ class PromptVersion(_ModelRegistryEntity):
         self._version: str = str(version)  # Store as string internally
         self._creation_time: int = creation_timestamp or 0
 
+        # Initialize tags first
+        tags = tags or {}
+
+        # Determine prompt type and set it
+        if isinstance(template, list) and len(template) > 0:
+            try:
+                all(ChatMessage.model_validate(msg) for msg in template)
+            except ValidationError as e:
+                raise ValueError("Template must be a list of dicts with role and content") from e
+            self._prompt_type = PROMPT_TYPE_CHAT
+            tags[PROMPT_TYPE_TAG_KEY] = PROMPT_TYPE_CHAT
+        else:
+            self._prompt_type = PROMPT_TYPE_TEXT
+            tags[PROMPT_TYPE_TAG_KEY] = PROMPT_TYPE_TEXT
+
         # Store template text as a tag
         tags = tags or {}
-        tags[PROMPT_TEXT_TAG_KEY] = template
+        tags[PROMPT_TEXT_TAG_KEY] = template if isinstance(template, str) else json.dumps(template)
         tags[IS_PROMPT_TAG_KEY] = "true"
+
+        if response_format:
+            tags[RESPONSE_FORMAT_TAG_KEY] = json.dumps(
+                self.convert_response_format_to_dict(response_format)
+            )
 
         # Store the tags dict
         self._tags: dict[str, str] = tags
 
-        self._variables = set(PROMPT_TEMPLATE_VARIABLE_PATTERN.findall(template))
+        template_text = template if isinstance(template, str) else json.dumps(template)
+        self._variables = set(PROMPT_TEMPLATE_VARIABLE_PATTERN.findall(template_text))
         self._last_updated_timestamp: Optional[int] = last_updated_timestamp
         self._description: Optional[str] = commit_message
         self._user_id: Optional[str] = user_id
         self._aliases: list[str] = aliases or []
 
     def __repr__(self) -> str:
-        text = (
-            self.template[:PROMPT_TEXT_DISPLAY_LIMIT] + "..."
-            if len(self.template) > PROMPT_TEXT_DISPLAY_LIMIT
-            else self.template
-        )
+        if self.is_text_prompt:
+            text = (
+                self.template[:PROMPT_TEXT_DISPLAY_LIMIT] + "..."
+                if len(self.template) > PROMPT_TEXT_DISPLAY_LIMIT
+                else self.template
+            )
+        else:
+            short_msgs = [json.dumps(m)[:PROMPT_TEXT_DISPLAY_LIMIT] + "..." for m in self.template]
+            text = "[" + ",".join(short_msgs) + "]"
         return f"PromptVersion(name={self.name}, version={self.version}, template={text})"
 
     # Core PromptVersion properties
     @property
-    def template(self) -> str:
+    def template(self) -> Union[str, list[dict[str, ContentType]]]:
         """
-        Return the template text of the prompt.
-        """
-        return self._tags[PROMPT_TEXT_TAG_KEY]
+        Return the template content of the prompt.
 
-    def to_single_brace_format(self) -> str:
+        Returns:
+            Either a string (for text prompts) or a list of chat message dictionaries
+            (for chat prompts) with 'role' and 'content' keys.
         """
-        Convert the template text to single brace format. This is useful for integrating with other
+        if self.is_text_prompt:
+            return self._tags[PROMPT_TEXT_TAG_KEY]
+        else:
+            return json.loads(self._tags[PROMPT_TEXT_TAG_KEY])
+
+    @property
+    def is_text_prompt(self) -> bool:
+        """
+        Return True if the prompt is a text prompt, False if it's a chat prompt.
+
+        Returns:
+            True for text prompts (string templates), False for chat prompts (list of messages).
+        """
+        return self._prompt_type == PROMPT_TYPE_TEXT
+
+    @property
+    def response_format(self) -> dict[str, Any] | None:
+        """
+        Return the response format specification for the prompt.
+
+        Returns:
+            A dictionary defining the expected response structure, or None if no
+            response format is specified. This can be used to validate or structure
+            the output from LLM calls.
+        """
+        if RESPONSE_FORMAT_TAG_KEY not in self._tags:
+            return None
+        return json.loads(self._tags[RESPONSE_FORMAT_TAG_KEY])
+
+    def to_single_brace_format(self) -> Union[str, list[dict[str, ContentType]]]:
+        """
+        Convert the template to single brace format. This is useful for integrating with other
         systems that use single curly braces for variable replacement, such as LangChain's prompt
-        template. Default is False.
+        template.
+
+        Returns:
+            The template with variables converted from {{variable}} to {variable} format.
+            For text prompts, returns a string. For chat prompts, returns a list of messages.
         """
-        t = self.template
+        t = self.template if self.is_text_prompt else json.dumps(self.template)
         for var in self.variables:
             t = re.sub(r"\{\{\s*" + var + r"\s*\}\}", "{" + var + "}", t)
-        return t
+        return t if self.is_text_prompt else json.loads(t)
+
+    @staticmethod
+    def convert_response_format_to_dict(
+        response_format: BaseModel | dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Convert a response format specification to a dictionary representation.
+
+        Args:
+            response_format: Either a Pydantic BaseModel class or a dictionary defining
+                the response structure.
+
+        Returns:
+            A dictionary representation of the response format. If a Pydantic class is
+            provided, returns its JSON schema. If a dictionary is provided, returns it as-is.
+        """
+        if isinstance(response_format, type) and issubclass(response_format, BaseModel):
+            return response_format.model_json_schema()
+        else:
+            return response_format
 
     @property
     def variables(self) -> set[str]:
@@ -191,20 +290,37 @@ class PromptVersion(_ModelRegistryEntity):
     def _add_tag(self, tag: ModelVersionTag):
         self._tags[tag.key] = tag.value
 
-    def format(self, allow_partial: bool = False, **kwargs) -> Union[PromptVersion, str]:
+    def format(
+        self, allow_partial: bool = False, **kwargs
+    ) -> Union[PromptVersion, str, list[dict[str, ContentType]]]:
         """
-        Format the template text with the given keyword arguments.
+        Format the template with the given keyword arguments.
         By default, it raises an error if there are missing variables. To format
-        the prompt text partially, set `allow_partial=True`.
+        the prompt partially, set `allow_partial=True`.
 
         Example:
 
         .. code-block:: python
 
-            prompt = Prompt("my-prompt", 1, "Hello, {{title}} {{name}}!")
+            # Text prompt formatting
+            prompt = PromptVersion("my-prompt", 1, "Hello, {{title}} {{name}}!")
             formatted = prompt.format(title="Ms", name="Alice")
             print(formatted)
             # Output: "Hello, Ms Alice!"
+
+            # Chat prompt formatting
+            chat_prompt = PromptVersion(
+                "assistant",
+                1,
+                [
+                    {"role": "system", "content": "You are a {{style}} assistant."},
+                    {"role": "user", "content": "{{question}}"},
+                ],
+            )
+            formatted = chat_prompt.format(style="friendly", question="How are you?")
+            print(formatted)
+            # Output: [{"role": "system", "content": "You are a friendly assistant."},
+            #          {"role": "user", "content": "How are you?"}]
 
             # Partial formatting
             formatted = prompt.format(title="Ms", allow_partial=True)
@@ -218,10 +334,10 @@ class PromptVersion(_ModelRegistryEntity):
             kwargs: Keyword arguments to replace the variables in the template.
         """
         input_keys = set(kwargs.keys())
-
-        template = self.template
+        template_str = self.template if self.is_text_prompt else json.dumps(self.template)
         for key, value in kwargs.items():
-            template = re.sub(r"\{\{\s*" + key + r"\s*\}\}", str(value), template)
+            template_str = re.sub(r"\{\{\s*" + key + r"\s*\}\}", str(value), template_str)
+        template = template_str if self.is_text_prompt else json.loads(template_str)
 
         if missing_keys := self.variables - input_keys:
             if not allow_partial:
@@ -234,6 +350,7 @@ class PromptVersion(_ModelRegistryEntity):
                     name=self.name,
                     version=int(self.version),
                     template=template,
+                    response_format=self.response_format,
                     commit_message=self.commit_message,
                     creation_timestamp=self.creation_timestamp,
                     tags=self.tags,

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import re
-from functools import lru_cache
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ValidationError
@@ -59,6 +58,7 @@ class PromptVersion(_ModelRegistryEntity):
         aliases: List of aliases for this prompt version. Optional.
         last_updated_timestamp: Timestamp of last update. Optional.
         user_id: User ID that created this prompt version. Optional.
+
     """
 
     def __init__(
@@ -140,17 +140,7 @@ class PromptVersion(_ModelRegistryEntity):
         if self.is_text_prompt:
             return self._tags[PROMPT_TEXT_TAG_KEY]
         else:
-            return self._get_deserialized_template()
-
-    @lru_cache(maxsize=1)
-    def _get_deserialized_template(self) -> list[dict[str, ContentType]]:
-        """
-        Get the deserialized template for chat prompts. Cached to avoid repeated JSON parsing.
-
-        Returns:
-            The deserialized list of chat message dictionaries.
-        """
-        return json.loads(self._tags[PROMPT_TEXT_TAG_KEY])
+            return json.loads(self._tags[PROMPT_TEXT_TAG_KEY])
 
     @property
     def is_text_prompt(self) -> bool:
@@ -174,16 +164,6 @@ class PromptVersion(_ModelRegistryEntity):
         """
         if RESPONSE_FORMAT_TAG_KEY not in self._tags:
             return None
-        return self._get_deserialized_response_format()
-
-    @lru_cache(maxsize=1)
-    def _get_deserialized_response_format(self) -> dict[str, Any]:
-        """
-        Get the deserialized response format. Cached to avoid repeated JSON parsing.
-
-        Returns:
-            The deserialized response format dictionary.
-        """
         return json.loads(self._tags[RESPONSE_FORMAT_TAG_KEY])
 
     def to_single_brace_format(self) -> Union[str, list[dict[str, ContentType]]]:

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -70,7 +70,7 @@ class PromptVersion(_ModelRegistryEntity):
         name: str,
         version: int,
         template: Union[str, list[dict[str, "ContentType"]]],
-        response_format: BaseModel | dict[str, Any] | None = None,
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         commit_message: Optional[str] = None,
         creation_timestamp: Optional[int] = None,
         tags: Optional[dict[str, str]] = None,
@@ -159,7 +159,7 @@ class PromptVersion(_ModelRegistryEntity):
         return self._prompt_type == PROMPT_TYPE_TEXT
 
     @property
-    def response_format(self) -> dict[str, Any] | None:
+    def response_format(self) -> Optional[dict[str, Any]]:
         """
         Return the response format specification for the prompt.
 
@@ -189,7 +189,7 @@ class PromptVersion(_ModelRegistryEntity):
 
     @staticmethod
     def convert_response_format_to_dict(
-        response_format: BaseModel | dict[str, Any],
+        response_format: Union[BaseModel, dict[str, Any]],
     ) -> dict[str, Any]:
         """
         Convert a response format specification to a dictionary representation.

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -42,12 +42,14 @@ class PromptVersion(_ModelRegistryEntity):
         name: The name of the prompt.
         version: The version number of the prompt.
         template: The template content of the prompt. Can be either:
+
             - A string containing text with variables enclosed in double curly braces,
               e.g. {{variable}}, which will be replaced with actual values by the `format` method.
               MLflow uses the same variable naming rules as Jinja2:
               https://jinja.palletsprojects.com/en/stable/api/#notes-on-identifiers
             - A list of dictionaries representing chat messages, where each message has
               'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+
         response_format: Optional Pydantic class or dictionary defining the expected response
             structure. This can be used to specify the schema for structured outputs.
         commit_message: The commit message for the prompt version. Optional.

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+from functools import lru_cache
 from typing import Any, Optional, Union
 
 from pydantic import BaseModel, ValidationError
@@ -96,7 +97,6 @@ class PromptVersion(_ModelRegistryEntity):
             tags[PROMPT_TYPE_TAG_KEY] = PROMPT_TYPE_TEXT
 
         # Store template text as a tag
-        tags = tags or {}
         tags[PROMPT_TEXT_TAG_KEY] = template if isinstance(template, str) else json.dumps(template)
         tags[IS_PROMPT_TAG_KEY] = "true"
 
@@ -140,7 +140,17 @@ class PromptVersion(_ModelRegistryEntity):
         if self.is_text_prompt:
             return self._tags[PROMPT_TEXT_TAG_KEY]
         else:
-            return json.loads(self._tags[PROMPT_TEXT_TAG_KEY])
+            return self._get_deserialized_template()
+
+    @lru_cache(maxsize=1)
+    def _get_deserialized_template(self) -> list[dict[str, ContentType]]:
+        """
+        Get the deserialized template for chat prompts. Cached to avoid repeated JSON parsing.
+
+        Returns:
+            The deserialized list of chat message dictionaries.
+        """
+        return json.loads(self._tags[PROMPT_TEXT_TAG_KEY])
 
     @property
     def is_text_prompt(self) -> bool:
@@ -164,6 +174,16 @@ class PromptVersion(_ModelRegistryEntity):
         """
         if RESPONSE_FORMAT_TAG_KEY not in self._tags:
             return None
+        return self._get_deserialized_response_format()
+
+    @lru_cache(maxsize=1)
+    def _get_deserialized_response_format(self) -> dict[str, Any]:
+        """
+        Get the deserialized response format. Cached to avoid repeated JSON parsing.
+
+        Returns:
+            The deserialized response format dictionary.
+        """
         return json.loads(self._tags[RESPONSE_FORMAT_TAG_KEY])
 
     def to_single_brace_format(self) -> Union[str, list[dict[str, ContentType]]]:

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -1,12 +1,15 @@
 import warnings
 from contextlib import contextmanager
-from typing import Optional, Union
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel
 
 import mlflow.tracking._model_registry.fluent as registry_api
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.prompt.registry_utils import require_prompt_registry
 from mlflow.store.entities.paged_list import PagedList
+from mlflow.types.chat import ContentType
 from mlflow.utils.annotations import experimental
 
 
@@ -26,7 +29,8 @@ def suppress_genai_migration_warning():
 @require_prompt_registry
 def register_prompt(
     name: str,
-    template: str,
+    template: Union[str, list[dict[str, ContentType]]],
+    response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     commit_message: Optional[str] = None,
     tags: Optional[dict[str, str]] = None,
 ) -> PromptVersion:
@@ -34,7 +38,7 @@ def register_prompt(
     Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
 
     A :py:class:`Prompt <mlflow.entities.Prompt>` is a pair of name and
-    template text at minimum. With MLflow Prompt Registry, you can create, manage, and
+    template content at minimum. With MLflow Prompt Registry, you can create, manage, and
     version control prompts with the MLflow's robust model tracking framework.
 
     If there is no registered prompt with the given name, a new prompt will be created.
@@ -43,9 +47,11 @@ def register_prompt(
 
     Args:
         name: The name of the prompt.
-        template: The template text of the prompt. It can contain variables enclosed in
-            double curly braces, e.g. {variable}, which will be replaced with actual values
-            by the `format` method.
+        template: The template content of the prompt. Can be either:
+            - A string containing text with variables enclosed in double curly braces,
+              e.g. {{variable}}, which will be replaced with actual values by the `format` method.
+            - A list of dictionaries representing chat messages, where each message has
+              'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
 
             .. note::
 
@@ -57,6 +63,9 @@ def register_prompt(
 
                     prompt = client.load_prompt("my_prompt")
                     langchain_format = prompt.to_single_brace_format()
+
+        response_format: Optional Pydantic class or dictionary defining the expected response
+            structure. This can be used to specify the schema for structured outputs from LLM calls.
 
         commit_message: A message describing the changes made to the prompt, similar to a
             Git commit message. Optional.
@@ -72,15 +81,27 @@ def register_prompt(
     .. code-block:: python
 
         import mlflow
+        from pydantic import BaseModel
 
-        # Register a new prompt
+        # Register a text prompt
         mlflow.genai.register_prompt(
-            name="my_prompt",
+            name="greeting_prompt",
             template="Respond to the user's message as a {{style}} AI.",
+            response_format={"type": "string", "description": "A friendly response"},
         )
 
-        # Load the prompt from the registry
-        prompt = mlflow.genai.load_prompt("my_prompt")
+        # Register a chat prompt with multiple messages
+        mlflow.genai.register_prompt(
+            name="assistant_prompt",
+            template=[
+                {"role": "system", "content": "You are a helpful {{style}} assistant."},
+                {"role": "user", "content": "{{question}}"},
+            ],
+            response_format={"type": "object", "properties": {"answer": {"type": "string"}}},
+        )
+
+        # Load and use the prompt
+        prompt = mlflow.genai.load_prompt("greeting_prompt")
 
         # Use the prompt in your application
         import openai
@@ -96,7 +117,7 @@ def register_prompt(
 
         # Update the prompt with a new version
         prompt = mlflow.genai.register_prompt(
-            name="my_prompt",
+            name="greeting_prompt",
             template="Respond to the user's message as a {{style}} AI. {{greeting}}",
             commit_message="Add a greeting to the prompt.",
             tags={"author": "Bob"},
@@ -106,6 +127,7 @@ def register_prompt(
         return registry_api.register_prompt(
             name=name,
             template=template,
+            response_format=response_format,
             commit_message=commit_message,
             tags=tags,
         )
@@ -124,7 +146,9 @@ def search_prompts(
 @experimental(version="3.0.0")
 @require_prompt_registry
 def load_prompt(
-    name_or_uri: str, version: Optional[Union[str, int]] = None, allow_missing: bool = False
+    name_or_uri: str,
+    version: Optional[Union[str, int]] = None,
+    allow_missing: bool = False,
 ) -> PromptVersion:
     """
     Load a :py:class:`Prompt <mlflow.entities.Prompt>` from the MLflow Prompt Registry.

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -44,7 +44,6 @@ def register_prompt(
     If there is no registered prompt with the given name, a new prompt will be created.
     Otherwise, a new version of the existing prompt will be created.
 
-
     Args:
         name: The name of the prompt.
         template: The template content of the prompt. Can be either:
@@ -66,7 +65,6 @@ def register_prompt(
 
         response_format: Optional Pydantic class or dictionary defining the expected response
             structure. This can be used to specify the schema for structured outputs from LLM calls.
-
         commit_message: A message describing the changes made to the prompt, similar to a
             Git commit message. Optional.
         tags: A dictionary of tags associated with the **prompt version**.
@@ -120,6 +118,7 @@ def register_prompt(
             commit_message="Add a greeting to the prompt.",
             tags={"author": "Bob"},
         )
+
     """
     with suppress_genai_migration_warning():
         return registry_api.register_prompt(

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -1,6 +1,6 @@
 import warnings
 from contextlib import contextmanager
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import BaseModel
 
@@ -9,8 +9,10 @@ from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.prompt.registry_utils import require_prompt_registry
 from mlflow.store.entities.paged_list import PagedList
-from mlflow.types.chat import ContentType
 from mlflow.utils.annotations import experimental
+
+if TYPE_CHECKING:
+    from mlflow.types.chat import ContentType
 
 
 @contextmanager
@@ -29,7 +31,7 @@ def suppress_genai_migration_warning():
 @require_prompt_registry
 def register_prompt(
     name: str,
-    template: Union[str, list[dict[str, ContentType]]],
+    template: Union[str, list[dict[str, "ContentType"]]],
     response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     commit_message: Optional[str] = None,
     tags: Optional[dict[str, str]] = None,

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -81,13 +81,11 @@ def register_prompt(
     .. code-block:: python
 
         import mlflow
-        from pydantic import BaseModel
 
         # Register a text prompt
         mlflow.genai.register_prompt(
             name="greeting_prompt",
             template="Respond to the user's message as a {{style}} AI.",
-            response_format={"type": "string", "description": "A friendly response"},
         )
 
         # Register a chat prompt with multiple messages

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -47,10 +47,12 @@ def register_prompt(
     Args:
         name: The name of the prompt.
         template: The template content of the prompt. Can be either:
+
             - A string containing text with variables enclosed in double curly braces,
               e.g. {{variable}}, which will be replaced with actual values by the `format` method.
             - A list of dictionaries representing chat messages, where each message has
               'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+
 
             .. note::
 

--- a/mlflow/prompt/constants.py
+++ b/mlflow/prompt/constants.py
@@ -7,6 +7,14 @@ PROMPT_TEXT_TAG_KEY = "mlflow.prompt.text"
 
 LINKED_PROMPTS_TAG_KEY = "mlflow.linkedPrompts"
 
+# New tag keys for enhanced prompt features
+PROMPT_TYPE_TAG_KEY = "mlflow.prompt.type"
+RESPONSE_FORMAT_TAG_KEY = "mlflow.prompt.response_format"
+
+# Prompt types
+PROMPT_TYPE_TEXT = "text"
+PROMPT_TYPE_CHAT = "chat"
+
 # A special tag to store associated run IDs for prompts
 PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY = "mlflow.prompt.associatedRunIds"
 

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -1,4 +1,5 @@
 import functools
+import json
 import re
 from textwrap import dedent
 from typing import Any, Optional, Union
@@ -8,7 +9,14 @@ from mlflow.entities.model_registry.model_version import ModelVersion
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.entities.model_registry.registered_model_tag import RegisteredModelTag
 from mlflow.exceptions import MlflowException
-from mlflow.prompt.constants import IS_PROMPT_TAG_KEY, PROMPT_NAME_RULE, PROMPT_TEXT_TAG_KEY
+from mlflow.prompt.constants import (
+    IS_PROMPT_TAG_KEY,
+    PROMPT_NAME_RULE,
+    PROMPT_TEXT_TAG_KEY,
+    PROMPT_TYPE_CHAT,
+    PROMPT_TYPE_TAG_KEY,
+    RESPONSE_FORMAT_TAG_KEY,
+)
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE, RESOURCE_ALREADY_EXISTS
 
 
@@ -36,10 +44,21 @@ def model_version_to_prompt_version(
             f"Prompt `{model_version.name}` does not contain a prompt text"
         )
 
+    if model_version.tags.get(PROMPT_TYPE_TAG_KEY) == PROMPT_TYPE_CHAT:
+        template = json.loads(model_version.tags[PROMPT_TEXT_TAG_KEY])
+    else:
+        template = model_version.tags[PROMPT_TEXT_TAG_KEY]
+
+    if RESPONSE_FORMAT_TAG_KEY in model_version.tags:
+        response_format = json.loads(model_version.tags[RESPONSE_FORMAT_TAG_KEY])
+    else:
+        response_format = None
+
     return PromptVersion(
         name=model_version.name,
         version=int(model_version.version),
-        template=model_version.tags[PROMPT_TEXT_TAG_KEY],
+        template=template,
+        response_format=response_format,
         commit_message=model_version.description,
         creation_timestamp=model_version.creation_timestamp,
         tags=model_version.tags,

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -5,6 +5,8 @@ from abc import ABCMeta, abstractmethod
 from time import sleep, time
 from typing import Any, Optional, Union
 
+from pydantic import BaseModel
+
 from mlflow.entities.logged_model_tag import LoggedModelTag
 from mlflow.entities.model_registry import ModelVersionTag, RegisteredModelTag
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
@@ -16,6 +18,10 @@ from mlflow.prompt.constants import (
     IS_PROMPT_TAG_KEY,
     LINKED_PROMPTS_TAG_KEY,
     PROMPT_TEXT_TAG_KEY,
+    PROMPT_TYPE_CHAT,
+    PROMPT_TYPE_TAG_KEY,
+    PROMPT_TYPE_TEXT,
+    RESPONSE_FORMAT_TAG_KEY,
 )
 from mlflow.prompt.registry_utils import has_prompt_tag, model_version_to_prompt_version
 from mlflow.protos.databricks_pb2 import (
@@ -25,6 +31,7 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.store.entities.paged_list import PagedList
+from mlflow.types.chat import ContentType
 from mlflow.utils.annotations import developer_stable
 from mlflow.utils.logging_utils import eprint
 
@@ -679,7 +686,8 @@ class AbstractStore:
     def create_prompt_version(
         self,
         name: str,
-        template: str,
+        template: Union[str, list[dict[str, ContentType]]],
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         description: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
     ) -> PromptVersion:
@@ -691,7 +699,15 @@ class AbstractStore:
 
         Args:
             name: Name of the prompt.
-            template: The prompt template text.
+            template: The prompt template content. Can be either:
+                - A string containing text with variables enclosed in double curly braces,
+                  e.g. {{variable}}, which will be replaced with actual values by the `format`
+                  method.
+                - A list of dictionaries representing chat messages, where each message has
+                  'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+            response_format: Optional Pydantic class or dictionary defining the expected response
+                structure. This can be used to specify the schema for structured outputs from LLM
+                calls.
             description: Optional description of the prompt version.
             tags: Optional dictionary of version tags.
 
@@ -701,8 +717,25 @@ class AbstractStore:
         # Create version tags including template
         version_tags = [
             ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
-            ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value=template),
         ]
+        if isinstance(template, str):
+            version_tags.append(ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value=template))
+            version_tags.append(ModelVersionTag(key=PROMPT_TYPE_TAG_KEY, value=PROMPT_TYPE_TEXT))
+        else:
+            version_tags.append(
+                ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value=json.dumps(template))
+            )
+            version_tags.append(ModelVersionTag(key=PROMPT_TYPE_TAG_KEY, value=PROMPT_TYPE_CHAT))
+        if response_format:
+            version_tags.append(
+                ModelVersionTag(
+                    key=RESPONSE_FORMAT_TAG_KEY,
+                    value=json.dumps(
+                        PromptVersion.convert_response_format_to_dict(response_format)
+                    ),
+                )
+            )
+
         if tags:
             version_tags.extend([ModelVersionTag(key=k, value=v) for k, v in tags.items()])
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -3,7 +3,7 @@ import logging
 import threading
 from abc import ABCMeta, abstractmethod
 from time import sleep, time
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import BaseModel
 
@@ -31,13 +31,15 @@ from mlflow.protos.databricks_pb2 import (
     ErrorCode,
 )
 from mlflow.store.entities.paged_list import PagedList
-from mlflow.types.chat import ContentType
 from mlflow.utils.annotations import developer_stable
 from mlflow.utils.logging_utils import eprint
 
 _logger = logging.getLogger(__name__)
 
 AWAIT_MODEL_VERSION_CREATE_SLEEP_INTERVAL_SECONDS = 3
+
+if TYPE_CHECKING:
+    from mlflow.types.chat import ContentType
 
 
 @developer_stable
@@ -686,7 +688,7 @@ class AbstractStore:
     def create_prompt_version(
         self,
         name: str,
-        template: Union[str, list[dict[str, ContentType]]],
+        template: Union[str, list[dict[str, "ContentType"]]],
         response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         description: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -5,7 +5,7 @@ exposed in the :py:mod:`mlflow.tracking` module.
 """
 
 import logging
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import BaseModel
 
@@ -27,10 +27,13 @@ from mlflow.store.model_registry import (
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
 )
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS, utils
-from mlflow.types.chat import ContentType
 from mlflow.utils.arguments_utils import _get_arg_names
 
 _logger = logging.getLogger(__name__)
+
+
+if TYPE_CHECKING:
+    from mlflow.types.chat import ContentType
 
 
 class ModelRegistryClient:
@@ -539,7 +542,7 @@ class ModelRegistryClient:
     def create_prompt_version(
         self,
         name: str,
-        template: Union[str, list[dict[str, ContentType]]],
+        template: Union[str, list[dict[str, "ContentType"]]],
         response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         description: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -4,7 +4,7 @@ import logging
 import threading
 import uuid
 import warnings
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import BaseModel
 
@@ -37,7 +37,6 @@ from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import active_run, get_active_model_id
-from mlflow.types.chat import ContentType
 from mlflow.utils import get_results_from_paginated_fn, mlflow_tags
 from mlflow.utils.databricks_utils import (
     _construct_databricks_uc_registered_model_url,
@@ -48,6 +47,9 @@ from mlflow.utils.databricks_utils import (
 from mlflow.utils.env_pack import EnvPackType, pack_env_for_databricks_model_serving
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.uri import is_databricks_unity_catalog_uri
+
+if TYPE_CHECKING:
+    from mlflow.types.chat import ContentType
 
 _logger = logging.getLogger(__name__)
 
@@ -535,7 +537,7 @@ def set_model_version_tag(
 @require_prompt_registry
 def register_prompt(
     name: str,
-    template: Union[str, list[dict[str, ContentType]]],
+    template: Union[str, list[dict[str, "ContentType"]]],
     response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     commit_message: Optional[str] = None,
     tags: Optional[dict[str, str]] = None,

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -6,6 +6,8 @@ import uuid
 import warnings
 from typing import Any, Optional, Union
 
+from pydantic import BaseModel
+
 import mlflow
 from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry import ModelVersion, Prompt, PromptVersion, RegisteredModel
@@ -35,6 +37,7 @@ from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import active_run, get_active_model_id
+from mlflow.types.chat import ContentType
 from mlflow.utils import get_results_from_paginated_fn, mlflow_tags
 from mlflow.utils.databricks_utils import (
     _construct_databricks_uc_registered_model_url,
@@ -532,7 +535,8 @@ def set_model_version_tag(
 @require_prompt_registry
 def register_prompt(
     name: str,
-    template: str,
+    template: Union[str, list[dict[str, ContentType]]],
+    response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     commit_message: Optional[str] = None,
     tags: Optional[dict[str, str]] = None,
 ) -> PromptVersion:
@@ -540,7 +544,7 @@ def register_prompt(
     Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
 
     A :py:class:`Prompt <mlflow.entities.Prompt>` is a pair of name and
-    template text at minimum. With MLflow Prompt Registry, you can create, manage, and
+    template content at minimum. With MLflow Prompt Registry, you can create, manage, and
     version control prompts with the MLflow's robust model tracking framework.
 
     If there is no registered prompt with the given name, a new prompt will be created.
@@ -549,9 +553,11 @@ def register_prompt(
 
     Args:
         name: The name of the prompt.
-        template: The template text of the prompt. It can contain variables enclosed in
-            double curly braces, e.g. {variable}, which will be replaced with actual values
-            by the `format` method.
+        template: The template content of the prompt. Can be either:
+            - A string containing text with variables enclosed in double curly braces,
+              e.g. {{variable}}, which will be replaced with actual values by the `format` method.
+            - A list of dictionaries representing chat messages, where each message has
+              'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
 
             .. note::
 
@@ -563,6 +569,9 @@ def register_prompt(
 
                     prompt = client.load_prompt("my_prompt")
                     langchain_format = prompt.to_single_brace_format()
+
+        response_format: Optional Pydantic class or dictionary defining the expected response
+            structure. This can be used to specify the schema for structured outputs from LLM calls.
 
         commit_message: A message describing the changes made to the prompt, similar to a
             Git commit message. Optional.
@@ -578,15 +587,27 @@ def register_prompt(
     .. code-block:: python
 
         import mlflow
+        from pydantic import BaseModel
 
-        # Register a new prompt
+        # Register a text prompt
         mlflow.register_prompt(
-            name="my_prompt",
+            name="greeting_prompt",
             template="Respond to the user's message as a {{style}} AI.",
+            response_format={"type": "string", "description": "A friendly response"},
+        )
+
+        # Register a chat prompt with multiple messages
+        mlflow.register_prompt(
+            name="assistant_prompt",
+            template=[
+                {"role": "system", "content": "You are a helpful {{style}} assistant."},
+                {"role": "user", "content": "{{question}}"},
+            ],
+            response_format={"type": "object", "properties": {"answer": {"type": "string"}}},
         )
 
         # Load the prompt from the registry
-        prompt = mlflow.load_prompt("my_prompt")
+        prompt = mlflow.load_prompt("greeting_prompt")
 
         # Use the prompt in your application
         import openai
@@ -602,7 +623,7 @@ def register_prompt(
 
         # Update the prompt with a new version
         prompt = mlflow.register_prompt(
-            name="my_prompt",
+            name="greeting_prompt",
             template="Respond to the user's message as a {{style}} AI. {{greeting}}",
             commit_message="Add a greeting to the prompt.",
             tags={"author": "Bob"},
@@ -617,6 +638,7 @@ def register_prompt(
     return MlflowClient().register_prompt(
         name=name,
         template=template,
+        response_format=response_format,
         commit_message=commit_message,
         tags=tags,
     )

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -517,11 +517,13 @@ class MlflowClient:
         Args:
             name: The name of the prompt.
             template: The template content of the prompt. Can be either:
+
                 - A string containing text with variables enclosed in double curly braces,
                   e.g. {{variable}}, which will be replaced with actual values by the `format`
                   method.
                 - A list of dictionaries representing chat messages, where each message has
                   'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+
             response_format: Optional Pydantic class or dictionary defining the expected response
                 structure. This can be used to specify the schema for structured outputs from LLM
                 calls.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -102,7 +102,6 @@ from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.multimedia import Image, compress_image_size, convert_to_pil_image
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
-from mlflow.types.chat import ContentType
 from mlflow.utils import is_uuid
 from mlflow.utils.annotations import deprecated, experimental
 from mlflow.utils.async_logging.run_operations import RunOperations
@@ -131,6 +130,8 @@ if TYPE_CHECKING:
     import pandas
     import PIL
     import plotly
+
+    from mlflow.types.chat import ContentType
 
 
 _logger = logging.getLogger(__name__)
@@ -449,7 +450,7 @@ class MlflowClient:
     def register_prompt(
         self,
         name: str,
-        template: Union[str, list[dict[str, ContentType]]],
+        template: Union[str, list[dict[str, "ContentType"]]],
         response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         commit_message: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -20,6 +20,7 @@ import warnings
 from typing import TYPE_CHECKING, Any, Literal, Optional, Sequence, Union
 
 import yaml
+from pydantic import BaseModel
 
 import mlflow
 from mlflow.entities import (
@@ -56,6 +57,10 @@ from mlflow.prompt.constants import (
     IS_PROMPT_TAG_KEY,
     PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY,
     PROMPT_TEXT_TAG_KEY,
+    PROMPT_TYPE_CHAT,
+    PROMPT_TYPE_TAG_KEY,
+    PROMPT_TYPE_TEXT,
+    RESPONSE_FORMAT_TAG_KEY,
 )
 from mlflow.prompt.registry_utils import (
     has_prompt_tag,
@@ -97,6 +102,7 @@ from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking.artifact_utils import _upload_artifacts_to_databricks
 from mlflow.tracking.multimedia import Image, compress_image_size, convert_to_pil_image
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
+from mlflow.types.chat import ContentType
 from mlflow.utils import is_uuid
 from mlflow.utils.annotations import deprecated, experimental
 from mlflow.utils.async_logging.run_operations import RunOperations
@@ -443,7 +449,8 @@ class MlflowClient:
     def register_prompt(
         self,
         name: str,
-        template: str,
+        template: Union[str, list[dict[str, ContentType]]],
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         commit_message: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
     ) -> PromptVersion:
@@ -451,7 +458,7 @@ class MlflowClient:
         Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
 
         A :py:class:`Prompt <mlflow.entities.Prompt>` is a pair of name
-        and template text at minimum. With MLflow Prompt Registry, you can create, manage,
+        and template content at minimum. With MLflow Prompt Registry, you can create, manage,
         and version control prompts with the MLflow's robust model tracking framework.
 
         If there is no registered prompt with the given name, a new prompt will be created.
@@ -462,18 +469,30 @@ class MlflowClient:
         .. code-block:: python
 
             from mlflow import MlflowClient
+            from pydantic import BaseModel
 
             # Your prompt registry URI
             client = MlflowClient(registry_uri="sqlite:///prompt_registry.db")
 
-            # Register a new prompt
+            # Register a text prompt
             client.register_prompt(
-                name="my_prompt",
+                name="greeting_prompt",
                 template="Respond to the user's message as a {{style}} AI.",
+                response_format={"type": "string", "description": "A friendly response"},
+            )
+
+            # Register a chat prompt with multiple messages
+            client.register_prompt(
+                name="assistant_prompt",
+                template=[
+                    {"role": "system", "content": "You are a helpful {{style}} assistant."},
+                    {"role": "user", "content": "{{question}}"},
+                ],
+                response_format={"type": "object", "properties": {"answer": {"type": "string"}}},
             )
 
             # Load the prompt from the registry
-            prompt = client.load_prompt("my_prompt")
+            prompt = client.load_prompt("greeting_prompt")
 
             # Use the prompt in your application
             import openai
@@ -489,7 +508,7 @@ class MlflowClient:
 
             # Update the prompt with a new version
             prompt = client.register_prompt(
-                name="my_prompt",
+                name="greeting_prompt",
                 template="Respond to the user's message as a {{style}} AI. {{greeting}}",
                 commit_message="Add a greeting to the prompt.",
                 tags={"author": "Bob"},
@@ -497,9 +516,15 @@ class MlflowClient:
 
         Args:
             name: The name of the prompt.
-            template: The template text of the prompt. It can contain variables enclosed in
-                double curly braces, e.g. {{variable}}, which will be replaced with actual values
-                by the `format` method.
+            template: The template content of the prompt. Can be either:
+                - A string containing text with variables enclosed in double curly braces,
+                  e.g. {{variable}}, which will be replaced with actual values by the `format`
+                  method.
+                - A list of dictionaries representing chat messages, where each message has
+                  'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+            response_format: Optional Pydantic class or dictionary defining the expected response
+                structure. This can be used to specify the schema for structured outputs from LLM
+                calls.
             commit_message: A message describing the changes made to the prompt, similar to a
                 Git commit message. Optional.
             tags: A dictionary of tags associated with the **prompt version**.
@@ -529,6 +554,7 @@ class MlflowClient:
             prompt_version = registry_client.create_prompt_version(
                 name=name,
                 template=template,
+                response_format=response_format,
                 description=commit_message,
                 tags=tags or {},
             )
@@ -564,7 +590,21 @@ class MlflowClient:
 
         # Version metadata is represented as ModelVersion tags in the registry
         tags = tags or {}
-        tags.update({IS_PROMPT_TAG_KEY: "true", PROMPT_TEXT_TAG_KEY: template})
+        tags.update({IS_PROMPT_TAG_KEY: "true"})
+        if isinstance(template, list):
+            tags.update({PROMPT_TYPE_TAG_KEY: PROMPT_TYPE_CHAT})
+            tags.update({PROMPT_TEXT_TAG_KEY: json.dumps(template)})
+        else:
+            tags.update({PROMPT_TYPE_TAG_KEY: PROMPT_TYPE_TEXT})
+            tags.update({PROMPT_TEXT_TAG_KEY: template})
+        if response_format:
+            tags.update(
+                {
+                    RESPONSE_FORMAT_TAG_KEY: json.dumps(
+                        PromptVersion.convert_response_format_to_dict(response_format)
+                    ),
+                }
+            )
 
         try:
             mv: ModelVersion = registry_client.create_model_version(

--- a/mlflow/types/__init__.py
+++ b/mlflow/types/__init__.py
@@ -3,9 +3,9 @@ The :py:mod:`mlflow.types` module defines data types and utilities to be used by
 components to describe interface independent of other frameworks or languages.
 """
 
-from mlflow.version import IS_TRACING_SDK_ONLY
+from mlflow.version import IS_FULL_MLFLOW
 
-if not IS_TRACING_SDK_ONLY:
+if IS_FULL_MLFLOW:
     import mlflow.types.llm  # noqa: F401
 
     # Our typing system depends on numpy, which is not included in mlflow-tracing package

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -22,3 +22,4 @@ def _is_package_installed(package_name: str) -> bool:
 # This is used to determine whether to import modules that require
 # dependencies that are not included in the tracing SDK.
 IS_TRACING_SDK_ONLY = not any(_is_package_installed(pkg) for pkg in ["mlflow", "mlflow-skinny"])
+IS_FULL_MLFLOW = any(_is_package_installed(pkg) for pkg in ["mlflow"])

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -22,4 +22,4 @@ def _is_package_installed(package_name: str) -> bool:
 # This is used to determine whether to import modules that require
 # dependencies that are not included in the tracing SDK.
 IS_TRACING_SDK_ONLY = not any(_is_package_installed(pkg) for pkg in ["mlflow", "mlflow-skinny"])
-IS_FULL_MLFLOW = any(_is_package_installed(pkg) for pkg in ["mlflow"])
+IS_FULL_MLFLOW = _is_package_installed("mlflow")

--- a/tests/genai/prompts/test_prompts.py
+++ b/tests/genai/prompts/test_prompts.py
@@ -2,6 +2,7 @@ import warnings
 from contextlib import contextmanager
 
 import pytest
+from pydantic import BaseModel
 
 import mlflow
 
@@ -38,3 +39,230 @@ def test_prompt_api_migration_warning():
 
     with pytest.warns(FutureWarning, match="The `mlflow.delete_prompt_alias` API is"):
         mlflow.delete_prompt_alias("test_prompt", "test_alias")
+
+
+def test_register_chat_prompt_with_messages():
+    """Test registering chat prompts with list of message dictionaries."""
+    chat_template = [
+        {"role": "system", "content": "You are a {{style}} assistant."},
+        {"role": "user", "content": "{{question}}"},
+    ]
+
+    prompt = mlflow.genai.register_prompt(
+        name="test_chat", template=chat_template, commit_message="Test chat prompt"
+    )
+
+    not prompt.is_text_prompt
+    assert prompt.template == chat_template
+    assert prompt.commit_message == "Test chat prompt"
+
+
+def test_register_prompt_with_pydantic_response_format():
+    """Test registering prompts with Pydantic response format."""
+
+    class ResponseSchema(BaseModel):
+        answer: str
+        confidence: float
+
+    prompt = mlflow.genai.register_prompt(
+        name="test_response",
+        template="What is {{question}}?",
+        response_format=ResponseSchema,
+    )
+
+    expected_schema = ResponseSchema.model_json_schema()
+    assert prompt.response_format == expected_schema
+
+
+def test_register_prompt_with_dict_response_format():
+    """Test registering prompts with dictionary response format."""
+    response_format = {
+        "type": "object",
+        "properties": {
+            "answer": {"type": "string"},
+            "confidence": {"type": "number"},
+        },
+    }
+
+    prompt = mlflow.genai.register_prompt(
+        name="test_dict_response",
+        template="What is {{question}}?",
+        response_format=response_format,
+    )
+
+    assert prompt.response_format == response_format
+
+
+def test_register_prompt_error_handling_invalid_chat_format():
+    """Test error handling for invalid chat message formats."""
+    invalid_template = [{"content": "Hello"}]  # Missing role
+
+    with pytest.raises(ValueError, match="Template must be a list of dicts with role and content"):
+        mlflow.genai.register_prompt(name="test_invalid", template=invalid_template)
+
+
+def test_register_and_load_chat_prompt_integration():
+    """Test that registered chat prompts can be loaded and formatted correctly."""
+    chat_template = [
+        {"role": "system", "content": "You are a {{style}} assistant."},
+        {"role": "user", "content": "{{question}}"},
+    ]
+
+    mlflow.genai.register_prompt(name="test_integration", template=chat_template)
+
+    loaded_prompt = mlflow.genai.load_prompt("test_integration", version=1)
+
+    assert not loaded_prompt.is_text_prompt
+    assert loaded_prompt.template == chat_template
+
+    # Test formatting
+    formatted = loaded_prompt.format(style="helpful", question="How are you?")
+    expected = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "How are you?"},
+    ]
+    assert formatted == expected
+
+
+def test_register_text_prompt_backward_compatibility():
+    """Test that text prompt registration continues to work as before."""
+    prompt = mlflow.genai.register_prompt(
+        name="test_text_backward",
+        template="Hello {{name}}!",
+        commit_message="Test backward compatibility",
+    )
+
+    assert prompt.is_text_prompt
+    assert prompt.template == "Hello {{name}}!"
+    assert prompt.commit_message == "Test backward compatibility"
+
+
+def test_register_prompt_with_tags():
+    """Test registering prompts with custom tags."""
+    chat_template = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "{{question}}"},
+    ]
+
+    prompt = mlflow.genai.register_prompt(
+        name="test_with_tags",
+        template=chat_template,
+        tags={"author": "test_user", "model": "gpt-4"},
+    )
+
+    assert prompt.tags["author"] == "test_user"
+    assert prompt.tags["model"] == "gpt-4"
+
+
+def test_register_prompt_with_complex_response_format():
+    """Test registering prompts with complex Pydantic response format."""
+
+    class ComplexResponse(BaseModel):
+        summary: str
+        key_points: list[str]
+        confidence: float
+        metadata: dict[str, str] = {}
+
+    chat_template = [
+        {"role": "system", "content": "You are a data analyst."},
+        {"role": "user", "content": "Analyze this data: {{data}}"},
+    ]
+
+    prompt = mlflow.genai.register_prompt(
+        name="test_complex_response",
+        template=chat_template,
+        response_format=ComplexResponse,
+    )
+
+    expected_schema = ComplexResponse.model_json_schema()
+    assert prompt.response_format == expected_schema
+    assert "properties" in prompt.response_format
+    assert "summary" in prompt.response_format["properties"]
+    assert "key_points" in prompt.response_format["properties"]
+    assert "confidence" in prompt.response_format["properties"]
+    assert "metadata" in prompt.response_format["properties"]
+
+
+def test_register_prompt_with_none_response_format():
+    """Test registering prompts with None response format."""
+    prompt = mlflow.genai.register_prompt(
+        name="test_none_response", template="Hello {{name}}!", response_format=None
+    )
+
+    assert prompt.response_format is None
+
+
+def test_register_prompt_with_empty_chat_template():
+    """Test registering prompts with empty chat template list."""
+    # Empty list should be treated as text prompt
+    prompt = mlflow.genai.register_prompt(name="test_empty_chat", template=[])
+
+    assert prompt.is_text_prompt
+    assert prompt.template == "[]"  # Empty list serialized as string
+
+
+def test_register_prompt_with_single_message_chat():
+    """Test registering prompts with single message chat template."""
+    chat_template = [{"role": "user", "content": "Hello {{name}}!"}]
+
+    prompt = mlflow.genai.register_prompt(name="test_single_message", template=chat_template)
+
+    assert prompt.template == chat_template
+    assert prompt.variables == {"name"}
+
+
+def test_register_prompt_with_multiple_variables_in_chat():
+    """Test registering prompts with multiple variables in chat messages."""
+    chat_template = [
+        {
+            "role": "system",
+            "content": "You are a {{style}} assistant named {{name}}.",
+        },
+        {"role": "user", "content": "{{greeting}}! {{question}}"},
+        {
+            "role": "assistant",
+            "content": "I understand you're asking about {{topic}}.",
+        },
+    ]
+
+    prompt = mlflow.genai.register_prompt(name="test_multiple_variables", template=chat_template)
+
+    expected_variables = {"style", "name", "greeting", "question", "topic"}
+    assert prompt.variables == expected_variables
+
+
+def test_register_prompt_with_mixed_content_types():
+    """Test registering prompts with mixed content types in chat messages."""
+    chat_template = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello {{name}}!"},
+        {"role": "assistant", "content": "Hi there! How can I help you today?"},
+    ]
+
+    prompt = mlflow.genai.register_prompt(name="test_mixed_content", template=chat_template)
+
+    assert prompt.template == chat_template
+    assert prompt.variables == {"name"}
+
+
+def test_register_prompt_with_nested_variables():
+    """Test registering prompts with nested variable names."""
+    chat_template = [
+        {
+            "role": "system",
+            "content": "You are a {{user.preferences.style}} assistant.",
+        },
+        {
+            "role": "user",
+            "content": "Hello {{user.name}}! {{user.preferences.greeting}}",
+        },
+    ]
+
+    prompt = mlflow.genai.register_prompt(name="test_nested_variables", template=chat_template)
+
+    expected_variables = {
+        "user.preferences.style",
+        "user.name",
+        "user.preferences.greeting",
+    }
+    assert prompt.variables == expected_variables

--- a/tests/tracking/_model_registry/test_model_registry_fluent.py
+++ b/tests/tracking/_model_registry/test_model_registry_fluent.py
@@ -186,10 +186,7 @@ def test_prompt_alias(tmp_path):
     mlflow.delete_prompt_alias("p1", alias="production")
     with pytest.raises(
         MlflowException,
-        match=(
-            r"Prompt (.*) does not exist."
-            r"|Prompt alias (.*) not found."
-        ),
+        match=(r"Prompt (.*) does not exist.|Prompt alias (.*) not found."),
     ):
         mlflow.load_prompt("prompts:/p1@production")
 
@@ -227,10 +224,12 @@ def test_register_model_prints_uc_model_version_url(monkeypatch):
             return_value="https://databricks.com",
         ) as mock_url,
         mock.patch(
-            "mlflow.tracking._model_registry.fluent.get_workspace_id", return_value=workspace_id
+            "mlflow.tracking._model_registry.fluent.get_workspace_id",
+            return_value=workspace_id,
         ) as mock_workspace_id,
         mock.patch(
-            "mlflow.MlflowClient.create_registered_model", return_value=RegisteredModel(name)
+            "mlflow.MlflowClient.create_registered_model",
+            return_value=RegisteredModel(name),
         ) as mock_create_model,
         mock.patch(
             "mlflow.MlflowClient._create_model_version",
@@ -356,7 +355,8 @@ def test_register_model_with_env_pack(tmp_path, mock_dbr_version):
 
     with (
         mock.patch(
-            "mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)
+            "mlflow.utils.env_pack.download_artifacts",
+            return_value=str(mock_artifacts_dir),
         ),
         mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
         mock.patch(
@@ -409,7 +409,8 @@ def test_register_model_with_env_pack_staging_failure(tmp_path, mock_dbr_version
 
     with (
         mock.patch(
-            "mlflow.utils.env_pack.download_artifacts", return_value=str(mock_artifacts_dir)
+            "mlflow.utils.env_pack.download_artifacts",
+            return_value=str(mock_artifacts_dir),
         ),
         mock.patch("subprocess.run", return_value=mock.Mock(returncode=0)),
         mock.patch(
@@ -879,7 +880,10 @@ def test_load_prompt_caching_works():
 
         # Call with different version should hit the client again
         mock_client_load.return_value = PromptVersion(
-            name="cached_prompt", version=2, template="Hi, {{name}}!", creation_timestamp=123456790
+            name="cached_prompt",
+            version=2,
+            template="Hi, {{name}}!",
+            creation_timestamp=123456790,
         )
         prompt3 = mlflow.load_prompt("cached_prompt", version=2, link_to_model=False)
         assert prompt3.version == 2
@@ -906,13 +910,22 @@ def test_load_prompt_caching_respects_env_var():
         with mock.patch("mlflow.MlflowClient.load_prompt") as mock_client_load:
             mock_client_load.side_effect = [
                 PromptVersion(
-                    name="prompt_1", version=1, template="Template 1", creation_timestamp=1
+                    name="prompt_1",
+                    version=1,
+                    template="Template 1",
+                    creation_timestamp=1,
                 ),
                 PromptVersion(
-                    name="prompt_2", version=1, template="Template 2", creation_timestamp=2
+                    name="prompt_2",
+                    version=1,
+                    template="Template 2",
+                    creation_timestamp=2,
                 ),
                 PromptVersion(
-                    name="prompt_1", version=1, template="Template 1", creation_timestamp=1
+                    name="prompt_1",
+                    version=1,
+                    template="Template 1",
+                    creation_timestamp=1,
                 ),
             ]
 
@@ -959,7 +972,10 @@ def test_load_prompt_skip_cache_for_allow_missing_none():
 
         # But if we find a prompt, the pattern will change
         mock_prompt = PromptVersion(
-            name="nonexistent_prompt", version=1, template="Found!", creation_timestamp=123
+            name="nonexistent_prompt",
+            version=1,
+            template="Found!",
+            creation_timestamp=123,
         )
         mock_client_load.return_value = mock_prompt
 
@@ -1041,7 +1057,10 @@ def test_load_prompt_caching_with_different_parameters():
 
     with mock.patch("mlflow.MlflowClient.load_prompt") as mock_client_load:
         mock_prompt = PromptVersion(
-            name="param_test", version=1, template="Hello, {{name}}!", creation_timestamp=123
+            name="param_test",
+            version=1,
+            template="Hello, {{name}}!",
+            creation_timestamp=123,
         )
         mock_client_load.return_value = mock_prompt
 
@@ -1067,3 +1086,283 @@ def test_load_prompt_caching_with_different_parameters():
 
         # Cache should work - either same count or only one additional call
         assert call_count_after_fourth <= call_count_after_third + 1
+
+
+def test_register_prompt_chat_format_integration():
+    """Test full integration of registering and using chat prompts."""
+    chat_template = [
+        {"role": "system", "content": "You are a {{style}} assistant."},
+        {"role": "user", "content": "{{question}}"},
+    ]
+
+    response_format = {
+        "type": "object",
+        "properties": {
+            "answer": {"type": "string"},
+            "confidence": {"type": "number"},
+        },
+    }
+
+    # Register chat prompt
+    mlflow.register_prompt(
+        name="test_chat_integration",
+        template=chat_template,
+        response_format=response_format,
+        commit_message="Test chat prompt integration",
+        tags={"model": "test-model"},
+    )
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_chat_integration", version=1)
+    assert prompt.template == chat_template
+    assert prompt.response_format == response_format
+    assert prompt.commit_message == "Test chat prompt integration"
+    assert prompt.tags["model"] == "test-model"
+
+    # Test formatting
+    formatted = prompt.format(style="helpful", question="How are you?")
+    expected = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "How are you?"},
+    ]
+    assert formatted == expected
+
+
+def test_prompt_associate_with_run_chat_format():
+    """Test chat prompts associate with runs correctly."""
+    chat_template = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello!"},
+    ]
+
+    mlflow.register_prompt(name="test_chat_run", template=chat_template)
+
+    with mlflow.start_run() as run:
+        mlflow.load_prompt("test_chat_run", version=1)
+
+    # Verify linking
+    client = MlflowClient()
+    run_data = client.get_run(run.info.run_id)
+    linked_prompts_tag = run_data.data.tags.get(LINKED_PROMPTS_TAG_KEY)
+    assert linked_prompts_tag is not None
+
+    linked_prompts = json.loads(linked_prompts_tag)
+    assert len(linked_prompts) == 1
+    assert linked_prompts[0]["name"] == "test_chat_run"
+    assert linked_prompts[0]["version"] == "1"
+
+
+def test_register_prompt_with_pydantic_response_format():
+    """Test registering prompts with Pydantic response format."""
+    from pydantic import BaseModel
+
+    class ResponseSchema(BaseModel):
+        answer: str
+        confidence: float
+
+    # Register prompt with Pydantic response format
+    mlflow.register_prompt(
+        name="test_pydantic_response",
+        template="What is {{question}}?",
+        response_format=ResponseSchema,
+        commit_message="Test Pydantic response format",
+    )
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_pydantic_response", version=1)
+    assert prompt.response_format == ResponseSchema.model_json_schema()
+    assert prompt.commit_message == "Test Pydantic response format"
+
+
+def test_register_prompt_with_dict_response_format():
+    """Test registering prompts with dictionary response format."""
+    response_format = {
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"},
+            "key_points": {"type": "array", "items": {"type": "string"}},
+        },
+    }
+
+    # Register prompt with dict response format
+    mlflow.register_prompt(
+        name="test_dict_response",
+        template="Analyze this: {{text}}",
+        response_format=response_format,
+        tags={"analysis_type": "text"},
+    )
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_dict_response", version=1)
+    assert prompt.response_format == response_format
+    assert prompt.tags["analysis_type"] == "text"
+
+
+def test_register_prompt_text_backward_compatibility():
+    """Test that text prompt registration continues to work as before."""
+    # Register text prompt
+    mlflow.register_prompt(
+        name="test_text_backward",
+        template="Hello {{name}}!",
+        commit_message="Test backward compatibility",
+    )
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_text_backward", version=1)
+    assert prompt.is_text_prompt
+    assert prompt.template == "Hello {{name}}!"
+    assert prompt.commit_message == "Test backward compatibility"
+
+    # Test formatting
+    formatted = prompt.format(name="Alice")
+    assert formatted == "Hello Alice!"
+
+
+def test_register_prompt_complex_chat_template():
+    """Test registering prompts with complex chat templates."""
+    chat_template = [
+        {
+            "role": "system",
+            "content": "You are a {{style}} assistant named {{name}}.",
+        },
+        {"role": "user", "content": "{{greeting}}! {{question}}"},
+        {
+            "role": "assistant",
+            "content": "I understand you're asking about {{topic}}.",
+        },
+    ]
+
+    # Register complex chat prompt
+    mlflow.register_prompt(
+        name="test_complex_chat",
+        template=chat_template,
+        tags={"complexity": "high"},
+    )
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_complex_chat", version=1)
+    assert not prompt.is_text_prompt
+    assert prompt.template == chat_template
+    assert prompt.tags["complexity"] == "high"
+
+    # Test formatting
+    formatted = prompt.format(
+        style="friendly",
+        name="Alice",
+        greeting="Hello",
+        question="How are you?",
+        topic="wellbeing",
+    )
+    expected = [
+        {"role": "system", "content": "You are a friendly assistant named Alice."},
+        {"role": "user", "content": "Hello! How are you?"},
+        {
+            "role": "assistant",
+            "content": "I understand you're asking about wellbeing.",
+        },
+    ]
+    assert formatted == expected
+
+
+def test_register_prompt_with_none_response_format():
+    """Test registering prompts with None response format."""
+    # Register prompt with None response format
+    mlflow.register_prompt(
+        name="test_none_response", template="Hello {{name}}!", response_format=None
+    )
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_none_response", version=1)
+    assert prompt.response_format is None
+
+
+def test_register_prompt_with_empty_chat_template():
+    """Test registering prompts with empty chat template list."""
+    # Empty list should be treated as text prompt
+    mlflow.register_prompt(name="test_empty_chat", template=[])
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_empty_chat", version=1)
+    assert prompt.is_text_prompt
+    assert prompt.template == "[]"  # Empty list serialized as string
+
+
+def test_register_prompt_with_single_message_chat():
+    """Test registering prompts with single message chat template."""
+    chat_template = [{"role": "user", "content": "Hello {{name}}!"}]
+
+    # Register single message chat prompt
+    mlflow.register_prompt(name="test_single_message", template=chat_template)
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_single_message", version=1)
+    not prompt.is_text_prompt
+    assert prompt.template == chat_template
+    assert prompt.variables == {"name"}
+
+
+def test_register_prompt_with_multiple_variables_in_chat():
+    """Test registering prompts with multiple variables in chat messages."""
+    chat_template = [
+        {
+            "role": "system",
+            "content": "You are a {{style}} assistant named {{name}}.",
+        },
+        {"role": "user", "content": "{{greeting}}! {{question}}"},
+        {
+            "role": "assistant",
+            "content": "I understand you're asking about {{topic}}.",
+        },
+    ]
+
+    # Register prompt with multiple variables
+    mlflow.register_prompt(name="test_multiple_variables", template=chat_template)
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_multiple_variables", version=1)
+    expected_variables = {"style", "name", "greeting", "question", "topic"}
+    assert prompt.variables == expected_variables
+
+
+def test_register_prompt_with_mixed_content_types():
+    """Test registering prompts with mixed content types in chat messages."""
+    chat_template = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello {{name}}!"},
+        {"role": "assistant", "content": "Hi there! How can I help you today?"},
+    ]
+
+    # Register prompt with mixed content
+    mlflow.register_prompt(name="test_mixed_content", template=chat_template)
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_mixed_content", version=1)
+    not prompt.is_text_prompt
+    assert prompt.template == chat_template
+    assert prompt.variables == {"name"}
+
+
+def test_register_prompt_with_nested_variables():
+    """Test registering prompts with nested variable names."""
+    chat_template = [
+        {
+            "role": "system",
+            "content": "You are a {{user.preferences.style}} assistant.",
+        },
+        {
+            "role": "user",
+            "content": "Hello {{user.name}}! {{user.preferences.greeting}}",
+        },
+    ]
+
+    # Register prompt with nested variables
+    mlflow.register_prompt(name="test_nested_variables", template=chat_template)
+
+    # Load and verify
+    prompt = mlflow.load_prompt("test_nested_variables", version=1)
+    expected_variables = {
+        "user.preferences.style",
+        "user.name",
+        "user.preferences.greeting",
+    }
+    assert prompt.variables == expected_variables


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harshilprajapati96/mlflow/pull/16341?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16341/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16341/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16341/merge
```

</p>
</details>

Signed-off-by: Harshil Prajapati <47331144+harshilprajapati96@users.noreply.github.com>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #16259 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
