### PR TITLE
Add test validation for deprecated assessment source usage and update docstrings

### DIFF
--- a/mlflow/entities/assessment_source.py
+++ b/mlflow/entities/assessment_source.py
@@ -20,9 +20,15 @@ class AssessmentSource(_MlflowObject):
 
     Args:
         source_type: The type of the assessment source. Must be one of the values in
-            the AssessmentSourceType enum.
+            the AssessmentSourceType enum or an instance of the enumerator value.
         source_id: An identifier for the source, e.g. user ID or LLM judge ID. If not
             provided, the default value "default" is used.
+
+    Note:
+
+    The legacy AssessmentSourceType "AI_JUDGE" is deprecated and will be resolved as
+    "LLM_JUDGE". You will receive a warning if using this deprecated value. This legacy
+    term will be removed in a future version of MLflow.
 
     Example:
 
@@ -34,7 +40,7 @@ class AssessmentSource(_MlflowObject):
         from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 
         source = AssessmentSource(
-            source_type=AssessmentSourceType.HUMAN,
+            source_type=AssessmentSourceType.HUMAN,  # or "HUMAN"
             source_id="bob@example.com",
         )
 
@@ -46,7 +52,7 @@ class AssessmentSource(_MlflowObject):
         from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 
         source = AssessmentSource(
-            source_type=AssessmentSourceType.LLM_JUDGE,
+            source_type=AssessmentSourceType.LLM_JUDGE,  # or "LLM_JUDGE"
             source_id="gpt-4o-mini",
         )
 
@@ -58,7 +64,7 @@ class AssessmentSource(_MlflowObject):
         from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
 
         source = AssessmentSource(
-            source_type=AssessmentSourceType.CODE,
+            source_type=AssessmentSourceType.CODE,  # or "CODE"
             source_id="repo/evaluation_script.py",
         )
 
@@ -97,6 +103,56 @@ class AssessmentSource(_MlflowObject):
 
 @experimental(version="2.21.0")
 class AssessmentSourceType:
+    """
+    Enumeration and validator for assessment source types.
+
+    This class provides constants for valid assessment source types and handles validation
+    and standardization of source type values. It supports both direct constant access and
+    instance creation with string validation.
+
+    The class automatically handles:
+    - Case-insensitive string inputs (converts to uppercase)
+    - Deprecation warnings for legacy values (AI_JUDGE → LLM_JUDGE)
+    - Validation of source type values
+
+    Available source types:
+        - HUMAN: Assessment performed by a human evaluator
+        - LLM_JUDGE: Assessment performed by an LLM-as-a-judge (e.g., GPT-4)
+        - CODE: Assessment performed by deterministic code/heuristics
+        - SOURCE_TYPE_UNSPECIFIED: Default when source type is not specified
+
+    Note:
+        The legacy "AI_JUDGE" type is deprecated and automatically converted to "LLM_JUDGE"
+        with a deprecation warning. This ensures backward compatibility while encouraging
+        migration to the new terminology.
+
+    Example:
+        Using class constants directly:
+
+        .. code-block:: python
+
+            from mlflow.entities.assessment import AssessmentSource, AssessmentSourceType
+
+            # Direct constant usage
+            source = AssessmentSource(source_type=AssessmentSourceType.LLM_JUDGE, source_id="gpt-4")
+
+        String validation through instance creation:
+
+        .. code-block:: python
+
+            # String input - case insensitive
+            source = AssessmentSource(
+                source_type="llm_judge",  # Will be standardized to "LLM_JUDGE"
+                source_id="gpt-4",
+            )
+
+            # Deprecated value - triggers warning
+            source = AssessmentSource(
+                source_type="AI_JUDGE",  # Warning: converts to "LLM_JUDGE"
+                source_id="gpt-4",
+            )
+    """
+
     SOURCE_TYPE_UNSPECIFIED = "SOURCE_TYPE_UNSPECIFIED"
     LLM_JUDGE = "LLM_JUDGE"
     AI_JUDGE = "AI_JUDGE"  # Deprecated, use LLM_JUDGE instead

--- a/mlflow/tracing/assessment.py
+++ b/mlflow/tracing/assessment.py
@@ -205,15 +205,15 @@ def update_assessment(
 
         This API is currently only available for `Databricks Managed MLflow <https://www.databricks.com/product/managed-mlflow>`_.
 
-    Updates an existing expectation (ground truth) in a Trace.
+    Updates an existing expectation (ground truth) or feedback in a Trace.
 
     Args:
         trace_id: The ID of the trace.
-        assessment_id: The ID of the expectation assessment to update.
+        assessment_id: The ID of the expectation or feedback assessment to update.
         assessment: The updated assessment.
 
     Returns:
-        :py:class:`~mlflow.entities.Assessment`: The updated feedback assessment.
+        :py:class:`~mlflow.entities.Assessment`: The updated feedback or expectation assessment.
 
     Example:
 

--- a/tests/entities/test_assessment_source.py
+++ b/tests/entities/test_assessment_source.py
@@ -66,3 +66,11 @@ def test_assessment_source_case_insensitivity():
     assert source_4.source_type == "LLM_JUDGE"
     assert source_5.source_type == "LLM_JUDGE"
     assert source_6.source_type == "LLM_JUDGE"
+
+
+def test_ai_judge_deprecation_warning():
+    with pytest.warns(DeprecationWarning, match="AI_JUDGE is deprecated. Use LLM_JUDGE instead."):
+        source = AssessmentSource(source_type="AI_JUDGE", source_id="ai_1")
+
+    assert source.source_type == "LLM_JUDGE"
+    assert source.source_id == "ai_1"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/16690?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16690/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16690/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16690/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds validation that the usage of a deprecated assessments source type will warn users and fixes an incorrect docstring. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
