### PR TITLE
Implement Webhooks APIs: `RestStore`

### DIFF
--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -2,6 +2,7 @@ import logging
 from typing import Optional
 
 from mlflow.entities.model_registry import ModelVersion, RegisteredModel
+from mlflow.entities.webhook import Webhook, WebhookEvent, WebhookStatus
 from mlflow.protos.model_registry_pb2 import (
     CreateModelVersion,
     CreateRegisteredModel,
@@ -26,17 +27,28 @@ from mlflow.protos.model_registry_pb2 import (
     UpdateModelVersion,
     UpdateRegisteredModel,
 )
+from mlflow.protos.webhooks_pb2 import (
+    CreateWebhook,
+    DeleteWebhook,
+    GetWebhook,
+    ListWebhooks,
+    TestWebhook,
+    UpdateWebhook,
+    WebhookService,
+)
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.model_registry.base_rest_store import BaseRestStore
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import (
     _REST_API_PATH_PREFIX,
+    call_endpoint,
     extract_all_api_info_for_service,
     extract_api_info_for_service,
 )
 
 _METHOD_TO_INFO = extract_api_info_for_service(ModelRegistryService, _REST_API_PATH_PREFIX)
 _METHOD_TO_ALL_INFO = extract_all_api_info_for_service(ModelRegistryService, _REST_API_PATH_PREFIX)
+_WEBHOOK_METHOD_TO_INFO = extract_api_info_for_service(WebhookService, _REST_API_PATH_PREFIX)
 
 _logger = logging.getLogger(__name__)
 
@@ -59,6 +71,21 @@ class RestStore(BaseRestStore):
 
     def _get_all_endpoints_from_method(self, method):
         return _METHOD_TO_ALL_INFO[method]
+
+    def _get_webhook_endpoint_from_method(self, method):
+        return _WEBHOOK_METHOD_TO_INFO[method]
+
+    def _call_webhook_endpoint(
+        self,
+        api,
+        json_body: Optional[str] = None,
+        webhook_id: Optional[str] = None,
+    ):
+        endpoint, method = self._get_webhook_endpoint_from_method(api)
+        if webhook_id:
+            endpoint = endpoint.format(webhook_id=webhook_id)
+        response_proto = self._get_response_from_method(api)
+        return call_endpoint(self.get_host_creds(), endpoint, method, json_body, response_proto)
 
     # CRUD API for RegisteredModel objects
 
@@ -479,3 +506,71 @@ class RestStore(BaseRestStore):
         req_body = message_to_json(GetModelVersionByAlias(name=name, alias=alias))
         response_proto = self._call_endpoint(GetModelVersionByAlias, req_body)
         return ModelVersion.from_proto(response_proto.model_version)
+
+    # Webhook APIs
+    def create_webhook(
+        self,
+        name: str,
+        url: str,
+        events: list[WebhookEvent],
+        description: Optional[str] = None,
+        secret: Optional[str] = None,
+        status: Optional[WebhookStatus] = None,
+    ) -> Webhook:
+        req_body = message_to_json(
+            CreateWebhook(
+                name=name,
+                url=url,
+                events=events,
+                description=description,
+                secret=secret,
+                status=status,
+            )
+        )
+        response_proto = self._call_webhook_endpoint(CreateWebhook, req_body)
+        return Webhook.from_proto(response_proto.webhook)
+
+    def get_webhook(self, webhook_id: str) -> Webhook:
+        response_proto = self._call_webhook_endpoint(GetWebhook, webhook_id=webhook_id)
+        return Webhook.from_proto(response_proto.webhook)
+
+    def list_webhooks(
+        self,
+        max_results: Optional[int] = None,
+        page_token: Optional[str] = None,
+    ) -> tuple[list[Webhook], Optional[str]]:
+        req_body = message_to_json(ListWebhooks(max_results=max_results, page_token=page_token))
+        response_proto = self._call_webhook_endpoint(ListWebhooks, req_body)
+        webhooks = [Webhook.from_proto(webhook) for webhook in response_proto.webhooks]
+        return webhooks, response_proto.next_page_token
+
+    def update_webhook(
+        self,
+        webhook_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        url: Optional[str] = None,
+        events: Optional[list[str]] = None,
+        secret: Optional[str] = None,
+        status: Optional[str] = None,
+    ) -> Webhook:
+        req_body = message_to_json(
+            UpdateWebhook(
+                name=name,
+                description=description,
+                url=url,
+                events=events,
+                secret=secret,
+                status=status,
+            )
+        )
+        response_proto = self._call_webhook_endpoint(UpdateWebhook, req_body, webhook_id=webhook_id)
+        return Webhook.from_proto(response_proto.webhook)
+
+    def delete_webhook(self, webhook_id: str) -> None:
+        self._call_webhook_endpoint(DeleteWebhook, webhook_id=webhook_id)
+
+    def test_webhook(self, webhook_id: str):
+        req_body = message_to_json(TestWebhook(id=webhook_id))
+        response_proto = self._call_webhook_endpoint(TestWebhook, req_body)
+        return response_proto.result

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -520,10 +520,10 @@ class RestStore(BaseRestStore):
             CreateWebhook(
                 name=name,
                 url=url,
-                events=events,
+                events=[e.to_proto() for e in events],
                 description=description,
                 secret=secret,
-                status=status,
+                status=status.to_proto() if status else None,
             )
         )
         response_proto = self._call_webhook_endpoint(CreateWebhook, req_body)

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -549,18 +549,18 @@ class RestStore(BaseRestStore):
         name: Optional[str] = None,
         description: Optional[str] = None,
         url: Optional[str] = None,
-        events: Optional[list[str]] = None,
+        events: Optional[list[WebhookEvent]] = None,
         secret: Optional[str] = None,
-        status: Optional[str] = None,
+        status: Optional[WebhookStatus] = None,
     ) -> Webhook:
         req_body = message_to_json(
             UpdateWebhook(
                 name=name,
                 description=description,
                 url=url,
-                events=events,
+                events=[e.to_proto() for e in events] if events else None,
                 secret=secret,
-                status=status,
+                status=status.to_proto() if status else None,
             )
         )
         response_proto = self._call_webhook_endpoint(UpdateWebhook, req_body, webhook_id=webhook_id)

--- a/mlflow/store/model_registry/rest_store.py
+++ b/mlflow/store/model_registry/rest_store.py
@@ -32,7 +32,6 @@ from mlflow.protos.webhooks_pb2 import (
     DeleteWebhook,
     GetWebhook,
     ListWebhooks,
-    TestWebhook,
     UpdateWebhook,
     WebhookService,
 )
@@ -569,8 +568,3 @@ class RestStore(BaseRestStore):
 
     def delete_webhook(self, webhook_id: str) -> None:
         self._call_webhook_endpoint(DeleteWebhook, webhook_id=webhook_id)
-
-    def test_webhook(self, webhook_id: str):
-        req_body = message_to_json(TestWebhook(id=webhook_id))
-        response_proto = self._call_webhook_endpoint(TestWebhook, req_body)
-        return response_proto.result

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -717,5 +717,5 @@ def _validate_webhook_events(events: list[WebhookEvent]) -> None:
         or not all(isinstance(e, WebhookEvent) for e in events)
     ):
         raise MlflowException.invalid_parameter_value(
-            "Webhook events must be a non-empty list of WebhookEvent objects."
+            f"Webhook events must be a non-empty list of WebhookEvent objects: {events}."
         )

--- a/tests/store/model_registry/test_rest_store_webhooks.py
+++ b/tests/store/model_registry/test_rest_store_webhooks.py
@@ -178,7 +178,6 @@ def test_update_webhook_not_found(store: RestStore):
 @pytest.mark.parametrize(
     ("invalid_url", "expected_match"),
     [
-        ("", r"Webhook URL cannot be empty or just whitespace"),
         ("   ", r"Webhook URL cannot be empty or just whitespace"),
         ("ftp://example.com", r"Invalid webhook URL scheme"),
         ("http://[invalid", r"Invalid webhook URL"),

--- a/tests/store/model_registry/test_rest_store_webhooks.py
+++ b/tests/store/model_registry/test_rest_store_webhooks.py
@@ -1,3 +1,8 @@
+"""
+This test file verifies webhook CRUD operations with the REST client,
+testing both server handlers and the REST client together.
+"""
+
 import subprocess
 import sys
 from pathlib import Path

--- a/tests/store/model_registry/test_rest_store_webhooks.py
+++ b/tests/store/model_registry/test_rest_store_webhooks.py
@@ -1,0 +1,210 @@
+import subprocess
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from mlflow.entities.webhook import WebhookEvent, WebhookStatus
+from mlflow.exceptions import MlflowException
+from mlflow.store.model_registry.rest_store import RestStore
+from mlflow.utils.rest_utils import MlflowHostCreds
+
+from tests.helper_functions import get_safe_port
+
+
+@pytest.fixture
+def server(tmp_path: Path) -> Generator[str, None, None]:
+    port = get_safe_port()
+    sqlite_db_path = tmp_path / "mlflow.db"
+
+    with subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "server",
+            "--dev",
+            f"--port={port}",
+            "--backend-store-uri",
+            f"sqlite:///{sqlite_db_path}",
+        ],
+        cwd=tmp_path,
+    ) as process:
+        url = f"http://localhost:{port}"
+        try:
+            yield url
+        finally:
+            process.terminate()
+
+
+@pytest.fixture
+def store(server: str) -> RestStore:
+    return RestStore(lambda: MlflowHostCreds(server))
+
+
+def test_create_webhook(store: RestStore):
+    webhook = store.create_webhook(
+        name="test_webhook",
+        url="https://example.com/webhook",
+        events=[WebhookEvent.MODEL_VERSION_CREATED],
+    )
+    assert webhook.name == "test_webhook"
+    assert webhook.url == "https://example.com/webhook"
+    assert webhook.secret is None
+    assert webhook.events == [WebhookEvent.MODEL_VERSION_CREATED]
+
+    webhook = store.get_webhook(webhook.webhook_id)
+    assert webhook.name == "test_webhook"
+    assert webhook.url == "https://example.com/webhook"
+    assert webhook.secret is None
+
+    # With secret
+    webhook_with_secret = store.create_webhook(
+        name="test_webhook_with_secret",
+        url="https://example.com/webhook_with_secret",
+        events=[WebhookEvent.MODEL_VERSION_CREATED],
+        secret="my_secret",
+    )
+    assert webhook_with_secret.name == "test_webhook_with_secret"
+    assert webhook_with_secret.url == "https://example.com/webhook_with_secret"
+    assert webhook_with_secret.secret == "my_secret"
+    assert webhook_with_secret.events == [WebhookEvent.MODEL_VERSION_CREATED]
+
+    # Multiple events
+    webhook_multiple_events = store.create_webhook(
+        name="test_webhook_multiple_events",
+        url="https://example.com/webhook_multiple_events",
+        events=[
+            WebhookEvent.MODEL_VERSION_CREATED,
+            WebhookEvent.MODEL_VERSION_TRANSITIONED_STAGE,
+        ],
+    )
+    assert webhook_multiple_events.name == "test_webhook_multiple_events"
+    assert webhook_multiple_events.url == "https://example.com/webhook_multiple_events"
+    assert webhook_multiple_events.events == [
+        WebhookEvent.MODEL_VERSION_CREATED,
+        WebhookEvent.MODEL_VERSION_TRANSITIONED_STAGE,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("invalid_url", "expected_match"),
+    [
+        ("", r"Webhook URL cannot be empty or just whitespace"),
+        ("   ", r"Webhook URL cannot be empty or just whitespace"),
+        ("ftp://example.com", r"Invalid webhook URL scheme"),
+        ("http://[invalid", r"Invalid webhook URL"),
+    ],
+)
+def test_update_webhook_invalid_urls(store, invalid_url, expected_match):
+    # Create a valid webhook first
+    webhook = store.create_webhook(
+        name="test_webhook",
+        url="https://example.com/webhook",
+        events=[WebhookEvent.MODEL_VERSION_CREATED],
+    )
+    with pytest.raises(MlflowException, match=expected_match):
+        store.update_webhook(webhook_id=webhook.webhook_id, url=invalid_url)
+
+
+def test_get_webhook(store: RestStore):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    created_webhook = store.create_webhook(
+        name="test_webhook", url="https://example.com/webhook", events=events
+    )
+    retrieved_webhook = store.get_webhook(created_webhook.webhook_id)
+    assert retrieved_webhook.webhook_id == created_webhook.webhook_id
+    assert retrieved_webhook.name == "test_webhook"
+    assert retrieved_webhook.url == "https://example.com/webhook"
+    assert retrieved_webhook.events == events
+
+
+def test_get_webhook_not_found(store: RestStore):
+    with pytest.raises(MlflowException, match="Webhook with ID nonexistent not found"):
+        store.get_webhook("nonexistent")
+
+
+def test_list_webhooks(store: RestStore):
+    # Create multiple webhooks
+    webhook1 = store.create_webhook(
+        name="webhook1", url="https://example.com/1", events=[WebhookEvent.MODEL_VERSION_CREATED]
+    )
+    webhook2 = store.create_webhook(
+        name="webhook2", url="https://example.com/2", events=[WebhookEvent.REGISTERED_MODEL_CREATED]
+    )
+    webhooks, token = store.list_webhooks()
+    assert len(webhooks) == 2
+    assert token is None
+    webhook_ids = {w.webhook_id for w in webhooks}
+    assert webhook1.webhook_id in webhook_ids
+    assert webhook2.webhook_id in webhook_ids
+
+
+def test_update_webhook(store: RestStore):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    webhook = store.create_webhook(
+        name="original_name", url="https://example.com/original", events=events
+    )
+    # Update webhook
+    new_events = [WebhookEvent.MODEL_VERSION_CREATED, WebhookEvent.REGISTERED_MODEL_CREATED]
+    updated_webhook = store.update_webhook(
+        webhook_id=webhook.webhook_id,
+        name="updated_name",
+        url="https://example.com/updated",
+        events=new_events,
+        description="Updated description",
+        secret="new_secret",
+        status=WebhookStatus.DISABLED,
+    )
+    assert updated_webhook.webhook_id == webhook.webhook_id
+    assert updated_webhook.name == "updated_name"
+    assert updated_webhook.url == "https://example.com/updated"
+    assert updated_webhook.events == new_events
+    assert updated_webhook.description == "Updated description"
+    assert updated_webhook.status == WebhookStatus.DISABLED
+    assert updated_webhook.last_updated_timestamp > webhook.last_updated_timestamp
+
+
+def test_update_webhook_partial(store: RestStore):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    webhook = store.create_webhook(
+        name="original_name",
+        url="https://example.com/original",
+        events=events,
+        description="Original description",
+    )
+    # Update only the name
+    updated_webhook = store.update_webhook(
+        webhook_id=webhook.webhook_id,
+        name="updated_name",
+    )
+    assert updated_webhook.name == "updated_name"
+    assert updated_webhook.url == "https://example.com/original"
+    assert updated_webhook.events == events
+    assert updated_webhook.description == "Original description"
+
+
+def test_update_webhook_not_found(store: RestStore):
+    with pytest.raises(MlflowException, match="Webhook with ID nonexistent not found"):
+        store.update_webhook(webhook_id="nonexistent", name="new_name")
+
+
+def test_delete_webhook(store: RestStore):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    webhook = store.create_webhook(
+        name="test_webhook",
+        url="https://example.com/webhook",
+        events=events,
+    )
+    store.delete_webhook(webhook.webhook_id)
+    with pytest.raises(MlflowException, match=r"Webhook with ID .* not found"):
+        store.get_webhook(webhook.webhook_id)
+    webhooks, _ = store.list_webhooks()
+    webhook_ids = {w.webhook_id for w in webhooks}
+    assert webhook.webhook_id not in webhook_ids
+
+
+def test_delete_webhook_not_found(store: RestStore):
+    with pytest.raises(MlflowException, match="Webhook with ID nonexistent not found"):
+        store.delete_webhook("nonexistent")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16679?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16679/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16679/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16679/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Another `webhooks` PR. Implement `RestStore`. I'll implement `test_webhook` in a separate PR.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
