### PR TITLE
Replace CircleCI config with minimal placeholder

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,83 +1,12 @@
 version: 2.1
 
-commands:
-  fetch_merge_ref:
-    description: "Fetch the merge ref for a pull request"
-    steps:
-      - run:
-          name: Fetch merge ref
-          command: |
-            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-              PR_NUMBER=$(basename "$CIRCLE_PULL_REQUEST")
-              git fetch origin refs/pull/$PR_NUMBER/merge
-              git checkout FETCH_HEAD
-            fi
-
+# TODO: Remove this file after MLflow 3.1.3 release.
 jobs:
-  # TODO: Add a job to build the python and java api reference
   build_doc:
-    docker:
-      - image: cimg/python:3.10-node
-    resource_class: large
-
     steps:
-      - checkout
-      - fetch_merge_ref
       - run:
-          name: Set env vars
-          working_directory: docs
-          command: |
-            DOCS_BASE_URL="/output/job/$CIRCLE_WORKFLOW_JOB_ID/artifacts/0/docs/build/"
-            echo "export DOCS_BASE_URL=$DOCS_BASE_URL" >> "$BASH_ENV"
-            echo "export API_REFERENCE_PREFIX=https://output.circle-artifacts.com$DOCS_BASE_URL" >> "$BASH_ENV"
-            echo "export GTM_ID=GTM-TEST" >> "$BASH_ENV"
-      - run:
-          name: Install Java
-          command: |
-            sudo apt-get update --yes
-            sudo apt-get install default-jdk --yes
-            sudo apt-get install maven --yes
-            java -version
-      - run:
-          name: Install Pandoc
-          command: |
-            sudo apt-get install pandoc
-      - run:
-          name: Install Python dependencies
-          command: |
-            pip --version
-            pip install --progress-bar off -r requirements/doc-requirements.txt pytest pytest-cov plotly
-            pip install -e .[gateway]
-          environment:
-            PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
-      - run:
-          name: Show package release dates
-          command: |
-            python dev/show_package_release_dates.py
-      - run:
-          name: Install JS dependencies
-          working_directory: docs
-          command: |
-            yarn install --no-immutable
-            if [ -n "$(git status --porcelain yarn.lock)" ]; then
-              echo "yarn.lock has changed. Please run 'yarn install' locally and commit the changes."
-              exit 1
-            fi
-
-      - run:
-          name: Build documentation
-          working_directory: docs
-          environment:
-            JAVA_HOME: /usr/lib/jvm/default-java
-            PR_PREVIEW: "true"
-          command: |
-            yarn build-all -- --no-r
-      - run:
-          name: Show docs build size
-          working_directory: docs
-          command: |
-            echo "Total size of docs/build/latest directory:"
-            du -sh ./build/latest
+          name: Do nothing
+          command: ls
 
 workflows:
   build:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,7 @@ jobs:
     steps:
       - run: ls
 
-# Orchestrate our job run sequence
 workflows:
-  build_and_test:
+  build:
     jobs:
       - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,15 @@
 version: 2.1
 
-# TODO: Remove this file after MLflow 3.1.3 release.
+# TODO: Remove this job once MLflow 3.1.3 is released
 jobs:
-  build_doc:
-    steps:
-      - run:
-          name: Do nothing
-          command: ls
-
-workflows:
   build:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - run: ls
+
+# Orchestrate our job run sequence
+workflows:
+  build_and_test:
     jobs:
-      - build_doc
+      - build


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16647?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16647/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16647/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16647/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR replaces the existing CircleCI configuration with a minimal placeholder that only contains a simple `build` job. The placeholder includes a TODO comment to remove it once MLflow 3.1.3 is released.

Since everything has been migrated to GitHub Actions, the full CircleCI configuration is no longer needed. This change removes the `build_doc` job and all associated commands while keeping a minimal config file to avoid any CI disruptions until it can be fully removed.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)