### PR TITLE
Add ability to the UI to edit experiment tags

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTable.tsx
@@ -28,8 +28,11 @@ import { FormattedMessage, useIntl } from 'react-intl';
 import Utils from '../../common/utils/Utils';
 import { Link } from '../../common/utils/RoutingUtils';
 import Routes from '../routes';
+import { ExperimentListTableTagsCell } from './ExperimentListTableTagsCell';
 
-type ExperimentTableColumnDef = ColumnDef<ExperimentEntity>;
+export type ExperimentTableColumnDef = ColumnDef<ExperimentEntity>;
+
+export type ExperimentTableMetadata = { onEditTags: (editedEntity: ExperimentEntity) => void };
 
 const useExperimentsTableColumns = () => {
   const intl = useIntl();
@@ -84,6 +87,16 @@ const useExperimentsTableColumns = () => {
         accessorFn: ({ tags }) => tags?.find(({ key }) => key === 'mlflow.note.content')?.value ?? '-',
         enableSorting: false,
       },
+      {
+        header: intl.formatMessage({
+          defaultMessage: 'Tags',
+          description: 'Header for the tags column in the experiments table',
+        }),
+        id: 'tags',
+        accessorKey: 'tags',
+        enableSorting: false,
+        cell: ExperimentListTableTagsCell,
+      },
     ];
 
     return resultColumns;
@@ -98,6 +111,7 @@ export const ExperimentListTable = ({
   setRowSelection,
   cursorPaginationProps,
   sortingProps: { sorting, setSorting },
+  onEditTags,
 }: {
   experiments?: ExperimentEntity[];
   isFiltered?: boolean;
@@ -106,6 +120,7 @@ export const ExperimentListTable = ({
   setRowSelection: OnChangeFn<RowSelectionState>;
   cursorPaginationProps: Omit<CursorPaginationProps, 'componentId'>;
   sortingProps: { sorting: SortingState; setSorting: OnChangeFn<SortingState> };
+  onEditTags: (editedEntity: ExperimentEntity) => void;
 }) => {
   const { theme } = useDesignSystemTheme();
   const columns = useExperimentsTableColumns();
@@ -120,6 +135,7 @@ export const ExperimentListTable = ({
     onRowSelectionChange: setRowSelection,
     onSortingChange: setSorting,
     state: { rowSelection, sorting },
+    meta: { onEditTags } satisfies ExperimentTableMetadata,
   });
 
   const getEmptyState = () => {
@@ -202,7 +218,7 @@ export const ExperimentListTable = ({
   );
 };
 
-const ExperimentListTableCell: ColumnDef<ExperimentEntity>['cell'] = ({ row: { original } }) => {
+const ExperimentListTableCell: ExperimentTableColumnDef['cell'] = ({ row: { original } }) => {
   return (
     <Link
       className="experiment-link"
@@ -216,7 +232,7 @@ const ExperimentListTableCell: ColumnDef<ExperimentEntity>['cell'] = ({ row: { o
   );
 };
 
-const ExperimentListCheckbox: ColumnDef<ExperimentEntity>['cell'] = ({ row }) => {
+const ExperimentListCheckbox: ExperimentTableColumnDef['cell'] = ({ row }) => {
   return (
     <Checkbox
       componentId="mlflow.experiment_list_view.check_box"

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
@@ -26,22 +26,14 @@ export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
         ))}
       </div>
       <Button
-        componentId="mlflow.prompts.list.tag.add"
+        componentId="mlflow.experiment.list.tag.add"
         size="small"
         icon={!containsTags ? undefined : <PencilIcon />}
         onClick={() => onEditTags?.(original)}
         aria-label={intl.formatMessage({
           defaultMessage: 'Edit tags',
-          description: 'Label for the edit tags button in the registered prompts table',
+          description: 'Label for the edit tags button in the experiment list table',
         })}
-        children={
-          !containsTags ? (
-            <FormattedMessage
-              defaultMessage="Add tags"
-              description="Label for the add tags button in the registered prompts table"
-            />
-          ) : undefined
-        }
         css={{
           flexShrink: 0,
           opacity: 0,
@@ -53,7 +45,14 @@ export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
           },
         }}
         type="tertiary"
-      />
+      >
+        {!containsTags ? (
+          <FormattedMessage
+            defaultMessage="Add tags"
+            description="Label for the add tags button in the experiment list table"
+          />
+        ) : undefined}
+      </Button>
     </div>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListTableTagsCell.tsx
@@ -1,0 +1,59 @@
+import { Button, PencilIcon } from '@databricks/design-system';
+import 'react-virtualized/styles.css';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { KeyValueTag } from '../../common/components/KeyValueTag';
+import { isUserFacingTag } from '../../common/utils/TagUtils';
+import { ExperimentTableColumnDef, ExperimentTableMetadata } from './ExperimentListTable';
+
+export const ExperimentListTableTagsCell: ExperimentTableColumnDef['cell'] = ({
+  row: { original },
+  table: {
+    options: { meta },
+  },
+}) => {
+  const intl = useIntl();
+
+  const { onEditTags } = meta as ExperimentTableMetadata;
+
+  const visibleTagList = original?.tags?.filter((tag) => isUserFacingTag(tag.key)) || [];
+  const containsTags = visibleTagList.length > 0;
+
+  return (
+    <div css={{ display: 'flex' }}>
+      <div css={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', display: 'flex' }}>
+        {visibleTagList?.map((tag) => (
+          <KeyValueTag key={tag.key} tag={tag} />
+        ))}
+      </div>
+      <Button
+        componentId="mlflow.prompts.list.tag.add"
+        size="small"
+        icon={!containsTags ? undefined : <PencilIcon />}
+        onClick={() => onEditTags?.(original)}
+        aria-label={intl.formatMessage({
+          defaultMessage: 'Edit tags',
+          description: 'Label for the edit tags button in the registered prompts table',
+        })}
+        children={
+          !containsTags ? (
+            <FormattedMessage
+              defaultMessage="Add tags"
+              description="Label for the add tags button in the registered prompts table"
+            />
+          ) : undefined
+        }
+        css={{
+          flexShrink: 0,
+          opacity: 0,
+          '[role=row]:hover &': {
+            opacity: 1,
+          },
+          '[role=row]:focus-within &': {
+            opacity: 1,
+          },
+        }}
+        type="tertiary"
+      />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.test.tsx
@@ -9,10 +9,15 @@ import { ExperimentListView } from './ExperimentListView';
 import Fixtures from '../utils/test-utils/Fixtures';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { useExperimentListQuery } from './experiment-page/hooks/useExperimentListQuery';
+import { useUpdateExperimentTags } from './experiment-page/hooks/useUpdateExperimentTags';
 
 jest.mock('./experiment-page/hooks/useExperimentListQuery', () => ({
   useExperimentListQuery: jest.fn(),
   useInvalidateExperimentList: jest.fn(),
+}));
+
+jest.mock('./experiment-page/hooks/useUpdateExperimentTags', () => ({
+  useUpdateExperimentTags: jest.fn(),
 }));
 
 const mountComponent = (props: any) => {
@@ -39,6 +44,12 @@ const mountComponent = (props: any) => {
     sorting: [],
     setSorting: jest.fn(),
   }));
+
+  jest.mocked(useUpdateExperimentTags).mockReturnValue({
+    isLoading: false,
+    EditTagsModal: <span />,
+    showEditExperimentTagsModal: jest.fn(),
+  });
 
   return renderWithIntl(
     <DesignSystemProvider>

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
@@ -24,6 +24,7 @@ import { ExperimentListTable } from './ExperimentListTable';
 import { useNavigate } from '../../common/utils/RoutingUtils';
 import { BulkDeleteExperimentModal } from './modals/BulkDeleteExperimentModal';
 import { ErrorWrapper } from '../../common/utils/ErrorWrapper';
+import { useUpdateExperimentTags } from './experiment-page/hooks/useUpdateExperimentTags';
 
 type Props = {
   searchFilter: string;
@@ -44,6 +45,10 @@ export const ExperimentListView = ({ searchFilter, setSearchFilter }: Props) => 
     setSorting,
   } = useExperimentListQuery({ searchFilter });
   const invalidateExperimentList = useInvalidateExperimentList();
+
+  const { EditTagsModal, showEditExperimentTagsModal } = useUpdateExperimentTags({
+    onSuccess: invalidateExperimentList,
+  });
 
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [searchInput, setSearchInput] = useState('');
@@ -177,6 +182,7 @@ export const ExperimentListView = ({ searchFilter, setSearchFilter }: Props) => 
             pageSizeSelect,
           }}
           sortingProps={{ sorting, setSorting }}
+          onEditTags={showEditExperimentTagsModal}
         />
       </div>
       <CreateExperimentModal
@@ -193,6 +199,7 @@ export const ExperimentListView = ({ searchFilter, setSearchFilter }: Props) => 
           setRowSelection({});
         }}
       />
+      {EditTagsModal}
     </ScrollablePageWrapper>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.test.tsx
@@ -1,0 +1,102 @@
+import { renderHook, act, waitFor, render, screen, within } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { useUpdateExperimentTags } from './useUpdateExperimentTags';
+import { ExperimentEntity } from '../../../types';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { MlflowService } from '../../../sdk/MlflowService';
+import { IntlProvider } from 'react-intl';
+import userEvent from '@testing-library/user-event';
+
+jest.mock('../../../../common/utils/LocalStorageUtils');
+
+const mockExperiment = {
+  experiment_id: '12345',
+  name: 'test-experiment',
+  tags: [{ key: 'tag1', value: 'value1' }],
+} as unknown as ExperimentEntity;
+
+describe('useUpdateExperimentTags', () => {
+  beforeEach(() => {
+    jest.spyOn(MlflowService, 'setExperimentTag').mockResolvedValue({});
+    jest.spyOn(MlflowService, 'deleteExperimentTag').mockResolvedValue({});
+  });
+
+  const renderTestHook = (onSuccess: () => void) =>
+    renderHook(() => useUpdateExperimentTags({ onSuccess }), {
+      wrapper: ({ children }) => (
+        <IntlProvider locale="en">
+          <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+        </IntlProvider>
+      ),
+    });
+
+  it('should show nothing initially', () => {
+    const onSuccess = jest.fn();
+    const { result } = renderTestHook(onSuccess);
+
+    expect(result.current.EditTagsModal.props.visible).toBeFalsy();
+    expect(result.current.isLoading).toBe(false);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  it('should show edit modal if called with experiment', async () => {
+    const onSuccess = jest.fn();
+    const { result } = renderTestHook(onSuccess);
+
+    act(() => {
+      result.current.showEditExperimentTagsModal(mockExperiment);
+    });
+
+    await waitFor(() => {
+      expect(result.current.EditTagsModal).not.toBeNull();
+    });
+
+    expect(result.current.EditTagsModal.props.visible).toBeTruthy();
+    expect(result.current.isLoading).toBe(false);
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+
+  // it('should call api services and success callback when edited and saved', async () => {
+  //   const onSuccess = jest.fn();
+  //   const { result, rerender } = renderTestHook(onSuccess);
+
+  //   act(() => {
+  //     result.current.showEditExperimentTagsModal(mockExperiment);
+  //   });
+
+  //   rerender();
+
+  //   const { unmount } = render(<IntlProvider locale="en">{result.current.EditTagsModal}</IntlProvider>);
+
+  //   await userEvent.click(within(screen.getByRole('status', { name: 'tag1' })).getByRole('button'));
+
+  //   await userEvent.click(within(screen.getByRole('dialog')).getByRole('combobox'));
+  //   await userEvent.paste('tag2', {
+  //     clipboardData: { getData: jest.fn() },
+  //   } as any);
+  //   await userEvent.click(screen.getByText(/Add tag "tag2"/));
+
+  //   const valueInput = screen.getByLabelText('Value');
+  //   await userEvent.type(valueInput, 'value2');
+
+  //   await userEvent.click(screen.getByLabelText('Add tag'));
+
+  //   await userEvent.click(screen.getByRole('button', { name: 'Save tags' }));
+
+  //   await waitFor(() => {
+  //     expect(result.current.isLoading).toBe(true);
+  //   });
+
+  //   await waitFor(() => {
+  //     expect(MlflowService.deleteExperimentTag).toHaveBeenCalledWith(mockExperiment.experimentId, 'tag1');
+  //     expect(MlflowService.setExperimentTag).toHaveBeenCalledWith(mockExperiment.experimentId, 'tag2', 'value2');
+  //     expect(onSuccess).toHaveBeenCalled();
+  //   });
+
+  //   await waitFor(() => {
+  //     expect(result.current.isLoading).toBe(false);
+  //   });
+
+  //   expect(result.current.EditTagsModal.props.visible).toBeFalsy();
+  //   unmount();
+  // });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.tsx
@@ -1,0 +1,65 @@
+import { useMutation } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { useEditKeyValueTagsModal } from '../../../../common/hooks/useEditKeyValueTagsModal';
+import { useCallback } from 'react';
+import { diffCurrentAndNewTags, isUserFacingTag } from '../../../../common/utils/TagUtils';
+import { MlflowService } from '../../../sdk/MlflowService';
+import { ExperimentEntity } from '../../../types';
+
+type UpdateTagsPayload = {
+  experimentId: string;
+  toAdd: { key: string; value: string }[];
+  toDelete: { key: string }[];
+};
+
+export const useUpdateExperimentTags = ({ onSuccess }: { onSuccess?: () => void }) => {
+  const updateMutation = useMutation<unknown, Error, UpdateTagsPayload>({
+    mutationFn: async ({ toAdd, toDelete, experimentId }) => {
+      return Promise.all([
+        ...toAdd.map(({ key, value }) => MlflowService.setExperimentTag({ experiment_id: experimentId, key, value })),
+        ...toDelete.map(({ key }) => MlflowService.deleteExperimentTag({ experiment_id: experimentId, key })),
+      ]);
+    },
+  });
+
+  const { EditTagsModal, showEditTagsModal, isLoading } = useEditKeyValueTagsModal<
+    Pick<ExperimentEntity, 'experimentId' | 'name' | 'tags'>
+  >({
+    valueRequired: true,
+    saveTagsHandler: (experiment, currentTags, newTags) => {
+      const { addedOrModifiedTags, deletedTags } = diffCurrentAndNewTags(currentTags, newTags);
+
+      return new Promise<void>((resolve, reject) => {
+        if (!experiment) {
+          return reject();
+        }
+        // Send all requests to the mutation
+        updateMutation.mutate(
+          {
+            experimentId: experiment.experimentId,
+            toAdd: addedOrModifiedTags,
+            toDelete: deletedTags,
+          },
+          {
+            onSuccess: () => {
+              resolve();
+              onSuccess?.();
+            },
+            onError: reject,
+          },
+        );
+      });
+    },
+  });
+
+  const showEditExperimentTagsModal = useCallback(
+    (experiment: ExperimentEntity) =>
+      showEditTagsModal({
+        experimentId: experiment.experimentId,
+        name: experiment.name,
+        tags: experiment.tags.filter((tag) => isUserFacingTag(tag.key)),
+      }),
+    [showEditTagsModal],
+  );
+
+  return { EditTagsModal, showEditExperimentTagsModal, isLoading };
+};

--- a/mlflow/server/js/src/experiment-tracking/sdk/FieldNameTransformers.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/FieldNameTransformers.ts
@@ -49,6 +49,7 @@ const transformExperimentEntity = (snakeCaseExperimentEntity: any): Omit<Experim
   experimentId: snakeCaseExperimentEntity.experiment_id,
   lastUpdateTime: snakeCaseExperimentEntity.last_update_time,
   lifecycleStage: snakeCaseExperimentEntity.lifecycle_stage,
+  tags: snakeCaseExperimentEntity.tags ?? [],
 });
 
 export const transformGetRunResponse = (originalResponse: any): GetRunApiResponse => {

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2063,6 +2063,10 @@
     "defaultMessage": "Deleted traces cannot be restored. Are you sure you want to proceed?",
     "description": "Experiment page > traces view controls > Delete traces modal > Confirmation message"
   },
+  "Vk+30L": {
+    "defaultMessage": "Edit tags",
+    "description": "Label for the edit tags button in the experiment list table"
+  },
   "Vkr4Bs": {
     "defaultMessage": "Add description",
     "description": "experiment page > description modal > title"
@@ -2542,6 +2546,10 @@
   "cI+F/q": {
     "defaultMessage": "Name",
     "description": "Column title for name column in editable tags table view in MLflow"
+  },
+  "cI0kqF": {
+    "defaultMessage": "Add tags",
+    "description": "Label for the add tags button in the experiment list table"
   },
   "cIV9pX": {
     "defaultMessage": "Permission denied",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -895,6 +895,10 @@
     "defaultMessage": "Comparing version {baseline} with version {compared}",
     "description": "Label for comparing prompt versions in the prompt comparison view. Variables {baseline} and {compared} are numeric version numbers being compared."
   },
+  "BB6In/": {
+    "defaultMessage": "Tags",
+    "description": "Header for the tags column in the experiments table"
+  },
   "BCpX6U": {
     "defaultMessage": "Registered models",
     "description": "Run page > Overview > Run models section label"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16614?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16614/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16614/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16614/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Based on #16610 

### What changes are proposed in this pull request?

Update the UI to have ability to edit tags in the experiments table.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/44121590-47af-4a78-85ad-522872f5853d

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add ability to edit experiment tags from the experiments table on the MLflow UI.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
