### PR TITLE
Fix R crate() function calls to use explicit model parameter

### DIFF
--- a/mlflow/R/mlflow/tests/testthat/test-model.R
+++ b/mlflow/R/mlflow/tests/testthat/test-model.R
@@ -78,7 +78,7 @@ test_that("mlflow can log model and load it back with a uri", {
       list(some = "stuff"),
       class = "test"
     )
-    predictor <- crate(~ mean(as.matrix(.x)), model)
+    predictor <- crate(~ mean(as.matrix(.x)), model = model)
     predicted <- predictor(0:10)
     expect_true(5 == predicted)
     mlflow_log_model(predictor, testthat_model_name)
@@ -109,7 +109,7 @@ test_that("mlflow log model records correct metadata with the tracking server", 
       list(some = "stuff"),
       class = "test"
     )
-    predictor <- crate(~ mean(as.matrix(.x)), model)
+    predictor <- crate(~ mean(as.matrix(.x)), model = model)
     predicted <- predictor(0:10)
     expect_true(5 == predicted)
     mlflow_log_model(predictor, testthat_model_name)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16445?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16445/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16445/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16445/merge
```

</p>
</details>

### Related Issues/PRs

Related to https://github.com/r-lib/carrier/pull/19

### What changes are proposed in this pull request?

This PR fixes R `crate()` function calls in test files to use explicit parameter naming (`model = model`) instead of positional arguments. This change addresses compatibility requirements introduced in r-lib/carrier to avoid ambiguity in argument passing.

Fix for:

https://github.com/mlflow/mlflow/actions/runs/15867945692/job/44738287155

```
  2. ├─mlflow:::with.mlflow_run(...)
  3. │ ├─base::tryCatch(...)
  4. │ │ └─base (local) tryCatchList(expr, classes, parentenv, handlers)
  5. │ │   ├─base (local) tryCatchOne(...)
  6. │ │   │ └─base (local) doTryCatch(return(expr), name, parentenv, handler)
  7. │ │   └─base (local) tryCatchList(expr, names[-nh], parentenv, handlers[-nh])
  8. │ │     └─base (local) tryCatchOne(expr, names, parentenv, handlers[[1L]])
  9. │ │       └─base (local) doTryCatch(return(expr), name, parentenv, handler)
 10. │ └─base::force(expr)
 11. └─carrier::crate(~mean(as.matrix(.x)), model) at test-model.R:81:5
 12.   └─rlang::abort("All `...` arguments must be named")

Error ('test-model.R:106:3'): mlflow log model records correct metadata with the tracking server
Error: Error: Run with UUID cf5adaee03c34f2098d4a1f4a0f96101 is already active. To start a nested run, Call `mlflow_start_run()` with `nested = TRUE`.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests  
- [ ] Manual tests

The existing R test suite should continue to pass with these changes.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Language

- [x] `language/r`: R APIs and clients

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)