### PR TITLE
Show stored experiment description initially

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewDescriptionNotes.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/ExperimentViewDescriptionNotes.tsx
@@ -63,7 +63,8 @@ export const ExperimentViewDescriptionNotes = ({
   });
   setShowAddDescriptionButton(!storedNote);
 
-  const [tmpNote, setTmpNote] = useState(storedNote);
+  const effectiveNote = storedNote || defaultValue;
+  const [tmpNote, setTmpNote] = useState(effectiveNote);
   const [selectedTab, setSelectedTab] = useState<'write' | 'preview' | undefined>('write');
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -89,7 +90,7 @@ export const ExperimentViewDescriptionNotes = ({
 
   return (
     <div>
-      {(tmpNote ?? defaultValue) && (
+      {effectiveNote && (
         <div
           style={{
             whiteSpace: isExpanded ? 'normal' : 'pre-wrap',
@@ -113,7 +114,7 @@ export const ExperimentViewDescriptionNotes = ({
           >
             <div
               // eslint-disable-next-line react/no-danger
-              dangerouslySetInnerHTML={{ __html: getSanitizedHtmlContent(tmpNote ?? defaultValue) }}
+              dangerouslySetInnerHTML={{ __html: getSanitizedHtmlContent(effectiveNote) }}
             />
           </div>
           <Button
@@ -159,7 +160,7 @@ export const ExperimentViewDescriptionNotes = ({
           setEditing(false);
         }}
         onCancel={() => {
-          setTmpNote(storedNote);
+          setTmpNote(effectiveNote);
           setEditing(false);
         }}
       >

--- a/mlflow/server/js/src/experiment-tracking/reducers/Reducers.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/Reducers.test.ts
@@ -1389,7 +1389,7 @@ describe('test public accessors', () => {
     const A = {
       experimentId: 'a',
       name: 'A',
-      tags: [{ name: 'a', value: 'A' }, 'b'],
+      tags: [{ key: 'a', value: 'A' }],
     };
     const B = {
       experimentId: 'b',
@@ -1400,11 +1400,12 @@ describe('test public accessors', () => {
       payload: { experiments: [A, B] },
     });
     const state = rootReducer(undefined, action);
-    expect(state.entities.experimentTagsByExperimentId).toEqual({});
+    const expectedTags = { a: { a: (ExperimentTag as any).fromJs({ key: 'a', value: 'A' }) }, b: {} };
+    expect(state.entities.experimentTagsByExperimentId).toEqual(expectedTags);
     expect(getExperiments(state)).toEqual([A, B]);
     expect(getExperiment(A.experimentId, state)).toEqual(A);
-    expect(getExperimentTags(B.experimentId, state)).toEqual({});
-    expect(getExperimentTags(A.experimentId, state)).toEqual({});
+    expect(getExperimentTags(A.experimentId, state)).toEqual(expectedTags.a);
+    expect(getExperimentTags(B.experimentId, state)).toEqual(expectedTags.b);
   });
   test('tags, params and runinfo', () => {
     const key1 = 'key1';

--- a/mlflow/server/js/src/experiment-tracking/reducers/Reducers.ts
+++ b/mlflow/server/js/src/experiment-tracking/reducers/Reducers.ts
@@ -407,6 +407,18 @@ export const experimentTagsByExperimentId = (state = {}, action: any) => {
       const tag = { key: action.meta.key, value: action.meta.value };
       return amendExperimentTagsByExperimentId(state, [tag], action.meta.experimentId);
     }
+    case fulfilled(SEARCH_EXPERIMENTS_API): {
+      const newState = { ...state };
+      if (action.payload && action.payload.experiments) {
+        action.payload.experiments.forEach((eJson: any) => {
+          const experiment: ExperimentEntity = eJson;
+          const tags = experiment.tags || [];
+          // @ts-expect-error TS(7053): Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
+          newState[experiment.experimentId] = tagArrToObject(tags);
+        });
+      }
+      return newState;
+    }
     default:
       return state;
   }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16403?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16403/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16403/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16403/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #16393

### What changes are proposed in this pull request?

Show experiment description stored in the server in the experiment page

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

```python
import mlflow
from mlflow.tracking import MlflowClient


exp_name = "mlflow_connection_test"
mlflow.set_experiment(exp_name)

client = MlflowClient()
mlflow.set_experiment_tag("mlflow.note.content", "scriptted added")

experiment = client.get_experiment_by_name(exp_name)
print(f"Name: {experiment.name}")
print(f"Tags: {experiment.tags}")
```

<img width="790" alt="image" src="https://github.com/user-attachments/assets/8f209ca2-0d9c-4072-a374-e4248b963e72" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
