### PR TITLE
Deploy docs to Netlify instead of serving CircleCI artifacts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -109,8 +109,15 @@ jobs:
           working_directory: docs
           command: |
             yarn sitemap https://mlflow.org/docs/latest/sitemap.xml ./build/latest/sitemap.xml
+      - run:
+          name: Create docs archive
+          working_directory: docs/build
+          command: |
+            zip -r docs-html.zip latest
       - store_artifacts:
           path: docs/build/latest
+      - store_artifacts:
+          path: docs/build/docs-html.zip
       - run:
           name: Test examples
           working_directory: docs/api_reference

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -110,15 +110,6 @@ jobs:
           command: |
             yarn sitemap https://mlflow.org/docs/latest/sitemap.xml ./build/latest/sitemap.xml
       - run:
-          name: Create docs archive
-          working_directory: docs/build
-          command: |
-            zip -r docs-html.zip latest
-      - store_artifacts:
-          path: docs/build/latest
-      - store_artifacts:
-          path: docs/build/docs-html.zip
-      - run:
           name: Test examples
           working_directory: docs/api_reference
           command: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,25 +57,3 @@ jobs:
           path: docs/build
           retention-days: 1
           if-no-files-found: error
-      # NOTE: the following is only for testing, will be removed before the PR is merged
-      - name: Download build artifact
-        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
-        with:
-          name: docs-build-${{ github.run_id }}
-          path: downloaded-artifact
-      - name: Install netlify
-        run: |
-          npm install -g netlify-cli
-      - name: Deploy to Netlify
-        id: netlify_deploy
-        working-directory: downloaded-artifact
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-        run: |-
-          netlify deploy \
-            --dir=. \
-            --no-build \
-            --message="PR Preview #${PR_NUMBER} - GitHub Run ID: ${{ github.run_id }}" \
-            --alias="pr-${PR_NUMBER}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: ./.github/actions/setup-python
       - name: Install dependencies
         run: |
-          pip install --progress-bar off -r requirements/doc-requirements.txt
+          pip install -r ../requirements/doc-requirements.txt
           yarn install --immutable
       - name: Run lint
         run: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: website-build-${{ github.run_id }}
+          name: docs-build-${{ github.run_id }}
           path: docs/build
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,8 +35,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
+      - uses: ./.github/actions/setup-python
       - name: Install dependencies
         run: |
+          pip install --progress-bar off -r requirements/doc-requirements.txt
           yarn install --immutable
       - name: Run lint
         run: |
@@ -46,6 +48,7 @@ jobs:
           yarn prettier:check
       - name: Build docs
         run: |
+          yarn convert-notebooks
           yarn build
       - name: Upload build artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,3 +44,13 @@ jobs:
       - name: Run prettier
         run: |
           yarn prettier:check
+      - name: Build docs
+        run: |
+          yarn build
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: website-build-${{ github.run_id }}
+          path: build
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,3 +57,25 @@ jobs:
           path: docs/build
           retention-days: 1
           if-no-files-found: error
+      # NOTE: the following is only for testing, will be removed before the PR is merged
+      - name: Download build artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: docs-build-${{ github.run_id }}
+          path: downloaded-artifact
+      - name: Install netlify
+        run: |
+          npm install -g netlify-cli
+      - name: Deploy to Netlify
+        id: netlify_deploy
+        working-directory: downloaded-artifact
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |-
+          netlify deploy \
+            --dir=. \
+            --no-build \
+            --message="PR Preview #${PR_NUMBER} - GitHub Run ID: ${{ github.run_id }}" \
+            --alias="pr-${PR_NUMBER}"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,16 +22,36 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    working-directory: docs
+
 jobs:
-  docs:
+  check:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     permissions:
       contents: read
     timeout-minutes: 30
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: docs
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-node
+      - name: Install dependencies
+        run: |
+          yarn install --immutable
+      - name: Run lint
+        run: |
+          yarn eslint
+      - name: Run prettier
+        run: |
+          yarn prettier:check
+
+  build:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    permissions:
+      contents: read
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
@@ -40,12 +60,6 @@ jobs:
         run: |
           pip install -r ../requirements/doc-requirements.txt
           yarn install --immutable
-      - name: Run lint
-        run: |
-          yarn eslint
-      - name: Run prettier
-        run: |
-          yarn prettier:check
       - name: Build docs
         run: |
           yarn convert-notebooks

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -54,6 +54,6 @@ jobs:
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: website-build-${{ github.run_id }}
-          path: build
+          path: docs/build
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Download build artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
-          name: website-build-${{ github.event.workflow_run.id }}
+          name: docs-build-${{ github.event.workflow_run.id }}
           path: downloaded-artifact
       - name: Install dependencies
         run: |

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -14,15 +14,20 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: |
           pip install requests
+          npm install -g netlify-cli
       - name: Create preview link
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
         run: |
           python dev/preview_docs.py \
             --commit-sha ${{ github.event.pull_request.head.sha }} \
             --pull-number ${{ github.event.pull_request.number }} \
-            --workflow-run-id ${{ github.run_id }}
+            --workflow-run-id ${{ github.run_id }} \
+            --netlify-site-name "mlflow-docs-preview" \

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -27,13 +27,21 @@ jobs:
             --docs-workflow-run-url ${{ github.event.workflow_run.html_url }} \
             --stage requested
 
-  main:
+  fail-early:
     if: github.repository == 'mlflow/mlflow' && github.event.workflow_run.status == 'completed'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write # preview_docs.py comments on PRs
     timeout-minutes: 10
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event.workflow_run.conclusion == 'failure'
+      - uses: ./.github/actions/setup-python
+        if: github.event.workflow_run.conclusion == 'failure'
+      - name: Install dependencies
+        if: github.event.workflow_run.conclusion == 'failure'
+        run: |
+          pip install requests
       - name: Handle docs workflow failure
         if: github.event.workflow_run.conclusion == 'failure'
         env:
@@ -46,15 +54,24 @@ jobs:
             --workflow-run-id ${{ github.run_id }} \
             --docs-workflow-run-url ${{ github.event.workflow_run.html_url }} \
             --stage failed
-          exit 0 # Exit the job if the docs workflow failed
+          exit 1
+
+  main:
+    needs: [fail-early]
+    if: needs.fail-early.outputs.status == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # preview_docs.py comments on PRs
+    timeout-minutes: 10
+    steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/setup-python
-      - uses: ./.github/actions/setup-node
       - name: Download build artifact
         uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
         with:
           name: docs-build-${{ github.event.workflow_run.id }}
           path: downloaded-artifact
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-node
       - name: Install dependencies
         run: |
           pip install requests

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -3,30 +3,9 @@ name: Preview docs
 on:
   workflow_run:
     workflows: [docs]
-    types: [requested, completed]
+    types: [completed]
 
 jobs:
-  pre-deploy:
-    if: github.repository == 'mlflow/mlflow' && github.event.workflow_run.status == 'requested'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write # preview_docs.py comments on PRs
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: ./.github/actions/setup-python
-      - name: Post placeholder comment
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-        run: |
-          python dev/preview_docs.py \
-            --commit-sha ${{ github.event.workflow_run.head_sha }} \
-            --pull-number $PR_NUMBER \
-            --workflow-run-id ${{ github.run_id }} \
-            --docs-workflow-run-url ${{ github.event.workflow_run.html_url }} \
-            --stage requested
-
   fail-early:
     if: github.repository == 'mlflow/mlflow' && github.event.workflow_run.status == 'completed'
     runs-on: ubuntu-latest

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -70,7 +70,7 @@ jobs:
           netlify deploy \
             --dir=. \
             --no-build \
-            --message="PR Preview #${PR_NUMBER} - GitHub Run ID: ${github.run_id}" \
+            --message="PR Preview #${PR_NUMBER} - GitHub Run ID: ${{ github.run_id }}" \
             --alias="pr-${PR_NUMBER}"
         continue-on-error: true
       - name: Create preview link

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -6,7 +6,7 @@ on:
     types: [requested, completed]
 
 jobs:
-  placeholder_comment:
+  pre-deploy:
     if: github.repository == 'mlflow/mlflow' && github.event.workflow_run.status == 'requested'
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -1,33 +1,88 @@
 name: Preview docs
 
 on:
-  pull_request_target:
+  workflow_run:
+    workflows: [docs]
+    types: [requested, completed]
 
 jobs:
-  main:
-    if: github.repository == 'mlflow/mlflow'
+  placeholder_comment:
+    if: github.repository == 'mlflow/mlflow' && github.event.workflow_run.status == 'requested'
     runs-on: ubuntu-latest
     permissions:
-      statuses: read # preview_docs.py checks PR statuses
       pull-requests: write # preview_docs.py comments on PRs
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-python
+      - name: Post placeholder comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          python dev/preview_docs.py \
+            --commit-sha ${{ github.event.workflow_run.head_sha }} \
+            --pull-number $PR_NUMBER \
+            --workflow-run-id ${{ github.run_id }} \
+            --docs-workflow-run-url ${{ github.event.workflow_run.html_url }} \
+            --stage requested
+
+  main:
+    if: github.repository == 'mlflow/mlflow' && github.event.workflow_run.status == 'completed'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write # preview_docs.py comments on PRs
+    timeout-minutes: 10
+    steps:
+      - name: Handle docs workflow failure
+        if: github.event.workflow_run.conclusion == 'failure'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |
+          python dev/preview_docs.py \
+            --commit-sha ${{ github.event.workflow_run.head_sha }} \
+            --pull-number $PR_NUMBER \
+            --workflow-run-id ${{ github.run_id }} \
+            --docs-workflow-run-url ${{ github.event.workflow_run.html_url }} \
+            --stage failed
+          exit 0 # Exit the job if the docs workflow failed
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-node
+      - name: Download build artifact
+        uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          name: website-build-${{ github.event.workflow_run.id }}
+          path: downloaded-artifact
       - name: Install dependencies
         run: |
           pip install requests
           npm install -g netlify-cli
+      - name: Deploy to Netlify
+        id: netlify_deploy
+        working-directory: downloaded-artifact
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+        run: |-
+          netlify deploy \
+            --dir=. \
+            --no-build \
+            --message="PR Preview #${PR_NUMBER} - GitHub Run ID: ${github.run_id}" \
+            --alias="pr-${PR_NUMBER}"
+        continue-on-error: true
       - name: Create preview link
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CIRCLE_TOKEN: ${{ secrets.CIRCLE_TOKEN }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          NETLIFY_URL: https://pr-${PR_NUMBER}--mlflow-docs-preview.netlify.app
         run: |
           python dev/preview_docs.py \
-            --commit-sha ${{ github.event.pull_request.head.sha }} \
-            --pull-number ${{ github.event.pull_request.number }} \
+            --commit-sha ${{ github.event.workflow_run.head_sha }} \
+            --pull-number $PR_NUMBER \
             --workflow-run-id ${{ github.run_id }} \
-            --netlify-site-name "mlflow-docs-preview" \
+            --docs-workflow-run-url ${{ github.event.workflow_run.html_url }} \
+            --stage ${{ steps.netlify_deploy.outcome == 'success' && 'completed' || 'failed' }} \
+            --netlify-url $NETLIFY_URL

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -188,7 +188,9 @@ The [CircleCI job]({job_url}) failed. Please check the job logs for more details
 """
             upsert_comment(github_session, repo, args.pull_number, failure_comment_body)
             return
-        print(f"Job status: {build_doc_status['state'] if build_doc_status else 'not found'}, waiting...")
+        print(
+            f"Job status: {build_doc_status['state'] if build_doc_status else 'not found'}, waiting"
+        )
         time.sleep(3)
     else:
         print("Timed out waiting for CircleCI job to complete")
@@ -268,7 +270,7 @@ Documentation preview for {args.commit_sha} is available at:
         deployment_error_comment_body = f"""
 Documentation preview for {args.commit_sha} failed to deploy.
 
-The [CircleCI job]({job_url}) completed successfully, but deployment to Netlify failed: {str(e)}
+The [CircleCI job]({job_url}) completed successfully, but deployment to Netlify failed: {e!s}
 
 <details>
 <summary>More info</summary>

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -99,5 +99,7 @@ def main():
         upsert_comment(github_session, repo, args.pull_number, comment_body)
 
 
+# TODO: rewrite this in JavaScript so we don't have to setup both node (to deploy to netlify)
+# and python (to upsert pr comments with this script)
 if __name__ == "__main__":
     main()

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -63,7 +63,7 @@ def main():
     parser.add_argument("--commit-sha", required=True)
     parser.add_argument("--pull-number", required=True)
     parser.add_argument("--workflow-run-id", required=True)
-    parser.add_argument("--stage", choices=["requested", "completed", "failed"], required=True)
+    parser.add_argument("--stage", choices=["completed", "failed"], required=True)
     parser.add_argument("--netlify-url", required=False)
     parser.add_argument("--docs-workflow-run-url", required=True)
     args = parser.parse_args()
@@ -75,14 +75,7 @@ def main():
     repo = "mlflow/mlflow"
     workflow_run_link = f"https://github.com/{repo}/actions/runs/{args.workflow_run_id}"
 
-    if args.stage == "requested":
-        main_message = "will be available soon."
-        comment_body = _get_comment_template(
-            args.commit_sha, workflow_run_link, args.docs_workflow_run_url, main_message
-        )
-        upsert_comment(github_session, repo, args.pull_number, comment_body)
-
-    elif args.stage == "completed":
+    if args.stage == "completed":
         if not args.netlify_url:
             raise ValueError("netlify-url is required for completed stage")
         main_message = f"is available at:\n\n- {args.netlify_url}"

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -40,10 +40,7 @@ def upsert_comment(session, repo, pull_number, comment_body):
 
 
 def _get_comment_template(
-    commit_sha: str,
-    workflow_run_link: str,
-    docs_workflow_run_url: str,
-    main_message: str
+    commit_sha: str, workflow_run_link: str, docs_workflow_run_url: str, main_message: str
 ) -> str:
     return f"""
 Documentation preview for {commit_sha} {main_message}
@@ -59,6 +56,7 @@ Documentation preview for {commit_sha} {main_message}
 
 </details>
 """
+
 
 def main():
     parser = argparse.ArgumentParser()

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -161,7 +161,7 @@ completes successfully.
 
     # Wait for the build_doc job to complete
     print("Waiting for CircleCI job to complete...")
-    for _ in range(60):  # Wait up to 3 minutes (60 * 3 seconds)
+    for _ in range(15):  # Wait up to 15 minutes (15 * 60 seconds)
         status = github_session.get(
             f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status"
         )
@@ -191,7 +191,7 @@ The [CircleCI job]({job_url}) failed. Please check the job logs for more details
         print(
             f"Job status: {build_doc_status['state'] if build_doc_status else 'not found'}, waiting"
         )
-        time.sleep(3)
+        time.sleep(60)
     else:
         print("Timed out waiting for CircleCI job to complete")
         timeout_comment_body = f"""

--- a/dev/preview_docs.py
+++ b/dev/preview_docs.py
@@ -1,10 +1,5 @@
 import argparse
 import os
-import subprocess
-import tempfile
-import time
-import zipfile
-from urllib.parse import urlparse
 
 import requests
 
@@ -44,108 +39,14 @@ def upsert_comment(session, repo, pull_number, comment_body):
         session.patch(preview_docs_comment["url"], json={"body": comment_body_with_marker})
 
 
-def deploy_to_netlify(artifact_url: str, pull_number: int, site_name: str, action_url: str) -> str:
-    with tempfile.TemporaryDirectory() as tmpdir:
-        artifact_path = os.path.join(tmpdir, "docs-html.zip")
-        response = requests.get(artifact_url, stream=True)
-        response.raise_for_status()
-        with open(artifact_path, "wb") as f:
-            for chunk in response.iter_content(chunk_size=8192):
-                f.write(chunk)
-
-        with zipfile.ZipFile(artifact_path, "r") as zip_ref:
-            zip_ref.extractall(tmpdir)
-
-        build_dir = os.path.join(tmpdir, "build")
-        if not os.path.isdir(build_dir):
-            raise Exception(f"'build' directory not found in the artifact: {os.listdir(tmpdir)}")
-
-        alias = f"pr-{pull_number}"
-        message = f"PR Preview #{pull_number} - GitHub Action: {action_url}"
-        command = [
-            "netlify",
-            "deploy",
-            "--dir",
-            build_dir,
-            "--alias",
-            alias,
-            "--no-build",
-            "--message",
-            message,
-        ]
-        subprocess.run(
-            command,
-            check=True,
-            capture_output=True,
-            text=True,
-            env=os.environ.copy(),
-        )
-        return f"https://{alias}--{site_name}.netlify.app"
-
-
-def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--commit-sha", required=True)
-    parser.add_argument("--pull-number", required=True)
-    parser.add_argument("--workflow-run-id", required=True)
-    parser.add_argument("--netlify-site-name", required=True)
-    parser.add_argument("--action-url", required=True)
-    parser.add_argument("--netlify-site-name", required=True)
-    parser.add_argument("--action-url", required=True)
-    args = parser.parse_args()
-
-    github_session = Session()
-    if github_token := os.environ.get("GITHUB_TOKEN"):
-        github_session.headers.update({"Authorization": f"token {github_token}"})
-
-    circle_session = Session()
-    if circle_token := os.environ.get("CIRCLE_TOKEN"):
-        circle_session.headers.update({"Circle-Token": circle_token})
-
-    # Get the ID of the build_doc job
-    repo = "mlflow/mlflow"
-    build_doc_job_name = "build_doc"
-    job_id = None
-    job_url = None
-    workflow_run_link = f"https://github.com/{repo}/actions/runs/{args.workflow_run_id}"
-    for _ in range(5):
-        status = github_session.get(
-            f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status"
-        )
-        build_doc_status = next(
-            filter(lambda s: s["context"].endswith(build_doc_job_name), status["statuses"]),
-            None,
-        )
-        if build_doc_status:
-            job_id = urlparse(build_doc_status["target_url"]).path.split("/")[-1]
-            job_url = build_doc_status["target_url"]
-            break
-        print(f"Waiting for {build_doc_job_name} job status to be available...")
-        time.sleep(3)
-    else:
-        print(f"Could not find {build_doc_job_name} job status")
-        comment_body = f"""
-Failed to find a documentation preview for {args.commit_sha}.
-
-<details>
-<summary>More info</summary>
-
-- If the `ci/circleci: {build_doc_job_name}` job status is successful, you can see the preview with
-  the following steps:
-  1. Click `Details`.
-  2. Click `Artifacts`.
-  3. Click `docs/build/html/index.html`.
-- This comment was created by {workflow_run_link}.
-
-</details>
-"""
-        upsert_comment(github_session, repo, args.pull_number, comment_body)
-        return
-
-    # Post initial comment with CircleCI job link
-    initial_comment_body = f"""
-Documentation preview for {args.commit_sha} will be available when [this CircleCI job]({job_url})
-completes successfully.
+def _get_comment_template(
+    commit_sha: str,
+    workflow_run_link: str,
+    docs_workflow_run_url: str,
+    main_message: str
+) -> str:
+    return f"""
+Documentation preview for {commit_sha} {main_message}
 
 <details>
 <summary>More info</summary>
@@ -153,133 +54,51 @@ completes successfully.
 - Ignore this comment if this PR does not change the documentation.
 - It takes a few minutes for the preview to be available.
 - The preview is updated when a new commit is pushed to this PR.
-- This comment was created by {workflow_run_link}.
+- This comment was created by [this workflow run]({workflow_run_link}).
+- The documentation was built by [this workflow run]({docs_workflow_run_url}).
 
 </details>
 """
-    upsert_comment(github_session, repo, args.pull_number, initial_comment_body)
 
-    # Wait for the build_doc job to complete
-    print("Waiting for CircleCI job to complete...")
-    for _ in range(15):  # Wait up to 15 minutes (15 * 60 seconds)
-        status = github_session.get(
-            f"https://api.github.com/repos/{repo}/commits/{args.commit_sha}/status"
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--commit-sha", required=True)
+    parser.add_argument("--pull-number", required=True)
+    parser.add_argument("--workflow-run-id", required=True)
+    parser.add_argument("--stage", choices=["requested", "completed", "failed"], required=True)
+    parser.add_argument("--netlify-url", required=False)
+    parser.add_argument("--docs-workflow-run-url", required=True)
+    args = parser.parse_args()
+
+    github_session = Session()
+    if github_token := os.environ.get("GITHUB_TOKEN"):
+        github_session.headers.update({"Authorization": f"token {github_token}"})
+
+    repo = "mlflow/mlflow"
+    workflow_run_link = f"https://github.com/{repo}/actions/runs/{args.workflow_run_id}"
+
+    if args.stage == "requested":
+        main_message = "will be available soon."
+        comment_body = _get_comment_template(
+            args.commit_sha, workflow_run_link, args.docs_workflow_run_url, main_message
         )
-        build_doc_status = next(
-            filter(lambda s: s["context"].endswith(build_doc_job_name), status["statuses"]),
-            None,
+        upsert_comment(github_session, repo, args.pull_number, comment_body)
+
+    elif args.stage == "completed":
+        if not args.netlify_url:
+            raise ValueError("netlify-url is required for completed stage")
+        main_message = f"is available at:\n\n- {args.netlify_url}"
+        comment_body = _get_comment_template(
+            args.commit_sha, workflow_run_link, args.docs_workflow_run_url, main_message
         )
-        if build_doc_status and build_doc_status["state"] == "success":
-            print("CircleCI job completed successfully")
-            break
-        elif build_doc_status and build_doc_status["state"] == "failure":
-            print("CircleCI job failed")
-            failure_comment_body = f"""
-Documentation preview for {args.commit_sha} failed to build.
+        upsert_comment(github_session, repo, args.pull_number, comment_body)
 
-The [CircleCI job]({job_url}) failed. Please check the job logs for more details.
-
-<details>
-<summary>More info</summary>
-
-- This comment was created by {workflow_run_link}.
-
-</details>
-"""
-            upsert_comment(github_session, repo, args.pull_number, failure_comment_body)
-            return
-        print(
-            f"Job status: {build_doc_status['state'] if build_doc_status else 'not found'}, waiting"
+    elif args.stage == "failed":
+        main_message = "failed to build or deploy."
+        comment_body = _get_comment_template(
+            args.commit_sha, workflow_run_link, args.docs_workflow_run_url, main_message
         )
-        time.sleep(60)
-    else:
-        print("Timed out waiting for CircleCI job to complete")
-        timeout_comment_body = f"""
-Documentation preview for {args.commit_sha} is taking longer than expected to build.
-
-The [CircleCI job]({job_url}) is still running. Please check back later or check the job directly.
-
-<details>
-<summary>More info</summary>
-
-- This comment was created by {workflow_run_link}.
-
-</details>
-"""
-        upsert_comment(github_session, repo, args.pull_number, timeout_comment_body)
-        return
-
-    # Get CircleCI job details and deploy to Netlify
-    for _ in range(5):
-        try:
-            # Despite using a valid CircleCI token, the request occasionally fails with a 403 error.
-            job = circle_session.get(f"https://circleci.com/api/v2/project/gh/{repo}/job/{job_id}")
-            workflow_id = job["latest_workflow"]["id"]
-            workflow = circle_session.get(f"https://circleci.com/api/v2/workflow/{workflow_id}/job")
-            break
-        except requests.HTTPError as e:
-            print(
-                f"Failed to get CircleCI job info: {e.response.status_code, e.response.text}, "
-                f"retrying..."
-            )
-            time.sleep(1)
-            continue
-    else:
-        upsert_comment(
-            github_session,
-            repo,
-            args.pull_number,
-            (
-                f"Failed to find a documentation preview for {args.commit_sha}. "
-                f"See {workflow_run_link} for what went wrong."
-            ),
-        )
-        return
-
-    build_doc_job = next(filter(lambda s: s["name"] == build_doc_job_name, workflow["items"]))
-    build_doc_job_id = build_doc_job["id"]
-    artifact_url = f"https://output.circle-artifacts.com/output/job/{build_doc_job_id}/artifacts/0/docs-html.zip"
-
-    # Deploy to Netlify and update comment with preview URL
-    print("Deploying to Netlify...")
-    try:
-        netlify_url = deploy_to_netlify(
-            artifact_url,
-            args.pull_number,
-            args.netlify_site_name,
-            args.action_url,
-        )
-        final_comment_body = f"""
-Documentation preview for {args.commit_sha} is available at:
-
-- {netlify_url}
-
-<details>
-<summary>More info</summary>
-
-- Ignore this comment if this PR does not change the documentation.
-- The preview is updated when a new commit is pushed to this PR.
-- This comment was created by {workflow_run_link}.
-
-</details>
-"""
-        upsert_comment(github_session, repo, args.pull_number, final_comment_body)
-        print(f"Documentation preview deployed successfully: {netlify_url}")
-    except Exception as e:
-        print(f"Failed to deploy to Netlify: {e}")
-        deployment_error_comment_body = f"""
-Documentation preview for {args.commit_sha} failed to deploy.
-
-The [CircleCI job]({job_url}) completed successfully, but deployment to Netlify failed: {e!s}
-
-<details>
-<summary>More info</summary>
-
-- This comment was created by {workflow_run_link}.
-
-</details>
-"""
-        upsert_comment(github_session, repo, args.pull_number, deployment_error_comment_body)
+        upsert_comment(github_session, repo, args.pull_number, comment_body)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16527?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16527/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16527/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16527/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Deploy preview docs to Netlify

- I wanted to keep as much of the existing logic as possible, so I modified the `preview_docs.py`
- I created a zip file in CircleCI job and store it as an artifact too. We can omit the build directory if it's no longer needed
- The updated python script now creates a comment as soon as it finds the workflow, but updates it when the `build_doc` job succeeds with the Netlify URL (I used AI for this so we need to check if it works correctly)
- Github uses the workflow that's in master, so we need a strategy to test this manually before merging it
- We need Netlify credentials in the repo for it to work

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
