### PR TITLE
Rename deprecated V2 trace methods

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -2498,130 +2498,6 @@ def _abort_multipart_upload_artifact(artifact_path):
 
 @catch_mlflow_exception
 @_disable_if_artifacts_only
-def _start_trace():
-    """
-    Deprecated. Use `_start_trace_v3` instead.
-    A request handler for `POST /mlflow/traces` to create a new TraceInfo record in tracking store.
-    """
-    request_message = _get_request_message(
-        StartTrace(),
-        schema={
-            "experiment_id": [_assert_string],
-            "timestamp_ms": [_assert_intlike],
-            "request_metadata": [_assert_map_key_present],
-            "tags": [_assert_map_key_present],
-        },
-    )
-    request_metadata = {e.key: e.value for e in request_message.request_metadata}
-    tags = {e.key: e.value for e in request_message.tags}
-
-    trace_info = _get_tracking_store().start_trace(
-        experiment_id=request_message.experiment_id,
-        timestamp_ms=request_message.timestamp_ms,
-        request_metadata=request_metadata,
-        tags=tags,
-    )
-
-    if isinstance(trace_info, TraceInfo):
-        trace_info = TraceInfoV2.from_v3(trace_info)
-
-    response_message = StartTrace.Response(trace_info=trace_info.to_proto())
-    return _wrap_response(response_message)
-
-
-@catch_mlflow_exception
-@_disable_if_artifacts_only
-def _end_trace(request_id):
-    """
-    Deprecated.
-    A request handler for `PATCH /mlflow/traces/{request_id}` to mark an existing TraceInfo
-    record completed in tracking store.
-    """
-    request_message = _get_request_message(
-        EndTrace(),
-        schema={
-            "timestamp_ms": [_assert_intlike],
-            "status": [_assert_string],
-            "request_metadata": [_assert_map_key_present],
-            "tags": [_assert_map_key_present],
-        },
-    )
-    request_metadata = {e.key: e.value for e in request_message.request_metadata}
-    tags = {e.key: e.value for e in request_message.tags}
-
-    trace_info = _get_tracking_store().end_trace(
-        request_id=request_id,
-        timestamp_ms=request_message.timestamp_ms,
-        status=TraceStatus.from_proto(request_message.status),
-        request_metadata=request_metadata,
-        tags=tags,
-    )
-
-    if isinstance(trace_info, TraceInfo):
-        trace_info = TraceInfoV2.from_v3(trace_info)
-
-    response_message = EndTrace.Response(trace_info=trace_info.to_proto())
-    return _wrap_response(response_message)
-
-
-@catch_mlflow_exception
-@_disable_if_artifacts_only
-def _get_trace_info(request_id):
-    """
-    Deprecated. Use `_get_trace_info_v3` instead.
-    A request handler for `GET /mlflow/traces/{request_id}/info` to retrieve
-    an existing TraceInfo record from tracking store.
-    """
-    trace_info = _get_tracking_store().get_trace_info(request_id)
-    if isinstance(trace_info, TraceInfo):
-        trace_info = TraceInfoV2.from_v3(trace_info)
-    response_message = GetTraceInfo.Response(trace_info=trace_info.to_proto())
-    return _wrap_response(response_message)
-
-
-@catch_mlflow_exception
-@_disable_if_artifacts_only
-def _search_traces():
-    """
-    Deprecated. Use `_search_traces_v3` instead.
-    A request handler for `GET /mlflow/traces` to search for TraceInfo records in tracking store.
-    """
-    request_message = _get_request_message(
-        SearchTraces(),
-        schema={
-            "experiment_ids": [
-                _assert_array,
-                _assert_item_type_string,
-                _assert_required,
-            ],
-            "filter": [_assert_string],
-            "max_results": [
-                _assert_intlike,
-                lambda x: _assert_less_than_or_equal(int(x), 500),
-            ],
-            "order_by": [_assert_array, _assert_item_type_string],
-            "page_token": [_assert_string],
-        },
-    )
-    traces, token = _get_tracking_store().search_traces(
-        experiment_ids=request_message.experiment_ids,
-        filter_string=request_message.filter,
-        max_results=request_message.max_results,
-        order_by=request_message.order_by,
-        page_token=request_message.page_token,
-    )
-    if traces and isinstance(traces[0], TraceInfo):
-        traces = [TraceInfoV2.from_v3(t) for t in traces]
-
-    response_message = SearchTraces.Response()
-    response_message.traces.extend([e.to_proto() for e in traces])
-    if token:
-        response_message.next_page_token = token
-    return _wrap_response(response_message)
-
-
-@catch_mlflow_exception
-@_disable_if_artifacts_only
 def _start_trace_v3():
     """
     A request handler for `POST /mlflow/traces` to create a new TraceInfo record in tracking store.
@@ -2631,7 +2507,7 @@ def _start_trace_v3():
         schema={"trace": [_assert_required]},
     )
     trace_info = TraceInfo.from_proto(request_message.trace.trace_info)
-    trace_info = _get_tracking_store().start_trace_v3(trace_info)
+    trace_info = _get_tracking_store().start_trace(trace_info)
     response_message = StartTraceV3.Response(trace=ProtoTrace(trace_info=trace_info.to_proto()))
     return _wrap_response(response_message)
 
@@ -2783,6 +2659,122 @@ def get_trace_artifact_handler():
         download_name=TRACE_DATA_FILE_NAME,
     )
     return _response_with_file_attachment_headers(TRACE_DATA_FILE_NAME, file_sender_response)
+
+
+# Deprecated MLflow Tracing APIs. Kept for backward compatibility but do not use.
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
+def _deprecated_start_trace_v2():
+    """
+    A request handler for `POST /mlflow/traces` to create a new TraceInfo record in tracking store.
+    """
+    request_message = _get_request_message(
+        StartTrace(),
+        schema={
+            "experiment_id": [_assert_string],
+            "timestamp_ms": [_assert_intlike],
+            "request_metadata": [_assert_map_key_present],
+            "tags": [_assert_map_key_present],
+        },
+    )
+    request_metadata = {e.key: e.value for e in request_message.request_metadata}
+    tags = {e.key: e.value for e in request_message.tags}
+
+    trace_info = _get_tracking_store().deprecated_start_trace_v2(
+        experiment_id=request_message.experiment_id,
+        timestamp_ms=request_message.timestamp_ms,
+        request_metadata=request_metadata,
+        tags=tags,
+    )
+    response_message = StartTrace.Response(trace_info=trace_info.to_proto())
+    return _wrap_response(response_message)
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
+def _deprecated_end_trace_v2(request_id):
+    """
+    A request handler for `PATCH /mlflow/traces/{request_id}` to mark an existing TraceInfo
+    record completed in tracking store.
+    """
+    request_message = _get_request_message(
+        EndTrace(),
+        schema={
+            "timestamp_ms": [_assert_intlike],
+            "status": [_assert_string],
+            "request_metadata": [_assert_map_key_present],
+            "tags": [_assert_map_key_present],
+        },
+    )
+    request_metadata = {e.key: e.value for e in request_message.request_metadata}
+    tags = {e.key: e.value for e in request_message.tags}
+
+    trace_info = _get_tracking_store().deprecated_end_trace_v2(
+        request_id=request_id,
+        timestamp_ms=request_message.timestamp_ms,
+        status=TraceStatus.from_proto(request_message.status),
+        request_metadata=request_metadata,
+        tags=tags,
+    )
+
+    if isinstance(trace_info, TraceInfo):
+        trace_info = TraceInfoV2.from_v3(trace_info)
+
+    response_message = EndTrace.Response(trace_info=trace_info.to_proto())
+    return _wrap_response(response_message)
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
+def _deprecated_get_trace_info_v2(request_id):
+    """
+    A request handler for `GET /mlflow/traces/{request_id}/info` to retrieve
+    an existing TraceInfo record from tracking store.
+    """
+    trace_info = _get_tracking_store().get_trace_info(request_id)
+    trace_info = TraceInfoV2.from_v3(trace_info)
+    response_message = GetTraceInfo.Response(trace_info=trace_info.to_proto())
+    return _wrap_response(response_message)
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
+def _deprecated_search_traces_v2():
+    """
+    A request handler for `GET /mlflow/traces` to search for TraceInfo records in tracking store.
+    """
+    request_message = _get_request_message(
+        SearchTraces(),
+        schema={
+            "experiment_ids": [
+                _assert_array,
+                _assert_item_type_string,
+                _assert_required,
+            ],
+            "filter": [_assert_string],
+            "max_results": [
+                _assert_intlike,
+                lambda x: _assert_less_than_or_equal(int(x), 500),
+            ],
+            "order_by": [_assert_array, _assert_item_type_string],
+            "page_token": [_assert_string],
+        },
+    )
+    traces, token = _get_tracking_store().search_traces(
+        experiment_ids=request_message.experiment_ids,
+        filter_string=request_message.filter,
+        max_results=request_message.max_results,
+        order_by=request_message.order_by,
+        page_token=request_message.page_token,
+    )
+    traces = [TraceInfoV2.from_v3(t) for t in traces]
+    response_message = SearchTraces.Response()
+    response_message.traces.extend([e.to_proto() for e in traces])
+    if token:
+        response_message.next_page_token = token
+    return _wrap_response(response_message)
 
 
 # Logged Models APIs
@@ -3143,10 +3135,10 @@ HANDLERS = {
     SetTraceTag: _set_trace_tag,
     DeleteTraceTag: _delete_trace_tag,
     # Legacy MLflow Tracing V2 APIs. Kept for backward compatibility but do not use.
-    StartTrace: _start_trace,
-    EndTrace: _end_trace,
-    GetTraceInfo: _get_trace_info,
-    SearchTraces: _search_traces,
+    StartTrace: _deprecated_start_trace_v2,
+    EndTrace: _deprecated_end_trace_v2,
+    GetTraceInfo: _deprecated_get_trace_info_v2,
+    SearchTraces: _deprecated_search_traces_v2,
     # Logged Models APIs
     CreateLoggedModel: _create_logged_model,
     GetLoggedModel: _get_logged_model,

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -14,8 +14,6 @@ from mlflow.entities import (
 )
 from mlflow.entities.metric import MetricWithRunId
 from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_info_v2 import TraceInfoV2
-from mlflow.entities.trace_status import TraceStatus
 from mlflow.exceptions import MlflowException
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT, SEARCH_TRACES_DEFAULT_MAX_RESULTS
@@ -241,57 +239,7 @@ class AbstractStore:
 
         """
 
-    # TODO: rename this to create_trace_info
-    def start_trace(
-        self,
-        experiment_id: str,
-        timestamp_ms: int,
-        request_metadata: dict[str, str],
-        tags: dict[str, str],
-    ) -> TraceInfoV2:
-        """
-        Start an initial TraceInfo object in the backend store.
-
-        Args:
-            experiment_id: String id of the experiment for this run.
-            timestamp_ms: Start time of the trace, in milliseconds since the UNIX epoch.
-            request_metadata: Metadata of the trace.
-            tags: Tags of the trace.
-
-        Returns:
-            The created TraceInfo object.
-        """
-        raise NotImplementedError
-
-    # TODO: rename this to update_trace_info
-    # can we pass in execution_time_ms instead of timestamp_ms directly?
-    def end_trace(
-        self,
-        request_id: str,
-        timestamp_ms: int,
-        status: TraceStatus,
-        request_metadata: dict[str, str],
-        tags: dict[str, str],
-    ) -> TraceInfoV2:
-        """
-        Update the TraceInfo object in the backend store with the completed trace info.
-
-        Args:
-            request_id : Unique string identifier of the trace.
-            timestamp_ms: End time of the trace, in milliseconds. The execution time field
-                in the TraceInfo will be calculated by subtracting the start time from this.
-            status: Status of the trace.
-            request_metadata: Metadata of the trace. This will be merged with the existing
-                metadata logged during the start_trace call.
-            tags: Tags of the trace. This will be merged with the existing tags logged
-                during the start_trace or set_trace_tag calls.
-
-        Returns:
-            The updated TraceInfo object.
-        """
-        raise NotImplementedError
-
-    def start_trace_v3(self, trace_info: TraceInfo) -> TraceInfo:
+    def start_trace(self, trace_info: TraceInfo) -> TraceInfo:
         """
         Create a trace using the V3 API format with a complete Trace object.
 
@@ -299,7 +247,7 @@ class AbstractStore:
             trace_info: The TraceInfo object to create in the backend.
 
         Returns:
-            The created TraceInfo object from the backend.
+            The returned TraceInfo object from the backend.
         """
         raise NotImplementedError
 

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -38,8 +38,7 @@ from mlflow.entities import (
 )
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.entities.run_info import check_run_is_active
-from mlflow.entities.trace_location import TraceLocation
-from mlflow.entities.trace_state import TraceState
+from mlflow.entities.trace_info_v2 import TraceInfoV2
 from mlflow.entities.trace_status import TraceStatus
 from mlflow.environment_variables import MLFLOW_TRACKING_DIR
 from mlflow.exceptions import MissingConfigException, MlflowException
@@ -1606,48 +1605,6 @@ class FileStore(AbstractStore):
             FileStore.ARTIFACTS_FOLDER_NAME,
         )
 
-    def start_trace(
-        self,
-        experiment_id: str,
-        timestamp_ms: int,
-        request_metadata: dict[str, str],
-        tags: dict[str, str],
-    ) -> TraceInfo:
-        """
-        Start an initial TraceInfo object in the backend store.
-
-        Args:
-            experiment_id: String id of the experiment for this run.
-            timestamp_ms: Start time of the trace, in milliseconds since the UNIX epoch.
-            request_metadata: Metadata of the trace.
-            tags: Tags of the trace.
-
-        Returns:
-            The created TraceInfo object.
-        """
-        request_id = generate_request_id_v2()
-        _validate_experiment_id(experiment_id)
-        experiment_dir = self._get_experiment_path(
-            experiment_id, view_type=ViewType.ACTIVE_ONLY, assert_exists=True
-        )
-        mkdir(experiment_dir, FileStore.TRACES_FOLDER_NAME)
-        traces_dir = os.path.join(experiment_dir, FileStore.TRACES_FOLDER_NAME)
-        mkdir(traces_dir, request_id)
-        trace_dir = os.path.join(traces_dir, request_id)
-        artifact_uri = self._get_traces_artifact_dir(experiment_id, request_id)
-        tags.update({MLFLOW_ARTIFACT_LOCATION: artifact_uri})
-        trace_info = TraceInfo(
-            trace_id=request_id,
-            trace_location=TraceLocation.from_experiment_id(experiment_id),
-            request_time=timestamp_ms,
-            execution_duration=None,
-            state=TraceState.IN_PROGRESS,
-            trace_metadata=request_metadata,
-            tags=tags,
-        )
-        self._save_trace_info(trace_info, trace_dir)
-        return trace_info
-
     def _save_trace_info(self, trace_info: TraceInfo, trace_dir, overwrite=False):
         """
         TraceInfo is saved into `traces` folder under the experiment, each trace
@@ -1714,39 +1671,7 @@ class FileStore(AbstractStore):
             dictionary[file_name] = value
         return dictionary
 
-    def end_trace(
-        self,
-        request_id: str,
-        timestamp_ms: int,
-        status: TraceStatus,
-        request_metadata: dict[str, str],
-        tags: dict[str, str],
-    ) -> TraceInfo:
-        """
-        Update the TraceInfo object in the backend store with the completed trace info.
-
-        Args:
-            request_id : Unique string identifier of the trace.
-            timestamp_ms: End time of the trace, in milliseconds. The execution time field
-                in the TraceInfo will be calculated by subtracting the start time from this.
-            status: Status of the trace.
-            request_metadata: Metadata of the trace. This will be merged with the existing
-                metadata logged during the start_trace call.
-            tags: Tags of the trace. This will be merged with the existing tags logged
-                during the start_trace or set_trace_tag calls.
-
-        Returns:
-            The updated TraceInfo object.
-        """
-        trace_info, trace_dir = self._get_trace_info_and_dir(request_id)
-        trace_info.execution_duration = timestamp_ms - trace_info.request_time
-        trace_info.state = status.to_state()
-        trace_info.trace_metadata.update(request_metadata)
-        trace_info.tags.update(tags)
-        self._save_trace_info(trace_info, trace_dir, overwrite=True)
-        return trace_info
-
-    def start_trace_v3(self, trace_info: TraceInfo) -> TraceInfo:
+    def start_trace(self, trace_info: TraceInfo) -> TraceInfo:
         """
         Create a trace using the V3 API format with a complete Trace object.
 
@@ -2418,3 +2343,84 @@ class FileStore(AbstractStore):
                     "Malformed model '%s'. Detailed error %s", m_id, str(exc), exc_info=True
                 )
         return models
+
+    #######################################################################################
+    # Below are legacy V2 Tracing APIs. DO NOT USE. Use the V3 APIs instead.
+    #######################################################################################
+    def deprecated_start_trace_v2(
+        self,
+        experiment_id: str,
+        timestamp_ms: int,
+        request_metadata: dict[str, str],
+        tags: dict[str, str],
+    ) -> TraceInfoV2:
+        """
+        DEPRECATED. DO NOT USE.
+
+        Start an initial TraceInfo object in the backend store.
+
+        Args:
+            experiment_id: String id of the experiment for this run.
+            timestamp_ms: Start time of the trace, in milliseconds since the UNIX epoch.
+            request_metadata: Metadata of the trace.
+            tags: Tags of the trace.
+
+        Returns:
+            The created TraceInfo object.
+        """
+        request_id = generate_request_id_v2()
+        _validate_experiment_id(experiment_id)
+        experiment_dir = self._get_experiment_path(
+            experiment_id, view_type=ViewType.ACTIVE_ONLY, assert_exists=True
+        )
+        mkdir(experiment_dir, FileStore.TRACES_FOLDER_NAME)
+        traces_dir = os.path.join(experiment_dir, FileStore.TRACES_FOLDER_NAME)
+        mkdir(traces_dir, request_id)
+        trace_dir = os.path.join(traces_dir, request_id)
+        artifact_uri = self._get_traces_artifact_dir(experiment_id, request_id)
+        tags.update({MLFLOW_ARTIFACT_LOCATION: artifact_uri})
+        trace_info = TraceInfoV2(
+            request_id=request_id,
+            experiment_id=experiment_id,
+            timestamp_ms=timestamp_ms,
+            execution_time_ms=None,
+            status=TraceStatus.IN_PROGRESS,
+            request_metadata=request_metadata,
+            tags=tags,
+        )
+        self._save_trace_info(trace_info.to_v3(), trace_dir)
+        return trace_info
+
+    def deprecated_end_trace_v2(
+        self,
+        request_id: str,
+        timestamp_ms: int,
+        status: TraceStatus,
+        request_metadata: dict[str, str],
+        tags: dict[str, str],
+    ) -> TraceInfoV2:
+        """
+        DEPRECATED. DO NOT USE.
+
+        Update the TraceInfo object in the backend store with the completed trace info.
+
+        Args:
+            request_id : Unique string identifier of the trace.
+            timestamp_ms: End time of the trace, in milliseconds. The execution time field
+                in the TraceInfo will be calculated by subtracting the start time from this.
+            status: Status of the trace.
+            request_metadata: Metadata of the trace. This will be merged with the existing
+                metadata logged during the start_trace call.
+            tags: Tags of the trace. This will be merged with the existing tags logged
+                during the start_trace or set_trace_tag calls.
+
+        Returns:
+            The updated TraceInfo object.
+        """
+        trace_info, trace_dir = self._get_trace_info_and_dir(request_id)
+        trace_info.execution_duration = timestamp_ms - trace_info.request_time
+        trace_info.state = status.to_state()
+        trace_info.trace_metadata.update(request_metadata)
+        trace_info.tags.update(tags)
+        self._save_trace_info(trace_info, trace_dir, overwrite=True)
+        return TraceInfoV2.from_v3(trace_info)

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -69,7 +69,7 @@ class TracingClient:
         Returns:
             The returned TraceInfoV3 object from the backend.
         """
-        return self.store.start_trace_v3(trace_info=trace_info)
+        return self.store.start_trace(trace_info=trace_info)
 
     def delete_traces(
         self,

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -78,7 +78,7 @@ def store(tmp_path):
 def store_and_trace_info(store):
     exp_id = store.create_experiment("test")
     timestamp_ms = get_current_time_millis()
-    return store, store.start_trace_v3(
+    return store, store.start_trace(
         TraceInfo(
             trace_id=f"tr-{uuid.uuid4()}",
             trace_location=TraceLocation.from_experiment_id(exp_id),
@@ -127,7 +127,7 @@ def generate_trace_infos(store):
             tags={TraceTagKey.TRACE_NAME: f"trace_{i}", "test_tag": f"tag_{i}"},
             trace_metadata=metadata,
         )
-        trace_info = store.start_trace_v3(trace_info)
+        trace_info = store.start_trace(trace_info)
         trace_infos.append(trace_info)
         trace_ids.append(trace_info.trace_id)
     return TraceInfos(trace_infos, store, exp_id, trace_ids, timestamps)
@@ -2982,17 +2982,17 @@ def test_legacy_start_trace_v2(store):
     exp_id = store.create_experiment("test")
     timestamp_ms = get_current_time_millis()
     tags = {"some_key": "test"}
-    trace_info = store.start_trace(exp_id, timestamp_ms, {}, tags)
+    trace_info = store.deprecated_start_trace_v2(exp_id, timestamp_ms, {}, tags)
     assert trace_info.request_id is not None
     assert trace_info.experiment_id == exp_id
     assert trace_info.timestamp_ms == timestamp_ms
     assert trace_info.execution_time_ms is None
     assert trace_info.status == TraceStatus.IN_PROGRESS
-    assert trace_info.request_metadata == {TRACE_SCHEMA_VERSION_KEY: "3"}
+    assert trace_info.request_metadata == {TRACE_SCHEMA_VERSION_KEY: "2"}
     assert trace_info.tags == tags
 
     with pytest.raises(MlflowException, match=r"Experiment fake_exp_id does not exist."):
-        store.start_trace("fake_exp_id", timestamp_ms, {}, {})
+        store.deprecated_start_trace_v2("fake_exp_id", timestamp_ms, {}, {})
 
 
 def test_legacy_end_trace(store_and_trace_info):
@@ -3001,10 +3001,10 @@ def test_legacy_end_trace(store_and_trace_info):
     request_metadata = {
         TraceMetadataKey.INPUTS: {"query": "test"},
         TraceMetadataKey.OUTPUTS: "test",
-        TRACE_SCHEMA_VERSION_KEY: "3",
+        TRACE_SCHEMA_VERSION_KEY: "2",
     }
     tags = {TraceTagKey.TRACE_NAME: "mlflow_trace"}
-    trace_info = store.end_trace(
+    trace_info = store.deprecated_end_trace_v2(
         trace.request_id, timestamp_ms, TraceStatus.OK, request_metadata, tags
     )
     assert trace_info.request_id == trace.request_id
@@ -3015,7 +3015,9 @@ def test_legacy_end_trace(store_and_trace_info):
     assert trace_info.tags == {**trace.tags, **tags}
 
     with pytest.raises(MlflowException, match=r"Trace with ID 'fake_request_id' not found"):
-        store.end_trace("fake_request_id", timestamp_ms, TraceStatus.OK, request_metadata, tags)
+        store.deprecated_end_trace_v2(
+            "fake_request_id", timestamp_ms, TraceStatus.OK, request_metadata, tags
+        )
 
 
 def test_start_trace(store):
@@ -3033,7 +3035,7 @@ def test_start_trace(store):
         request_preview=None,
         response_preview=None,
     )
-    new_trace_info = store.start_trace_v3(trace_info)
+    new_trace_info = store.start_trace(trace_info)
 
     assert new_trace_info.trace_id == trace_info.trace_id
     assert new_trace_info.experiment_id == exp_id
@@ -3118,7 +3120,7 @@ def test_delete_traces(store):
             request_time=timestamps[i],
             state=TraceState.OK,
         )
-        trace_info = store.start_trace_v3(trace_info)
+        trace_info = store.start_trace(trace_info)
         trace_ids.append(trace_info.trace_id)
 
     # delete with max_timestamp_millis
@@ -3274,7 +3276,7 @@ def test_search_traces_filter(generate_trace_infos):
 def test_search_traces_filter_trace_metadata(store):
     exp_id = store.create_experiment("test")
     timestamp_ms_1 = get_current_time_millis()
-    trace_info_1 = store.start_trace_v3(
+    trace_info_1 = store.start_trace(
         TraceInfo(
             trace_id=f"tr-{uuid.uuid4()}",
             trace_location=TraceLocation.from_experiment_id(exp_id),
@@ -3288,7 +3290,7 @@ def test_search_traces_filter_trace_metadata(store):
     )
     time.sleep(0.001)  # ensure unique timestamps
     timestamp_ms_2 = get_current_time_millis()
-    trace_info_2 = store.start_trace_v3(
+    trace_info_2 = store.start_trace(
         TraceInfo(
             trace_id=f"tr-{uuid.uuid4()}",
             trace_location=TraceLocation.from_experiment_id(exp_id),
@@ -3418,7 +3420,7 @@ def test_search_traces_order(generate_trace_infos):
 
     # order by experiment_id
     exp_id2 = store.create_experiment("test2")
-    trace_info = store.start_trace_v3(
+    trace_info = store.start_trace(
         TraceInfo(
             trace_id=f"tr-{uuid.uuid4()}",
             trace_location=TraceLocation.from_experiment_id(exp_id2),

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -585,7 +585,7 @@ def test_get_metric_history_on_non_existent_metric_key():
         assert metrics == []
 
 
-def test_start_trace():
+def test_deprecated_start_trace_v2():
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
 
@@ -619,7 +619,7 @@ def test_start_trace():
         }
     )
     with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
-        res = store.start_trace(
+        res = store.deprecated_start_trace_v2(
             experiment_id=experiment_id,
             timestamp_ms=timestamp_ms,
             request_metadata=metadata,
@@ -636,7 +636,7 @@ def test_start_trace():
         assert res.tags == {k: str(v) for k, v in tags.items()}
 
 
-def test_start_trace_v3(monkeypatch):
+def test_start_trace(monkeypatch):
     monkeypatch.setenv(MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT.name, "1")
 
     creds = MlflowHostCreds("https://hello")
@@ -662,7 +662,7 @@ def test_start_trace_v3(monkeypatch):
     expected_request = StartTraceV3(trace=trace.to_proto())
 
     with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
-        store.start_trace_v3(trace.info)
+        store.start_trace(trace.info)
         _verify_requests(
             mock_http,
             creds,
@@ -674,7 +674,7 @@ def test_start_trace_v3(monkeypatch):
         )
 
 
-def test_end_trace():
+def test_deprecated_end_trace_v2():
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)
 
@@ -708,7 +708,7 @@ def test_end_trace():
     )
 
     with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
-        res = store.end_trace(
+        res = store.deprecated_end_trace_v2(
             request_id=request_id,
             timestamp_ms=timestamp_ms,
             status=status,

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -4204,9 +4204,9 @@ def test_create_run_appends_to_artifact_uri_path_correctly(input_uri, expected_u
     _assert_create_run_appends_to_artifact_uri_path_correctly(input_uri, expected_uri)
 
 
-def test_start_and_end_trace(store: SqlAlchemyStore):
+def test_legacy_start_and_end_trace_v2(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_experiment")
-    trace_info = store.start_trace(
+    trace_info = store.deprecated_start_trace_v2(
         experiment_id=experiment_id,
         timestamp_ms=1234,
         request_metadata={"rq1": "foo", "rq2": "bar"},
@@ -4222,7 +4222,7 @@ def test_start_and_end_trace(store: SqlAlchemyStore):
     assert trace_info.request_metadata == {
         "rq1": "foo",
         "rq2": "bar",
-        TRACE_SCHEMA_VERSION_KEY: "3",
+        TRACE_SCHEMA_VERSION_KEY: "2",
     }
     artifact_location = trace_info.tags[MLFLOW_ARTIFACT_LOCATION]
     assert artifact_location.endswith(f"/{experiment_id}/traces/{request_id}/artifacts")
@@ -4231,9 +4231,9 @@ def test_start_and_end_trace(store: SqlAlchemyStore):
         "tag2": "orange",
         MLFLOW_ARTIFACT_LOCATION: artifact_location,
     }
-    assert trace_info == store.get_trace_info(request_id)
+    assert trace_info.to_v3() == store.get_trace_info(request_id)
 
-    trace_info = store.end_trace(
+    trace_info = store.deprecated_end_trace_v2(
         request_id=request_id,
         timestamp_ms=2345,
         status=TraceStatus.OK,
@@ -4253,7 +4253,7 @@ def test_start_and_end_trace(store: SqlAlchemyStore):
         "rq1": "updated",
         "rq2": "bar",
         "rq3": "baz",
-        TRACE_SCHEMA_VERSION_KEY: "3",
+        TRACE_SCHEMA_VERSION_KEY: "2",
     }
     assert trace_info.tags == {
         "tag1": "updated",
@@ -4261,10 +4261,10 @@ def test_start_and_end_trace(store: SqlAlchemyStore):
         "tag3": "grape",
         MLFLOW_ARTIFACT_LOCATION: artifact_location,
     }
-    assert trace_info == store.get_trace_info(request_id)
+    assert trace_info.to_v3() == store.get_trace_info(request_id)
 
 
-def test_start_trace_v3(store: SqlAlchemyStore):
+def test_start_trace(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_experiment")
     trace_info = TraceInfo(
         trace_id="tr-123",
@@ -4275,7 +4275,7 @@ def test_start_trace_v3(store: SqlAlchemyStore):
         tags={"tag1": "apple", "tag2": "orange"},
         trace_metadata={"rq1": "foo", "rq2": "bar"},
     )
-    trace_info = store.start_trace_v3(trace_info)
+    trace_info = store.start_trace(trace_info)
     trace_id = trace_info.trace_id
 
     assert trace_info.trace_id is not None
@@ -4317,7 +4317,7 @@ def _create_trace(
         tags=tags or {},
         trace_metadata=trace_metadata or {},
     )
-    return store.start_trace_v3(trace_info)
+    return store.start_trace(trace_info)
 
 
 @pytest.fixture

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -494,8 +494,8 @@ def test_log_assessment_on_in_progress_trace(store, tracking_uri, legacy_api):
     mlflow.flush_trace_async_logging()
 
     # Two assessments should be logged as a part of StartTraceV3 call
-    store.start_trace_v3.assert_called_once()
-    trace_info = store.start_trace_v3.call_args[1]["trace_info"]
+    store.start_trace.assert_called_once()
+    trace_info = store.start_trace.call_args[1]["trace_info"]
     assert trace_info.request_id == mlflow.get_last_active_trace_id()
     assert len(trace_info.assessments) == 2
     assert trace_info.assessments[0].name == "feedback"
@@ -526,8 +526,8 @@ async def test_log_assessment_on_in_progress_trace_async(store, tracking_uri):
 
     store.create_assessment.assert_not_called()
 
-    store.start_trace_v3.assert_called_once()
-    trace_info = store.start_trace_v3.call_args[1]["trace_info"]
+    store.start_trace.assert_called_once()
+    trace_info = store.start_trace.call_args[1]["trace_info"]
     assert trace_info.request_id == mlflow.get_last_active_trace_id()
     assert len(trace_info.assessments) == 2
     assert trace_info.assessments[0].name == "feedback"
@@ -546,8 +546,8 @@ def test_log_assessment_on_in_progress_with_span_id(store, tracking_uri):
     mlflow.flush_trace_async_logging()
 
     # Two assessments should be logged as a part of StartTraceV3 call
-    store.start_trace_v3.assert_called_once()
-    trace_info = store.start_trace_v3.call_args[1]["trace_info"]
+    store.start_trace.assert_called_once()
+    trace_info = store.start_trace.call_args[1]["trace_info"]
     assert trace_info.request_id == mlflow.get_last_active_trace_id()
     assert len(trace_info.assessments) == 1
     assert trace_info.assessments[0].name == "feedback"
@@ -573,4 +573,4 @@ def test_log_assessment_on_in_progress_trace_works_when_tracing_is_disabled(stor
 
     # Neither CreateAssessment nor StartTraceV3 should be called
     store.create_assessment.assert_not_called()
-    store.start_trace_v3.assert_not_called()
+    store.start_trace.assert_not_called()

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -324,7 +324,7 @@ def test_trace_with_databricks_tracking_uri(databricks_tracking_uri, monkeypatch
         model.predict(2, 5)
         mlflow.flush_trace_async_logging(terminate=True)
 
-    mock_get_store().start_trace_v3.assert_called_once()
+    mock_get_store().start_trace.assert_called_once()
     mock_upload_trace_data.assert_called_once()
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2373,7 +2373,7 @@ def test_get_run_and_experiment_graphql(mlflow_client):
     assert json["data"]["mlflowGetRun"]["run"]["modelVersions"][0]["name"] == name
 
 
-def test_start_and_end_trace(mlflow_client):
+def test_legacy_start_and_end_trace_v2(mlflow_client):
     experiment_id = mlflow_client.create_experiment("start end trace")
 
     # Trace CRUD APIs are not directly exposed as public API of MlflowClient,
@@ -2384,13 +2384,12 @@ def test_start_and_end_trace(mlflow_client):
     def _exclude_system_tags(tags: dict[str, str]):
         return {k: v for k, v in tags.items() if not k.startswith("mlflow.")}
 
-    trace_info = store.start_trace(
+    trace_info = store.deprecated_start_trace_v2(
         experiment_id=experiment_id,
         timestamp_ms=1000,
         request_metadata={
             "meta1": "apple",
             "meta2": "grape",
-            TRACE_SCHEMA_VERSION_KEY: "2",
         },
         tags={
             "tag1": "football",
@@ -2412,7 +2411,7 @@ def test_start_and_end_trace(mlflow_client):
         "tag2": "basketball",
     }
 
-    trace_info = store.end_trace(
+    trace_info = store.deprecated_end_trace_v2(
         request_id=trace_info.request_id,
         timestamp_ms=3000,
         status=TraceStatus.OK,
@@ -2444,7 +2443,7 @@ def test_start_and_end_trace(mlflow_client):
     }
 
 
-def test_start_trace_v3(mlflow_client):
+def test_start_trace(mlflow_client):
     experiment_id = mlflow_client.create_experiment("start end trace")
 
     # Trace CRUD APIs are not directly exposed as public API of MlflowClient,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16486?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16486/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16486/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16486/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Rename V2 methods `start_trace` and `end_trace` from store classes to avoid confusing humans and code bots. We need to keep them in store implementations to keep V3 server backward compatible, i.e., serves V2 Rest APIs. Note that we cannot simply use V3 store methods under V2 REST APIs, because the way it handles trace ID is different.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
