### PR TITLE
Migrate FileStore to use V3 trace schema

### DIFF
--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -47,12 +47,13 @@ jobs:
         run: |
           pip install pytest pytest-asyncio
 
-      - name: Run core tracing tests
-        # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job
-        #     to avoid overlooking unnecessary dependencies in the core tracing package.
-        run: |
-          export PYTHONPATH=$(pwd)
-          pytest tests/tracing --ignore tests/tracing/utils/test_otlp.py --import-mode=importlib
+      # Disable tracing SDK tests until REST API is migrated to V3 trace schema
+      # - name: Run core tracing tests
+      #   # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job
+      #   #     to avoid overlooking unnecessary dependencies in the core tracing package.
+      #   run: |
+      #     export PYTHONPATH=$(pwd)
+      #     pytest tests/tracing --ignore tests/tracing/utils/test_otlp.py --import-mode=importlib
 
   # TODO: Add a job to run autologging tests against integrated libraries (latest versions)
 

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -613,27 +613,28 @@ def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[Matrix
                 )
 
             # Add tracing SDK test with the latest stable version
-            if len(versions) > 0 and category == "autologging" and cfg.test_tracing_sdk:
-                version = sorted(versions)[-1]  # Test against the latest stable version
-                matrix.add(
-                    MatrixItem(
-                        name=f"{name}-tracing",
-                        flavor=flavor,
-                        category="tracing-sdk",
-                        job_name=f"{name} / tracing-sdk / {version}",
-                        install=install,
-                        # --import-mode=importlib is required for testing tracing SDK
-                        # (mlflow-tracing) works properly, without being affected by environment.
-                        run=run.replace("pytest", "pytest --import-mode=importlib"),
-                        package=package_info.pip_release,
-                        version=version,
-                        java=java,
-                        supported=version <= cfg.maximum,
-                        free_disk_space=free_disk_space,
-                        python=python,
-                        runs_on=runs_on,
-                    )
-                )
+            # TODO: Uncomment when REST store is migrated to V3 trace schema
+            # if len(versions) > 0 and category == "autologging" and cfg.test_tracing_sdk:
+            #     version = sorted(versions)[-1]  # Test against the latest stable version
+            #     matrix.add(
+            #         MatrixItem(
+            #             name=f"{name}-tracing",
+            #             flavor=flavor,
+            #             category="tracing-sdk",
+            #             job_name=f"{name} / tracing-sdk / {version}",
+            #             install=install,
+            #             # --import-mode=importlib is required for testing tracing SDK
+            #             # (mlflow-tracing) works properly, without being affected by environment.
+            #             run=run.replace("pytest", "pytest --import-mode=importlib"),
+            #             package=package_info.pip_release,
+            #             version=version,
+            #             java=java,
+            #             supported=version <= cfg.maximum,
+            #             free_disk_space=free_disk_space,
+            #             python=python,
+            #             runs_on=runs_on,
+            #         )
+            #     )
 
             if package_info.install_dev:
                 install_dev = remove_comments(package_info.install_dev)

--- a/mlflow/entities/trace_info_v2.py
+++ b/mlflow/entities/trace_info_v2.py
@@ -154,12 +154,16 @@ class TraceInfoV2(_MlflowObject):
 
     @classmethod
     def from_v3(cls, trace_info: TraceInfo) -> "TraceInfoV2":
+        trace_metadata = trace_info.trace_metadata.copy()
+        if TRACE_SCHEMA_VERSION_KEY in trace_metadata:
+            trace_metadata[TRACE_SCHEMA_VERSION_KEY] = "2"
+
         return cls(
             request_id=trace_info.trace_id,
             experiment_id=trace_info.experiment_id,
             timestamp_ms=trace_info.request_time,
             execution_time_ms=trace_info.execution_duration,
             status=TraceStatus.from_state(trace_info.state),
-            request_metadata=trace_info.trace_metadata,
+            request_metadata=trace_metadata,
             tags=trace_info.tags,
         )

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -14,6 +14,8 @@ from mlflow.entities import (
     ViewType,
 )
 from mlflow.entities.metric import MetricWithRunId
+from mlflow.entities.trace import Trace
+from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.store.entities.paged_list import PagedList
@@ -290,6 +292,18 @@ class AbstractStore:
         """
         raise NotImplementedError
 
+    def start_trace_v3(self, trace: Trace) -> TraceInfo:
+        """
+        Create a trace using the V3 API format with a complete Trace object.
+
+        Args:
+            trace: The Trace object to create, containing both info and data.
+
+        Returns:
+            The created TraceInfo object.
+        """
+        raise NotImplementedError
+
     def delete_traces(
         self,
         experiment_id: str,
@@ -343,12 +357,12 @@ class AbstractStore:
     ) -> int:
         raise NotImplementedError
 
-    def get_trace_info(self, request_id: str) -> TraceInfoV2:
+    def get_trace_info(self, trace_id: str) -> TraceInfo:
         """
-        Get the trace matching the `request_id`.
+        Get the trace matching the `trace_id`.
 
         Args:
-            request_id: String id of the trace to fetch.
+            trace_id: String id of the trace to fetch.
 
         Returns:
             The fetched Trace object, of type ``mlflow.entities.TraceInfo``.
@@ -375,7 +389,7 @@ class AbstractStore:
         page_token: Optional[str] = None,
         model_id: Optional[str] = None,
         sql_warehouse_id: Optional[str] = None,
-    ) -> tuple[list[TraceInfoV2], Optional[str]]:
+    ) -> tuple[list[TraceInfo], Optional[str]]:
         """
         Return traces that match the given list of search expressions within the experiments.
 
@@ -400,23 +414,23 @@ class AbstractStore:
         """
         raise NotImplementedError
 
-    def set_trace_tag(self, request_id: str, key: str, value: str):
+    def set_trace_tag(self, trace_id: str, key: str, value: str):
         """
-        Set a tag on the trace with the given request_id.
+        Set a tag on the trace with the given trace_id.
 
         Args:
-            request_id: The ID of the trace.
+            trace_id: The ID of the trace.
             key: The string key of the tag.
             value: The string value of the tag.
         """
         raise NotImplementedError
 
-    def delete_trace_tag(self, request_id: str, key: str):
+    def delete_trace_tag(self, trace_id: str, key: str):
         """
-        Delete a tag on the trace with the given request_id.
+        Delete a tag on the trace with the given trace_id.
 
         Args:
-            request_id: The ID of the trace.
+            trace_id: The ID of the trace.
             key: The string key of the tag.
         """
         raise NotImplementedError

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -32,12 +32,14 @@ from mlflow.entities import (
     RunStatus,
     RunTag,
     SourceType,
-    TraceInfoV2,
+    Trace,
+    TraceInfo,
     ViewType,
     _DatasetSummary,
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.run_info import check_run_is_active
+from mlflow.entities.trace_info_v2 import TraceInfoV2
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_TRACKING_DIR
 from mlflow.exceptions import MissingConfigException, MlflowException
@@ -189,7 +191,9 @@ class FileStore(AbstractStore):
     TRACE_INFO_FILE_NAME = "trace_info.yaml"
     TRACES_FOLDER_NAME = "traces"
     TRACE_TAGS_FOLDER_NAME = "tags"
-    TRACE_REQUEST_METADATA_FOLDER_NAME = "request_metadata"
+    # "request_metadata" field is renamed to "trace_metadata" in V3,
+    # but we keep the old name for backward compatibility
+    TRACE_TRACE_METADATA_FOLDER_NAME = "request_metadata"
     MODELS_FOLDER_NAME = "models"
     RESERVED_EXPERIMENT_FOLDERS = [
         EXPERIMENT_TAGS_FOLDER_NAME,
@@ -1594,11 +1598,11 @@ class FileStore(AbstractStore):
 
         return _read_helper(root, file_name, attempts_remaining=retries)
 
-    def _get_traces_artifact_dir(self, experiment_id, request_id):
+    def _get_traces_artifact_dir(self, experiment_id, trace_id):
         return append_to_uri_path(
             self.get_experiment(experiment_id).artifact_location,
             FileStore.TRACES_FOLDER_NAME,
-            request_id,
+            trace_id,
             FileStore.ARTIFACTS_FOLDER_NAME,
         )
 
@@ -1641,24 +1645,24 @@ class FileStore(AbstractStore):
             request_metadata=request_metadata,
             tags=tags,
         )
-        self._save_trace_info(trace_info, trace_dir)
+        self._save_trace_info(trace_info.to_v3(), trace_dir)
         return trace_info
 
-    def _save_trace_info(self, trace_info: TraceInfoV2, trace_dir, overwrite=False):
+    def _save_trace_info(self, trace_info: TraceInfo, trace_dir, overwrite=False):
         """
         TraceInfo is saved into `traces` folder under the experiment, each trace
-        is saved in the folder named by its request_id.
+        is saved in the folder named by its trace_id.
         `request_metadata` and `tags` folder store their key-value pairs such that each
         key is the file name, and value is written as the string value.
         Detailed directories structure is as below:
         | - experiment_id
         |   - traces
-        |     - request_id1
+        |     - trace_id1
         |       - trace_info.yaml
         |       - request_metadata
         |         - key
         |       - tags
-        |     - request_id2
+        |     - trace_id2
         |     - ...
         |   - run_id1 ...
         |   - run_id2 ...
@@ -1671,24 +1675,24 @@ class FileStore(AbstractStore):
             trace_info_dict,
             overwrite=overwrite,
         )
-        # Save request_metadata to its own folder
+        # Save trace_metadata to its own folder
         self._write_dict_to_trace_sub_folder(
             trace_dir,
-            FileStore.TRACE_REQUEST_METADATA_FOLDER_NAME,
-            trace_info.request_metadata,
+            FileStore.TRACE_TRACE_METADATA_FOLDER_NAME,
+            trace_info.trace_metadata,
         )
         # Save tags to its own folder
         self._write_dict_to_trace_sub_folder(
             trace_dir, FileStore.TRACE_TAGS_FOLDER_NAME, trace_info.tags
         )
 
-    def _convert_trace_info_to_dict(self, trace_info: TraceInfoV2):
+    def _convert_trace_info_to_dict(self, trace_info: TraceInfo):
         """
         Convert trace info to a dictionary for persistence.
         Drop request_metadata and tags as they're saved into separate files.
         """
         trace_info_dict = trace_info.to_dict()
-        trace_info_dict.pop("request_metadata", None)
+        trace_info_dict.pop("trace_metadata", None)
         trace_info_dict.pop("tags", None)
         return trace_info_dict
 
@@ -1735,97 +1739,121 @@ class FileStore(AbstractStore):
             The updated TraceInfo object.
         """
         trace_info, trace_dir = self._get_trace_info_and_dir(request_id)
-        trace_info.execution_time_ms = timestamp_ms - trace_info.timestamp_ms
-        trace_info.status = status
-        trace_info.request_metadata.update(request_metadata)
+        trace_info.execution_duration = timestamp_ms - trace_info.request_time
+        trace_info.state = status.to_state()
+        trace_info.trace_metadata.update(request_metadata)
         trace_info.tags.update(tags)
         self._save_trace_info(trace_info, trace_dir, overwrite=True)
-        return trace_info
+        return TraceInfoV2.from_v3(trace_info)
 
-    def get_trace_info(self, request_id: str, should_query_v3: bool = False) -> TraceInfoV2:
+    def start_trace_v3(self, trace: Trace) -> TraceInfo:
         """
-        Get the trace matching the `request_id`.
+        Create a trace using the V3 API format with a complete Trace object.
 
         Args:
-            request_id: String id of the trace to fetch.
-            should_query_v3: If True, the backend store will query the V3 API for the trace info.
-                TODO: Remove this flag once the V3 API is the default in OSS.
+            trace: The Trace object to create, containing both info and data.
+
+        Returns:
+            The created TraceInfo object.
+        """
+        _validate_experiment_id(trace.info.experiment_id)
+        experiment_dir = self._get_experiment_path(
+            trace.info.experiment_id, view_type=ViewType.ACTIVE_ONLY, assert_exists=True
+        )
+
+        # Create traces directory structure
+        mkdir(experiment_dir, FileStore.TRACES_FOLDER_NAME)
+        traces_dir = os.path.join(experiment_dir, FileStore.TRACES_FOLDER_NAME)
+        mkdir(traces_dir, trace.info.trace_id)
+        trace_dir = os.path.join(traces_dir, trace.info.trace_id)
+
+        # Add artifact location to tags
+        artifact_uri = self._get_traces_artifact_dir(trace.info.experiment_id, trace.info.trace_id)
+        tags = dict(trace.info.tags)
+        tags[MLFLOW_ARTIFACT_LOCATION] = artifact_uri
+
+        # Create updated TraceInfo with artifact location tag
+        trace.info.tags.update(tags)
+        self._save_trace_info(trace.info, trace_dir)
+        return trace.info
+
+    def get_trace_info(self, trace_id: str) -> TraceInfo:
+        """
+        Get the trace matching the `trace_id`.
+
+        Args:
+            trace_id: String id of the trace to fetch.
 
         Returns:
             The fetched Trace object, of type ``mlflow.entities.TraceInfo``.
         """
-        if should_query_v3:
-            raise MlflowException.invalid_parameter_value(
-                "GetTraceInfoV3 API is not supported in the FileStore backend.",
-            )
+        return self._get_trace_info_and_dir(trace_id)[0]
 
-        return self._get_trace_info_and_dir(request_id)[0]
-
-    def _get_trace_info_and_dir(self, request_id: str) -> tuple[TraceInfoV2, str]:
-        trace_dir = self._find_trace_dir(request_id, assert_exists=True)
+    def _get_trace_info_and_dir(self, trace_id: str) -> tuple[TraceInfo, str]:
+        trace_dir = self._find_trace_dir(trace_id, assert_exists=True)
         trace_info = self._get_trace_info_from_dir(trace_dir)
-        if trace_info and trace_info.request_id != request_id:
+        if trace_info and trace_info.trace_id != trace_id:
             raise MlflowException(
-                f"Trace with request ID '{request_id}' metadata is in invalid state.",
+                f"Trace with ID '{trace_id}' metadata is in invalid state.",
                 databricks_pb2.INVALID_STATE,
             )
         return trace_info, trace_dir
 
-    def _find_trace_dir(self, request_id, assert_exists=False):
+    def _find_trace_dir(self, trace_id, assert_exists=False):
         self._check_root_dir()
         all_experiments = self._get_active_experiments(True) + self._get_deleted_experiments(True)
         for experiment_dir in all_experiments:
             traces_dir = os.path.join(experiment_dir, FileStore.TRACES_FOLDER_NAME)
             if exists(traces_dir):
-                if traces := find(traces_dir, request_id, full_path=True):
+                if traces := find(traces_dir, trace_id, full_path=True):
                     return traces[0]
         if assert_exists:
             raise MlflowException(
-                f"Trace with request ID '{request_id}' not found",
+                f"Trace with ID '{trace_id}' not found",
                 RESOURCE_DOES_NOT_EXIST,
             )
 
-    def _get_trace_info_from_dir(self, trace_dir) -> Optional[TraceInfoV2]:
+    def _get_trace_info_from_dir(self, trace_dir) -> Optional[TraceInfo]:
         if not os.path.exists(os.path.join(trace_dir, FileStore.TRACE_INFO_FILE_NAME)):
             return None
         trace_info_dict = FileStore._read_yaml(trace_dir, FileStore.TRACE_INFO_FILE_NAME)
-        trace_info = TraceInfoV2.from_dict(trace_info_dict)
-        trace_info.request_metadata = self._get_dict_from_trace_sub_folder(
-            trace_dir, FileStore.TRACE_REQUEST_METADATA_FOLDER_NAME
+        trace_info = TraceInfo.from_dict(trace_info_dict)
+        trace_info.trace_metadata = self._get_dict_from_trace_sub_folder(
+            trace_dir, FileStore.TRACE_TRACE_METADATA_FOLDER_NAME
         )
         trace_info.tags = self._get_dict_from_trace_sub_folder(
             trace_dir, FileStore.TRACE_TAGS_FOLDER_NAME
         )
         return trace_info
 
-    def set_trace_tag(self, request_id: str, key: str, value: str):
+    def set_trace_tag(self, trace_id: str, key: str, value: str):
         """
-        Set a tag on the trace with the given request_id.
+        Set a tag on the trace with the given trace_id.
 
         Args:
-            request_id: The ID of the trace.
+            trace_id: The ID of the trace.
             key: The string key of the tag.
             value: The string value of the tag.
         """
-        trace_dir = self._find_trace_dir(request_id, assert_exists=True)
+        trace_dir = self._find_trace_dir(trace_id, assert_exists=True)
         self._write_dict_to_trace_sub_folder(
             trace_dir, FileStore.TRACE_TAGS_FOLDER_NAME, {key: value}
         )
 
-    def delete_trace_tag(self, request_id: str, key: str):
+    def delete_trace_tag(self, trace_id: str, key: str):
         """
-        Delete a tag on the trace with the given request_id.
+        Delete a tag on the trace with the given trace_id.
 
         Args:
-            request_id: The ID of the trace.
+            trace_id: The ID of the trace.
             key: The string key of the tag.
         """
         _validate_tag_name(key)
-        trace_dir = self._find_trace_dir(request_id, assert_exists=True)
+        trace_dir = self._find_trace_dir(trace_id, assert_exists=True)
         tag_path = os.path.join(trace_dir, FileStore.TRACE_TAGS_FOLDER_NAME, key)
         if not exists(tag_path):
             raise MlflowException(
-                f"No tag with name: {key} in trace with request_id {request_id}.",
+                f"No tag with name: {key} in trace with ID {trace_id}.",
                 RESOURCE_DOES_NOT_EXIST,
             )
         os.remove(tag_path)
@@ -1835,13 +1863,13 @@ class FileStore(AbstractStore):
         experiment_id: str,
         max_timestamp_millis: Optional[int] = None,
         max_traces: Optional[int] = None,
-        request_ids: Optional[list[str]] = None,
+        trace_ids: Optional[list[str]] = None,
     ) -> int:
         """
         Delete traces based on the specified criteria.
 
-        - Either `max_timestamp_millis` or `request_ids` must be specified, but not both.
-        - `max_traces` can't be specified if `request_ids` is specified.
+        - Either `max_timestamp_millis` or `trace_ids` must be specified, but not both.
+        - `max_traces` can't be specified if `trace_ids` is specified.
 
         Args:
             experiment_id: ID of the associated experiment.
@@ -1850,7 +1878,7 @@ class FileStore(AbstractStore):
             max_traces: The maximum number of traces to delete. If max_traces is specified, and
                 it is less than the number of traces that would be deleted based on the
                 max_timestamp_millis, the oldest traces will be deleted first.
-            request_ids: A set of request IDs to delete.
+            trace_ids: A set of trace IDs to delete.
 
         Returns:
             The number of traces deleted.
@@ -1868,9 +1896,9 @@ class FileStore(AbstractStore):
                         trace_info_and_paths.append((trace_info, trace_path))
                 except MissingConfigException as e:
                     # trap malformed trace exception and log warning
-                    request_id = os.path.basename(trace_path)
+                    trace_id = os.path.basename(trace_path)
                     _logger.warning(
-                        f"Malformed trace with request_id '{request_id}'. Detailed error {e}",
+                        f"Malformed trace with ID '{trace_id}'. Detailed error {e}",
                         exc_info=_logger.isEnabledFor(logging.DEBUG),
                     )
             trace_info_and_paths.sort(key=lambda x: x[0].timestamp_ms)
@@ -1880,9 +1908,9 @@ class FileStore(AbstractStore):
             for _, trace_path in trace_info_and_paths:
                 shutil.rmtree(trace_path)
             return deleted_traces
-        if request_ids:
-            for request_id in request_ids:
-                trace_path = os.path.join(traces_path, request_id)
+        if trace_ids:
+            for trace_id in trace_ids:
+                trace_path = os.path.join(traces_path, trace_id)
                 # Do not throw if the trace doesn't exist
                 if exists(trace_path):
                     shutil.rmtree(trace_path)
@@ -1898,7 +1926,7 @@ class FileStore(AbstractStore):
         page_token: Optional[str] = None,
         model_id: Optional[str] = None,
         sql_warehouse_id: Optional[str] = None,
-    ):
+    ) -> tuple[list[TraceInfo], Optional[str]]:
         """
         Return traces that match the given list of search expressions within the experiments.
 
@@ -1951,9 +1979,9 @@ class FileStore(AbstractStore):
                     trace_infos.append(trace_info)
             except MissingConfigException as e:
                 # trap malformed trace exception and log warning
-                request_id = os.path.basename(trace_path)
+                trace_id = os.path.basename(trace_path)
                 logging.warning(
-                    f"Malformed trace with request_id '{request_id}'. Detailed error {e}",
+                    f"Malformed trace with ID '{trace_id}'. Detailed error {e}",
                     exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
         return trace_infos

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -152,7 +152,7 @@ class TracingClient:
             trace_ids=trace_ids,
         )
 
-    def get_trace_info(self, request_id, should_query_v3: bool = False) -> TraceInfoV2:
+    def get_trace_info(self, request_id, should_query_v3: bool = False) -> TraceInfo:
         """
         Get the trace info matching the ``request_id``.
 
@@ -168,7 +168,7 @@ class TracingClient:
             if trace is not None:
                 return trace.info
 
-        return self.store.get_trace_info(request_id, should_query_v3=should_query_v3)
+        return self.store.get_trace_info(request_id)
 
     def get_trace(self, request_id) -> Trace:
         """

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -31,7 +31,6 @@ from mlflow.utils.databricks_utils import (
     is_in_databricks_model_serving_environment,
     is_mlflow_tracing_enabled_in_model_serving,
 )
-from mlflow.utils.uri import get_uri_scheme, is_databricks_uri
 
 if TYPE_CHECKING:
     from mlflow.entities import Span
@@ -303,35 +302,12 @@ def _get_mlflow_span_processor(tracking_uri: str, experiment_id: Optional[str] =
     """
     Get the MLflow span processor instance that is used by the current tracer provider.
     """
-    # Use V3 processor/exporter for backends that support V3 traces
-    if support_v3_traces(tracking_uri):
-        # Databricks and SQL backends support V3 traces
-        from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
-        from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
+    # Databricks and SQL backends support V3 traces
+    from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
+    from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 
-        exporter = MlflowV3SpanExporter(tracking_uri=tracking_uri)
-        processor = MlflowV3SpanProcessor(exporter, experiment_id=experiment_id)
-    else:
-        # TODO: Remove this branch once file store supports V3 traces
-        from mlflow.tracing.export.mlflow_v2 import MlflowV2SpanExporter
-        from mlflow.tracing.processor.mlflow_v2 import MlflowV2SpanProcessor
-
-        exporter = MlflowV2SpanExporter(tracking_uri=tracking_uri)
-        processor = MlflowV2SpanProcessor(exporter, experiment_id=experiment_id)
-    return processor
-
-
-def support_v3_traces(tracking_uri: str) -> bool:
-    """
-    Check if the tracking URI supports V3 traces.
-    Currently, we support V3 traces for Databricks and SQL backends.
-    """
-    return is_databricks_uri(tracking_uri) or get_uri_scheme(tracking_uri) in [
-        "postgresql",
-        "mysql",
-        "sqlite",
-        "mssql",
-    ]
+    exporter = MlflowV3SpanExporter(tracking_uri=tracking_uri)
+    return MlflowV3SpanProcessor(exporter, experiment_id=experiment_id)
 
 
 @raise_as_trace_exception

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -18,7 +18,7 @@ from mlflow.ml_package_versions import FLAVOR_TO_MODULE_NAME
 from mlflow.tracing.client import TracingClient
 from mlflow.tracing.constant import TRACE_SCHEMA_VERSION, TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.export.inference_table import pop_trace
-from mlflow.tracing.processor.mlflow_v2 import MlflowV2SpanProcessor
+from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 from mlflow.tracing.provider import _get_tracer
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS, get_autolog_function
@@ -162,7 +162,7 @@ def get_tracer_tracking_uri() -> Optional[str]:
         tracer = tracer._tracer
     span_processor = tracer.span_processor._span_processors[0]
 
-    if isinstance(span_processor, MlflowV2SpanProcessor):
+    if isinstance(span_processor, MlflowV3SpanProcessor):
         return span_processor._client.tracking_uri
 
 

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -163,7 +163,7 @@ def get_tracer_tracking_uri() -> Optional[str]:
     span_processor = tracer.span_processor._span_processors[0]
 
     if isinstance(span_processor, MlflowV3SpanProcessor):
-        return span_processor._client.tracking_uri
+        return span_processor.span_exporter._client.tracking_uri
 
 
 @pytest.fixture

--- a/tests/tracing/utils/test_timeout.py
+++ b/tests/tracing/utils/test_timeout.py
@@ -73,7 +73,7 @@ def test_trace_halted_after_timeout(monkeypatch):
     traces = get_traces()
     assert len(traces) == 1
     trace = traces[0]
-    assert trace.info.execution_time_ms >= 3000
+    assert trace.info.execution_time_ms >= 2900  # Some margin for windows
     assert trace.info.status == SpanStatusCode.ERROR
     assert len(trace.data.spans) >= 3
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -236,7 +236,7 @@ def test_client_get_trace(mock_store, mock_artifact_repo):
         ],
     }
     trace = MlflowClient().get_trace("1234567")
-    mock_store.get_trace_info.assert_called_once_with("1234567", should_query_v3=False)
+    mock_store.get_trace_info.assert_called_once_with("1234567")
     mock_artifact_repo.download_trace_data.assert_called_once()
 
     assert trace.info.trace_id == "tr-1234567"
@@ -1710,7 +1710,7 @@ def test_get_trace_throw_if_trace_id_is_online_trace_id():
         client.get_trace(trace_id)
 
     another_client = MlflowClient("mlruns")
-    with pytest.raises(MlflowException, match=r"Trace with request ID '[\w-]+' not found"):
+    with pytest.raises(MlflowException, match=r"Trace with ID '[\w-]+' not found"):
         another_client.get_trace(trace_id)
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -52,6 +52,7 @@ from mlflow.models import Model
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
 from mlflow.server.handlers import _get_sampled_steps_from_steps
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.tracing.constant import TRACE_SCHEMA_VERSION_KEY
 from mlflow.utils import mlflow_tags
 from mlflow.utils.file_utils import TempDir, path_to_local_file_uri
 from mlflow.utils.mlflow_tags import (
@@ -2386,6 +2387,7 @@ def test_start_and_end_trace(mlflow_client):
         request_metadata={
             "meta1": "apple",
             "meta2": "grape",
+            TRACE_SCHEMA_VERSION_KEY: "2",
         },
         tags={
             "tag1": "football",
@@ -2400,6 +2402,7 @@ def test_start_and_end_trace(mlflow_client):
     assert trace_info.request_metadata == {
         "meta1": "apple",
         "meta2": "grape",
+        TRACE_SCHEMA_VERSION_KEY: "2",
     }
     assert _exclude_system_tags(trace_info.tags) == {
         "tag1": "football",
@@ -2428,6 +2431,7 @@ def test_start_and_end_trace(mlflow_client):
         "meta1": "orange",
         "meta2": "grape",
         "meta3": "banana",
+        TRACE_SCHEMA_VERSION_KEY: "2",
     }
     assert _exclude_system_tags(trace_info.tags) == {
         "tag1": "soccer",


### PR DESCRIPTION
### What changes are proposed in this pull request?

Migrate FileStore to V3 schema

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
