### PR TITLE
Do not copy file permissions when logging artifacts to local artifact repo

### DIFF
--- a/mlflow/store/artifact/local_artifact_repo.py
+++ b/mlflow/store/artifact/local_artifact_repo.py
@@ -14,6 +14,7 @@ from mlflow.utils.file_utils import (
     local_file_uri_to_path,
     mkdir,
     relative_path_to_artifact_path,
+    shutil_copytree_without_file_permissions,
 )
 from mlflow.utils.uri import validate_path_is_safe
 
@@ -64,7 +65,7 @@ class LocalArtifactRepository(ArtifactRepository):
         )
         if not os.path.exists(artifact_dir):
             mkdir(artifact_dir)
-        shutil.copytree(src=local_dir, dst=artifact_dir, dirs_exist_ok=True)
+        shutil_copytree_without_file_permissions(local_dir, artifact_dir)
 
     def download_artifacts(self, artifact_path, dst_path=None):
         """

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -826,7 +826,8 @@ def shutil_copytree_without_file_permissions(src_dir, dst_dir):
             # For each directory <dirname> immediately under <dirpath>, create an equivalently-named
             # directory under the destination directory
             abs_dir_path = os.path.join(dst_dir, relative_dir_path)
-            os.mkdir(abs_dir_path)
+            if not os.path.exists(abs_dir_path):
+                os.mkdir(abs_dir_path)
         for filename in filenames:
             # For each file with name <filename> immediately under <dirpath>, copy that file to
             # the appropriate location in the destination directory


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/connortann/mlflow/pull/16642?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16642/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16642/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16642/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #16612

### What changes are proposed in this pull request?

When logging artifacts to a local artifact repo, use `shutil_copytree_without_file_permissions` rather than `shutil.copytree`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested manually as follows:

Make a local artifact location owned by a group `testgrp` with the setgid bit set:

```bash
rm -rf ./foo
mkdir ./foo
sudo groupadd testgrp
sudo chgrp testgrp ./foo
sudo chmod g+s ./foo
```

Log a model:

```python
import mlflow
from sklearn import datasets
from sklearn.linear_model import LogisticRegression

mlflow.set_tracking_uri("./foo")
mlflow.set_experiment("Test")
with mlflow.start_run():
    X, y = datasets.load_iris(return_X_y=True)
    lr = LogisticRegression()
    lr.fit(X, y)
    mlflow.sklearn.log_model(sk_model=lr, name="iris_model")
```

Finally, examine the contents of the model directory, to confirm the model `artifacts` directory has the right group owner and the setgid bit.
The particular path may vary, but we are looking at a path like `foo/...models/m-...`.

```bash
# Before fix
ls -l foo/952654319968295147/models/m-7ff8efce43de4d378034bc090432070c/
total 20
drwxr-xr-x 2 connor testgrp 4096 Jul  8 12:47 artifacts  # setgid bit not set
-rw-r--r-- 1 connor testgrp  397 Jul  8 12:47 meta.yaml
drwxr-sr-x 2 connor testgrp 4096 Jul  8 12:47 metrics
drwxr-sr-x 2 connor testgrp 4096 Jul  8 12:47 params
drwxr-sr-x 2 connor testgrp 4096 Jul  8 12:47 tags

# After fix
$ ls -l foo/490555791144880264/models/m-92e02668deb04ce3984c939c32c98d25/
total 20
drwxr-sr-x 2 connor testgrp 4096 Jul  8 12:52 artifacts    # setgid bit is set
-rw-r--r-- 1 connor testgrp  397 Jul  8 12:52 meta.yaml
drwxr-sr-x 2 connor testgrp 4096 Jul  8 12:52 metrics
drwxr-sr-x 2 connor testgrp 4096 Jul  8 12:52 params
drwxr-sr-x 2 connor testgrp 4096 Jul  8 12:52 tags
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When artifacts are logged to a local file store, artifacts inherit group ownership from the file store directory.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
