### PR TITLE
[TS #4] Add `startSpan` API and in-memory trace manager

### DIFF
--- a/packages/typescript/.eslintrc.json
+++ b/packages/typescript/.eslintrc.json
@@ -30,7 +30,7 @@
     "@typescript-eslint/no-unsafe-assignment": "off",
 
     // General JavaScript/TypeScript rules
-    "no-console": ["warn", { "allow": ["warn", "error"] }],
+    "no-console": ["warn", { "allow": ["debug", "warn", "error"] }],
     "no-debugger": "error",
     "no-alert": "error",
     "prefer-const": "error",

--- a/packages/typescript/src/core/api.ts
+++ b/packages/typescript/src/core/api.ts
@@ -1,0 +1,74 @@
+import { trace, context } from '@opentelemetry/api';
+import { Span as OTelSpan } from '@opentelemetry/sdk-trace-node';
+import { SpanAttributeKey, SpanType } from './constants';
+import { createMlflowSpan, LiveSpan, NoOpSpan } from './entities/span';
+import { getTracer } from './provider';
+import { InMemoryTraceManager } from './trace_manager';
+import { convertNanoSecondsToHrTime } from './utils';
+
+/**
+ * Start a new span with the given name and span type.
+ *
+ * This function does NOT attach the created span to the current context.
+ * The span must be ended by calling `end` method on the returned Span object.
+ *
+ * @param name The name of the span.
+ * @param span_type The type of the span.
+ * @param inputs The inputs of the span.
+ * @param attributes The attributes of the span.
+ * @param startTimeNs The start time of the span in nanoseconds.
+ * @param parent The parent span object.
+ */
+export function startSpan(options: {
+  name: string;
+  span_type?: SpanType;
+  inputs?: any;
+  attributes?: Record<string, any>;
+  startTimeNs?: bigint | number;
+  parent?: LiveSpan;
+}): LiveSpan {
+  try {
+    const tracer = getTracer('default');
+
+    // If parent is provided, use it as the parent spanAdd commentMore actions
+    let parentContext = context.active();
+    if (options.parent) {
+      parentContext = trace.setSpan(parentContext, options.parent._span);
+    }
+
+    // Convert startTimeNs to OTel format
+    const startTime = options.startTimeNs
+      ? convertNanoSecondsToHrTime(options.startTimeNs)
+      : undefined;
+
+    const otel_span = tracer.startSpan(
+      options.name,
+      { startTime: startTime },
+      parentContext
+    ) as OTelSpan;
+
+    // Trace ID is set to the span attribute in SpanProcessor.onStart()
+    const trace_id = JSON.parse(
+      otel_span.attributes[SpanAttributeKey.TRACE_ID] as string
+    ) as string;
+
+    // Create the MLflow span from the OTel span
+    const mlflow_span = createMlflowSpan(otel_span, trace_id, options.span_type) as LiveSpan;
+
+    if (options.inputs) {
+      mlflow_span.setInputs(options.inputs);
+    }
+
+    if (options.attributes) {
+      mlflow_span.setAttributes(options.attributes);
+    }
+
+    const trace_manager = InMemoryTraceManager.getInstance();
+    trace_manager.registerSpan(mlflow_span);
+
+    return mlflow_span;
+  } catch (error) {
+    console.warn('Failed to start span', error);
+    return new NoOpSpan();
+  }
+}

--- a/packages/typescript/src/core/api.ts
+++ b/packages/typescript/src/core/api.ts
@@ -1,32 +1,37 @@
-import { trace, context } from '@opentelemetry/api';
+import { trace, context, Span as ApiSpan } from '@opentelemetry/api';
 import { Span as OTelSpan } from '@opentelemetry/sdk-trace-node';
-import { SpanAttributeKey, SpanType } from './constants';
+import { SpanType } from './constants';
 import { createMlflowSpan, LiveSpan, NoOpSpan } from './entities/span';
 import { getTracer } from './provider';
 import { InMemoryTraceManager } from './trace_manager';
 import { convertNanoSecondsToHrTime } from './utils';
+
+/*
+ * Options for starting a span
+ *
+ * @param name The name of the span.
+ * @param span_type The type of the span.
+ * @param inputs The inputs of the span.
+ * @param attributes The attributes of the span.
+ * @param startTimeNs The start time of the span in nanoseconds. If not provided, the current time will be used.
+ * @param parent The parent span object.
+ */
+export interface SpanOptions {
+  name: string;
+  span_type?: SpanType;
+  inputs?: any;
+  attributes?: Record<string, any>;
+  startTimeNs?: number;
+  parent?: LiveSpan;
+}
 
 /**
  * Start a new span with the given name and span type.
  *
  * This function does NOT attach the created span to the current context.
  * The span must be ended by calling `end` method on the returned Span object.
- *
- * @param name The name of the span.
- * @param span_type The type of the span.
- * @param inputs The inputs of the span.
- * @param attributes The attributes of the span.
- * @param startTimeNs The start time of the span in nanoseconds.
- * @param parent The parent span object.
  */
-export function startSpan(options: {
-  name: string;
-  span_type?: SpanType;
-  inputs?: any;
-  attributes?: Record<string, any>;
-  startTimeNs?: bigint | number;
-  parent?: LiveSpan;
-}): LiveSpan {
+export function startSpan(options: SpanOptions): LiveSpan {
   try {
     const tracer = getTracer('default');
 
@@ -41,34 +46,61 @@ export function startSpan(options: {
       ? convertNanoSecondsToHrTime(options.startTimeNs)
       : undefined;
 
-    const otel_span = tracer.startSpan(
+    const otelSpan = tracer.startSpan(
       options.name,
       { startTime: startTime },
       parentContext
     ) as OTelSpan;
 
-    // Trace ID is set to the span attribute in SpanProcessor.onStart()
-    const trace_id = JSON.parse(
-      otel_span.attributes[SpanAttributeKey.TRACE_ID] as string
-    ) as string;
+    // Create and register the MLflow span
+    const mlflowSpan = createAndRegisterMlflowSpan(
+      otelSpan,
+      options.span_type,
+      options.inputs,
+      options.attributes
+    );
 
-    // Create the MLflow span from the OTel span
-    const mlflow_span = createMlflowSpan(otel_span, trace_id, options.span_type) as LiveSpan;
-
-    if (options.inputs) {
-      mlflow_span.setInputs(options.inputs);
-    }
-
-    if (options.attributes) {
-      mlflow_span.setAttributes(options.attributes);
-    }
-
-    const trace_manager = InMemoryTraceManager.getInstance();
-    trace_manager.registerSpan(mlflow_span);
-
-    return mlflow_span;
+    return mlflowSpan;
   } catch (error) {
     console.warn('Failed to start span', error);
     return new NoOpSpan();
   }
+}
+
+/**
+ * Helper function to create and register an MLflow span from an OpenTelemetry span
+ * @param otelSpan The OpenTelemetry span
+ * @param spanType The MLflow span type
+ * @param inputs Optional inputs to set on the span
+ * @param attributes Optional attributes to set on the span
+ * @returns The created and registered MLflow LiveSpan
+ */
+function createAndRegisterMlflowSpan(
+  otelSpan: OTelSpan | ApiSpan,
+  spanType?: SpanType,
+  inputs?: any,
+  attributes?: Record<string, any>
+): LiveSpan {
+  // Get the MLflow trace ID from the OpenTelemetry trace ID
+  const otelTraceId = otelSpan.spanContext().traceId;
+  const traceId =
+    InMemoryTraceManager.getInstance().getMlflowTraceIdFromOtelId(otelTraceId) || otelTraceId;
+
+  // Create the MLflow span from the OTel span
+  const mlflowSpan = createMlflowSpan(otelSpan, traceId, spanType) as LiveSpan;
+
+  // Set initial properties if provided
+  if (inputs) {
+    mlflowSpan.setInputs(inputs);
+  }
+
+  if (attributes) {
+    mlflowSpan.setAttributes(attributes);
+  }
+
+  // Register the span with the trace manager
+  const traceManager = InMemoryTraceManager.getInstance();
+  traceManager.registerSpan(mlflowSpan);
+
+  return mlflowSpan;
 }

--- a/packages/typescript/src/core/api.ts
+++ b/packages/typescript/src/core/api.ts
@@ -36,10 +36,9 @@ export function startSpan(options: SpanOptions): LiveSpan {
     const tracer = getTracer('default');
 
     // If parent is provided, use it as the parent spanAdd commentMore actions
-    let parentContext = context.active();
-    if (options.parent) {
-      parentContext = trace.setSpan(parentContext, options.parent._span);
-    }
+    const parentContext = options.parent
+      ? trace.setSpan(context.active(), options.parent._span)
+      : context.active();
 
     // Convert startTimeNs to OTel format
     const startTime = options.startTimeNs

--- a/packages/typescript/src/core/entities/span_status.ts
+++ b/packages/typescript/src/core/entities/span_status.ts
@@ -9,15 +9,15 @@ import { SpanStatus as OTelStatus, SpanStatusCode as OTelSpanStatusCode } from '
 
 /**
  * Enum for status code of a span
- * Uses the same set of status codes as OpenTelemetry
+ * Uses the same set of status codes as OTLP SpanStatusCode
  */
 export enum SpanStatusCode {
   /** Status is unset/unspecified */
-  UNSET = 'UNSET',
+  UNSET = 'STATUS_CODE_UNSET',
   /** The operation completed successfully */
-  OK = 'OK',
+  OK = 'STATUS_CODE_OK',
   /** The operation encountered an error */
-  ERROR = 'ERROR'
+  ERROR = 'STATUS_CODE_ERROR'
 }
 
 /**

--- a/packages/typescript/src/core/entities/span_status.ts
+++ b/packages/typescript/src/core/entities/span_status.ts
@@ -10,6 +10,8 @@ import { SpanStatus as OTelStatus, SpanStatusCode as OTelSpanStatusCode } from '
 /**
  * Enum for status code of a span
  * Uses the same set of status codes as OTLP SpanStatusCode
+ * https://github.com/open-telemetry/opentelemetry-proto/blob/189b2648d29aa6039aeb2
+lemetry/proto/trace/v1/trace.proto#L314-L322
  */
 export enum SpanStatusCode {
   /** Status is unset/unspecified */

--- a/packages/typescript/src/core/entities/trace_data.ts
+++ b/packages/typescript/src/core/entities/trace_data.ts
@@ -38,7 +38,6 @@ export class TraceData {
   }
 }
 
-
 export interface SerializedTraceData {
   spans: SerializedSpan[];
 }

--- a/packages/typescript/src/core/entities/trace_info.ts
+++ b/packages/typescript/src/core/entities/trace_info.ts
@@ -147,7 +147,7 @@ export class TraceInfo {
       responsePreview: json.response_preview,
       requestTime: json.request_time ? new Date(json.request_time).getTime() : Date.now(),
       executionDuration: json.execution_duration
-        ? parseFloat((json.execution_duration).replace('s', '')) * 1000
+        ? parseFloat(json.execution_duration.replace('s', '')) * 1000
         : undefined,
       state: json.state,
       traceMetadata: json.trace_metadata || {},
@@ -165,11 +165,11 @@ export interface SerializedTraceInfo {
     type: TraceLocationType;
     mlflow_experiment?: {
       experiment_id: string;
-    },
+    };
     inference_table?: {
       full_table_name: string;
-    }
-  }
+    };
+  };
   request_preview?: string;
   response_preview?: string;
   // "request_time": "2025-06-15T14:07:41.282Z"

--- a/packages/typescript/src/core/provider.ts
+++ b/packages/typescript/src/core/provider.ts
@@ -1,0 +1,13 @@
+import { trace, Tracer } from '@opentelemetry/api';
+import { MlflowSpanExporter, MlflowSpanProcessor } from '../exporters/mlflow';
+import { NodeSDK } from '@opentelemetry/sdk-node';
+
+// TODO: Implement branching logic to actually set span processor and exporter
+const exporter = new MlflowSpanExporter();
+const processor = new MlflowSpanProcessor(exporter);
+const sdk = new NodeSDK({ spanProcessors: [processor] });
+sdk.start();
+
+export function getTracer(module_name: string): Tracer {
+  return trace.getTracer(module_name);
+}

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -1,0 +1,143 @@
+import { LiveSpan, Span } from './entities/span';
+import { TraceInfo } from './entities/trace_info';
+import { Trace } from './entities/trace';
+import { TraceData } from './entities/trace_data';
+import { SpanAttributeKey } from './constants';
+
+/**
+ * Internal representation to keep the state of a trace.
+ * Uses a Map<string, LiveSpan> instead of TraceData to allow access by span_id.
+ */
+class _Trace {
+  info: TraceInfo;
+  spanDict: Map<string, LiveSpan>;
+
+  constructor(info: TraceInfo) {
+    this.info = info;
+    this.spanDict = new Map<string, LiveSpan>();
+  }
+
+  /**
+   * Convert the internal trace representation to an MLflow Trace object
+   */
+  toMlflowTrace(): Trace {
+    const traceData = new TraceData();
+
+    // Convert LiveSpan, mutable objects, into immutable Span objects before persisting
+    for (const span of this.spanDict.values()) {
+      traceData.spans.push(span as Span);
+    }
+
+    const root_span = traceData.spans.find((span) => span.parentId == null);
+    if (root_span) {
+      // Accessing the OTel span directly get serialized value directly.
+      this.info.requestPreview = root_span.attributes[SpanAttributeKey.INPUTS];
+      this.info.responsePreview = root_span.attributes[SpanAttributeKey.OUTPUTS];
+    }
+
+    return new Trace(this.info, traceData);
+  }
+}
+
+/**
+ * Manage spans and traces created by the tracing system in memory.
+ * This class is implemented as a singleton.
+ */
+export class InMemoryTraceManager {
+  private static _instance: InMemoryTraceManager | null = null;
+
+  // In-memory cache to store trace_id -> _Trace mapping
+  // TODO: Add TTL to the trace buffer similarly to Python SDK
+  private _traces: Map<string, _Trace>;
+  // Store mapping between OpenTelemetry trace ID and MLflow trace ID
+  private _otelIdToMlflowTraceId: Map<string, string>;
+
+  /**
+   * Singleton pattern implementation
+   */
+  static getInstance(): InMemoryTraceManager {
+    if (InMemoryTraceManager._instance == null) {
+      InMemoryTraceManager._instance = new InMemoryTraceManager();
+    }
+    return InMemoryTraceManager._instance;
+  }
+
+  private constructor() {
+    this._traces = new Map<string, _Trace>();
+    this._otelIdToMlflowTraceId = new Map<string, string>();
+  }
+
+  /**
+   * Register a new trace info object to the in-memory trace registry.
+   * @param otelTraceId The OpenTelemetry trace ID for the new trace
+   * @param traceInfo The trace info object to be stored
+   */
+  registerTrace(otelTraceId: string, traceInfo: TraceInfo): void {
+    this._traces.set(traceInfo.traceId, new _Trace(traceInfo));
+    this._otelIdToMlflowTraceId.set(otelTraceId, traceInfo.traceId);
+  }
+
+  /**
+   * Store the given span in the in-memory trace data.
+   * @param span The span to be stored
+   */
+  registerSpan(span: LiveSpan): void {
+    const trace = this._traces.get(span.traceId);
+    if (trace) {
+      trace.spanDict.set(span.spanId, span);
+    } else {
+      console.debug(`Tried to register span ${span.spanId} for trace ${span.traceId}
+                     but trace not found. Please make sure to register the trace first.`);
+    }
+  }
+
+  /**
+   * Get the trace for the given trace ID.
+   * Returns the trace object or null if not found.
+   * @param traceId The trace ID to look up
+   */
+  getTrace(traceId: string): _Trace | null {
+    return this._traces.get(traceId) || null;
+  }
+
+  /**
+   * Get the MLflow trace ID for the given OpenTelemetry trace ID.
+   * @param otelTraceId The OpenTelemetry trace ID
+   */
+  getMlflowTraceIdFromOtelId(otelTraceId: string): string | null {
+    return this._otelIdToMlflowTraceId.get(otelTraceId) || null;
+  }
+
+  /**
+   * Pop trace data for the given OpenTelemetry trace ID and return it as
+   * a ready-to-publish Trace object.
+   * @param otelTraceId The OpenTelemetry trace ID
+   */
+  popTrace(otelTraceId: string): Trace | null {
+    const mlflowTraceId = this._otelIdToMlflowTraceId.get(otelTraceId);
+    if (!mlflowTraceId) {
+      console.debug(`Tried to pop trace ${otelTraceId} but no trace found.`);
+      return null;
+    }
+
+    this._otelIdToMlflowTraceId.delete(otelTraceId);
+    const trace = this._traces.get(mlflowTraceId);
+    if (trace) {
+      this._traces.delete(mlflowTraceId);
+      return trace.toMlflowTrace();
+    }
+    console.debug(`Tried to pop trace ${otelTraceId} but trace not found.`);
+    return null;
+  }
+
+  /**
+   * Clear all the aggregated trace data. This should only be used for testing.
+   */
+  static reset(): void {
+    if (InMemoryTraceManager._instance) {
+      InMemoryTraceManager._instance._traces.clear();
+      InMemoryTraceManager._instance._otelIdToMlflowTraceId.clear();
+      InMemoryTraceManager._instance = null;
+    }
+  }
+}

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -31,8 +31,8 @@ class _Trace {
     const root_span = traceData.spans.find((span) => span.parentId == null);
     if (root_span) {
       // Accessing the OTel span directly get serialized value directly.
-      this.info.requestPreview = root_span.attributes[SpanAttributeKey.INPUTS];
-      this.info.responsePreview = root_span.attributes[SpanAttributeKey.OUTPUTS];
+      this.info.requestPreview = root_span._span.attributes[SpanAttributeKey.INPUTS]?.toString();
+      this.info.responsePreview = root_span._span.attributes[SpanAttributeKey.OUTPUTS]?.toString();
     }
 
     return new Trace(this.info, traceData);

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -21,12 +21,8 @@ class _Trace {
    * Convert the internal trace representation to an MLflow Trace object
    */
   toMlflowTrace(): Trace {
-    const traceData = new TraceData();
-
     // Convert LiveSpan, mutable objects, into immutable Span objects before persisting
-    for (const span of this.spanDict.values()) {
-      traceData.spans.push(span as Span);
-    }
+    const traceData = new TraceData([...this.spanDict.values()] as Span[]);
 
     const root_span = traceData.spans.find((span) => span.parentId == null);
     if (root_span) {
@@ -45,7 +41,7 @@ class _Trace {
  * This class is implemented as a singleton.
  */
 export class InMemoryTraceManager {
-  private static _instance: InMemoryTraceManager | null = null;
+  private static _instance: InMemoryTraceManager | undefined;
 
   // In-memory cache to store trace_id -> _Trace mapping
   // TODO: Add TTL to the trace buffer similarly to Python SDK
@@ -138,7 +134,7 @@ export class InMemoryTraceManager {
     if (InMemoryTraceManager._instance) {
       InMemoryTraceManager._instance._traces.clear();
       InMemoryTraceManager._instance._otelIdToMlflowTraceId.clear();
-      InMemoryTraceManager._instance = null;
+      InMemoryTraceManager._instance = undefined;
     }
   }
 }

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -31,8 +31,9 @@ class _Trace {
     const root_span = traceData.spans.find((span) => span.parentId == null);
     if (root_span) {
       // Accessing the OTel span directly get serialized value directly.
-      this.info.requestPreview = root_span._span.attributes[SpanAttributeKey.INPUTS]?.toString();
-      this.info.responsePreview = root_span._span.attributes[SpanAttributeKey.OUTPUTS]?.toString();
+      // TODO: Implement the smart truncation logic.
+      this.info.requestPreview = root_span._span.attributes[SpanAttributeKey.INPUTS] as string;
+      this.info.responsePreview = root_span._span.attributes[SpanAttributeKey.OUTPUTS] as string;
     }
 
     return new Trace(this.info, traceData);

--- a/packages/typescript/src/core/utils/index.ts
+++ b/packages/typescript/src/core/utils/index.ts
@@ -1,4 +1,5 @@
 import type { HrTime } from '@opentelemetry/api';
+import { LiveSpan } from '../entities/span';
 
 /**
  * OpenTelemetry Typescript SDK uses a unique timestamp format `HrTime` to represent
@@ -27,6 +28,15 @@ export function convertNanoSecondsToHrTime(nanoseconds: number | bigint): HrTime
  */
 export function convertHrTimeToNanoSeconds(hrTime: HrTime): bigint {
   return BigInt(hrTime[0]) * 1_000_000_000n + BigInt(hrTime[1]);
+}
+
+/**
+ * Convert HrTime to milliseconds
+ * @param hrTime HrTime tuple [seconds, nanoseconds]
+ * @returns Milliseconds
+ */
+export function convertHrTimeToMs(hrTime: HrTime): number {
+  return hrTime[0] * 1e3 + hrTime[1] / 1e6;
 }
 
 /**
@@ -83,4 +93,48 @@ export function decodeIdFromBase64(base64SpanId: string): string {
   return Array.from(bytes)
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
+}
+
+/**
+ * Deduplicate span names in the trace data by appending an index number to the span name.
+ *
+ * This is only applied when there are multiple spans with the same name. The span names
+ * are modified in place to avoid unnecessary copying.
+ *
+ * Examples:
+ *   ["red", "red"] -> ["red_1", "red_2"]
+ *   ["red", "red", "blue"] -> ["red_1", "red_2", "blue"]
+ *
+ * @param spans A list of spans to deduplicate
+ */
+export function deduplicateSpanNamesInPlace(spans: LiveSpan[]): void {
+  // Count occurrences of each span name
+  const spanNameCounter = new Map<string, number>();
+
+  for (const span of spans) {
+    const name = span.name;
+    spanNameCounter.set(name, (spanNameCounter.get(name) || 0) + 1);
+  }
+
+  // Apply renaming only for duplicated spans
+  const spanNameIndexes = new Map<string, number>();
+  for (const [name, count] of spanNameCounter.entries()) {
+    if (count > 1) {
+      spanNameIndexes.set(name, 1);
+    }
+  }
+
+  // Add index to the duplicated span names
+  for (const span of spans) {
+    const name = span.name;
+    const currentIndex = spanNameIndexes.get(name);
+
+    if (currentIndex !== undefined) {
+      // Modify the span name in place by accessing the internal OpenTelemetry span
+      // The 'name' field is readonly in OTel but we need to jail-break it here
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (span._span as any).name = `${name}_${currentIndex}`;
+      spanNameIndexes.set(name, currentIndex + 1);
+    }
+  }
 }

--- a/packages/typescript/src/exporters/mlflow.ts
+++ b/packages/typescript/src/exporters/mlflow.ts
@@ -1,0 +1,158 @@
+import { Trace } from '../core/entities/trace';
+import { ExportResult } from '@opentelemetry/core';
+import {
+  Span as OTelSpan,
+  SpanProcessor,
+  ReadableSpan as OTelReadableSpan,
+  SpanExporter
+} from '@opentelemetry/sdk-trace-base';
+import { Context } from '@opentelemetry/api';
+import { InMemoryTraceManager } from '../core/trace_manager';
+import { TraceInfo } from '../core/entities/trace_info';
+import { createTraceLocationFromExperimentId } from '../core/entities/trace_location';
+import { fromOtelStatus, TraceState } from '../core/entities/trace_state';
+import { SpanAttributeKey, TRACE_ID_PREFIX } from '../core/constants';
+import { convertHrTimeToMs, deduplicateSpanNamesInPlace } from '../core/utils';
+
+// TODO: Remove these once we have a proper exporter.
+let _traces: Trace[] = [];
+export function getTraces(): Trace[] {
+  return _traces;
+}
+export function resetTraces(): void {
+  _traces = [];
+}
+
+/**
+ * Generate a MLflow-compatible trace ID for the given span.
+ * @param span The span to generate the trace ID for
+ */
+function generateTraceId(span: OTelSpan): string {
+  // NB: trace Id is already hex string in Typescript OpenTelemetry SDK
+  return TRACE_ID_PREFIX + span.spanContext().traceId;
+}
+
+export class MlflowSpanProcessor implements SpanProcessor {
+  private _exporter: SpanExporter;
+
+  constructor(exporter: SpanExporter) {
+    this._exporter = exporter;
+  }
+
+  /**
+   * Called when a {@link Span} is started, if the `span.isRecording()`
+   * returns true.
+   * @param span the Span that just started.
+   */
+  onStart(span: OTelSpan, _parentContext: Context): void {
+    const otelTraceId = span.spanContext().traceId;
+
+    let traceId: string;
+
+    if (!span.parentSpanContext?.spanId) {
+      // This is a root span
+      traceId = generateTraceId(span);
+      const trace_info = new TraceInfo({
+        traceId: traceId,
+        // TODO: Set correct experiment ID once we implement an API for setting trace destination
+        traceLocation: createTraceLocationFromExperimentId(''),
+        requestTime: convertHrTimeToMs(span.startTime),
+        executionDuration: 0,
+        state: TraceState.IN_PROGRESS,
+        traceMetadata: {},
+        tags: {},
+        assessments: []
+      });
+      InMemoryTraceManager.getInstance().registerTrace(otelTraceId, trace_info);
+    } else {
+      traceId = InMemoryTraceManager.getInstance().getMlflowTraceIdFromOtelId(otelTraceId) || '';
+
+      if (!traceId) {
+        console.warn(`No trace ID found for span ${span.name}. Skipping.`);
+        return;
+      }
+    }
+
+    // Set trace ID to the span
+    span.setAttribute(SpanAttributeKey.TRACE_ID, JSON.stringify(traceId));
+  }
+
+  /**
+   * Called when a {@link ReadableSpan} is ended, if the `span.isRecording()`
+   * returns true.
+   * @param span the Span that just ended.
+   */
+  onEnd(span: OTelReadableSpan): void {
+    // Only trigger trace export for root span completion
+    if (span.parentSpanContext?.spanId) {
+      return;
+    }
+
+    // Update trace info
+    const traceId = JSON.parse(span.attributes[SpanAttributeKey.TRACE_ID] as string) as string;
+    const trace = InMemoryTraceManager.getInstance().getTrace(traceId);
+    if (!trace) {
+      console.warn(`No trace found for span ${span.name}. Skipping.`);
+      return;
+    }
+
+    this.updateTraceInfo(trace.info, span);
+    deduplicateSpanNamesInPlace(Array.from(trace.spanDict.values()));
+
+    this._exporter.export([span], (_) => {});
+  }
+
+  /**
+   * Update the trace info with the span end time and status.
+   * @param trace The trace to update
+   * @param span The span to update the trace with
+   */
+  updateTraceInfo(traceInfo: TraceInfo, span: OTelReadableSpan): void {
+    traceInfo.executionDuration = convertHrTimeToMs(span.endTime) - traceInfo.requestTime;
+    traceInfo.state = fromOtelStatus(span.status.code);
+  }
+
+  /**
+   * Shuts down the processor. Called when SDK is shut down. This is an
+   * opportunity for processor to do any cleanup required.
+   */
+  shutdown(): Promise<void> {
+    // TODO: Implement this
+    return Promise.resolve();
+  }
+
+  /**
+   * Forces to export all finished spans
+   */
+  forceFlush(): Promise<void> {
+    // TODO: Implement this
+    return Promise.resolve();
+  }
+}
+
+export class MlflowSpanExporter implements SpanExporter {
+  export(spans: OTelReadableSpan[], _resultCallback: (result: ExportResult) => void): void {
+    for (const span of spans) {
+      // Only export root spans
+      if (span.parentSpanContext?.spanId) {
+        continue;
+      }
+
+      const trace = InMemoryTraceManager.getInstance().popTrace(span.spanContext().traceId);
+      if (!trace) {
+        console.warn(`No trace found for span ${span.name}. Skipping.`);
+        continue;
+      }
+
+      // setLastActiveTraceId(trace.info.traceId);
+
+      // TODO: Implement the actual export logic to MLflow backend
+      _traces.push(trace);
+    }
+  }
+
+  shutdown(): Promise<void> {
+    // TODO: Implement this
+    return Promise.resolve();
+  }
+}

--- a/packages/typescript/tests/core/api.test.ts
+++ b/packages/typescript/tests/core/api.test.ts
@@ -1,0 +1,149 @@
+import { startSpan } from '../../src/core/api';
+import { SpanType } from '../../src/core/constants';
+import { LiveSpan } from '../../src/core/entities/span';
+import { SpanStatus, SpanStatusCode } from '../../src/core/entities/span_status';
+import { TraceState } from '../../src/core/entities/trace_state';
+import { InMemoryTraceManager } from '../../src/core/trace_manager';
+import { convertHrTimeToMs } from '../../src/core/utils';
+import { getTraces, resetTraces } from '../../src/exporters/mlflow';
+
+describe('API', () => {
+  describe('startSpan', () => {
+    it('should create a span with span type', () => {
+      const span = startSpan({ name: 'test-span' });
+      expect(span).toBeInstanceOf(LiveSpan);
+
+      span.setInputs({ prompt: 'Hello, world!' });
+      span.setOutputs({ response: 'Hello, world!' });
+      span.setAttributes({ model: 'gpt-4' });
+      span.setStatus('OK');
+      span.end();
+
+      // Validate traces pushed to the in-memory buffer
+      const traces = getTraces();
+      expect(traces.length).toBe(1);
+
+      const trace = traces[0];
+      expect(trace.info.traceId).toBe(span.traceId);
+      expect(trace.info.state).toBe(TraceState.OK);
+      expect(trace.info.requestTime).toBeCloseTo(convertHrTimeToMs(span.startTime));
+      expect(trace.info.executionDuration).toBeCloseTo(
+        convertHrTimeToMs(span.endTime!) - convertHrTimeToMs(span.startTime)
+      );
+      expect(trace.data.spans.length).toBe(1);
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.traceId).toBe(span.traceId);
+      expect(loggedSpan.name).toBe('test-span');
+      expect(loggedSpan.spanType).toBe(SpanType.UNKNOWN);
+      expect(loggedSpan.inputs).toEqual({ prompt: 'Hello, world!' });
+      expect(loggedSpan.outputs).toEqual({ response: 'Hello, world!' });
+      expect(loggedSpan.attributes['model']).toBe('gpt-4');
+      expect(loggedSpan.startTime).toBe(span.startTime);
+      expect(loggedSpan.endTime).toBe(span.endTime);
+      expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.OK);
+    });
+
+    it('should create a span with other options', () => {
+      const span = startSpan({
+        name: 'test-span',
+        span_type: SpanType.LLM,
+        inputs: { prompt: 'Hello, world!' },
+        attributes: { model: 'gpt-4' },
+        startTimeNs: 1e9 // 1 second
+      });
+      span.end({
+        outputs: { response: 'Hello, world!' },
+        attributes: { model: 'gpt-4' },
+        status: SpanStatusCode.ERROR,
+        endTimeNs: 3e9 // 3 seconds
+      });
+
+      // Validate traces pushed to the in-memory buffer
+      const traces = getTraces();
+      expect(traces.length).toBe(1);
+
+      const trace = traces[0];
+      expect(trace.info.traceId).toBe(span.traceId);
+      expect(trace.info.state).toBe(TraceState.ERROR);
+      expect(trace.info.requestTime).toBeCloseTo(1e3); // requestTime is in milliseconds
+      expect(trace.info.executionDuration).toBeCloseTo(2e3); // executionDuration is in milliseconds
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.traceId).toBe(span.traceId);
+      expect(loggedSpan.name).toBe('test-span');
+      expect(loggedSpan.spanType).toBe(SpanType.LLM);
+      expect(loggedSpan.inputs).toEqual({ prompt: 'Hello, world!' });
+      expect(loggedSpan.outputs).toEqual({ response: 'Hello, world!' });
+      expect(loggedSpan.attributes['model']).toBe('gpt-4');
+      expect(loggedSpan.startTime[0]).toBe(1);
+      expect(loggedSpan.startTime[1]).toBe(0);
+      expect(loggedSpan.endTime?.[0]).toBe(3);
+      expect(loggedSpan.endTime?.[1]).toBe(0);
+      expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.ERROR);
+    });
+
+    it('should create a span with an exception', () => {
+      const span = startSpan({ name: 'test-span', span_type: SpanType.LLM });
+      expect(span).toBeInstanceOf(LiveSpan);
+
+      span.recordException(new Error('test-error'));
+      span.end({ status: new SpanStatus(SpanStatusCode.ERROR, 'test-error') });
+
+      // Validate traces pushed to the in-memory buffer
+      const traces = getTraces();
+      expect(traces.length).toBe(1);
+
+      const trace = traces[0];
+      expect(trace.info.traceId).toBe(span.traceId);
+      expect(trace.info.state).toBe(TraceState.ERROR);
+      expect(trace.info.requestTime).toBeCloseTo(convertHrTimeToMs(span.startTime));
+      expect(trace.info.executionDuration).toBeCloseTo(
+        convertHrTimeToMs(span.endTime!) - convertHrTimeToMs(span.startTime)
+      );
+      expect(trace.data.spans.length).toBe(1);
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.ERROR);
+      expect(loggedSpan.status?.description).toBe('test-error');
+    });
+
+    it('should create nested spans', () => {
+      const parentSpan = startSpan({ name: 'parent-span' });
+      const childSpan1 = startSpan({ name: 'child-span-1', parent: parentSpan });
+      childSpan1.end();
+      const childSpan2 = startSpan({ name: 'child-span-2', parent: parentSpan });
+      const childSpan3 = startSpan({ name: 'child-span-3', parent: childSpan2 });
+      childSpan3.end();
+      childSpan2.end();
+
+      // This should not be a child of parentSpan
+      const independentSpan = startSpan({ name: 'independent-span' });
+      independentSpan.end();
+
+      parentSpan.end();
+
+      const traces = getTraces();
+      expect(traces.length).toBe(2);
+
+      const trace1 = traces[0];
+      expect(trace1.data.spans.length).toBe(1);
+      expect(trace1.data.spans[0].name).toBe('independent-span');
+
+      const trace2 = traces[1];
+      expect(trace2.data.spans.length).toBe(4);
+      expect(trace2.data.spans[0].name).toBe('parent-span');
+      expect(trace2.data.spans[1].name).toBe('child-span-1');
+      expect(trace2.data.spans[1].parentId).toBe(trace2.data.spans[0].spanId);
+      expect(trace2.data.spans[2].name).toBe('child-span-2');
+      expect(trace2.data.spans[2].parentId).toBe(trace2.data.spans[0].spanId);
+      expect(trace2.data.spans[3].name).toBe('child-span-3');
+      expect(trace2.data.spans[3].parentId).toBe(trace2.data.spans[2].spanId);
+    });
+  });
+
+  afterEach(() => {
+    InMemoryTraceManager.reset();
+    resetTraces();
+  });
+});

--- a/packages/typescript/tests/core/entities/span.test.ts
+++ b/packages/typescript/tests/core/entities/span.test.ts
@@ -225,7 +225,7 @@ describe('Span', () => {
 
       // Validate status format
       expect(json.status).toHaveProperty('code');
-      expect(json.status.code).toBe('OK');
+      expect(json.status.code).toBe('STATUS_CODE_OK');
 
       // Validate timestamps are bigint for precision
       expect(typeof json.start_time_unix_nano).toBe('bigint');

--- a/packages/typescript/tests/core/entities/span.test.ts
+++ b/packages/typescript/tests/core/entities/span.test.ts
@@ -1,5 +1,5 @@
 import { trace } from '@opentelemetry/api';
-import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-node';
 import {
   createMlflowSpan,
   Span,

--- a/packages/typescript/tests/core/entities/span_status.test.ts
+++ b/packages/typescript/tests/core/entities/span_status.test.ts
@@ -5,9 +5,9 @@ describe('SpanStatus', () => {
   describe('initialization', () => {
     // Test both enum and string initialization (parameterized test equivalent)
     const testCases = [
-      { input: 'OK', expected: SpanStatusCode.OK },
-      { input: 'ERROR', expected: SpanStatusCode.ERROR },
-      { input: 'UNSET', expected: SpanStatusCode.UNSET }
+      { input: 'STATUS_CODE_OK', expected: SpanStatusCode.OK },
+      { input: 'STATUS_CODE_ERROR', expected: SpanStatusCode.ERROR },
+      { input: 'STATUS_CODE_UNSET', expected: SpanStatusCode.UNSET }
     ];
 
     testCases.forEach(({ input, expected }) => {

--- a/packages/typescript/tests/core/entities/trace.test.ts
+++ b/packages/typescript/tests/core/entities/trace.test.ts
@@ -1,5 +1,5 @@
 import { trace } from '@opentelemetry/api';
-import { BasicTracerProvider } from '@opentelemetry/sdk-trace-base';
+import { BasicTracerProvider } from '@opentelemetry/sdk-trace-node';
 import { Trace } from '../../../src/core/entities/trace';
 import { TraceInfo } from '../../../src/core/entities/trace_info';
 import { TraceData } from '../../../src/core/entities/trace_data';
@@ -68,17 +68,17 @@ describe('Trace', () => {
       expect(json.data).toMatchObject({
         spans: [
           {
-            "name": "parent",
-            "trace_id": expect.any(String),
-            "span_id": expect.any(String),
-            "parent_span_id": null,
-            "start_time_unix_nano": expect.any(BigInt),
-            "end_time_unix_nano": expect.any(BigInt),
-            "attributes": {
-              "mlflow.spanType": "UNKNOWN"
+            name: 'parent',
+            trace_id: expect.any(String),
+            span_id: expect.any(String),
+            parent_span_id: null,
+            start_time_unix_nano: expect.any(BigInt),
+            end_time_unix_nano: expect.any(BigInt),
+            attributes: {
+              'mlflow.spanType': 'UNKNOWN'
             },
-            "status": {"code": "UNSET"},
-            "events": []
+            status: { code: 'UNSET' },
+            events: []
           }
         ]
       });

--- a/packages/typescript/tests/core/entities/trace.test.ts
+++ b/packages/typescript/tests/core/entities/trace.test.ts
@@ -71,13 +71,13 @@ describe('Trace', () => {
             name: 'parent',
             trace_id: expect.any(String),
             span_id: expect.any(String),
-            parent_span_id: null,
+            parent_span_id: '',
             start_time_unix_nano: expect.any(BigInt),
             end_time_unix_nano: expect.any(BigInt),
             attributes: {
               'mlflow.spanType': 'UNKNOWN'
             },
-            status: { code: 'UNSET' },
+            status: { code: 'STATUS_CODE_UNSET' },
             events: []
           }
         ]

--- a/packages/typescript/tests/core/trace_manager.test.ts
+++ b/packages/typescript/tests/core/trace_manager.test.ts
@@ -1,0 +1,74 @@
+import { InMemoryTraceManager } from '../../src/core/trace_manager';
+import { Trace } from '../../src/core/entities/trace';
+import { TraceInfo } from '../../src/core/entities/trace_info';
+import { createTraceLocationFromExperimentId } from '../../src/core/entities/trace_location';
+import { TraceState } from '../../src/core/entities/trace_state';
+import { createTestSpan } from '../helper';
+import { Span } from '../../src/core/entities/span';
+
+/**
+ * Helper function to create a test TraceInfo object
+ */
+function createTestTraceInfo(traceId: string): TraceInfo {
+  return new TraceInfo({
+    traceId,
+    traceLocation: createTraceLocationFromExperimentId('1'),
+    requestTime: Date.now(),
+    state: TraceState.IN_PROGRESS,
+    requestPreview: undefined,
+    responsePreview: undefined,
+    traceMetadata: {},
+    tags: {}
+  });
+}
+
+describe('InMemoryTraceManager', () => {
+  beforeEach(() => {
+    // Reset the singleton instance before each test
+    InMemoryTraceManager.reset();
+  });
+
+  afterEach(() => {
+    // Clean up after each test
+    InMemoryTraceManager.reset();
+  });
+
+  it('should return the same instance when called multiple times', () => {
+    const obj1 = InMemoryTraceManager.getInstance();
+    const obj2 = InMemoryTraceManager.getInstance();
+    expect(obj1).toBe(obj2);
+  });
+
+  it('should add spans and pop traces correctly', () => {
+    const traceManager = InMemoryTraceManager.getInstance();
+
+    // Add a new trace info
+    const traceId = 'tr-1';
+    const otelTraceId = '12345';
+    traceManager.registerTrace(otelTraceId, createTestTraceInfo(traceId));
+
+    // Add a span for a new trace
+    const span11 = createTestSpan('test', traceId, 'span11');
+    traceManager.registerSpan(span11);
+
+    expect(traceManager.getTrace(traceId)).toBeTruthy();
+    const trace1 = traceManager.getTrace(traceId);
+    expect(trace1?.info.traceId).toBe(traceId);
+    expect(trace1?.spanDict.size).toBe(1);
+
+    // Add more spans to the same trace
+    const span111 = createTestSpan('test', traceId, 'span111');
+    const span112 = createTestSpan('test', traceId, 'span112');
+    traceManager.registerSpan(span111);
+    traceManager.registerSpan(span112);
+    expect(trace1?.spanDict.size).toBe(3);
+
+    // Pop the trace data
+    const poppedTrace1 = traceManager.popTrace(otelTraceId);
+    expect(poppedTrace1).toBeInstanceOf(Trace);
+    expect(poppedTrace1?.info.traceId).toBe(traceId);
+    expect(poppedTrace1?.data.spans.length).toBe(3);
+    expect(traceManager.getTrace(traceId)).toBeNull();
+    expect(poppedTrace1?.data.spans[0]).toBeInstanceOf(Span);
+  });
+});

--- a/packages/typescript/tests/core/utils/index.test.ts
+++ b/packages/typescript/tests/core/utils/index.test.ts
@@ -4,8 +4,11 @@ import {
   convertHrTimeToNanoSeconds,
   encodeSpanIdToBase64,
   encodeTraceIdToBase64,
-  decodeIdFromBase64
+  decodeIdFromBase64,
+  deduplicateSpanNamesInPlace
 } from '../../../src/core/utils';
+import { createTestSpan } from '../../helper';
+import { LiveSpan } from '../../../src/core/entities/span';
 
 describe('utils', () => {
   describe('convertNanoSecondsToHrTime', () => {
@@ -282,5 +285,62 @@ describe('utils', () => {
       const traceBase64_2 = encodeTraceIdToBase64(traceId);
       expect(traceBase64_1).toBe(traceBase64_2);
     });
+  });
+});
+
+describe('deduplicateSpanNamesInPlace', () => {
+  it('should deduplicate spans with duplicate names', () => {
+    const spans = [createTestSpan('red'), createTestSpan('red')];
+
+    deduplicateSpanNamesInPlace(spans);
+
+    expect(spans[0].name).toBe('red_1');
+    expect(spans[1].name).toBe('red_2');
+  });
+
+  it('should deduplicate only duplicate names, leaving unique names unchanged', () => {
+    const spans = [createTestSpan('red'), createTestSpan('red'), createTestSpan('blue')];
+
+    deduplicateSpanNamesInPlace(spans);
+
+    expect(spans[0].name).toBe('red_1');
+    expect(spans[1].name).toBe('red_2');
+    expect(spans[2].name).toBe('blue');
+  });
+
+  it('should handle multiple sets of duplicates', () => {
+    const spans = [
+      createTestSpan('red'),
+      createTestSpan('blue'),
+      createTestSpan('red'),
+      createTestSpan('green'),
+      createTestSpan('blue'),
+      createTestSpan('red')
+    ];
+    deduplicateSpanNamesInPlace(spans);
+
+    expect(spans[0].name).toBe('red_1');
+    expect(spans[1].name).toBe('blue_1');
+    expect(spans[2].name).toBe('red_2');
+    expect(spans[3].name).toBe('green');
+    expect(spans[4].name).toBe('blue_2');
+    expect(spans[5].name).toBe('red_3');
+  });
+
+  it('should handle spans with no duplicates', () => {
+    const spans = [createTestSpan('red'), createTestSpan('blue'), createTestSpan('green')];
+
+    deduplicateSpanNamesInPlace(spans);
+
+    expect(spans[0].name).toBe('red');
+    expect(spans[1].name).toBe('blue');
+    expect(spans[2].name).toBe('green');
+  });
+
+  it('should handle empty array', () => {
+    const spans: LiveSpan[] = [];
+
+    expect(() => deduplicateSpanNamesInPlace(spans)).not.toThrow();
+    expect(spans.length).toBe(0);
   });
 });

--- a/packages/typescript/tests/helper.ts
+++ b/packages/typescript/tests/helper.ts
@@ -1,0 +1,63 @@
+import { LiveSpan } from '../src/core/entities/span';
+import { SpanType } from '../src/core/constants';
+
+/**
+ * Mock OpenTelemetry span class for testing
+ */
+export class MockOtelSpan {
+  name: string;
+  attributes: Record<string, any>;
+  spanId: string;
+  traceId: string;
+
+  constructor(
+    name: string = 'test-span',
+    spanId: string = 'test-span-id',
+    traceId: string = 'test-trace-id'
+  ) {
+    this.name = name;
+    this.spanId = spanId;
+    this.traceId = traceId;
+    this.attributes = {};
+  }
+
+  getAttribute(key: string): any {
+    return this.attributes[key];
+  }
+
+  setAttribute(key: string, value: any): void {
+    this.attributes[key] = value;
+  }
+
+  spanContext() {
+    return {
+      spanId: this.spanId,
+      traceId: this.traceId
+    };
+  }
+}
+
+/**
+ * Create a mock OpenTelemetry span with the given parameters
+ */
+export function createMockOtelSpan(
+  name: string = 'test-span',
+  spanId: string = 'test-span-id',
+  traceId: string = 'test-trace-id'
+): MockOtelSpan {
+  return new MockOtelSpan(name, spanId, traceId);
+}
+
+/**
+ * Create a test LiveSpan with mock OpenTelemetry span
+ */
+export function createTestSpan(
+  name: string = 'test-span',
+  traceId: string = 'test-trace-id',
+  spanId: string = 'test-span-id',
+  spanType: SpanType = SpanType.UNKNOWN
+): LiveSpan {
+  const mockOtelSpan = createMockOtelSpan(name, spanId, traceId);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  return new LiveSpan(mockOtelSpan as any, traceId, spanType);
+}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16349?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16349/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16349/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16349/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Add `startSpan` API and trace manager (equivalent to Python's `client.start_span()` and `InMemoryTraceManager`. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
