### PR TITLE
Small fixes for new experiment view

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowHeader.tsx
+++ b/mlflow/server/js/src/common/components/MlflowHeader.tsx
@@ -21,55 +21,51 @@ export const MlflowHeader = ({
     <header
       css={{
         backgroundColor: theme.colors.backgroundSecondary,
-        height: '60px',
         color: theme.colors.textSecondary,
         display: 'flex',
-        gap: 24,
+        paddingLeft: theme.spacing.sm,
+        paddingRight: theme.spacing.md,
+        paddingTop: theme.spacing.sm + theme.spacing.xs,
+        paddingBottom: theme.spacing.xs,
         a: {
           color: theme.colors.textSecondary,
         },
+        alignItems: 'center',
       }}
     >
       <div
         css={{
           display: 'flex',
-          alignItems: 'flex-end',
+          alignItems: 'center',
         }}
       >
         <Button
           type="tertiary"
           componentId="mlflow_header.toggle_sidebar_button"
-          css={{ margin: theme.spacing.sm }}
           onClick={toggleSidebar}
           aria-label="Toggle sidebar"
           aria-pressed={sidebarOpen}
-        >
-          <MenuIcon />
-        </Button>
-
+          icon={<MenuIcon />}
+        />
         <Link to={ExperimentTrackingRoutes.rootRoute}>
           <MlflowLogo
             css={{
               display: 'block',
-              height: 40,
-              marginTop: 10,
-              marginBottom: 10,
+              height: theme.spacing.md * 2,
               color: theme.colors.textPrimary,
             }}
           />
         </Link>
         <span
           css={{
-            fontSize: 12,
-            marginLeft: 5,
-            marginBottom: 13,
+            fontSize: theme.typography.fontSizeSm,
           }}
         >
           {Version}
         </span>
       </div>
       <div css={{ flex: 1 }} />
-      <div css={{ display: 'flex', gap: 24, paddingTop: 20, fontSize: 16, marginRight: 24 }}>
+      <div css={{ display: 'flex', gap: theme.spacing.lg }}>
         <DarkThemeSwitch isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
         <a href="https://github.com/mlflow/mlflow">GitHub</a>
         <a href={HomePageDocsUrl}>Docs</a>

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
@@ -23,6 +23,7 @@ import { ExperimentSearchSyntaxDocUrl } from '../../common/constants';
 import { ExperimentListTable } from './ExperimentListTable';
 import { useNavigate } from '../../common/utils/RoutingUtils';
 import { BulkDeleteExperimentModal } from './modals/BulkDeleteExperimentModal';
+import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
 
 type Props = {
   searchFilter: string;
@@ -129,7 +130,16 @@ export const ExperimentListView = ({ searchFilter, setSearchFilter }: Props) => 
         <Alert
           css={{ marginBlockEnd: theme.spacing.sm }}
           type="error"
-          message={error.message || 'A network error occurred.'}
+          message={
+            error instanceof ErrorWrapper
+              ? error.getMessageField()
+              : error.message || (
+                  <FormattedMessage
+                    defaultMessage="A network error occurred."
+                    description="Error message for generic network error"
+                  />
+                )
+          }
           componentId="mlflow.experiment_list_view.error"
           closable={false}
         />

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -747,6 +747,10 @@
     "defaultMessage": "Delete Model Version",
     "description": "Title text for model version deletion modal in model versions view page"
   },
+  "9Bj7oS": {
+    "defaultMessage": "A network error occurred.",
+    "description": "Error message for generic network error"
+  },
   "9CqEWy": {
     "defaultMessage": "Load more",
     "description": "Load more button text to load more experiment runs"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/16490?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16490/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16490/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16490/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

1. Make the mlflow logo smaller / fix spacing in the header
2. Use the actual error message field for search errors

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:



https://github.com/user-attachments/assets/a7c3664c-6107-46f5-93ca-5ffb25fea4e5

After:

<img width="1727" alt="Screenshot 2025-06-30 at 10 35 58 AM" src="https://github.com/user-attachments/assets/29d86f7a-a30a-4372-afe7-996a747b96ed" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
