### PR TITLE
Add lint rule to enforce parameterized generic types

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -291,21 +291,21 @@ class TypeAnnotationVisitor(ast.NodeVisitor):
             self.linter._check(Location.from_node(node), rules.IncorrectTypeAnnotation(node.id))
 
         if self._is_bare_generic_type(node):
-            self.linter._check(Location.from_node(node), rules.UnparameterizedGeneric(node.id))
+            self.linter._check(Location.from_node(node), rules.UnparameterizedGenericType(node.id))
 
         self.generic_visit(node)
 
     def visit_Attribute(self, node):
         if self._is_bare_generic_type(node):
             self.linter._check(
-                Location.from_node(node), rules.UnparameterizedGeneric(ast.unparse(node))
+                Location.from_node(node), rules.UnparameterizedGenericType(ast.unparse(node))
             )
 
         self.generic_visit(node)
 
     def _is_bare_generic_type(self, node: ast.Name | ast.Attribute) -> bool:
         """Check if this Name node represents a bare generic type (not parameterized)."""
-        if not rules.UnparameterizedGeneric.is_generic_type(node, self.linter.resolver):
+        if not rules.UnparameterizedGenericType.is_generic_type(node, self.linter.resolver):
             return False
 
         # Check if this Name is the value of a Subscript (e.g., the 'dict' in 'dict[str, int]')

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -720,7 +720,7 @@ class Linter(ast.NodeVisitor):
             self._check(Location.from_node(node), rules.OsEnvironDeleteInTest())
         self.generic_visit(node)
 
-    def visit_type_annotation(self, node: ast.AST) -> None:
+    def visit_type_annotation(self, node: ast.expr) -> None:
         visitor = TypeAnnotationVisitor(self)
         visitor.visit(node)
 

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -295,9 +295,17 @@ class TypeAnnotationVisitor(ast.NodeVisitor):
 
         self.generic_visit(node)
 
-    def _is_bare_generic_type(self, node: ast.Name) -> bool:
+    def visit_Attribute(self, node):
+        if self._is_bare_generic_type(node):
+            self.linter._check(
+                Location.from_node(node), rules.UnparameterizedGeneric(ast.unparse(node))
+            )
+
+        self.generic_visit(node)
+
+    def _is_bare_generic_type(self, node: ast.Name | ast.Attribute) -> bool:
         """Check if this Name node represents a bare generic type (not parameterized)."""
-        if node.id not in rules.UnparameterizedGeneric.UNPARAMETERIZED_TYPES:
+        if not rules.UnparameterizedGeneric.is_generic_type(node, self.linter.resolver):
             return False
 
         # Check if this Name is the value of a Subscript (e.g., the 'dict' in 'dict[str, int]')

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -445,6 +445,30 @@ class InvalidExperimentalDecorator(Rule):
         return False
 
 
+class UnparameterizedGeneric(Rule):
+    UNPARAMETERIZED_TYPES = {
+        "dict",
+        "list",
+        "set",
+        "tuple",
+        "frozenset",
+        "Callable",
+    }
+
+    def __init__(self, type_hint: str) -> None:
+        self.type_hint = type_hint
+
+    @staticmethod
+    def check(node: ast.Name) -> bool:
+        return node.id in UnparameterizedGeneric.UNPARAMETERIZED_TYPES
+
+    def _message(self) -> str:
+        return (
+            f"Generic type `{self.type_hint}` must be parameterized "
+            "(e.g., `list[str]` rather than `list`)."
+        )
+
+
 class DoNotDisable(Rule):
     DO_NOT_DISABLE = {"B006"}
 

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -446,22 +446,25 @@ class InvalidExperimentalDecorator(Rule):
 
 
 class UnparameterizedGeneric(Rule):
-    UNPARAMETERIZED_TYPES = {
-        "dict",
-        "list",
-        "set",
-        "tuple",
-        "frozenset",
-        "Callable",
-        "Sequence",
-    }
-
     def __init__(self, type_hint: str) -> None:
         self.type_hint = type_hint
 
     @staticmethod
-    def check(node: ast.Name) -> bool:
-        return node.id in UnparameterizedGeneric.UNPARAMETERIZED_TYPES
+    def is_generic_type(node: ast.Name | ast.Attribute, resolver: Resolver) -> bool:
+        if resolved := resolver.resolve(node):
+            return tuple(resolved) in {
+                ("typing", "Callable"),
+                ("typing", "Sequence"),
+            }
+        elif isinstance(node, ast.Name):
+            return node.id in {
+                "dict",
+                "list",
+                "set",
+                "tuple",
+                "frozenset",
+            }
+        return False
 
     def _message(self) -> str:
         return (

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -445,7 +445,7 @@ class InvalidExperimentalDecorator(Rule):
         return False
 
 
-class UnparameterizedGeneric(Rule):
+class UnparameterizedGenericType(Rule):
     def __init__(self, type_hint: str) -> None:
         self.type_hint = type_hint
 

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -453,6 +453,7 @@ class UnparameterizedGeneric(Rule):
         "tuple",
         "frozenset",
         "Callable",
+        "Sequence",
     }
 
     def __init__(self, type_hint: str) -> None:

--- a/docs/docs/classic-ml/deep-learning/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
+++ b/docs/docs/classic-ml/deep-learning/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,3 +586,4 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
+

--- a/docs/docs/classic-ml/deep-learning/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
+++ b/docs/docs/classic-ml/deep-learning/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
@@ -586,4 +586,3 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
-

--- a/docs/docs/classic-ml/deep-learning/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
+++ b/docs/docs/classic-ml/deep-learning/sentence-transformers/tutorials/paraphrase-mining/paraphrase-mining-sentence-transformers.ipynb
@@ -71,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +101,10 @@
     "            raise ValueError(f\"Error loading model and corpus: {e}\")\n",
     "\n",
     "    def _sort_and_filter_matches(\n",
-    "        self, query: str, paraphrase_pairs: list[tuple], similarity_threshold: float\n",
+    "        self,\n",
+    "        query: str,\n",
+    "        paraphrase_pairs: list[tuple[float, int, int]],\n",
+    "        similarity_threshold: float,\n",
     "    ):\n",
     "        \"\"\"Sort and filter the matches by similarity score.\"\"\"\n",
     "\n",

--- a/examples/promptflow/basic/_utils.py
+++ b/examples/promptflow/basic/_utils.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional
+from typing import Any, Optional
 
 
 def try_parse_name_and_content(role_prompt):
@@ -56,7 +56,9 @@ def validate_role(role: str, valid_roles: Optional[list[str]] = None):
         raise ValueError(error_message)
 
 
-def parse_chat(chat_str, images: Optional[list] = None, valid_roles: Optional[list[str]] = None):
+def parse_chat(
+    chat_str, images: Optional[list[Any]] = None, valid_roles: Optional[list[str]] = None
+):
     if not valid_roles:
         valid_roles = ["system", "user", "assistant", "function"]
 

--- a/examples/promptflow/basic/hello.py
+++ b/examples/promptflow/basic/hello.py
@@ -1,5 +1,5 @@
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from _utils import parse_chat
 from openai import OpenAI
@@ -32,10 +32,10 @@ def my_python_tool(
     temperature: float = 1.0,
     top_p: float = 1.0,
     n: int = 1,
-    stop: Optional[list] = None,
+    stop: Optional[list[str]] = None,
     presence_penalty: float = 0,
     frequency_penalty: float = 0,
-    logit_bias: Optional[dict] = None,
+    logit_bias: Optional[dict[str, Any]] = None,
     user: str = "",
     **kwargs,
 ) -> str:

--- a/mlflow/anthropic/chat.py
+++ b/mlflow/anthropic/chat.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union
+from typing import Any, Union
 
 from pydantic import BaseModel
 
@@ -17,7 +17,7 @@ from mlflow.types.chat import (
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 
-def convert_message_to_mlflow_chat(message: Union[BaseModel, dict]) -> ChatMessage:
+def convert_message_to_mlflow_chat(message: Union[BaseModel, dict[str, Any]]) -> ChatMessage:
     """
     Convert Anthropic message object into MLflow's standard format (OpenAI compatible).
 
@@ -93,7 +93,7 @@ def convert_message_to_mlflow_chat(message: Union[BaseModel, dict]) -> ChatMessa
         )
 
 
-def _parse_content(content: Union[str, dict]) -> Union[TextContentPart, ImageContentPart]:
+def _parse_content(content: Union[str, dict[str, Any]]) -> Union[TextContentPart, ImageContentPart]:
     if isinstance(content, str):
         return TextContentPart(text=content, type="text")
 
@@ -122,7 +122,7 @@ def _parse_content(content: Union[str, dict]) -> Union[TextContentPart, ImageCon
         )
 
 
-def convert_tool_to_mlflow_chat_tool(tool: dict) -> ChatTool:
+def convert_tool_to_mlflow_chat_tool(tool: dict[str, Any]) -> ChatTool:
     """
     Convert Anthropic tool definition into MLflow's standard format (OpenAI compatible).
 

--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -6,7 +6,7 @@ import json
 import pathlib
 import posixpath
 import tempfile
-from typing import Optional
+from typing import Any, Optional
 
 from mlflow.entities.file_info import FileInfo
 from mlflow.exceptions import MlflowException
@@ -178,7 +178,7 @@ def load_text(artifact_uri: str) -> str:
                 raise MlflowException("Unable to form a str object from file content", BAD_REQUEST)
 
 
-def load_dict(artifact_uri: str) -> dict:
+def load_dict(artifact_uri: str) -> dict[str, Any]:
     """Loads the artifact contents as a dictionary.
 
     Args:

--- a/mlflow/bedrock/_autolog.py
+++ b/mlflow/bedrock/_autolog.py
@@ -172,7 +172,9 @@ def _patched_converse_stream(original, self, *args, **kwargs):
     return result
 
 
-def _set_chat_messages_attributes(span, messages: list[dict], response: Optional[dict]):
+def _set_chat_messages_attributes(
+    span, messages: list[dict[str, Any]], response: Optional[dict[str, Any]]
+):
     """
     Extract standard chat span attributes for the Bedrock Converse API call.
 

--- a/mlflow/bedrock/chat.py
+++ b/mlflow/bedrock/chat.py
@@ -1,7 +1,7 @@
 import base64
 import json
 import logging
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from mlflow.types.chat import (
     ChatMessage,
@@ -17,7 +17,7 @@ from mlflow.types.chat import (
 _logger = logging.getLogger(__name__)
 
 
-def convert_message_to_mlflow_chat(message: dict) -> ChatMessage:
+def convert_message_to_mlflow_chat(message: dict[str, Any]) -> ChatMessage:
     """
     Convert Bedrock Converse API's message object into MLflow's standard format (OpenAI compatible).
 
@@ -68,7 +68,7 @@ def convert_message_to_mlflow_chat(message: dict) -> ChatMessage:
     return message
 
 
-def _parse_content(content: dict) -> Optional[Union[TextContentPart, ImageContentPart]]:
+def _parse_content(content: dict[str, Any]) -> Optional[Union[TextContentPart, ImageContentPart]]:
     """
     Parse a single content block in the Bedrock message object.
 
@@ -99,7 +99,7 @@ def _parse_content(content: dict) -> Optional[Union[TextContentPart, ImageConten
         return None
 
 
-def convert_tool_to_mlflow_chat_tool(tool: dict) -> ChatTool:
+def convert_tool_to_mlflow_chat_tool(tool: dict[str, Any]) -> ChatTool:
     """
     Convert Bedrock tool definition into MLflow's standard format (OpenAI compatible).
 

--- a/mlflow/bedrock/stream.py
+++ b/mlflow/bedrock/stream.py
@@ -123,7 +123,7 @@ class _ConverseMessageBuilder:
         self._tool_use = {}
         self._response = {}
 
-    def process_event(self, event_name: str, event_attr: dict):
+    def process_event(self, event_name: str, event_attr: dict[str, Any]):
         if event_name == "messageStart":
             self._role = event_attr["role"]
         elif event_name == "contentBlockStart":

--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -123,7 +123,7 @@ def register_constructor(
     return registered_constructor_name
 
 
-def get_registered_constructors() -> dict[str, Callable[..., Any]]:
+def get_registered_constructors() -> dict[str, Callable[[Optional[str], Optional[str]], Dataset]]:
     """Obtains the registered dataset constructors.
 
     Returns:

--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 from contextlib import suppress
-from typing import Any, Callable, Optional
+from typing import Callable, Optional
 
 import mlflow.data
 from mlflow.data.dataset import Dataset
@@ -62,7 +62,10 @@ class DatasetRegistry:
                 )
 
     @staticmethod
-    def _validate_constructor(constructor_fn: Callable[..., Any], constructor_name: str):
+    def _validate_constructor(
+        constructor_fn: Callable[[Optional[str], Optional[str]], Dataset],
+        constructor_name: str,
+    ):
         if not constructor_name.startswith("load_") and not constructor_name.startswith("from_"):
             raise MlflowException(
                 f"Invalid dataset constructor name: {constructor_name}."
@@ -93,7 +96,8 @@ class DatasetRegistry:
 
 
 def register_constructor(
-    constructor_fn: Callable[..., Any], constructor_name: Optional[str] = None
+    constructor_fn: Callable[[Optional[str], Optional[str]], Dataset],
+    constructor_name: Optional[str] = None,
 ) -> str:
     """Registers a dataset constructor.
 

--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -15,7 +15,9 @@ class DatasetRegistry:
         self.constructors = {}
 
     def register_constructor(
-        self, constructor_fn: Callable[..., Any], constructor_name: Optional[str] = None
+        self,
+        constructor_fn: Callable[[Optional[str], Optional[str]], Dataset],
+        constructor_name: Optional[str] = None,
     ) -> str:
         """Registers a dataset constructor.
 

--- a/mlflow/data/dataset_registry.py
+++ b/mlflow/data/dataset_registry.py
@@ -1,7 +1,7 @@
 import inspect
 import warnings
 from contextlib import suppress
-from typing import Callable, Optional
+from typing import Any, Callable, Optional
 
 import mlflow.data
 from mlflow.data.dataset import Dataset
@@ -15,7 +15,7 @@ class DatasetRegistry:
         self.constructors = {}
 
     def register_constructor(
-        self, constructor_fn: Callable, constructor_name: Optional[str] = None
+        self, constructor_fn: Callable[..., Any], constructor_name: Optional[str] = None
     ) -> str:
         """Registers a dataset constructor.
 
@@ -60,7 +60,7 @@ class DatasetRegistry:
                 )
 
     @staticmethod
-    def _validate_constructor(constructor_fn: Callable, constructor_name: str):
+    def _validate_constructor(constructor_fn: Callable[..., Any], constructor_name: str):
         if not constructor_name.startswith("load_") and not constructor_name.startswith("from_"):
             raise MlflowException(
                 f"Invalid dataset constructor name: {constructor_name}."
@@ -90,7 +90,9 @@ class DatasetRegistry:
             )
 
 
-def register_constructor(constructor_fn: Callable, constructor_name: Optional[str] = None) -> str:
+def register_constructor(
+    constructor_fn: Callable[..., Any], constructor_name: Optional[str] = None
+) -> str:
     """Registers a dataset constructor.
 
     Args:
@@ -119,7 +121,7 @@ def register_constructor(constructor_fn: Callable, constructor_name: Optional[st
     return registered_constructor_name
 
 
-def get_registered_constructors() -> dict[str, Callable]:
+def get_registered_constructors() -> dict[str, Callable[..., Any]]:
     """Obtains the registered dataset constructors.
 
     Returns:

--- a/mlflow/dspy/util.py
+++ b/mlflow/dspy/util.py
@@ -2,7 +2,7 @@ import logging
 import tempfile
 from collections import defaultdict
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 from dspy import Example
 
@@ -66,8 +66,8 @@ def log_dspy_dataset(dataset: list["Example"], file_name: str):
 
 
 def _flatten_dspy_module_state(
-    d, parent_key="", sep=".", exclude_keys: Optional[set] = None
-) -> dict:
+    d, parent_key="", sep=".", exclude_keys: Optional[set[str]] = None
+) -> dict[str, Any]:
     """
     Flattens a nested dictionary and accumulates the key names.
 
@@ -84,7 +84,7 @@ def _flatten_dspy_module_state(
         >>> _flatten_dspy_module_state({"a": {"b": [5, 6]}})
         {'a.b.0': 5, 'a.b.1': 6}
     """
-    items = {}
+    items: dict[str, Any] = {}
 
     if isinstance(d, dict):
         for k, v in d.items():

--- a/mlflow/gateway/uc_function_utils.py
+++ b/mlflow/gateway/uc_function_utils.py
@@ -71,7 +71,7 @@ def uc_type_to_json_schema_type(uc_type_json: Union[str, dict[str, Any]]) -> dic
             raise TypeError(f"Unknown type {uc_type_json}. Try upgrading this package.")
 
 
-def extract_param_metadata(p: "FunctionParameterInfo") -> dict:
+def extract_param_metadata(p: "FunctionParameterInfo") -> dict[str, Any]:
     type_json = json.loads(p.type_json)["type"]
     json_schema_type = uc_type_to_json_schema_type(type_json)
     json_schema_type["name"] = p.name

--- a/mlflow/genai/datasets/evaluation_dataset.py
+++ b/mlflow/genai/datasets/evaluation_dataset.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from mlflow.data import Dataset
 from mlflow.data.digest_utils import compute_pandas_digest
@@ -94,7 +94,7 @@ class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
 
     def merge_records(
         self,
-        records: Union[list[dict], "pd.DataFrame", "pyspark.sql.DataFrame"],
+        records: Union[list[dict[str, Any]], "pd.DataFrame", "pyspark.sql.DataFrame"],
     ) -> "EvaluationDataset":
         """Merge records into the dataset."""
         dataset = self._dataset.merge_records(records)

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -295,7 +295,7 @@ def evaluate(
 
 
 @experimental(version="3.0.0")
-def to_predict_fn(endpoint_uri: str) -> Callable:
+def to_predict_fn(endpoint_uri: str) -> Callable[..., Any]:
     """
     Convert an endpoint URI to a predict function.
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -35,7 +35,7 @@ class SerializedScorer:
 
     # Builtin scorer fields (for scorers from mlflow.genai.scorers.builtin_scorers)
     builtin_scorer_class: Optional[str] = None
-    builtin_scorer_pydantic_data: Optional[dict] = None
+    builtin_scorer_pydantic_data: Optional[dict[str, Any]] = None
 
     # Decorator scorer fields (for @scorer decorated functions)
     call_source: Optional[str] = None
@@ -46,9 +46,9 @@ class SerializedScorer:
 @experimental(version="3.0.0")
 class Scorer(BaseModel):
     name: str
-    aggregations: Optional[list] = None
+    aggregations: Optional[list[str]] = None
 
-    def model_dump(self, **kwargs) -> dict:
+    def model_dump(self, **kwargs) -> dict[str, Any]:
         """Override model_dump to include source code."""
         # Create serialized scorer with core fields
         serialized = SerializedScorer(
@@ -79,7 +79,7 @@ class Scorer(BaseModel):
 
         return asdict(serialized)
 
-    def _extract_source_code_info(self) -> dict:
+    def _extract_source_code_info(self) -> dict[str, Optional[str]]:
         """Extract source code information for the original decorated function."""
         from mlflow.genai.scorers.scorer_utils import extract_function_body
 
@@ -323,7 +323,12 @@ def scorer(
     *,
     name: Optional[str] = None,
     aggregations: Optional[
-        list[Union[Literal["min", "max", "mean", "median", "variance", "p90", "p99"], Callable]]
+        list[
+            Union[
+                Literal["min", "max", "mean", "median", "variance", "p90", "p99"],
+                Callable[[list[Union[int, float]]], Union[int, float]],
+            ]
+        ]
     ] = None,
 ):
     """
@@ -459,7 +464,7 @@ def scorer(
 
     class CustomScorer(Scorer):
         # Store reference to the original function
-        _original_func: Optional[Callable] = PrivateAttr(default=None)
+        _original_func: Optional[Callable[..., Any]] = PrivateAttr(default=None)
 
         def __init__(self, **data):
             super().__init__(**data)

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -27,7 +27,7 @@ class BuiltInScorer(Scorer):
     name: str
     required_columns: set[str] = set()
 
-    def model_dump(self, **kwargs) -> dict:
+    def model_dump(self, **kwargs) -> dict[str, Any]:
         """Override model_dump to handle builtin scorer serialization."""
         # Use mode='json' to automatically convert sets to lists for JSON compatibility
         from pydantic import BaseModel

--- a/mlflow/genai/scorers/scorer_utils.py
+++ b/mlflow/genai/scorers/scorer_utils.py
@@ -72,7 +72,7 @@ def extract_function_body(func: Callable[..., Any]) -> tuple[str, int]:
     return extractor.function_body, extractor.indent_unit
 
 
-def recreate_function(source: str, signature: str, func_name: str) -> Optional[Callable]:
+def recreate_function(source: str, signature: str, func_name: str) -> Optional[Callable[..., Any]]:
     """
     Recreate a function from its source code, signature, and name.
 

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -91,7 +91,7 @@ def validate_scorers(scorers: list[Any]) -> list[Scorer]:
 def valid_data_for_builtin_scorers(
     data: "pd.DataFrame",
     builtin_scorers: list[BuiltInScorer],
-    predict_fn: Optional[Callable] = None,
+    predict_fn: Optional[Callable[..., Any]] = None,
 ) -> None:
     """
     Validate that the required columns are present in the data for running the builtin scorers.

--- a/mlflow/genai/utils/data_validation.py
+++ b/mlflow/genai/utils/data_validation.py
@@ -8,7 +8,7 @@ from mlflow.tracing.provider import trace_disabled
 _logger = logging.getLogger(__name__)
 
 
-def check_model_prediction(predict_fn: Callable, sample_input: Any):
+def check_model_prediction(predict_fn: Callable[..., Any], sample_input: Any):
     """
     Validate if the predict function executes properly with the provided input.
 
@@ -32,8 +32,8 @@ def check_model_prediction(predict_fn: Callable, sample_input: Any):
 
 
 def _validate_function_and_input_compatibility(
-    predict_fn: Callable, sample_input: dict[str, Any], e: Exception
-) -> Callable:
+    predict_fn: Callable[..., Any], sample_input: dict[str, Any], e: Exception
+) -> Callable[..., Any]:
     """
     Validate the data format in the input column against the predict_fn.
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -15,7 +15,7 @@ from mlflow.tracking.client import MlflowClient
 _logger = logging.getLogger(__name__)
 
 
-def convert_predict_fn(predict_fn: Callable, sample_input: Any) -> Callable:
+def convert_predict_fn(predict_fn: Callable[..., Any], sample_input: Any) -> Callable[..., Any]:
     """
     Check the predict_fn is callable and add trace decorator if it is not already traced.
     """
@@ -76,7 +76,7 @@ def parse_output_to_str(output: Any) -> str:
     return input_output_utils.response_to_string(output)
 
 
-def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> dict[str, list]:
+def extract_retrieval_context_from_trace(trace: Optional[Trace]) -> dict[str, list[Any]]:
     """
     Extract the retrieval context from the trace.
     Only consider the last retrieval span in the trace if there are multiple retrieval spans.

--- a/mlflow/langchain/api_request_parallel_processor.py
+++ b/mlflow/langchain/api_request_parallel_processor.py
@@ -96,9 +96,9 @@ class APIRequest:
 
     index: int
     lc_model: langchain.chains.base.Chain
-    request_json: dict
+    request_json: dict[str, Any]
     results: list[tuple[int, str]]
-    errors: dict
+    errors: dict[int, str]
     convert_chat_responses: bool
     did_perform_chat_conversion: bool
     stream: bool

--- a/mlflow/langchain/chat_agent_langgraph.py
+++ b/mlflow/langchain/chat_agent_langgraph.py
@@ -40,7 +40,10 @@ from mlflow.types.agent import ChatAgentMessage
 from mlflow.utils.annotations import experimental
 
 
-def _add_agent_messages(left: Union[dict, list[dict]], right: Union[dict, list[dict]]):
+def _add_agent_messages(
+    left: Union[dict[str, Any], list[dict[str, Any]]],
+    right: Union[dict[str, Any], list[dict[str, Any]]],
+):
     if not isinstance(left, list):
         left = [left]
     if not isinstance(right, list):
@@ -264,14 +267,14 @@ class ChatAgentState(TypedDict):
     ChatAgent" section of the docstring of :py:class:`ChatAgent <mlflow.pyfunc.ChatAgent>`.
     """
 
-    messages: Annotated[list, _add_agent_messages]
+    messages: Annotated[list[dict[str, Any]], _add_agent_messages]
     context: Optional[dict[str, Any]]
     custom_inputs: Optional[dict[str, Any]]
     custom_outputs: Optional[dict[str, Any]]
 
 
 def parse_message(
-    msg: AnyMessage, name: Optional[str] = None, attachments: Optional[dict] = None
+    msg: AnyMessage, name: Optional[str] = None, attachments: Optional[dict[str, Any]] = None
 ) -> dict[str, Any]:
     """
     Parse different LangChain message types into their ChatAgentMessage schema dict equivalents

--- a/mlflow/langchain/utils/chat.py
+++ b/mlflow/langchain/utils/chat.py
@@ -102,7 +102,7 @@ def _chat_model_to_langchain_message(message: ChatMessage) -> BaseMessage:
         )
 
 
-def _get_tool_calls_from_ai_message(message: AIMessage) -> list[dict]:
+def _get_tool_calls_from_ai_message(message: AIMessage) -> list[dict[str, Any]]:
     # AIMessage does not have tool_calls field in LangChain < 0.1.0.
     if not hasattr(message, "tool_calls"):
         return []
@@ -162,7 +162,7 @@ def convert_lc_generation_to_chat_message(lc_gen: Generation) -> ChatMessage:
     return ChatMessage(role="assistant", content=lc_gen.text)
 
 
-def try_transform_response_to_chat_format(response: Any) -> dict:
+def try_transform_response_to_chat_format(response: Any) -> dict[str, Any]:
     """
     Try to convert the response to the standard chat format and return its dict representation.
 
@@ -262,7 +262,7 @@ def _convert_chat_request_or_throw(chat_request: dict[str, Any]) -> list[Union[B
     return [_chat_model_to_langchain_message(message) for message in model.messages]
 
 
-def _convert_chat_request(chat_request: Union[dict, list[dict]]):
+def _convert_chat_request(chat_request: Union[dict[str, Any], list[dict[str, Any]]]):
     if isinstance(chat_request, list):
         return [_convert_chat_request_or_throw(request) for request in chat_request]
     else:
@@ -329,7 +329,7 @@ def transform_request_json_for_chat_if_necessary(request_json, lc_model):
             and isinstance(json_message["messages"], list)
         )
 
-    def is_list_of_chat_messages(json_message: list[dict]):
+    def is_list_of_chat_messages(json_message: list[dict[str, Any]]):
         return isinstance(json_message, list) and all(
             json_dict_might_be_chat_request(message) for message in json_message
         )

--- a/mlflow/langchain/utils/logging.py
+++ b/mlflow/langchain/utils/logging.py
@@ -12,7 +12,7 @@ import types
 import warnings
 from functools import lru_cache
 from importlib.util import find_spec
-from typing import Callable, NamedTuple
+from typing import Any, Callable, NamedTuple
 
 import cloudpickle
 import yaml
@@ -162,7 +162,7 @@ def get_unsupported_model_message(model_type):
 @lru_cache
 def custom_type_to_loader_dict():
     # helper function to load output_parsers from config
-    def _load_output_parser(config: dict) -> dict:
+    def _load_output_parser(config: dict[str, Any]) -> Any:
         """Load output parser."""
         from langchain.schema.output_parser import StrOutputParser
 
@@ -439,7 +439,7 @@ def _get_path_by_key(root_path, key, conf):
     return os.path.join(root_path, key_path) if key_path else None
 
 
-def _patch_loader(loader_func: Callable) -> Callable:
+def _patch_loader(loader_func: Callable[..., Any]) -> Callable[..., Any]:
     """
     Patch LangChain loader function like load_chain() to handle the breaking change introduced in
     LangChain 0.1.12.

--- a/mlflow/llama_index/pyfunc_wrapper.py
+++ b/mlflow/llama_index/pyfunc_wrapper.py
@@ -78,7 +78,7 @@ class _LlamaIndexModelWrapperBase:
     def _format_predict_input(self, data):
         raise NotImplementedError
 
-    def _do_inference(self, input, params: Optional[dict[str, Any]]) -> dict:
+    def _do_inference(self, input, params: Optional[dict[str, Any]]) -> dict[str, Any]:
         """
         Perform engine inference on a single engine input e.g. not an iterable of
         engine inputs. The engine inputs must already be preprocessed/cleaned.
@@ -107,7 +107,9 @@ class ChatEngineWrapper(_LlamaIndexModelWrapperBase):
         return self._llama_model.chat(*args, **kwargs).response
 
     @staticmethod
-    def _convert_chat_message_history_to_chat_message_objects(data: dict) -> dict:
+    def _convert_chat_message_history_to_chat_message_objects(
+        data: dict[str, Any],
+    ) -> dict[str, Any]:
         from llama_index.core.llms import ChatMessage
 
         if chat_message_history := data.get(_CHAT_MESSAGE_HISTORY_PARAMETER_NAME):
@@ -124,7 +126,7 @@ class ChatEngineWrapper(_LlamaIndexModelWrapperBase):
 
         return data
 
-    def _format_predict_input(self, data) -> Union[str, dict, list]:
+    def _format_predict_input(self, data) -> Union[str, dict[str, Any], list[Any]]:
         data = _convert_llm_input_data_with_unwrapping(data)
 
         if isinstance(data, str):
@@ -159,7 +161,7 @@ class RetrieverEngineWrapper(_LlamaIndexModelWrapperBase):
     def engine_type(self):
         return RETRIEVER_ENGINE_NAME
 
-    def _predict_single(self, *args, **kwargs) -> list[dict]:
+    def _predict_single(self, *args, **kwargs) -> list[dict[str, Any]]:
         response = self._llama_model.retrieve(*args, **kwargs)
         return [node.dict() for node in response]
 
@@ -188,7 +190,9 @@ class WorkflowWrapper(_LlamaIndexModelWrapperBase):
         should_unwrap = len(data) == 1 and isinstance(predictions, list)
         return predictions[0] if should_unwrap else predictions
 
-    def _format_predict_input(self, data, params: Optional[dict[str, Any]] = None) -> list[dict]:
+    def _format_predict_input(
+        self, data, params: Optional[dict[str, Any]] = None
+    ) -> list[dict[str, Any]]:
         inputs = _convert_llm_input_data_with_unwrapping(data)
         params = params or {}
         if isinstance(inputs, dict):

--- a/mlflow/llama_index/serialize_objects.py
+++ b/mlflow/llama_index/serialize_objects.py
@@ -62,7 +62,7 @@ def object_to_dict(o: object):
 
 
 def _construct_prompt_template_object(
-    constructor: Callable, kwargs: dict[str, Any]
+    constructor: Callable[..., PromptTemplate], kwargs: dict[str, Any]
 ) -> PromptTemplate:
     """Construct a PromptTemplate object based on the constructor and kwargs.
 

--- a/mlflow/mistral/chat.py
+++ b/mlflow/mistral/chat.py
@@ -1,5 +1,5 @@
 import json
-from typing import Union
+from typing import Any, Union
 
 from pydantic import BaseModel
 
@@ -23,7 +23,7 @@ def _to_dict(obj: BaseModel):
     return obj.dict()
 
 
-def convert_message_to_mlflow_chat(message: Union[BaseModel, dict]) -> ChatMessage:
+def convert_message_to_mlflow_chat(message: Union[BaseModel, dict[str, Any]]) -> ChatMessage:
     """
     Convert Mistral AI message object into MLflow's standard format (OpenAI compatible).
 
@@ -91,7 +91,7 @@ def convert_message_to_mlflow_chat(message: Union[BaseModel, dict]) -> ChatMessa
         )
 
 
-def _parse_content(content: Union[str, dict]) -> Union[TextContentPart, ImageContentPart]:
+def _parse_content(content: Union[str, dict[str, Any]]) -> Union[TextContentPart, ImageContentPart]:
     if isinstance(content, str):
         return TextContentPart(text=content, type="text")
 
@@ -112,7 +112,7 @@ def _parse_content(content: Union[str, dict]) -> Union[TextContentPart, ImageCon
         )
 
 
-def convert_tool_to_mlflow_chat_tool(tool: dict) -> ChatTool:
+def convert_tool_to_mlflow_chat_tool(tool: dict[str, Any]) -> ChatTool:
     """
     Convert Mistral AI tool definition into MLflow's standard format (OpenAI compatible).
 

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from mlflow.utils.annotations import experimental
 
@@ -172,7 +172,7 @@ def _get_dependencies_schemas():
         _clear_dependencies_schemas()
 
 
-def _get_dependencies_schema_from_model(model: "Model") -> Optional[dict]:
+def _get_dependencies_schema_from_model(model: "Model") -> Optional[dict[str, Any]]:
     """
     Get the dependencies schema from the logged model metadata.
 
@@ -273,7 +273,7 @@ class RetrieverSchema(Schema):
 class DependenciesSchemas:
     retriever_schemas: list[RetrieverSchema] = field(default_factory=list)
 
-    def to_dict(self) -> dict[str, dict[DependenciesSchemasType, list[dict]]]:
+    def to_dict(self) -> dict[str, dict[DependenciesSchemasType, list[dict[str, Any]]]]:
         if not self.retriever_schemas:
             return None
 

--- a/mlflow/models/evaluation/default_evaluator.py
+++ b/mlflow/models/evaluation/default_evaluator.py
@@ -61,7 +61,7 @@ def _extract_raw_model(model):
 
 
 def _extract_output_and_other_columns(
-    model_predictions: Union[list, dict, pd.DataFrame, pd.Series],
+    model_predictions: Union[list[Any], dict[str, Any], pd.DataFrame, pd.Series],
     output_column_name: Optional[str],
 ) -> tuple[pd.Series, Optional[pd.DataFrame], str]:
     y_pred = None
@@ -146,7 +146,7 @@ def _extract_output_and_other_columns(
     )
 
 
-def _extract_predict_fn(model: Any) -> Optional[Callable]:
+def _extract_predict_fn(model: Any) -> Optional[Callable[..., Any]]:
     """
     Extracts the predict function from the given model or raw_model.
 
@@ -223,7 +223,7 @@ class _CustomArtifact(NamedTuple):
     artifacts_dir : the path to a temporary directory to store produced artifacts of the function
     """
 
-    function: Callable
+    function: Callable[..., Any]
     name: str
     index: int
     artifacts_dir: str

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -404,7 +404,7 @@ class Model:
         flavors=None,
         signature=None,  # ModelSignature
         saved_input_example_info: Optional[dict[str, Any]] = None,
-        model_uuid: Union[str, Callable, None] = lambda: uuid.uuid4().hex,
+        model_uuid: Union[str, Callable[[], str], None] = lambda: uuid.uuid4().hex,
         mlflow_version: Union[str, None] = mlflow.version.VERSION,
         metadata: Optional[dict[str, Any]] = None,
         model_size_bytes: Optional[int] = None,
@@ -619,7 +619,7 @@ class Model:
 
     @experimental(version="2.13.0")
     @property
-    def resources(self) -> dict[str, dict[ResourceType, list[dict]]]:
+    def resources(self) -> dict[str, dict[ResourceType, list[dict[str, Any]]]]:
         """
         An optional dictionary that contains the resources required to serve the model.
 
@@ -642,7 +642,7 @@ class Model:
 
     @experimental(version="2.21.0")
     @property
-    def auth_policy(self) -> dict[str, dict]:
+    def auth_policy(self) -> dict[str, dict[str, Any]]:
         """
         An optional dictionary that contains the auth policy required to serve the model.
 
@@ -654,7 +654,7 @@ class Model:
 
     @experimental(version="2.21.0")
     @auth_policy.setter
-    def auth_policy(self, value: Optional[Union[dict, AuthPolicy]]) -> None:
+    def auth_policy(self, value: Optional[Union[dict[str, Any], AuthPolicy]]) -> None:
         self._auth_policy = value.to_dict() if isinstance(value, AuthPolicy) else value
 
     @property

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -282,7 +282,7 @@ class _ResourceBuilder:
     @staticmethod
     def from_resources(
         resources: list[Resource], api_version: str = DEFAULT_API_VERSION
-    ) -> dict[str, dict[ResourceType, list[dict]]]:
+    ) -> dict[str, dict[ResourceType, list[dict[str, Any]]]]:
         resource_dict = {}
         for resource in resources:
             resource_data = resource.to_dict()
@@ -295,7 +295,7 @@ class _ResourceBuilder:
         return resource_dict
 
     @staticmethod
-    def from_dict(data) -> dict[str, dict[ResourceType, list[dict]]]:
+    def from_dict(data) -> dict[str, dict[ResourceType, list[dict[str, Any]]]]:
         resources = []
         api_version = data.pop("api_version")
         if api_version == "1":
@@ -312,7 +312,7 @@ class _ResourceBuilder:
         return _ResourceBuilder.from_resources(resources, api_version)
 
     @staticmethod
-    def from_yaml_file(path: str) -> dict[str, dict[ResourceType, list[dict]]]:
+    def from_yaml_file(path: str) -> dict[str, dict[ResourceType, list[dict[str, Any]]]]:
         if not os.path.exists(path):
             raise OSError(f"No such file or directory: '{path}'")
         path = os.path.abspath(path)

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -163,7 +163,7 @@ def _handle_ndarray_nans(x: np.ndarray):
         return x
 
 
-def _handle_ndarray_input(input_array: Union[np.ndarray, dict]):
+def _handle_ndarray_input(input_array: Union[np.ndarray, dict[str, Any]]):
     if isinstance(input_array, dict):
         result = {}
         for name in input_array.keys():
@@ -521,7 +521,9 @@ def _save_example(  # noqa: D417
     return example
 
 
-def _get_mlflow_model_input_example_dict(mlflow_model: Model, uri_or_path: str) -> Optional[dict]:
+def _get_mlflow_model_input_example_dict(
+    mlflow_model: Model, uri_or_path: str
+) -> Optional[dict[str, Any]]:
     """
     Args:
         mlflow_model: Model metadata.
@@ -1778,7 +1780,7 @@ def _convert_llm_ndarray_to_list(data):
     return data
 
 
-def _convert_llm_input_data(data: Any) -> Union[list, dict]:
+def _convert_llm_input_data(data: Any) -> Union[list[Any], dict[str, Any]]:
     """
     Convert input data to a format that can be passed to the model with GenAI flavors such as
     LangChain and LLamaIndex.

--- a/mlflow/openai/api_request_parallel_processor.py
+++ b/mlflow/openai/api_request_parallel_processor.py
@@ -61,7 +61,10 @@ class StatusTracker:
 
 
 def call_api(
-    index: int, results: list[tuple[int, Any]], task: Callable, status_tracker: StatusTracker
+    index: int,
+    results: list[tuple[int, Any]],
+    task: Callable[[], Any],
+    status_tracker: StatusTracker,
 ):
     import openai
 

--- a/mlflow/openai/utils/chat_schema.py
+++ b/mlflow/openai/utils/chat_schema.py
@@ -325,7 +325,7 @@ def _parse_tools(inputs: dict[str, Any]) -> list[ChatTool]:
     return parsed_tools
 
 
-def _parse_usage(output: Any) -> Optional[dict]:
+def _parse_usage(output: Any) -> Optional[dict[str, Any]]:
     """
     Parse token usage information from OpenAI response objects.
 

--- a/mlflow/promptflow/__init__.py
+++ b/mlflow/promptflow/__init__.py
@@ -421,7 +421,7 @@ class _PromptflowModelWrapper:
         self,
         data: Union[pd.DataFrame, list[Union[str, dict[str, Any]]]],
         params: Optional[dict[str, Any]] = None,  # pylint: disable=unused-argument
-    ) -> Union[dict, list]:
+    ) -> Union[dict[str, Any], list[Any]]:
         """
         Args:
             data: Model input data. Either a pandas DataFrame with only 1 row or a dictionary.

--- a/mlflow/pyfunc/context.py
+++ b/mlflow/pyfunc/context.py
@@ -1,7 +1,7 @@
 import contextlib
 from contextvars import ContextVar
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 # A thread local variable to store the context of the current prediction request.
 # This is particularly used to associate logs/traces with a specific prediction request in the
@@ -17,7 +17,7 @@ class Context:
     # Whether the current prediction request is as a part of MLflow model evaluation.
     is_evaluate: bool = False
     # The schema of the dependencies to be added into the tag of trace info.
-    dependencies_schemas: Optional[dict] = None
+    dependencies_schemas: Optional[dict[str, Any]] = None
     # The logged model ID associated with the current prediction request
     model_id: Optional[str] = None
     # The model serving endpoint name where the prediction request is made
@@ -27,7 +27,7 @@ class Context:
         self,
         request_id: Optional[str] = None,
         is_evaluate: bool = False,
-        dependencies_schemas: Optional[dict] = None,
+        dependencies_schemas: Optional[dict[str, Any]] = None,
         model_id: Optional[str] = None,
         endpoint_name: Optional[str] = None,
         # Accept extra kwargs so we don't need to worry backward compatibility

--- a/mlflow/pyfunc/scoring_server/__init__.py
+++ b/mlflow/pyfunc/scoring_server/__init__.py
@@ -403,7 +403,7 @@ def invocations(data, content_type, model, input_schema):
 
 class ParsedJsonInput(NamedTuple):
     data: Any
-    params: Optional[dict]
+    params: Optional[dict[str, Any]]
     is_unified_llm_input: bool
 
 

--- a/mlflow/pyfunc/utils/serving_data_parser.py
+++ b/mlflow/pyfunc/utils/serving_data_parser.py
@@ -1,9 +1,11 @@
 # Support unwrapped JSON with these keys for LLM use cases of Chat, Completions, Embeddings tasks
+from typing import Any
+
 LLM_CHAT_KEY = "messages"
 LLM_COMPLETIONS_KEY = "prompt"
 LLM_EMBEDDINGS_KEY = "input"
 SUPPORTED_LLM_FORMATS = {LLM_CHAT_KEY, LLM_COMPLETIONS_KEY, LLM_EMBEDDINGS_KEY}
 
 
-def is_unified_llm_input(json_input: dict):
+def is_unified_llm_input(json_input: dict[str, Any]):
     return any(x in json_input for x in SUPPORTED_LLM_FORMATS)

--- a/mlflow/pyfunc/utils/serving_data_parser.py
+++ b/mlflow/pyfunc/utils/serving_data_parser.py
@@ -1,6 +1,6 @@
-# Support unwrapped JSON with these keys for LLM use cases of Chat, Completions, Embeddings tasks
 from typing import Any
 
+# Support unwrapped JSON with these keys for LLM use cases of Chat, Completions, Embeddings tasks
 LLM_CHAT_KEY = "messages"
 LLM_COMPLETIONS_KEY = "prompt"
 LLM_EMBEDDINGS_KEY = "input"

--- a/mlflow/store/artifact/databricks_artifact_repo.py
+++ b/mlflow/store/artifact/databricks_artifact_repo.py
@@ -16,6 +16,7 @@ from mlflow.azure.client import (
     put_block,
     put_block_list,
 )
+from mlflow.entities import FileInfo
 from mlflow.environment_variables import (
     MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT,
     MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE,
@@ -719,7 +720,7 @@ class DatabricksArtifactRepository(CloudArtifactRepository):
             artifact_file_path=artifact_file_path,
         )
 
-    def list_artifacts(self, path: Optional[str] = None) -> list:
+    def list_artifacts(self, path: Optional[str] = None) -> list[FileInfo]:
         return self.resource.list_artifacts(path)
 
     def delete_artifacts(self, artifact_path=None):

--- a/mlflow/store/artifact/dbfs_artifact_repo.py
+++ b/mlflow/store/artifact/dbfs_artifact_repo.py
@@ -139,7 +139,7 @@ class DbfsRestArtifactRepository(ArtifactRepository):
                 file_path = os.path.join(dirpath, name)
                 self.log_artifact(file_path, artifact_subdir)
 
-    def list_artifacts(self, path: Optional[str] = None) -> list:
+    def list_artifacts(self, path: Optional[str] = None) -> list[FileInfo]:
         dbfs_path = self._get_dbfs_path(path) if path else self._get_dbfs_path("")
         dbfs_list_json = {"path": dbfs_path}
         response = self._dbfs_list_api(dbfs_list_json)

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -6,7 +6,7 @@ from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass
 from queue import Empty, Queue
 from queue import Full as queue_Full
-from typing import Callable, Sequence
+from typing import Any, Callable, Sequence
 
 from mlflow.environment_variables import (
     MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE,
@@ -20,7 +20,7 @@ _logger = logging.getLogger(__name__)
 class Task:
     """A dataclass to represent a simple task."""
 
-    handler: Callable
+    handler: Callable[..., Any]
     args: Sequence
     error_msg: str = ""
 

--- a/mlflow/tracing/export/async_export_queue.py
+++ b/mlflow/tracing/export/async_export_queue.py
@@ -21,7 +21,7 @@ class Task:
     """A dataclass to represent a simple task."""
 
     handler: Callable[..., Any]
-    args: Sequence
+    args: Sequence[Any]
     error_msg: str = ""
 
     def handle(self) -> None:

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -59,12 +59,12 @@ _EVAL_REQUEST_ID_TO_TRACE_ID = TTLCache(maxsize=10000, ttl=3600)
 
 
 def trace(
-    func: Optional[Callable] = None,
+    func: Optional[Callable[..., Any]] = None,
     name: Optional[str] = None,
     span_type: str = SpanType.UNKNOWN,
     attributes: Optional[dict[str, Any]] = None,
-    output_reducer: Optional[Callable] = None,
-) -> Callable:
+    output_reducer: Optional[Callable[[list[Any]], Any]] = None,
+) -> Callable[..., Any]:
     """
     A decorator that creates a new span for the decorated function.
 
@@ -196,11 +196,11 @@ def trace(
 
 
 def _wrap_function(
-    fn: Callable,
+    fn: Callable[..., Any],
     name: Optional[str] = None,
     span_type: str = SpanType.UNKNOWN,
     attributes: Optional[dict[str, Any]] = None,
-) -> Callable:
+) -> Callable[..., Any]:
     class _WrappingContext:
         # define the wrapping logic as a coroutine to avoid code duplication
         # between sync and async cases
@@ -254,12 +254,12 @@ def _wrap_function(
 
 
 def _wrap_generator(
-    fn: Callable,
+    fn: Callable[..., Any],
     name: Optional[str] = None,
     span_type: str = SpanType.UNKNOWN,
     attributes: Optional[dict[str, Any]] = None,
-    output_reducer: Optional[Callable] = None,
-) -> Callable:
+    output_reducer: Optional[Callable[[list[Any]], Any]] = None,
+) -> Callable[..., Any]:
     """
     Wrap a generator function to create a span.
     Generator functions need special handling because of its lazy evaluation nature.
@@ -304,7 +304,7 @@ def _wrap_generator(
         span: LiveSpan,
         inputs: Optional[dict[str, Any]] = None,
         outputs: Optional[list[Any]] = None,
-        output_reducer: Optional[Callable] = None,
+        output_reducer: Optional[Callable[[list[Any]], Any]] = None,
         error: Optional[Exception] = None,
     ):
         if error:
@@ -385,7 +385,7 @@ def _wrap_generator(
     return _wrap_function_safe(fn, wrapper)
 
 
-def _wrap_function_safe(fn: Callable, wrapper: Callable) -> Callable:
+def _wrap_function_safe(fn: Callable[..., Any], wrapper: Callable[..., Any]) -> Callable[..., Any]:
     wrapped = functools.wraps(fn)(wrapper)
     # Update the signature of the wrapper to match the signature of the original (safely)
     try:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -278,7 +278,7 @@ def maybe_get_request_id(is_evaluate=False) -> Optional[str]:
     return context.request_id
 
 
-def maybe_get_dependencies_schemas() -> Optional[dict]:
+def maybe_get_dependencies_schemas() -> Optional[dict[str, Any]]:
     context = _try_get_prediction_context()
     if context:
         return context.dependencies_schemas
@@ -349,7 +349,7 @@ def maybe_set_prediction_context(context: Optional["Context"]):
 
 def set_span_chat_messages(
     span: LiveSpan,
-    messages: list[Union[dict, ChatMessage]],
+    messages: list[Union[dict[str, Any], ChatMessage]],
     append=False,
 ):
     """

--- a/mlflow/tracking/multimedia.py
+++ b/mlflow/tracking/multimedia.py
@@ -4,7 +4,7 @@ exposed to users at the top-level :py:mod:`mlflow` module.
 """
 
 import warnings
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     import numpy
@@ -32,7 +32,7 @@ def compress_image_size(
     return image.resize((new_width, new_height))
 
 
-def convert_to_pil_image(image: Union["numpy.ndarray", list]) -> "PIL.Image.Image":
+def convert_to_pil_image(image: Union["numpy.ndarray", list[Any]]) -> "PIL.Image.Image":
     """
     Convert a numpy array to a PIL image.
     """
@@ -129,7 +129,7 @@ class Image:
         pixel_values = image_obj.to_list()
     """
 
-    def __init__(self, image: Union["numpy.ndarray", "PIL.Image.Image", str, list]):
+    def __init__(self, image: Union["numpy.ndarray", "PIL.Image.Image", str, list[Any]]):
         import numpy as np
 
         try:

--- a/mlflow/transformers/llm_inference_utils.py
+++ b/mlflow/transformers/llm_inference_utils.py
@@ -81,7 +81,7 @@ def infer_signature_from_llm_inference_task(
     return inferred_signature
 
 
-def convert_messages_to_prompt(messages: list[dict], tokenizer) -> str:
+def convert_messages_to_prompt(messages: list[dict[str, Any]], tokenizer) -> str:
     """For the Chat inference task, apply chat template to messages to create prompt.
 
     Args:
@@ -104,7 +104,7 @@ def convert_messages_to_prompt(messages: list[dict], tokenizer) -> str:
 
 
 def preprocess_llm_inference_input(
-    data: Union[pd.DataFrame, dict],
+    data: Union[pd.DataFrame, dict[str, Any]],
     params: Optional[dict[str, Any]] = None,
     flavor_config: Optional[dict[str, Any]] = None,
 ) -> tuple[list[Any], dict[str, Any]]:

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -842,7 +842,7 @@ class TensorInfo:
         return self._dtype
 
     @property
-    def shape(self) -> tuple[Any, ...]:
+    def shape(self) -> tuple[int, ...]:
         """The tensor shape"""
         return self._shape
 
@@ -875,7 +875,7 @@ class TensorSpec:
     def __init__(
         self,
         type: np.dtype,
-        shape: Union[tuple[Any, ...], list[Any]],
+        shape: Union[tuple[int, ...], list[int]],
         name: Optional[str] = None,
     ):
         self._name = name
@@ -895,7 +895,7 @@ class TensorSpec:
         return self._name
 
     @property
-    def shape(self) -> tuple[Any, ...]:
+    def shape(self) -> tuple[int, ...]:
         """The tensor shape"""
         return self._tensorInfo.shape
 

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -142,7 +142,7 @@ class BaseType(ABC):
         """
 
     @abstractmethod
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         """
         Dictionary representation of the object.
         """
@@ -812,7 +812,7 @@ class TensorInfo:
     Representation of the shape and type of a Tensor.
     """
 
-    def __init__(self, dtype: np.dtype, shape: Union[tuple, list]):
+    def __init__(self, dtype: np.dtype, shape: Union[tuple[Any, ...], list[Any]]):
         if not isinstance(dtype, np.dtype):
             raise TypeError(
                 f"Expected `dtype` to be instance of `{np.dtype}`, received `{dtype.__class__}`"
@@ -842,7 +842,7 @@ class TensorInfo:
         return self._dtype
 
     @property
-    def shape(self) -> tuple:
+    def shape(self) -> tuple[Any, ...]:
         """The tensor shape"""
         return self._shape
 
@@ -875,7 +875,7 @@ class TensorSpec:
     def __init__(
         self,
         type: np.dtype,
-        shape: Union[tuple, list],
+        shape: Union[tuple[Any, ...], list[Any]],
         name: Optional[str] = None,
     ):
         self._name = name
@@ -895,7 +895,7 @@ class TensorSpec:
         return self._name
 
     @property
-    def shape(self) -> tuple:
+    def shape(self) -> tuple[Any, ...]:
         """The tensor shape"""
         return self._tensorInfo.shape
 
@@ -1092,7 +1092,7 @@ class Schema:
     def from_json(cls, json_str: str):
         """Deserialize from a json string."""
 
-        def read_input(x: dict):
+        def read_input(x: dict[str, Any]):
             return (
                 TensorSpec.from_json_dict(**x)
                 if x["type"] == "tensor"
@@ -1215,7 +1215,7 @@ class ParamSpec:
         return self._default
 
     @property
-    def shape(self) -> Optional[tuple]:
+    def shape(self) -> Optional[tuple[int, ...]]:
         """
         The parameter shape.
         If shape is None, the parameter is a scalar.

--- a/mlflow/types/utils.py
+++ b/mlflow/types/utils.py
@@ -39,7 +39,7 @@ class TensorsNotSupportedException(MlflowException):
         super().__init__(f"Multidimensional arrays (aka tensors) are not supported. {msg}")
 
 
-def _get_tensor_shape(data, variable_dimension: Optional[int] = 0) -> tuple:
+def _get_tensor_shape(data, variable_dimension: Optional[int] = 0) -> tuple[int, ...]:
     """Infer the shape of the inputted data.
 
     This method creates the shape of the tensor to store in the TensorSpec. The variable dimension
@@ -168,7 +168,7 @@ def _infer_datatype(data: Any) -> Optional[Union[DataType, Array, Object, AnyTyp
     return _infer_scalar_datatype(data)
 
 
-def _infer_array_datatype(data: Union[list, np.ndarray]) -> Optional[Array]:
+def _infer_array_datatype(data: Union[list[Any], np.ndarray]) -> Optional[Array]:
     """Infer schema from an array. This tries to infer type if there is at least one
     non-null item in the list, assuming the list has a homogeneous type. However,
     if the list is empty or all items are null, returns None as a sign of undetermined.

--- a/mlflow/utils/autologging_utils/config.py
+++ b/mlflow/utils/autologging_utils/config.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS
 
@@ -16,7 +16,7 @@ class AutoLoggingConfig:
     log_input_examples: bool
     log_model_signatures: bool
     log_traces: bool
-    extra_tags: Optional[dict] = None
+    extra_tags: Optional[dict[str, Any]] = None
     log_models: bool = True
 
     @classmethod

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -2,10 +2,9 @@ import abc
 import functools
 import inspect
 import itertools
-import typing
 import uuid
 from contextlib import asynccontextmanager, contextmanager
-from typing import Optional
+from typing import Any, Callable, NamedTuple, Optional
 
 import mlflow
 import mlflow.utils.autologging_utils
@@ -850,7 +849,7 @@ def _validate_autologging_run(autologging_integration, run_id):
     )
 
 
-class ValidationExemptArgument(typing.NamedTuple):
+class ValidationExemptArgument(NamedTuple):
     """
     A NamedTuple representing the properties of an argument that is exempt from validation
 
@@ -864,7 +863,7 @@ class ValidationExemptArgument(typing.NamedTuple):
 
     autologging_integration: str
     function_name: str
-    type_function: typing.Callable
+    type_function: Callable[..., Any]
     positional_argument_index: Optional[int] = None
     keyword_argument_name: Optional[str] = None
 

--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -1,5 +1,6 @@
 import textwrap
 import warnings
+from typing import Any
 
 from mlflow.ml_package_versions import _ML_PACKAGE_VERSIONS
 from mlflow.utils.autologging_utils.versioning import (
@@ -11,7 +12,7 @@ def _create_placeholder(key: str):
     return "{{ " + key + " }}"
 
 
-def _replace_keys_with_placeholders(d: dict) -> dict:
+def _replace_keys_with_placeholders(d: dict[str, Any]) -> dict[str, Any]:
     return {_create_placeholder(k): v for k, v in d.items()}
 
 

--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -525,7 +525,7 @@ def _lock_requirements(
         in_file = tmp_dir_path / "requirements.in"
         in_file.write_text("\n".join(requirements))
         out_file = tmp_dir_path / "requirements.out"
-        constraints_opt: list = []
+        constraints_opt: list[str] = []
         if constraints:
             constraints_file = tmp_dir_path / "constraints.txt"
             constraints_file.write_text("\n".join(constraints))

--- a/mlflow/utils/pydantic_utils.py
+++ b/mlflow/utils/pydantic_utils.py
@@ -8,7 +8,7 @@ IS_PYDANTIC_V2_OR_NEWER = Version(pydantic.VERSION).major >= 2
 
 
 def field_validator(field: str, mode: str = "before"):
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         if IS_PYDANTIC_V2_OR_NEWER:
             from pydantic import field_validator as pydantic_field_validator
 
@@ -26,7 +26,7 @@ def model_validator(mode: str, skip_on_failure: bool = False):
     Note that the `skip_on_failure` argument is only available in Pydantic v1.
     """
 
-    def decorator(func: Callable) -> Callable:
+    def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         if IS_PYDANTIC_V2_OR_NEWER:
             from pydantic import model_validator as pydantic_model_validator
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -5,7 +5,7 @@ import random
 import time
 import warnings
 from functools import lru_cache
-from typing import Callable
+from typing import Any, Callable
 
 import requests
 
@@ -384,7 +384,7 @@ def _time_sleep(seconds: float) -> None:
 
 def _retry_databricks_sdk_call_with_exponential_backoff(
     *,
-    call_func: Callable,
+    call_func: Callable[..., Any],
     retry_codes: list[int],
     retry_timeout_seconds: int,
     backoff_factor: int,

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -1,5 +1,6 @@
 import uuid
 from importlib import import_module
+from typing import Any
 from unittest import mock
 from unittest.mock import patch
 
@@ -226,7 +227,7 @@ def test_evaluate_with_managed_dataset():
             self.records[dataset_id].extend(records)
 
         def upsert_dataset_record_expectations(
-            self, name: str, dataset_id: str, record_id: str, expectations: list[dict]
+            self, name: str, dataset_id: str, record_id: str, expectations: list[dict[str, Any]]
         ):
             for record in self.records[dataset_id]:
                 if record.id == record_id:

--- a/tests/pyfunc/test_mlserver.py
+++ b/tests/pyfunc/test_mlserver.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 import pytest
 
@@ -47,7 +48,7 @@ from mlflow.pyfunc.mlserver import MLServerDefaultModelName, MLServerMLflowRunti
         ({}, {"MLSERVER_MODEL_NAME": MLServerDefaultModelName}),
     ],
 )
-def test_get_cmd(params: dict, expected: dict):
+def test_get_cmd(params: dict[str, Any], expected: dict[str, Any]):
     model_uri = "/foo/bar"
     cmd, cmd_env = get_cmd(model_uri=model_uri, **params)
 

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -5,6 +5,7 @@ import random
 import signal
 from collections import namedtuple
 from io import StringIO
+from typing import Any
 
 import keras
 import numpy as np
@@ -764,7 +765,7 @@ def test_parse_json_input_including_path():
         ({"timeout": 30}, "", "30"),
     ],
 )
-def test_get_cmd(args: dict, expected: str, timeout: str):
+def test_get_cmd(args: dict[str, Any], expected: str, timeout: str):
     cmd, env = get_cmd(model_uri="foo", **args)
 
     assert cmd == (f"uvicorn {expected} mlflow.pyfunc.scoring_server.app:app")

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -242,7 +242,7 @@ def _cleanup_database(store: SqlAlchemyStore):
             session.execute(sqlalchemy.sql.text(reset_experiment_id))
 
 
-def _create_experiments(store: SqlAlchemyStore, names) -> Union[str, list]:
+def _create_experiments(store: SqlAlchemyStore, names) -> Union[str, list[str]]:
     if isinstance(names, (list, tuple)):
         ids = []
         for name in names:

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -3,7 +3,7 @@ import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 from unittest import mock
 
 import opentelemetry.trace as trace_api
@@ -190,7 +190,7 @@ def reset_autolog_state():
     AUTOLOGGING_INTEGRATIONS.clear()
 
 
-def score_in_model_serving(model_uri: str, model_input: dict):
+def score_in_model_serving(model_uri: str, model_input: dict[str, Any]):
     """
     A helper function to emulate model prediction inside a Databricks model serving environment.
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16394?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16394/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16394/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16394/merge
```

</p>
</details>

### Related Issues/PRs

<!-- No related issues for this improvement -->

### What changes are proposed in this pull request?

This PR adds a new `UnparameterizedGeneric` lint rule to the custom clint linter that detects and flags usage of generic types without type parameters in type annotations.

**Key Changes:**
- **New Rule Class**: `UnparameterizedGeneric` in `dev/clint/src/clint/rules.py`
- **Dedicated Visitor**: `TypeAnnotationVisitor` in `dev/clint/src/clint/linter.py` for precise AST context tracking
- **Detects**: `dict`, `list`, `set`, `tuple`, `frozenset`, `Callable` used without type parameters
- **Examples**: Flags `dict` but allows `dict[str, int]`

The rule encourages developers to use specific parameterized types like `dict[str, int]` instead of bare `dict`, improving type safety and code clarity according to the coding guidelines in CLAUDE.md.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

**Manual Testing:**
- Tested with various type annotation scenarios
- Verified correct detection of unparameterized types (`dict`, `list`, etc.)
- Verified proper handling of parameterized types (`dict[str, int]`, `list[str]`, etc.)
- Confirmed error messages are clear and actionable
- All existing clint and ruff checks pass

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

This is an internal development tool improvement that affects the linting process but not end-user functionality.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)