### PR TITLE
[TS #5] Add withSpan API

### DIFF
--- a/packages/typescript/CLAUDE.md
+++ b/packages/typescript/CLAUDE.md
@@ -79,7 +79,7 @@ The SDK communicates with MLflow backends through REST APIs:
 
 ### High-Level APIs (`src/core/api.ts`)
 
-**`withSpan(options?, callback)`**:
+**`withSpan(callback, options?)`**:
 
 - Automatic span lifecycle management
 - Supports both inline and options-based usage

--- a/packages/typescript/src/core/api.ts
+++ b/packages/typescript/src/core/api.ts
@@ -1,10 +1,11 @@
 import { trace, context, Span as ApiSpan } from '@opentelemetry/api';
 import { Span as OTelSpan } from '@opentelemetry/sdk-trace-node';
-import { SpanType } from './constants';
+import { DEFAULT_SPAN_NAME, SpanType } from './constants';
 import { createMlflowSpan, LiveSpan, NoOpSpan } from './entities/span';
 import { getTracer } from './provider';
 import { InMemoryTraceManager } from './trace_manager';
 import { convertNanoSecondsToHrTime } from './utils';
+import { SpanStatusCode } from './entities/span_status';
 
 /*
  * Options for starting a span
@@ -64,6 +65,103 @@ export function startSpan(options: SpanOptions): LiveSpan {
     console.warn('Failed to start span', error);
     return new NoOpSpan();
   }
+}
+
+/**
+ * Execute a function within a span context. The span is automatically started before
+ * the function executes and ended after it completes (or throws an error).
+ *
+ * This function uses OpenTelemetry's active span context to automatically manage
+ * parent-child relationships between spans.
+ *
+ * This function supports two usage patterns:
+ * 1. Inline: withSpan(callback) - span properties set within the callback
+ * 2. Options: withSpan(options, callback) - span properties set via options object
+ *
+ * @param optionsOrCallback Either span options or the callback function
+ * @param callback The callback function (when options are provided)
+ * @returns The result of the callback function
+ */
+export function withSpan<T>(callback: (span: LiveSpan) => T | Promise<T>): T | Promise<T>;
+export function withSpan<T>(
+  options: Omit<SpanOptions, 'parent'>,
+  callback: (span: LiveSpan) => T | Promise<T>
+): T | Promise<T>;
+
+export function withSpan<T>(
+  optionsOrCallback: Omit<SpanOptions, 'parent'> | ((span: LiveSpan) => T | Promise<T>),
+  callback?: (span: LiveSpan) => T | Promise<T>
+): T | Promise<T> {
+  // Determine if first argument is options or callback
+  const isOptionsProvided = typeof optionsOrCallback === 'object' && optionsOrCallback != null;
+  const spanOptions: Omit<SpanOptions, 'parent'> = isOptionsProvided
+    ? optionsOrCallback
+    : { name: DEFAULT_SPAN_NAME };
+  const actualCallback = isOptionsProvided
+    ? (callback ??
+      (() => {
+        throw new Error('Callback is required when options are provided');
+      }))
+    : optionsOrCallback;
+
+  // Generate a default span name if not provided
+  const spanName = spanOptions.name ?? 'span';
+
+  const tracer = getTracer('default');
+
+  // Convert startTimeNs to OTel format if provided
+  const startTime = spanOptions.startTimeNs
+    ? convertNanoSecondsToHrTime(spanOptions.startTimeNs)
+    : undefined;
+
+  // Use startActiveSpan to automatically manage context and parent-child relationships
+  return tracer.startActiveSpan(spanName, { startTime }, (otelSpan: ApiSpan) => {
+    // Create and register the MLflow span
+    const mlflowSpan = createAndRegisterMlflowSpan(
+      otelSpan,
+      spanOptions.span_type,
+      spanOptions.inputs,
+      spanOptions.attributes
+    );
+
+    try {
+      // Execute the callback with the span
+      const result = actualCallback(mlflowSpan);
+
+      // Handle both sync and async results
+      if (result instanceof Promise) {
+        return result
+          .then((value) => {
+            // Set outputs if they are not already set
+            if (mlflowSpan.outputs === undefined) {
+              mlflowSpan.setOutputs(value);
+            }
+            mlflowSpan.end();
+            return value;
+          })
+          .catch((error: Error) => {
+            // Set error status and re-throw
+            mlflowSpan.setStatus(SpanStatusCode.ERROR, error.message);
+            mlflowSpan.recordException(error);
+            mlflowSpan.end();
+            throw error;
+          });
+      } else {
+        // Synchronous execution
+        if (mlflowSpan.outputs === undefined) {
+          mlflowSpan.setOutputs(result);
+        }
+        mlflowSpan.end();
+        return result;
+      }
+    } catch (error) {
+      // Handle synchronous errors - use the already created span
+      mlflowSpan.setStatus(SpanStatusCode.ERROR, (error as Error).message);
+      mlflowSpan.recordException(error as Error);
+      mlflowSpan.end();
+      throw error;
+    }
+  });
 }
 
 /**

--- a/packages/typescript/src/core/constants.ts
+++ b/packages/typescript/src/core/constants.ts
@@ -50,6 +50,11 @@ export const TRACE_SCHEMA_VERSION = '3';
 export const TRACE_ID_PREFIX = 'tr-';
 
 /**
+ * The default name for spans if the name is not provided when starting a span
+ */
+export const DEFAULT_SPAN_NAME = 'span';
+
+/**
  * Trace ID for no-op spans
  */
 export const NO_OP_SPAN_TRACE_ID = 'no-op-span-trace-id';

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -111,11 +111,7 @@ export class InMemoryTraceManager {
    * @param spanId The span ID
    */
   getSpan(traceId: string, spanId: string): LiveSpan | null {
-    const trace = this._traces.get(traceId);
-    if (trace) {
-      return trace.spanDict.get(spanId) || null;
-    }
-    return null;
+    return this._traces.get(traceId)?.spanDict.get(spanId) || null;
   }
 
   /**

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -106,6 +106,19 @@ export class InMemoryTraceManager {
   }
 
   /**
+   * Get the span for the given trace ID and span ID.
+   * @param traceId The trace ID
+   * @param spanId The span ID
+   */
+  getSpan(traceId: string, spanId: string): LiveSpan | null {
+    const trace = this._traces.get(traceId);
+    if (trace) {
+      return trace.spanDict.get(spanId) || null;
+    }
+    return null;
+  }
+
+  /**
    * Pop trace data for the given OpenTelemetry trace ID and return it as
    * a ready-to-publish Trace object.
    * @param otelTraceId The OpenTelemetry trace ID

--- a/packages/typescript/src/exporters/mlflow.ts
+++ b/packages/typescript/src/exporters/mlflow.ts
@@ -89,7 +89,13 @@ export class MlflowSpanProcessor implements SpanProcessor {
     }
 
     // Update trace info
-    const traceId = JSON.parse(span.attributes[SpanAttributeKey.TRACE_ID] as string) as string;
+    const otelTraceId = span.spanContext().traceId;
+    const traceId = InMemoryTraceManager.getInstance().getMlflowTraceIdFromOtelId(otelTraceId);
+    if (!traceId) {
+      console.warn(`No trace ID found for span ${span.name}. Skipping.`);
+      return;
+    }
+
     const trace = InMemoryTraceManager.getInstance().getTrace(traceId);
     if (!trace) {
       console.warn(`No trace found for span ${span.name}. Skipping.`);

--- a/packages/typescript/tests/core/api.test.ts
+++ b/packages/typescript/tests/core/api.test.ts
@@ -1,4 +1,4 @@
-import { startSpan } from '../../src/core/api';
+import { startSpan, withSpan } from '../../src/core/api';
 import { SpanType } from '../../src/core/constants';
 import { LiveSpan } from '../../src/core/entities/span';
 import { SpanStatus, SpanStatusCode } from '../../src/core/entities/span_status';
@@ -145,5 +145,344 @@ describe('API', () => {
   afterEach(() => {
     InMemoryTraceManager.reset();
     resetTraces();
+  });
+
+  describe('withSpan', () => {
+    describe('inline usage pattern', () => {
+      it('should execute synchronous callback and auto-set outputs', () => {
+        const result = withSpan((span) => {
+          span.setInputs({ a: 5, b: 3 });
+          return 5 + 3; // Auto-set outputs from return value
+        });
+
+        expect(result).toBe(8);
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.name).toBe('span');
+        expect(loggedSpan.inputs).toEqual({ a: 5, b: 3 });
+        expect(loggedSpan.outputs).toBe(8); // Auto-set from return value
+        expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.OK);
+      });
+
+      it('should execute synchronous callback with explicit outputs', () => {
+        const result = withSpan((span) => {
+          span.setInputs({ a: 5, b: 3 });
+          const sum = 5 + 3;
+          span.setOutputs({ result: sum });
+          return sum;
+        });
+
+        expect(result).toBe(8);
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.outputs).toEqual({ result: 8 }); // Explicit outputs take precedence
+      });
+
+      it('should execute asynchronous callback and auto-set outputs', async () => {
+        const result = await withSpan(async (span) => {
+          span.setInputs({ delay: 100 });
+          await new Promise((resolve) => setTimeout(resolve, 10));
+          const value = 'async result';
+          return value;
+        });
+
+        expect(result).toBe('async result');
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.inputs).toEqual({ delay: 100 });
+        expect(loggedSpan.outputs).toBe('async result');
+        expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.OK);
+      });
+
+      it('should handle synchronous errors', () => {
+        expect(() => {
+          void withSpan((span) => {
+            span.setInputs({ operation: 'divide by zero' });
+            throw new Error('Division by zero');
+          });
+        }).toThrow('Division by zero');
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.ERROR);
+        expect(loggedSpan.status?.description).toBe('Division by zero');
+      });
+
+      it('should handle asynchronous errors', async () => {
+        await expect(
+          withSpan(async (span) => {
+            span.setInputs({ operation: 'async error' });
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            throw new Error('Async error');
+          })
+        ).rejects.toThrow('Async error');
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.ERROR);
+        expect(loggedSpan.status?.description).toBe('Async error');
+      });
+    });
+
+    describe('options-based usage pattern', () => {
+      it('should execute with pre-configured options', () => {
+        const result = withSpan(
+          {
+            name: 'add-function',
+            span_type: SpanType.LLM,
+            inputs: { a: 10, b: 20 },
+            attributes: { model: 'test-model' }
+          },
+          () => {
+            return 10 + 20;
+          }
+        );
+
+        expect(result).toBe(30);
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.name).toBe('add-function');
+        expect(loggedSpan.spanType).toBe(SpanType.LLM);
+        expect(loggedSpan.inputs).toEqual({ a: 10, b: 20 });
+        expect(loggedSpan.outputs).toEqual(30);
+        expect(loggedSpan.attributes['model']).toBe('test-model');
+      });
+
+      it('should execute async with pre-configured options', async () => {
+        const result = await withSpan(
+          {
+            name: 'async-operation',
+            inputs: { data: 'test' },
+            attributes: { version: '1.0' }
+          },
+          async () => {
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            return 'processed-test';
+          }
+        );
+
+        expect(result).toBe('processed-test');
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.name).toBe('async-operation');
+        expect(loggedSpan.inputs).toEqual({ data: 'test' });
+        expect(loggedSpan.outputs).toBe('processed-test');
+        expect(loggedSpan.attributes['version']).toBe('1.0');
+      });
+
+      it('should handle nested spans with automatic parent-child relationship', () => {
+        const result = withSpan(
+          {
+            name: 'parent',
+            inputs: { operation: 'parent operation' }
+          },
+          (parentSpan) => {
+            // Nested withSpan call - should automatically be a child of the parent
+            const childResult = withSpan(
+              {
+                name: 'child',
+                inputs: { nested: true }
+              },
+              (childSpan) => {
+                childSpan.setAttributes({ nested: true });
+                return 'child result';
+              }
+            );
+
+            parentSpan.setOutputs({ childResult });
+            return childResult;
+          }
+        );
+
+        expect(result).toBe('child result');
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+        expect(traces[0].data.spans.length).toBe(2);
+
+        const parentSpan = traces[0].data.spans.find((s) => s.name === 'parent');
+        expect(parentSpan?.inputs).toEqual({ operation: 'parent operation' });
+        expect(parentSpan?.outputs).toEqual({ childResult: 'child result' });
+
+        const childSpan = traces[0].data.spans.find((s) => s.name === 'child');
+        expect(childSpan?.parentId).toBe(parentSpan?.spanId);
+        expect(childSpan?.inputs).toEqual({ nested: true });
+        expect(childSpan?.outputs).toEqual('child result');
+        expect(childSpan?.attributes['nested']).toBe(true);
+      });
+    });
+
+    describe('edge cases', () => {
+      it('should handle null return values', () => {
+        const result = withSpan((span) => {
+          span.setInputs({ test: true });
+          return null;
+        });
+
+        expect(result).toBeNull();
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.outputs).toBe(null); // Should auto-set null
+      });
+
+      it('should handle complex return objects', () => {
+        const complexObject = {
+          data: [1, 2, 3],
+          metadata: { type: 'array', length: 3 }
+        };
+
+        const result = withSpan((span) => {
+          span.setInputs({ operation: 'create complex object' });
+          return complexObject;
+        });
+
+        expect(result).toEqual(complexObject);
+
+        const traces = getTraces();
+        expect(traces.length).toBe(1);
+
+        const loggedSpan = traces[0].data.spans[0];
+        expect(loggedSpan.outputs).toEqual(complexObject);
+      });
+
+      it('should handle multiple async tasks with proper parent-child relationships', async () => {
+        // Test complex async scenario with multiple traces and nested spans
+        const results = await Promise.all([
+          // First trace with nested async operations
+          withSpan({ name: 'trace1-parent', inputs: { traceId: 1 } }, async (parentSpan) => {
+            // Simulate some async work
+            await new Promise((resolve) => setTimeout(resolve, 5));
+
+            // Create multiple child spans in parallel
+            const childResults = await Promise.all([
+              withSpan({ name: 'trace1-child1', inputs: { childId: 1 } }, async (childSpan) => {
+                await new Promise((resolve) => setTimeout(resolve, 3));
+                childSpan.setOutputs({ processed: true });
+                return 'child1-result';
+              }),
+              withSpan({ name: 'trace1-child2', inputs: { childId: 2 } }, async (childSpan) => {
+                await new Promise((resolve) => setTimeout(resolve, 2));
+                // Nested grandchild
+                const grandchildResult = await withSpan(
+                  { name: 'trace1-grandchild', inputs: { grandchildId: 1 } },
+                  async () => {
+                    await new Promise((resolve) => setTimeout(resolve, 1));
+                    return 'grandchild-result';
+                  }
+                );
+                childSpan.setOutputs({ grandchildResult });
+                return 'child2-result';
+              })
+            ]);
+
+            parentSpan.setOutputs({ childResults });
+            return childResults;
+          }),
+
+          // Second independent trace running concurrently
+          withSpan({ name: 'trace2-parent', inputs: { traceId: 2 } }, async (parentSpan) => {
+            await new Promise((resolve) => setTimeout(resolve, 4));
+
+            const result = await withSpan(
+              { name: 'trace2-child', inputs: { childId: 1 } },
+              async () => {
+                await new Promise((resolve) => setTimeout(resolve, 2));
+                return 'trace2-child-result';
+              }
+            );
+
+            parentSpan.setOutputs({ childResult: result });
+            return result;
+          }),
+
+          // Third independent trace with synchronous operation
+          withSpan({ name: 'trace3-simple', inputs: { traceId: 3 } }, (span) => {
+            span.setOutputs({ immediate: true });
+            return 'trace3-result';
+          })
+        ]);
+
+        // Verify results
+        expect(results[0]).toEqual(['child1-result', 'child2-result']);
+        expect(results[1]).toBe('trace2-child-result');
+        expect(results[2]).toBe('trace3-result');
+
+        // Verify traces structure
+        const traces = getTraces();
+        expect(traces.length).toBe(3);
+
+        // Verify first trace (most complex with grandchild)
+        const trace1 = traces.find((t) => t.data.spans.some((s) => s.name === 'trace1-parent'));
+        expect(trace1).toBeDefined();
+        expect(trace1!.data.spans.length).toBe(4); // parent + 2 children + 1 grandchild
+
+        const trace1Parent = trace1!.data.spans.find((s) => s.name === 'trace1-parent');
+        const trace1Child1 = trace1!.data.spans.find((s) => s.name === 'trace1-child1');
+        const trace1Child2 = trace1!.data.spans.find((s) => s.name === 'trace1-child2');
+        const trace1Grandchild = trace1!.data.spans.find((s) => s.name === 'trace1-grandchild');
+
+        expect(trace1Parent).toBeDefined();
+        expect(trace1Child1).toBeDefined();
+        expect(trace1Child2).toBeDefined();
+        expect(trace1Grandchild).toBeDefined();
+
+        // Verify parent-child relationships in trace1
+        expect(trace1Child1!.parentId).toBe(trace1Parent!.spanId);
+        expect(trace1Child2!.parentId).toBe(trace1Parent!.spanId);
+        expect(trace1Grandchild!.parentId).toBe(trace1Child2!.spanId);
+
+        // Verify outputs
+        expect(trace1Parent!.outputs).toEqual({ childResults: ['child1-result', 'child2-result'] });
+        expect(trace1Child1!.outputs).toEqual({ processed: true });
+        expect(trace1Child2!.outputs).toEqual({ grandchildResult: 'grandchild-result' });
+        expect(trace1Grandchild!.outputs).toBe('grandchild-result');
+
+        // Verify second trace
+        const trace2 = traces.find((t) => t.data.spans.some((s) => s.name === 'trace2-parent'));
+        expect(trace2).toBeDefined();
+        expect(trace2!.data.spans.length).toBe(2); // parent + 1 child
+
+        const trace2Parent = trace2!.data.spans.find((s) => s.name === 'trace2-parent');
+        const trace2Child = trace2!.data.spans.find((s) => s.name === 'trace2-child');
+
+        expect(trace2Parent).toBeDefined();
+        expect(trace2Child).toBeDefined();
+        expect(trace2Child!.parentId).toBe(trace2Parent!.spanId);
+        expect(trace2Parent!.outputs).toEqual({ childResult: 'trace2-child-result' });
+        expect(trace2Child!.outputs).toBe('trace2-child-result');
+
+        // Verify third trace (simple synchronous)
+        const trace3 = traces.find((t) => t.data.spans.some((s) => s.name === 'trace3-simple'));
+        expect(trace3).toBeDefined();
+        expect(trace3!.data.spans.length).toBe(1);
+
+        const trace3Span = trace3!.data.spans[0];
+        expect(trace3Span.name).toBe('trace3-simple');
+        expect(trace3Span.parentId).toBeNull();
+        expect(trace3Span.outputs).toEqual({ immediate: true });
+      });
+    });
   });
 });


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16437?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16437/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16437/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16437/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This PR depends on https://github.com/mlflow/mlflow/pull/16349, see the last commit for the actual delta.

Add `withSpan` API, a convenient version of `startSpan` corresponding to Python's decorator.

```
// example 1: setting span properties in-line
function add(a: number, b: number) {
  const sum = withSpan(async (span: LiveSpan) => {
    span.setInputs({ a, b });
    const result = a + b;

    // specifying outputs can be optional here,
    // we can default to the return value of the
    // function
    span.setOutputs(result);

    return result;
  });

  return sum;
}

// example 2: setting span properties in first arg
function add(a: number, b: number) {
  const sum =withSpan(
    {
      inputs: { a, b },
      attributes: ...,
    },
    async (span:LiveSpan) => {
      const result = a + b;
      span.setOutputs(result)
      return result
    }
  );

  return sum;
}
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
