### PR TITLE
[clint] Add per-file-ignores configuration with regex pattern support

### DIFF
--- a/dev/clint/src/clint/config.py
+++ b/dev/clint/src/clint/config.py
@@ -14,7 +14,7 @@ class Config:
     forbidden_top_level_imports: dict[str, list[str]] = field(default_factory=dict)
     typing_extensions_allowlist: list[str] = field(default_factory=list)
     example_rules: list[str] = field(default_factory=list)
-    # Compiled regex pattern -> List of rule names to ignore for files matching the pattern
+    # Compiled regex pattern -> Set of rule names to ignore for files matching the pattern
     per_file_ignores: dict[re.Pattern[str], set[str]] = field(default_factory=dict)
 
     @classmethod

--- a/dev/clint/src/clint/config.py
+++ b/dev/clint/src/clint/config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -13,6 +14,8 @@ class Config:
     forbidden_top_level_imports: dict[str, list[str]] = field(default_factory=dict)
     typing_extensions_allowlist: list[str] = field(default_factory=list)
     example_rules: list[str] = field(default_factory=list)
+    # Compiled regex pattern -> List of rule names to ignore for files matching the pattern
+    per_file_ignores: dict[re.Pattern[str], set[str]] = field(default_factory=dict)
 
     @classmethod
     def load(cls) -> Config:
@@ -27,9 +30,15 @@ class Config:
         if not clint:
             return cls()
 
+        per_file_ignores_raw = clint.get("per-file-ignores", {})
+        per_file_ignores: dict[re.Pattern[str], list[str]] = {}
+        for pattern, rules in per_file_ignores_raw.items():
+            per_file_ignores[re.compile(pattern)] = set(rules)
+
         return cls(
             exclude=clint.get("exclude", []),
             forbidden_top_level_imports=clint.get("forbidden-top-level-imports", {}),
             typing_extensions_allowlist=clint.get("typing-extensions-allowlist", []),
             example_rules=clint.get("example-rules", []),
+            per_file_ignores=per_file_ignores,
         )

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -16,6 +16,7 @@ from clint.comments import Noqa, iter_comments
 from clint.config import Config
 from clint.index import SymbolIndex
 from clint.resolver import Resolver
+from clint.utils import get_ignored_rules_for_file
 
 PARAM_REGEX = re.compile(r"\s+:param\s+\w+:", re.MULTILINE)
 RETURN_REGEX = re.compile(r"\s+:returns?:", re.MULTILINE)
@@ -40,19 +41,6 @@ def ignore_map(code: str) -> dict[str, set[int]]:
         if m := DISABLE_COMMENT_REGEX.search(tok.string):
             mapping.setdefault(m.group(1), set()).add(tok.start[0] - 1)
     return mapping
-
-
-def _is_set_active_model(node: ast.AST) -> bool:
-    """
-    Is this node a call to `set_active_model`?
-    """
-    if isinstance(node, ast.Name):
-        return "set_active_model" == node.id
-
-    elif isinstance(node, ast.Attribute):
-        return "set_active_model" == node.attr
-
-    return False
 
 
 @dataclass
@@ -355,9 +343,14 @@ class Linter(ast.NodeVisitor):
         self.offset = offset or Location(0, 0)
         self.resolver = Resolver()
         self.index = index
+        self.ignored_rules = get_ignored_rules_for_file(path, config.per_file_ignores)
 
     def _check(self, loc: Location, rule: rules.Rule) -> None:
+        # Check line-level ignores
         if (lines := self.ignore.get(rule.name)) and loc.lineno in lines:
+            return
+        # Check per-file ignores
+        if rule.name in self.ignored_rules:
             return
         self.violations.append(
             Violation(
@@ -619,7 +612,7 @@ class Linter(ast.NodeVisitor):
         if self._is_at_top_level() and not self.in_TYPE_CHECKING:
             self._check_forbidden_top_level_import(node, node.module)
 
-        if self.path.parts[0] != "tests" and not self.is_mlflow_init_py:
+        if not self.is_mlflow_init_py:
             for alias in node.names:
                 if alias.name.split(".")[-1] == "set_active_model":
                     self._check_forbidden_set_active_model_usage(node)
@@ -667,18 +660,13 @@ class Linter(ast.NodeVisitor):
         if rules.UseSysExecutable.check(node, self.resolver):
             self._check(Location.from_node(node), rules.UseSysExecutable())
 
-        if self.path.parts[0] != "tests" and rules.ForbiddenSetActiveModelUsage.check(
-            node, self.resolver
-        ):
+        if rules.ForbiddenSetActiveModelUsage.check(node, self.resolver):
             self._check(Location.from_node(node), rules.ForbiddenSetActiveModelUsage())
 
-        if self.path.parts[0] != "tests" and rules.UnnamedThread.check(node, self.resolver):
+        if rules.UnnamedThread.check(node, self.resolver):
             self._check(Location.from_node(node), rules.UnnamedThread())
 
-        if self.path.parts[0] not in (
-            "tests",
-            "examples",
-        ) and rules.ThreadPoolExecutorWithoutThreadNamePrefix.check(node, self.resolver):
+        if rules.ThreadPoolExecutorWithoutThreadNamePrefix.check(node, self.resolver):
             self._check(Location.from_node(node), rules.ThreadPoolExecutorWithoutThreadNamePrefix())
 
         self.generic_visit(node)

--- a/dev/clint/src/clint/utils.py
+++ b/dev/clint/src/clint/utils.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import ast
+import re
+from pathlib import Path
 
 
 def resolve_expr(expr: ast.expr) -> list[str] | None:
@@ -18,3 +20,23 @@ def resolve_expr(expr: ast.expr) -> list[str] | None:
         return [expr.id]
 
     return None
+
+
+def get_ignored_rules_for_file(
+    file_path: Path, per_file_ignores: dict[re.Pattern[str], set[str]]
+) -> set[str]:
+    """
+    Returns a set of rule names that should be ignored for the given file path.
+
+    Args:
+        file_path: The file path to check
+        per_file_ignores: Dict mapping compiled regex patterns to lists of rule names to ignore
+
+    Returns:
+        Set of rule names to ignore for this file
+    """
+    ignored_rules: set[str] = set()
+    for pattern, rules in per_file_ignores.items():
+        if pattern.fullmatch(file_path.as_posix()):
+            ignored_rules |= rules
+    return ignored_rules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,7 +298,7 @@ example-rules = [
 
 [tool.clint.per-file-ignores]
 # Rules that should only be enabled for files in the root mlflow directory
-"^(?!mlflow/).*\\.py$" = [
+"^(?!mlflow/).*$" = [
   "forbidden-set-active-model-usage",
   "unnamed-thread",
   "thread-pool-executor-without-thread-name-prefix",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,6 +296,14 @@ example-rules = [
   "unknown-mlflow-arguments",
 ]
 
+[tool.clint.per-file-ignores]
+# Rules that should only be enabled for files in the root mlflow directory
+"^(?!mlflow/).*\\.py$" = [
+  "forbidden-set-active-model-usage",
+  "unnamed-thread",
+  "thread-pool-executor-without-thread-name-prefix",
+]
+
 [tool.clint.forbidden-top-level-imports]
 "mlflow/gateway/providers/*" = ["fastapi", "starlette", "aiohttp"]
 # Databricks SDK/Agents should not be imported at the top level


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16487?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16487/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16487/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16487/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #N/A

### What changes are proposed in this pull request?

This PR adds per-file-ignores configuration support to clint, allowing specific lint rules to be ignored for files matching regex patterns.

**Changes:**
- Added `per_file_ignores` field to Config class that stores compiled regex patterns as keys (`dict[re.Pattern[str], set[str]]`)
- Added `get_ignored_rules_for_file` utility function to determine which rules to ignore for a given file
- Integrated per-file-ignores into the linter to skip rules for matching files
- Updated `pyproject.toml` with per-file-ignores configuration using regex patterns
- Patterns are compiled once at config load time for better performance

**Example configuration:**
```toml
[tool.clint.per-file-ignores]
# Match all Python files that are NOT in the mlflow directory
"^(?!mlflow/).*\\.py$" = [
  "forbidden-set-active-model-usage",
  "unnamed-thread",
  "thread-pool-executor-without-thread-name-prefix",
]
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The existing tests should cover this change as the linter continues to work as expected.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is an internal development tool change.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)