### PR TITLE
Fix `tests/tracing/test_fluent.py::test_mlflow_trace_isolated_from_other_otel_processors`

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,4 +18,11 @@ pyspark<3.5.6
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
 
+langsmith<0.4.3
+openai<1.92.2
+boto3<1.38.45
+botocore<1.38.45
 litellm<1.73.2
+plotly<6.2.0
+transformers<4.53.0
+fastapi<0.115.14

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,4 +18,4 @@ pyspark<3.5.6
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
 
-openai<1.92.2
+openai<1.92

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,12 +17,7 @@ pyspark<3.5.6
 # https://github.com/microsoft/FLAML/blob/01c3c836534a244ac8038535455a7fde367366ad/flaml/fabric/mlflow.py#L67-L68
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
-
-langsmith<0.4.3
-openai<1.92.2
-boto3<1.38.45
-botocore<1.38.45
-litellm<1.73.2
-plotly<6.2.0
+# transformers >= 4.53.0 uses OpenTelemetry for metrics monitoring, which interferes with
+# `tests/tracing/test_fluent.py::test_mlflow_trace_isolated_from_other_otel_processors`
+# https://github.com/huggingface/transformers/commit/211f2b08751cdee4bd6b84892b91f4a18dbfe305
 transformers<4.53.0
-fastapi<0.115.14

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,4 +18,4 @@ pyspark<3.5.6
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
 
-openai<1.92
+litellm<1.73.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -18,4 +18,4 @@ pyspark<3.5.6
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
 
-langsmith<0.4.3
+openai<1.92.2

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,3 +17,5 @@ pyspark<3.5.6
 # https://github.com/microsoft/FLAML/blob/01c3c836534a244ac8038535455a7fde367366ad/flaml/fabric/mlflow.py#L67-L68
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
+
+langsmith<0.4.3


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16475?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16475/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16475/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16475/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

`tests/tracing/test_fluent.py::test_mlflow_trace_isolated_from_other_otel_processors` started failing today. This PR fixes it.

https://github.com/mlflow/mlflow/actions/runs/15922913200/job/44913592060

```
____________ test_mlflow_trace_isolated_from_other_otel_processors _____________

    def test_mlflow_trace_isolated_from_other_otel_processors():
        # Set up non-MLFlow tracer
        import opentelemetry.sdk.trace as trace_sdk
        from opentelemetry import trace
    
        class MockOtelExporter(trace_sdk.export.SpanExporter):
            def __init__(self):
                self.exported_spans = []
    
            def export(self, spans):
                self.exported_spans.extend(spans)
    
        other_exporter = MockOtelExporter()
        provider = trace_sdk.TracerProvider()
        processor = trace_sdk.export.SimpleSpanProcessor(other_exporter)
        provider.add_span_processor(processor)
        trace.set_tracer_provider(provider)
    
        # Create MLflow trace
        with mlflow.start_span(name="mlflow_span"):
            pass
    
        # Create non-MLflow trace
        tracer = trace.get_tracer(__name__)
        with tracer.start_as_current_span("non_mlflow_span"):
            pass
    
        # MLflow only processes spans created with MLflow APIs
        assert len(get_traces()) == 1
        assert mlflow.get_trace(mlflow.get_last_active_trace_id()).data.spans[0].name == "mlflow_span"
    
        # Other spans are processed by the other processor
>       assert len(other_exporter.exported_spans) == 1
E       assert 0 == 1
E        +  where 0 = len([])
E        +    where [] = <tests.tracing.test_fluent.test_mlflow_trace_isolated_from_other_otel_processors.<locals>.MockOtelExporter object at 0x7fd6152bfd60>.exported_spans
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
