### PR TITLE
Fix TS type error and include type check in ci

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Run extract-i18n lint
         run: |
           yarn i18n:check
+      - name: Run type-check
+        run: |
+          yarn type-check
       - name: Run tests
         run: |
           yarn test --silent ${{ matrix.option }} src/experiment-tracking/components

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -17,6 +17,7 @@
     "prettier:check": "prettier . --check",
     "i18n:check": "yarn i18n --lint",
     "i18n": "node scripts/extract-i18n.js",
+    "check-all": "yarn lint && yarn prettier:check && yarn i18n:check && yarn type-check",
     "knip": "knip --reporter markdown --preprocessor ./knip-preprocessor.ts",
     "graphql-codegen": "python ../../../dev/proto_to_graphql/code_generator.py && yarn graphql-codegen:clean && yarn graphql-codegen:base",
     "graphql-codegen:base": "graphql-codegen --config ./src/graphql/graphql-codegen.ts",

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/ShowArtifactVideoView.enzyme.test.tsx
@@ -18,6 +18,7 @@ describe('ShowArtifactVideoView', () => {
         path="foo/bar/video.mp4"
         getArtifact={getArtifactMock}
         isLoggedModelsMode={false}
+        experimentId="experiment-123"
       />,
     );
 

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/utils/fetchArtifactUnified.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/utils/fetchArtifactUnified.test.tsx
@@ -1,7 +1,6 @@
 import { rest } from 'msw';
 import { setupServer } from '../../../../common/utils/setup-msw';
 import { fetchArtifactUnified } from './fetchArtifactUnified';
-import { shouldUseSPNForArtifacts } from '../../../../common/utils/FeatureUtils';
 
 describe('fetchArtifactUnified', () => {
   const experimentId = 'test-experiment-id';

--- a/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-compare/RunsCompare.test.tsx
@@ -227,6 +227,7 @@ describe.each(testCases)('RunsCompare $description', ({ setup: testCaseSetup }) 
             hideEmptyCharts={uiState.hideEmptyCharts}
             chartsSearchFilter={uiState.chartsSearchFilter}
             storageKey="some-experiment-id"
+            minWidth={800}
           />
         </ExperimentPageUIStateContextProvider>
       );

--- a/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelVersionTable.test.tsx
@@ -23,6 +23,12 @@ describe('ModelVersionTable', () => {
     onMetadataUpdated: jest.fn(),
     usingNextModelsUI: false,
     aliases: [],
+    isLoading: false,
+    pagination: <div>Pagination</div>,
+    orderByKey: 'name',
+    orderByAsc: true,
+    getSortFieldName: jest.fn().mockReturnValue('name'),
+    onSortChange: jest.fn(),
   };
 
   const mockStoreFactory = configureStore([thunk, promiseMiddleware()]);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16509?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16509/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16509/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16509/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR fixes the ts type error occurring in the MLflow frontend and add a step for ts type check in github actions

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
