### PR TITLE
[TS #13] Add updateCurrentTrace API

### DIFF
--- a/packages/typescript/core/src/core/trace_manager.ts
+++ b/packages/typescript/core/src/core/trace_manager.ts
@@ -28,8 +28,13 @@ class _Trace {
     if (root_span) {
       // Accessing the OTel span directly get serialized value directly.
       // TODO: Implement the smart truncation logic.
-      this.info.requestPreview = root_span._span.attributes[SpanAttributeKey.INPUTS] as string;
-      this.info.responsePreview = root_span._span.attributes[SpanAttributeKey.OUTPUTS] as string;
+      // Only set previews if they haven't been explicitly set by updateCurrentTrace
+      if (!this.info.requestPreview) {
+        this.info.requestPreview = root_span._span.attributes[SpanAttributeKey.INPUTS] as string;
+      }
+      if (!this.info.responsePreview) {
+        this.info.responsePreview = root_span._span.attributes[SpanAttributeKey.OUTPUTS] as string;
+      }
     }
 
     return new Trace(this.info, traceData);

--- a/packages/typescript/core/src/index.ts
+++ b/packages/typescript/core/src/index.ts
@@ -1,9 +1,26 @@
 import { init } from './core/config';
-import { getLastActiveTraceId, startSpan, trace, withSpan } from './core/api';
+import {
+  getLastActiveTraceId,
+  getCurrentActiveSpan,
+  updateCurrentTrace,
+  startSpan,
+  trace,
+  withSpan
+} from './core/api';
 import { flushTraces } from './core/provider';
 import { MlflowClient } from './clients';
 
-export { getLastActiveTraceId, flushTraces, init, startSpan, trace, withSpan, MlflowClient };
+export {
+  getLastActiveTraceId,
+  getCurrentActiveSpan,
+  updateCurrentTrace,
+  flushTraces,
+  init,
+  startSpan,
+  trace,
+  withSpan,
+  MlflowClient
+};
 
 // Export entities
 export * from './core/constants';
@@ -12,3 +29,4 @@ export type { Trace } from './core/entities/trace';
 export type { TraceInfo } from './core/entities/trace_info';
 export type { TraceData } from './core/entities/trace_data';
 export { SpanStatusCode } from './core/entities/span_status';
+export type { UpdateCurrentTraceOptions } from './core/api';

--- a/packages/typescript/core/tests/core/api.test.ts
+++ b/packages/typescript/core/tests/core/api.test.ts
@@ -712,14 +712,14 @@ describe('API', () => {
   describe('getCurrentActiveSpan', () => {
     it('should return undefined when no span is active', () => {
       const activeSpan = mlflow.getCurrentActiveSpan();
-      expect(activeSpan).toBeUndefined();
+      expect(activeSpan).toBeNull();
     });
 
     it('should return the current active span within withSpan context', () => {
       void mlflow.withSpan(
         (span) => {
           const activeSpan = mlflow.getCurrentActiveSpan();
-          expect(activeSpan).toBeDefined();
+          expect(activeSpan).not.toBeNull();
           expect(activeSpan?.spanId).toBe(span.spanId);
           expect(activeSpan?.traceId).toBe(span.traceId);
         },
@@ -730,7 +730,7 @@ describe('API', () => {
     it('should return the current active span within traced function', () => {
       const tracedFunc = mlflow.trace(() => {
         const activeSpan = mlflow.getCurrentActiveSpan();
-        expect(activeSpan).toBeDefined();
+        expect(activeSpan).not.toBeNull();
         expect(activeSpan?.name).toBe('span'); // Default span name when function name is not available
         return 'result';
       });


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16677?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16677/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16677/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16677/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Add an equivalent of Python's `mlflow.update_current_trace()` API: https://mlflow.org/docs/latest/api_reference/python_api/mlflow.html#mlflow.update_current_trace, to allow setting trace-level info such as tags, client request ID, and more.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
