### PR TITLE
Fix docsearch issues

### DIFF
--- a/docs/api_reference/theme/mlflow/layout.html
+++ b/docs/api_reference/theme/mlflow/layout.html
@@ -53,6 +53,10 @@
   {# Algolia / Docusaurus Indexing #}
   <meta name="docsearch:docusaurus_tag" content="docs-default-current" data-rh="true">
   <meta name="docusaurus_tag" content="docs-default-current" data-rh="true">
+  <meta name="docusaurus_version" content="current" data-rh="true">
+  <meta name="docsearch:version" content="current" data-rh="true">
+  <meta name="docusaurus_locale" content="en" data-rh="true">
+  <meta name="docsearch:language" content="en" data-rh="true">
 
   {# OPENSEARCH #}
   {% if not embedded %}

--- a/docs/docs/genai/tracing/integrations/listing/ag2.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/ag2.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 [AG2](https://ag2.ai/) is an open-source framework for building and orchestrating AI agent interactions.
 
-[MLflow Tracing](../) provides automatic tracing capability for AG2, an open-source multi-agent framework. By enabling auto tracing
+[MLflow Tracing](../../) provides automatic tracing capability for AG2, an open-source multi-agent framework. By enabling auto tracing
 for AG2 by calling the <APILink fn="mlflow.ag2.autolog" /> function, MLflow will capture nested traces and logged them to the active MLflow Experiment upon agents execution.
 Note that since AG2 is built based on [AutoGen 0.2](https://microsoft.github.io/autogen/0.2/), this integration can be used when you use AutoGen 0.2.
 

--- a/docs/docs/genai/tracing/integrations/listing/autogen.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/autogen.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 [AutoGen AgentChat](https://microsoft.github.io/autogen/stable/index.html) is an open-source framework for building conversational single and multi-agent applications.
 
-[MLflow Tracing](../) provides automatic tracing capability for AutoGen AgentChat. By enabling auto tracing
+[MLflow Tracing](../../) provides automatic tracing capability for AutoGen AgentChat. By enabling auto tracing
 for AutoGen by calling the <APILink fn="mlflow.autogen.autolog" /> function, MLflow will capture nested traces and log them to the active MLflow Experiment upon agents execution.
 
 ```python
@@ -28,7 +28,7 @@ mlflow.autogen.autolog()
 
 Note that `mlflow.autogen.autolog()` should be called after importing AutoGen classes that are traced.
 Subclasses of `ChatCompletionClient` such as `OpenAIChatCompletionClient` or `AnthropicChatCompletionClient` and subclasses of `BaseChatAgent` such as `AssistantAgent` or `CodeExecutorAgent` should be imported before calling `mlflow.autogen.autolog()`.
-Also note that this integration is for AutoGen 0.4.9 or above. If you are using AutoGen 0.2, please use the [AG2 integration](./ag2) instead.
+Also note that this integration is for AutoGen 0.4.9 or above. If you are using AutoGen 0.2, please use the [AG2 integration](../ag2) instead.
 
 :::
 

--- a/docs/docs/genai/tracing/integrations/listing/crewai.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/crewai.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 [CrewAI](https://www.crewai.com/) is an open-source framework for orchestrating role-playing, autonomous AI agent.
 
-[MLflow Tracing](../) provides automatic tracing capability for [CrewAI](https://www.crewai.com/), an open source framework for building multi-agent applications. By enabling auto tracing
+[MLflow Tracing](../../) provides automatic tracing capability for [CrewAI](https://www.crewai.com/), an open source framework for building multi-agent applications. By enabling auto tracing
 for CrewAI by calling the <APILink fn="mlflow.crewai.autolog" /> function, , MLflow will capture nested traces for CrewAI workflow execution and logged them to the active MLflow Experiment.
 
 ```python

--- a/docs/docs/genai/tracing/integrations/listing/deepseek.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/deepseek.mdx
@@ -7,7 +7,7 @@ sidebar_label: DeepSeek
 
 ![Deepseek Tracing via autolog](/images/llms/deepseek/deepseek-tracing-agent.png)
 
-[MLflow Tracing](../) provides automatic tracing capability for Deepseek models through the OpenAI SDK integration. Since DeepSeek uses an OpenAI-compatible API format, you can use `mlflow.openai.autolog()` to trace interactions with DeepSeek models.
+[MLflow Tracing](../../) provides automatic tracing capability for Deepseek models through the OpenAI SDK integration. Since DeepSeek uses an OpenAI-compatible API format, you can use `mlflow.openai.autolog()` to trace interactions with DeepSeek models.
 
 ```python
 import mlflow
@@ -75,7 +75,7 @@ The above example should generate a trace in the `DeepSeek` experiment in the ML
 
 ## Streaming and Async Support
 
-MLflow supports tracing for streaming and async DeepSeek APIs. Visit the [OpenAI Tracing documentation](openai) for example code snippets for tracing streaming and async calls through OpenAI SDK.
+MLflow supports tracing for streaming and async DeepSeek APIs. Visit the [OpenAI Tracing documentation](../openai) for example code snippets for tracing streaming and async calls through OpenAI SDK.
 
 ## Advanced Example: Function Calling Agent
 

--- a/docs/docs/genai/tracing/integrations/listing/dspy.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/dspy.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 [DSPy](https://dspy.ai/) is an open-source framework for building modular AI systems and offers algorithms for optimizing their prompts and weights.
 
-[MLflow Tracing](../) provides automatic tracing capability for DSPy. You can enable tracing
+[MLflow Tracing](../../) provides automatic tracing capability for DSPy. You can enable tracing
 for DSPy by calling the <APILink fn="mlflow.dspy.autolog" /> function, and nested traces are automatically logged to the active MLflow Experiment upon invocation of DSPy modules.
 
 ```python

--- a/docs/docs/genai/tracing/integrations/listing/gemini.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/gemini.mdx
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 ![OpenAI Tracing via autolog](/images/llms/gemini/gemini-tracing.png)
 
-[MLflow Tracing](../) provides automatic tracing capability for Google Gemini. By enabling auto tracing
+[MLflow Tracing](../../) provides automatic tracing capability for Google Gemini. By enabling auto tracing
 for Gemini by calling the <APILink fn="mlflow.gemini.autolog" /> function, MLflow will capture nested traces and log them to the active MLflow Experiment upon invocation of Gemini Python SDK.
 
 ```python

--- a/docs/docs/genai/tracing/integrations/listing/litellm.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/litellm.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
 
 [LiteLLM](https://www.litellm.ai/) is an open-source LLM Gateway that allow accessing 100+ LLMs in the unified interface.
 
-[MLflow Tracing](../) provides automatic tracing capability for LiteLLM. By enabling auto tracing
+[MLflow Tracing](../../) provides automatic tracing capability for LiteLLM. By enabling auto tracing
 for LiteLLM by calling the <APILink fn="mlflow.litellm.autolog" /> function, MLflow will capture traces for LLM invocation and log them to the active MLflow Experiment.
 
 ```python

--- a/docs/docs/genai/tracing/integrations/listing/swarm.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/swarm.mdx
@@ -14,7 +14,7 @@ import TabItem from "@theme/TabItem";
 :::warning
 
     OpenAI Swarm integration has been deprecated because the library is being replaced by the
-    new [OpenAI Agents SDK](./openai-agent). Please consider migrating to the new SDK for the latest features and support.
+    new [OpenAI Agents SDK](../openai-agent). Please consider migrating to the new SDK for the latest features and support.
 
 :::
 

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -12,6 +12,9 @@ const config: Config = {
   tagline: 'MLflow Documentation',
   favicon: 'images/favicon.ico',
 
+  // Docusaurus sets the canonical URL to the preferred one, so the pages are consolidated and double search results are prevented.
+  trailingSlash: true,
+
   // Set the production url of your site here
   url: 'https://mlflow.org',
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16515?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16515/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16515/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16515/merge
```

</p>
</details>

Signed-off-by: Fatih Altinok <fatihaltinok@live.com>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

#### Missing API reference results
I checked [troubleshooting section of Docusaurus](https://docusaurus.io/docs/search#algolia-troubleshooting), which shows the default facet filters sent, which seems similar to ours. The screenshot in the collapsible sections is also similar to ours.

The only thing missing in our index is that API reference docs are not versioned. My guess is that this is the missing fields are the reason for no API reference results, so I tried adding them. I want to deploy a preview version of this and test it manually with the crawler.

#### Double results
This is caused because we haven't set a trailing slash preference, so both versions are created and each have its own canonical URL, resulting in duplicate content. Docsearch [has a section about this](https://docsearch.algolia.com/docs/crawler/#why-do-i-have-duplicate-content-in-my-results) and recommends consolidating canonical URLs.

I experimented with the Docusaurus `trailingSlash` config and when one is set, the other uses the correct canonical URL so duplicates are consolidated. It may have redirection logic in production, which I haven't tried. I opted for `trailingSlash: false` because I find it more beautiful, but we can change it.

Edit: See comment https://github.com/mlflow/mlflow/pull/16515#issuecomment-3023863226

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
