### PR TITLE
Fix assessments handling in get_trace() and search_traces()

### DIFF
--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -1678,6 +1678,9 @@ class FileStore(AbstractStore):
         self._write_dict_to_trace_sub_folder(
             trace_dir, FileStore.TRACE_TAGS_FOLDER_NAME, trace_info.tags
         )
+        # Save assessments to its own folder
+        for assessment in trace_info.assessments:
+            self.create_assessment(assessment)
 
     def _convert_trace_info_to_dict(self, trace_info: TraceInfo):
         """
@@ -1785,6 +1788,7 @@ class FileStore(AbstractStore):
         trace_info.tags = self._get_dict_from_trace_sub_folder(
             trace_dir, FileStore.TRACE_TAGS_FOLDER_NAME
         )
+        trace_info.assessments = self._load_assessments(trace_info.trace_id)
         return trace_info
 
     def set_trace_tag(self, trace_id: str, key: str, value: str):
@@ -1838,6 +1842,16 @@ class FileStore(AbstractStore):
             data=assessment_dict,
             overwrite=True,
         )
+
+    def _load_assessments(self, trace_id: str) -> list[Assessment]:
+        assessments_dir = self._get_assessments_dir(trace_id)
+        if not exists(assessments_dir):
+            return []
+        assessment_paths = os.listdir(assessments_dir)
+        return [
+            self._load_assessment(trace_id, assessment_path.split(".")[0])
+            for assessment_path in assessment_paths
+        ]
 
     def _load_assessment(self, trace_id: str, assessment_id: str) -> Assessment:
         assessment_path = self._get_assessment_path(trace_id, assessment_id)

--- a/tests/tracing/test_assessment.py
+++ b/tests/tracing/test_assessment.py
@@ -1,4 +1,5 @@
-from unittest import mock
+import os
+import sys
 
 import pytest
 
@@ -7,24 +8,10 @@ from mlflow.entities.assessment import (
     AssessmentError,
     AssessmentSource,
     Expectation,
-    ExpectationValue,
     Feedback,
-    FeedbackValue,
 )
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
-from mlflow.entities.trace_data import TraceData
-from mlflow.entities.trace_info import TraceInfo
-from mlflow.entities.trace_location import TraceLocation
-from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
-
-
-@pytest.fixture
-def store():
-    mock_store = mock.MagicMock()
-    with mock.patch("mlflow.tracing.client._get_store", return_value=mock_store):
-        yield mock_store
-
 
 _HUMAN_ASSESSMENT_SOURCE = AssessmentSource(
     source_type=AssessmentSourceType.HUMAN,
@@ -37,11 +24,47 @@ _LLM_ASSESSMENT_SOURCE = AssessmentSource(
 )
 
 
+@pytest.fixture
+def trace_id():
+    with mlflow.start_span(name="test_span") as span:
+        pass
+
+    return span.trace_id
+
+
+@pytest.fixture(params=["file", "sqlalchemy"], autouse=True)
+def tracking_uri(request, tmp_path):
+    """Set an MLflow Tracking URI with different type of backend."""
+    if "MLFLOW_SKINNY" in os.environ and request.param == "sqlalchemy":
+        pytest.skip("SQLAlchemy store is not available in skinny.")
+
+    original_tracking_uri = mlflow.get_tracking_uri()
+
+    if request.param == "file":
+        tracking_uri = tmp_path.joinpath("file").as_uri()
+    elif request.param == "sqlalchemy":
+        path = tmp_path.joinpath("sqlalchemy.db").as_uri()
+        tracking_uri = ("sqlite://" if sys.platform == "win32" else "sqlite:////") + path[
+            len("file://") :
+        ]
+
+    # NB: MLflow tracer does not handle the change of tracking URI well,
+    # so we need to reset the tracer to switch the tracking URI during testing.
+    mlflow.tracing.disable()
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.tracing.enable()
+
+    yield tracking_uri
+
+    # Reset tracking URI
+    mlflow.set_tracking_uri(original_tracking_uri)
+
+
 @pytest.mark.parametrize("legacy_api", [True, False])
-def test_log_expectation(store, legacy_api):
+def test_log_expectation(trace_id, legacy_api):
     if legacy_api:
         mlflow.log_expectation(
-            trace_id="1234",
+            trace_id=trace_id,
             name="expected_answer",
             value="MLflow",
             source=_HUMAN_ASSESSMENT_SOURCE,
@@ -54,21 +77,21 @@ def test_log_expectation(store, legacy_api):
             source=_HUMAN_ASSESSMENT_SOURCE,
             metadata={"key": "value"},
         )
-        mlflow.log_assessment(trace_id="1234", assessment=feedback)
+        mlflow.log_assessment(trace_id=trace_id, assessment=feedback)
 
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
-    assert assessment.trace_id == "1234"
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
+    assert isinstance(assessment, Expectation)
+    assert assessment.trace_id == trace_id
     assert assessment.name == "expected_answer"
-    assert assessment.trace_id == "1234"
+    assert assessment.value == "MLflow"
+    assert assessment.trace_id == trace_id
     assert assessment.span_id is None
     assert assessment.source == _HUMAN_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
     assert assessment.last_update_time_ms is not None
     assert assessment.expectation.value == "MLflow"
-    assert assessment.feedback is None
     assert assessment.rationale is None
     assert assessment.metadata == {"key": "value"}
 
@@ -82,30 +105,41 @@ def test_log_expectation_invalid_parameters():
         )
 
 
-def test_update_expectation(store):
-    assessment = Expectation(name="expected_answer", value="MLflow")
-    mlflow.update_assessment(
-        assessment_id="1234",
-        trace_id="tr-1234",
-        assessment=assessment,
+def test_update_expectation(trace_id):
+    assessment_id = mlflow.log_expectation(
+        trace_id=trace_id,
+        name="expected_answer",
+        value="MLflow",
+    ).assessment_id
+
+    updated_assessment = Expectation(
+        name="expected_answer",
+        value="Spark",
+        metadata={"reason": "human override"},
     )
 
-    assert store.update_assessment.call_count == 1
-    call_args = store.update_assessment.call_args[1]
-    assert call_args["trace_id"] == "tr-1234"
-    assert call_args["assessment_id"] == "1234"
-    assert call_args["name"] == "expected_answer"
-    assert call_args["expectation"] == ExpectationValue(value="MLflow")
-    assert call_args["feedback"] is None
-    assert call_args["rationale"] is None
-    assert call_args["metadata"] is None
+    mlflow.update_assessment(
+        assessment_id=assessment_id,
+        trace_id=trace_id,
+        assessment=updated_assessment,
+    )
+
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
+    assert assessment.trace_id == trace_id
+    assert assessment.name == "expected_answer"
+    assert assessment.expectation.value == "Spark"
+    assert assessment.feedback is None
+    assert assessment.rationale is None
+    assert assessment.metadata == {"reason": "human override"}
 
 
 @pytest.mark.parametrize("legacy_api", [True, False])
-def test_log_feedback(store, legacy_api):
+def test_log_feedback(trace_id, legacy_api):
     if legacy_api:
         mlflow.log_feedback(
-            trace_id="1234",
+            trace_id=trace_id,
             name="faithfulness",
             value=1.0,
             source=_LLM_ASSESSMENT_SOURCE,
@@ -120,15 +154,14 @@ def test_log_feedback(store, legacy_api):
             rationale="This answer is very faithful.",
             metadata={"model": "gpt-4o-mini"},
         )
-        mlflow.log_assessment(trace_id="1234", assessment=feedback)
+        mlflow.log_assessment(trace_id=trace_id, assessment=feedback)
 
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
-    assert assessment.trace_id == "1234"
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
+    assert isinstance(assessment, Feedback)
+    assert assessment.trace_id == trace_id
     assert assessment.name == "faithfulness"
-    assert assessment.trace_id == "1234"
     assert assessment.span_id is None
     assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
@@ -141,10 +174,10 @@ def test_log_feedback(store, legacy_api):
 
 
 @pytest.mark.parametrize("legacy_api", [True, False])
-def test_log_feedback_with_error(store, legacy_api):
+def test_log_feedback_with_error(trace_id, legacy_api):
     if legacy_api:
         mlflow.log_feedback(
-            trace_id="1234",
+            trace_id=trace_id,
             name="faithfulness",
             source=_LLM_ASSESSMENT_SOURCE,
             error=AssessmentError(
@@ -162,14 +195,13 @@ def test_log_feedback_with_error(store, legacy_api):
                 error_message="Rate limit for the judge exceeded.",
             ),
         )
-        mlflow.log_assessment(trace_id="1234", assessment=feedback)
+        mlflow.log_assessment(trace_id=trace_id, assessment=feedback)
 
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
     assert assessment.name == "faithfulness"
-    assert assessment.trace_id == "1234"
+    assert assessment.trace_id == trace_id
     assert assessment.span_id is None
     assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
@@ -182,13 +214,13 @@ def test_log_feedback_with_error(store, legacy_api):
 
 
 @pytest.mark.parametrize("legacy_api", [True, False])
-def test_log_feedback_with_exception_object(store, legacy_api):
+def test_log_feedback_with_exception_object(trace_id, legacy_api):
     """Test that log_feedback correctly accepts Exception objects."""
     test_exception = ValueError("Test exception message")
 
     if legacy_api:
         mlflow.log_feedback(
-            trace_id="1234",
+            trace_id=trace_id,
             name="faithfulness",
             source=_LLM_ASSESSMENT_SOURCE,
             error=test_exception,
@@ -200,14 +232,13 @@ def test_log_feedback_with_exception_object(store, legacy_api):
             source=_LLM_ASSESSMENT_SOURCE,
             error=test_exception,
         )
-        mlflow.log_assessment(trace_id="1234", assessment=feedback)
+        mlflow.log_assessment(trace_id=trace_id, assessment=feedback)
 
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
     assert assessment.name == "faithfulness"
-    assert assessment.trace_id == "1234"
+    assert assessment.trace_id == trace_id
     assert assessment.span_id is None
     assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
@@ -222,10 +253,10 @@ def test_log_feedback_with_exception_object(store, legacy_api):
 
 
 @pytest.mark.parametrize("legacy_api", [True, False])
-def test_log_feedback_with_value_and_error(store, legacy_api):
+def test_log_feedback_with_value_and_error(trace_id, legacy_api):
     if legacy_api:
         mlflow.log_feedback(
-            trace_id="1234",
+            trace_id=trace_id,
             name="faithfulness",
             source=_LLM_ASSESSMENT_SOURCE,
             value=0.5,
@@ -244,14 +275,13 @@ def test_log_feedback_with_value_and_error(store, legacy_api):
                 error_message="Rate limit for the judge exceeded.",
             ),
         )
-        mlflow.log_assessment(trace_id="1234", assessment=feedback)
+        mlflow.log_assessment(trace_id=trace_id, assessment=feedback)
 
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
     assert assessment.name == "faithfulness"
-    assert assessment.trace_id == "1234"
+    assert assessment.trace_id == trace_id
     assert assessment.span_id is None
     assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
@@ -281,168 +311,131 @@ def test_log_feedback_invalid_parameters():
         )
 
 
-def test_update_feedback(store):
-    feedback = Feedback(
+def test_update_feedback(trace_id):
+    assessment_id = mlflow.log_feedback(
+        trace_id=trace_id,
         name="faithfulness",
         value=1.0,
         rationale="This answer is very faithful.",
         metadata={"model": "gpt-4o-mini"},
+    ).assessment_id
+
+    updated_feedback = Feedback(
+        name="faithfulness",
+        value=0,
+        rationale="This answer is not faithful.",
+        metadata={"reason": "human override"},
     )
     mlflow.update_assessment(
-        assessment_id="1234",
-        trace_id="tr-1234",
-        assessment=feedback,
+        assessment_id=assessment_id,
+        trace_id=trace_id,
+        assessment=updated_feedback,
     )
 
-    assert store.update_assessment.call_count == 1
-    call_args = store.update_assessment.call_args[1]
-    assert call_args["trace_id"] == "tr-1234"
-    assert call_args["assessment_id"] == "1234"
-    assert call_args["name"] == "faithfulness"
-    assert call_args["expectation"] is None
-    assert call_args["feedback"] == FeedbackValue(value=1.0)
-    assert call_args["rationale"] == "This answer is very faithful."
-    assert call_args["metadata"] == {"model": "gpt-4o-mini"}
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
+    assert assessment.name == "faithfulness"
+    assert assessment.trace_id == trace_id
+    assert assessment.feedback.value == 0
+    assert assessment.feedback.error is None
+    assert assessment.rationale == "This answer is not faithful."
+    assert assessment.metadata == {
+        "model": "gpt-4o-mini",
+        "reason": "human override",
+    }
 
 
-def test_override_feedback(store):
-    # Mock the store's get_assessment method to return a feedback
-    old_feedback = Feedback(
-        trace_id="tr-321",
+def test_override_feedback(trace_id):
+    assessment_id = mlflow.log_feedback(
+        trace_id=trace_id,
         name="faithfulness",
         value=0.5,
         source=_LLM_ASSESSMENT_SOURCE,
         rationale="Original feedback",
         metadata={"model": "gpt-3.5"},
-    )
-    old_feedback.assessment_id = "a-1234"
-    store.get_assessment.return_value = old_feedback
+    ).assessment_id
 
-    mlflow.override_feedback(
-        trace_id="tr-321",
-        assessment_id="a-1234",
+    new_assessment_id = mlflow.override_feedback(
+        trace_id=trace_id,
+        assessment_id=assessment_id,
         value=1.0,
         source=_LLM_ASSESSMENT_SOURCE,
         rationale="This answer is very faithful.",
         metadata={"model": "gpt-4o-mini"},
-    )
+    ).assessment_id
 
-    # assert that the old feedback is fetched
-    store.get_assessment.assert_called_once_with("tr-321", "a-1234")
-
-    # assert that the new feedback is created
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
-    assert assessment.trace_id == "tr-321"
+    # New assessment should have the same trace_id as the original assessment
+    assessment = mlflow.get_assessment(trace_id, new_assessment_id)
+    assert assessment.trace_id == trace_id
     assert assessment.name == "faithfulness"
-    assert assessment.trace_id == "tr-321"
     assert assessment.span_id is None
     assert assessment.source == _LLM_ASSESSMENT_SOURCE
     assert assessment.create_time_ms is not None
     assert assessment.last_update_time_ms is not None
-    assert assessment.feedback.value == 1.0
-    assert assessment.feedback.error is None
-    assert assessment.expectation is None
+    assert assessment.value == 1.0
+    assert assessment.error is None
     assert assessment.rationale == "This answer is very faithful."
     assert assessment.metadata == {"model": "gpt-4o-mini"}
-    assert assessment.overrides == "a-1234"
+    assert assessment.overrides == assessment_id
+    assert assessment.valid is True
+
+    # Original assessment should be invalidated
+    original_assessment = mlflow.get_assessment(trace_id, assessment_id)
+    assert original_assessment.valid is False
+    assert original_assessment.feedback.value == 0.5
 
 
-def test_delete_assessment(store):
-    mlflow.delete_assessment(trace_id="tr-1234", assessment_id="1234")
+def test_delete_assessment(trace_id):
+    assessment_id = mlflow.log_feedback(
+        trace_id=trace_id,
+        name="faithfulness",
+        value=1.0,
+    ).assessment_id
 
-    assert store.delete_assessment.call_count == 1
-    call_args = store.delete_assessment.call_args[1]
-    assert call_args["assessment_id"] == "1234"
-    assert call_args["trace_id"] == "tr-1234"
+    mlflow.delete_assessment(trace_id=trace_id, assessment_id=assessment_id)
 
+    with pytest.raises(MlflowException, match=r"Assessment with ID"):
+        assert mlflow.get_assessment(trace_id, assessment_id) is None
 
-def test_search_traces_with_assessments(store):
-    # Create a trace info with an assessment
-    assessment = Feedback(
-        trace_id="test",
-        name="test",
-        value="test",
-        source=AssessmentSource(source_id="test", source_type=AssessmentSourceType.HUMAN),
-        create_time_ms=0,
-        last_update_time_ms=0,
-    )
-
-    trace_info = TraceInfo(
-        trace_id="test",
-        trace_location=TraceLocation.from_experiment_id("test"),
-        request_time=0,
-        execution_duration=0,
-        state=TraceState.OK,
-        tags={"mlflow.artifactLocation": "test"},
-        assessments=[assessment],  # Include the assessment here
-    )
-
-    # Mock the search_traces to return our trace_info
-    store.search_traces.return_value = ([trace_info, trace_info], None)
-
-    # Now when search_traces is called, it should use our trace_info with the assessment
-    with mock.patch(
-        "mlflow.tracing.client.TracingClient._download_trace_data", return_value=TraceData()
-    ):
-        res = mlflow.search_traces(
-            experiment_ids=["0"],
-            max_results=2,
-            return_type="list",
-        )
-
-    # Verify the results
-    assert len(res) == 2
-    for trace in res:
-        assert trace.info.assessments is not None
-        assert len(trace.info.assessments) == 1
-        assert trace.info.assessments[0].trace_id == "test"
-        assert trace.info.assessments[0].name == "test"
-
-    # Verify the search_traces was called
-    assert store.search_traces.call_count == 1
-
-    # We no longer expect get_trace_info to be called
-    assert store.get_trace_info.call_count == 0
+    # Assessment should be deleted from the trace
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 0
 
 
-def test_log_feedback_default_source(store):
+def test_log_feedback_default_source(trace_id):
     # Test that the default CODE source is used when no source is provided
     feedback = Feedback(
-        trace_id="1234",
+        trace_id=trace_id,
         name="faithfulness",
         value=1.0,
     )
-    mlflow.log_assessment(trace_id="1234", assessment=feedback)
+    mlflow.log_assessment(trace_id=trace_id, assessment=feedback)
 
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
     assert assessment.name == "faithfulness"
-    assert assessment.trace_id == "1234"
+    assert assessment.trace_id == trace_id
     assert assessment.source.source_type == AssessmentSourceType.CODE
     assert assessment.source.source_id == "default"
     assert assessment.feedback.value == 1.0
 
 
-def test_log_expectation_default_source(store):
+def test_log_expectation_default_source(trace_id):
     # Test that the default HUMAN source is used when no source is provided
     expectation = Expectation(
-        trace_id="1234",
+        trace_id=trace_id,
         name="expected_answer",
         value="MLflow",
     )
-    mlflow.log_assessment(trace_id="1234", assessment=expectation)
+    mlflow.log_assessment(trace_id=trace_id, assessment=expectation)
 
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assessment = trace.info.assessments[0]
     assert assessment.name == "expected_answer"
-    assert assessment.trace_id == "1234"
+    assert assessment.trace_id == trace_id
     assert assessment.source.source_type == AssessmentSourceType.HUMAN
     assert assessment.source.source_id == "default"
     assert assessment.expectation.value == "MLflow"
@@ -457,46 +450,38 @@ def test_log_feedback_and_exception_blocks_positional_args():
 
 
 @pytest.mark.parametrize("legacy_api", [True, False])
-def test_log_assessment_on_in_progress_trace(store, legacy_api):
+def test_log_assessment_on_in_progress_trace(trace_id, legacy_api):
     @mlflow.trace
     def func(x: int, y: int) -> int:
-        trace_id = mlflow.get_active_trace_id()
+        active_trace_id = mlflow.get_active_trace_id()
         if legacy_api:
-            mlflow.log_assessment(trace_id, Feedback(name="feedback", value=1.0))
-            mlflow.log_assessment(trace_id, Expectation(name="expectation", value="MLflow"))
-            mlflow.log_assessment("other_trace_id", Feedback(name="other", value=2.0))
+            mlflow.log_assessment(active_trace_id, Feedback(name="feedback", value=1.0))
+            mlflow.log_assessment(active_trace_id, Expectation(name="expectation", value="MLflow"))
+            mlflow.log_assessment(trace_id, Feedback(name="other", value=2.0))
         else:
-            mlflow.log_feedback(trace_id=trace_id, name="feedback", value=1.0)
-            mlflow.log_expectation(trace_id=trace_id, name="expectation", value="MLflow")
-            mlflow.log_feedback(trace_id="other_trace_id", name="other", value=2.0)
+            mlflow.log_feedback(trace_id=active_trace_id, name="feedback", value=1.0)
+            mlflow.log_expectation(trace_id=active_trace_id, name="expectation", value="MLflow")
+            mlflow.log_feedback(trace_id=trace_id, name="other", value=2.0)
         return x + y
 
     assert func(1, 2) == 3
 
-    mlflow.flush_trace_async_logging()
-
     # Two assessments should be logged as a part of StartTraceV3 call
-    store.start_trace.assert_called_once()
-    trace_info = store.start_trace.call_args[1]["trace_info"]
-    assert trace_info.request_id == mlflow.get_last_active_trace_id()
-    assert len(trace_info.assessments) == 2
-    assert trace_info.assessments[0].name == "feedback"
-    assert trace_info.assessments[0].feedback.value == 1.0
-    assert trace_info.assessments[1].name == "expectation"
-    assert trace_info.assessments[1].expectation.value == "MLflow"
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert len(trace.info.assessments) == 2
+    assessments = {a.name: a for a in trace.info.assessments}
+    assert assessments["feedback"].value == 1.0
+    assert assessments["expectation"].value == "MLflow"
 
-    # CreateAssessment should be called for the assessment on the other trace (both V2 and V3)
-    store.create_assessment.assert_called_once()
-    call_args = store.create_assessment.call_args
-    assessment = call_args[0][0]
-
-    assert assessment.trace_id == "other_trace_id"
-    assert assessment.name == "other"
-    assert assessment.feedback.value == 2.0
+    # Assessment on the other trace
+    trace = mlflow.get_trace(trace_id)
+    assert len(trace.info.assessments) == 1
+    assert trace.info.assessments[0].name == "other"
+    assert trace.info.assessments[0].feedback.value == 2.0
 
 
 @pytest.mark.asyncio
-async def test_log_assessment_on_in_progress_trace_async(store):
+async def test_log_assessment_on_in_progress_trace_async():
     @mlflow.trace
     async def func(x: int, y: int) -> int:
         trace_id = mlflow.get_active_trace_id()
@@ -508,11 +493,8 @@ async def test_log_assessment_on_in_progress_trace_async(store):
 
     mlflow.flush_trace_async_logging()
 
-    store.create_assessment.assert_not_called()
-
-    store.start_trace.assert_called_once()
-    trace_info = store.start_trace.call_args[1]["trace_info"]
-    assert trace_info.request_id == mlflow.get_last_active_trace_id()
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    trace_info = trace.info
     assert len(trace_info.assessments) == 2
     assert trace_info.assessments[0].name == "feedback"
     assert trace_info.assessments[0].feedback.value == 1.0
@@ -520,7 +502,7 @@ async def test_log_assessment_on_in_progress_trace_async(store):
     assert trace_info.assessments[1].expectation.value == "MLflow"
 
 
-def test_log_assessment_on_in_progress_with_span_id(store):
+def test_log_assessment_on_in_progress_with_span_id():
     with mlflow.start_span(name="test_span") as span:
         # Only proceed if we have a real span (not NO_OP)
         if span.span_id is not None and span.trace_id != "MLFLOW_NO_OP_SPAN_TRACE_ID":
@@ -532,18 +514,15 @@ def test_log_assessment_on_in_progress_with_span_id(store):
     mlflow.flush_trace_async_logging()
 
     # Two assessments should be logged as a part of StartTraceV3 call
-    store.start_trace.assert_called_once()
-    trace_info = store.start_trace.call_args[1]["trace_info"]
-    assert trace_info.request_id == mlflow.get_last_active_trace_id()
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    trace_info = trace.info
     assert len(trace_info.assessments) == 1
     assert trace_info.assessments[0].name == "feedback"
     assert trace_info.assessments[0].feedback.value == 1.0
     assert trace_info.assessments[0].span_id == span.span_id
 
-    store.create_assessment.assert_not_called()
 
-
-def test_log_assessment_on_in_progress_trace_works_when_tracing_is_disabled(store):
+def test_log_assessment_on_in_progress_trace_works_when_tracing_is_disabled():
     # Calling log_assessment to an active trace should not fail when tracing is disabled.
     mlflow.tracing.disable()
 
@@ -557,80 +536,83 @@ def test_log_assessment_on_in_progress_trace_works_when_tracing_is_disabled(stor
 
     mlflow.flush_trace_async_logging()
 
-    # Neither CreateAssessment nor StartTraceV3 should be called
-    store.create_assessment.assert_not_called()
-    store.start_trace.assert_not_called()
 
-
-def test_get_assessment(store):
+def test_get_assessment(trace_id):
     """Test get_assessment calls store correctly"""
-    mock_assessment = mock.Mock()
-    store.get_assessment.return_value = mock_assessment
+    assessment_id = mlflow.log_feedback(
+        trace_id=trace_id,
+        name="faithfulness",
+        value=1.0,
+    ).assessment_id
 
-    result = mlflow.get_assessment("trace_123", "assessment_456")
+    result = mlflow.get_assessment(trace_id, assessment_id)
 
-    store.get_assessment.assert_called_once_with("trace_123", "assessment_456")
-    assert result == mock_assessment
+    assert isinstance(result, Feedback)
+    assert result.name == "faithfulness"
+    assert result.trace_id == trace_id
+    assert result.value == 1.0
+    assert result.error is None
+    assert result.source.source_type == AssessmentSourceType.CODE
+    assert result.source.source_id == "default"
+    assert result.create_time_ms is not None
+    assert result.last_update_time_ms is not None
+    assert result.valid is True
+    assert result.overrides is None
 
 
-def test_assessment_end_to_end_workflow(store):
-    """Test complete assessment workflow"""
-    # Mock assessment for override test
-    original_feedback = Feedback(
-        name="quality", value=0.6, source=_LLM_ASSESSMENT_SOURCE, rationale="Original assessment"
+def test_search_traces_with_assessments():
+    # Create traces with assessments
+    with mlflow.start_span(name="trace_1") as span_1:
+        mlflow.log_feedback(
+            trace_id=span_1.trace_id,
+            name="feedback_1",
+            value=1.0,
+        )
+        mlflow.log_expectation(
+            trace_id=span_1.trace_id,
+            name="expectation_1",
+            value="test",
+            source=AssessmentSource(source_id="test", source_type=AssessmentSourceType.LLM_JUDGE),
+        )
+        with mlflow.start_span(name="child") as span_1_child:
+            mlflow.log_feedback(
+                trace_id=span_1_child.trace_id,
+                name="feedback_2",
+                value=1.0,
+                span_id=span_1_child.span_id,
+            )
+
+    with mlflow.start_span(name="trace_2") as span_2:
+        mlflow.log_feedback(
+            trace_id=span_2.trace_id,
+            name="feedback_3",
+            value=1.0,
+        )
+
+    traces = mlflow.search_traces(
+        experiment_ids=["0"],
+        max_results=2,
+        return_type="list",
+        order_by=["timestamp_ms"],
     )
-    original_feedback.assessment_id = "original_id"
-    store.get_assessment.return_value = original_feedback
 
-    # Test creating initial assessment
-    initial_assessment = Feedback(
-        name="quality",
-        value=0.8,
-        source=_HUMAN_ASSESSMENT_SOURCE,
-        rationale="Good response quality",
-    )
+    # Verify the results
+    assert len(traces) == 2
+    assert len(traces[0].info.assessments) == 3
 
-    mlflow.log_assessment(trace_id="tr-123", assessment=initial_assessment)
+    assessments = {a.name: a for a in traces[0].info.assessments}
+    assert assessments["feedback_1"].trace_id == span_1.trace_id
+    assert assessments["feedback_1"].name == "feedback_1"
+    assert assessments["feedback_1"].value == 1.0
+    assert assessments["expectation_1"].trace_id == span_1.trace_id
+    assert assessments["expectation_1"].name == "expectation_1"
+    assert assessments["expectation_1"].value == "test"
+    assert assessments["feedback_2"].trace_id == span_1_child.trace_id
+    assert assessments["feedback_2"].name == "feedback_2"
+    assert assessments["feedback_2"].value == 1.0
 
-    # Verify creation
-    assert store.create_assessment.call_count == 1
-    call_args = store.create_assessment.call_args
-    assert call_args[0][0].trace_id == "tr-123"
-    assert call_args[0][0].value == 0.8
-
-    # Test updating assessment
-    updated_assessment = Feedback(
-        name="quality", value=0.9, source=_HUMAN_ASSESSMENT_SOURCE, rationale="Updated assessment"
-    )
-
-    mlflow.update_assessment(
-        trace_id="tr-123", assessment_id="test_id", assessment=updated_assessment
-    )
-
-    # Verify update
-    assert store.update_assessment.call_count == 1
-    update_args = store.update_assessment.call_args[1]
-    assert update_args["trace_id"] == "tr-123"
-    assert update_args["assessment_id"] == "test_id"
-    assert update_args["feedback"].value == 0.9
-
-    # Test override functionality
-    mlflow.override_feedback(
-        trace_id="tr-123",
-        assessment_id="original_id",
-        value=0.95,
-        rationale="Human override of LLM assessment",
-    )
-
-    assert store.create_assessment.call_count == 2  # Initial + override
-    override_call = store.create_assessment.call_args
-    override_assessment = override_call[0][0]
-    assert override_assessment.overrides == "original_id"
-    assert override_assessment.value == 0.95
-
-    mlflow.delete_assessment(trace_id="tr-123", assessment_id="test_id")
-
-    assert store.delete_assessment.call_count == 1
-    delete_args = store.delete_assessment.call_args[1]
-    assert delete_args["trace_id"] == "tr-123"
-    assert delete_args["assessment_id"] == "test_id"
+    assert len(traces[1].info.assessments) == 1
+    assessment = traces[1].info.assessments[0]
+    assert assessment.trace_id == span_2.trace_id
+    assert assessment.name == "feedback_3"
+    assert assessment.value == 1.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16686?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16686/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16686/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16686/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.get_trace()` and `mlflow.search_traces()` API should return traces with assessments. The store implementation doesn't handle that read path (always set assessments field empty).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
