### PR TITLE
Fix docs routing for `classic-ml` pages in `docs/changed_pages.py`

### DIFF
--- a/docs/changed_pages.py
+++ b/docs/changed_pages.py
@@ -1,4 +1,5 @@
 import os
+import re
 from pathlib import Path
 
 import requests
@@ -37,10 +38,13 @@ def main() -> None:
             )
             changed_pages.append(path.relative_to(DOCS_DIR))
 
-    links = "".join(f'<li><a href="{p}"><h2>{p}</h2></a></li>' for p in changed_pages)
+    # `classic-ml/` is routed as `ml/` in the docs, so we need to adjust the links.
+    regex = re.compile(r"^classic-ml/")
+    links = [regex.sub("ml/", str(p)) for p in changed_pages]
+    items = "".join(f'<li><a href="{l}"><h2>{l}</h2></a></li>' for l in links)
     diff_html = f"""
 <h1>Changed Pages</h1>
-<ul>{links}</ul>
+<ul>{items}</ul>
 """
     BUILD_DIR.mkdir(exist_ok=True)
     BUILD_DIR.joinpath("diff.html").write_text(diff_html)

--- a/docs/changed_pages.py
+++ b/docs/changed_pages.py
@@ -40,11 +40,11 @@ def main() -> None:
 
     # Adjust links because pages under `classic-ml/` are served as `ml/`.
     regex = re.compile(r"^classic-ml/")
-    links = [regex.sub("ml/", str(p)) for p in changed_pages]
-    items = "".join(f'<li><a href="{l}"><h2>{l}</h2></a></li>' for l in links)
+    links = (regex.sub("ml/", str(p)) for p in changed_pages)
+    list_items = "".join(f'<li><a href="{l}"><h2>{l}</h2></a></li>' for l in links)
     diff_html = f"""
 <h1>Changed Pages</h1>
-<ul>{items}</ul>
+<ul>{list_items}</ul>
 """
     BUILD_DIR.mkdir(exist_ok=True)
     BUILD_DIR.joinpath("diff.html").write_text(diff_html)

--- a/docs/changed_pages.py
+++ b/docs/changed_pages.py
@@ -38,7 +38,7 @@ def main() -> None:
             )
             changed_pages.append(path.relative_to(DOCS_DIR))
 
-    # `classic-ml/` is routed as `ml/` in the docs, so we need to adjust the links.
+    # Adjust links because pages under `classic-ml/` are served as `ml/`.
     regex = re.compile(r"^classic-ml/")
     links = [regex.sub("ml/", str(p)) for p in changed_pages]
     items = "".join(f'<li><a href="{l}"><h2>{l}</h2></a></li>' for l in links)

--- a/docs/docs/classic-ml/evaluation/dataset-eval.mdx
+++ b/docs/docs/classic-ml/evaluation/dataset-eval.mdx
@@ -9,6 +9,7 @@ import TabItem from "@theme/TabItem";
 
 # Dataset Evaluation
 
+
 Dataset evaluation allows you to assess model performance on pre-computed predictions without re-running the model. This is particularly useful for evaluating large-scale batch inference results, historical predictions, or when you want to separate the prediction and evaluation phases.
 
 ## Quick Start: Evaluating Static Predictions

--- a/docs/docs/classic-ml/evaluation/dataset-eval.mdx
+++ b/docs/docs/classic-ml/evaluation/dataset-eval.mdx
@@ -9,7 +9,6 @@ import TabItem from "@theme/TabItem";
 
 # Dataset Evaluation
 
-
 Dataset evaluation allows you to assess model performance on pre-computed predictions without re-running the model. This is particularly useful for evaluating large-scale batch inference results, historical predictions, or when you want to separate the prediction and evaluation phases.
 
 ## Quick Start: Evaluating Static Predictions


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR fixes the link generation in `docs/changed_pages.py` to account for the routing behavior where the `classic-ml/` directory is served as `ml/` in the documentation. The script now replaces the `classic-ml/` prefix with `ml/` to ensure the generated links work correctly.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- The change is straightforward and doesn't require additional tests as it only affects the link generation in the documentation build process. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- This is an internal documentation build fix that doesn't affect end users. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>