### PR TITLE
Deprecate mlflow.transformers.generate_signature_output

### DIFF
--- a/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
+++ b/docs/docs/classic-ml/deep-learning/transformers/guide/index.mdx
@@ -171,22 +171,13 @@ import transformers
 # Read a pre-trained conversation pipeline from HuggingFace hub
 conversational_pipeline = transformers.pipeline(model="microsoft/DialoGPT-medium")
 
-# Define the signature
-signature = mlflow.models.infer_signature(
-    "Hi there, chatbot!",
-    mlflow.transformers.generate_signature_output(
-        conversational_pipeline, "Hi there, chatbot!"
-    ),
-)
-
 # Log the pipeline
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=conversational_pipeline,
         name="chatbot",
         task="conversational",
-        signature=signature,
-        input_example="A clever and witty question",
+        input_example="Hi there, chatbot!",  # Signature is inferred from input_example
     )
 
 # Load the saved pipeline as pyfunc
@@ -292,7 +283,7 @@ per each of the samples.
 ```python
 import mlflow
 from mlflow.models import infer_signature
-from mlflow.transformers import generate_signature_output
+# generate_signature_output is deprecated
 import transformers
 
 architecture = "mrm8488/t5-base-finetuned-common_gen"
@@ -302,12 +293,6 @@ model = transformers.pipeline(
     model=transformers.T5ForConditionalGeneration.from_pretrained(architecture),
 )
 data = "pencil draw paper"
-
-# Infer the signature
-signature = infer_signature(
-    data,
-    generate_signature_output(model, data),
-)
 
 # Define an model_config
 model_config = {
@@ -322,7 +307,7 @@ mlflow.transformers.save_model(
     model,
     path="text2text",
     model_config=model_config,
-    signature=signature,
+    input_example=data,  # Signature is inferred from input_example
 )
 
 pyfunc_loaded = mlflow.pyfunc.load_model("text2text")
@@ -345,7 +330,7 @@ when calling `predict`.
 ```python
 import mlflow
 from mlflow.models import infer_signature
-from mlflow.transformers import generate_signature_output
+# generate_signature_output is deprecated
 import transformers
 
 architecture = "mrm8488/t5-base-finetuned-common_gen"
@@ -368,19 +353,12 @@ inference_params = {
     "do_sample": True,
 }
 
-# Infer the signature including params
-signature_with_params = infer_signature(
-    data,
-    generate_signature_output(model, data),
-    params=inference_params,
-)
-
 # Saving model with signature and model config
 mlflow.transformers.save_model(
     model,
     path="text2text",
     model_config=model_config,
-    signature=signature_with_params,
+    input_example=(data, inference_params),  # Signature is inferred from input_example tuple
 )
 
 pyfunc_loaded = mlflow.pyfunc.load_model("text2text")
@@ -570,11 +548,9 @@ Model license information was introduced in **MLflow 2.10.0**. Previous versions
 
 For pipelines that support `pyfunc`, there are 3 means of attaching a model signature to the `MLmodel` file.
 
-- Provide a model signature explicitly via setting a valid `ModelSignature` to the `signature` attribute. This can be generated via the helper utility <APILink fn="mlflow.transformers.generate_signature_output" />
-
-- Provide an `input_example`. The signature will be inferred and validated that it matches the appropriate input type. The output type will be validated by performing inference automatically (if the model is a `pyfunc` supported type).
-
-- Do nothing. The `transformers` flavor will automatically apply the appropriate general signature that the pipeline type supports (only for a single-entity; collections will not be inferred).
+- Provide a model signature explicitly via setting a valid `ModelSignature` to the `signature` attribute.
+- Provide an `input_example`. The signature will be inferred. If the model accepts inference parameters (e.g., `max_length`, `temperature`), you can provide `input_example` as a tuple: `(your_input_data, your_parameters_dict)` to include these parameters in the inferred signature.
+- Do nothing. The `transformers` flavor will automatically apply the appropriate general signature that the pipeline type supports (only for a single-entity; collections will not be inferred). The utility `mlflow.transformers.generate_signature_output` was previously available to help generate outputs for explicit signature creation but is now deprecated in favor of using `input_example`.
 
 ## Scale Inference with Overriding Pytorch dtype \{#scalability-for-inference}
 
@@ -718,15 +694,15 @@ An example of specifying an appropriate uri-based input model signature for an a
 
 ```python
 from mlflow.models import infer_signature
-from mlflow.transformers import generate_signature_output
+# generate_signature_output is deprecated
 
 url = "https://www.mywebsite.com/sound/files/for/transcription/file111.mp3"
-signature = infer_signature(url, generate_signature_output(my_audio_pipeline, url))
+# Signature is inferred from input_example in log_model
 with mlflow.start_run():
     mlflow.transformers.log_model(
         transformers_model=my_audio_pipeline,
         name="my_transcriber",
-        signature=signature,
+        input_example=url,
     )
 ```
 

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/audio-transcription/whisper.ipynb
@@ -266,7 +266,8 @@
     ")\n",
     "\n",
     "# Visualize the signature\n",
-    "signature"
+    "# The signature is now inferred directly in log_model from input_example and model_config (params)\n",
+    "# You can inspect the logged model's signature via model_info.signature if needed after logging."
    ]
   },
   {
@@ -315,13 +316,13 @@
     "\n",
     "#### Key Components of Model Logging\n",
     "\n",
-    "- **Model Information**: Includes the model, its signature, and an input example.\n",
-    "- **Model Configuration**: Any specific parameters set for the model, like *chunk length* or *stride length*.\n",
+    "- **Model Information**: Includes the model, its signature (inferred from `input_example`), and an input example.\n",
+    "- **Model Configuration**: Any specific parameters set for the model, like *chunk length* or *stride length* (used for signature inference if part of `input_example`).\n",
     "\n",
     "#### Using MLflow's `log_model` Function\n",
     "This function is utilized within an MLflow run to log the model and its configurations. It ensures that all necessary components for model usage are recorded.\n",
     "\n",
-    "Executing the code in the next cell will log the Whisper model in the current MLflow experiment. This includes storing the model in a specified artifact path and documenting the default configurations that will be applied during inference."
+    "Executing the code in the next cell will log the Whisper model in the current MLflow experiment. This includes storing the model in a specified artifact path and documenting the default configurations that will be applied during inference. The signature will be inferred from the `input_example` (which now includes `model_config` for params)."
    ]
   },
   {
@@ -335,9 +336,11 @@
     "    model_info = mlflow.transformers.log_model(\n",
     "        transformers_model=audio_transcription_pipeline,\n",
     "        name=\"whisper_transcriber\",\n",
-    "        signature=signature,\n",
-    "        input_example=audio,\n",
-    "        model_config=model_config,\n",
+    "        input_example=(\n",
+    "            audio,\n",
+    "            model_config,\n",
+    "        ),  # Signature is inferred from this tuple (input, params)\n",
+    "        model_config=model_config,  # model_config is still useful for other settings\n",
     "        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n",
     "        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n",
     "        # following line:\n",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/conversational/conversational-model.ipynb
@@ -75,7 +75,7 @@
     "Using the `transformers.pipeline` function, we set up a conversational pipeline. We choose the \"`microsoft/DialoGPT-medium`\" model, balancing performance and resource efficiency, ideal for conversational AI. This step is pivotal for ensuring the model is ready for interaction and integration into various applications.\n",
     "\n",
     "#### Inferring the Model Signature with MLflow\n",
-    "Model signature is key in defining how the model interacts with input data. To infer it, we use a sample input (\"`Hi there, chatbot!`\") and leverage `mlflow.transformers.generate_signature_output` to understand the model's input-output schema. This process ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n",
+    "Model signature is key in defining how the model interacts with input data. To infer the model's input-output schema, we provide a sample input (e.g., \"`Hi there, chatbot!`\") directly to `mlflow.transformers.log_model` via the `input_example` parameter. This process ensures clarity in the model's data requirements and prediction format, crucial for seamless deployment and usage.\n",
     "\n",
     "This configuration phase sets the stage for a robust conversational AI system, leveraging the strengths of DialoGPT and MLflow for efficient and effective conversational interactions."
    ]
@@ -103,11 +103,10 @@
     "# Define our pipeline, using the default configuration specified in the model card for DialoGPT-medium\n",
     "conversational_pipeline = transformers.pipeline(model=\"microsoft/DialoGPT-medium\")\n",
     "\n",
-    "# Infer the signature by providing a representnative input and the output from the pipeline inference abstraction in the transformers flavor in MLflow\n",
-    "signature = mlflow.models.infer_signature(\n",
-    "    \"Hi there, chatbot!\",\n",
-    "    mlflow.transformers.generate_signature_output(conversational_pipeline, \"Hi there, chatbot!\"),\n",
-    ")"
+    "# The signature will be inferred by MLflow during the log_model call using the input_example provided there.\n",
+    "# If you need to inspect the signature beforehand or have a more complex scenario,\n",
+    "# you could still use mlflow.models.infer_signature with a sample output if necessary,\n",
+    "# but for direct logging, relying on input_example is preferred."
    ]
   },
   {
@@ -162,8 +161,7 @@
     "- **transformers_model**: We pass our DialoGPT conversational pipeline.\n",
     "- **artifact_path**: The storage location within the MLflow run, aptly named `\"chatbot\"`.\n",
     "- **task**: Set to `\"conversational\"` to reflect the model's purpose.\n",
-    "- **signature**: The inferred model signature, dictating expected inputs and outputs.\n",
-    "- **input_example**: A sample prompt, like `\"A clever and witty question\"`, to demonstrate expected usage.\n",
+    "- **input_example**: A sample prompt, like `\"Hi there, chatbot!\"`. MLflow will use this to infer the model signature.\n",
     "\n",
     "Through this process, MLflow not only tracks our model but also organizes its metadata, facilitating future retrieval, understanding, and deployment."
    ]
@@ -179,8 +177,7 @@
     "        transformers_model=conversational_pipeline,\n",
     "        name=\"chatbot\",\n",
     "        task=\"conversational\",\n",
-    "        signature=signature,\n",
-    "        input_example=\"A clever and witty question\",\n",
+    "        input_example=\"Hi there, chatbot!\",  # Signature is inferred from this\n",
     "    )"
    ]
   },

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/fine-tuning/transformers-fine-tuning.ipynb
@@ -879,7 +879,10 @@
     "        tuned_pipeline, [\"This is a test response!\", \"So is this.\"]\n",
     "    ),\n",
     "    params=model_config,\n",
-    ")"
+    ")\n",
+    "\n",
+    "# The signature is now inferred directly in log_model from input_example and model_config (params)\n",
+    "# You can inspect the logged model's signature via model_info.signature if needed after logging."
    ]
   },
   {
@@ -903,8 +906,7 @@
     "\n",
     "   - **transformers_model**: The fine-tuned model pipeline.\n",
     "   - **artifact_path**: The path where the model artifacts will be stored.\n",
-    "   - **signature**: The inferred signature of the model, which includes input and output schemas.\n",
-    "   - **input_example**: Sample inputs to give users an idea of what input the model expects.\n",
+    "   - **input_example**: Sample inputs (and parameters if needed, as a tuple) to give users an idea of what input the model expects and from which MLflow will infer the signature.\n",
     "   - **model_config**: The configuration parameters of the model.\n",
     "\n",
     "#### Importance of Model Logging\n",
@@ -936,9 +938,8 @@
     "    model_info = mlflow.transformers.log_model(\n",
     "        transformers_model=tuned_pipeline,\n",
     "        name=\"fine_tuned\",\n",
-    "        signature=signature,\n",
-    "        input_example=[\"Pass in a string\", \"And have it mark as spam or not.\"],\n",
-    "        model_config=model_config,\n",
+    "        input_example=([\"This is a test!\", \"And this is also a test.\"], model_config),\n",
+    "        model_config=model_config,  # model_config is also used for other settings\n",
     "    )"
    ]
   },

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/prompt-templating/prompt-templating.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/prompt-templating/prompt-templating.ipynb
@@ -142,7 +142,7 @@
     "\n",
     "A model signature codifies a model's expected inputs, outputs, and inference params. MLflow enforces this signature at inference time, and will raise a helpful exception if the user input does not match up with the expected format.\n",
     "\n",
-    "Creating a signature can be done simply by calling `mlflow.models.infer_signature()`, and providing a sample input and output value. We can use `mlflow.transformers.generate_signature_output()` to easily generate a sample output. If we want to pass any additional arguments to the pipeline at inference time (e.g. `max_new_tokens` above), we can do so via `params`."
+    "The signature is typically inferred by MLflow when you log a model using `input_example`. If you provide `input_example` as a tuple `(sample_input, params_dict)`, MLflow will also infer the parameters part of the signature. The `mlflow.transformers.generate_signature_output()` function was previously used to help generate sample outputs for manual signature inference but is now deprecated."
    ]
   },
   {
@@ -178,14 +178,23 @@
     "\n",
     "sample_input = \"Tell me the largest bird\"\n",
     "params = {\"max_new_tokens\": 15}\n",
-    "signature = mlflow.models.infer_signature(\n",
+    "\n",
+    "# For demonstration: Manually inferring signature (though often not needed when logging with input_example)\n",
+    "# If you log the model with input_example=(sample_input, params), MLflow infers this automatically.\n",
+    "# The generate_signature_output function is deprecated.\n",
+    "from mlflow.models import infer_signature\n",
+    "from mlflow.transformers.signature import (\n",
+    "    generate_signature_output,\n",
+    ")  #  Importing directly as it's deprecated from mlflow.transformers directly\n",
+    "\n",
+    "signature_for_inspection = infer_signature(\n",
     "    sample_input,\n",
-    "    mlflow.transformers.generate_signature_output(generator, sample_input, params=params),\n",
+    "    generate_signature_output(generator, sample_input, params=params),\n",
     "    params=params,\n",
     ")\n",
     "\n",
-    "# visualize the signature\n",
-    "signature"
+    "# visualize the signature (for inspection)\n",
+    "signature_for_inspection"
    ]
   },
   {
@@ -196,7 +205,7 @@
     "We create a new [MLflow Experiment](https://mlflow.org/docs/latest/ml/tracking.html#experiments) so that the run we're going to log our model to does not log to the default experiment and instead has its own contextually relevant entry.\n",
     "\n",
     "### Logging the model with the prompt template\n",
-    "Logging the model using MLflow saves the model and its essential metadata so it can be efficiently tracked and versioned. We'll use `mlflow.transformers.log_model()`, which is tailored to make this process as seamless as possible. To save the prompt template, all we have to do is pass it in using the `prompt_template` keyword argument.\n",
+    "Logging the model using MLflow saves the model and its essential metadata so it can be efficiently tracked and versioned. We'll use `mlflow.transformers.log_model()`, which is tailored to make this process as seamless as possible. To save the prompt template, all we have to do is pass it in using the `prompt_template` keyword argument. The signature will be inferred from `input_example`.\n",
     "\n",
     "Two important thing to take note of:\n",
     "\n",
@@ -235,8 +244,7 @@
     "        transformers_model=generator,\n",
     "        name=\"model\",\n",
     "        task=\"text-generation\",\n",
-    "        signature=signature,\n",
-    "        input_example=\"Tell me the largest bird\",\n",
+    "        input_example=(sample_input, params),  # Signature is inferred from this tuple\n",
     "        prompt_template=prompt_template,\n",
     "        # Since MLflow 2.11.0, you can save the model in 'reference-only' mode to reduce storage usage by not saving\n",
     "        # the base model weights but only the reference to the HuggingFace model hub. To enable this, uncomment the\n",

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/text-generation/text-generation.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/text-generation/text-generation.ipynb
@@ -187,8 +187,10 @@
     "    parameters,\n",
     ")\n",
     "\n",
-    "# Visualize the signature\n",
-    "signature"
+    "# Visualize the signature (optional, as it will be inferred during log_model)\n",
+    "# signature\n",
+    "# The signature is now inferred directly in log_model from input_example and parameters.\n",
+    "# You can inspect the logged model's signature via model_info.signature if needed after logging."
    ]
   },
   {
@@ -237,7 +239,7 @@
     "\n",
     "Utilizing the [mlflow.transformers.log_model](https://www.mlflow.org/docs/latest/python_api/mlflow.transformers.html#mlflow.transformers.log_model) function, specifically tailored for models and components from the `transformers` library, simplifies this task. This function is adept at handling various aspects of the models from this library, including their complex pipelines and configurations.\n",
     "\n",
-    "When logging the model, crucial metadata such as the model's signature, which was previously established, is included. This metadata plays a significant role in the subsequent stages of the model's lifecycle, from tracking its evolution to facilitating its deployment in different environments. The signature, in particular, ensures the model's compatibility and consistent performance across various platforms, thereby enhancing its utility and reliability in practical applications.\n",
+    "When logging the model, crucial metadata such as the model's signature (inferred from `input_example`) is included. This metadata plays a significant role in the subsequent stages of the model's lifecycle, from tracking its evolution to facilitating its deployment in different environments. The signature, in particular, ensures the model's compatibility and consistent performance across various platforms, thereby enhancing its utility and reliability in practical applications.\n",
     "\n",
     "By logging our model in this way, we ensure that it is not only well-documented but also primed for future use, whether it be for further development, comparative analysis, or deployment.\n",
     "\n",
@@ -259,8 +261,7 @@
     "    model_info = mlflow.transformers.log_model(\n",
     "        transformers_model=generation_pipeline,\n",
     "        name=\"text_generator\",\n",
-    "        input_example=input_example,\n",
-    "        signature=signature,\n",
+    "        input_example=(input_example, parameters),  # Signature is inferred from this tuple\n",
     "        # Uncomment the following line to save the model in 'reference-only' mode:\n",
     "        # save_pretrained=False,\n",
     "    )"

--- a/docs/docs/classic-ml/deep-learning/transformers/tutorials/translation/component-translation.ipynb
+++ b/docs/docs/classic-ml/deep-learning/transformers/tutorials/translation/component-translation.ipynb
@@ -204,7 +204,10 @@
     "    \"This is a sample input sentence.\",\n",
     "    mlflow.transformers.generate_signature_output(translation_pipeline, \"This is another sample.\"),\n",
     "    params=model_params,\n",
-    ")"
+    ")\n",
+    "\n",
+    "# The signature is now inferred directly in log_model from input_example and model_params.\n",
+    "# You can inspect the logged model's signature via model_info.signature if needed after logging."
    ]
   },
   {
@@ -221,7 +224,7 @@
     "- **Outputs:** The output data types, which in our case is a string representing the translated text.\n",
     "- **Parameters:** Additional configurable settings like `max_length`, determining the maximum length of the translation output.\n",
     "\n",
-    "Reviewing the signature through the `signature` command allows us to validate the data formats and ensure that our model will function as expected when deployed. This step is vital for consistent model performance and avoiding errors in a production environment.\n",
+    "Reviewing the signature (e.g., by inspecting `model_info.signature` after logging) allows us to validate the data formats and ensure that our model will function as expected when deployed. This step is vital for consistent model performance and avoiding errors in a production environment.\n",
     "Furthermore, the inclusion of parameters in the signature with default values ensures that any modifications during inference are deliberate and well-documented, contributing to the model's predictability and transparency."
    ]
   },
@@ -247,8 +250,23 @@
     }
    ],
    "source": [
-    "# Visualize the model signature\n",
-    "signature"
+    "# Visualize the model signature (example of how it would look)\n",
+    "# In the new flow, this signature is inferred by log_model.\n",
+    "# For inspection, you would typically look at model_info.signature after the model is logged.\n",
+    "if \"signature\" in locals():\n",
+    "    print(signature)\n",
+    "else:\n",
+    "    # Create a dummy signature for visualization if the old code block was removed\n",
+    "    from mlflow.models.signature import ModelSignature\n",
+    "    from mlflow.types.schema import ColSpec, ParamSchema, ParamSpec, Schema\n",
+    "\n",
+    "    dummy_signature = ModelSignature(\n",
+    "        inputs=Schema([ColSpec(\"string\")]),\n",
+    "        outputs=Schema([ColSpec(\"string\")]),\n",
+    "        params=ParamSchema([ParamSpec(\"max_length\", \"long\", 1000)]),\n",
+    "    )\n",
+    "    print(\"Example signature (would be inferred by log_model):\")\n",
+    "    print(dummy_signature)"
    ]
   },
   {
@@ -301,11 +319,11 @@
     "\n",
     "- **Model Pipeline**: The complete translation model pipeline, encompassing the model and tokenizer.\n",
     "- **Artifact Path**: The directory path in the MLflow run where the model artifacts are stored.\n",
-    "- **Model Signature**: The pre-defined signature indicating the model's expected input-output formats.\n",
-    "- **Model Parameters**: Key parameters of the model, like `max_length`, providing insights into model behavior.\n",
+    "- **Input Example**: A sample input (and parameters, if needed, as a tuple) from which MLflow will infer the model signature.\n",
+    "- **Model Parameters**: Key parameters of the model, like `max_length`, providing insights into model behavior and used for signature inference if part of `input_example`.\n",
     "\n",
     "#### Outcome of Model Logging\n",
-    "Post logging, we obtain the `model_info` object, which encompasses all the essential metadata about the logged model, such as its storage location. This metadata is vital for future deployment and performance analysis."
+    "Post logging, we obtain the `model_info` object, which encompasses all the essential metadata about the logged model, such as its storage location and the inferred signature. This metadata is vital for future deployment and performance analysis."
    ]
   },
   {
@@ -318,8 +336,8 @@
     "    model_info = mlflow.transformers.log_model(\n",
     "        transformers_model=translation_pipeline,\n",
     "        name=\"french_translator\",\n",
-    "        signature=signature,\n",
-    "        model_params=model_params,\n",
+    "        input_example=(\"This is a sample input sentence.\", model_params),\n",
+    "        model_params=model_params,  # model_params is also used for other settings\n",
     "    )"
    ]
   },

--- a/examples/transformers/conversational.py
+++ b/examples/transformers/conversational.py
@@ -4,18 +4,12 @@ import mlflow
 
 conversational_pipeline = transformers.pipeline(model="microsoft/DialoGPT-medium")
 
-signature = mlflow.models.infer_signature(
-    "Hi there, chatbot!",
-    mlflow.transformers.generate_signature_output(conversational_pipeline, "Hi there, chatbot!"),
-)
-
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=conversational_pipeline,
         name="chatbot",
         task="conversational",
-        signature=signature,
-        input_example="A clever and witty question",
+        input_example="Hi there, chatbot!",  # This will be used for signature inference and saved as the input example
     )
 
 # Load the conversational pipeline as an interactive chatbot

--- a/examples/transformers/load_components.py
+++ b/examples/transformers/load_components.py
@@ -8,16 +8,11 @@ translation_pipeline = transformers.pipeline(
     tokenizer=transformers.T5TokenizerFast.from_pretrained("t5-small", model_max_length=100),
 )
 
-signature = mlflow.models.infer_signature(
-    "Hi there, chatbot!",
-    mlflow.transformers.generate_signature_output(translation_pipeline, "Hi there, chatbot!"),
-)
-
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=translation_pipeline,
         name="french_translator",
-        signature=signature,
+        input_example="Hi there, chatbot!",  # Signature is inferred from this
     )
 
 translation_components = mlflow.transformers.load_model(

--- a/examples/transformers/whisper.py
+++ b/examples/transformers/whisper.py
@@ -29,10 +29,6 @@ audio_transcription_pipeline = transformers.pipeline(
 # one created here. For other supported types (i.e., numpy array of float32 with the
 # correct bitrate extraction), a signature is required to override the default of "binary" input
 # type.
-signature = mlflow.models.infer_signature(
-    audio,
-    mlflow.transformers.generate_signature_output(audio_transcription_pipeline, audio),
-)
 
 inference_config = {
     "return_timestamps": False,
@@ -41,13 +37,13 @@ inference_config = {
 }
 
 # Log the pipeline
+# The signature will be inferred from the input_example (audio, inference_config)
 with mlflow.start_run():
     model_info = mlflow.transformers.log_model(
         transformers_model=audio_transcription_pipeline,
         name="whisper_transcriber",
-        signature=signature,
-        input_example=audio,
-        inference_config=inference_config,
+        input_example=(audio, inference_config),
+        inference_config=inference_config,  # Used for setting model's default inference params
     )
 
 # Load the pipeline in its native format

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -173,7 +173,30 @@ def format_input_example_for_special_cases(input_example, pipeline):
     return input_data if not isinstance(input_example, tuple) else (input_data, input_example[1])
 
 
+import warnings
+
+
 def generate_signature_output(pipeline, data, model_config=None, flavor_config=None, params=None):
+    """
+    .. warning::
+        This function is deprecated. MLflow now supports inferring the signature directly from
+        an ``input_example`` when logging a model with
+        :py:func:`mlflow.transformers.log_model`.
+        Please pass your input example directly to ``mlflow.transformers.log_model`` via the
+        ``input_example`` parameter.
+
+    Generates a typical signature output for a Transformers pipeline.
+    This is used by :py:func:`mlflow.models.infer_signature` to determine the model signature.
+    """
+    warnings.warn(
+        "The function `mlflow.transformers.generate_signature_output` is deprecated. "
+        "MLflow now supports inferring the signature directly from an `input_example` "
+        "when logging a model with `mlflow.transformers.log_model`. "
+        "Please pass your input example directly to `mlflow.transformers.log_model` "
+        "via the `input_example` parameter.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     # Lazy import to avoid circular dependencies. Ideally we should move _TransformersWrapper
     # out from __init__.py to avoid this.
     from mlflow.transformers import _TransformersWrapper

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -173,7 +173,6 @@ def format_input_example_for_special_cases(input_example, pipeline):
     return input_data if not isinstance(input_example, tuple) else (input_data, input_example[1])
 
 
-import warnings
 
 
 def generate_signature_output(pipeline, data, model_config=None, flavor_config=None, params=None):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/vamsivk99/mlflow/pull/16584?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16584/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16584/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16584/merge
```

</p>
</details>

This function is deprecated in favor of inferring model signatures directly from `input_example` (and `params` if provided as a tuple with the input example) when using `mlflow.transformers.log_model` or `mlflow.transformers.save_model`.

- Marked `generate_signature_output` with a `DeprecationWarning`.
- Updated its docstring to guide users to the new approach.
- Updated examples and tutorials in the documentation to use `input_example` for signature inference instead of the deprecated function.

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #13327 

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
