### PR TITLE
Support async tracing for Gemini

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
@@ -31,11 +31,6 @@ MLflow trace automatically captures the following information about Anthropic ca
 - Function calling if returned in the response
 - Any exception if raised
 
-:::note
-
-Currently, MLflow Anthropic integration only support tracing for synchronous calls for text interactions. Async APIs are not traced, and full inputs cannot be recorded for multi-modal inputs.
-
-:::
 
 ## Supported APIs
 

--- a/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/anthropic.mdx
@@ -31,7 +31,6 @@ MLflow trace automatically captures the following information about Anthropic ca
 - Function calling if returned in the response
 - Any exception if raised
 
-
 ## Supported APIs
 
 MLflow supports automatic tracing for the following Anthropic APIs:

--- a/docs/docs/genai/tracing/integrations/listing/gemini.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/gemini.mdx
@@ -38,14 +38,13 @@ MLflow trace automatically captures the following information about Gemini calls
 - Function calling if returned in the response
 - Any exception if raised
 
-
 ## Supported APIs
 
 MLflow supports automatic tracing for the following Anthropic APIs:
 
 | Text Generation | Chat | Function Calling | Streaming |  Async   | Image | Video |
 | :-------------: | :--: | :--------------: | :-------: | :------: | :---: | :---: |
-|       ✅        |  ✅  |        ✅        |    -      | ✅ (\*1) |  -    |   -   |
+|       ✅        |  ✅  |        ✅        |     -     | ✅ (\*1) |   -   |   -   |
 
 <div style={{ fontSize: '0.9em', marginTop: '10px' }}>
 
@@ -54,7 +53,6 @@ MLflow supports automatic tracing for the following Anthropic APIs:
 </div>
 
 To request support for additional APIs, please open a [feature request](https://github.com/mlflow/mlflow/issues) on GitHub.
-
 
 ### Basic Example
 

--- a/docs/docs/genai/tracing/integrations/listing/gemini.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/gemini.mdx
@@ -38,11 +38,23 @@ MLflow trace automatically captures the following information about Gemini calls
 - Function calling if returned in the response
 - Any exception if raised
 
-:::note
 
-Currently, MLflow Gemini integration only supports tracing of synchronous calls for text interactions. Async APIs are not traced and full inputs may not be recorded for multi-modal inputs.
+## Supported APIs
 
-:::
+MLflow supports automatic tracing for the following Anthropic APIs:
+
+| Text Generation | Chat | Function Calling | Streaming |  Async   | Image | Video |
+| :-------------: | :--: | :--------------: | :-------: | :------: | :---: | :---: |
+|       ✅        |  ✅  |        ✅        |    -      | ✅ (\*1) |  -    |   -   |
+
+<div style={{ fontSize: '0.9em', marginTop: '10px' }}>
+
+(\*1) Async support was added in MLflow 3.2.0.
+
+</div>
+
+To request support for additional APIs, please open a [feature request](https://github.com/mlflow/mlflow/issues) on GitHub.
+
 
 ### Basic Example
 
@@ -82,6 +94,20 @@ response = chat.send_message("In one sentence, explain how a computer works to a
 print(response.text)
 response = chat.send_message("Okay, how about a more detailed explanation to a high schooler?")
 print(response.text)
+```
+
+### Async
+
+MLflow Tracing supports asynchronous API of the Gemini SDK since MLflow 3.2.0. The usage is same as the synchronous API.
+
+```python
+# Configure the SDK with your API key.
+client = genai.Client(api_key=os.environ["GEMINI_API_KEY"])
+
+# Async API is invoked through the `aio` namespace.
+response = await client.aio.models.generate_content(
+    model="gemini-1.5-flash", contents="The opposite of hot is"
+)
 ```
 
 ### Embeddings

--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -76,13 +76,10 @@ class TracingSession:
     def _exit_impl(self, exc_type, exc_val, exc_tb) -> None:
         if self.span:
             if exc_val:
-                self.span.add_event(SpanEvent.from_exception(exc_val))
-                status = SpanStatusCode.ERROR
-            else:
-                status = SpanStatusCode.OK
+                self.span.record_exception(exc_val)
 
             _set_chat_message_attribute(self.span, self.inputs, self.output)
-            self.span.end(status=status, outputs=self.output)
+            self.span.end(outputs=self.output)
 
 
 def _get_span_type(task_name: str) -> str:

--- a/mlflow/anthropic/autolog.py
+++ b/mlflow/anthropic/autolog.py
@@ -6,8 +6,6 @@ import mlflow.anthropic
 from mlflow.anthropic.chat import convert_message_to_mlflow_chat, convert_tool_to_mlflow_chat_tool
 from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
-from mlflow.entities.span_event import SpanEvent
-from mlflow.entities.span_status import SpanStatusCode
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.utils import (

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -474,7 +474,12 @@ class LiveSpan(Span):
                 INVALID_PARAMETER_VALUE,
             )
 
-        self.set_status(SpanStatusCode.ERROR)
+        self.set_status(
+            SpanStatus(
+                status_code=SpanStatusCode.ERROR,
+                description=f"{type(exception).__name__}: {exception}",
+            )
+        )
 
     def end(
         self,

--- a/mlflow/gemini/__init__.py
+++ b/mlflow/gemini/__init__.py
@@ -3,6 +3,7 @@ The ``mlflow.gemini`` module provides an API for tracing the interaction with Ge
 """
 
 from mlflow.gemini.autolog import (
+    async_patched_class_call,
     patched_class_call,
     patched_module_call,
 )
@@ -22,7 +23,7 @@ def autolog(
     """
     Enables (or disables) and configures autologging from Gemini to MLflow.
     Currently, both legacy SDK google-generativeai and new SDK google-genai are supported.
-    Only synchronous calls are supported. Asynchronous APIs and streaming are not recorded.
+    Both synchronous and asynchronous calls are supported for the new SDK.
 
     Args:
         log_traces: If ``True``, traces are logged for Gemini models.
@@ -70,12 +71,25 @@ def autolog(
                 method,
                 patched_class_call,
             )
+            safe_patch(
+                FLAVOR_NAME,
+                genai.models.AsyncModels,
+                method,
+                async_patched_class_call,
+            )
+
 
         safe_patch(
             FLAVOR_NAME,
             genai.chats.Chat,
             "send_message",
             patched_class_call,
+        )
+        safe_patch(
+            FLAVOR_NAME,
+            genai.chats.AsyncChat,
+            "send_message",
+            async_patched_class_call,
         )
     except ImportError:
         pass

--- a/mlflow/gemini/__init__.py
+++ b/mlflow/gemini/__init__.py
@@ -78,7 +78,6 @@ def autolog(
                 async_patched_class_call,
             )
 
-
         safe_patch(
             FLAVOR_NAME,
             genai.chats.Chat,

--- a/mlflow/gemini/autolog.py
+++ b/mlflow/gemini/autolog.py
@@ -8,7 +8,8 @@ from mlflow.gemini.chat import (
     convert_gemini_func_to_mlflow_chat_tool,
     parse_gemini_content_to_mlflow_chat_messages,
 )
-from mlflow.tracing.utils import set_span_chat_messages, set_span_chat_tools
+from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
+from mlflow.tracing.utils import construct_full_inputs, set_span_chat_messages, set_span_chat_tools
 from mlflow.types.chat import ChatMessage
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 
@@ -36,42 +37,102 @@ def patched_class_call(original, self, *args, **kwargs):
     This method is used for patching class methods of gemini SDKs.
     This patch creates a span and set input and output of the original method to the span.
     """
-    config = AutoLoggingConfig.init(flavor_name=mlflow.gemini.FLAVOR_NAME)
+    with TracingSession(original, self, args, kwargs) as manager:
+        output = original(self, *args, **kwargs)
+        manager.output = output
+        return output
 
-    if config.log_traces:
-        with mlflow.start_span(
-            name=f"{self.__class__.__name__}.{original.__name__}",
-            span_type=_get_span_type(original.__name__),
-        ) as span:
-            inputs = _construct_full_inputs(original, self, *args, **kwargs)
-            span.set_inputs(inputs)
-            if has_generativeai and isinstance(self, generativeai.GenerativeModel):
-                _log_generativeai_tool_definition(self, span)
-            if has_genai and isinstance(self, (genai.models.Models, genai.chats.Chat)):
-                _log_genai_tool_definition(self, inputs, span)
 
-            result = original(self, *args, **kwargs)
+async def async_patched_class_call(original, self, *args, **kwargs):
+    """
+    This method is used for patching async class methods of gemini SDKs.
+    This patch creates a span and set input and output of the original method to the span.
+    """
+    async with TracingSession(original, self, args, kwargs) as manager:
+        output = await original(self, *args, **kwargs)
+        manager.output = output
+        return output
 
+class TracingSession:
+    """Context manager for handling MLflow spans in both sync and async contexts."""
+
+    def __init__(self, original, instance, args, kwargs):
+        self.original = original
+        self.instance = instance
+        self.inputs = construct_full_inputs(original, instance, *args, **kwargs)
+
+        # These attributes are set outside the constructor.
+        self.span = None
+        self.token = None
+        self.output = None
+
+    def __enter__(self):
+        return self._enter_impl()
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+
+    async def __aenter__(self):
+        return self._enter_impl()
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self._exit_impl(exc_type, exc_val, exc_tb)
+
+    def _enter_impl(self):
+        config = AutoLoggingConfig.init(flavor_name=mlflow.gemini.FLAVOR_NAME)
+        if config.log_traces:
+            self.span = mlflow.start_span_no_context(
+                name=f"{self.instance.__class__.__name__}.{self.original.__name__}",
+                span_type=_get_span_type(self.original.__name__),
+                inputs=self.inputs,
+            )
+            if has_generativeai and isinstance(self.instance, generativeai.GenerativeModel):
+                _log_generativeai_tool_definition(self.instance, self.span)
+
+            if _is_genai_model_or_chat(self.instance):
+                _log_genai_tool_definition(self.instance, self.inputs, self.span)
+
+            # Attach the span to the current context. This is necessary because single Gemini
+            # SDK call might create multiple child spans.
+            self.token = set_span_in_context(self.span)
+
+        return self
+
+    def _exit_impl(self, exc_type, exc_val, exc_tb) -> None:
+        if self.span:
+            # Detach span from the context at first. This must not be interrupted by any exception,
+            # otherwise the span context will leak and pollute other traces created next.
+            detach_span_from_context(self.token)
+
+            if exc_val:
+                self.span.record_exception(exc_val)
+
+            result = self.output
             if (
                 has_generativeai and isinstance(result, generativeai.types.GenerateContentResponse)
             ) or (has_genai and isinstance(result, genai.types.GenerateContentResponse)):
                 try:
-                    content = _get_keys(inputs, ["contents", "content", "message"])
+                    content = _get_keys(self.inputs, ["contents", "content", "message"])
                     messages = parse_gemini_content_to_mlflow_chat_messages(content)
                     messages += _parse_outputs(result)
                     if messages:
-                        set_span_chat_messages(span=span, messages=messages)
+                        set_span_chat_messages(span=self.span, messages=messages)
                 except Exception as e:
                     _logger.warning(
-                        f"An exception occurred on logging chat attributes for {span}. Error: {e}"
+                        f"An exception occurred on logging chat attributes for {self.span}. Error: {e}"
                     )
 
             # need to convert the response of generate_content for better visualization
             outputs = result.to_dict() if hasattr(result, "to_dict") else result
-            span.set_outputs(outputs)
+            self.span.end(outputs=outputs)
 
-            return result
-
+def _is_genai_model_or_chat(instance) -> bool:
+    return has_genai and isinstance(instance, (
+        genai.models.Models,
+        genai.chats.Chat,
+        genai.models.AsyncModels,
+        genai.chats.AsyncChat,
+    ))
 
 def patched_module_call(original, *args, **kwargs):
     """

--- a/mlflow/gemini/autolog.py
+++ b/mlflow/gemini/autolog.py
@@ -53,6 +53,7 @@ async def async_patched_class_call(original, self, *args, **kwargs):
         manager.output = output
         return output
 
+
 class TracingSession:
     """Context manager for handling MLflow spans in both sync and async contexts."""
 
@@ -118,21 +119,24 @@ class TracingSession:
                     if messages:
                         set_span_chat_messages(span=self.span, messages=messages)
                 except Exception as e:
-                    _logger.warning(
-                        f"An exception occurred on logging chat attributes for {self.span}. Error: {e}"
-                    )
+                    _logger.warning(f"Failed to set chat attributes for {self.span}. Error: {e}")
 
             # need to convert the response of generate_content for better visualization
             outputs = result.to_dict() if hasattr(result, "to_dict") else result
             self.span.end(outputs=outputs)
 
+
 def _is_genai_model_or_chat(instance) -> bool:
-    return has_genai and isinstance(instance, (
-        genai.models.Models,
-        genai.chats.Chat,
-        genai.models.AsyncModels,
-        genai.chats.AsyncChat,
-    ))
+    return has_genai and isinstance(
+        instance,
+        (
+            genai.models.Models,
+            genai.chats.Chat,
+            genai.models.AsyncModels,
+            genai.chats.AsyncChat,
+        ),
+    )
+
 
 def patched_module_call(original, *args, **kwargs):
     """

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -3,6 +3,7 @@ This file contains unit tests for the new Gemini Python SDK
 https://github.com/googleapis/python-genai
 """
 
+import asyncio
 import base64
 import importlib.metadata
 from unittest.mock import patch
@@ -63,8 +64,15 @@ _CHAT_MESSAGES = [
 ]
 
 
-def _generate_content(self, model, contents, config):
-    return _DUMMY_GENERATE_CONTENT_RESPONSE
+def _dummy_generate_content(is_async: bool):
+    if is_async:
+        async def _generate_content(self, model, contents, config):
+            return _DUMMY_GENERATE_CONTENT_RESPONSE
+    else:
+        def _generate_content(self, model, contents, config):
+            return _DUMMY_GENERATE_CONTENT_RESPONSE
+
+    return _generate_content
 
 
 def send_message(self, content):
@@ -108,25 +116,51 @@ def cleanup():
     mlflow.gemini.autolog(disable=True)
 
 
-def test_generate_content_enable_disable_autolog():
-    with patch("google.genai.models.Models._generate_content", new=_generate_content):
+@pytest.fixture(params=[True, False], ids=["async", "sync"])
+def is_async(request):
+    return request.param
+
+
+def _call_generate_content(is_async: bool, contents: str, model: str = "gemini-1.5-flash", config = None):
+    client = genai.Client(api_key="dummy")
+    if is_async:
+        return asyncio.run(client.aio.models.generate_content(model=model, contents=contents, config=config))
+    else:
+        return client.models.generate_content(model=model, contents=contents, config=config)
+
+
+def _create_chat_and_send_message(is_async: bool, message: str):
+    client = genai.Client(api_key="dummy")
+    if is_async:
+        chat = client.aio.chats.create(model="gemini-1.5-flash")
+        return asyncio.run(chat.send_message(message))
+    else:
+        chat = client.chats.create(model="gemini-1.5-flash")
+        return chat.send_message(message)
+
+
+def test_generate_content_enable_disable_autolog(is_async):
+    cls = "AsyncModels" if is_async else "Models"
+    with (
+        patch(f"google.genai.models.{cls}._generate_content", new=_dummy_generate_content(is_async)),
+    ):
         mlflow.gemini.autolog()
-        client = genai.Client(api_key="dummy")
-        client.models.generate_content(model="gemini-1.5-flash", contents="test content")
+        _call_generate_content(is_async, "test content")
 
         traces = get_traces()
         assert len(traces) == 1
         assert traces[0].info.status == "OK"
         assert len(traces[0].data.spans) == 2
+
         span = traces[0].data.spans[0]
-        assert span.name == "Models.generate_content"
+        assert span.name == f"{cls}.generate_content"
         assert span.span_type == SpanType.LLM
-        assert span.inputs == {"contents": "test content", "model": "gemini-1.5-flash"}
+        assert span.inputs == {"contents": "test content", "model": "gemini-1.5-flash", "config": None}
         assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
         assert span.get_attribute("mlflow.chat.messages") == _CHAT_MESSAGES
 
         span1 = traces[0].data.spans[1]
-        assert span1.name == "Models._generate_content"
+        assert span1.name == f"{cls}._generate_content"
         assert span1.span_type == SpanType.LLM
         assert span1.inputs == {
             "contents": "test content",
@@ -137,23 +171,27 @@ def test_generate_content_enable_disable_autolog():
         assert span1.get_attribute("mlflow.chat.messages") == _CHAT_MESSAGES
 
         mlflow.gemini.autolog(disable=True)
-        client = genai.Client(api_key="dummy")
-        client.models.generate_content(model="gemini-1.5-flash", contents="test content")
+        _call_generate_content(is_async, "test content")
 
         # No new trace should be created
         traces = get_traces()
         assert len(traces) == 1
 
 
-def test_generate_content_tracing_with_error():
-    with patch(
-        "google.genai.models.Models._generate_content", side_effect=Exception("dummy error")
-    ):
+def test_generate_content_tracing_with_error(is_async):
+    if is_async:
+        async def _generate_content(self, model, contents, config):
+            raise Exception("dummy error")
+    else:
+        def _generate_content(self, model, contents, config):
+            raise Exception("dummy error")
+
+    cls = "AsyncModels" if is_async else "Models"
+    with patch(f"google.genai.models.{cls}._generate_content", new=_generate_content):
         mlflow.gemini.autolog()
-        client = genai.Client(api_key="dummy")
 
         with pytest.raises(Exception, match="dummy error"):
-            client.models.generate_content(model="gemini-1.5-flash", contents="test content")
+            _call_generate_content(is_async, "test content")
 
     traces = get_traces()
     assert len(traces) == 1
@@ -172,10 +210,11 @@ def test_generate_content_image_autolog():
         genai.types.Part.from_bytes(mime_type="image/jpeg", data=image),
         "Caption this image",
     ]
-    with patch("google.genai.models.Models._generate_content", new=_generate_content):
+    cls = "AsyncModels" if is_async else "Models"
+    with patch(f"google.genai.models.{cls}._generate_content",
+               new=_dummy_generate_content(is_async)):
         mlflow.gemini.autolog()
-        client = genai.Client(api_key="dummy")
-        client.models.generate_content(model="gemini-1.5-flash", contents=request)
+        _call_generate_content(is_async, request)
 
     traces = get_traces()
     assert len(traces) == 1
@@ -183,7 +222,7 @@ def test_generate_content_image_autolog():
     assert len(traces[0].data.spans) == 2
 
     span = traces[0].data.spans[0]
-    assert span.name == "Models.generate_content"
+    assert span.name == f"{cls}.generate_content"
     assert span.span_type == SpanType.LLM
     assert span.inputs["model"] == "gemini-1.5-flash"
     extra = {"display_name": None} if google_gemini_version >= Version("1.15.0") else {}
@@ -209,7 +248,7 @@ def test_generate_content_image_autolog():
     ]
 
     span1 = traces[0].data.spans[1]
-    assert span1.name == "Models._generate_content"
+    assert span1.name == f"{cls}._generate_content"
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == span.span_id
     assert span1.inputs["model"] == "gemini-1.5-flash"
@@ -222,7 +261,7 @@ def test_generate_content_image_autolog():
     assert span1.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
 
 
-def test_generate_content_tool_calling_autolog():
+def test_generate_content_tool_calling_autolog(is_async):
     tool_call_content = {
         "parts": [
             {
@@ -258,13 +297,19 @@ def test_generate_content_tool_calling_autolog():
         },
     ]
 
-    def _generate_content(self, model, contents, config):
-        return response
+    if is_async:
+        async def _generate_content(self, model, contents, config):
+            return response
+    else:
+        def _generate_content(self, model, contents, config):
+            return response
 
-    with patch("google.genai.models.Models._generate_content", new=_generate_content):
+    cls = "AsyncModels" if is_async else "Models"
+
+    with patch(f"google.genai.models.{cls}._generate_content", new=_generate_content):
         mlflow.gemini.autolog()
-        client = genai.Client(api_key="dummy")
-        client.models.generate_content(
+        _call_generate_content(
+            is_async,
             model="gemini-1.5-flash",
             contents="I have 57 cats, each owns 44 mittens, how many mittens is that in total?",
             config=genai.types.GenerateContentConfig(
@@ -279,7 +324,7 @@ def test_generate_content_tool_calling_autolog():
     assert len(traces[0].data.spans) == 2
 
     span = traces[0].data.spans[0]
-    assert span.name == "Models.generate_content"
+    assert span.name == f"{cls}.generate_content"
     assert span.span_type == SpanType.LLM
     assert (
         span.inputs["contents"]
@@ -289,7 +334,7 @@ def test_generate_content_tool_calling_autolog():
     assert span.get_attribute("mlflow.chat.messages") == chat_messages
 
     span1 = traces[0].data.spans[1]
-    assert span1.name == "Models._generate_content"
+    assert span1.name == f"{cls}._generate_content"
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == span.span_id
     assert (
@@ -300,7 +345,7 @@ def test_generate_content_tool_calling_autolog():
     assert span1.get_attribute("mlflow.chat.messages") == chat_messages
 
 
-def test_generate_content_tool_calling_chat_history_autolog():
+def test_generate_content_tool_calling_chat_history_autolog(is_async):
     question_content = genai.types.Content(
         **{
             "parts": [
@@ -389,13 +434,19 @@ def test_generate_content_tool_calling_chat_history_autolog():
         },
     ]
 
-    def _generate_content(self, model, contents, config):
-        return response
+    cls = "AsyncModels" if is_async else "Models"
 
-    with patch("google.genai.models.Models._generate_content", new=_generate_content):
+    if is_async:
+        async def _generate_content(self, model, contents, config):
+            return response
+    else:
+        def _generate_content(self, model, contents, config):
+            return response
+
+    with patch(f"google.genai.models.{cls}._generate_content", new=_generate_content):
         mlflow.gemini.autolog()
-        client = genai.Client(api_key="dummy")
-        client.models.generate_content(
+        _call_generate_content(
+            is_async,
             model="gemini-1.5-flash",
             contents=[question_content, tool_call_content, tool_response_content],
             config=genai.types.GenerateContentConfig(
@@ -410,7 +461,7 @@ def test_generate_content_tool_calling_chat_history_autolog():
     assert len(traces[0].data.spans) == 2
 
     span = traces[0].data.spans[0]
-    assert span.name == "Models.generate_content"
+    assert span.name == f"{cls}.generate_content"
     assert span.span_type == SpanType.LLM
     assert span.inputs["contents"] == [
         question_content.dict(),
@@ -422,7 +473,7 @@ def test_generate_content_tool_calling_chat_history_autolog():
     assert span.get_attribute("mlflow.chat.messages") == chat_messages
 
     span1 = traces[0].data.spans[1]
-    assert span1.name == "Models._generate_content"
+    assert span1.name == f"{cls}._generate_content"
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == span.span_id
     assert span1.inputs["contents"] == [
@@ -435,27 +486,25 @@ def test_generate_content_tool_calling_chat_history_autolog():
     assert span1.get_attribute("mlflow.chat.messages") == chat_messages
 
 
-def test_chat_session_autolog():
-    with patch("google.genai.models.Models._generate_content", new=_generate_content):
+def test_chat_session_autolog(is_async):
+    cls = "AsyncModels" if is_async else "Models"
+    with patch(f"google.genai.models.{cls}._generate_content", new=_dummy_generate_content(is_async)):
         mlflow.gemini.autolog()
-        client = genai.Client(api_key="dummy")
-        chat = client.chats.create(model="gemini-1.5-flash")
-        chat.send_message("test content")
+        _create_chat_and_send_message(is_async, "test content")
 
         traces = get_traces()
         assert len(traces) == 1
         assert traces[0].info.status == "OK"
         assert len(traces[0].data.spans) == 3
         span = traces[0].data.spans[0]
-        assert span.name == "Chat.send_message"
+        assert span.name == "AsyncChat.send_message" if is_async else "Chat.send_message"
         assert span.span_type == SpanType.CHAT_MODEL
         assert span.inputs == {"message": "test content"}
         assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
         assert span.get_attribute("mlflow.chat.messages") == _CHAT_MESSAGES
 
         mlflow.gemini.autolog(disable=True)
-        chat = client.chats.create(model="gemini-1.5-flash")
-        chat.send_message("test content")
+        _create_chat_and_send_message(is_async, "test content")
 
         # No new trace should be created
         traces = get_traces()

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -66,9 +66,11 @@ _CHAT_MESSAGES = [
 
 def _dummy_generate_content(is_async: bool):
     if is_async:
+
         async def _generate_content(self, model, contents, config):
             return _DUMMY_GENERATE_CONTENT_RESPONSE
     else:
+
         def _generate_content(self, model, contents, config):
             return _DUMMY_GENERATE_CONTENT_RESPONSE
 
@@ -121,10 +123,14 @@ def is_async(request):
     return request.param
 
 
-def _call_generate_content(is_async: bool, contents: str, model: str = "gemini-1.5-flash", config = None):
+def _call_generate_content(
+    is_async: bool, contents: str, model: str = "gemini-1.5-flash", config=None
+):
     client = genai.Client(api_key="dummy")
     if is_async:
-        return asyncio.run(client.aio.models.generate_content(model=model, contents=contents, config=config))
+        return asyncio.run(
+            client.aio.models.generate_content(model=model, contents=contents, config=config)
+        )
     else:
         return client.models.generate_content(model=model, contents=contents, config=config)
 
@@ -142,7 +148,9 @@ def _create_chat_and_send_message(is_async: bool, message: str):
 def test_generate_content_enable_disable_autolog(is_async):
     cls = "AsyncModels" if is_async else "Models"
     with (
-        patch(f"google.genai.models.{cls}._generate_content", new=_dummy_generate_content(is_async)),
+        patch(
+            f"google.genai.models.{cls}._generate_content", new=_dummy_generate_content(is_async)
+        ),
     ):
         mlflow.gemini.autolog()
         _call_generate_content(is_async, "test content")
@@ -155,7 +163,11 @@ def test_generate_content_enable_disable_autolog(is_async):
         span = traces[0].data.spans[0]
         assert span.name == f"{cls}.generate_content"
         assert span.span_type == SpanType.LLM
-        assert span.inputs == {"contents": "test content", "model": "gemini-1.5-flash", "config": None}
+        assert span.inputs == {
+            "contents": "test content",
+            "model": "gemini-1.5-flash",
+            "config": None,
+        }
         assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
         assert span.get_attribute("mlflow.chat.messages") == _CHAT_MESSAGES
 
@@ -180,9 +192,11 @@ def test_generate_content_enable_disable_autolog(is_async):
 
 def test_generate_content_tracing_with_error(is_async):
     if is_async:
+
         async def _generate_content(self, model, contents, config):
             raise Exception("dummy error")
     else:
+
         def _generate_content(self, model, contents, config):
             raise Exception("dummy error")
 
@@ -211,8 +225,9 @@ def test_generate_content_image_autolog():
         "Caption this image",
     ]
     cls = "AsyncModels" if is_async else "Models"
-    with patch(f"google.genai.models.{cls}._generate_content",
-               new=_dummy_generate_content(is_async)):
+    with patch(
+        f"google.genai.models.{cls}._generate_content", new=_dummy_generate_content(is_async)
+    ):
         mlflow.gemini.autolog()
         _call_generate_content(is_async, request)
 
@@ -298,9 +313,11 @@ def test_generate_content_tool_calling_autolog(is_async):
     ]
 
     if is_async:
+
         async def _generate_content(self, model, contents, config):
             return response
     else:
+
         def _generate_content(self, model, contents, config):
             return response
 
@@ -437,9 +454,11 @@ def test_generate_content_tool_calling_chat_history_autolog(is_async):
     cls = "AsyncModels" if is_async else "Models"
 
     if is_async:
+
         async def _generate_content(self, model, contents, config):
             return response
     else:
+
         def _generate_content(self, model, contents, config):
             return response
 
@@ -488,7 +507,9 @@ def test_generate_content_tool_calling_chat_history_autolog(is_async):
 
 def test_chat_session_autolog(is_async):
     cls = "AsyncModels" if is_async else "Models"
-    with patch(f"google.genai.models.{cls}._generate_content", new=_dummy_generate_content(is_async)):
+    with patch(
+        f"google.genai.models.{cls}._generate_content", new=_dummy_generate_content(is_async)
+    ):
         mlflow.gemini.autolog()
         _create_chat_and_send_message(is_async, "test content")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16632?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16632/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16632/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16632/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Support tracing async Gemini APIs. Using the same implementation pattern as [anthropic tracing](https://github.com/mlflow/mlflow/blob/973bd80c0aeb81c053226497403c412857dc1d3f/mlflow/anthropic/autolog.py) to minimize code duplication. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support tracing async Gemini APIs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
