### PR TITLE
Add Agent and LLM complete name

### DIFF
--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -62,7 +62,8 @@ def autolog(
         if not get_autologging_config(FLAVOR_NAME, "log_traces"):
             return await original(self, *args, **kwargs)
         else:
-            with mlflow.start_span(original.__name__, span_type=SpanType.LLM) as span:
+            name = f"{self.__class__.__name__}.{original.__name__}"
+            with mlflow.start_span(name, span_type=SpanType.LLM) as span:
                 inputs = construct_full_inputs(original, self, *args, **kwargs)
                 span.set_inputs(
                     {key: _convert_value_to_dict(value) for key, value in inputs.items()}
@@ -91,7 +92,9 @@ def autolog(
         if not get_autologging_config(FLAVOR_NAME, "log_traces"):
             return await original(self, *args, **kwargs)
         else:
-            with mlflow.start_span(original.__name__, span_type=SpanType.AGENT) as span:
+            agent_name = getattr(self, "name", self.__class__.__name__)
+            name = f"{agent_name}.{original.__name__}"
+            with mlflow.start_span(name, span_type=SpanType.AGENT) as span:
                 inputs = construct_full_inputs(original, self, *args, **kwargs)
                 span.set_inputs(
                     {key: _convert_value_to_dict(value) for key, value in inputs.items()}

--- a/tests/autogen/test_autogen_autolog.py
+++ b/tests/autogen/test_autogen_autolog.py
@@ -40,7 +40,7 @@ async def test_autolog_assistant_agent(disable):
         assert trace.info.status == "OK"
         assert len(trace.data.spans) == 3
         span = trace.data.spans[0]
-        assert span.name == "run"
+        assert span.name == "assistant.run"
         assert span.span_type == SpanType.AGENT
         assert span.inputs == {"task": "1+1"}
         messages = span.outputs["messages"]
@@ -67,7 +67,7 @@ async def test_autolog_assistant_agent(disable):
         )
 
         span = trace.data.spans[1]
-        assert span.name == "on_messages"
+        assert span.name == "assistant.on_messages"
         assert span.span_type == SpanType.AGENT
         assert (
             span.outputs["chat_message"].items()
@@ -81,7 +81,7 @@ async def test_autolog_assistant_agent(disable):
         )
 
         span = trace.data.spans[2]
-        assert span.name == "create"
+        assert span.name == "ReplayChatCompletionClient.create"
         assert span.span_type == SpanType.LLM
         assert span.inputs["messages"] == [
             {"content": _SYSTEM_MESSAGE, "type": "SystemMessage"},
@@ -157,7 +157,7 @@ async def test_autolog_tool_agent():
     assert trace.info.status == "OK"
     assert len(trace.data.spans) == 3
     span = trace.data.spans[0]
-    assert span.name == "run"
+    assert span.name == "assistant.run"
     assert span.span_type == SpanType.AGENT
     assert span.inputs == {"task": "1+1"}
     messages = span.outputs["messages"]
@@ -218,7 +218,7 @@ async def test_autolog_tool_agent():
     )
 
     span = trace.data.spans[1]
-    assert span.name == "on_messages"
+    assert span.name == "assistant.on_messages"
     assert span.span_type == SpanType.AGENT
     assert (
         span.outputs["chat_message"].items()
@@ -233,7 +233,7 @@ async def test_autolog_tool_agent():
     assert span.get_attribute("mlflow.chat.tools") == TOOL_ATTRIBUTES
 
     span = trace.data.spans[2]
-    assert span.name == "create"
+    assert span.name == "ReplayChatCompletionClient.create"
     assert span.span_type == SpanType.LLM
     assert span.inputs["messages"] == [
         {"content": _SYSTEM_MESSAGE, "type": "SystemMessage"},
@@ -294,7 +294,7 @@ async def test_autolog_multi_modal():
     assert trace.info.status == "OK"
     assert len(trace.data.spans) == 3
     span = trace.data.spans[0]
-    assert span.name == "run"
+    assert span.name == "assistant.run"
     assert span.span_type == SpanType.AGENT
     assert span.inputs["task"]["content"][0] == "Can you describe the number in the image?"
     assert "data" in span.inputs["task"]["content"][1]
@@ -327,7 +327,7 @@ async def test_autolog_multi_modal():
     )
 
     span = trace.data.spans[1]
-    assert span.name == "on_messages"
+    assert span.name == "assistant.on_messages"
     assert span.span_type == SpanType.AGENT
     assert (
         span.outputs["chat_message"].items()
@@ -341,7 +341,7 @@ async def test_autolog_multi_modal():
     )
 
     span = trace.data.spans[2]
-    assert span.name == "create"
+    assert span.name == "ReplayChatCompletionClient.create"
     assert span.span_type == SpanType.LLM
     assert span.inputs["messages"] == [
         {"content": _SYSTEM_MESSAGE, "type": "SystemMessage"},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/16613?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16613/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16613/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16613/merge
```

</p>
</details>

### Related Issues/PRs

Fix #16608 

### What changes are proposed in this pull request?

Add Agent and LLM complete name in Autogen autotracing

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

![Screenshot 2025-07-07 at 9 20 59 PM](https://github.com/user-attachments/assets/f15ba1b4-ec4f-414f-9226-09e4e2354d71)


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add Agent and LLM complete name in Autogen autotracing

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
