### PR TITLE
Add support for OpenAI ChatCompletions parse method

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -114,8 +114,18 @@ def _autolog(
     for task in (ChatCompletions, Completions, Embeddings):
         safe_patch(FLAVOR_NAME, task, "create", patched_call)
 
+    if hasattr(ChatCompletions, "parse"):
+        # In openai>=1.92.0, `ChatCompletions` has a `parse` method:
+        # https://github.com/openai/openai-python/commit/0e358ed66b317038705fb38958a449d284f3cb88
+        safe_patch(FLAVOR_NAME, ChatCompletions, "parse", patched_call)
+
     for task in (AsyncChatCompletions, AsyncCompletions, AsyncEmbeddings):
         safe_patch(FLAVOR_NAME, task, "create", async_patched_call)
+
+    if hasattr(AsyncChatCompletions, "parse"):
+        # In openai>=1.92.0, `AsyncChatCompletions` has a `parse` method:
+        # https://github.com/openai/openai-python/commit/0e358ed66b317038705fb38958a449d284f3cb88
+        safe_patch(FLAVOR_NAME, AsyncChatCompletions, "parse", async_patched_call)
 
     try:
         from openai.resources.beta.chat.completions import AsyncCompletions, Completions
@@ -190,7 +200,9 @@ def _get_span_type(task: type) -> str:
         span_type_mapping[BetaChatCompletions] = SpanType.CHAT_MODEL
         span_type_mapping[BetaAsyncChatCompletions] = SpanType.CHAT_MODEL
     except ImportError:
-        pass
+        _logger.debug(
+            "Failed to import `BetaChatCompletions` or `BetaAsyncChatCompletions`", exc_info=True
+        )
 
     try:
         # Responses API only available in openai>=1.66.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16493?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16493/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16493/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16493/merge
```

</p>
</details>

$(cat <<'EOF'
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add patching for the new `parse` method in ChatCompletions and AsyncChatCompletions classes introduced in openai>=1.92.0. This ensures MLflow autologging works correctly with structured outputs using the parse method.

Fixes https://github.com/mlflow/dev/actions/runs/15955588230/job/45007725376#step:13:409

```
        assert response.choices[0].message.parsed == Person(name="Angelo", age=42)
        trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
>       assert len(trace.data.spans) == 1
E       AttributeError: 'NoneType' object has no attribute 'data'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added support for OpenAI ChatCompletions parse method in MLflow autologging for structured outputs (openai>=1.92.0).

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)