### PR TITLE
Add rest handlers for assessments APIs

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2692,11 +2692,15 @@ def get_trace_artifact_handler():
     return _response_with_file_attachment_headers(TRACE_DATA_FILE_NAME, file_sender_response)
 
 
+# Assessments API handlers
+
+
 @catch_mlflow_exception
 @_disable_if_artifacts_only
 def _create_assessment():
     """
-    A request handler for `POST /mlflow/traces/{assessment.trace_id}/assessments` to create a new assessment.
+    A request handler for `POST /mlflow/traces/{assessment.trace_id}/assessments`
+    to create a new assessment.
     """
     request_message = _get_request_message(
         CreateAssessment(),
@@ -2717,7 +2721,8 @@ def _create_assessment():
 @_disable_if_artifacts_only
 def _get_assessment(trace_id, assessment_id):
     """
-    A request handler for `GET /mlflow/traces/{trace_id}/assessments/{assessment_id}` to get an assessment.
+    A request handler for `GET /mlflow/traces/{trace_id}/assessments/{assessment_id}`
+    to get an assessment.
     """
     assessment = _get_tracking_store().get_assessment(trace_id, assessment_id)
 
@@ -2729,7 +2734,8 @@ def _get_assessment(trace_id, assessment_id):
 @_disable_if_artifacts_only
 def _update_assessment(trace_id, assessment_id):
     """
-    A request handler for `PATCH /mlflow/traces/{trace_id}/assessments/{assessment_id}` to update an assessment.
+    A request handler for `PATCH /mlflow/traces/{trace_id}/assessments/{assessment_id}`
+    to update an assessment.
     """
     request_message = _get_request_message(
         UpdateAssessment(),
@@ -2770,7 +2776,8 @@ def _update_assessment(trace_id, assessment_id):
 @_disable_if_artifacts_only
 def _delete_assessment(trace_id, assessment_id):
     """
-    A request handler for `DELETE /mlflow/traces/{trace_id}/assessments/{assessment_id}` to delete an assessment.
+    A request handler for `DELETE /mlflow/traces/{trace_id}/assessments/{assessment_id}`
+    to delete an assessment.
     """
     _get_tracking_store().delete_assessment(trace_id, assessment_id)
 

--- a/mlflow/store/db_migrations/versions/770bee3ae1dd_add_assessments_table.py
+++ b/mlflow/store/db_migrations/versions/770bee3ae1dd_add_assessments_table.py
@@ -5,15 +5,15 @@ Revises: 6953534de441
 Create Date: 2025-06-23 11:26:19.855639
 
 """
-from alembic import op
+
 import sqlalchemy as sa
+from alembic import op
 
 from mlflow.store.tracking.dbmodels.models import SqlAssessments
 
-
 # revision identifiers, used by Alembic.
-revision = '770bee3ae1dd'
-down_revision = '6953534de441'
+revision = "770bee3ae1dd"
+down_revision = "6953534de441"
 branch_labels = None
 depends_on = None
 
@@ -45,27 +45,27 @@ def upgrade():
         ),
         sa.PrimaryKeyConstraint("assessment_id", name="assessments_pk"),
     )
-    
+
     with op.batch_alter_table(SqlAssessments.__tablename__, schema=None) as batch_op:
         batch_op.create_index(
             f"index_{SqlAssessments.__tablename__}_trace_id_created_timestamp",
             ["trace_id", "created_timestamp"],
-            unique=False
+            unique=False,
         )
         batch_op.create_index(
-            f"index_{SqlAssessments.__tablename__}_run_id_created_timestamp", 
+            f"index_{SqlAssessments.__tablename__}_run_id_created_timestamp",
             ["run_id", "created_timestamp"],
-            unique=False
+            unique=False,
         )
         batch_op.create_index(
             f"index_{SqlAssessments.__tablename__}_last_updated_timestamp",
             ["last_updated_timestamp"],
-            unique=False
+            unique=False,
         )
         batch_op.create_index(
             f"index_{SqlAssessments.__tablename__}_assessment_type",
             ["assessment_type"],
-            unique=False
+            unique=False,
         )
 
 

--- a/mlflow/store/db_migrations/versions/770bee3ae1dd_add_assessments_table.py
+++ b/mlflow/store/db_migrations/versions/770bee3ae1dd_add_assessments_table.py
@@ -1,0 +1,73 @@
+"""add assessments table
+
+Revision ID: 770bee3ae1dd
+Revises: 6953534de441
+Create Date: 2025-06-23 11:26:19.855639
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from mlflow.store.tracking.dbmodels.models import SqlAssessments
+
+
+# revision identifiers, used by Alembic.
+revision = '770bee3ae1dd'
+down_revision = '6953534de441'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        SqlAssessments.__tablename__,
+        sa.Column("assessment_id", sa.String(length=50), nullable=False),
+        sa.Column("trace_id", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=250), nullable=False),
+        sa.Column("assessment_type", sa.String(length=20), nullable=False),
+        sa.Column("value", sa.Text(), nullable=False),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("created_timestamp", sa.BigInteger(), nullable=False),
+        sa.Column("last_updated_timestamp", sa.BigInteger(), nullable=False),
+        sa.Column("source_type", sa.String(length=50), nullable=False),
+        sa.Column("source_id", sa.String(length=250), nullable=True),
+        sa.Column("run_id", sa.String(length=32), nullable=True),
+        sa.Column("span_id", sa.String(length=50), nullable=True),
+        sa.Column("rationale", sa.Text(), nullable=True),
+        sa.Column("overrides", sa.String(length=50), nullable=True),
+        sa.Column("valid", sa.Boolean(), nullable=False, default=True),
+        sa.Column("assessment_metadata", sa.Text(), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["trace_id"],
+            ["trace_info.request_id"],
+            name="fk_assessments_trace_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("assessment_id", name="assessments_pk"),
+    )
+    
+    with op.batch_alter_table(SqlAssessments.__tablename__, schema=None) as batch_op:
+        batch_op.create_index(
+            f"index_{SqlAssessments.__tablename__}_trace_id_created_timestamp",
+            ["trace_id", "created_timestamp"],
+            unique=False
+        )
+        batch_op.create_index(
+            f"index_{SqlAssessments.__tablename__}_run_id_created_timestamp", 
+            ["run_id", "created_timestamp"],
+            unique=False
+        )
+        batch_op.create_index(
+            f"index_{SqlAssessments.__tablename__}_last_updated_timestamp",
+            ["last_updated_timestamp"],
+            unique=False
+        )
+        batch_op.create_index(
+            f"index_{SqlAssessments.__tablename__}_assessment_type",
+            ["assessment_type"],
+            unique=False
+        )
+
+
+def downgrade():
+    op.drop_table(SqlAssessments.__tablename__)

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -761,6 +761,97 @@ class SqlTraceRequestMetadata(Base):
     )
 
 
+class SqlAssessments(Base):
+    __tablename__ = "assessments"
+
+    assessment_id = Column(String(50), nullable=False)
+    """
+    Assessment ID: `String` (limit 50 characters). *Primary Key* for ``assessments`` table.
+    """
+    trace_id = Column(
+        String(50), ForeignKey("trace_info.request_id", ondelete="CASCADE"), nullable=False
+    )
+    """
+    Trace ID that a given assessment belongs to. *Foreign Key* into ``trace_info`` table.
+    """
+    name = Column(String(250), nullable=False)
+    """
+    Assessment Name: `String` (limit of 250 characters).
+    """
+    assessment_type = Column(String(50), nullable=False)
+    """
+    Assessment type: `String` (limit 50 characters). Either "feedback" or "expectation".
+    """
+    value = Column(Text, nullable=False)
+    """
+    The assessment's value data stored as JSON: `Text` for the actual value content.
+    """
+    error = Column(Text, nullable=True)
+    """
+    AssessmentError stored as JSON: `Text` for error information (feedback only).
+    """
+    created_timestamp = Column(BigInteger, nullable=False)
+    """
+    The assessment's creation timestamp: `BigInteger`.
+    """
+    last_updated_timestamp = Column(BigInteger, nullable=False)
+    """
+    The update time of an assessment if the assessment has been updated: `BigInteger`.
+    """
+    source_type = Column(String(50), nullable=False)
+    """
+    Assessment source type: `String` (limit 50 characters). e.g., "HUMAN", "CODE", "LLM_JUDGE".
+    """
+    source_id = Column(String(250), nullable=True)
+    """
+    Assessment source ID: `String` (limit 250 characters). e.g., "evaluator@company.com".
+    """
+    run_id = Column(String(32), nullable=True)
+    """
+    Run ID associated with the assessment if generated due to a run event:
+    `String` (limit of 32 characters).
+    """
+    span_id = Column(String(50), nullable=True)
+    """
+    Span ID if the assessment is applied to a Span within a Trace:
+    `String` (limit of 50 characters).
+    """
+    rationale = Column(Text, nullable=True)
+    """
+    Justification for the assessment: `Text` for longer explanations.
+    """
+    overrides = Column(String(50), nullable=True)
+    """
+    Overridden assessment_id if an assessment is intended to update and replace an existing
+    assessment: `String` (limit of 50 characters).
+    """
+    valid = Column(Boolean, nullable=False, default=True)
+    """
+    Indicator for whether an assessment has been marked as invalid: `Boolean`. Defaults to True.
+    """
+    assessment_metadata = Column(Text, nullable=True)
+    """
+    Assessment metadata stored as JSON: `Text` for complex metadata structures.
+    """
+
+    trace_info = relationship("SqlTraceInfo", backref=backref("assessments", cascade="all"))
+    """
+    SQLAlchemy relationship (many:one) with
+    :py:class:`mlflow.store.dbmodels.models.SqlTraceInfo`.
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint("assessment_id", name="assessments_pkey"),
+        Index(f"index_{__tablename__}_trace_id_created_timestamp", "trace_id", "created_timestamp"),
+        Index(f"index_{__tablename__}_run_id_created_timestamp", "run_id", "created_timestamp"),
+        Index(f"index_{__tablename__}_last_updated_timestamp", "last_updated_timestamp"),
+        Index(f"index_{__tablename__}_assessment_type", "assessment_type"),
+    )
+
+    def __repr__(self):
+        return f"<SqlAssessments({self.assessment_id}, {self.name}, {self.assessment_type})>"
+
+
 class SqlLoggedModel(Base):
     __tablename__ = "logged_models"
 

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -89,3 +89,6 @@ STREAM_CHUNK_EVENT_VALUE_KEY = "mlflow.chunk.value"
 DATABRICKS_OPTIONS_KEY = "databricks_options"
 RETURN_TRACE_OPTION_KEY = "return_trace"
 DATABRICKS_OUTPUT_KEY = "databricks_output"
+
+# Assessment constants
+ASSESSMENT_ID_PREFIX = "a-"

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -17,6 +17,7 @@ from packaging.version import Version
 
 from mlflow.exceptions import BAD_REQUEST, MlflowTracingException
 from mlflow.tracing.constant import (
+    ASSESSMENT_ID_PREFIX,
     TRACE_REQUEST_ID_PREFIX,
     SpanAttributeKey,
     TokenUsageKey,
@@ -543,3 +544,14 @@ def update_trace_state_from_span_conditionally(trace, root_span):
     # and we should preserve it
     if trace.info.state == TraceState.IN_PROGRESS:
         trace.info.state = TraceState.from_otel_status(root_span.status)
+
+
+def generate_assessment_id() -> str:
+    """
+    Generates an assessment ID of the form 'a-<uuid4>' in hex string format.
+
+    Returns:
+        A unique identifier for an assessment that will be logged to a trace tag.
+    """
+    id = uuid.uuid4().hex
+    return f"{ASSESSMENT_ID_PREFIX}{id}"

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -152,6 +152,28 @@ CREATE TABLE trace_info (
 )
 
 
+CREATE TABLE assessments (
+	assessment_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	name VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	assessment_type VARCHAR(20) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	value VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	error VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_timestamp BIGINT NOT NULL,
+	last_updated_timestamp BIGINT NOT NULL,
+	source_type VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	source_id VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	run_id VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	rationale VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	overrides VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	valid BIT NOT NULL,
+	assessment_metadata VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
+	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE latest_metrics (
 	key VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	value FLOAT NOT NULL,

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -157,6 +157,28 @@ CREATE TABLE trace_info (
 )
 
 
+CREATE TABLE assessments (
+	assessment_id VARCHAR(50) NOT NULL,
+	trace_id VARCHAR(50) NOT NULL,
+	name VARCHAR(250) NOT NULL,
+	assessment_type VARCHAR(20) NOT NULL,
+	value TEXT NOT NULL,
+	error TEXT,
+	created_timestamp BIGINT NOT NULL,
+	last_updated_timestamp BIGINT NOT NULL,
+	source_type VARCHAR(50) NOT NULL,
+	source_id VARCHAR(250),
+	run_id VARCHAR(32),
+	span_id VARCHAR(50),
+	rationale TEXT,
+	overrides VARCHAR(50),
+	valid TINYINT NOT NULL,
+	assessment_metadata TEXT,
+	PRIMARY KEY (assessment_id),
+	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE latest_metrics (
 	key VARCHAR(250) NOT NULL,
 	value DOUBLE NOT NULL,

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -158,6 +158,28 @@ CREATE TABLE trace_info (
 )
 
 
+CREATE TABLE assessments (
+	assessment_id VARCHAR(50) NOT NULL,
+	trace_id VARCHAR(50) NOT NULL,
+	name VARCHAR(250) NOT NULL,
+	assessment_type VARCHAR(20) NOT NULL,
+	value TEXT NOT NULL,
+	error TEXT,
+	created_timestamp BIGINT NOT NULL,
+	last_updated_timestamp BIGINT NOT NULL,
+	source_type VARCHAR(50) NOT NULL,
+	source_id VARCHAR(250),
+	run_id VARCHAR(32),
+	span_id VARCHAR(50),
+	rationale TEXT,
+	overrides VARCHAR(50),
+	valid BOOLEAN NOT NULL,
+	assessment_metadata TEXT,
+	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
+	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE latest_metrics (
 	key VARCHAR(250) NOT NULL,
 	value DOUBLE PRECISION NOT NULL,

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -159,6 +159,28 @@ CREATE TABLE trace_info (
 )
 
 
+CREATE TABLE assessments (
+	assessment_id VARCHAR(50) NOT NULL,
+	trace_id VARCHAR(50) NOT NULL,
+	name VARCHAR(250) NOT NULL,
+	assessment_type VARCHAR(20) NOT NULL,
+	value TEXT NOT NULL,
+	error TEXT,
+	created_timestamp BIGINT NOT NULL,
+	last_updated_timestamp BIGINT NOT NULL,
+	source_type VARCHAR(50) NOT NULL,
+	source_id VARCHAR(250),
+	run_id VARCHAR(32),
+	span_id VARCHAR(50),
+	rationale TEXT,
+	overrides VARCHAR(50),
+	valid BOOLEAN NOT NULL,
+	assessment_metadata TEXT,
+	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
+	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE latest_metrics (
 	key VARCHAR(250) NOT NULL,
 	value FLOAT NOT NULL,

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -159,6 +159,28 @@ CREATE TABLE trace_info (
 )
 
 
+CREATE TABLE assessments (
+	assessment_id VARCHAR(50) NOT NULL,
+	trace_id VARCHAR(50) NOT NULL,
+	name VARCHAR(250) NOT NULL,
+	assessment_type VARCHAR(20) NOT NULL,
+	value TEXT NOT NULL,
+	error TEXT,
+	created_timestamp BIGINT NOT NULL,
+	last_updated_timestamp BIGINT NOT NULL,
+	source_type VARCHAR(50) NOT NULL,
+	source_id VARCHAR(250),
+	run_id VARCHAR(32),
+	span_id VARCHAR(50),
+	rationale TEXT,
+	overrides VARCHAR(50),
+	valid BOOLEAN NOT NULL,
+	assessment_metadata TEXT,
+	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
+	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE latest_metrics (
 	key VARCHAR(250) NOT NULL,
 	value FLOAT NOT NULL,

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -1054,7 +1054,8 @@ def test_set_trace_tag():
             assert res is None
 
 
-def test_log_assessment_feedback():
+@pytest.mark.parametrize("is_databricks", [True, False])
+def test_log_assessment_feedback(is_databricks):
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
     response = mock.MagicMock()
@@ -1095,7 +1096,7 @@ def test_log_assessment_feedback():
     )
 
     request = CreateAssessment(assessment=feedback.to_proto())
-    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=True):
+    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=is_databricks):
         with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
             res = store.create_assessment(feedback)
 
@@ -1105,14 +1106,15 @@ def test_log_assessment_feedback():
                 "traces/tr-1234/assessments",
                 "POST",
                 message_to_json(request),
-                use_v3=True,
+                use_v3=is_databricks,
             )
             assert isinstance(res, Feedback)
             assert res.assessment_id is not None
             assert res.value == feedback.value
 
 
-def test_log_assessment_expectation():
+@pytest.mark.parametrize("is_databricks", [True, False])
+def test_log_assessment_expectation(is_databricks):
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
     response = mock.MagicMock()
@@ -1152,7 +1154,7 @@ def test_log_assessment_expectation():
     )
 
     request = CreateAssessment(assessment=expectation.to_proto())
-    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=True):
+    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=is_databricks):
         with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
             res = store.create_assessment(expectation)
 
@@ -1162,13 +1164,14 @@ def test_log_assessment_expectation():
                 "traces/tr-1234/assessments",
                 "POST",
                 message_to_json(request),
-                use_v3=True,
+                use_v3=is_databricks,
             )
             assert isinstance(res, Expectation)
             assert res.assessment_id is not None
             assert res.value == expectation.value
 
 
+@pytest.mark.parametrize("is_databricks", [True, False])
 @pytest.mark.parametrize(
     ("updates", "expected_request_json"),
     [
@@ -1213,7 +1216,7 @@ def test_log_assessment_expectation():
         ),
     ],
 )
-def test_update_assessment(updates, expected_request_json):
+def test_update_assessment(updates, expected_request_json, is_databricks):
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
     response = mock.MagicMock()
@@ -1239,7 +1242,7 @@ def test_update_assessment(updates, expected_request_json):
         }
     )
 
-    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=True):
+    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=is_databricks):
         with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
             res = store.update_assessment(
                 trace_id="tr-1234",
@@ -1253,12 +1256,13 @@ def test_update_assessment(updates, expected_request_json):
                 "traces/tr-1234/assessments/1234",
                 "PATCH",
                 json.dumps(expected_request_json),
-                use_v3=True,
+                use_v3=is_databricks,
             )
             assert isinstance(res, Assessment)
 
 
-def test_get_assessment():
+@pytest.mark.parametrize("is_databricks", [True, False])
+def test_get_assessment(is_databricks):
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
     response = mock.MagicMock()
@@ -1284,7 +1288,7 @@ def test_get_assessment():
         }
     )
 
-    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=True):
+    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=is_databricks):
         with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
             res = store.get_assessment(trace_id="tr-1234", assessment_id="1234")
 
@@ -1295,7 +1299,7 @@ def test_get_assessment():
             "traces/tr-1234/assessments/1234",
             "GET",
             json.dumps(expected_request_json),
-            use_v3=True,
+            use_v3=is_databricks,
         )
 
     assert isinstance(res, Feedback)
@@ -1307,14 +1311,15 @@ def test_get_assessment():
     assert res.value == "test value"
 
 
-def test_delete_assessment():
+@pytest.mark.parametrize("is_databricks", [True, False])
+def test_delete_assessment(is_databricks):
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
     response = mock.MagicMock()
     response.status_code = 200
     response.text = "{}"
 
-    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=True):
+    with mock.patch.object(store, "_is_databricks_tracking_uri", return_value=is_databricks):
         with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
             store.delete_assessment(trace_id="tr-1234", assessment_id="1234")
 
@@ -1325,7 +1330,7 @@ def test_delete_assessment():
             "traces/tr-1234/assessments/1234",
             "DELETE",
             json.dumps(expected_request_json),
-            use_v3=True,
+            use_v3=is_databricks,
         )
 
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -36,6 +36,7 @@ from mlflow.entities import (
     ViewType,
     _DatasetSummary,
 )
+from mlflow.entities.assessment import ExpectationValue, FeedbackValue
 from mlflow.entities.logged_model_output import LoggedModelOutput
 from mlflow.entities.logged_model_parameter import LoggedModelParameter
 from mlflow.entities.logged_model_status import LoggedModelStatus
@@ -66,7 +67,6 @@ from mlflow.store.tracking import (
 )
 from mlflow.store.tracking.dbmodels import models
 from mlflow.store.tracking.dbmodels.models import (
-    SqlAssessments,
     SqlDataset,
     SqlExperiment,
     SqlExperimentTag,
@@ -5551,13 +5551,13 @@ def test_create_and_get_assessment(store):
         span_id="span-123",
     )
 
-    created_feedback = store.create_assessment(feedback)
+    created_feedback = store.create_assessment(trace_info.request_id, feedback)
     assert created_feedback.assessment_id is not None
     assert created_feedback.assessment_id.startswith("a-")
     assert created_feedback.trace_id == trace_info.request_id
     assert created_feedback.create_time_ms is not None
     assert created_feedback.name == "correctness"
-    assert created_feedback.feedback.value is True
+    assert created_feedback.value is True
     assert created_feedback.rationale == "The response is correct and well-formatted"
     assert created_feedback.metadata == {"project": "test-project", "version": "1.0"}
     assert created_feedback.span_id == "span-123"
@@ -5574,17 +5574,17 @@ def test_create_and_get_assessment(store):
         span_id="span-456",
     )
 
-    created_expectation = store.create_assessment(expectation)
+    created_expectation = store.create_assessment(trace_info.request_id, expectation)
     assert created_expectation.assessment_id != created_feedback.assessment_id
     assert created_expectation.trace_id == trace_info.request_id
-    assert created_expectation.expectation.value == "The capital of France is Paris."
+    assert created_expectation.value == "The capital of France is Paris."
     assert created_expectation.metadata == {"context": "geography-qa", "difficulty": "easy"}
     assert created_expectation.span_id == "span-456"
     assert created_expectation.valid
 
     retrieved_feedback = store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
     assert retrieved_feedback.name == "correctness"
-    assert retrieved_feedback.feedback.value is True
+    assert retrieved_feedback.value is True
     assert retrieved_feedback.rationale == "The response is correct and well-formatted"
     assert retrieved_feedback.metadata == {"project": "test-project", "version": "1.0"}
     assert retrieved_feedback.span_id == "span-123"
@@ -5594,7 +5594,7 @@ def test_create_and_get_assessment(store):
     retrieved_expectation = store.get_assessment(
         trace_info.request_id, created_expectation.assessment_id
     )
-    assert retrieved_expectation.expectation.value == "The capital of France is Paris."
+    assert retrieved_expectation.value == "The capital of France is Paris."
     assert retrieved_expectation.metadata == {"context": "geography-qa", "difficulty": "easy"}
     assert retrieved_expectation.span_id == "span-456"
     assert retrieved_expectation.trace_id == trace_info.request_id
@@ -5610,69 +5610,12 @@ def test_get_assessment_errors(store):
 
     with pytest.raises(
         MlflowException,
-        match=r"Assessment with ID 'fake_assessment' not found for trace "
-        rf"'{trace_info.request_id}'",
+        match=r"Assessment with ID 'fake_assessment' not found for trace",
     ):
         store.get_assessment(trace_info.request_id, "fake_assessment")
 
 
-def test_create_assessment_with_complex_data_structures(store):
-    exp_id = store.create_experiment("test_complex_data")
-    timestamp_ms = get_current_time_millis()
-    trace_info = store.start_trace(exp_id, timestamp_ms, {}, {})
-
-    complex_feedback_value = {
-        "scores": {"accuracy": 0.95, "precision": 0.87, "recall": 0.92, "f1": 0.895},
-        "categories": ["correct", "well-formatted", "complete"],
-        "details": {
-            "reasoning_steps": [
-                {"step": 1, "description": "Identified key entities", "confidence": 0.9},
-                {"step": 2, "description": "Applied logical reasoning", "confidence": 0.85},
-                {"step": 3, "description": "Generated response", "confidence": 0.88},
-            ],
-            "error_analysis": None,
-            "alternative_answers": ["Paris, France", "Paris"],
-        },
-        "metadata": {
-            "model_version": "v2.1.0",
-            "temperature": 0.7,
-            "max_tokens": 150,
-            "stop_sequences": ["\n\n", "END"],
-        },
-    }
-
-    feedback = Feedback(
-        trace_id=trace_info.request_id,
-        name="detailed_evaluation",
-        value=complex_feedback_value,
-        rationale="Comprehensive evaluation with multiple metrics and detailed analysis",
-        source=AssessmentSource(
-            source_type=AssessmentSourceType.LLM_JUDGE, source_id="gpt-4-evaluator"
-        ),
-        metadata={"evaluation_framework": "comprehensive_v1", "batch_id": "eval_001"},
-    )
-
-    created_feedback = store.create_assessment(feedback)
-    assert created_feedback.assessment_id is not None
-    assert created_feedback.assessment_id.startswith("a-")
-    assert created_feedback.name == "detailed_evaluation"
-    assert created_feedback.feedback.value == complex_feedback_value
-    assert (
-        created_feedback.rationale
-        == "Comprehensive evaluation with multiple metrics and detailed analysis"
-    )
-    assert created_feedback.valid
-
-    retrieved_feedback = store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
-    assert retrieved_feedback.feedback.value == complex_feedback_value
-    assert retrieved_feedback.feedback.value["scores"]["accuracy"] == 0.95
-    assert len(retrieved_feedback.feedback.value["categories"]) == 3
-    assert retrieved_feedback.feedback.value["details"]["reasoning_steps"][0]["step"] == 1
-    assert retrieved_feedback.feedback.value["metadata"]["model_version"] == "v2.1.0"
-
-
-@pytest.mark.parametrize("valid", [True, False])
-def test_update_assessment_feedback(store, valid):
+def test_update_assessment_feedback(store):
     exp_id = store.create_experiment("test_update_feedback")
     trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
 
@@ -5688,75 +5631,35 @@ def test_update_assessment_feedback(store, valid):
         span_id="span-123",
     )
 
-    created_feedback = store.create_assessment(original_feedback)
+    created_feedback = store.create_assessment(trace_info.request_id, original_feedback)
     original_id = created_feedback.assessment_id
 
     updated_feedback = store.update_assessment(
         trace_id=trace_info.request_id,
         assessment_id=original_id,
-        feedback=Feedback(
-            name="correctness",
-            value=False,
-            source=AssessmentSource(
-                source_type=AssessmentSourceType.HUMAN, source_id="evaluator@company.com"
-            ),
-        ),
+        name="correctness_updated",
+        feedback=FeedbackValue(value=False),
         rationale="Updated rationale",
-        metadata={"project": "test-project", "version": "2.0"},
-        valid=valid,
+        metadata={"project": "test-project", "version": "2.0", "new_field": "added"},
     )
 
-    assert updated_feedback.assessment_id != original_id
-    assert updated_feedback.assessment_id.startswith("a-")
-    assert updated_feedback.name == "correctness"  # Name should remain unchanged
-    assert updated_feedback.feedback.value is False
+    assert updated_feedback.assessment_id == original_id
+    assert updated_feedback.name == "correctness_updated"
+    assert updated_feedback.value is False
     assert updated_feedback.rationale == "Updated rationale"
-    assert updated_feedback.metadata == {"project": "test-project", "version": "2.0"}
+    assert updated_feedback.metadata == {
+        "project": "test-project",
+        "version": "2.0",
+        "new_field": "added",
+    }
     assert updated_feedback.span_id == "span-123"
     assert updated_feedback.source.source_id == "evaluator@company.com"
     assert updated_feedback.valid is True
-    assert updated_feedback.overrides == original_id
 
-    original_retrieved = store.get_assessment(trace_info.request_id, original_id)
-    if valid:
-        assert original_retrieved.valid is True
-    else:
-        assert original_retrieved.valid is False
-
-    assert original_retrieved.feedback.value is True
-    assert original_retrieved.rationale == "Original rationale"
-
-
-def test_update_assessment_name(store):
-    """Test that assessment name can be updated"""
-    exp_id = store.create_experiment("test_update_name")
-    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
-
-    original_feedback = Feedback(
-        trace_id=trace_info.request_id,
-        name="original_name",
-        value=True,
-        source=AssessmentSource(
-            source_type=AssessmentSourceType.HUMAN, source_id="evaluator@company.com"
-        ),
-    )
-
-    created_feedback = store.create_assessment(original_feedback)
-    original_id = created_feedback.assessment_id
-
-    updated_feedback = store.update_assessment(
-        trace_id=trace_info.request_id,
-        assessment_id=original_id,
-        name="updated_name",
-    )
-
-    assert updated_feedback.name == "updated_name"
-    assert updated_feedback.assessment_id != original_id
-    assert updated_feedback.feedback.value is True  # Value should remain unchanged
-    assert updated_feedback.overrides == original_id
-
-    original_retrieved = store.get_assessment(trace_info.request_id, original_id)
-    assert original_retrieved.name == "original_name"
+    retrieved = store.get_assessment(trace_info.request_id, original_id)
+    assert retrieved.value is False
+    assert retrieved.name == "correctness_updated"
+    assert retrieved.rationale == "Updated rationale"
 
 
 def test_update_assessment_expectation(store):
@@ -5774,37 +5677,51 @@ def test_update_assessment_expectation(store):
         span_id="span-456",
     )
 
-    created_expectation = store.create_assessment(original_expectation)
+    created_expectation = store.create_assessment(trace_info.request_id, original_expectation)
     original_id = created_expectation.assessment_id
 
     updated_expectation = store.update_assessment(
         trace_id=trace_info.request_id,
         assessment_id=original_id,
-        expectation=Expectation(
-            name="expected_response",
-            value="The capital and largest city of France is Paris.",
-            source=AssessmentSource(
-                source_type=AssessmentSourceType.HUMAN, source_id="annotator@company.com"
-            ),
-        ),
+        expectation=ExpectationValue(value="The capital and largest city of France is Paris."),
         metadata={"context": "geography-qa", "updated": "true"},
     )
 
-    assert updated_expectation.assessment_id != original_id
+    assert updated_expectation.assessment_id == original_id
     assert updated_expectation.name == "expected_response"
-    assert (
-        updated_expectation.expectation.value == "The capital and largest city of France is Paris."
-    )
+    assert updated_expectation.value == "The capital and largest city of France is Paris."
     assert updated_expectation.metadata == {"context": "geography-qa", "updated": "true"}
     assert updated_expectation.span_id == "span-456"
     assert updated_expectation.source.source_id == "annotator@company.com"
-    assert updated_expectation.valid is True
-    assert updated_expectation.overrides == original_id
 
-    original_retrieved = store.get_assessment(trace_info.request_id, original_id)
-    assert original_retrieved.valid is True
-    assert original_retrieved.expectation.value == "The capital of France is Paris."
-    assert original_retrieved.name == "expected_response"
+
+def test_update_assessment_partial_fields(store):
+    exp_id = store.create_experiment("test_partial_updates")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+
+    original_feedback = Feedback(
+        trace_id=trace_info.request_id,
+        name="quality",
+        value=5,
+        rationale="Original rationale",
+        source=AssessmentSource(source_type=AssessmentSourceType.CODE),
+        metadata={"scorer": "automated"},
+    )
+
+    created_feedback = store.create_assessment(trace_info.request_id, original_feedback)
+    original_id = created_feedback.assessment_id
+
+    updated_feedback = store.update_assessment(
+        trace_id=trace_info.request_id,
+        assessment_id=original_id,
+        rationale="Updated rationale only",
+    )
+
+    assert updated_feedback.assessment_id == original_id
+    assert updated_feedback.name == "quality"
+    assert updated_feedback.value == 5
+    assert updated_feedback.rationale == "Updated rationale only"
+    assert updated_feedback.metadata == {"scorer": "automated"}
 
 
 def test_update_assessment_type_validation(store):
@@ -5817,7 +5734,7 @@ def test_update_assessment_type_validation(store):
         value="original",
         source=AssessmentSource(source_type=AssessmentSourceType.CODE),
     )
-    created_feedback = store.create_assessment(feedback)
+    created_feedback = store.create_assessment(trace_info.request_id, feedback)
 
     with pytest.raises(
         MlflowException, match=r"Cannot update expectation value on a Feedback assessment"
@@ -5825,7 +5742,7 @@ def test_update_assessment_type_validation(store):
         store.update_assessment(
             trace_id=trace_info.request_id,
             assessment_id=created_feedback.assessment_id,
-            expectation="This should fail",
+            expectation=ExpectationValue(value="This should fail"),
         )
 
     expectation = Expectation(
@@ -5834,7 +5751,7 @@ def test_update_assessment_type_validation(store):
         value="original_expected",
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
     )
-    created_expectation = store.create_assessment(expectation)
+    created_expectation = store.create_assessment(trace_info.request_id, expectation)
 
     with pytest.raises(
         MlflowException, match=r"Cannot update feedback value on an Expectation assessment"
@@ -5842,8 +5759,134 @@ def test_update_assessment_type_validation(store):
         store.update_assessment(
             trace_id=trace_info.request_id,
             assessment_id=created_expectation.assessment_id,
-            feedback="This should fail",
+            feedback=FeedbackValue(value="This should fail"),
         )
+
+
+def test_update_assessment_errors(store):
+    exp_id = store.create_experiment("test_update_errors")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+
+    with pytest.raises(MlflowException, match=r"Trace with request_id 'fake_trace' not found"):
+        store.update_assessment(
+            trace_id="fake_trace", assessment_id="fake_assessment", rationale="This should fail"
+        )
+
+    with pytest.raises(
+        MlflowException,
+        match=r"Assessment with ID 'fake_assessment' not found for trace",
+    ):
+        store.update_assessment(
+            trace_id=trace_info.request_id,
+            assessment_id="fake_assessment",
+            rationale="This should fail",
+        )
+
+
+def test_update_assessment_metadata_merging(store):
+    exp_id = store.create_experiment("test_metadata_merge")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+
+    original = Feedback(
+        trace_id=trace_info.request_id,
+        name="test",
+        value="original",
+        source=AssessmentSource(source_type=AssessmentSourceType.CODE),
+        metadata={"keep": "this", "override": "old_value", "remove_me": "will_stay"},
+    )
+
+    created = store.create_assessment(trace_info.request_id, original)
+
+    updated = store.update_assessment(
+        trace_id=trace_info.request_id,
+        assessment_id=created.assessment_id,
+        metadata={"override": "new_value", "new_key": "new_value"},
+    )
+
+    expected_metadata = {
+        "keep": "this",
+        "override": "new_value",
+        "remove_me": "will_stay",
+        "new_key": "new_value",
+    }
+    assert updated.metadata == expected_metadata
+
+
+def test_update_assessment_timestamps(store):
+    exp_id = store.create_experiment("test_timestamps")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+
+    original = Feedback(
+        trace_id=trace_info.request_id,
+        name="test",
+        value="original",
+        source=AssessmentSource(source_type=AssessmentSourceType.CODE),
+    )
+
+    created = store.create_assessment(trace_info.request_id, original)
+    original_create_time = created.create_time_ms
+    original_update_time = created.last_update_time_ms
+
+    time.sleep(0.001)
+
+    updated = store.update_assessment(
+        trace_id=trace_info.request_id,
+        assessment_id=created.assessment_id,
+        name="updated_name",
+    )
+
+    assert updated.create_time_ms == original_create_time
+    assert updated.last_update_time_ms > original_update_time
+
+
+def test_create_assessment_with_overrides(store):
+    exp_id = store.create_experiment("test_overrides")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+
+    original_feedback = Feedback(
+        trace_id=trace_info.request_id,
+        name="quality",
+        value="poor",
+        source=AssessmentSource(source_type=AssessmentSourceType.LLM_JUDGE),
+    )
+
+    created_original = store.create_assessment(trace_info.request_id, original_feedback)
+
+    override_feedback = Feedback(
+        trace_id=trace_info.request_id,
+        name="quality",
+        value="excellent",
+        source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        overrides=created_original.assessment_id,
+    )
+
+    created_override = store.create_assessment(trace_info.request_id, override_feedback)
+
+    assert created_override.overrides == created_original.assessment_id
+    assert created_override.value == "excellent"
+    assert created_override.valid is True
+
+    retrieved_original = store.get_assessment(trace_info.request_id, created_original.assessment_id)
+    assert retrieved_original.valid is False
+    assert retrieved_original.value == "poor"
+
+
+def test_create_assessment_override_nonexistent(store):
+    exp_id = store.create_experiment("test_override_error")
+    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
+
+    override_feedback = Feedback(
+        trace_id=trace_info.request_id,
+        name="quality",
+        value="excellent",
+        source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        overrides="nonexistent-assessment-id",
+    )
+
+    with pytest.raises(
+        MlflowException, match=r"Assessment with ID 'nonexistent-assessment-id' not found"
+    ):
+        store.create_assessment(trace_info.request_id, override_feedback)
 
 
 def test_delete_assessment_idempotent(store):
@@ -5857,30 +5900,24 @@ def test_delete_assessment_idempotent(store):
         source=AssessmentSource(source_type=AssessmentSourceType.CODE),
     )
 
-    created_feedback = store.create_assessment(feedback)
+    created_feedback = store.create_assessment(trace_info.request_id, feedback)
 
     retrieved = store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
     assert retrieved.assessment_id == created_feedback.assessment_id
 
     store.delete_assessment(trace_info.request_id, created_feedback.assessment_id)
 
-    # Verify assessment is deleted
     with pytest.raises(
         MlflowException,
-        match=rf"Assessment with ID '{created_feedback.assessment_id}' not"
-        rf" found for trace '{trace_info.request_id}'",
+        match=rf"Assessment with ID '{created_feedback.assessment_id}' not found for trace",
     ):
         store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
 
-    # Test idempotent behavior - should not raise error
     store.delete_assessment(trace_info.request_id, created_feedback.assessment_id)
-
-    # Delete non-existent assessment - should not raise error
     store.delete_assessment(trace_info.request_id, "fake_assessment_id")
 
 
 def test_assessment_with_run_id(store):
-    """Test assessments associated with runs"""
     exp_id = store.create_experiment("test_run_assessments")
     trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
 
@@ -5900,7 +5937,7 @@ def test_assessment_with_run_id(store):
     )
     feedback.run_id = run.info.run_id
 
-    created_feedback = store.create_assessment(feedback)
+    created_feedback = store.create_assessment(trace_info.request_id, feedback)
     assert created_feedback.run_id == run.info.run_id
 
     retrieved_feedback = store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
@@ -5908,7 +5945,6 @@ def test_assessment_with_run_id(store):
 
 
 def test_assessment_with_error(store):
-    """Test feedback assessments with errors including stack trace capture"""
     exp_id = store.create_experiment("test_error_assessments")
     trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
 
@@ -5923,62 +5959,16 @@ def test_assessment_with_error(store):
             source=AssessmentSource(source_type=AssessmentSourceType.CODE),
         )
 
-    created_feedback = store.create_assessment(feedback)
-    assert created_feedback.feedback.error is not None
-    assert created_feedback.feedback.error.error_message == "Test error message"
-    assert created_feedback.feedback.error.error_code == "ValueError"
-
-    assert created_feedback.feedback.error.stack_trace is not None
-    assert "ValueError: Test error message" in created_feedback.feedback.error.stack_trace
-    assert "test_assessment_with_error" in created_feedback.feedback.error.stack_trace
+    created_feedback = store.create_assessment(trace_info.request_id, feedback)
+    assert created_feedback.error.error_message == "Test error message"
+    assert created_feedback.error.error_code == "ValueError"
+    assert created_feedback.error.stack_trace is not None
+    assert "ValueError: Test error message" in created_feedback.error.stack_trace
+    assert "test_assessment_with_error" in created_feedback.error.stack_trace
 
     retrieved_feedback = store.get_assessment(trace_info.request_id, created_feedback.assessment_id)
-    assert retrieved_feedback.feedback.error is not None
-    assert retrieved_feedback.feedback.error.error_message == "Test error message"
-    assert retrieved_feedback.feedback.error.error_code == "ValueError"
-
-    assert retrieved_feedback.feedback.error.stack_trace is not None
-    assert "ValueError: Test error message" in retrieved_feedback.feedback.error.stack_trace
-    assert "test_assessment_with_error" in retrieved_feedback.feedback.error.stack_trace
-
-    assert (
-        created_feedback.feedback.error.stack_trace == retrieved_feedback.feedback.error.stack_trace
-    )
-
-
-def test_assessment_database_constraints(store):
-    """Test database-level constraints and relationships"""
-    exp_id = store.create_experiment("test_constraints")
-    trace_info = store.start_trace(exp_id, get_current_time_millis(), {}, {})
-
-    feedback = Feedback(
-        trace_id=trace_info.request_id,
-        name="test_feedback",
-        value="test",
-        source=AssessmentSource(source_type=AssessmentSourceType.CODE),
-    )
-
-    created_feedback = store.create_assessment(feedback)
-
-    # Test that deleting trace cascades to assessments
-    with store.ManagedSessionMaker() as session:
-        # Verify assessment exists in database
-        sql_assessment = (
-            session.query(SqlAssessments)
-            .filter_by(assessment_id=created_feedback.assessment_id)
-            .one_or_none()
-        )
-        assert sql_assessment is not None
-
-        # Delete the trace
-        sql_trace = session.query(SqlTraceInfo).filter_by(request_id=trace_info.request_id).one()
-        session.delete(sql_trace)
-        session.commit()
-
-        # Verify assessment was cascade deleted
-        sql_assessment = (
-            session.query(SqlAssessments)
-            .filter_by(assessment_id=created_feedback.assessment_id)
-            .one_or_none()
-        )
-        assert sql_assessment is None
+    assert retrieved_feedback.error.error_message == "Test error message"
+    assert retrieved_feedback.error.error_code == "ValueError"
+    assert retrieved_feedback.error.stack_trace is not None
+    assert "ValueError: Test error message" in retrieved_feedback.error.stack_trace
+    assert created_feedback.error.stack_trace == retrieved_feedback.error.stack_trace


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/16428?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16428/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16428/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16428/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Follow-on to #16402 to enable REST interface handlers for the assessments APIs

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
