### PR TITLE
Add webhook APIs in `MlflowClient`

### DIFF
--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -14,6 +14,7 @@ from mlflow.entities.model_registry import (
     RegisteredModelTag,
 )
 from mlflow.entities.model_registry.prompt import Prompt
+from mlflow.entities.webhook import Webhook, WebhookEvent, WebhookStatus
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.registry_utils import (
     add_prompt_filter_string,
@@ -762,3 +763,98 @@ class ModelRegistryClient:
             None
         """
         self.store.delete_prompt_version_tag(name, version, key)
+
+    # Webhook APIs
+
+    def create_webhook(
+        self,
+        name: str,
+        url: str,
+        events: list[WebhookEvent],
+        description: Optional[str] = None,
+        secret: Optional[str] = None,
+        status: Optional[WebhookStatus] = None,
+    ) -> Webhook:
+        """
+        Create a new webhook.
+
+        Args:
+            name: Unique name for the webhook.
+            url: Webhook endpoint URL.
+            events: List of event types that trigger this webhook.
+            description: Optional description of the webhook.
+            secret: Optional secret for HMAC signature verification.
+            status: Webhook status (defaults to ACTIVE).
+
+        Returns:
+            A :py:class:`mlflow.entities.webhook.Webhook` object representing the created webhook.
+        """
+        return self.store.create_webhook(name, url, events, description, secret, status)
+
+    def get_webhook(self, webhook_id: str) -> Webhook:
+        """
+        Get webhook instance by ID.
+
+        Args:
+            webhook_id: Webhook ID.
+
+        Returns:
+            A :py:class:`mlflow.entities.webhook.Webhook` object.
+        """
+        return self.store.get_webhook(webhook_id)
+
+    def list_webhooks(
+        self,
+        max_results: Optional[int] = None,
+        page_token: Optional[str] = None,
+    ) -> PagedList[Webhook]:
+        """
+        List webhooks.
+
+        Args:
+            max_results: Maximum number of webhooks to return.
+            page_token: Token specifying the next page of results.
+
+        Returns:
+            A :py:class:`mlflow.store.entities.paged_list.PagedList` of Webhook objects.
+        """
+        return self.store.list_webhooks(max_results, page_token)
+
+    def update_webhook(
+        self,
+        webhook_id: str,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        url: Optional[str] = None,
+        events: Optional[list[WebhookEvent]] = None,
+        secret: Optional[str] = None,
+        status: Optional[WebhookStatus] = None,
+    ) -> Webhook:
+        """
+        Update an existing webhook.
+
+        Args:
+            webhook_id: Webhook ID.
+            name: New webhook name.
+            description: New webhook description.
+            url: New webhook URL.
+            events: New list of event types.
+            secret: New webhook secret.
+            status: New webhook status.
+
+        Returns:
+            A :py:class:`mlflow.entities.webhook.Webhook` object representing the updated webhook.
+        """
+        return self.store.update_webhook(webhook_id, name, description, url, events, secret, status)
+
+    def delete_webhook(self, webhook_id: str) -> None:
+        """
+        Delete a webhook.
+
+        Args:
+            webhook_id: Webhook ID to delete.
+
+        Returns:
+            None
+        """
+        self.store.delete_webhook(webhook_id)

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -765,7 +765,6 @@ class ModelRegistryClient:
         self.store.delete_prompt_version_tag(name, version, key)
 
     # Webhook APIs
-
     def create_webhook(
         self,
         name: str,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5931,7 +5931,6 @@ class MlflowClient:
         return registry_client.delete_prompt(name)
 
     # Webhook APIs
-
     def create_webhook(
         self,
         name: str,

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5944,7 +5944,7 @@ class MlflowClient:
         Create a new webhook.
 
         Args:
-            name: Unique name for the webhook.
+            name: Name for the webhook.
             url: Webhook endpoint URL.
             events: List of event types that trigger this webhook. Can be strings or
                 WebhookEvent enums.
@@ -5963,17 +5963,17 @@ class MlflowClient:
         Returns:
             A :py:class:`mlflow.entities.webhook.Webhook` object representing the created webhook.
         """
-        # Convert string events to WebhookEvent enums
-        converted_events = [
-            WebhookEvent(event) if isinstance(event, str) else event for event in events
-        ]
-        # Convert string status to WebhookStatus enum if needed
-        converted_status = None
+        events = [WebhookEvent(e) if isinstance(e, str) else e for e in events]
         if status is not None:
-            converted_status = WebhookStatus(status) if isinstance(status, str) else status
+            status = WebhookStatus(status) if isinstance(status, str) else status
 
         return self._get_registry_client().create_webhook(
-            name, url, converted_events, description, secret, converted_status
+            name=name,
+            url=url,
+            events=events,
+            description=description,
+            secret=secret,
+            status=status,
         )
 
     def get_webhook(self, webhook_id: str) -> Webhook:
@@ -6038,20 +6038,20 @@ class MlflowClient:
         Returns:
             A :py:class:`mlflow.entities.webhook.Webhook` object representing the updated webhook.
         """
-        # Convert string events to WebhookEvent enums if provided
-        converted_events = None
         if events is not None:
-            converted_events = [
-                WebhookEvent(event) if isinstance(event, str) else event for event in events
-            ]
+            events = [WebhookEvent(e) if isinstance(e, str) else e for e in events]
 
-        # Convert string status to WebhookStatus enum if provided
-        converted_status = None
         if status is not None:
-            converted_status = WebhookStatus(status) if isinstance(status, str) else status
+            status = WebhookStatus(status) if isinstance(status, str) else status
 
         return self._get_registry_client().update_webhook(
-            webhook_id, name, description, url, converted_events, secret, converted_status
+            webhook_id=webhook_id,
+            name=name,
+            description=description,
+            url=url,
+            events=events,
+            secret=secret,
+            status=status,
         )
 
     def delete_webhook(self, webhook_id: str) -> None:

--- a/tests/tracking/test_client_webhooks.py
+++ b/tests/tracking/test_client_webhooks.py
@@ -1,0 +1,213 @@
+import subprocess
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+
+from mlflow.entities.webhook import WebhookEvent, WebhookStatus
+from mlflow.exceptions import MlflowException
+from mlflow.tracking import MlflowClient
+
+from tests.helper_functions import get_safe_port
+
+
+@pytest.fixture
+def server(tmp_path: Path) -> Generator[str, None, None]:
+    port = get_safe_port()
+    sqlite_db_path = tmp_path / "mlflow.db"
+    with subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "server",
+            f"--port={port}",
+            f"--backend-store-uri=sqlite:///{sqlite_db_path}",
+        ],
+        cwd=tmp_path,
+    ) as process:
+        try:
+            yield f"http://localhost:{port}"
+        finally:
+            process.terminate()
+
+
+@pytest.fixture
+def client(server: str) -> MlflowClient:
+    return MlflowClient(server)
+
+
+def test_create_webhook(client: MlflowClient):
+    webhook = client.create_webhook(
+        name="test_webhook",
+        url="https://example.com/webhook",
+        events=[WebhookEvent.MODEL_VERSION_CREATED],
+    )
+    assert webhook.name == "test_webhook"
+    assert webhook.url == "https://example.com/webhook"
+    assert webhook.secret is None
+    assert webhook.events == [WebhookEvent.MODEL_VERSION_CREATED]
+
+    webhook = client.get_webhook(webhook.webhook_id)
+    assert webhook.name == "test_webhook"
+    assert webhook.url == "https://example.com/webhook"
+    assert webhook.secret is None
+
+    # With secret
+    webhook_with_secret = client.create_webhook(
+        name="test_webhook_with_secret",
+        url="https://example.com/webhook_with_secret",
+        events=[WebhookEvent.MODEL_VERSION_CREATED],
+        secret="my_secret",
+    )
+    assert webhook_with_secret.name == "test_webhook_with_secret"
+    assert webhook_with_secret.url == "https://example.com/webhook_with_secret"
+    assert webhook_with_secret.secret is None
+    assert webhook_with_secret.events == [WebhookEvent.MODEL_VERSION_CREATED]
+
+    # Multiple events
+    webhook_multiple_events = client.create_webhook(
+        name="test_webhook_multiple_events",
+        url="https://example.com/webhook_multiple_events",
+        events=[
+            WebhookEvent.MODEL_VERSION_ALIAS_CREATED,
+            WebhookEvent.MODEL_VERSION_CREATED,
+        ],
+    )
+    assert webhook_multiple_events.name == "test_webhook_multiple_events"
+    assert webhook_multiple_events.url == "https://example.com/webhook_multiple_events"
+    assert sorted(webhook_multiple_events.events) == [
+        WebhookEvent.MODEL_VERSION_ALIAS_CREATED,
+        WebhookEvent.MODEL_VERSION_CREATED,
+    ]
+    assert webhook_multiple_events.secret is None
+
+
+def test_get_webhook(client: MlflowClient):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    created_webhook = client.create_webhook(
+        name="test_webhook", url="https://example.com/webhook", events=events
+    )
+    retrieved_webhook = client.get_webhook(created_webhook.webhook_id)
+    assert retrieved_webhook.webhook_id == created_webhook.webhook_id
+    assert retrieved_webhook.name == "test_webhook"
+    assert retrieved_webhook.url == "https://example.com/webhook"
+    assert retrieved_webhook.events == events
+
+
+def test_get_webhook_not_found(client: MlflowClient):
+    with pytest.raises(MlflowException, match="Webhook with ID nonexistent not found"):
+        client.get_webhook("nonexistent")
+
+
+def test_list_webhooks(client: MlflowClient):
+    # Create more webhooks than max_results
+    created_webhooks = []
+    for i in range(5):
+        webhook = client.create_webhook(
+            name=f"webhook{i}",
+            url=f"https://example.com/{i}",
+            events=[WebhookEvent.MODEL_VERSION_CREATED],
+        )
+        created_webhooks.append(webhook)
+    # Test pagination with max_results=2
+    webhooks_page = client.list_webhooks(max_results=2)
+    assert len(webhooks_page) == 2
+    assert webhooks_page.token is not None
+    # Get next page
+    next_webhooks_page = client.list_webhooks(max_results=2, page_token=webhooks_page.token)
+    assert len(next_webhooks_page) == 2
+    assert next_webhooks_page.token is not None
+    # Verify we don't get duplicates
+    first_page_ids = {w.webhook_id for w in webhooks_page}
+    second_page_ids = {w.webhook_id for w in next_webhooks_page}
+    assert first_page_ids.isdisjoint(second_page_ids)
+
+
+def test_update_webhook(client: MlflowClient):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    webhook = client.create_webhook(
+        name="original_name", url="https://example.com/original", events=events
+    )
+    # Update webhook
+    new_events = [WebhookEvent.MODEL_VERSION_CREATED, WebhookEvent.REGISTERED_MODEL_CREATED]
+    updated_webhook = client.update_webhook(
+        webhook_id=webhook.webhook_id,
+        name="updated_name",
+        url="https://example.com/updated",
+        events=new_events,
+        description="Updated description",
+        secret="new_secret",
+        status=WebhookStatus.DISABLED,
+    )
+    assert updated_webhook.webhook_id == webhook.webhook_id
+    assert updated_webhook.name == "updated_name"
+    assert updated_webhook.url == "https://example.com/updated"
+    assert updated_webhook.events == new_events
+    assert updated_webhook.description == "Updated description"
+    assert updated_webhook.status == WebhookStatus.DISABLED
+    assert updated_webhook.last_updated_timestamp > webhook.last_updated_timestamp
+
+
+def test_update_webhook_partial(client: MlflowClient):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    webhook = client.create_webhook(
+        name="original_name",
+        url="https://example.com/original",
+        events=events,
+        description="Original description",
+    )
+    # Update only the name
+    updated_webhook = client.update_webhook(
+        webhook_id=webhook.webhook_id,
+        name="updated_name",
+    )
+    assert updated_webhook.name == "updated_name"
+    assert updated_webhook.url == "https://example.com/original"
+    assert updated_webhook.events == events
+    assert updated_webhook.description == "Original description"
+
+
+def test_update_webhook_not_found(client: MlflowClient):
+    with pytest.raises(MlflowException, match="Webhook with ID nonexistent not found"):
+        client.update_webhook(webhook_id="nonexistent", name="new_name")
+
+
+@pytest.mark.parametrize(
+    ("invalid_url", "expected_match"),
+    [
+        ("   ", r"Webhook URL cannot be empty or just whitespace"),
+        ("ftp://example.com", r"Invalid webhook URL scheme"),
+        ("http://[invalid", r"Invalid webhook URL"),
+    ],
+)
+def test_update_webhook_invalid_urls(store, invalid_url, expected_match):
+    # Create a valid webhook first
+    webhook = client.create_webhook(
+        name="test_webhook",
+        url="https://example.com/webhook",
+        events=[WebhookEvent.MODEL_VERSION_CREATED],
+    )
+    with pytest.raises(MlflowException, match=expected_match):
+        client.update_webhook(webhook_id=webhook.webhook_id, url=invalid_url)
+
+
+def test_delete_webhook(client: MlflowClient):
+    events = [WebhookEvent.MODEL_VERSION_CREATED]
+    webhook = client.create_webhook(
+        name="test_webhook",
+        url="https://example.com/webhook",
+        events=events,
+    )
+    client.delete_webhook(webhook.webhook_id)
+    with pytest.raises(MlflowException, match=r"Webhook with ID .* not found"):
+        client.get_webhook(webhook.webhook_id)
+    webhooks_page = client.list_webhooks()
+    webhook_ids = {w.webhook_id for w in webhooks_page}
+    assert webhook.webhook_id not in webhook_ids
+
+
+def test_delete_webhook_not_found(client: MlflowClient):
+    with pytest.raises(MlflowException, match="Webhook with ID nonexistent not found"):
+        client.delete_webhook("nonexistent")

--- a/tests/tracking/test_client_webhooks.py
+++ b/tests/tracking/test_client_webhooks.py
@@ -1,11 +1,14 @@
+import os
 import subprocess
 import sys
 from pathlib import Path
 from typing import Generator
 
 import pytest
+from cryptography.fernet import Fernet
 
 from mlflow.entities.webhook import WebhookEvent, WebhookStatus
+from mlflow.environment_variables import MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY
 from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 
@@ -26,6 +29,8 @@ def server(tmp_path: Path) -> Generator[str, None, None]:
             f"--backend-store-uri=sqlite:///{sqlite_db_path}",
         ],
         cwd=tmp_path,
+        env=os.environ.copy()
+        | {MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY.name: Fernet.generate_key().decode("utf-8")},
     ) as process:
         try:
             yield f"http://localhost:{port}"

--- a/tests/tracking/test_client_webhooks.py
+++ b/tests/tracking/test_client_webhooks.py
@@ -182,7 +182,7 @@ def test_update_webhook_not_found(client: MlflowClient):
         ("http://[invalid", r"Invalid webhook URL"),
     ],
 )
-def test_update_webhook_invalid_urls(store, invalid_url, expected_match):
+def test_update_webhook_invalid_urls(client: MlflowClient, invalid_url: str, expected_match: str):
     # Create a valid webhook first
     webhook = client.create_webhook(
         name="test_webhook",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16696?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16696/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16696/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16696/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Depends on #16695. This PR adds webhook APIs in `MlflowClient`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
