### PR TITLE
Proper chat message reconstruction from OAI streaming response

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -375,7 +375,10 @@ def _reconstruct_completion_from_stream(chunks: list[Any]) -> Any:
 
     if chunks[0].object == "text_completion":
         # Handling for the deprecated Completions API. Keep the legacy behavior for now.
-        return "".join(chunk.choices[0].text for chunk in chunks)
+        def _extract_content(chunk: Any) -> str:
+            return chunk.choices[0].text if chunk.choices else ""
+
+        return "".join(_extract_content(chunk) or "" for chunk in chunks)
 
     if chunks[0].object != "chat.completion.chunk":
         return chunks  # Ignore non-chat chunks
@@ -409,7 +412,6 @@ def _reconstruct_completion_from_stream(chunks: list[Any]) -> Any:
         created=last_chunk.created,
         model=last_chunk.model,
         object="chat.completion",
-        service_tier=last_chunk.service_tier,
         system_fingerprint=last_chunk.system_fingerprint,
         usage=last_chunk.usage,
     )

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -311,13 +311,13 @@ class RestStore(AbstractStore):
         Create a new trace using the V2 API format. This is a fallback for the case where the
         client is v3 but the tracking server does not support v3 yet(<= 3.2.0).
         """
-        trace_info_v2 = self.start_trace(
+        trace_info_v2 = self.deprecated_start_trace_v2(
             experiment_id=trace_info.experiment_id,
             timestamp_ms=trace_info.request_time,
             request_metadata=trace_info.trace_metadata,
             tags=trace_info.tags,
         )
-        self.end_trace(
+        self.deprecated_end_trace_v2(
             request_id=trace_info_v2.request_id,
             timestamp_ms=trace_info.request_time + trace_info.execution_duration,
             status=trace_info.status,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16519?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16519/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16519/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16519/merge
```

</p>
</details>

### What changes are proposed in this pull request?

MLflow OpenAI auto-tracing support streaming response. It aggregates chunks into a single string output, dropping other metadata such as usage. This PR updates the chunk aggregation logic to actually reconstruct the chat completion object from chunks.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
import openai
import mlflow

# Enable trace logging
mlflow.openai.autolog()

client = openai.OpenAI()

stream = client.chat.completions.create(
    model="gpt-4o-mini",
    messages=[
        {"role": "user", "content": "How fast would a glass of water freeze on Titan?"}
    ],
    stream=True,  # Enable streaming response,
)
for chunk in stream:
    print(chunk.choices[0].delta.content or "", end="")
```

![Screenshot 2025-07-02 at 1 22 42](https://github.com/user-attachments/assets/76f547f9-67b0-45fd-ba96-5836b045f498)
![Screenshot 2025-07-02 at 1 23 09](https://github.com/user-attachments/assets/d302bfa3-8d64-4f84-9692-d1c101415c21)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix chunk aggregation logic for OpenAI auto tracing for chat completion streaming.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
