### PR TITLE
Add span size stats in trace metadata

### DIFF
--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -38,7 +38,10 @@ class TokenUsageKey:
 class TraceSizeStatsKey:
     TOTAL_SIZE_BYTES = "total_size_bytes"
     NUM_SPANS = "num_spans"
-    MAX_SPAN_SIZE_BYTES = "max_span_size_bytes"
+    MAX_SPAN_SIZE_BYTES = "max"
+    P25_SPAN_SIZE_BYTES = "p25"
+    P50_SPAN_SIZE_BYTES = "p50"
+    P75_SPAN_SIZE_BYTES = "p75"
 
 
 # A set of reserved attribute keys

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -4,7 +4,8 @@ class TraceMetadataKey:
     OUTPUTS = "mlflow.traceOutputs"
     SOURCE_RUN = "mlflow.sourceRun"
     MODEL_ID = "mlflow.modelId"
-    SIZE_BYTES = "mlflow.trace.sizeBytes"
+    # Trace size statistics including total size, number of spans, and max span size
+    SIZE_STATS = "mlflow.trace.sizeStats"
     # Aggregated token usage information in a single trace, stored as a dumped JSON string.
     TOKEN_USAGE = "mlflow.trace.tokenUsage"
     # Store the user ID/name of the application request. Do not confuse this with mlflow.user
@@ -12,6 +13,9 @@ class TraceMetadataKey:
     TRACE_USER = "mlflow.trace.user"
     # Store the session ID of the application request.
     TRACE_SESSION = "mlflow.trace.session"
+
+    # Total size of the trace in bytes. Deprecated, use SIZE_STATS instead.
+    SIZE_BYTES = "mlflow.trace.sizeBytes"
 
 
 class TraceTagKey:
@@ -29,6 +33,12 @@ class TokenUsageKey:
     @classmethod
     def all_keys(cls):
         return [cls.INPUT_TOKENS, cls.OUTPUT_TOKENS, cls.TOTAL_TOKENS]
+
+
+class TraceSizeStatsKey:
+    TOTAL_SIZE_BYTES = "total_size_bytes"
+    NUM_SPANS = "num_spans"
+    MAX_SPAN_SIZE_BYTES = "max_span_size_bytes"
 
 
 # A set of reserved attribute keys

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -17,7 +17,7 @@ from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
 from mlflow.tracing.export.utils import try_link_prompts_to_trace
 from mlflow.tracing.fluent import _set_last_active_trace_id
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.utils import add_size_bytes_to_trace_metadata
+from mlflow.tracing.utils import add_size_stats_to_trace_metadata
 
 _logger = logging.getLogger(__name__)
 
@@ -119,10 +119,7 @@ class InferenceTableSpanExporter(SpanExporter):
                     )
 
     def _log_trace_to_mlflow_backend(self, trace: Trace, prompts: Sequence[PromptVersion]):
-        try:
-            add_size_bytes_to_trace_metadata(trace)
-        except Exception:
-            _logger.warning("Failed to add size bytes to trace metadata.", exc_info=True)
+        add_size_stats_to_trace_metadata(trace)
 
         returned_trace_info = self._client.start_trace(trace.info)
         self._client._upload_trace_data(returned_trace_info, trace.data)

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -102,7 +102,7 @@ class MlflowV3SpanExporter(SpanExporter):
             # minorly affected), so we don't have to await successful linking
             try_link_prompts_to_trace(
                 client=self._client,
-                trace_id=returned_trace_info.trace_id,
+                trace_id=trace.info.trace_id,
                 prompts=prompts,
                 synchronous=False,
             )

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -16,7 +16,7 @@ from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
 from mlflow.tracing.export.utils import try_link_prompts_to_trace
 from mlflow.tracing.fluent import _EVAL_REQUEST_ID_TO_TRACE_ID, _set_last_active_trace_id
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.utils import add_size_bytes_to_trace_metadata, maybe_get_request_id
+from mlflow.tracing.utils import add_size_stats_to_trace_metadata, maybe_get_request_id
 from mlflow.utils.databricks_utils import is_in_databricks_notebook
 from mlflow.utils.uri import is_databricks_uri
 
@@ -87,26 +87,27 @@ class MlflowV3SpanExporter(SpanExporter):
         """
         try:
             if trace:
-                try:
-                    add_size_bytes_to_trace_metadata(trace)
-                except Exception:
-                    _logger.warning("Failed to add size bytes to trace metadata.", exc_info=True)
+                add_size_stats_to_trace_metadata(trace)
                 returned_trace_info = self._client.start_trace(trace.info)
                 self._client._upload_trace_data(returned_trace_info, trace.data)
-                # Always run prompt linking asynchronously since (1) prompt linking API calls
-                # would otherwise add latency to the export procedure and (2) prompt linking is not
-                # critical for trace export (if the prompt fails to link, the user's workflow is
-                # minorly affected), so we don't have to await successful linking
-                try_link_prompts_to_trace(
-                    client=self._client,
-                    trace_id=returned_trace_info.trace_id,
-                    prompts=prompts,
-                    synchronous=False,
-                )
             else:
                 _logger.warning("No trace or trace info provided, unable to export")
         except Exception as e:
             _logger.warning(f"Failed to send trace to MLflow backend: {e}")
+
+        try:
+            # Always run prompt linking asynchronously since (1) prompt linking API calls
+            # would otherwise add latency to the export procedure and (2) prompt linking is not
+            # critical for trace export (if the prompt fails to link, the user's workflow is
+            # minorly affected), so we don't have to await successful linking
+            try_link_prompts_to_trace(
+                client=self._client,
+                trace_id=returned_trace_info.trace_id,
+                prompts=prompts,
+                synchronous=False,
+            )
+        except Exception as e:
+            _logger.warning(f"Failed to link prompts to trace: {e}")
 
     def _should_enable_async_logging(self):
         if (

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -516,25 +516,25 @@ def set_chat_attributes_special_case(span: LiveSpan, inputs: Any, outputs: Any):
 def _calculate_percentile(sorted_data: list[float], percentile: float) -> float:
     """
     Calculate the percentile value from sorted data.
-    
+
     Args:
         sorted_data: A sorted list of numeric values
         percentile: The percentile to calculate (e.g., 0.25 for 25th percentile)
-    
+
     Returns:
         The percentile value
     """
     if not sorted_data:
         return 0.0
-    
+
     n = len(sorted_data)
     index = percentile * (n - 1)
     lower = int(index)
     upper = lower + 1
-    
+
     if upper >= n:
         return sorted_data[-1]
-    
+
     # Linear interpolation between two nearest values
     weight = index - lower
     return sorted_data[lower] * (1 - weight) + sorted_data[upper] * weight
@@ -568,17 +568,23 @@ def add_size_stats_to_trace_metadata(trace: Trace):
 
         # NB: len(span_sizes) *2 count the size of comma separators between spans (", ").
         trace_size_bytes = sum(span_sizes) + metadata_size + (len(span_sizes) - 1) * 2
-        
+
         # Sort span sizes for percentile calculation
         sorted_span_sizes = sorted(span_sizes)
-        
+
         size_stats = {
             TraceSizeStatsKey.TOTAL_SIZE_BYTES: trace_size_bytes,
             TraceSizeStatsKey.NUM_SPANS: len(span_sizes),
             TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES: max(span_sizes),
-            TraceSizeStatsKey.P25_SPAN_SIZE_BYTES: int(_calculate_percentile(sorted_span_sizes, 0.25)),
-            TraceSizeStatsKey.P50_SPAN_SIZE_BYTES: int(_calculate_percentile(sorted_span_sizes, 0.50)),
-            TraceSizeStatsKey.P75_SPAN_SIZE_BYTES: int(_calculate_percentile(sorted_span_sizes, 0.75)),
+            TraceSizeStatsKey.P25_SPAN_SIZE_BYTES: int(
+                _calculate_percentile(sorted_span_sizes, 0.25)
+            ),
+            TraceSizeStatsKey.P50_SPAN_SIZE_BYTES: int(
+                _calculate_percentile(sorted_span_sizes, 0.50)
+            ),
+            TraceSizeStatsKey.P75_SPAN_SIZE_BYTES: int(
+                _calculate_percentile(sorted_span_sizes, 0.75)
+            ),
         }
 
         trace.info.trace_metadata[TraceMetadataKey.SIZE_STATS] = json.dumps(size_stats)

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -21,6 +21,7 @@ from mlflow.tracing.constant import (
     SpanAttributeKey,
     TokenUsageKey,
     TraceMetadataKey,
+    TraceSizeStatsKey,
 )
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
 from mlflow.version import IS_TRACING_SDK_ONLY
@@ -512,17 +513,45 @@ def set_chat_attributes_special_case(span: LiveSpan, inputs: Any, outputs: Any):
         pass
 
 
-def add_size_bytes_to_trace_metadata(trace: Trace):
+def add_size_stats_to_trace_metadata(trace: Trace):
     """
-    Calculate the size of the trace in bytes and add it as a tag to the trace.
+    Calculate the stats of trace and span sizes and add it as a metadata to the trace.
 
     This method modifies the trace object in place by adding a new tag.
 
     Note: For simplicity, we calculate the size without considering the size metadata itself.
     This provides a close approximation without requiring complex calculations.
+
+    This function must not throw an exception.
     """
-    trace_size_bytes = len(trace.to_json().encode("utf-8"))
-    trace.info.trace_metadata[TraceMetadataKey.SIZE_BYTES] = str(trace_size_bytes)
+    from mlflow.entities import Trace, TraceData
+
+    try:
+        span_sizes = []
+        for span in trace.data.spans:
+            span_json = json.dumps(span.to_dict(), cls=TraceJSONEncoder)
+            span_sizes.append(len(span_json.encode("utf-8")))
+
+        # NB: To compute the size of the total trace, we need to include the size of the
+        # the trace info and the parent dicts for the spans. To avoid serializing spans
+        # again (which can be expensive), we compute the size of the trace without spans
+        # and combine it with the total size of the spans.
+        empty_trace = Trace(info=trace.info, data=TraceData(spans=[]))
+        metadata_size = len(empty_trace.to_json().encode("utf-8"))
+
+        # NB: len(span_sizes) *2 count the size of comma separators between spans (", ").
+        trace_size_bytes = sum(span_sizes) + metadata_size + (len(span_sizes) - 1) * 2
+        size_stats = {
+            TraceSizeStatsKey.TOTAL_SIZE_BYTES: trace_size_bytes,
+            TraceSizeStatsKey.NUM_SPANS: len(span_sizes),
+            TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES: max(span_sizes),
+        }
+
+        trace.info.trace_metadata[TraceMetadataKey.SIZE_STATS] = json.dumps(size_stats)
+        # Keep the total size as a separate metadata for backward compatibility
+        trace.info.trace_metadata[TraceMetadataKey.SIZE_BYTES] = str(trace_size_bytes)
+    except Exception:
+        _logger.warning("Failed to add size stats to trace metadata.", exc_info=True)
 
 
 def update_trace_state_from_span_conditionally(trace, root_span):

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -513,6 +513,33 @@ def set_chat_attributes_special_case(span: LiveSpan, inputs: Any, outputs: Any):
         pass
 
 
+def _calculate_percentile(sorted_data: list[float], percentile: float) -> float:
+    """
+    Calculate the percentile value from sorted data.
+    
+    Args:
+        sorted_data: A sorted list of numeric values
+        percentile: The percentile to calculate (e.g., 0.25 for 25th percentile)
+    
+    Returns:
+        The percentile value
+    """
+    if not sorted_data:
+        return 0.0
+    
+    n = len(sorted_data)
+    index = percentile * (n - 1)
+    lower = int(index)
+    upper = lower + 1
+    
+    if upper >= n:
+        return sorted_data[-1]
+    
+    # Linear interpolation between two nearest values
+    weight = index - lower
+    return sorted_data[lower] * (1 - weight) + sorted_data[upper] * weight
+
+
 def add_size_stats_to_trace_metadata(trace: Trace):
     """
     Calculate the stats of trace and span sizes and add it as a metadata to the trace.
@@ -541,10 +568,17 @@ def add_size_stats_to_trace_metadata(trace: Trace):
 
         # NB: len(span_sizes) *2 count the size of comma separators between spans (", ").
         trace_size_bytes = sum(span_sizes) + metadata_size + (len(span_sizes) - 1) * 2
+        
+        # Sort span sizes for percentile calculation
+        sorted_span_sizes = sorted(span_sizes)
+        
         size_stats = {
             TraceSizeStatsKey.TOTAL_SIZE_BYTES: trace_size_bytes,
             TraceSizeStatsKey.NUM_SPANS: len(span_sizes),
             TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES: max(span_sizes),
+            TraceSizeStatsKey.P25_SPAN_SIZE_BYTES: int(_calculate_percentile(sorted_span_sizes, 0.25)),
+            TraceSizeStatsKey.P50_SPAN_SIZE_BYTES: int(_calculate_percentile(sorted_span_sizes, 0.50)),
+            TraceSizeStatsKey.P75_SPAN_SIZE_BYTES: int(_calculate_percentile(sorted_span_sizes, 0.75)),
         }
 
         trace.info.trace_metadata[TraceMetadataKey.SIZE_STATS] = json.dumps(size_stats)

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -566,7 +566,7 @@ def add_size_stats_to_trace_metadata(trace: Trace):
         empty_trace = Trace(info=trace.info, data=TraceData(spans=[]))
         metadata_size = len(empty_trace.to_json().encode("utf-8"))
 
-        # NB: len(span_sizes) *2 count the size of comma separators between spans (", ").
+        # NB: the third term is the size of comma separators between spans (", ").
         trace_size_bytes = sum(span_sizes) + metadata_size + (len(span_sizes) - 1) * 2
 
         # Sort span sizes for percentile calculation

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -94,6 +94,7 @@ def test_json_deserialization(monkeypatch):
                 "mlflow.source.git.repoURL": mock.ANY,
                 "mlflow.user": mock.ANY,
                 "mlflow.trace.sizeBytes": mock.ANY,
+                "mlflow.trace.sizeStats": mock.ANY,
             },
             "tags": {
                 "mlflow.traceName": "predict",

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -208,9 +208,19 @@ def test_size_bytes_in_trace_sent_to_mlflow_backend(monkeypatch):
     assert TraceSizeStatsKey.P75_SPAN_SIZE_BYTES in size_stats
 
     # With only one span, all percentiles should equal the max span size
-    assert size_stats[TraceSizeStatsKey.P25_SPAN_SIZE_BYTES] == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
-    assert size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES] == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
-    assert size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES] == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    assert (
+        size_stats[TraceSizeStatsKey.P25_SPAN_SIZE_BYTES]
+        == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    )
+    assert (
+        size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES]
+        == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    )
+    assert (
+        size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES]
+        == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    )
+
 
 def test_prompt_linking_with_dual_write(monkeypatch):
     """Test that prompts are correctly linked when dual write to MLflow backend is enabled."""

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -202,6 +202,15 @@ def test_size_bytes_in_trace_sent_to_mlflow_backend(monkeypatch):
     assert size_stats[TraceSizeStatsKey.NUM_SPANS] == 1
     assert size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES] > 0
 
+    # Verify percentile stats are included
+    assert TraceSizeStatsKey.P25_SPAN_SIZE_BYTES in size_stats
+    assert TraceSizeStatsKey.P50_SPAN_SIZE_BYTES in size_stats
+    assert TraceSizeStatsKey.P75_SPAN_SIZE_BYTES in size_stats
+
+    # With only one span, all percentiles should equal the max span size
+    assert size_stats[TraceSizeStatsKey.P25_SPAN_SIZE_BYTES] == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    assert size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES] == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    assert size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES] == size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
 
 def test_prompt_linking_with_dual_write(monkeypatch):
     """Test that prompts are correctly linked when dual write to MLflow backend is enabled."""

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -101,7 +101,21 @@ def test_export(is_async, monkeypatch):
     assert size_stats[TraceSizeStatsKey.TOTAL_SIZE_BYTES] == expected_size_bytes
     assert size_stats[TraceSizeStatsKey.NUM_SPANS] == 2
     assert size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES] > 0
-    assert size_stats is None
+
+    # Verify percentile stats are included
+    assert TraceSizeStatsKey.P25_SPAN_SIZE_BYTES in size_stats
+    assert TraceSizeStatsKey.P50_SPAN_SIZE_BYTES in size_stats
+    assert TraceSizeStatsKey.P75_SPAN_SIZE_BYTES in size_stats
+
+    # Verify percentiles are valid integers
+    assert isinstance(size_stats[TraceSizeStatsKey.P25_SPAN_SIZE_BYTES], int)
+    assert isinstance(size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES], int)
+    assert isinstance(size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES], int)
+
+    # Verify percentile ordering: P25 <= P50 <= P75 <= max
+    assert size_stats[TraceSizeStatsKey.P25_SPAN_SIZE_BYTES] <= size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES]
+    assert size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES] <= size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES]
+    assert size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES] <= size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
 
     # Validate the data was passed to upload_trace_data
     call_args = mock_upload_trace_data.call_args

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -241,7 +241,6 @@ def test_prompt_linking_in_mlflow_v3_exporter(is_async, monkeypatch):
     with (
         mock.patch(
             "mlflow.tracing.client.TracingClient.start_trace",
-            return_value=mock.MagicMock(trace_id="test-trace-id"),
         ) as mock_start_trace,
         mock.patch(
             "mlflow.tracing.client.TracingClient._upload_trace_data", return_value=None
@@ -315,7 +314,7 @@ def test_prompt_linking_in_mlflow_v3_exporter(is_async, monkeypatch):
     assert prompt_names == {"test_prompt_1", "test_prompt_2"}
 
     # Verify the trace ID matches
-    assert captured_trace_id == "test-trace-id"
+    assert captured_trace_id == trace_id
 
     # Verify other client methods were also called
     mock_start_trace.assert_called_once()

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -113,9 +113,18 @@ def test_export(is_async, monkeypatch):
     assert isinstance(size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES], int)
 
     # Verify percentile ordering: P25 <= P50 <= P75 <= max
-    assert size_stats[TraceSizeStatsKey.P25_SPAN_SIZE_BYTES] <= size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES]
-    assert size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES] <= size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES]
-    assert size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES] <= size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    assert (
+        size_stats[TraceSizeStatsKey.P25_SPAN_SIZE_BYTES]
+        <= size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES]
+    )
+    assert (
+        size_stats[TraceSizeStatsKey.P50_SPAN_SIZE_BYTES]
+        <= size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES]
+    )
+    assert (
+        size_stats[TraceSizeStatsKey.P75_SPAN_SIZE_BYTES]
+        <= size_stats[TraceSizeStatsKey.MAX_SPAN_SIZE_BYTES]
+    )
 
     # Validate the data was passed to upload_trace_data
     call_args = mock_upload_trace_data.call_args


### PR DESCRIPTION
### What changes are proposed in this pull request?

Currently, trace metadata includes the total size of the trace, which is useful for backend management.

This PR adds a few more extra values to the metadata
- Number of spans
- Max span size
- Percentile of span size (P25, P50, P75)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
