### PR TITLE
Remove `transformers` constraint in requirements/constraints.txt when running `transformers` cross version tests

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -155,6 +155,7 @@ jobs:
             sed -i '/^transformers</d' requirements/constraints.txt
             git config user.name 'mlflow-app[bot]'
             git config user.email 'mlflow-app[bot]@users.noreply.github.com'
+            git diff
             git add requirements/constraints.txt
             git commit -m "Remove constraints for testing"
           fi
@@ -221,6 +222,7 @@ jobs:
             sed -i '/^transformers</d' requirements/constraints.txt
             git config user.name 'mlflow-app[bot]'
             git config user.email 'mlflow-app[bot]@users.noreply.github.com'
+            git diff
             git add requirements/constraints.txt
             git commit -m "Remove constraints for testing"
           fi

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -146,15 +146,17 @@ jobs:
       - uses: ./.github/actions/setup-java
         with:
           java-version: ${{ matrix.java }}
-      # TODO: Remove this step once we remove the pyspark constraint in requirements/constraints.txt
-      - name: Remove pyspark constraint
+      - name: Remove constraints
         run: |
           if [ "${{ matrix.package }}" = "pyspark" ]; then
+            # TODO: Remove once we remove the pyspark constraint in requirements/constraints.txt
             sed -i '/^pyspark/d' requirements/constraints.txt
+            # TODO: Remove once https://github.com/huggingface/transformers/issues/39115 is resolved
+            sed -i '/^transformers</d' requirements/constraints.txt
             git config user.name 'mlflow-app[bot]'
             git config user.email 'mlflow-app[bot]@users.noreply.github.com'
             git add requirements/constraints.txt
-            git commit -m "Remove pyspark constraints for testing"
+            git commit -m "Remove constraints for testing"
           fi
       - name: Install mlflow & test dependencies
         run: |
@@ -210,15 +212,17 @@ jobs:
       - uses: ./.github/actions/setup-java
         with:
           java-version: ${{ matrix.java }}
-      # TODO: Remove this step once we remove the pyspark constraint in requirements/constraints.txt
-      - name: Remove pyspark constraint
+      - name: Remove constraints
         run: |
           if [ "${{ matrix.package }}" = "pyspark" ]; then
+            # TODO: Remove once we remove the pyspark constraint in requirements/constraints.txt
             sed -i '/^pyspark/d' requirements/constraints.txt
+            # TODO: Remove once https://github.com/huggingface/transformers/issues/39115 is resolved
+            sed -i '/^transformers</d' requirements/constraints.txt
             git config user.name 'mlflow-app[bot]'
             git config user.email 'mlflow-app[bot]@users.noreply.github.com'
             git add requirements/constraints.txt
-            git commit -m "Remove pyspark constraints for testing"
+            git commit -m "Remove constraints for testing"
           fi
       - name: Install mlflow & test dependencies
         run: |

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -151,11 +151,15 @@ jobs:
           if [ "${{ matrix.package }}" = "pyspark" ]; then
             # TODO: Remove once we remove the pyspark constraint in requirements/constraints.txt
             sed -i '/^pyspark/d' requirements/constraints.txt
+          elif [ "${{ matrix.package }}" = "transformers" ]; then
             # TODO: Remove once https://github.com/huggingface/transformers/issues/39115 is resolved
             sed -i '/^transformers</d' requirements/constraints.txt
+          fi
+
+          if ! git diff --exit-code requirements/constraints.txt; then
+            git diff
             git config user.name 'mlflow-app[bot]'
             git config user.email 'mlflow-app[bot]@users.noreply.github.com'
-            git diff
             git add requirements/constraints.txt
             git commit -m "Remove constraints for testing"
           fi
@@ -218,11 +222,15 @@ jobs:
           if [ "${{ matrix.package }}" = "pyspark" ]; then
             # TODO: Remove once we remove the pyspark constraint in requirements/constraints.txt
             sed -i '/^pyspark/d' requirements/constraints.txt
+          elif [ "${{ matrix.package }}" = "transformers" ]; then
             # TODO: Remove once https://github.com/huggingface/transformers/issues/39115 is resolved
             sed -i '/^transformers</d' requirements/constraints.txt
+          fi
+
+          if ! git diff --exit-code requirements/constraints.txt; then
+            git diff
             git config user.name 'mlflow-app[bot]'
             git config user.email 'mlflow-app[bot]@users.noreply.github.com'
-            git diff
             git add requirements/constraints.txt
             git commit -m "Remove constraints for testing"
           fi

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -282,7 +282,6 @@ spark:
       ">= 3.5.0": ["torch<2.6.0", "scikit-learn", "torcheval"]
       ">= 3.5.0, < dev": ["pyspark[connect]"]
     run: |
-      echo test
       SAGEMAKER_OUT=$(mktemp)
       if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
         echo "Sagemaker container build succeeded.";
@@ -310,7 +309,6 @@ spark:
       ">= 0.0.0": ["scikit-learn", "numpy<2"]
       "< 3.4.0": ["pandas<2"]
     run: |
-      echo test
       # Build Java package
       # Pyspark 4.0 ('dev' version) exclusively supports Scala 2.13
       if [[ $(python -c "import pyspark;from packaging.version import Version;print(Version(pyspark.__version__).major >= 4)") = "True" ]]; then
@@ -479,7 +477,6 @@ transformers:
       export PYTHONPATH=./
       python tests/transformers/helper.py
     run: |
-      echo test
       # Run all Transformers tests except autologging
       pytest tests/transformers --ignore tests/transformers/test_transformers_autolog.py
       pip uninstall -y accelerate
@@ -518,7 +515,6 @@ transformers:
       "< 4.41": ["huggingface_hub<0.24.0", "datasets<=2.4.0", "evaluate<0.4.3"]
       "< 4.52.0.dev0": ["accelerate<1"]
     run: |
-      echo test
       pytest tests/transformers/test_transformers_autolog.py
 
 openai:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -282,6 +282,7 @@ spark:
       ">= 3.5.0": ["torch<2.6.0", "scikit-learn", "torcheval"]
       ">= 3.5.0, < dev": ["pyspark[connect]"]
     run: |
+      echo test
       SAGEMAKER_OUT=$(mktemp)
       if mlflow sagemaker build-and-push-container --no-push --mlflow-home . > $SAGEMAKER_OUT 2>&1; then
         echo "Sagemaker container build succeeded.";
@@ -309,6 +310,7 @@ spark:
       ">= 0.0.0": ["scikit-learn", "numpy<2"]
       "< 3.4.0": ["pandas<2"]
     run: |
+      echo test
       # Build Java package
       # Pyspark 4.0 ('dev' version) exclusively supports Scala 2.13
       if [[ $(python -c "import pyspark;from packaging.version import Version;print(Version(pyspark.__version__).major >= 4)") = "True" ]]; then
@@ -477,6 +479,7 @@ transformers:
       export PYTHONPATH=./
       python tests/transformers/helper.py
     run: |
+      echo test
       # Run all Transformers tests except autologging
       pytest tests/transformers --ignore tests/transformers/test_transformers_autolog.py
       pip uninstall -y accelerate
@@ -515,6 +518,7 @@ transformers:
       "< 4.41": ["huggingface_hub<0.24.0", "datasets<=2.4.0", "evaluate<0.4.3"]
       "< 4.52.0.dev0": ["accelerate<1"]
     run: |
+      echo test
       pytest tests/transformers/test_transformers_autolog.py
 
 openai:

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -17,6 +17,7 @@ pyspark<3.5.6
 # https://github.com/microsoft/FLAML/blob/01c3c836534a244ac8038535455a7fde367366ad/flaml/fabric/mlflow.py#L67-L68
 # This interferes with `test_autologging_warnings_are_redirected_as_expected`.
 FLAML<2.3.5
+# TODO: Remove this constraint once https://github.com/huggingface/transformers/issues/39115 is resolved.
 # transformers >= 4.53.0 uses OpenTelemetry for metrics monitoring, which interferes with
 # `tests/tracing/test_fluent.py::test_mlflow_trace_isolated_from_other_otel_processors`
 # https://github.com/huggingface/transformers/commit/211f2b08751cdee4bd6b84892b91f4a18dbfe305


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16495?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16495/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16495/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16495/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

#16475 added `transformers<4.53.0` but this change broke cross-version tests for transformers >= 4.53.0. This PR fixes it.

```
+ pip install transformers==4.53.0 'boto3<1.36' datasets hf_transfer 'huggingface_hub!=0.22.0' optuna setfit tensorflow tf-keras torch torchvision
Looking in indexes: https://pypi.org/simple, https://download.pytorch.org/whl/cpu
ERROR: Cannot install transformers==4.53.0 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested transformers==4.53.0
    The user requested (constraint) transformers!=4.51.0,!=4.52.1,!=4.52.2,<4.53.0

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip to attempt to solve the dependency conflict
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
