### PR TITLE
Add tests for 5 clint rules and fix MarkdownLink rule

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -466,6 +466,7 @@ class Linter(ast.NodeVisitor):
         self._no_rst(node)
         self._syntax_error_example(node)
         self._mlflow_class_name(node)
+        self._markdown_link(node)
         for deco in node.decorator_list:
             self.visit_decorator(deco)
         with self.resolver.scope():
@@ -511,10 +512,10 @@ class Linter(ast.NodeVisitor):
     def visit_Name(self, node) -> None:
         self.generic_visit(node)
 
-    def _markdown_link(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+    def _markdown_link(self, node: ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef) -> None:
         if docstring := self._docstring(node):
             if MARKDOWN_LINK_RE.search(docstring.s):
-                self._check(docstring, rules.MarkdownLink())
+                self._check(Location.from_node(docstring), rules.MarkdownLink())
 
     def _pytest_mark_repeat(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         # Only check in test files

--- a/dev/clint/tests/rules/test_empty_notebook_cell.py
+++ b/dev/clint/tests/rules/test_empty_notebook_cell.py
@@ -1,0 +1,54 @@
+import json
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import lint_file
+from clint.rules.empty_notebook_cell import EmptyNotebookCell
+
+
+def test_empty_notebook_cell(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test_notebook.ipynb"
+    notebook_content = {
+        "cells": [
+            {
+                "cell_type": "markdown",
+                "source": ["# Test"],
+                "metadata": {},
+                "execution_count": None,
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "source": [],  # Empty cell
+                "metadata": {},
+                "execution_count": None,
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "source": ["x = 5"],
+                "metadata": {},
+                "execution_count": None,
+                "outputs": [],
+            },
+            {
+                "cell_type": "code",
+                "source": [],  # Another empty cell
+                "metadata": {},
+                "execution_count": None,
+                "outputs": [],
+            },
+        ],
+        "metadata": {
+            "kernelspec": {"display_name": "Python 3", "language": "python", "name": "python3"}
+        },
+        "nbformat": 4,
+        "nbformat_minor": 4,
+    }
+    tmp_file.write_text(json.dumps(notebook_content))
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 2
+    assert all(isinstance(v.rule, EmptyNotebookCell) for v in violations)
+    assert violations[0].cell == 2
+    assert violations[1].cell == 4

--- a/dev/clint/tests/rules/test_log_model_artifact_path.py
+++ b/dev/clint/tests/rules/test_log_model_artifact_path.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules.log_model_artifact_path import LogModelArtifactPath
+
+
+def test_log_model_artifact_path(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text(
+        """
+import mlflow
+
+# Bad - using deprecated artifact_path positionally
+mlflow.sklearn.log_model(model, "model")
+
+# Bad - using deprecated artifact_path as keyword
+mlflow.tensorflow.log_model(model, artifact_path="tf_model")
+
+# Good - using the new 'name' parameter
+mlflow.sklearn.log_model(model, name="my_model")
+
+# Good - spark flavor is exempted from this rule
+mlflow.spark.log_model(spark_model, "spark_model")
+
+# Bad - another flavor with artifact_path
+mlflow.pytorch.log_model(model, artifact_path="pytorch_model")
+"""
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 3
+    assert all(isinstance(v.rule, LogModelArtifactPath) for v in violations)
+    assert violations[0].loc == Location(4, 0)
+    assert violations[1].loc == Location(7, 0)
+    assert violations[2].loc == Location(16, 0)

--- a/dev/clint/tests/rules/test_markdown_link.py
+++ b/dev/clint/tests/rules/test_markdown_link.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from clint.config import Config
 from clint.index import SymbolIndex
-from clint.linter import lint_file
+from clint.linter import Location, lint_file
 from clint.rules.markdown_link import MarkdownLink
 
 
@@ -10,25 +10,33 @@ def test_markdown_link(index: SymbolIndex, config: Config, tmp_path: Path) -> No
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
+# Bad
 def function_with_markdown_link():
     """
     This function has a [markdown link](https://example.com).
     """
 
-def function_with_rest_link():
+async def async_function_with_markdown_link():
     """
-    This function has a `reST link <https://example.com>`_.
+    This async function has a [markdown link](https://example.com).
     """
 
 class MyClass:
     """
     Class with [another markdown link](https://test.com).
     """
+
+# Good
+def function_with_rest_link():
+    """
+    This function has a `reST link <https://example.com>`_.
+    """
 '''
     )
 
     violations = lint_file(tmp_file, config, index)
-    assert len(violations) == 2
+    assert len(violations) == 3
     assert all(isinstance(v.rule, MarkdownLink) for v in violations)
-    assert violations[0].loc.lineno == 2  # Function docstring
-    assert violations[1].loc.lineno == 12  # Class docstring
+    assert violations[0].loc == Location(3, 4)
+    assert violations[1].loc == Location(8, 4)
+    assert violations[2].loc == Location(13, 4)

--- a/dev/clint/tests/rules/test_markdown_link.py
+++ b/dev/clint/tests/rules/test_markdown_link.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import lint_file
+from clint.rules.markdown_link import MarkdownLink
+
+
+def test_markdown_link(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text(
+        '''
+def function_with_markdown_link():
+    """
+    This function has a [markdown link](https://example.com).
+    """
+
+def function_with_rest_link():
+    """
+    This function has a `reST link <https://example.com>`_.
+    """
+
+class MyClass:
+    """
+    Class with [another markdown link](https://test.com).
+    """
+'''
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 2
+    assert all(isinstance(v.rule, MarkdownLink) for v in violations)
+    assert violations[0].loc.lineno == 2  # Function docstring
+    assert violations[1].loc.lineno == 12  # Class docstring

--- a/dev/clint/tests/rules/test_os_environ_delete_in_test.py
+++ b/dev/clint/tests/rules/test_os_environ_delete_in_test.py
@@ -1,0 +1,27 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules.os_environ_delete_in_test import OsEnvironDeleteInTest
+
+
+def test_os_environ_delete_in_test(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test_env.py"
+    tmp_file.write_text(
+        """
+import os
+
+def test_something():
+    # Bad
+    del os.environ["MY_VAR"]
+
+    # Good
+    # monkeypatch.delenv("MY_VAR")
+"""
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, OsEnvironDeleteInTest) for v in violations)
+    assert violations[0].loc == Location(5, 4)

--- a/dev/clint/tests/rules/test_test_name_typo.py
+++ b/dev/clint/tests/rules/test_test_name_typo.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules.test_name_typo import TestNameTypo
+
+
+def test_test_name_typo(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test_something.py"
+    tmp_file.write_text(
+        """import pytest
+
+# Bad - starts with 'test' but missing underscore
+def testSomething():
+    assert True
+
+# Bad - another one without underscore
+def testAnother():
+    assert True
+
+# Good - properly named test
+def test_valid_function():
+    assert True
+
+# Good - not a test function
+def helper_function():
+    return 42
+
+# Good - starts with something else
+def tset_something():
+    pass
+"""
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 2
+    assert all(isinstance(v.rule, TestNameTypo) for v in violations)
+    assert violations[0].loc == Location(3, 0)
+    assert violations[1].loc == Location(7, 0)

--- a/mlflow/genai/scheduled_scorers.py
+++ b/mlflow/genai/scheduled_scorers.py
@@ -17,7 +17,8 @@ class ScorerScheduleConfig:
     A scheduled scorer configuration for automated monitoring of generative AI applications.
 
     Scheduled scorers are used to automatically evaluate traces logged to MLflow experiments
-    by production applications. They are part of [Databricks Lakehouse Monitoring for GenAI](https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/monitoring),
+    by production applications. They are part of `Databricks Lakehouse Monitoring for GenAI
+    <https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/monitoring>`_,
     which helps track quality metrics like groundedness, safety, and guideline adherence
     alongside operational metrics like volume, latency, and cost.
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16702?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16702/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16702/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16702/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds comprehensive test coverage for 5 clint rules that previously lacked tests:

1. **test_empty_notebook_cell.py**: Tests the EmptyNotebookCell rule that detects empty code cells in Jupyter notebooks
2. **test_os_environ_delete_in_test.py**: Tests the OsEnvironDeleteInTest rule that warns against directly deleting from os.environ in tests (recommends using monkeypatch.delenv)
3. **test_test_name_typo.py**: Tests the TestNameTypo rule that detects function names starting with "test" but missing the underscore (e.g., "testSomething" instead of "test_something")
4. **test_markdown_link.py**: Tests the MarkdownLink rule that detects markdown-style links in docstrings and suggests using reST syntax instead
5. **test_log_model_artifact_path.py**: Tests the LogModelArtifactPath rule that detects deprecated use of the `artifact_path` parameter in MLflow's log_model functions

Additionally, this PR fixes a bug in the MarkdownLink rule:
- Extends checking to class docstrings in addition to function docstrings
- Fixes a TypeError by using `Location.from_node(docstring)` instead of passing the AST node directly

### How is this PR tested?

- [x] New unit/integration tests
- [x] Existing unit/integration tests

All 5 new test files pass and follow the existing test patterns in the clint codebase. Each test includes both positive and negative cases to ensure proper rule validation.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

This is an internal improvement to test coverage and bug fix that doesn't affect user-facing functionality.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)