### PR TITLE
Experiment home view fixes roundup

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -72,7 +72,7 @@ export const MlflowRouter = ({
                 overflowX: 'auto',
               }}
             >
-              <React.Suspense fallback={<LegacySkeleton />}>
+              <React.Suspense fallback={<LegacySkeleton css={{ padding: theme.spacing.md }} />}>
                 <Routes>
                   {routes.map(({ element, pageId, path }) => (
                     <Route key={pageId} path={path} element={element} />

--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -58,7 +58,7 @@ export const MlflowRouter = ({
               backgroundColor: theme.colors.backgroundSecondary,
               display: 'flex',
               flexDirection: 'row',
-              minHeight: 'calc(100% - 60px)', // 60px comes from header height
+              height: '100%',
               justifyContent: 'stretch',
             }}
           >

--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -59,6 +59,7 @@ export const MlflowRouter = ({
               display: 'flex',
               flexDirection: 'row',
               flexGrow: 1,
+              minHeight: 0,
             }}
           >
             {showSidebar && <MlflowSidebar />}

--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -58,8 +58,7 @@ export const MlflowRouter = ({
               backgroundColor: theme.colors.backgroundSecondary,
               display: 'flex',
               flexDirection: 'row',
-              height: '100%',
-              justifyContent: 'stretch',
+              flexGrow: 1,
             }}
           >
             {showSidebar && <MlflowSidebar />}
@@ -70,6 +69,7 @@ export const MlflowRouter = ({
                 margin: theme.spacing.sm,
                 borderRadius: theme.borders.borderRadiusMd,
                 boxShadow: theme.shadows.md,
+                overflowX: 'auto',
               }}
             >
               <React.Suspense fallback={<LegacySkeleton />}>

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -160,7 +160,7 @@ export const ExperimentListTable = ({
     return null;
   };
 
-  const selectColumnStyles = { flex: 'none', height: 40 };
+  const selectColumnStyles = { flex: 'none', height: theme.general.heightBase };
 
   return (
     <Table

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -160,7 +160,7 @@ export const ExperimentListTable = ({
     return null;
   };
 
-  const selectColumnStyles = { flex: 'none' };
+  const selectColumnStyles = { flex: 'none', height: 40 };
 
   return (
     <Table

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -20,6 +20,7 @@ import {
   getCoreRowModel,
   OnChangeFn,
   RowSelectionState,
+  SortingState,
   useReactTable,
 } from '@tanstack/react-table';
 import { isEmpty } from 'lodash';
@@ -44,6 +45,7 @@ const useExperimentsTableColumns = () => {
         ),
         id: 'select',
         cell: ExperimentListCheckbox,
+        enableSorting: false,
       },
       {
         header: intl.formatMessage({
@@ -53,22 +55,25 @@ const useExperimentsTableColumns = () => {
         accessorKey: 'name',
         id: 'name',
         cell: ExperimentListTableCell,
+        enableSorting: true,
       },
       {
         header: intl.formatMessage({
           defaultMessage: 'Time created',
           description: 'Header for the time created column in the experiments table',
         }),
-        id: 'timeCreated',
+        id: 'creation_time',
         accessorFn: ({ creationTime }) => Utils.formatTimestamp(creationTime, intl),
+        enableSorting: true,
       },
       {
         header: intl.formatMessage({
           defaultMessage: 'Last modified',
           description: 'Header for the last modified column in the experiments table',
         }),
-        id: 'lastModified',
+        id: 'last_update_time',
         accessorFn: ({ lastUpdateTime }) => Utils.formatTimestamp(lastUpdateTime, intl),
+        enableSorting: true,
       },
       {
         header: intl.formatMessage({
@@ -77,6 +82,7 @@ const useExperimentsTableColumns = () => {
         }),
         id: 'description',
         accessorFn: ({ tags }) => tags?.find(({ key }) => key === 'mlflow.note.content')?.value ?? '-',
+        enableSorting: false,
       },
     ];
 
@@ -91,6 +97,7 @@ export const ExperimentListTable = ({
   rowSelection,
   setRowSelection,
   cursorPaginationProps,
+  sortingProps: { sorting, setSorting },
 }: {
   experiments?: ExperimentEntity[];
   isFiltered?: boolean;
@@ -98,6 +105,7 @@ export const ExperimentListTable = ({
   rowSelection: RowSelectionState;
   setRowSelection: OnChangeFn<RowSelectionState>;
   cursorPaginationProps: Omit<CursorPaginationProps, 'componentId'>;
+  sortingProps: { sorting: SortingState; setSorting: OnChangeFn<SortingState> };
 }) => {
   const { theme } = useDesignSystemTheme();
   const columns = useExperimentsTableColumns();
@@ -110,7 +118,8 @@ export const ExperimentListTable = ({
     enableRowSelection: true,
     enableMultiRowSelection: true,
     onRowSelectionChange: setRowSelection,
-    state: { rowSelection },
+    onSortingChange: setSorting,
+    state: { rowSelection, sorting },
   });
 
   const getEmptyState = () => {
@@ -165,6 +174,9 @@ export const ExperimentListTable = ({
             componentId="mlflow.experiment_list_view.table.header"
             key={header.id}
             css={header.column.id === 'select' ? selectColumnStyles : undefined}
+            sortable={header.column.getCanSort()}
+            sortDirection={header.column.getIsSorted() || 'none'}
+            onToggleSort={header.column.getToggleSortingHandler()}
           >
             {flexRender(header.column.columnDef.header, header.getContext())}
           </TableHeader>

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
@@ -36,6 +36,8 @@ const mountComponent = (props: any) => {
       default: 10,
       onChange: jest.fn(),
     },
+    sorting: [],
+    setSorting: jest.fn(),
   }));
 
   return renderWithIntl(

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
@@ -40,6 +40,8 @@ export const ExperimentListView = ({ searchFilter, setSearchFilter }: Props) => 
     onNextPage,
     onPreviousPage,
     pageSizeSelect,
+    sorting,
+    setSorting,
   } = useExperimentListQuery({ searchFilter });
   const invalidateExperimentList = useInvalidateExperimentList();
 
@@ -174,6 +176,7 @@ export const ExperimentListView = ({ searchFilter, setSearchFilter }: Props) => 
             onPreviousPage,
             pageSizeSelect,
           }}
+          sortingProps={{ sorting, setSorting }}
         />
       </div>
       <CreateExperimentModal

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.tsx
@@ -20,7 +20,7 @@ const ExperimentPage = () => {
   const shouldRenderTabbedView = isExperimentLoggedModelsUIEnabled() && Boolean(tabName);
 
   return (
-    <div css={{ display: 'flex', height: 'calc(100% - 60px)' }}>
+    <div css={{ display: 'flex', height: '100%' }}>
       {shouldRenderTabbedView && <ExperimentPageTabs />}
       {!shouldRenderTabbedView && (
         // Main content with the experiment view

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentPage.tsx
@@ -24,7 +24,7 @@ const ExperimentPage = () => {
       {shouldRenderTabbedView && <ExperimentPageTabs />}
       {!shouldRenderTabbedView && (
         // Main content with the experiment view
-        <div css={{ height: '100%', flex: 1, padding: theme.spacing.md }}>
+        <div css={{ height: '100%', flex: 1, padding: theme.spacing.md, width: '100%' }}>
           <GetExperimentsContextProvider actions={getExperimentActions}>
             <ExperimentView />
           </GetExperimentsContextProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useExperimentListQuery.ts
@@ -6,7 +6,7 @@ import { useLocalStorage } from '@mlflow/mlflow/src/shared/web-shared/hooks/useL
 import { CursorPaginationProps } from '@databricks/design-system';
 
 const STORE_KEY = 'experiments_page_page_size';
-const DEFAULT_PAGE_SIZE = 10;
+const DEFAULT_PAGE_SIZE = 25;
 
 const ExperimentListQueryKeyHeader = 'experiment_list';
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
@@ -72,7 +72,6 @@ const ExperimentPageTabs = () => {
         display: 'flex',
         flexDirection: 'column',
         padding: theme.spacing.md,
-        paddingTop: theme.spacing.lg,
       }}
     >
       <ExperimentPageTabsImpl />


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16499?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16499/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16499/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16499/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Based on #16464 

### What changes are proposed in this pull request?

- Set default page size for experiments to 25
- Fix overflow and spacing issues for experiment page tabs
  - tracing tab overflow
  - models tab top padding inconsistency
  - persistent 60px bottom padding
- Add ability to sort the experiments table (server-side) by name and date columns

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
