### PR TITLE
[TS #10] Support `mlflow.trace` function wrapper 

### DIFF
--- a/packages/typescript/.eslintrc.json
+++ b/packages/typescript/.eslintrc.json
@@ -30,6 +30,7 @@
     "@typescript-eslint/no-unsafe-assignment": "off",
     // Namespaces are useful for organizing API specifications
     "@typescript-eslint/no-namespace": "off",
+    "@typescript-eslint/ban-types": "off",
 
     // General JavaScript/TypeScript rules
     "no-console": ["warn", { "allow": ["debug", "warn", "error"] }],
@@ -58,7 +59,9 @@
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-unsafe-member-access": "off",
         "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-non-null-assertion": "off"
+        "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/no-unsafe-return": "off",
+        "@typescript-eslint/no-implied-eval": "off"
       }
     }
   ]

--- a/packages/typescript/.eslintrc.json
+++ b/packages/typescript/.eslintrc.json
@@ -59,9 +59,7 @@
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-unsafe-member-access": "off",
         "@typescript-eslint/no-unsafe-argument": "off",
-        "@typescript-eslint/no-non-null-assertion": "off",
-        "@typescript-eslint/no-unsafe-return": "off",
-        "@typescript-eslint/no-implied-eval": "off"
+        "@typescript-eslint/no-non-null-assertion": "off"
       }
     }
   ]

--- a/packages/typescript/src/core/api.ts
+++ b/packages/typescript/src/core/api.ts
@@ -32,7 +32,6 @@ export interface SpanOptions {
 export interface TraceOptions
   extends Omit<SpanOptions, 'parent' | 'startTimeNs' | 'inputs' | 'name'> {
   name?: string;
-  clientRequestId?: string;
 }
 
 /**
@@ -194,7 +193,6 @@ function createAndRegisterMlflowSpan(
   return mlflowSpan;
 }
 
-
 /**
  * Create a traced version of a function.
  *
@@ -206,7 +204,7 @@ function createAndRegisterMlflowSpan(
  * - Any exception thrown by the function
  *
  * @param func The function to trace
- * @param options Optional trace options including name, spanType, attributes, and clientRequestId
+ * @param options Optional trace options including name, spanType, and attributes
  * @returns The traced function
  *
  * @example
@@ -232,14 +230,7 @@ export function trace<T extends (...args: any[]) => any>(func: T, options?: Trac
     };
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-    return withSpan((span) => {
-      // Set the client request ID for the trace
-      if (options?.clientRequestId) {
-        InMemoryTraceManager.getInstance().setClientRequestId(
-          span.traceId,
-          options.clientRequestId
-        );
-      }
+    return withSpan((_span) => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-return
       return func.apply(this, args);
     }, spanOptions) as ReturnType<T>;

--- a/packages/typescript/src/core/api.ts
+++ b/packages/typescript/src/core/api.ts
@@ -1,10 +1,10 @@
-import { trace, context, Span as ApiSpan } from '@opentelemetry/api';
+import { trace as otelTrace, context, Span as ApiSpan } from '@opentelemetry/api';
 import { Span as OTelSpan } from '@opentelemetry/sdk-trace-node';
 import { DEFAULT_SPAN_NAME, SpanType } from './constants';
 import { createMlflowSpan, LiveSpan, NoOpSpan } from './entities/span';
 import { getTracer } from './provider';
 import { InMemoryTraceManager } from './trace_manager';
-import { convertNanoSecondsToHrTime } from './utils';
+import { convertNanoSecondsToHrTime, mapArgsToObject } from './utils';
 import { SpanStatusCode } from './entities/span_status';
 
 /*
@@ -19,11 +19,20 @@ import { SpanStatusCode } from './entities/span_status';
  */
 export interface SpanOptions {
   name: string;
-  span_type?: SpanType;
+  spanType?: SpanType;
   inputs?: any;
   attributes?: Record<string, any>;
   startTimeNs?: number;
   parent?: LiveSpan;
+}
+
+/**
+ * Options for tracing a function
+ */
+export interface TraceOptions
+  extends Omit<SpanOptions, 'parent' | 'startTimeNs' | 'inputs' | 'name'> {
+  name?: string;
+  clientRequestId?: string;
 }
 
 /**
@@ -38,7 +47,7 @@ export function startSpan(options: SpanOptions): LiveSpan {
 
     // If parent is provided, use it as the parent spanAdd commentMore actions
     const parentContext = options.parent
-      ? trace.setSpan(context.active(), options.parent._span)
+      ? otelTrace.setSpan(context.active(), options.parent._span)
       : context.active();
 
     // Convert startTimeNs to OTel format
@@ -55,7 +64,7 @@ export function startSpan(options: SpanOptions): LiveSpan {
     // Create and register the MLflow span
     const mlflowSpan = createAndRegisterMlflowSpan(
       otelSpan,
-      options.span_type,
+      options.spanType,
       options.inputs,
       options.attributes
     );
@@ -103,7 +112,7 @@ export function withSpan<T>(
     // Create and register the MLflow span
     const mlflowSpan = createAndRegisterMlflowSpan(
       otelSpan,
-      spanOptions.span_type,
+      spanOptions.spanType,
       spanOptions.inputs,
       spanOptions.attributes
     );
@@ -185,6 +194,76 @@ function createAndRegisterMlflowSpan(
   return mlflowSpan;
 }
 
+
+/**
+ * Create a traced version of a function.
+ *
+ * When the function is called, the span will automatically capture:
+ * - The function inputs
+ * - The function outputs
+ * - The function name as the span name
+ * - The function execution time
+ * - Any exception thrown by the function
+ *
+ * @param func The function to trace
+ * @param options Optional trace options including name, spanType, attributes, and clientRequestId
+ * @returns The traced function
+ *
+ * @example
+ * // With no options (uses function name as span name)
+ * const tracedFunc = trace(myFunc);
+ *
+ * @example
+ * // With options
+ * const tracedFunc = trace(myFunc, { name: 'custom_span_name', spanType: 'LLM' });
+
+ * @example
+ * // Inline declaration
+ * const myFunc = trace(async (a: number, b: number) => a + b, { spanType: 'TOOL' });
+ */
+export function trace<T extends (...args: any[]) => any>(func: T, options?: TraceOptions): T {
+  // Create a wrapper function that preserves the original function's properties
+  const wrapper = function (this: any, ...args: Parameters<T>): ReturnType<T> {
+    const spanOptions: Omit<SpanOptions, 'parent'> = {
+      name: options?.name || func.name || DEFAULT_SPAN_NAME,
+      spanType: options?.spanType,
+      attributes: options?.attributes,
+      inputs: mapArgsToObject(func, args)
+    };
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return withSpan((span) => {
+      // Set the client request ID for the trace
+      if (options?.clientRequestId) {
+        InMemoryTraceManager.getInstance().setClientRequestId(
+          span.traceId,
+          options.clientRequestId
+        );
+      }
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return func.apply(this, args);
+    }, spanOptions) as ReturnType<T>;
+  };
+
+  // Preserve function properties
+  Object.defineProperty(wrapper, 'length', { value: func.length });
+  Object.defineProperty(wrapper, 'name', { value: func.name });
+
+  // Copy any additional properties from the original function
+  for (const prop in func) {
+    if (Object.prototype.hasOwnProperty.call(func, prop)) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (wrapper as any)[prop] = (func as any)[prop];
+    }
+  }
+
+  return wrapper as T;
+}
+
+/**
+ * Get the last active trace ID.
+ * @returns The last active trace ID.
+ */
 export function getLastActiveTraceId(): string | undefined {
   const traceManager = InMemoryTraceManager.getInstance();
   return traceManager.lastActiveTraceId;

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -101,21 +101,6 @@ export class InMemoryTraceManager {
   }
 
   /**
-   * Set the client request ID for the given trace ID.
-   * @param traceId The trace ID to set the client request ID for
-   * @param clientRequestId The client request ID to set
-   */
-  setClientRequestId(traceId: string, clientRequestId: string): void {
-    const trace = this._traces.get(traceId);
-    if (trace) {
-      trace.info.clientRequestId = clientRequestId;
-    } else {
-      console.debug(`Tried to set client request ID ${clientRequestId} for trace ${traceId}
-                     but trace not found. Please make sure to register the trace first.`);
-    }
-  }
-
-  /**
    * Get the MLflow trace ID for the given OpenTelemetry trace ID.
    * @param otelTraceId The OpenTelemetry trace ID
    */

--- a/packages/typescript/src/core/trace_manager.ts
+++ b/packages/typescript/src/core/trace_manager.ts
@@ -101,6 +101,21 @@ export class InMemoryTraceManager {
   }
 
   /**
+   * Set the client request ID for the given trace ID.
+   * @param traceId The trace ID to set the client request ID for
+   * @param clientRequestId The client request ID to set
+   */
+  setClientRequestId(traceId: string, clientRequestId: string): void {
+    const trace = this._traces.get(traceId);
+    if (trace) {
+      trace.info.clientRequestId = clientRequestId;
+    } else {
+      console.debug(`Tried to set client request ID ${clientRequestId} for trace ${traceId}
+                     but trace not found. Please make sure to register the trace first.`);
+    }
+  }
+
+  /**
    * Get the MLflow trace ID for the given OpenTelemetry trace ID.
    * @param otelTraceId The OpenTelemetry trace ID
    */

--- a/packages/typescript/src/index.ts
+++ b/packages/typescript/src/index.ts
@@ -1,5 +1,13 @@
 import { init } from './core/config';
-import { getLastActiveTraceId, startSpan, withSpan } from './core/api';
+import { getLastActiveTraceId, startSpan, trace, withSpan } from './core/api';
 import { flushTraces } from './core/provider';
 
-export { getLastActiveTraceId, flushTraces, init, startSpan, withSpan };
+export { getLastActiveTraceId, flushTraces, init, startSpan, trace, withSpan };
+
+// Export entities
+export { SpanType } from './core/constants';
+export type { LiveSpan } from './core/entities/span';
+export type { Trace } from './core/entities/trace';
+export type { TraceInfo } from './core/entities/trace_info';
+export type { TraceData } from './core/entities/trace_data';
+export { SpanStatusCode } from './core/entities/span_status';

--- a/packages/typescript/tests/core/api.test.ts
+++ b/packages/typescript/tests/core/api.test.ts
@@ -571,8 +571,7 @@ describe('API', () => {
       const tracedFunc = mlflow.trace(myFunc, {
         name: 'custom_span_name',
         spanType: SpanType.LLM,
-        attributes: { key: 'value' },
-        clientRequestId: 'abc-xyz'
+        attributes: { key: 'value' }
       });
 
       const result = tracedFunc(2, 3);
@@ -580,7 +579,6 @@ describe('API', () => {
 
       const trace = await getLastActiveTrace();
       expect(trace.info.state).toBe('OK');
-      expect(trace.info.clientRequestId).toBe('abc-xyz');
       expect(trace.data.spans.length).toBe(1);
 
       const loggedSpan = trace.data.spans[0];

--- a/packages/typescript/tests/core/api.test.ts
+++ b/packages/typescript/tests/core/api.test.ts
@@ -1,5 +1,5 @@
 import { MlflowClient } from '../../src/clients';
-import { getLastActiveTraceId, flushTraces, init, startSpan, withSpan } from '../../src';
+import * as mlflow from '../../src';
 import { SpanType } from '../../src/core/constants';
 import { LiveSpan } from '../../src/core/entities/span';
 import { SpanStatus, SpanStatusCode } from '../../src/core/entities/span_status';
@@ -13,8 +13,8 @@ describe('API', () => {
   let experimentId: string;
 
   const getLastActiveTrace = async (): Promise<Trace> => {
-    await flushTraces();
-    const traceId = getLastActiveTraceId();
+    await mlflow.flushTraces();
+    const traceId = mlflow.getLastActiveTraceId();
     const trace = await client.getTrace(traceId!);
     return trace;
   };
@@ -25,7 +25,7 @@ describe('API', () => {
     // Create a new experiment
     const experimentName = `test-experiment-${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;
     experimentId = await client.createExperiment(experimentName);
-    init({
+    mlflow.init({
       trackingUri: TEST_TRACKING_URI,
       experimentId: experimentId
     });
@@ -37,7 +37,7 @@ describe('API', () => {
 
   describe('startSpan', () => {
     it('should create a span with span type', async () => {
-      const span = startSpan({ name: 'test-span' });
+      const span = mlflow.startSpan({ name: 'test-span' });
       expect(span).toBeInstanceOf(LiveSpan);
 
       span.setInputs({ prompt: 'Hello, world!' });
@@ -47,7 +47,7 @@ describe('API', () => {
       span.end();
 
       // Validate traces pushed to the backend
-      await flushTraces();
+      await mlflow.flushTraces();
       const trace = await client.getTrace(span.traceId);
 
       expect(trace.info.traceId).toBe(span.traceId);
@@ -71,9 +71,9 @@ describe('API', () => {
     });
 
     it('should create a span with other options', async () => {
-      const span = startSpan({
+      const span = mlflow.startSpan({
         name: 'test-span',
-        span_type: SpanType.LLM,
+        spanType: SpanType.LLM,
         inputs: { prompt: 'Hello, world!' },
         attributes: { model: 'gpt-4' },
         startTimeNs: 1e9 // 1 second
@@ -107,14 +107,14 @@ describe('API', () => {
     });
 
     it('should create a span with an exception', async () => {
-      const span = startSpan({ name: 'test-span-with-exception', span_type: SpanType.LLM });
+      const span = mlflow.startSpan({ name: 'test-span-with-exception', spanType: SpanType.LLM });
       expect(span).toBeInstanceOf(LiveSpan);
 
       span.recordException(new Error('test-error'));
       span.end({ status: new SpanStatus(SpanStatusCode.ERROR, 'test-error') });
 
       // Validate traces pushed to the backend
-      await flushTraces();
+      await mlflow.flushTraces();
       const trace = await client.getTrace(span.traceId);
       expect(trace.info.state).toBe(TraceState.ERROR);
       expect(trace.info.requestTime).toBeCloseTo(convertHrTimeToMs(span.startTime));
@@ -129,21 +129,21 @@ describe('API', () => {
     });
 
     it('should create nested spans', async () => {
-      const parentSpan = startSpan({ name: 'parent-span' });
-      const childSpan1 = startSpan({ name: 'child-span-1', parent: parentSpan });
+      const parentSpan = mlflow.startSpan({ name: 'parent-span' });
+      const childSpan1 = mlflow.startSpan({ name: 'child-span-1', parent: parentSpan });
       childSpan1.end();
-      const childSpan2 = startSpan({ name: 'child-span-2', parent: parentSpan });
-      const childSpan3 = startSpan({ name: 'child-span-3', parent: childSpan2 });
+      const childSpan2 = mlflow.startSpan({ name: 'child-span-2', parent: parentSpan });
+      const childSpan3 = mlflow.startSpan({ name: 'child-span-3', parent: childSpan2 });
       childSpan3.end();
       childSpan2.end();
 
       // This should not be a child of parentSpan
-      const independentSpan = startSpan({ name: 'independent-span' });
+      const independentSpan = mlflow.startSpan({ name: 'independent-span' });
       independentSpan.end();
 
       parentSpan.end();
 
-      await flushTraces();
+      await mlflow.flushTraces();
       const trace1 = await client.getTrace(independentSpan.traceId);
       expect(trace1.data.spans.length).toBe(1);
       expect(trace1.data.spans[0].name).toBe('independent-span');
@@ -163,7 +163,7 @@ describe('API', () => {
   describe('withSpan', () => {
     describe('inline usage pattern', () => {
       it('should execute synchronous callback and auto-set outputs', async () => {
-        const result = withSpan((span) => {
+        const result = mlflow.withSpan((span) => {
           span.setInputs({ a: 5, b: 3 });
           return 5 + 3; // Auto-set outputs from return value
         });
@@ -181,7 +181,7 @@ describe('API', () => {
       });
 
       it('should execute synchronous callback with explicit outputs', async () => {
-        const result = withSpan((span) => {
+        const result = mlflow.withSpan((span) => {
           span.setInputs({ a: 5, b: 3 });
           const sum = 5 + 3;
           span.setOutputs({ result: sum });
@@ -198,7 +198,7 @@ describe('API', () => {
       });
 
       it('should execute asynchronous callback and auto-set outputs', async () => {
-        const result = await withSpan(async (span) => {
+        const result = await mlflow.withSpan(async (span) => {
           span.setInputs({ delay: 100 });
           await new Promise((resolve) => setTimeout(resolve, 10));
           const value = 'async result';
@@ -218,7 +218,7 @@ describe('API', () => {
 
       it('should handle synchronous errors', async () => {
         expect(() => {
-          void withSpan((span) => {
+          void mlflow.withSpan((span) => {
             span.setInputs({ operation: 'divide by zero' });
             throw new Error('Division by zero');
           });
@@ -234,7 +234,7 @@ describe('API', () => {
 
       it('should handle asynchronous errors', async () => {
         await expect(
-          withSpan(async (span) => {
+          mlflow.withSpan(async (span) => {
             span.setInputs({ operation: 'async error' });
             await new Promise((resolve) => setTimeout(resolve, 10));
             throw new Error('Async error');
@@ -254,7 +254,7 @@ describe('API', () => {
       it('should execute with pre-configured options', async () => {
         // Example: Creating a traced addition function
         const add = (a: number, b: number) => {
-          const sum = withSpan(
+          const sum = mlflow.withSpan(
             (span) => {
               const result = a + b;
               span.setOutputs(result);
@@ -262,7 +262,7 @@ describe('API', () => {
             },
             {
               name: 'add',
-              span_type: SpanType.TOOL,
+              spanType: SpanType.TOOL,
               inputs: { a, b },
               attributes: { operation: 'addition' }
             }
@@ -287,7 +287,7 @@ describe('API', () => {
       it('should execute async with pre-configured options', async () => {
         // Example: Creating a traced async function that fetches user data
         const fetchUserData = (userId: string) => {
-          return withSpan(
+          return mlflow.withSpan(
             async (span) => {
               // Simulate API call
               await new Promise((resolve) => setTimeout(resolve, 10));
@@ -302,7 +302,7 @@ describe('API', () => {
             },
             {
               name: 'fetchUserData',
-              span_type: SpanType.RETRIEVER,
+              spanType: SpanType.RETRIEVER,
               inputs: { userId },
               attributes: { service: 'user-api', version: 1 }
             }
@@ -330,10 +330,10 @@ describe('API', () => {
       });
 
       it('should handle nested spans with automatic parent-child relationship', async () => {
-        const result = withSpan(
+        const result = mlflow.withSpan(
           (parentSpan) => {
             // Nested withSpan call - should automatically be a child of the parent
-            const childResult = withSpan(
+            const childResult = mlflow.withSpan(
               (childSpan) => {
                 childSpan.setAttributes({ nested: true });
                 return 'child result';
@@ -373,7 +373,7 @@ describe('API', () => {
 
     describe('edge cases', () => {
       it('should handle null return values', async () => {
-        const result = withSpan((span) => {
+        const result = mlflow.withSpan((span) => {
           span.setInputs({ test: true });
           return null;
         });
@@ -393,7 +393,7 @@ describe('API', () => {
           metadata: { type: 'array', length: 3 }
         };
 
-        const result = withSpan((span) => {
+        const result = mlflow.withSpan((span) => {
           span.setInputs({ operation: 'create complex object' });
           return complexObject;
         });
@@ -413,7 +413,7 @@ describe('API', () => {
         const traceIds: Record<string, string> = {};
         const results = await Promise.all([
           // First trace with nested async operations
-          withSpan(
+          mlflow.withSpan(
             async (parentSpan) => {
               // Simulate some async work
               await new Promise((resolve) => setTimeout(resolve, 5));
@@ -421,7 +421,7 @@ describe('API', () => {
 
               // Create multiple child spans in parallel
               const childResults = await Promise.all([
-                withSpan(
+                mlflow.withSpan(
                   async (childSpan) => {
                     await new Promise((resolve) => setTimeout(resolve, 3));
                     childSpan.setOutputs({ processed: true });
@@ -429,11 +429,11 @@ describe('API', () => {
                   },
                   { name: 'trace1-child1', inputs: { childId: 1 } }
                 ),
-                withSpan(
+                mlflow.withSpan(
                   async (childSpan) => {
                     await new Promise((resolve) => setTimeout(resolve, 2));
                     // Nested grandchild
-                    const grandchildResult = await withSpan(
+                    const grandchildResult = await mlflow.withSpan(
                       async () => {
                         await new Promise((resolve) => setTimeout(resolve, 1));
                         return 'grandchild-result';
@@ -454,11 +454,11 @@ describe('API', () => {
           ),
 
           // Second independent trace running concurrently
-          withSpan(
+          mlflow.withSpan(
             async (parentSpan) => {
               await new Promise((resolve) => setTimeout(resolve, 4));
               traceIds['trace2-parent'] = parentSpan.traceId;
-              const result = await withSpan(
+              const result = await mlflow.withSpan(
                 async () => {
                   await new Promise((resolve) => setTimeout(resolve, 2));
                   return 'trace2-child-result';
@@ -473,7 +473,7 @@ describe('API', () => {
           ),
 
           // Third independent trace with synchronous operation
-          withSpan(
+          mlflow.withSpan(
             (span) => {
               traceIds['trace3-simple'] = span.traceId;
               span.setOutputs({ immediate: true });
@@ -488,7 +488,7 @@ describe('API', () => {
         expect(results[1]).toBe('trace2-child-result');
         expect(results[2]).toBe('trace3-result');
 
-        await flushTraces();
+        await mlflow.flushTraces();
 
         // Verify first trace (most complex with grandchild)
         const trace1 = await client.getTrace(traceIds['trace1-parent']);
@@ -542,5 +542,172 @@ describe('API', () => {
         expect(trace3Span.outputs).toEqual({ immediate: true });
       });
     });
+  });
+
+  describe('trace wrapper function', () => {
+    it('should trace a synchronous function', async () => {
+      const myFunc = (x: number) => x * 2;
+
+      const tracedFunc = mlflow.trace(myFunc);
+      const result = tracedFunc(5);
+      expect(result).toBe(10);
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.state).toBe('OK');
+      expect(trace.data.spans.length).toBe(1);
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.name).toBe('myFunc');
+      expect(loggedSpan.spanType).toBe(SpanType.UNKNOWN);
+      expect(loggedSpan.inputs).toEqual({ x: 5 });
+      expect(loggedSpan.outputs).toEqual(10);
+      expect(loggedSpan.startTime).toBeDefined();
+      expect(loggedSpan.endTime).toBeDefined();
+    });
+
+    it('should trace a synchronous function with options', async () => {
+      const myFunc = (a: number, b: number) => a + b;
+
+      const tracedFunc = mlflow.trace(myFunc, {
+        name: 'custom_span_name',
+        spanType: SpanType.LLM,
+        attributes: { key: 'value' },
+        clientRequestId: 'abc-xyz'
+      });
+
+      const result = tracedFunc(2, 3);
+      expect(result).toBe(5);
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.state).toBe('OK');
+      expect(trace.info.clientRequestId).toBe('abc-xyz');
+      expect(trace.data.spans.length).toBe(1);
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.name).toBe('custom_span_name');
+      expect(loggedSpan.spanType).toBe(SpanType.LLM);
+      expect(loggedSpan.attributes['key']).toBe('value');
+    });
+
+    it('should trace an async function', async () => {
+      async function myAsyncFunc(a: number, b: number): Promise<number> {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return a + b;
+      }
+
+      const tracedFunc = mlflow.trace(myAsyncFunc, {
+        name: 'async_span',
+        spanType: SpanType.CHAIN
+      });
+
+      const result = await tracedFunc(10, 20);
+      expect(result).toBe(30);
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.state).toBe('OK');
+      expect(trace.data.spans.length).toBe(1);
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.name).toBe('async_span');
+      expect(loggedSpan.spanType).toBe(SpanType.CHAIN);
+      expect(loggedSpan.inputs).toEqual({ a: 10, b: 20 });
+      expect(loggedSpan.outputs).toEqual(30);
+      expect(loggedSpan.startTime).toBeDefined();
+      expect(loggedSpan.endTime).toBeDefined();
+    });
+
+    it('should support inline function declaration', async () => {
+      const myFunc = mlflow.trace(
+        function myInlineFunc(a: number, b: number) {
+          return a + b;
+        },
+        { spanType: SpanType.AGENT }
+      );
+
+      const result = myFunc(3, 4);
+      expect(result).toBe(7);
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.state).toBe('OK');
+      expect(trace.data.spans.length).toBe(1);
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.name).toBe('myInlineFunc');
+      expect(loggedSpan.spanType).toBe(SpanType.AGENT);
+      expect(loggedSpan.inputs).toEqual({ a: 3, b: 4 });
+      expect(loggedSpan.outputs).toEqual(7);
+      expect(loggedSpan.startTime).toBeDefined();
+      expect(loggedSpan.endTime).toBeDefined();
+    });
+
+    it('should support inline async function', async () => {
+      const myFunc = mlflow.trace(
+        async (prompt: string) => {
+          await new Promise((resolve) => setTimeout(resolve, 5));
+          return `Response to: ${prompt}`;
+        },
+        { spanType: SpanType.LLM }
+      );
+
+      const result = await myFunc('Hello');
+      expect(result).toBe('Response to: Hello');
+
+      const trace = await getLastActiveTrace();
+      expect(trace.info.state).toBe('OK');
+      expect(trace.data.spans.length).toBe(1);
+
+      const loggedSpan = trace.data.spans[0];
+      expect(loggedSpan.name).toBe('span'); // arrow function doesn't have a name
+      expect(loggedSpan.spanType).toBe(SpanType.LLM);
+      expect(loggedSpan.inputs).toEqual({ prompt: 'Hello' });
+      expect(loggedSpan.outputs).toEqual('Response to: Hello');
+      expect(loggedSpan.startTime).toBeDefined();
+      expect(loggedSpan.endTime).toBeDefined();
+    });
+  });
+
+  it('should handle synchronous errors in the traced function', async () => {
+    const errorFunc = mlflow.trace(() => {
+      throw new Error('Test error');
+    });
+
+    expect(() => errorFunc()).toThrow('Test error');
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('ERROR');
+    expect(trace.data.spans.length).toBe(1);
+
+    const loggedSpan = trace.data.spans[0];
+    expect(loggedSpan.name).toBe('span'); // arrow function doesn't have a name
+    expect(loggedSpan.inputs).toEqual({});
+    expect(loggedSpan.outputs).toBeUndefined();
+    expect(loggedSpan.startTime).toBeDefined();
+    expect(loggedSpan.endTime).toBeDefined();
+    expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.ERROR);
+  });
+
+  it('should handle async errors in the traced function', async () => {
+    const errorFunc = mlflow.trace(
+      async () => {
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        throw new Error('Async test error');
+      },
+      { name: 'async_error_span', spanType: SpanType.LLM }
+    );
+
+    await expect(errorFunc()).rejects.toThrow('Async test error');
+
+    const trace = await getLastActiveTrace();
+    expect(trace.info.state).toBe('ERROR');
+    expect(trace.data.spans.length).toBe(1);
+
+    const loggedSpan = trace.data.spans[0];
+    expect(loggedSpan.name).toBe('async_error_span');
+    expect(loggedSpan.spanType).toBe(SpanType.LLM);
+    expect(loggedSpan.inputs).toEqual({});
+    expect(loggedSpan.outputs).toBeUndefined();
+    expect(loggedSpan.startTime).toBeDefined();
+    expect(loggedSpan.endTime).toBeDefined();
+    expect(loggedSpan.status?.statusCode).toBe(SpanStatusCode.ERROR);
   });
 });

--- a/packages/typescript/tests/core/utils/index.test.ts
+++ b/packages/typescript/tests/core/utils/index.test.ts
@@ -5,21 +5,34 @@ import {
   encodeSpanIdToBase64,
   encodeTraceIdToBase64,
   decodeIdFromBase64,
-  deduplicateSpanNamesInPlace
+  deduplicateSpanNamesInPlace,
+  mapArgsToObject
 } from '../../../src/core/utils';
 import { createTestSpan } from '../../helper';
 import { LiveSpan } from '../../../src/core/entities/span';
 
 describe('utils', () => {
   describe('convertNanoSecondsToHrTime', () => {
-    it('should convert small nanosecond values correctly', () => {
-      const result = convertNanoSecondsToHrTime(123456789);
-      expect(result).toEqual([0, 123456789]);
-    });
-
-    it('should convert values exactly at 1 second', () => {
-      const result = convertNanoSecondsToHrTime(1_000_000_000);
-      expect(result).toEqual([1, 0]);
+    // Using table-driven tests with test.each for time conversion
+    test.each([
+      {
+        description: 'small nanosecond values',
+        input: 123456789,
+        expected: [0, 123456789]
+      },
+      {
+        description: 'values exactly at 1 second',
+        input: 1_000_000_000,
+        expected: [1, 0]
+      },
+      {
+        description: 'zero',
+        input: 0,
+        expected: [0, 0]
+      }
+    ])('should convert $description correctly', ({ input, expected }) => {
+      const result = convertNanoSecondsToHrTime(input);
+      expect(result).toEqual(expected);
     });
 
     it('should convert large nanosecond values correctly', () => {
@@ -32,11 +45,6 @@ describe('utils', () => {
       expect(result[0]).toBe(seconds);
       // Due to precision loss in the calculation above
       expect(result[1]).toBe(123456768);
-    });
-
-    it('should handle zero', () => {
-      const result = convertNanoSecondsToHrTime(0);
-      expect(result).toEqual([0, 0]);
     });
 
     it('should handle maximum safe integer', () => {
@@ -85,29 +93,15 @@ describe('utils', () => {
   });
 
   describe('encodeSpanIdToBase64', () => {
-    it('should encode a standard 16-character hex span ID', () => {
-      const spanId = '0123456789abcdef';
+    // Using array syntax for test.each (alternative to object syntax)
+    test.each([
+      ['standard 16-character hex span ID', '0123456789abcdef', 'ASNFZ4mrze8='],
+      ['short span IDs with zero padding', 'abc', 'AAAAAAAACrw='],
+      ['all zeros', '0000000000000000', 'AAAAAAAAAAA='],
+      ['all F characters', 'ffffffffffffffff', '//////////8=']
+    ])('should encode %s', (description, spanId, expected) => {
       const result = encodeSpanIdToBase64(spanId);
-      expect(result).toBe('ASNFZ4mrze8=');
-    });
-
-    it('should pad short span IDs with zeros', () => {
-      const spanId = 'abc';
-      const result = encodeSpanIdToBase64(spanId);
-      // Should be padded to '0000000000000abc'
-      expect(result).toBe('AAAAAAAACrw=');
-    });
-
-    it('should handle all zeros', () => {
-      const spanId = '0000000000000000';
-      const result = encodeSpanIdToBase64(spanId);
-      expect(result).toBe('AAAAAAAAAAA=');
-    });
-
-    it('should handle all F characters', () => {
-      const spanId = 'ffffffffffffffff';
-      const result = encodeSpanIdToBase64(spanId);
-      expect(result).toBe('//////////8=');
+      expect(result).toBe(expected);
     });
 
     it('should handle mixed case hex strings', () => {
@@ -342,5 +336,122 @@ describe('deduplicateSpanNamesInPlace', () => {
 
     expect(() => deduplicateSpanNamesInPlace(spans)).not.toThrow();
     expect(spans.length).toBe(0);
+  });
+});
+
+describe('mapArgsToObject', () => {
+  // Basic argument mapping test cases
+  test.each([
+    {
+      description: 'regular functions',
+      func: function add(a: number, b: number) {
+        return a + b;
+      },
+      args: [5, 10],
+      expected: { a: 5, b: 10 }
+    },
+    {
+      description: 'arrow functions',
+      func: (x: number, y: number) => x * y,
+      args: [3, 4],
+      expected: { x: 3, y: 4 }
+    },
+    {
+      description: 'single parameter functions',
+      func: (value: number) => value * 2,
+      args: [7],
+      expected: { value: 7 }
+    },
+    {
+      description: 'functions with no parameters',
+      func: () => 42,
+      args: [],
+      expected: {}
+    },
+    {
+      description: 'functions with default parameters',
+      func: function withDefaults(name: string, greeting: string = 'Hello') {
+        return greeting + ' ' + name;
+      },
+      args: ['World'],
+      expected: { name: 'World' }
+    },
+    {
+      description: 'functions with type annotations',
+      func: function typed(id: number, name: string, active: boolean) {
+        return { id, name, active };
+      },
+      args: [123, 'John', true],
+      expected: { id: 123, name: 'John', active: true }
+    },
+    {
+      description: 'anonymous functions',
+      func: function (first: string, second: number) {
+        return first + second;
+      },
+      args: ['hello', 42],
+      expected: { first: 'hello', second: 42 }
+    },
+    {
+      description: 'fewer arguments than parameters',
+      func: function threeParams(a: number, b: number, c: number) {
+        return a + b + c;
+      },
+      args: [1, 2],
+      expected: { a: 1, b: 2 }
+    },
+    {
+      description: 'more arguments than parameters',
+      func: function twoParams(a: number, b: number) {
+        return a + b;
+      },
+      args: [1, 2, 3, 4],
+      expected: { a: 1, b: 2 }
+    },
+    {
+      description: 'complex argument types (objects, arrays)',
+      func: function complex(obj: object, arr: any[], str: string) {
+        return { obj, arr, str };
+      },
+      args: [{ key: 'value' }, [1, 2, 3], 'test'],
+      expected: { obj: { key: 'value' }, arr: [1, 2, 3], str: 'test' }
+    },
+    {
+      description: 'null and undefined arguments',
+      func: function nullable(a: any, b: any, c: any) {
+        return a + b + c;
+      },
+      args: [null, undefined, 'value'],
+      expected: { a: null, b: undefined, c: 'value' }
+    },
+    {
+      description: 'functions with destructured parameters gracefully',
+      func: function withDestructuring({ prop }: any, normal: string) {
+        return prop + normal;
+      },
+      args: [{ prop: 'value' }, 'normal'],
+      expected: { normal: { prop: 'value' } }
+    },
+    {
+      description: 'fallback to args array when parameter extraction fails',
+      func: new Function('return arguments[0] + arguments[1];'),
+      args: [1, 2],
+      expected: { args: [1, 2] }
+    },
+    {
+      description: 'empty object for no parameters and no arguments',
+      func: () => {},
+      args: [],
+      expected: {}
+    },
+    {
+      description: 'edge case with only whitespace parameters',
+      func: () => {},
+      args: [],
+      expected: {}
+    }
+  ])('should handle $description', ({ func, args, expected }) => {
+    const result = mapArgsToObject(func, args);
+    expect(result).toEqual(expected);
   });
 });

--- a/packages/typescript/tests/core/utils/index.test.ts
+++ b/packages/typescript/tests/core/utils/index.test.ts
@@ -419,6 +419,7 @@ describe('mapArgsToObject', () => {
     {
       description: 'null and undefined arguments',
       func: function nullable(a: any, b: any, c: any) {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return a + b + c;
       },
       args: [null, undefined, 'value'],
@@ -434,6 +435,7 @@ describe('mapArgsToObject', () => {
     },
     {
       description: 'fallback to args array when parameter extraction fails',
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
       func: new Function('return arguments[0] + arguments[1];'),
       args: [1, 2],
       expected: { args: [1, 2] }
@@ -449,6 +451,12 @@ describe('mapArgsToObject', () => {
       func: () => {},
       args: [],
       expected: {}
+    },
+    {
+      description: 'functions with object destructuring parameters (JS/TS kwarg-only pattern)',
+      func: ({ a, b }: { a: number; b: number }) => a + b,
+      args: [{ a: 5, b: 10 }],
+      expected: { args: [{ a: 5, b: 10 }] }
     }
   ])('should handle $description', ({ func, args, expected }) => {
     const result = mapArgsToObject(func, args);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16567?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16567/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16567/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16567/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Support `mlflow.trace` API that allow users to wrap a function to create a trace.

Example 1:
```
const myFunc = (a: number, b: number) => a + b;

const tracedMyFunc = mlflow.trace(myFunc, { spanType: SpanType.LLM });

// This creates a span with name "myFunc" that captures inputs, outputs, latency, and exception.
tracedMyFunc(1, 2);
```

Example 2 (inline function):
```
const myFunc = mlflow.trace(
  async (prompt: string) => {
    await new Promise((resolve) => setTimeout(resolve, 5));
    return `Response to: ${prompt}`;
  },
  { spanType: SpanType.LLM }
);
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
