### PR TITLE
[DOC-FIX] Correct 'Resgitry' typo to 'Registry' in Model Registry docs

### DIFF
--- a/docs/docs/classic-ml/model-registry/index.mdx
+++ b/docs/docs/classic-ml/model-registry/index.mdx
@@ -153,7 +153,7 @@ You can register models, track versions, add tags and descriptions, and transiti
 
 To learn more about the OSS Model Registry, refer to the [tutorial on the model registry](./tutorial).
 
-### Model Resgitry in Databricks
+### Model Registry in Databricks
 
 Databricks extends MLflow’s capabilities by integrating the Model Registry with Unity Catalog, enabling centralized governance, fine-grained access control, and cross-workspace collaboration.
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/shushantrishav/mlflow/pull/16479?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16479/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16479/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16479/merge
```

</p>
</details>

Related Issues/PRs
Resolve #16468

What changes are proposed in this pull request?
Corrected a minor misspelling of 'Resgitry' to 'Registry' in the MLflow Model Registry documentation section for Databricks.

How is this PR tested?
 Manual tests
✔️ Verified the rendered documentation to confirm the corrected spelling.

Does this PR require documentation update?
 No. You can skip the rest of this section.
(Doc itself is being fixed in this PR — no separate update needed.)

Release Notes
Is this a user-facing change?
 Yes. Documentation wording correction visible to users.

What component(s), interfaces, languages, and integrations does this PR affect?
Components

 area/docs: MLflow documentation pages

<a name="release-note-category"></a>

How should the PR be classified in the release notes? Choose one:
 rn/documentation - A user-facing documentation change worth mentioning in the release notes

Should this PR be included in the next patch release?
 Yes (this PR will be cherry-picked and included in the next patch release)