### PR TITLE
Experiment home view fixes

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -58,7 +58,7 @@ export const MlflowRouter = ({
               backgroundColor: theme.colors.backgroundSecondary,
               display: 'flex',
               flexDirection: 'row',
-              height: '100%',
+              minHeight: 'calc(100% - 60px)', // 60px comes from header height
               justifyContent: 'stretch',
             }}
           >

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -24,9 +24,7 @@ import Routes from '../../experiment-tracking/routes';
 import { FormattedMessage } from 'react-intl';
 
 const isExperimentsActive = (location: Location) =>
-  matchPath('/', location.pathname) ||
-  matchPath('/experiments/*', location.pathname) ||
-  matchPath('/compare-experiments/*', location.pathname);
+  matchPath('/experiments/*', location.pathname) || matchPath('/compare-experiments/*', location.pathname);
 const isModelsActive = (location: Location) => matchPath('/models/*', location.pathname);
 const isPromptsActive = (location: Location) => matchPath('/prompts/*', location.pathname);
 

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -41,29 +41,65 @@ export function MlflowSidebar() {
     onSuccess: ({ promptName }) => navigate(Routes.getPromptDetailsPageRoute(promptName)),
   });
 
-  const ulStyles: Interpolation<Theme> = {
-    listStyleType: 'none',
-    padding: 0,
-    margin: 0,
-  };
-
-  const linkStyles: Interpolation<Theme> = {
-    display: 'flex',
-    alignItems: 'center',
-    gap: theme.spacing.sm,
-    color: theme.colors.textPrimary,
-    paddingInline: theme.spacing.md,
-    paddingBlock: theme.spacing.xs,
-    borderRadius: theme.borders.borderRadiusSm,
-    '&:hover': {
-      color: theme.colors.actionLinkHover,
+  const menuItems = [
+    {
+      key: 'experiments',
+      icon: <BeakerIcon />,
+      linkProps: {
+        to: ExperimentTrackingRoutes.experimentsObservatoryRoute,
+        isActive: isExperimentsActive,
+        children: <FormattedMessage defaultMessage="Experiments" description="Sidebar link for experiments tab" />,
+      },
+      dropdownProps: {
+        componentId: 'mlflow_sidebar.create_experiment_button',
+        onClick: () => setShowCreateExperimentModal(true),
+        children: (
+          <FormattedMessage
+            defaultMessage="Experiment"
+            description="Sidebar button inside the 'new' popover to create new experiment"
+          />
+        ),
+      },
     },
-    '&[aria-current="page"]': {
-      backgroundColor: theme.colors.actionDefaultBackgroundPress,
-      color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
-      fontWeight: theme.typography.typographyBoldFontWeight,
+    {
+      key: 'models',
+      icon: <ModelsIcon />,
+      linkProps: {
+        to: ModelRegistryRoutes.modelListPageRoute,
+        isActive: isModelsActive,
+        children: <FormattedMessage defaultMessage="Models" description="Sidebar link for models tab" />,
+      },
+      dropdownProps: {
+        componentId: 'mlflow_sidebar.create_model_button',
+        onClick: () => setShowCreateModelModal(true),
+        children: (
+          <FormattedMessage
+            defaultMessage="Model"
+            description="Sidebar button inside the 'new' popover to create new model"
+          />
+        ),
+      },
     },
-  };
+    {
+      key: 'prompts',
+      icon: <TextBoxIcon />,
+      linkProps: {
+        to: ExperimentTrackingRoutes.promptsPageRoute,
+        isActive: isPromptsActive,
+        children: <FormattedMessage defaultMessage="Prompts" description="Sidebar link for prompts tab" />,
+      },
+      dropdownProps: {
+        componentId: 'mlflow_sidebar.create_prompt_button',
+        onClick: openCreatePromptModal,
+        children: (
+          <FormattedMessage
+            defaultMessage="Prompt"
+            description="Sidebar button inside the 'new' popover to create new prompt"
+          />
+        ),
+      },
+    },
+  ];
 
   return (
     <aside
@@ -87,74 +123,51 @@ export function MlflowSidebar() {
         </DropdownMenu.Trigger>
 
         <DropdownMenu.Content side="right" sideOffset={theme.spacing.sm} align="start">
-          <DropdownMenu.Item
-            componentId="mlflow_sidebar.create_experiment_button"
-            onClick={() => setShowCreateExperimentModal(true)}
-          >
-            <DropdownMenu.IconWrapper>
-              <BeakerIcon />
-            </DropdownMenu.IconWrapper>
-            <FormattedMessage
-              defaultMessage="Experiment"
-              description="Sidebar button inside the 'new' popover to create new experiment"
-            />
-          </DropdownMenu.Item>
-          <DropdownMenu.Item
-            componentId="mlflow_sidebar.create_model_button"
-            onClick={() => setShowCreateModelModal(true)}
-          >
-            <DropdownMenu.IconWrapper>
-              <ModelsIcon />
-            </DropdownMenu.IconWrapper>
-            <FormattedMessage
-              defaultMessage="Model"
-              description="Sidebar button inside the 'new' popover to create new model"
-            />
-          </DropdownMenu.Item>
-          <DropdownMenu.Item componentId="mlflow_sidebar.create_prompt_button" onClick={openCreatePromptModal}>
-            <DropdownMenu.IconWrapper>
-              <TextBoxIcon />
-            </DropdownMenu.IconWrapper>
-            <FormattedMessage
-              defaultMessage="Prompt"
-              description="Sidebar button inside the 'new' popover to create new prompt"
-            />
-          </DropdownMenu.Item>
+          {menuItems.map(({ key, icon, dropdownProps }) => (
+            <DropdownMenu.Item key={key} componentId={dropdownProps.componentId} onClick={dropdownProps.onClick}>
+              <DropdownMenu.IconWrapper>{icon}</DropdownMenu.IconWrapper>
+              {dropdownProps.children}
+            </DropdownMenu.Item>
+          ))}
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
       <nav>
-        <ul css={ulStyles}>
-          <li>
-            <Link
-              to={ExperimentTrackingRoutes.experimentsObservatoryRoute}
-              aria-current={isExperimentsActive(location) ? 'page' : undefined}
-              css={linkStyles}
-            >
-              <BeakerIcon />
-              <FormattedMessage defaultMessage="Experiments" description="Sidebar link for experiments tab" />
-            </Link>
-          </li>
-          <li>
-            <Link
-              to={ModelRegistryRoutes.modelListPageRoute}
-              aria-current={isModelsActive(location) ? 'page' : undefined}
-              css={linkStyles}
-            >
-              <ModelsIcon />
-              <FormattedMessage defaultMessage="Models" description="Sidebar link for models tab" />
-            </Link>
-          </li>
-          <li>
-            <Link
-              to={ExperimentTrackingRoutes.promptsPageRoute}
-              aria-current={isPromptsActive(location) ? 'page' : undefined}
-              css={linkStyles}
-            >
-              <TextBoxIcon />
-              <FormattedMessage defaultMessage="Prompts" description="Sidebar link for prompts tab" />
-            </Link>
-          </li>
+        <ul
+          css={{
+            listStyleType: 'none',
+            padding: 0,
+            margin: 0,
+          }}
+        >
+          {menuItems.map(({ key, icon, linkProps }) => (
+            <li key={key}>
+              <Link
+                to={linkProps.to}
+                aria-current={linkProps.isActive(location) ? 'page' : undefined}
+                css={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: theme.spacing.sm,
+                  color: theme.colors.textPrimary,
+                  paddingInline: theme.spacing.md,
+                  paddingBlock: theme.spacing.xs,
+                  borderRadius: theme.borders.borderRadiusSm,
+                  '&:hover': {
+                    color: theme.colors.actionLinkHover,
+                  },
+                  '&[aria-current="page"]': {
+                    backgroundColor: theme.colors.actionDefaultBackgroundPress,
+                    color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+                    fontWeight: theme.typography.typographyBoldFontWeight,
+                  },
+                }}
+              >
+                {icon}
+                {linkProps.children}
+              </Link>
+            </li>
+          ))}
         </ul>
       </nav>
 

--- a/mlflow/server/js/src/common/components/PageContainer.tsx
+++ b/mlflow/server/js/src/common/components/PageContainer.tsx
@@ -34,7 +34,7 @@ PageContainer.defaultProps = {
 
 const styles = {
   useFullHeightLayout: {
-    height: 'calc(100% - 60px)', // 60px comes from header height
+    height: '100%',
     display: 'flex',
     flexDirection: 'column',
     '&:last-child': {

--- a/mlflow/server/js/src/common/components/ScrollablePageWrapper.tsx
+++ b/mlflow/server/js/src/common/components/ScrollablePageWrapper.tsx
@@ -7,7 +7,7 @@ export const ScrollablePageWrapper = ({ children, className }: { children: React
   return (
     <PageWrapper
       // Subtract header height
-      css={{ height: 'calc(100% - 60px)' }}
+      css={{ height: '100%' }}
       className={className}
     >
       {children}

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListPage.tsx
@@ -1,0 +1,10 @@
+import ExperimentListView from './ExperimentListView';
+import { useSearchFilter } from './experiment-page/hooks/useSearchFilter';
+
+const ExperimentListPage = () => {
+  const [searchFilter, setSearchFilter] = useSearchFilter();
+
+  return <ExperimentListView searchFilter={searchFilter} setSearchFilter={setSearchFilter} />;
+};
+
+export default ExperimentListPage;

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -10,6 +10,7 @@ import {
   TableHeader,
   TableCell,
   CursorPaginationProps,
+  TableSkeletonRows,
 } from '@databricks/design-system';
 import 'react-virtualized/styles.css';
 import { ExperimentEntity } from '../types';
@@ -86,12 +87,14 @@ const useExperimentsTableColumns = () => {
 export const ExperimentListTable = ({
   experiments,
   isFiltered,
+  isLoading,
   rowSelection,
   setRowSelection,
   cursorPaginationProps,
 }: {
   experiments?: ExperimentEntity[];
   isFiltered?: boolean;
+  isLoading: boolean;
   rowSelection: RowSelectionState;
   setRowSelection: OnChangeFn<RowSelectionState>;
   cursorPaginationProps: Omit<CursorPaginationProps, 'componentId'>;
@@ -111,7 +114,7 @@ export const ExperimentListTable = ({
   });
 
   const getEmptyState = () => {
-    const isEmptyList = isEmpty(experiments);
+    const isEmptyList = !isLoading && isEmpty(experiments);
     if (isEmptyList && isFiltered) {
       return (
         <Empty
@@ -167,18 +170,22 @@ export const ExperimentListTable = ({
           </TableHeader>
         ))}
       </TableRow>
-      {table.getRowModel().rows.map((row) => (
-        <TableRow key={row.id} css={{ height: theme.general.buttonHeight }} data-testid="experiment-list-item">
-          {row.getAllCells().map((cell) => (
-            <TableCell
-              key={cell.id}
-              css={{ alignItems: 'center', ...(cell.column.id === 'select' ? selectColumnStyles : undefined) }}
-            >
-              {flexRender(cell.column.columnDef.cell, cell.getContext())}
-            </TableCell>
-          ))}
-        </TableRow>
-      ))}
+      {isLoading ? (
+        <TableSkeletonRows table={table} />
+      ) : (
+        table.getRowModel().rows.map((row) => (
+          <TableRow key={row.id} css={{ height: theme.general.buttonHeight }} data-testid="experiment-list-item">
+            {row.getAllCells().map((cell) => (
+              <TableCell
+                key={cell.id}
+                css={{ alignItems: 'center', ...(cell.column.id === 'select' ? selectColumnStyles : undefined) }}
+              >
+                {flexRender(cell.column.columnDef.cell, cell.getContext())}
+              </TableCell>
+            ))}
+          </TableRow>
+        ))
+      )}
     </Table>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.tsx
@@ -24,7 +24,7 @@ const ExperimentPage = () => {
       {shouldRenderTabbedView && <ExperimentPageTabs />}
       {!shouldRenderTabbedView && (
         // Main content with the experiment view
-        <div css={{ height: '100%', flex: 1, padding: theme.spacing.md, paddingTop: theme.spacing.lg }}>
+        <div css={{ height: '100%', flex: 1, padding: theme.spacing.md }}>
           <GetExperimentsContextProvider actions={getExperimentActions}>
             <ExperimentView />
           </GetExperimentsContextProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
@@ -1,10 +1,8 @@
-import ExperimentListView from './ExperimentListView';
-import { useSearchFilter } from './experiment-page/hooks/useSearchFilter';
+import { Navigate } from '../../common/utils/RoutingUtils';
+import Routes from '../routes';
 
 const HomePage = () => {
-  const [searchFilter, setSearchFilter] = useSearchFilter();
-
-  return <ExperimentListView searchFilter={searchFilter} setSearchFilter={setSearchFilter} />;
+  return <Navigate to={Routes.experimentsObservatoryRoute} />;
 };
 
 export default HomePage;

--- a/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/HomePage.tsx
@@ -1,46 +1,10 @@
 import ExperimentListView from './ExperimentListView';
-import { useExperimentListQuery } from './experiment-page/hooks/useExperimentListQuery';
 import { useSearchFilter } from './experiment-page/hooks/useSearchFilter';
-import { Spinner } from '@databricks/design-system';
 
 const HomePage = () => {
   const [searchFilter, setSearchFilter] = useSearchFilter();
-  const {
-    data: experiments,
-    error,
-    isLoading,
-    hasNextPage,
-    hasPreviousPage,
-    onNextPage,
-    onPreviousPage,
-    pageSizeSelect,
-  } = useExperimentListQuery({ searchFilter });
 
-  const loadingState = (
-    <div css={{ height: '100%', display: 'flex', justifyContent: 'center', alignItems: 'center' }}>
-      <Spinner size="large" />
-    </div>
-  );
-
-  if (isLoading) {
-    return loadingState;
-  }
-
-  return (
-    <ExperimentListView
-      experiments={experiments || []}
-      error={error}
-      searchFilter={searchFilter}
-      setSearchFilter={setSearchFilter}
-      cursorPaginationProps={{
-        hasNextPage,
-        hasPreviousPage,
-        onNextPage,
-        onPreviousPage,
-        pageSizeSelect,
-      }}
-    />
-  );
+  return <ExperimentListView searchFilter={searchFilter} setSearchFilter={setSearchFilter} />;
 };
 
 export default HomePage;

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -21,7 +21,7 @@ export const getRouteDefs = () => [
   {
     path: RoutePaths.experimentObservatory,
     element: createLazyRouteElement(() => {
-      return import('./components/HomePage');
+      return import('./components/ExperimentListPage');
     }),
     pageId: 'mlflow.experiment.list',
   },

--- a/mlflow/server/js/src/model-registry/components/ModelListPage.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelListPage.tsx
@@ -20,9 +20,7 @@ import { searchRegisteredModelsApi } from '../actions';
 import LocalStorageUtils from '../../common/utils/LocalStorageUtils';
 import { withRouterNext } from '../../common/utils/withRouterNext';
 import type { WithRouterNextProps } from '../../common/utils/withRouterNext';
-import { ScrollablePageWrapper } from '../../common/components/ScrollablePageWrapper';
 import { createMLflowRoutePath } from '../../common/utils/RoutingUtils';
-import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
 
 type ModelListPageImplProps = WithRouterNextProps & {
   models?: any[];
@@ -301,25 +299,23 @@ export class ModelListPageImpl extends React.Component<ModelListPageImplProps, M
     } = this.state;
     const { models } = this.props;
     return (
-      <ScrollablePageWrapper>
-        <ModelListView
-          // @ts-expect-error TS(2322): Type '{ models: any[] | undefined; loading: any; e... Remove this comment to see the full error message
-          models={models}
-          loading={this.state.loading}
-          error={this.state.error}
-          searchInput={searchInput}
-          orderByKey={orderByKey}
-          orderByAsc={orderByAsc}
-          currentPage={currentPage}
-          nextPageToken={pageTokens[currentPage + 1]}
-          onSearch={this.handleSearch}
-          onClickNext={this.handleClickNext}
-          onClickPrev={this.handleClickPrev}
-          onClickSortableColumn={this.handleClickSortableColumn}
-          onSetMaxResult={this.handleMaxResultsChange}
-          maxResultValue={this.getMaxResultsSelection()}
-        />
-      </ScrollablePageWrapper>
+      <ModelListView
+        // @ts-expect-error TS(2322): Type '{ models: any[] | undefined; loading: any; e... Remove this comment to see the full error message
+        models={models}
+        loading={this.state.loading}
+        error={this.state.error}
+        searchInput={searchInput}
+        orderByKey={orderByKey}
+        orderByAsc={orderByAsc}
+        currentPage={currentPage}
+        nextPageToken={pageTokens[currentPage + 1]}
+        onSearch={this.handleSearch}
+        onClickNext={this.handleClickNext}
+        onClickPrev={this.handleClickPrev}
+        onClickSortableColumn={this.handleClickSortableColumn}
+        onSetMaxResult={this.handleMaxResultsChange}
+        maxResultValue={this.getMaxResultsSelection()}
+      />
     );
   }
 }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16390?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16390/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16390/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16390/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve -->
Based on #16359, should be rebased and merged after it. [See the actual work done here.](https://github.com/mlflow/mlflow/pull/16390/files/c63bf143d98ee6955f347263498c37fd6021b4b1..87015fc591374cbee736fadff1a7cfee90ee56d6)

### What changes are proposed in this pull request?

1. Fixed styling inconsistencies seen when changing tabs, like spacing and height
2. Removed loading state handling from experiments home page to experiments table. Handling it at page level was causing persistent UI elements such as pagination and subpage header to be unloaded when the next page was requested. This allowed me to move data query logic down, reducing prop drilling.
3. Renamed `HomePage` to `ExperimentListPage` and added a separate `HomePage` that redirects to experiment observatory.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
