### PR TITLE
Fix PR number handling for fork PRs in docs workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -57,7 +57,7 @@ jobs:
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-python
       - run: |
-          uv pip install --system . -r ../requirements/doc-requirements.txt
+          uv pip install --system .. -r ../requirements/doc-requirements.txt
       - run: |
           yarn install --immutable
       - name: Build docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,9 +56,9 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: ./.github/actions/setup-node
       - uses: ./.github/actions/setup-python
-      - name: Install dependencies
-        run: |
-          pip install -r ../requirements/doc-requirements.txt
+      - run: |
+          uv pip install --system . -r ../requirements/doc-requirements.txt
+      - run: |
           yarn install --immutable
       - name: Build docs
         run: |
@@ -69,5 +69,19 @@ jobs:
         with:
           name: docs-build-${{ github.run_id }}
           path: docs/build
+          retention-days: 1
+          if-no-files-found: error
+
+      # `github.event.workflow_run.pull_requests` is empty when a PR is created from a fork:
+      # https://github.com/orgs/community/discussions/25220#discussioncomment-11001085
+      - name: Save PR number
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          echo $PR_NUMBER > /tmp/pr_number.txt
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: pr_number
+          path: /tmp/pr_number.txt
           retention-days: 1
           if-no-files-found: error

--- a/.github/workflows/preview-docs.yml
+++ b/.github/workflows/preview-docs.yml
@@ -14,7 +14,18 @@ jobs:
     timeout-minutes: 10
     outputs:
       should_continue: ${{ github.event.workflow_run.conclusion == 'success' }}
+      pr_number: ${{ steps.pr_number.outputs.pr_number }}
     steps:
+      - uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+          name: pr_number
+          path: /tmp
+      - name: Set PR number
+        id: pr_number
+        run: |
+          echo "pr_number=$(cat /tmp/pr_number.txt)" >> $GITHUB_OUTPUT
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: github.event.workflow_run.conclusion == 'failure'
         with:
@@ -25,7 +36,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
-          PULL_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PULL_NUMBER: ${{ steps.pr_number.outputs.pr_number }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           STAGE: failed
           DOCS_WORKFLOW_RUN_URL: ${{ github.event.workflow_run.html_url }}
@@ -63,7 +74,7 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PR_NUMBER: ${{ needs.fail-early.outputs.pr_number }}
           RUN_ID: ${{ github.run_id }}
         run: |-
           OUTPUT=$(npx -y netlify-cli deploy \
@@ -79,7 +90,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
-          PULL_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PULL_NUMBER: ${{ needs.fail-early.outputs.pr_number }}
           WORKFLOW_RUN_ID: ${{ github.run_id }}
           STAGE: ${{ steps.netlify_deploy.outcome == 'success' && 'completed' || 'failed' }}
           NETLIFY_URL: ${{ steps.netlify_deploy.outputs.deploy_url }}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16563?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16563/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16563/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16563/merge
```

</p>
</details>



### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

- Upload PR number as artifact in docs.yml workflow
- Download and use PR number artifact in preview-docs.yml workflow
- This fixes the issue where `github.event.workflow_run.pull_requests` is empty for PRs from forks

🤖 Generated with [Claude Code](https://claude.ai/code)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
