### PR TITLE
Show linked prompts in the run page

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
@@ -17,6 +17,7 @@ import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/util
 import type { LoggedModelProto } from '../../types';
 import { type RunPageModelVersionSummary } from './hooks/useUnifiedRegisteredModelVersionsSummariesForRun';
 import { useExperimentTrackingDetailsPageLayoutStyles } from '../../hooks/useExperimentTrackingDetailsPageLayoutStyles';
+import { LINKED_PROMPTS_TAG_KEY } from '../../pages/prompts/utils';
 
 jest.mock('../../hooks/useExperimentTrackingDetailsPageLayoutStyles', () => ({
   useExperimentTrackingDetailsPageLayoutStyles: jest.fn(),
@@ -40,6 +41,7 @@ jest.mock('@mlflow/mlflow/src/common/utils/FeatureUtils', () => ({
 
 const testPromptName = 'test-prompt';
 const testPromptVersion = 1;
+const testPromptName2 = 'test-prompt-2';
 
 jest.mock('../../pages/prompts/hooks/usePromptVersionsForRunQuery', () => ({
   usePromptVersionsForRunQuery: jest.fn(() => ({
@@ -361,7 +363,22 @@ describe('RunViewOverview integration', () => {
     });
   });
 
-  test('Run overview contains prompts', async () => {
+  test('Run overview contains prompts from run tags', async () => {
+    renderComponent({
+      tags: {
+        [LINKED_PROMPTS_TAG_KEY]: {
+          key: LINKED_PROMPTS_TAG_KEY,
+          value: JSON.stringify([{ name: testPromptName2, version: testPromptVersion.toString() }]),
+        },
+      },
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(`${testPromptName2} (v${testPromptVersion})`)).toBeInTheDocument();
+    });
+  });
+
+  test('Run overview contains prompts from prompt version tags', async () => {
     renderComponent();
 
     await waitFor(() => {

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.tsx
@@ -108,7 +108,7 @@ export const RunViewOverview = ({
             description="Run page > Overview > Run prompts section label"
           />
         }
-        value={<RunViewRegisteredPromptsBox runUuid={runUuid} />}
+        value={<RunViewRegisteredPromptsBox tags={tags} runUuid={runUuid} />}
       />
     );
   };

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewRegisteredPromptsBox.tsx
@@ -2,11 +2,22 @@ import { ParagraphSkeleton, Typography, useDesignSystemTheme } from '@databricks
 import { Link } from '../../../../common/utils/RoutingUtils';
 import { usePromptVersionsForRunQuery } from '../../../pages/prompts/hooks/usePromptVersionsForRunQuery';
 import Routes from '../../../routes';
+import { parseLinkedPromptsFromRunTags } from '../../../pages/prompts/utils';
+import type { KeyValueEntity } from '../../../types';
 
-export const RunViewRegisteredPromptsBox = ({ runUuid }: { runUuid: string }) => {
+export const RunViewRegisteredPromptsBox = ({
+  tags,
+  runUuid,
+}: {
+  tags: Record<string, KeyValueEntity>;
+  runUuid: string;
+}) => {
   const { theme } = useDesignSystemTheme();
+  // This part is for supporting prompt versions created using mlflow < 3.1.0
   const { data, error, isLoading } = usePromptVersionsForRunQuery({ runUuid });
-  const promptVersions = data?.model_versions;
+  const promptVersionsFromPromptTags = data?.model_versions || [];
+  const promptVersionsFromRunTags = parseLinkedPromptsFromRunTags(tags);
+  const promptVersions = [...promptVersionsFromPromptTags, ...promptVersionsFromRunTags];
 
   if (isLoading) {
     return <ParagraphSkeleton />;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
@@ -17,7 +17,6 @@ import userEvent from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { getTableRowByCellText } from '@databricks/design-system/test-utils/rtl';
 import { MockedReduxStoreProvider } from '../../../common/utils/TestUtils';
-import { REGISTERED_PROMPT_SOURCE_RUN_ID, REGISTERED_PROMPT_SOURCE_RUN_IDS } from './utils';
 
 jest.setTimeout(30000); // increase timeout due to heavier use of tables, modals and forms
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/test-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/test-utils.ts
@@ -1,5 +1,5 @@
 import { rest } from 'msw';
-import { REGISTERED_PROMPT_CONTENT_TAG_KEY, REGISTERED_PROMPT_SOURCE_RUN_ID } from './utils';
+import { REGISTERED_PROMPT_CONTENT_TAG_KEY } from './utils';
 import { KeyValueEntity, ModelAliasMap } from '../../types';
 
 export const getMockedRegisteredPromptSetTagsResponse = (spyFn = jest.fn()) =>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16410?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16410/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16410/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16410/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #16361

### What changes are proposed in this pull request?

Since https://github.com/mlflow/mlflow/pull/16168/files, the linkage between prompt versions and runs are stored as a run tag, and the UI has been failing to display the linkage properly. This PR fixes the issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="867" alt="image" src="https://github.com/user-attachments/assets/58b4e635-b9ad-45f8-ab43-8a56069587a0" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
