### PR TITLE
Use empty Resource when instantiating OTel provider to fix LiteLLM tracing issue

### DIFF
--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Optional
 
 from opentelemetry import context as context_api
 from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 
 import mlflow
@@ -277,7 +278,10 @@ def _setup_tracer_provider(disabled=False):
         # Default to MLflow Tracking Server
         processor = _get_mlflow_span_processor(tracking_uri=mlflow.get_tracking_uri())
 
-    tracer_provider = TracerProvider()
+    # Setting an empty resource to avoid triggering resource aggregation, which causes
+    # an issue in LiteLLM tracing: https://github.com/mlflow/mlflow/issues/16296
+    # MLflow tracing does not use resource right now.
+    tracer_provider = TracerProvider(resource=Resource.get_empty())
     tracer_provider.add_span_processor(processor)
     _MLFLOW_TRACER_PROVIDER = tracer_provider
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16590?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16590/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16590/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16590/merge
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/16296

### What changes are proposed in this pull request?

LiteLLM triggers tracing callback in a background thread pool, which is not joined when the process exist. This triggers an exception like this in LiteLm Tracing:

```
22:18:50 - LiteLLM:DEBUG: mlflow.py:32 - MLflow logging start for success event
2025/07/05 22:18:50 WARNING mlflow.tracing.fluent: Failed to start span litellm-completion: cannot schedule new futures after interpreter shutdown. For full traceback, set logging level to debug.
Traceback (most recent call last):
  File "/Users/yuki.watanabe/Workspace/mlflow/tracing/fluent.py", line 549, in start_span_no_context
    otel_span = provider.start_detached_span(
  File "/Users/yuki.watanabe/Workspace/mlflow/tracing/provider.py", line 91, in start_detached_span
    tracer = _get_tracer(__name__)
  File "/Users/yuki.watanabe/Workspace/mlflow/tracing/provider.py", line 213, in _get_tracer
    _MLFLOW_TRACER_PROVIDER_INITIALIZED.do_once(_setup_tracer_provider)
  File "/Users/yuki.watanabe/Workspace/mlflow/tracing/utils/once.py", line 33, in do_once
    func()
  File "/Users/yuki.watanabe/Workspace/mlflow/tracing/provider.py", line 280, in _setup_tracer_provider
    tracer_provider = TracerProvider()
  File "/Users/yuki.watanabe/Workspace/mlflow/.venv/310/lib/python3.10/site-packages/opentelemetry/sdk/trace/__init__.py", line 1206, in __init__
    self._resource = Resource.create({})
  File "/Users/yuki.watanabe/Workspace/mlflow/.venv/310/lib/python3.10/site-packages/opentelemetry/sdk/resources/__init__.py", line 229, in create
    resource = get_aggregated_resources(
  File "/Users/yuki.watanabe/Workspace/mlflow/.venv/310/lib/python3.10/site-packages/opentelemetry/sdk/resources/__init__.py", line 518, in get_aggregated_resources
    futures = [executor.submit(detector.detect) for detector in detectors]
  File "/Users/yuki.watanabe/Workspace/mlflow/.venv/310/lib/python3.10/site-packages/opentelemetry/sdk/resources/__init__.py", line 518, in <listcomp>
    futures = [executor.submit(detector.detect) for detector in detectors]
  File "/Users/yuki.watanabe/.local/share/uv/python/cpython-3.10.16-macos-aarch64-none/lib/python3.10/concurrent/futures/thread.py", line 169, in submit
    raise RuntimeError('cannot schedule new futures after '
RuntimeError: cannot schedule new futures after interpreter shutdown
```

Reading the exception, the "cannot schedule new futures after interpreter shutdown" is actually triggered in the Otel Tracer Provider initialization. It tries to submit a future to thread pool executor in [get_aggregated_resources](https://github.com/open-telemetry/opentelemetry-python/blob/main/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py#L517-L518) call, which collects environment information to instantiate the `Resource` object. 

However, MLflow does not use `Resource` at all. Therefore, we can pass an empty `Resource` object as a workaround.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

The repro script produces a trace successfully.

<img width="1453" alt="Screenshot 2025-07-05 at 22 42 36" src="https://github.com/user-attachments/assets/6547e6ea-2f91-42cc-bb59-c05a28298de0" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the future submission issue in LiteLLM tracing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
