### PR TITLE
Prevent resizable columns from overflowing the page width

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListCharts.tsx
@@ -29,10 +29,12 @@ const ExperimentLoggedModelListChartsImpl = memo(
     chartData,
     uiState,
     metricKeysByDataset,
+    minWidth,
   }: {
     chartData: RunsChartsRunData[];
     uiState: ExperimentRunsChartsUIConfiguration;
     metricKeysByDataset: RunsChartsMetricByDatasetEntry[];
+    minWidth: number;
   }) => {
     const { theme } = useDesignSystemTheme();
     const { formatMessage } = useIntl();
@@ -103,6 +105,7 @@ const ExperimentLoggedModelListChartsImpl = memo(
           flex: 1,
           overflow: 'hidden',
           display: 'flex',
+          minWidth,
         }}
       >
         <div
@@ -184,7 +187,15 @@ const ExperimentLoggedModelListChartsImpl = memo(
 );
 
 export const ExperimentLoggedModelListCharts = memo(
-  ({ loggedModels, experimentId }: { loggedModels: LoggedModelProto[]; experimentId: string }) => {
+  ({
+    loggedModels,
+    experimentId,
+    minWidth,
+  }: {
+    loggedModels: LoggedModelProto[];
+    experimentId: string;
+    minWidth: number;
+  }) => {
     const { theme } = useDesignSystemTheme();
 
     // Perform deep comparison on the logged models to avoid re-rendering the charts when the logged models change.
@@ -224,6 +235,7 @@ export const ExperimentLoggedModelListCharts = memo(
           chartData={chartData}
           uiState={chartUIState}
           metricKeysByDataset={metricsByDataset}
+          minWidth={minWidth}
         />
       </RunsChartsUIConfigurationContextProvider>
     );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRuns.tsx
@@ -34,6 +34,7 @@ import { ExperimentViewRunsTableResizer } from './ExperimentViewRunsTableResizer
 import { RunsChartsSetHighlightContextProvider } from '../../../runs-charts/hooks/useRunsChartTraceHighlight';
 import { useLoggedModelsForExperimentRunsTable } from '../../hooks/useLoggedModelsForExperimentRunsTable';
 import { ExperimentViewRunsRequestError } from '../ExperimentViewRunsRequestError';
+import { useResizableMaxWidth } from '@mlflow/mlflow/src/shared/web-shared/hooks';
 
 export interface ExperimentViewRunsOwnProps {
   isLoading: boolean;
@@ -67,6 +68,7 @@ const createCurrentTime = () => {
 };
 
 const INITIAL_RUN_COLUMN_SIZE = 295;
+const CHARTS_MIN_WIDTH = 350;
 
 export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) => {
   const [compareRunsMode] = useExperimentPageViewMode();
@@ -240,6 +242,8 @@ export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) =>
     [experiments],
   );
 
+  const { resizableMaxWidth, ref } = useResizableMaxWidth(CHARTS_MIN_WIDTH);
+
   return (
     <CreateNewRunContextProvider visibleRuns={visibleRuns} refreshRuns={refreshRuns}>
       <RunsChartsSetHighlightContextProvider>
@@ -257,6 +261,7 @@ export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) =>
           isLoading={isLoadingRuns}
         />
         <div
+          ref={ref}
           css={{
             minHeight: 225, // This is the exact height for displaying a minimum five rows and table header
             height: '100%',
@@ -269,6 +274,7 @@ export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) =>
               onResize={setTableAreaWidth}
               runListHidden={runListHidden}
               width={tableAreaWidth}
+              maxWidth={resizableMaxWidth}
             >
               {tableElement}
             </ExperimentViewRunsTableResizer>
@@ -290,6 +296,7 @@ export const ExperimentViewRuns = React.memo((props: ExperimentViewRunsProps) =>
               globalLineChartConfig={uiState.globalLineChartConfig}
               chartsSearchFilter={uiState.chartsSearchFilter}
               storageKey={configStorageKey}
+              minWidth={CHARTS_MIN_WIDTH}
             />
           )}
           {compareRunsMode === 'ARTIFACT' && (

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableResizer.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTableResizer.tsx
@@ -16,11 +16,13 @@ export const ExperimentViewRunsTableResizer = ({
   onResize,
   children,
   onHiddenChange,
+  maxWidth,
 }: React.PropsWithChildren<{
   runListHidden: boolean;
   width: number;
   onResize: React.Dispatch<React.SetStateAction<number>>;
   onHiddenChange?: (isHidden: boolean) => void;
+  maxWidth: number | undefined;
 }>) => {
   const updateUIState = useUpdateExperimentViewUIState();
   const [dragging, setDragging] = useState(false);
@@ -34,6 +36,7 @@ export const ExperimentViewRunsTableResizer = ({
         axis="x"
         resizeHandles={['e']}
         minConstraints={[250, 0]}
+        maxConstraints={maxWidth === undefined ? undefined : [maxWidth, 0]}
         handle={
           <ExperimentViewRunsTableResizerHandle
             runListHidden={runListHidden}

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.tsx
@@ -64,6 +64,7 @@ export interface RunsCompareProps {
   globalLineChartConfig?: RunsChartsGlobalLineChartConfig;
   chartsSearchFilter?: string;
   storageKey: string;
+  minWidth: number;
 }
 
 /**
@@ -147,6 +148,7 @@ const RunsCompareImpl = ({
   hideEmptyCharts,
   globalLineChartConfig,
   chartsSearchFilter,
+  minWidth,
 }: RunsCompareProps) => {
   // Updater function for the general experiment view UI state
   const updateUIState = useUpdateExperimentViewUIState();
@@ -385,7 +387,7 @@ const RunsCompareImpl = ({
         overflowY: 'auto' as const,
 
         // Make sure charts are visible even on small screens
-        minWidth: 320,
+        minWidth,
       }}
       data-testid="experiment-view-compare-runs-chart-area"
     >

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-logged-models/ExperimentLoggedModelListPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-logged-models/ExperimentLoggedModelListPage.tsx
@@ -28,8 +28,10 @@ import { ExperimentLoggedModelListCharts } from '../../components/experiment-log
 import { ExperimentLoggedModelListPageRowVisibilityContextProvider } from '../../components/experiment-logged-models/hooks/useExperimentLoggedModelListPageRowVisibility';
 import { RunsChartsSetHighlightContextProvider } from '../../components/runs-charts/hooks/useRunsChartTraceHighlight';
 import { BadRequestError } from '@databricks/web-shared/errors';
+import { useResizableMaxWidth } from '@mlflow/mlflow/src/shared/web-shared/hooks';
 
 const INITIAL_RUN_COLUMN_SIZE = 295;
+const CHARTS_MIN_WIDTH = 350;
 
 const ExperimentLoggedModelListPageImpl = () => {
   const { experimentId } = useParams();
@@ -132,6 +134,8 @@ const ExperimentLoggedModelListPageImpl = () => {
       />
     );
 
+  const { resizableMaxWidth, ref } = useResizableMaxWidth(CHARTS_MIN_WIDTH);
+
   return (
     <ExperimentLoggedModelOpenDatasetDetailsContextProvider>
       <ExperimentLoggedModelListPageRowVisibilityContextProvider
@@ -172,17 +176,22 @@ const ExperimentLoggedModelListPageImpl = () => {
         )}
         {isCompactTableMode ? (
           <RunsChartsSetHighlightContextProvider>
-            <div css={{ display: 'flex', flex: 1, overflow: 'hidden', position: 'relative' }}>
+            <div ref={ref} css={{ display: 'flex', flex: 1, overflow: 'hidden', position: 'relative' }}>
               <ExperimentViewRunsTableResizer
                 onResize={setTableAreaWidth}
                 runListHidden={tableHidden}
                 width={tableAreaWidth}
                 onHiddenChange={setTableHidden}
+                maxWidth={resizableMaxWidth}
               >
                 {tableElement}
               </ExperimentViewRunsTableResizer>
               {viewMode === ExperimentLoggedModelListPageMode.CHART && (
-                <ExperimentLoggedModelListCharts loggedModels={loggedModels ?? []} experimentId={experimentId} />
+                <ExperimentLoggedModelListCharts
+                  loggedModels={loggedModels ?? []}
+                  experimentId={experimentId}
+                  minWidth={CHARTS_MIN_WIDTH}
+                />
               )}
             </div>
           </RunsChartsSetHighlightContextProvider>

--- a/mlflow/server/js/src/shared/web-shared/hooks/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/hooks/index.ts
@@ -1,1 +1,2 @@
 export { useMediaQuery } from './useMediaQuery';
+export { useResizableMaxWidth } from './useResizableMaxWidth';

--- a/mlflow/server/js/src/shared/web-shared/hooks/useResizableMaxWidth.ts
+++ b/mlflow/server/js/src/shared/web-shared/hooks/useResizableMaxWidth.ts
@@ -1,0 +1,29 @@
+import { MutableRefObject, useCallback, useLayoutEffect, useRef, useState } from 'react';
+
+export function useResizableMaxWidth(minWidth: number) {
+  const ref: MutableRefObject<HTMLDivElement | null> = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState<number | undefined>(undefined);
+
+  const updateWidth = useCallback(() => {
+    if (ref.current) {
+      setContainerWidth(ref.current.clientWidth);
+    }
+  }, []);
+
+  useLayoutEffect(() => {
+    updateWidth();
+    window.addEventListener('resize', updateWidth);
+    return () => window.removeEventListener('resize', updateWidth);
+  }, [updateWidth]);
+
+  const refCallback = useCallback(
+    (node: HTMLDivElement) => {
+      ref.current = node;
+      updateWidth();
+    },
+    [updateWidth],
+  );
+
+  const resizableMaxWidth = containerWidth === undefined ? undefined : containerWidth - minWidth;
+  return { resizableMaxWidth, ref: refCallback };
+}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16395?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16395/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16395/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16395/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #14806

### What changes are proposed in this pull request?

When a resizable column is expanded too much, the page width increases and it causes horizontal overflow. It should be constrained to not go beyond the minimum width of the other pane.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
