### PR TITLE
Convert trace column in search_traces() response to JSON string

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -111,7 +111,7 @@ class Trace(_MlflowObject):
     def to_pandas_dataframe_row(self) -> dict[str, Any]:
         return {
             "trace_id": self.info.trace_id,
-            "trace": self,
+            "trace": self.to_json(),  # json string to be compatible with Spark DataFrame
             "client_request_id": self.info.client_request_id,
             "state": self.info.state,
             "request_time": self.info.request_time,
@@ -121,7 +121,7 @@ class Trace(_MlflowObject):
             "trace_metadata": self.info.trace_metadata,
             "tags": self.info.tags,
             "spans": [span.to_dict() for span in self.data.spans],
-            "assessments": self.info.assessments,
+            "assessments": [assessment.to_dictionary() for assessment in self.info.assessments],
         }
 
     def _deserialize_json_attr(self, value: str):

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -156,7 +156,7 @@ def get_test_traces(type=Literal["pandas", "list"]):
     # Add assessments. Since log_assessment API is not supported in OSS MLflow yet, we
     # need to add it to the trace info manually.
     source = AssessmentSource(source_id="test", source_type="HUMAN")
-    trace = traces[0] if type == "list" else traces.iloc[0]["trace"]
+    trace = traces[0] if type == "list" else Trace.from_json(traces.iloc[0]["trace"])
     trace.info.assessments.extend(
         [
             # 1. Expectation with reserved name "expected_response"
@@ -196,7 +196,11 @@ def get_test_traces(type=Literal["pandas", "list"]):
             ),
         ]
     )
-    return [{"trace": trace} for trace in traces] if type == "list" else traces
+    if type == "pandas":
+        traces.at[0, "trace"] = trace.to_json()
+    else:
+        traces = [{"trace": trace} for trace in traces]
+    return traces
 
 
 @pytest.mark.parametrize("input_type", ["list", "pandas"])

--- a/tests/pyfunc/test_logged_models.py
+++ b/tests/pyfunc/test_logged_models.py
@@ -72,9 +72,9 @@ def test_model_id_tracking_thread_safety():
         for f in futures:
             f.result()
 
-    traces = mlflow.search_traces()
+    traces = mlflow.search_traces(return_type="list")
     assert len(traces) == len(models)
-    for trace in mlflow.search_traces()["trace"]:
+    for trace in traces:
         trace_inputs = trace.info.request_metadata["mlflow.traceInputs"]
         index = json.loads(trace_inputs)["model_input"][0]
         model_id = trace.info.request_metadata["mlflow.modelId"]

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -965,7 +965,7 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
     ]
     for idx, trace in enumerate(expected_traces):
         assert df.iloc[idx].trace_id == trace.info.trace_id
-        assert df.iloc[idx].trace.info.trace_id == trace.info.trace_id
+        assert Trace.from_json(df.iloc[idx].trace).info.trace_id == trace.info.trace_id
         assert df.iloc[idx].client_request_id == trace.info.client_request_id
         assert df.iloc[idx].state == trace.info.state
         assert df.iloc[idx].request_time == trace.info.request_time
@@ -984,7 +984,7 @@ def test_search_traces_handles_missing_response_tags_and_metadata(mock_client):
         [
             Trace(
                 info=TraceInfo(
-                    trace_id=5,
+                    trace_id="5",
                     trace_location=TraceLocation.from_experiment_id("test"),
                     request_time=1,
                     execution_duration=2,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16523?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16523/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16523/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16523/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.search_traces()` API returns a Pandas DataFrame with `trace` column, which stores the trace object as is. This creates a problem in DBX environment where the notebook cannot handle complex object value.

![Screenshot 2025-07-02 at 15 55 20](https://github.com/user-attachments/assets/f62fc0f4-9677-41b2-94c5-7d7f6038fcfd)

This PR fixes the issue by storing JSON serialize trace in the dataframe. The GenAI evaluation API is also updated to handle new types.

![Screenshot 2025-07-02 at 15 55 12](https://github.com/user-attachments/assets/3a24e4da-0ac8-4074-a08e-2f6ffe3471c9)

Validated GenAI evaluation works fine as well:

```
import mlflow
from mlflow.genai.scorers import Guidelines, get_all_scorers

traces = mlflow.search_traces(run_id="...")

mlflow.genai.evaluate(
  data=traces,
  scorers=[*get_all_scorers(), Guidelines(name="is_kind", guidelines=["Be kind", "Be polite"])],
)
```
<img width="1301" alt="Screenshot 2025-07-02 at 16 38 09" src="https://github.com/user-attachments/assets/1d741ed5-7147-4740-8f83-cee39ccd8793" />

(showing two assessments cuz I ran it twice)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Fix display issue of `mlflow.search_traces()` response by changing the column type from object to string.

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
