### PR TITLE
Add ESLint rule to validate NotebookDownloadButton URLs

### DIFF
--- a/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/part2-logging-plots/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/part2-logging-plots/index.mdx
@@ -293,7 +293,7 @@ predictive quality in general?
 If you're interested, get a copy of the notebook by clicking on the button below and follow along with the instructions.
 
 <p>
-  <NotebookDownloadButton href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/notebooks/logging-plots-in-mlflow.ipyn">Download the notebook</NotebookDownloadButton>
+  <NotebookDownloadButton href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/notebooks/logging-plots-in-mlflow.ipynb">Download the notebook</NotebookDownloadButton>
 </p>
 
 After downloading the notebook and opening it with Jupyter:

--- a/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/part2-logging-plots/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/part2-logging-plots/index.mdx
@@ -293,7 +293,7 @@ predictive quality in general?
 If you're interested, get a copy of the notebook by clicking on the button below and follow along with the instructions.
 
 <p>
-  <NotebookDownloadButton href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/notebooks/logging-plots-in-mlflow.ipynb">Download the notebook</NotebookDownloadButton>
+  <NotebookDownloadButton href="https://raw.githubusercontent.com/mlflow/mlflow/master/docs/docs/classic-ml/traditional-ml/tutorials/hyperparameter-tuning/notebooks/logging-plots-in-mlflow.ipyn">Download the notebook</NotebookDownloadButton>
 </p>
 
 After downloading the notebook and opening it with Jupyter:

--- a/docs/eslint-plugin-mlflow-docs/index.js
+++ b/docs/eslint-plugin-mlflow-docs/index.js
@@ -1,0 +1,11 @@
+/**
+ * ESLint plugin for MLflow documentation with custom rules.
+ *
+ * @type {import('eslint').ESLint.Plugin}
+ */
+module.exports = {
+  rules: {
+    /** Rule to validate NotebookDownloadButton URLs */
+    "valid-notebook-url": require("./rules/valid-notebook-url"),
+  },
+};

--- a/docs/eslint-plugin-mlflow-docs/rules/valid-notebook-url.js
+++ b/docs/eslint-plugin-mlflow-docs/rules/valid-notebook-url.js
@@ -88,6 +88,8 @@ module.exports = {
  * @returns {string|null} The href value or null if it can't be determined
  */
 function getHrefValue(attr) {
+  // Guard against attr.value being null or undefined
+  if (!attr.value) return null;
   // Handle string literals: href="value"
   if (attr.value.type === "Literal") {
     return attr.value.value;

--- a/docs/eslint-plugin-mlflow-docs/rules/valid-notebook-url.js
+++ b/docs/eslint-plugin-mlflow-docs/rules/valid-notebook-url.js
@@ -1,0 +1,176 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * ESLint rule to validate NotebookDownloadButton URLs.
+ *
+ * This rule ensures that NotebookDownloadButton components have valid MLflow repository URLs
+ * that point to existing files in the repository.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Detect NotebookDownloadButton with invalid MLflow repository URLs",
+      category: "Possible Errors",
+    },
+    fixable: null,
+    schema: [],
+    messages: {
+      missingHref: "NotebookDownloadButton is missing href attribute",
+      emptyHref: "NotebookDownloadButton href is empty",
+      invalidFormat:
+        'NotebookDownloadButton href must start with "https://raw.githubusercontent.com/mlflow/mlflow/master/"',
+      fileNotFound: 'NotebookDownloadButton href points to non-existent file: "{{path}}"',
+    },
+  },
+
+  /**
+   * Creates the rule implementation.
+   *
+   * @param {import('eslint').Rule.RuleContext} context - The ESLint rule context
+   * @returns {import('eslint').Rule.RuleListener} The rule visitor methods
+   */
+  create(context) {
+    return {
+      /**
+       * Validates JSX opening elements for NotebookDownloadButton components.
+       *
+       * @param {import('estree').Node} node - The JSX opening element node
+       */
+      JSXOpeningElement(node) {
+        // Check if it's <NotebookDownloadButton >
+        if (
+          node.type !== "JSXOpeningElement" ||
+          node.name.type !== "JSXIdentifier" ||
+          node.name.name !== "NotebookDownloadButton"
+        ) {
+          return;
+        }
+
+        // Find href attribute
+        const hrefAttr = node.attributes.find(
+          (attr) => attr.type === "JSXAttribute" && attr.name.name === "href"
+        );
+
+        if (!hrefAttr) {
+          context.report({
+            node,
+            messageId: "missingHref",
+          });
+          return;
+        }
+
+        // Get href value
+        const hrefValue = getHrefValue(hrefAttr);
+
+        if (!hrefValue) {
+          context.report({
+            node: hrefAttr,
+            messageId: "emptyHref",
+          });
+          return;
+        }
+
+        // Validate MLflow repository URL
+        validateMlflowUrl(context, hrefAttr, hrefValue);
+      },
+    };
+  },
+};
+
+/**
+ * Extracts the href value from a JSX attribute.
+ *
+ * @param {import('estree-jsx').JSXAttribute} attr - The JSX attribute node
+ * @returns {string|null} The href value or null if it can't be determined
+ */
+function getHrefValue(attr) {
+  // Handle string literals: href="value"
+  if (attr.value.type === "Literal") {
+    return attr.value.value;
+  }
+
+  // Handle JSX expressions with literals: href={"value"}
+  if (attr.value.type === "JSXExpressionContainer" && attr.value.expression.type === "Literal") {
+    return attr.value.expression.value;
+  }
+
+  // Handle template literals with no expressions: href={`value`}
+  if (
+    attr.value.type === "JSXExpressionContainer" &&
+    attr.value.expression.type === "TemplateLiteral" &&
+    attr.value.expression.expressions.length === 0
+  ) {
+    return attr.value.expression.quasis[0].value.raw;
+  }
+
+  // Can't determine value for dynamic expressions
+  return null;
+}
+
+/**
+ * Validates that an href points to a valid MLflow repository URL.
+ *
+ * Checks two things:
+ * 1. URL format: Must start with https://raw.githubusercontent.com/mlflow/mlflow/master/
+ * 2. File existence: The referenced file must exist in the local repository
+ *
+ * @param {import('eslint').Rule.RuleContext} context - The ESLint rule context
+ * @param {import('estree-jsx').JSXAttribute} hrefAttr - The href attribute node
+ * @param {string} href - The href value to validate
+ */
+function validateMlflowUrl(context, hrefAttr, href) {
+  const expectedPrefix = "https://raw.githubusercontent.com/mlflow/mlflow/master/";
+
+  // Check if URL starts with the expected prefix
+  if (!href.startsWith(expectedPrefix)) {
+    context.report({
+      node: hrefAttr,
+      messageId: "invalidFormat",
+    });
+    return;
+  }
+
+  // Extract the path after the prefix
+  const filePath = href.substring(expectedPrefix.length);
+
+  // Check if the file exists in the repository
+  const repoRoot = findRepoRoot(context.filename);
+  if (repoRoot) {
+    const fullPath = path.join(repoRoot, filePath);
+
+    if (!fs.existsSync(fullPath)) {
+      context.report({
+        node: hrefAttr,
+        messageId: "fileNotFound",
+        data: { path: filePath },
+      });
+    }
+  }
+}
+
+/**
+ * Finds the root directory of the git repository.
+ *
+ * Walks up the directory tree from the given file path until it finds
+ * a .git directory, indicating the repository root.
+ *
+ * @param {string} startPath - The file path to start searching from
+ * @returns {string|null} The repository root path or null if not found
+ */
+function findRepoRoot(startPath) {
+  let currentDir = path.dirname(startPath);
+
+  // Look for .git directory by walking up the directory tree
+  while (currentDir !== path.dirname(currentDir)) {
+    if (fs.existsSync(path.join(currentDir, ".git"))) {
+      return currentDir;
+    }
+    currentDir = path.dirname(currentDir);
+  }
+
+  return null;
+}

--- a/docs/eslint-plugin-mlflow-docs/rules/valid-notebook-url.js
+++ b/docs/eslint-plugin-mlflow-docs/rules/valid-notebook-url.js
@@ -41,7 +41,6 @@ module.exports = {
        * @param {import('estree').Node} node - The JSX opening element node
        */
       JSXOpeningElement(node) {
-        // Check if it's <NotebookDownloadButton >
         if (
           node.type !== "JSXOpeningElement" ||
           node.name.type !== "JSXIdentifier" ||
@@ -49,8 +48,6 @@ module.exports = {
         ) {
           return;
         }
-
-        // Find href attribute
         const hrefAttr = node.attributes.find(
           (attr) => attr.type === "JSXAttribute" && attr.name.name === "href"
         );
@@ -63,7 +60,6 @@ module.exports = {
           return;
         }
 
-        // Get href value
         const hrefValue = getHrefValue(hrefAttr);
 
         if (!hrefValue) {
@@ -74,7 +70,6 @@ module.exports = {
           return;
         }
 
-        // Validate MLflow repository URL
         validateMlflowUrl(context, hrefAttr, hrefValue);
       },
     };
@@ -88,19 +83,16 @@ module.exports = {
  * @returns {string|null} The href value or null if it can't be determined
  */
 function getHrefValue(attr) {
-  // Guard against attr.value being null or undefined
   if (!attr.value) return null;
-  // Handle string literals: href="value"
+
   if (attr.value.type === "Literal") {
     return attr.value.value;
   }
 
-  // Handle JSX expressions with literals: href={"value"}
   if (attr.value.type === "JSXExpressionContainer" && attr.value.expression.type === "Literal") {
     return attr.value.expression.value;
   }
 
-  // Handle template literals with no expressions: href={`value`}
   if (
     attr.value.type === "JSXExpressionContainer" &&
     attr.value.expression.type === "TemplateLiteral" &&
@@ -127,7 +119,6 @@ function getHrefValue(attr) {
 function validateMlflowUrl(context, hrefAttr, href) {
   const expectedPrefix = "https://raw.githubusercontent.com/mlflow/mlflow/master/";
 
-  // Check if URL starts with the expected prefix
   if (!href.startsWith(expectedPrefix)) {
     context.report({
       node: hrefAttr,
@@ -136,10 +127,7 @@ function validateMlflowUrl(context, hrefAttr, href) {
     return;
   }
 
-  // Extract the path after the prefix
   const filePath = href.substring(expectedPrefix.length);
-
-  // Check if the file exists in the repository
   const repoRoot = findRepoRoot(context.filename);
   if (repoRoot) {
     const fullPath = path.join(repoRoot, filePath);
@@ -166,7 +154,6 @@ function validateMlflowUrl(context, hrefAttr, href) {
 function findRepoRoot(startPath) {
   let currentDir = path.dirname(startPath);
 
-  // Look for .git directory by walking up the directory tree
   while (currentDir !== path.dirname(currentDir)) {
     if (fs.existsSync(path.join(currentDir, ".git"))) {
       return currentDir;

--- a/docs/eslint.config.js
+++ b/docs/eslint.config.js
@@ -1,5 +1,6 @@
 const { defineConfig } = require("eslint/config");
 const docusaurusEslintPlugin = require("@docusaurus/eslint-plugin");
+const mlflowDocsPlugin = require("./eslint-plugin-mlflow-docs");
 const js = require("@eslint/js");
 const { FlatCompat } = require("@eslint/eslintrc");
 
@@ -15,9 +16,11 @@ module.exports = defineConfig([
     extends: compat.extends("plugin:mdx/recommended"),
     plugins: {
       "@docusaurus": docusaurusEslintPlugin,
+      "mlflow-docs": mlflowDocsPlugin,
     },
     rules: {
       "@docusaurus/no-html-links": "error",
+      "mlflow-docs/valid-notebook-url": "error",
     },
   },
 ]);

--- a/docs/package.json
+++ b/docs/package.json
@@ -45,6 +45,8 @@
     "@docusaurus/module-type-aliases": "^3.6.3",
     "@docusaurus/tsconfig": "^3.5.2",
     "@docusaurus/types": "^3.5.2",
+    "@types/estree": "^1.0.8",
+    "@types/estree-jsx": "^1.0.5",
     "eslint": "^9.29.0",
     "eslint-plugin-mdx": "^3.5.0",
     "node-fetch": "^3.3.2",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3051,14 +3051,14 @@
     "@types/estree" "*"
     "@types/json-schema" "*"
 
-"@types/estree-jsx@^1.0.0":
+"@types/estree-jsx@^1.0.0", "@types/estree-jsx@^1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree-jsx/-/estree-jsx-1.0.5.tgz#858a88ea20f34fe65111f005a689fa1ebf70dc18"
   integrity sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==
   dependencies:
     "@types/estree" "*"
 
-"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.6":
+"@types/estree@*", "@types/estree@^1.0.0", "@types/estree@^1.0.6", "@types/estree@^1.0.8":
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.8.tgz#958b91c991b1867ced318bedea0e215ee050726e"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16433?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16433/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16433/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16433/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR adds a custom ESLint rule to ensure `NotebookDownloadButton` components in MLflow documentation have valid URLs that point to existing files in the repository.

The rule validates:
- URL format must start with `https://raw.githubusercontent.com/mlflow/mlflow/master/`
- Referenced file must exist in the local repository

This helps prevent broken download links in the documentation by catching issues at development time.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual testing:
- Created test MDX files with various invalid URLs
- Verified the rule correctly reports missing href, invalid format, and non-existent files
- Confirmed the rule passes for valid existing file URLs

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)