### PR TITLE
Refactor `LogModelArtifactPath` rule to use `SymbolIndex`

### DIFF
--- a/dev/clint/src/clint/index.py
+++ b/dev/clint/src/clint/index.py
@@ -59,7 +59,6 @@ class FunctionInfo:
 
     @property
     def all_args(self) -> list[str]:
-        """All arguments including positional, keyword-only, and variable arguments."""
         return self.posonlyargs + self.args + self.kwonlyargs
 
 

--- a/dev/clint/src/clint/index.py
+++ b/dev/clint/src/clint/index.py
@@ -57,6 +57,11 @@ class FunctionInfo:
             posonlyargs=[arg.arg for arg in node.args.posonlyargs],
         )
 
+    @property
+    def all_args(self) -> list[str]:
+        """All arguments including positional, keyword-only, and variable arguments."""
+        return self.posonlyargs + self.args + self.kwonlyargs
+
 
 class ModuleSymbolExtractor(ast.NodeVisitor):
     """Extracts function definitions and import mappings from a Python module."""

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -5,10 +5,15 @@ import inspect
 import itertools
 import re
 from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
 
 from packaging.version import InvalidVersion, Version
 
 from clint.resolver import Resolver
+from clint.utils import resolve_expr
+
+if TYPE_CHECKING:
+    from clint.index import SymbolIndex
 
 
 class Rule(ABC):
@@ -68,6 +73,50 @@ class TestNameTypo(Rule):
 class LogModelArtifactPath(Rule):
     def _message(self) -> str:
         return "`artifact_path` parameter of `log_model` is deprecated. Use `name` instead."
+
+    @staticmethod
+    def check(node: ast.Call, index: "SymbolIndex") -> bool:
+        """
+        Returns True if the call looks like `mlflow.<flavor>.log_model(...)` and
+        the `artifact_path` argument is specified.
+        """
+        parts = resolve_expr(node.func)
+        if not parts or len(parts) != 3:
+            return False
+
+        first, second, third = parts
+        if not (first == "mlflow" and third == "log_model"):
+            return False
+
+        # TODO: Remove this once spark flavor supports logging models as logged model artifacts
+        if second == "spark":
+            return False
+
+        if index is None:
+            return False
+
+        function_name = f"{first}.{second}.log_model"
+        artifact_path_idx = LogModelArtifactPath._find_artifact_path_index(index, function_name)
+        if artifact_path_idx is None:
+            return False
+
+        if len(node.args) > artifact_path_idx:
+            return True
+        else:
+            return any(kw.arg and kw.arg == "artifact_path" for kw in node.keywords)
+
+    @staticmethod
+    def _find_artifact_path_index(index: "SymbolIndex", function_name: str) -> int | None:
+        """
+        Finds the index of the `artifact_path` argument in the function signature of `log_model`
+        using the SymbolIndex.
+        """
+        if f := index.resolve(function_name):
+            try:
+                return f.all_args.index("artifact_path")
+            except ValueError:
+                return None
+        return None
 
 
 class ExampleSyntaxError(Rule):

--- a/dev/clint/src/clint/rules.py
+++ b/dev/clint/src/clint/rules.py
@@ -92,9 +92,6 @@ class LogModelArtifactPath(Rule):
         if second == "spark":
             return False
 
-        if index is None:
-            return False
-
         function_name = f"{first}.{second}.log_model"
         artifact_path_idx = LogModelArtifactPath._find_artifact_path_index(index, function_name)
         if artifact_path_idx is None:

--- a/dev/clint/src/clint/utils.py
+++ b/dev/clint/src/clint/utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import ast
+
+
+def resolve_expr(expr: ast.expr) -> list[str] | None:
+    """
+    Resolves `expr` to a list of attribute names. For example, given `expr` like
+    `some.module.attribute`, ['some', 'module', 'attribute'] is returned.
+    If `expr` is not resolvable, `None` is returned.
+    """
+    if isinstance(expr, ast.Attribute):
+        base = resolve_expr(expr.value)
+        if base is None:
+            return None
+        return base + [expr.attr]
+    elif isinstance(expr, ast.Name):
+        return [expr.id]
+
+    return None

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -147,7 +147,7 @@ def load_prompt(
         prompt = mlflow.genai.load_prompt("my_prompt", version=1)
 
         # Load a specific version of the prompt by URI
-        prompt = mlflow.genai.load_prompt(uri="prompts:/my_prompt/1")
+        prompt = mlflow.genai.load_prompt("prompts:/my_prompt/1")
 
         # Load a prompt version with an alias "production"
         prompt = mlflow.genai.load_prompt("prompts:/my_prompt@production")

--- a/mlflow/metrics/genai/base.py
+++ b/mlflow/metrics/genai/base.py
@@ -21,7 +21,7 @@ class EvaluationExample:
     .. code-block:: python
         :caption: Example for creating an EvaluationExample
 
-        from mlflow.metrics.base import EvaluationExample
+        from mlflow.metrics.genai import EvaluationExample
 
         example = EvaluationExample(
             input="What is MLflow?",

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1165,7 +1165,7 @@ __all__ = [
 try:
     from mlflow.pytorch._lightning_autolog import MlflowModelCheckpointCallback  # noqa: F401
 
-    __all__.append("MLflowModelCheckpointCallback")
+    __all__.append("MlflowModelCheckpointCallback")
 except ImportError:
     # Swallow exception if pytorch-lightning is not installed.
     pass

--- a/mlflow/pytorch/_lightning_autolog.py
+++ b/mlflow/pytorch/_lightning_autolog.py
@@ -309,7 +309,7 @@ class MlflowModelCheckpointCallback(pl.Callback, MlflowModelCheckpointCallbackBa
         :caption: Example
 
         import mlflow
-        from mlflow.pytorch import MLflowModelCheckpointCallback
+        from mlflow.pytorch import MlflowModelCheckpointCallback
         from pytorch_lightning import Trainer
 
         mlflow.pytorch.autolog(checkpoint=True)
@@ -317,7 +317,7 @@ class MlflowModelCheckpointCallback(pl.Callback, MlflowModelCheckpointCallbackBa
         model = MyLightningModuleNet()  # A custom-pytorch lightning model
         train_loader = create_train_dataset_loader()
 
-        mlflow_checkpoint_callback = MLflowModelCheckpointCallback()
+        mlflow_checkpoint_callback = MlflowModelCheckpointCallback()
 
         trainer = Trainer(callbacks=[mlflow_checkpoint_callback])
 

--- a/mlflow/sagemaker/__init__.py
+++ b/mlflow/sagemaker/__init__.py
@@ -287,7 +287,7 @@ def _deploy(
                             "subnet-123456abc",
                         ],
                     }
-                    mfs.deploy(..., vpc_config=vpc_config)
+                    mfs._deploy(..., vpc_config=vpc_config)
 
         flavor: The name of the flavor of the model to use for deployment. Must be either
             ``None`` or one of mlflow.sagemaker.SUPPORTED_DEPLOYMENT_FLAVORS. If ``None``,
@@ -322,7 +322,7 @@ def _deploy(
                     "DestinationS3Uri": "s3://my-bucket/path",
                     "CaptureOptions": [{"CaptureMode": "Output"}],
                 }
-                mfs.deploy(..., data_capture_config=data_capture_config)
+                mfs._deploy(..., data_capture_config=data_capture_config)
 
         variant_name: The name to assign to the new production variant.
         async_inference_config: The name to assign to the endpoint_config

--- a/mlflow/spark/__init__.py
+++ b/mlflow/spark/__init__.py
@@ -919,7 +919,7 @@ def load_model(model_uri, dfs_tmpdir=None, dst_path=None):
     .. code-block:: python
         :caption: Example
 
-        from mlflow import spark
+        import mlflow
 
         model = mlflow.spark.load_model("spark-model")
         # Prepare test documents, which are unlabeled (id, text) tuples.

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -678,7 +678,7 @@ def load_prompt(
         prompt = mlflow.load_prompt("my_prompt", version=1)
 
         # Load a specific version of the prompt by URI
-        prompt = mlflow.load_prompt(uri="prompts:/my_prompt/1")
+        prompt = mlflow.load_prompt("prompts:/my_prompt/1")
 
         # Load a prompt version with an alias "production"
         prompt = mlflow.load_prompt("prompts:/my_prompt@production")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16465?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16465/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16465/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16465/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Internal refactoring to improve code consistency -->

### What changes are proposed in this pull request?

This PR refactors the `LogModelArtifactPath` rule in the clint linter to use the existing `SymbolIndex` infrastructure instead of custom AST parsing logic.

**Key changes:**
- Move logic from `_log_model_with_artifact_path` method to `LogModelArtifactPath.check` static method
- Remove `_ArtifactPathFinder` class and `_find_artifact_path_index_from_symbol_index` helper function
- Use existing `SymbolIndex` to resolve function signatures and find `artifact_path` argument positions
- Clean up unused imports and improve code consistency with other rule implementations

**Benefits:**
- **Performance**: Leverages pre-built `SymbolIndex` instead of parsing files on-demand
- **Consistency**: Aligns with the architecture where `SymbolIndex` is the single source of truth for function signatures  
- **Maintainability**: Removes duplicate logic and follows established patterns used by other rules

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Manually tested the linter functionality:
- Verified linter runs without errors on MLflow codebase files containing `log_model` calls
- Confirmed all ruff/clint linting checks pass
- Tested on examples with `log_model` usage to ensure rule detection still works

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)