### PR TITLE
Fix regression of destination file path of a single artifact download

### DIFF
--- a/mlflow/store/artifact/runs_artifact_repo.py
+++ b/mlflow/store/artifact/runs_artifact_repo.py
@@ -213,7 +213,14 @@ class RunsArtifactRepository(ArtifactRepository):
 
         # If there are artifacts with the same name in the run and model, the model artifacts
         # will overwrite the run artifacts.
-        model_out_path = self._download_model_artifacts(artifact_path, dst_path=dst_path)
+        model_out_path: Optional[str] = None
+        try:
+            model_out_path = self._download_model_artifacts(artifact_path, dst_path=dst_path)
+        except Exception:
+            _logger.debug(
+                f"Failed to download model artifacts from {self.artifact_uri}/{artifact_path}.",
+                exc_info=True,
+            )
         path = run_out_path or model_out_path
         if path is None:
             raise MlflowException(

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -356,3 +356,18 @@ def test_download_artifacts_with_client_and_tracking_uri(tmp_path: pathlib.Path)
         dst_path=dst_path,
     )
     assert tmp_file.name in [p.name for p in dst_path.rglob("*")]
+
+
+def test_run_artifact_download_when_both_run_and_model_artifacts_exist(tmp_path):
+    class DummyModel(mlflow.pyfunc.PythonModel):
+        def predict(self, model_input: list[str]) -> list[str]:
+            return model_input
+
+    with mlflow.start_run() as run:
+        mlflow.pyfunc.log_model(python_model=DummyModel(), name="model")
+        mlflow.log_text("test", "model/file.txt")
+
+    out = mlflow.artifacts.download_artifacts(
+        run_id=run.info.run_id, artifact_path="model/file.txt", dst_path=tmp_path
+    )
+    assert pathlib.Path(out).read_text() == "test"

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -358,7 +358,7 @@ def test_download_artifacts_with_client_and_tracking_uri(tmp_path: pathlib.Path)
     assert tmp_file.name in [p.name for p in dst_path.rglob("*")]
 
 
-def test_run_artifact_download_when_both_run_and_model_artifacts_exist(tmp_path):
+def test_single_run_artifact_download_when_both_run_and_model_artifacts_exist(tmp_path):
     class DummyModel(mlflow.pyfunc.PythonModel):
         def predict(self, model_input: list[str]) -> list[str]:
             return model_input

--- a/tests/test_mlflow_version_comp.py
+++ b/tests/test_mlflow_version_comp.py
@@ -183,9 +183,6 @@ def test_mlflow_3_x_comp(tmp_path: Path) -> None:
     check_list_artifacts_with_run_id_and_path(run_id=run_id, path="model")
     check_list_artifacts_with_model_uri(model_uri=runs_model_uri)
     check_download_artifacts_with_run_id_and_path(run_id=run_id, path="model", tmp_path=tmp_path)
-    check_download_artifacts_with_run_id_and_path(
-        run_id=run_id, path="model/test.txt", tmp_path=tmp_path
-    )
     check_download_artifacts_with_model_uri(model_uri=runs_model_uri, tmp_path=tmp_path)
     check_evaluate(model_uri=runs_model_uri)
     check_spark_udf(model_uri=runs_model_uri)

--- a/tests/test_mlflow_version_comp.py
+++ b/tests/test_mlflow_version_comp.py
@@ -183,6 +183,9 @@ def test_mlflow_3_x_comp(tmp_path: Path) -> None:
     check_list_artifacts_with_run_id_and_path(run_id=run_id, path="model")
     check_list_artifacts_with_model_uri(model_uri=runs_model_uri)
     check_download_artifacts_with_run_id_and_path(run_id=run_id, path="model", tmp_path=tmp_path)
+    check_download_artifacts_with_run_id_and_path(
+        run_id=run_id, path="model/test.txt", tmp_path=tmp_path
+    )
     check_download_artifacts_with_model_uri(model_uri=runs_model_uri, tmp_path=tmp_path)
     check_evaluate(model_uri=runs_model_uri)
     check_spark_udf(model_uri=runs_model_uri)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16443?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16443/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16443/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16443/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fix #16429

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix regression of destination file path of a single artifact download:

```python
import tempfile
from pathlib import Path

import mlflow

with (
    tempfile.TemporaryDirectory() as tracking_path,
    tempfile.TemporaryDirectory() as dst_path,
):
    tracking_uri = Path(tracking_path).as_uri()
    mlflow.set_tracking_uri(tracking_uri)
    mlflow.set_experiment(experiment_name="my_experiment")

    with mlflow.start_run() as run:
        mlflow.log_text("my_content", "my_dir/my_file.txt")

    mlflow.artifacts.download_artifacts(
        run_id=run.info.run_id,
        artifact_path="my_dir/my_file.txt",  # this line throws
        tracking_uri=None,
        dst_path=dst_path,
    )

    file_paths = [x.relative_to(dst_path) for x in Path(dst_path).glob("**/*.txt")]

print(file_paths)  # [PosixPath('my_file.txt')]
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
