### PR TITLE
Use tracking uri in download_artifacts

### DIFF
--- a/mlflow/artifacts/__init__.py
+++ b/mlflow/artifacts/__init__.py
@@ -82,7 +82,7 @@ def download_artifacts(
         return _download_artifact_from_uri(artifact_uri, output_path=dst_path)
 
     # Use `runs:/<run_id>/<artifact_path>` to download both run and model (if exists) artifacts
-    if run_id and artifact_path:
+    if run_id and artifact_path and tracking_uri is None:
         return _download_artifact_from_uri(
             f"runs:/{posixpath.join(run_id, artifact_path)}", output_path=dst_path
         )
@@ -133,7 +133,7 @@ def list_artifacts(
         return get_artifact_repository(artifact_uri=root_uri).list_artifacts(artifact_path)
 
     # Use `runs:/<run_id>/<artifact_path>` to list both run and model (if exists) artifacts
-    if run_id and artifact_path:
+    if run_id and artifact_path and tracking_uri is None:
         return get_artifact_repository(artifact_uri=f"runs:/{run_id}").list_artifacts(artifact_path)
 
     store = _get_store(store_uri=tracking_uri)

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -97,34 +97,34 @@ def test_download_artifacts_throws_for_invalid_arguments():
 def test_download_artifacts_with_different_tracking_uri(tmp_path):
     original_tracking_uri = mlflow.get_tracking_uri()
 
-    tracking_uri_1 = str(tmp_path / "mlruns1")
-    mlflow.set_tracking_uri(tracking_uri_1)
+    try:
+        tracking_uri_1 = str(tmp_path / "mlruns1")
+        mlflow.set_tracking_uri(tracking_uri_1)
 
-    artifact_content = "test content"
-    local_file = tmp_path / "local_test.txt"
-    local_file.write_text(artifact_content)
+        artifact_content = "test content"
+        local_file = tmp_path / "local_test.txt"
+        local_file.write_text(artifact_content)
 
-    with mlflow.start_run() as run:
-        mlflow.log_artifact(str(local_file))
-        run_id = run.info.run_id
+        with mlflow.start_run() as run:
+            mlflow.log_artifact(str(local_file))
+            run_id = run.info.run_id
 
-    tracking_uri_2 = str(tmp_path / "mlruns2")
-    mlflow.set_tracking_uri(tracking_uri_2)
+        tracking_uri_2 = str(tmp_path / "mlruns2")
+        mlflow.set_tracking_uri(tracking_uri_2)
 
-    dst_path = tmp_path / "download_dest"
-    download_path = mlflow.artifacts.download_artifacts(
-        run_id=run_id,
-        artifact_path="local_test.txt",
-        tracking_uri=tracking_uri_1,
-        dst_path=str(dst_path),
-    )
+        dst_path = tmp_path / "download_dest"
+        download_path = mlflow.artifacts.download_artifacts(
+            run_id=run_id,
+            artifact_path="local_test.txt",
+            tracking_uri=tracking_uri_1,
+            dst_path=str(dst_path),
+        )
 
-    downloaded_file = pathlib.Path(download_path)
-    assert downloaded_file.read_text() == artifact_content
+        downloaded_file = pathlib.Path(download_path)
+        assert downloaded_file.read_text() == artifact_content
 
-    mlflow.set_tracking_uri(original_tracking_uri)
-
-
+    finally:
+        mlflow.set_tracking_uri(original_tracking_uri)
 @pytest.fixture
 def run_with_text_artifact():
     artifact_path = "test/file.txt"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16423?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16423/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16423/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16423/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #16412

### What changes are proposed in this pull request?

Fix the issue that if both a run_id and an artifact_path are specified, `download_artifacts` ignores the tracking_uri

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
