### PR TITLE
Fix the position of added tracking_uri param to artifact store implementations

### DIFF
--- a/mlflow/store/artifact/azure_blob_artifact_repo.py
+++ b/mlflow/store/artifact/azure_blob_artifact_repo.py
@@ -41,7 +41,7 @@ class AzureBlobArtifactRepository(ArtifactRepository, MultipartUploadMixin):
     - DefaultAzureCredential is configured
     """
 
-    def __init__(self, artifact_uri: str, tracking_uri: Optional[str] = None, client=None) -> None:
+    def __init__(self, artifact_uri: str, client=None, tracking_uri: Optional[str] = None) -> None:
         super().__init__(artifact_uri, tracking_uri)
 
         _DEFAULT_TIMEOUT = 600  # 10 minutes

--- a/mlflow/store/artifact/azure_data_lake_artifact_repo.py
+++ b/mlflow/store/artifact/azure_data_lake_artifact_repo.py
@@ -82,9 +82,9 @@ class AzureDataLakeArtifactRepository(CloudArtifactRepository):
     def __init__(
         self,
         artifact_uri: str,
-        tracking_uri: Optional[str] = None,
         credential=None,
         credential_refresh_def=None,
+        tracking_uri: Optional[str] = None,
     ) -> None:
         super().__init__(artifact_uri, tracking_uri)
         _DEFAULT_TIMEOUT = 600  # 10 minutes

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -43,9 +43,9 @@ class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):
     def __init__(
         self,
         artifact_uri: str,
-        tracking_uri: Optional[str] = None,
         client=None,
         credential_refresh_def=None,
+        tracking_uri: Optional[str] = None,
     ) -> None:
         super().__init__(artifact_uri, tracking_uri)
         from google.auth.exceptions import DefaultCredentialsError

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -122,16 +122,54 @@ def _get_s3_client(
 
 
 class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
-    """Stores artifacts on Amazon S3."""
+    """
+    Stores artifacts on Amazon S3.
+
+    This repository provides MLflow artifact storage using Amazon S3 as the backend.
+    It supports both single-file uploads and multipart uploads for large files,
+    with automatic content type detection and configurable upload parameters.
+
+    The repository uses boto3 for S3 operations and supports various authentication
+    methods including AWS credentials, IAM roles, and environment variables.
+
+    Environment Variables:
+        AWS_ACCESS_KEY_ID: AWS access key ID for authentication
+        AWS_SECRET_ACCESS_KEY: AWS secret access key for authentication
+        AWS_SESSION_TOKEN: AWS session token for temporary credentials
+        AWS_DEFAULT_REGION: Default AWS region for S3 operations
+        MLFLOW_S3_ENDPOINT_URL: Custom S3 endpoint URL (for S3-compatible storage)
+        MLFLOW_S3_IGNORE_TLS: Set to 'true' to disable TLS verification
+        MLFLOW_S3_UPLOAD_EXTRA_ARGS: JSON string of extra arguments for S3 uploads
+        MLFLOW_BOTO_CLIENT_ADDRESSING_STYLE: S3 addressing style ('path' or 'virtual')
+
+    Note:
+        This class inherits from both ArtifactRepository and MultipartUploadMixin,
+        providing full artifact management capabilities including efficient large file uploads.
+    """
 
     def __init__(
         self,
         artifact_uri: str,
-        tracking_uri: Optional[str] = None,
         access_key_id=None,
         secret_access_key=None,
         session_token=None,
+        tracking_uri: Optional[str] = None,
     ) -> None:
+        """
+        Initialize an S3 artifact repository.
+
+        Args:
+            artifact_uri: S3 URI in the format 's3://bucket-name/path/to/artifacts'.
+                The URI must be a valid S3 URI with a bucket that exists and is accessible.
+            access_key_id: Optional AWS access key ID. If None, uses default AWS credential
+                resolution (environment variables, IAM roles, etc.).
+            secret_access_key: Optional AWS secret access key. Must be provided if
+                access_key_id is provided.
+            session_token: Optional AWS session token for temporary credentials.
+                Used with STS tokens or IAM roles.
+            tracking_uri: Optional URI for the MLflow tracking server.
+                If None, uses the current tracking URI context.
+        """
         super().__init__(artifact_uri, tracking_uri)
         self._access_key_id = access_key_id
         self._secret_access_key = secret_access_key
@@ -145,7 +183,17 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         )
 
     def parse_s3_compliant_uri(self, uri):
-        """Parse an S3 URI, returning (bucket, path)"""
+        """
+        Parse an S3 URI into bucket and path components.
+
+        Args:
+            uri: S3 URI in the format 's3://bucket-name/path/to/object'
+
+        Returns:
+            A tuple containing (bucket_name, object_path) where:
+            - bucket_name: The S3 bucket name
+            - object_path: The path within the bucket (without leading slash)
+        """
         parsed = urllib.parse.urlparse(uri)
         if parsed.scheme != "s3":
             raise Exception(f"Not an S3 URI: {uri}")
@@ -156,6 +204,17 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
 
     @staticmethod
     def get_s3_file_upload_extra_args():
+        """
+        Get additional S3 upload arguments from environment variables.
+
+        Returns:
+            Dictionary of extra arguments for S3 uploads, or None if not configured.
+            These arguments are passed to boto3's upload_file method.
+
+        Environment Variables:
+            MLFLOW_S3_UPLOAD_EXTRA_ARGS: JSON string containing extra arguments
+                for S3 uploads (e.g., '{"ServerSideEncryption": "AES256"}')
+        """
         s3_file_upload_extra_args = MLFLOW_S3_UPLOAD_EXTRA_ARGS.get()
         if s3_file_upload_extra_args:
             return json.loads(s3_file_upload_extra_args)
@@ -175,6 +234,19 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         s3_client.upload_file(Filename=local_file, Bucket=bucket, Key=key, ExtraArgs=extra_args)
 
     def log_artifact(self, local_file, artifact_path=None):
+        """
+        Log a local file as an artifact to S3.
+
+        This method uploads a single file to S3 with automatic content type detection
+        and optional extra upload arguments from environment variables.
+
+        Args:
+            local_file: Absolute path to the local file to upload. The file must
+                exist and be readable.
+            artifact_path: Optional relative path within the S3 bucket where the
+                artifact should be stored. If None, the file is stored in the root
+                of the configured S3 path. Use forward slashes (/) for path separators.
+        """
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -184,6 +256,20 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         )
 
     def log_artifacts(self, local_dir, artifact_path=None):
+        """
+        Log all files in a local directory as artifacts to S3.
+
+        This method recursively uploads all files in the specified directory,
+        preserving the directory structure in S3. Each file is uploaded with
+        automatic content type detection.
+
+        Args:
+            local_dir: Absolute path to the local directory containing files to upload.
+                The directory must exist and be readable.
+            artifact_path: Optional relative path within the S3 bucket where the
+                artifacts should be stored. If None, files are stored in the root
+                of the configured S3 path. Use forward slashes (/) for path separators.
+        """
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -205,6 +291,25 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 )
 
     def list_artifacts(self, path=None):
+        """
+        List all artifacts directly under the specified S3 path.
+
+        This method uses S3's list_objects_v2 API with pagination to efficiently
+        list artifacts. It treats S3 prefixes as directories and returns both
+        files and directories as FileInfo objects.
+
+        Args:
+            path: Optional relative path within the S3 bucket to list. If None,
+                lists artifacts in the root of the configured S3 path. If the path
+                refers to a single file, returns an empty list per MLflow convention.
+
+        Returns:
+            A list of FileInfo objects representing artifacts directly under the
+            specified path. Each FileInfo contains:
+            - path: Relative path of the artifact from the repository root
+            - is_dir: True if the artifact represents a directory (S3 prefix)
+            - file_size: Size in bytes for files, None for directories
+        """
         (bucket, artifact_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         dest_path = artifact_path
         if path:
@@ -247,6 +352,18 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             )
 
     def _download_file(self, remote_file_path, local_path):
+        """
+        Download a file from S3 to the local filesystem.
+
+        This method downloads a single file from S3 to the specified local path.
+        It's used internally by the download_artifacts method.
+
+        Args:
+            remote_file_path: Relative path of the file within the S3 bucket,
+                relative to the repository's root path.
+            local_path: Absolute path where the file should be saved locally.
+                The parent directory must exist.
+        """
         (bucket, s3_root_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         s3_full_path = posixpath.join(s3_root_path, remote_file_path)
         s3_client = self._get_s3_client()
@@ -273,6 +390,28 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 s3_client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
+        """
+        Initiate a multipart upload for efficient large file uploads to S3.
+
+        This method creates a multipart upload session in S3 and generates
+        presigned URLs for uploading each part. This is more efficient than
+        single-part uploads for large files and provides better error recovery.
+
+        Args:
+            local_file: Absolute path to the local file to upload. The file must
+                exist and be readable.
+            num_parts: Number of parts to split the upload into. Must be between
+                1 and 10,000 (S3 limit). More parts allow greater parallelism
+                but increase overhead.
+            artifact_path: Optional relative path within the S3 bucket where the
+                artifact should be stored. If None, the file is stored in the root
+                of the configured S3 path.
+
+        Returns:
+            CreateMultipartUploadResponse containing:
+            - credentials: List of MultipartUploadCredential objects with presigned URLs
+            - upload_id: S3 upload ID for tracking this multipart upload
+        """
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -307,6 +446,23 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         )
 
     def complete_multipart_upload(self, local_file, upload_id, parts=None, artifact_path=None):
+        """
+        Complete a multipart upload by combining all parts into a single S3 object.
+
+        This method should be called after all parts have been successfully uploaded
+        using the presigned URLs from create_multipart_upload. It tells S3 to combine
+        all the parts into the final object.
+
+        Args:
+            local_file: Absolute path to the local file that was uploaded. Must match
+                the local_file used in create_multipart_upload.
+            upload_id: The S3 upload ID returned by create_multipart_upload.
+            parts: List of MultipartUploadPart objects containing metadata for each
+                successfully uploaded part. Must include part_number and etag for each part.
+                Parts must be provided in order (part 1, part 2, etc.).
+            artifact_path: Optional relative path where the artifact should be stored.
+                Must match the artifact_path used in create_multipart_upload.
+        """
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)
@@ -318,6 +474,20 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         )
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
+        """
+        Abort a multipart upload and clean up any uploaded parts.
+
+        This method should be called if a multipart upload fails or is cancelled.
+        It cleans up any parts that were successfully uploaded and cancels the
+        multipart upload session in S3.
+
+        Args:
+            local_file: Absolute path to the local file that was being uploaded.
+                Must match the local_file used in create_multipart_upload.
+            upload_id: The S3 upload ID returned by create_multipart_upload.
+            artifact_path: Optional relative path where the artifact would have been stored.
+                Must match the artifact_path used in create_multipart_upload.
+        """
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         if artifact_path:
             dest_path = posixpath.join(dest_path, artifact_path)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/16653?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16653/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16653/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16653/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

#16442 introduced a breaking change to public APIs by inserting an optional additional argument to the API signature. 
This PR relocates this parameter to the end of signatures to make the update backwards compatible with positional-reference usage of these APIs.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
