### PR TITLE
Add function signature breaking change detector

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -36,6 +36,10 @@ jobs:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          # To ensure `git diff` works correctly in dev/check_function_signatures.py,
+          # we need to fetch enough history to include the base branch.
+          fetch-depth: 300
       - uses: ./.github/actions/untracked
       - uses: ./.github/actions/setup-python
         id: setup-python
@@ -68,3 +72,6 @@ jobs:
         run: |
           uv run --isolated --no-project --with pytest==8.4.0 --with ./dev/clint \
             pytest --confcutdir=dev/clint dev/clint
+
+      - run: |
+          python dev/check_function_signatures.py

--- a/dev/check_function_signatures.py
+++ b/dev/check_function_signatures.py
@@ -1,0 +1,383 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import os
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+
+def is_github_actions() -> bool:
+    return os.environ.get("GITHUB_ACTIONS") == "true"
+
+
+@dataclass
+class Error:
+    file_path: Path
+    line: int
+    column: int
+    lines: list[str]
+
+    def format(self, github: bool = False) -> str:
+        message = " ".join(self.lines)
+        if github:
+            return f"::warning file={self.file_path},line={self.line},col={self.column}::{message}"
+        else:
+            return f"{self.file_path}:{self.line}:{self.column}: {message}"
+
+
+@dataclass
+class Parameter:
+    name: str
+    position: Optional[int]  # None for keyword-only
+    is_required: bool
+    is_positional_only: bool
+    is_keyword_only: bool
+    lineno: int
+    col_offset: int
+
+
+@dataclass
+class Signature:
+    positional: list[Parameter]  # Includes positional-only and regular positional
+    keyword_only: list[Parameter]
+    has_var_positional: bool  # *args
+    has_var_keyword: bool  # **kwargs
+
+
+@dataclass
+class ParameterError:
+    message: str
+    param_name: str
+    lineno: int
+    col_offset: int
+
+
+def parse_signature(args: ast.arguments) -> Signature:
+    """Convert ast.arguments to a Signature dataclass for easier processing."""
+    parameters_positional: list[Parameter] = []
+    parameters_keyword_only: list[Parameter] = []
+
+    # Process positional-only parameters
+    for i, arg in enumerate(args.posonlyargs):
+        parameters_positional.append(
+            Parameter(
+                name=arg.arg,
+                position=i,
+                is_required=True,  # All positional-only are required
+                is_positional_only=True,
+                is_keyword_only=False,
+                lineno=arg.lineno,
+                col_offset=arg.col_offset,
+            )
+        )
+
+    # Process regular positional parameters
+    offset = len(args.posonlyargs)
+    first_optional_idx = len(args.posonlyargs + args.args) - len(args.defaults)
+
+    for i, arg in enumerate(args.args):
+        pos = offset + i
+        parameters_positional.append(
+            Parameter(
+                name=arg.arg,
+                position=pos,
+                is_required=pos < first_optional_idx,
+                is_positional_only=False,
+                is_keyword_only=False,
+                lineno=arg.lineno,
+                col_offset=arg.col_offset,
+            )
+        )
+
+    # Process keyword-only parameters
+    for arg, default in zip(args.kwonlyargs, args.kw_defaults):
+        parameters_keyword_only.append(
+            Parameter(
+                name=arg.arg,
+                position=None,
+                is_required=default is None,
+                is_positional_only=False,
+                is_keyword_only=True,
+                lineno=arg.lineno,
+                col_offset=arg.col_offset,
+            )
+        )
+
+    return Signature(
+        positional=parameters_positional,
+        keyword_only=parameters_keyword_only,
+        has_var_positional=args.vararg is not None,
+        has_var_keyword=args.kwarg is not None,
+    )
+
+
+def check_signature_compatibility(
+    old_fn: ast.FunctionDef | ast.AsyncFunctionDef,
+    new_fn: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> list[ParameterError]:
+    """
+    Return list of error messages when *new_fn* is not backward-compatible with *old_fn*,
+    or None if compatible.
+
+    Compatibility rules
+    -------------------
+    • Positional / positional-only parameters
+        - Cannot be reordered, renamed, or removed.
+        - Adding **required** ones is breaking.
+        - Adding **optional** ones is allowed only at the end.
+        - Making an optional parameter required is breaking.
+
+    • Keyword-only parameters (order does not matter)
+        - Cannot be renamed or removed.
+        - Making an optional parameter required is breaking.
+        - Adding a required parameter is breaking; adding an optional parameter is fine.
+    """
+    old_sig = parse_signature(old_fn.args)
+    new_sig = parse_signature(new_fn.args)
+    errors: list[ParameterError] = []
+
+    # ------------------------------------------------------------------ #
+    # 1. Positional / pos-only parameters
+    # ------------------------------------------------------------------ #
+
+    # (a) existing parameters must line up
+    for idx, old_param in enumerate(old_sig.positional):
+        if idx >= len(new_sig.positional):
+            errors.append(
+                ParameterError(
+                    message=f"Positional param '{old_param.name}' was removed.",
+                    param_name=old_param.name,
+                    lineno=old_param.lineno,
+                    col_offset=old_param.col_offset,
+                )
+            )
+            continue
+
+        new_param = new_sig.positional[idx]
+        if old_param.name != new_param.name:
+            errors.append(
+                ParameterError(
+                    message=(
+                        f"Positional param order/name changed: "
+                        f"'{old_param.name}' -> '{new_param.name}'."
+                    ),
+                    param_name=new_param.name,
+                    lineno=new_param.lineno,
+                    col_offset=new_param.col_offset,
+                )
+            )
+            # Stop checking further positional params after first order/name mismatch
+            break
+
+        if (not old_param.is_required) and new_param.is_required:
+            errors.append(
+                ParameterError(
+                    message=f"Optional positional param '{old_param.name}' became required.",
+                    param_name=new_param.name,
+                    lineno=new_param.lineno,
+                    col_offset=new_param.col_offset,
+                )
+            )
+
+    # (b) any extra new positional params must be optional and appended
+    if len(new_sig.positional) > len(old_sig.positional):
+        for idx in range(len(old_sig.positional), len(new_sig.positional)):
+            new_param = new_sig.positional[idx]
+            if new_param.is_required:
+                errors.append(
+                    ParameterError(
+                        message=f"New required positional param '{new_param.name}' added.",
+                        param_name=new_param.name,
+                        lineno=new_param.lineno,
+                        col_offset=new_param.col_offset,
+                    )
+                )
+
+    # ------------------------------------------------------------------ #
+    # 2. Keyword-only parameters (order-agnostic)
+    # ------------------------------------------------------------------ #
+    old_kw_names = {p.name for p in old_sig.keyword_only}
+    new_kw_names = {p.name for p in new_sig.keyword_only}
+
+    # Build mappings for easier lookup
+    old_kw_by_name = {p.name: p for p in old_sig.keyword_only}
+    new_kw_by_name = {p.name: p for p in new_sig.keyword_only}
+
+    # removed or renamed
+    for name in old_kw_names - new_kw_names:
+        old_param = old_kw_by_name[name]
+        errors.append(
+            ParameterError(
+                message=f"Keyword-only param '{name}' was removed.",
+                param_name=name,
+                lineno=old_param.lineno,
+                col_offset=old_param.col_offset,
+            )
+        )
+
+    # optional -> required upgrades
+    for name in old_kw_names & new_kw_names:
+        if not old_kw_by_name[name].is_required and new_kw_by_name[name].is_required:
+            new_param = new_kw_by_name[name]
+            errors.append(
+                ParameterError(
+                    message=f"Keyword-only param '{name}' became required.",
+                    param_name=name,
+                    lineno=new_param.lineno,
+                    col_offset=new_param.col_offset,
+                )
+            )
+
+    # new required keyword-only params
+    for param in new_sig.keyword_only:
+        if param.is_required and param.name not in old_kw_names:
+            errors.append(
+                ParameterError(
+                    message=f"New required keyword-only param '{param.name}' added.",
+                    param_name=param.name,
+                    lineno=param.lineno,
+                    col_offset=param.col_offset,
+                )
+            )
+
+    return errors
+
+
+def _is_private(n: str) -> bool:
+    return n.startswith("_") and not n.startswith("__") and not n.endswith("__")
+
+
+class FunctionSignatureExtractor(ast.NodeVisitor):
+    def __init__(self):
+        self.functions: dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+        self.stack: list[ast.ClassDef] = []
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self.stack.append(node)
+        self.generic_visit(node)
+        self.stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        # Is this a private function or a function in a private class?
+        # If so, skip it.
+        if _is_private(node.name) or (self.stack and _is_private(self.stack[-1].name)):
+            return
+
+        names = [*(c.name for c in self.stack), node.name]
+        self.functions[".".join(names)] = node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        if _is_private(node.name) or (self.stack and _is_private(self.stack[-1].name)):
+            return
+
+        names = [*(c.name for c in self.stack), node.name]
+        self.functions[".".join(names)] = node
+
+
+def get_changed_python_files(base_branch: str = "master") -> list[Path]:
+    # In GitHub Actions PR context, we need to fetch the base branch first
+    if is_github_actions():
+        # Fetch the base branch to ensure we have it locally
+        subprocess.check_call(
+            ["git", "fetch", "origin", f"{base_branch}:{base_branch}"],
+        )
+
+    result = subprocess.check_output(
+        ["git", "diff", "--name-only", f"{base_branch}...HEAD"], text=True
+    )
+    files = [s.strip() for s in result.splitlines()]
+    return [Path(f) for f in files if f]
+
+
+def parse_functions(content: str) -> dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    tree = ast.parse(content)
+    extractor = FunctionSignatureExtractor()
+    extractor.visit(tree)
+    return extractor.functions
+
+
+def get_file_content_at_revision(file_path: Path, revision: str) -> Optional[str]:
+    try:
+        return subprocess.check_output(["git", "show", f"{revision}:{file_path}"], text=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Warning: Failed to get file content at revision: {e}", file=sys.stderr)
+        return None
+
+
+def compare_signatures(base_branch: str = "master") -> list[Error]:
+    errors: list[Error] = []
+    for file_path in get_changed_python_files(base_branch):
+        # Ignore non-Python files
+        if not file_path.suffix == ".py":
+            continue
+
+        # Ignore files not in the mlflow directory
+        if file_path.parts[0] != "mlflow":
+            continue
+
+        # Ignore private modules
+        if any(part.startswith("_") for part in file_path.parts):
+            continue
+
+        base_content = get_file_content_at_revision(file_path, base_branch)
+        if base_content is None:
+            # Find not found in the base branch, likely added in the current branch
+            continue
+
+        if not file_path.exists():
+            # File not found, likely deleted in the current branch
+            continue
+
+        current_content = file_path.read_text()
+        base_functions = parse_functions(base_content)
+        current_functions = parse_functions(current_content)
+        for func_name in set(base_functions.keys()) & set(current_functions.keys()):
+            base_func = base_functions[func_name]
+            current_func = current_functions[func_name]
+            if param_errors := check_signature_compatibility(base_func, current_func):
+                # Create individual errors for each problematic parameter
+                for param_error in param_errors:
+                    errors.append(
+                        Error(
+                            file_path=file_path,
+                            line=param_error.lineno,
+                            column=param_error.col_offset + 1,
+                            lines=[
+                                "[Non-blocking]",
+                                param_error.message,
+                                f"This breaks existing `{func_name}` calls.",
+                                "If this is not intended, please fix it.",
+                            ],
+                        )
+                    )
+
+    return errors
+
+
+@dataclass
+class Args:
+    base_branch: str
+
+
+def parse_args() -> Args:
+    parser = argparse.ArgumentParser(
+        description="Check for breaking changes in Python function signatures"
+    )
+    parser.add_argument("--base-branch", default=os.environ.get("GITHUB_BASE_REF", "master"))
+    args = parser.parse_args()
+    return Args(base_branch=args.base_branch)
+
+
+def main():
+    args = parse_args()
+    errors = compare_signatures(args.base_branch)
+    for error in errors:
+        print(error.format(github=is_github_actions()))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dev/test_check_function_signatures.py
+++ b/tests/dev/test_check_function_signatures.py
@@ -1,0 +1,230 @@
+import ast
+
+from dev.check_function_signatures import check_signature_compatibility
+
+
+def test_no_changes():
+    old_code = "def func(a, b=1): pass"
+    new_code = "def func(a, b=1): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 0
+
+
+def test_positional_param_removed():
+    old_code = "def func(a, b, c): pass"
+    new_code = "def func(a, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].message == "Positional param 'c' was removed."
+    assert errors[0].param_name == "c"
+
+
+def test_positional_param_renamed():
+    old_code = "def func(a, b): pass"
+    new_code = "def func(x, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert "Positional param order/name changed: 'a' -> 'x'." in errors[0].message
+    assert errors[0].param_name == "x"
+
+
+def test_only_first_positional_rename_flagged():
+    old_code = "def func(a, b, c, d): pass"
+    new_code = "def func(x, y, z, w): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert "Positional param order/name changed: 'a' -> 'x'." in errors[0].message
+
+
+def test_optional_positional_became_required():
+    old_code = "def func(a, b=1): pass"
+    new_code = "def func(a, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].message == "Optional positional param 'b' became required."
+    assert errors[0].param_name == "b"
+
+
+def test_multiple_optional_became_required():
+    old_code = "def func(a, b=1, c=2): pass"
+    new_code = "def func(a, b, c): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 2
+    assert errors[0].message == "Optional positional param 'b' became required."
+    assert errors[1].message == "Optional positional param 'c' became required."
+
+
+def test_new_required_positional_param():
+    old_code = "def func(a): pass"
+    new_code = "def func(a, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].message == "New required positional param 'b' added."
+    assert errors[0].param_name == "b"
+
+
+def test_new_optional_positional_param_allowed():
+    old_code = "def func(a): pass"
+    new_code = "def func(a, b=1): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 0
+
+
+def test_keyword_only_param_removed():
+    old_code = "def func(*, a, b): pass"
+    new_code = "def func(*, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].message == "Keyword-only param 'a' was removed."
+    assert errors[0].param_name == "a"
+
+
+def test_multiple_keyword_only_removed():
+    old_code = "def func(*, a, b, c): pass"
+    new_code = "def func(*, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 2
+    error_messages = {e.message for e in errors}
+    assert "Keyword-only param 'a' was removed." in error_messages
+    assert "Keyword-only param 'c' was removed." in error_messages
+
+
+def test_optional_keyword_only_became_required():
+    old_code = "def func(*, a=1): pass"
+    new_code = "def func(*, a): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].message == "Keyword-only param 'a' became required."
+    assert errors[0].param_name == "a"
+
+
+def test_new_required_keyword_only_param():
+    old_code = "def func(*, a): pass"
+    new_code = "def func(*, a, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].message == "New required keyword-only param 'b' added."
+    assert errors[0].param_name == "b"
+
+
+def test_new_optional_keyword_only_allowed():
+    old_code = "def func(*, a): pass"
+    new_code = "def func(*, a, b=1): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 0
+
+
+def test_complex_mixed_violations():
+    old_code = "def func(a, b=1, *, c, d=2): pass"
+    new_code = "def func(x, b, *, c=3, e): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 3
+    error_messages = [e.message for e in errors]
+    assert any("Positional param order/name changed: 'a' -> 'x'." in msg for msg in error_messages)
+    assert any("Keyword-only param 'd' was removed." in msg for msg in error_messages)
+    assert any("New required keyword-only param 'e' added." in msg for msg in error_messages)
+
+
+def test_parameter_error_has_location_info():
+    old_code = "def func(a): pass"
+    new_code = "def func(b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].lineno == 1
+    assert errors[0].col_offset > 0
+
+
+def test_async_function_compatibility():
+    old_code = "async def func(a, b=1): pass"
+    new_code = "async def func(a, b): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert errors[0].message == "Optional positional param 'b' became required."
+
+
+def test_positional_only_compatibility():
+    old_code = "def func(a, /): pass"
+    new_code = "def func(b, /): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert "Positional param order/name changed: 'a' -> 'b'." in errors[0].message
+
+
+def test_rename_stops_further_positional_checks():
+    old_code = "def func(a, b=1, c=2): pass"
+    new_code = "def func(x, b, c): pass"
+
+    old_tree = ast.parse(old_code)
+    new_tree = ast.parse(new_code)
+    errors = check_signature_compatibility(old_tree.body[0], new_tree.body[0])
+
+    assert len(errors) == 1
+    assert "Positional param order/name changed: 'a' -> 'x'." in errors[0].message


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16658?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16658/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16658/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16658/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a script to detect breaking changes in Python function signatures between branches. The script helps maintain backward compatibility by identifying when:

- New required parameters are added to existing functions
- Parameters are removed from existing functions  
- Parameter order is changed

**Files Added:**
- `dev/check_function_signatures.py` - Main detection script
- `dev/check-function-signatures.yml` - Sample GitHub Actions workflow

This change warns PRs like https://github.com/mlflow/mlflow/pull/16442.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing:**
- Tested script with `--help` flag
- Verified GitHub Actions environment detection
- Tested on actual function signature changes in codebase

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>