### PR TITLE
Add custom rule for having H1 header in notebooks

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -803,6 +803,19 @@ def lint_file(path: Path, config: Config, index: SymbolIndex) -> list[Violation]
                         cell_index=cell_idx,
                     )
                 )
+            if not any(
+                line.strip().startswith("# ")
+                for cell in cells
+                if cell.get("cell_type") == "markdown"
+                for line in cell.get("source", [])
+            ):
+                violations.append(
+                    Violation(
+                        rules.MissingNotebookH1Header(),
+                        path,
+                        Location(0, 0),
+                    )
+                )
         return violations
     elif path.suffix in {".rst", ".md", ".mdx"}:
         violations = []

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -788,6 +788,15 @@ def _lint_cell(
     return violations
 
 
+def _has_h1_header(cells: list[dict[str, Any]]) -> bool:
+    return any(
+        line.strip().startswith("# ")
+        for cell in cells
+        if cell.get("cell_type") == "markdown"
+        for line in cell.get("source", [])
+    )
+
+
 def lint_file(path: Path, config: Config, index: SymbolIndex) -> list[Violation]:
     code = path.read_text()
     if path.suffix == ".ipynb":
@@ -803,12 +812,7 @@ def lint_file(path: Path, config: Config, index: SymbolIndex) -> list[Violation]
                         cell_index=cell_idx,
                     )
                 )
-            if not any(
-                line.strip().startswith("# ")
-                for cell in cells
-                if cell.get("cell_type") == "markdown"
-                for line in cell.get("source", [])
-            ):
+            if not _has_h1_header(cells):
                 violations.append(
                     Violation(
                         rules.MissingNotebookH1Header(),

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -16,6 +16,7 @@ from clint.rules.lazy_module import LazyModule
 from clint.rules.log_model_artifact_path import LogModelArtifactPath
 from clint.rules.markdown_link import MarkdownLink
 from clint.rules.missing_docstring_param import MissingDocstringParam
+from clint.rules.missing_notebook_h1_header import MissingNotebookH1Header
 from clint.rules.mlflow_class_name import MlflowClassName
 from clint.rules.multi_assign import MultiAssign
 from clint.rules.no_rst import NoRst
@@ -52,6 +53,7 @@ __all__ = [
     "LogModelArtifactPath",
     "MarkdownLink",
     "MissingDocstringParam",
+    "MissingNotebookH1Header",
     "MlflowClassName",
     "NoRst",
     "OsEnvironDeleteInTest",

--- a/dev/clint/src/clint/rules/missing_notebook_h1_header.py
+++ b/dev/clint/src/clint/rules/missing_notebook_h1_header.py
@@ -1,0 +1,6 @@
+from clint.rules.base import Rule
+
+
+class MissingNotebookH1Header(Rule):
+    def _message(self) -> str:
+        return "Notebook should have at least one H1 header for the title."

--- a/dev/clint/tests/rules/test_missing_notebook_h1_header.py
+++ b/dev/clint/tests/rules/test_missing_notebook_h1_header.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import lint_file
+from clint.rules import MissingNotebookH1Header
+
+
+def test_missing_notebook_h1_header(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": ["## Some other header"],
+            },
+            {
+                "cell_type": "code",
+                "source": ["print('hello')"],
+            },
+        ]
+    }
+    tmp_file = tmp_path / "test.ipynb"
+    tmp_file.write_text(json.dumps(notebook))
+    results = lint_file(tmp_file, config, index)
+    assert len(results) == 1
+    assert isinstance(results[0].rule, MissingNotebookH1Header)
+
+
+def test_missing_notebook_h1_header_positive(
+    index: SymbolIndex, config: Config, tmp_path: Path
+) -> None:
+    notebook = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": ["# This is a title"],
+            },
+            {
+                "cell_type": "code",
+                "source": ["print('hello')"],
+            },
+        ]
+    }
+    tmp_file = tmp_path / "test_positive.ipynb"
+    tmp_file.write_text(json.dumps(notebook))
+    results = lint_file(tmp_file, config, index)
+    assert len(results) == 0

--- a/examples/evaluation/huggingface-evaluation.ipynb
+++ b/examples/evaluation/huggingface-evaluation.ipynb
@@ -4,7 +4,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Evaluate a 🤗 Hugging Face LLM with mlflow.evaluate()\n",
+    "# Evaluate a 🤗 Hugging Face LLM with mlflow.evaluate()\n",
     "\n",
     "This guide will show how to load a pre-trained Hugging Face pipeline, log it to MLflow, and use `mlflow.evaluate()` to evaluate builtin metrics as well as custom LLM-judged metrics for the model.\n",
     "\n",

--- a/examples/h2o/random_forest.ipynb
+++ b/examples/h2o/random_forest.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train Random Forest Estimator with H2O"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},

--- a/examples/rapids/mlflow_project/notebooks/rapids_mlflow.ipynb
+++ b/examples/rapids/mlflow_project/notebooks/rapids_mlflow.ipynb
@@ -1,6 +1,13 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Train and Publish Locally With RAPIDS and MLflow"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/examples/restore_model_dependencies/restore_model_dependencies_example.ipynb
+++ b/examples/restore_model_dependencies/restore_model_dependencies_example.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+   "cell_type": "markdown",
+   "id": "ec6a8805",
+   "metadata": {},
+   "source": [
+    "# Restore model dependencies with mlflow.pyfunc.get_model_dependencies()"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "70a2b95e",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16524?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16524/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16524/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16524/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR introduces a new rule ensuring notebooks have at least one H1 header for the title.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
