### PR TITLE
Add tests for 5 clint rules

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -496,14 +496,20 @@ class Linter(ast.NodeVisitor):
                 func_args_set = set(func_args)
                 doc_args_set = set(doc_args)
                 if diff := func_args_set - doc_args_set:
-                    self._check(Location.from_node(node), rules.MissingDocstringParam(diff))
+                    self._check(
+                        Location.from_node(docstring_node), rules.MissingDocstringParam(diff)
+                    )
 
                 if diff := doc_args_set - func_args_set:
-                    self._check(Location.from_node(node), rules.ExtraneousDocstringParam(diff))
+                    self._check(
+                        Location.from_node(docstring_node), rules.ExtraneousDocstringParam(diff)
+                    )
 
                 if func_args_set == doc_args_set and func_args != doc_args:
                     params = [a for a, b in zip(func_args, doc_args) if a != b]
-                    self._check(Location.from_node(node), rules.DocstringParamOrder(params))
+                    self._check(
+                        Location.from_node(docstring_node), rules.DocstringParamOrder(params)
+                    )
 
     def _invalid_abstract_method(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         if rules.InvalidAbstractMethod.check(node, self.resolver):

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -496,20 +496,14 @@ class Linter(ast.NodeVisitor):
                 func_args_set = set(func_args)
                 doc_args_set = set(doc_args)
                 if diff := func_args_set - doc_args_set:
-                    self._check(
-                        Location.from_node(docstring_node), rules.MissingDocstringParam(diff)
-                    )
+                    self._check(Location.from_node(node), rules.MissingDocstringParam(diff))
 
                 if diff := doc_args_set - func_args_set:
-                    self._check(
-                        Location.from_node(docstring_node), rules.ExtraneousDocstringParam(diff)
-                    )
+                    self._check(Location.from_node(node), rules.ExtraneousDocstringParam(diff))
 
                 if func_args_set == doc_args_set and func_args != doc_args:
                     params = [a for a, b in zip(func_args, doc_args) if a != b]
-                    self._check(
-                        Location.from_node(docstring_node), rules.DocstringParamOrder(params)
-                    )
+                    self._check(Location.from_node(node), rules.DocstringParamOrder(params))
 
     def _invalid_abstract_method(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
         if rules.InvalidAbstractMethod.check(node, self.resolver):

--- a/dev/clint/tests/rules/test_docstring_param_order.py
+++ b/dev/clint/tests/rules/test_docstring_param_order.py
@@ -31,4 +31,4 @@ def f(a: int, b: str) -> None:
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, DocstringParamOrder) for v in violations)
-    assert violations[0].loc == Location(lineno=2, col_offset=0)
+    assert violations[0].loc == Location(3, 4)

--- a/dev/clint/tests/rules/test_docstring_param_order.py
+++ b/dev/clint/tests/rules/test_docstring_param_order.py
@@ -31,4 +31,4 @@ def f(a: int, b: str) -> None:
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, DocstringParamOrder) for v in violations)
-    assert violations[0].loc == Location(3, 4)
+    assert violations[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_extraneous_docstring_param.py
+++ b/dev/clint/tests/rules/test_extraneous_docstring_param.py
@@ -34,4 +34,4 @@ def good_function(param1: str, param2: int) -> None:
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, ExtraneousDocstringParam) for v in violations)
-    assert violations[0].loc == Location(2, 4)
+    assert violations[0].loc == Location(1, 0)

--- a/dev/clint/tests/rules/test_extraneous_docstring_param.py
+++ b/dev/clint/tests/rules/test_extraneous_docstring_param.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules.extraneous_docstring_param import ExtraneousDocstringParam
+
+
+def test_extraneous_docstring_param(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text(
+        '''
+def bad_function(param1: str) -> None:
+    """
+    Example function docstring.
+
+    Args:
+        param1: First parameter
+        param2: This parameter doesn't exist in function signature
+        param3: Another non-existent parameter
+    """
+
+def good_function(param1: str, param2: int) -> None:
+    """
+    Good function with matching parameters.
+
+    Args:
+        param1: First parameter
+        param2: Second parameter
+    """
+'''
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, ExtraneousDocstringParam) for v in violations)
+    assert violations[0].loc == Location(2, 4)

--- a/dev/clint/tests/rules/test_forbidden_trace_ui_in_notebook.py
+++ b/dev/clint/tests/rules/test_forbidden_trace_ui_in_notebook.py
@@ -1,0 +1,67 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import lint_file
+from clint.rules.forbidden_trace_ui_in_notebook import ForbiddenTraceUIInNotebook
+
+
+def test_forbidden_trace_ui_in_notebook(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.ipynb"
+    notebook_content = """
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is a normal cell"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<iframe src='http://localhost:5000/static-files/lib/notebook-trace-renderer/index.html'></iframe>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# This cell contains trace UI output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# This is a normal cell"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}
+"""
+    tmp_file.write_text(notebook_content)
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, ForbiddenTraceUIInNotebook) for v in violations)
+    assert violations[0].cell == 2

--- a/dev/clint/tests/rules/test_incorrect_type_annotation.py
+++ b/dev/clint/tests/rules/test_incorrect_type_annotation.py
@@ -1,0 +1,30 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules.incorrect_type_annotation import IncorrectTypeAnnotation
+
+
+def test_incorrect_type_annotation(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text(
+        """
+def bad_function_callable(param: callable) -> callable:
+    ...
+
+def bad_function_any(param: any) -> any:
+    ...
+
+def good_function(param: Callable[[str], str]) -> Any:
+    ...
+"""
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 4
+    assert all(isinstance(v.rule, IncorrectTypeAnnotation) for v in violations)
+    assert violations[0].loc == Location(1, 33)  # callable
+    assert violations[1].loc == Location(1, 46)  # callable
+    assert violations[2].loc == Location(4, 28)  # any
+    assert violations[3].loc == Location(4, 36)  # any

--- a/dev/clint/tests/rules/test_invalid_abstract_method.py
+++ b/dev/clint/tests/rules/test_invalid_abstract_method.py
@@ -1,0 +1,43 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules.invalid_abstract_method import InvalidAbstractMethod
+
+
+def test_invalid_abstract_method(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text(
+        """
+import abc
+
+class AbstractExample(abc.ABC):
+    @abc.abstractmethod
+    def good_abstract_method_pass(self) -> None:
+        pass
+
+    @abc.abstractmethod
+    def good_abstract_method_ellipsis(self) -> None:
+        ...
+
+    @abc.abstractmethod
+    def good_abstract_method_docstring(self) -> None:
+        '''This is a valid docstring'''
+
+    @abc.abstractmethod
+    def bad_abstract_method_implemented(self) -> None:
+        return "This should not be here"
+
+    @abc.abstractmethod
+    def bad_abstract_method_mulitple_statements(self) -> None:
+        pass
+        ...
+"""
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 2
+    assert all(isinstance(v.rule, InvalidAbstractMethod) for v in violations)
+    assert violations[0].loc == Location(17, 4)
+    assert violations[1].loc == Location(21, 4)

--- a/dev/clint/tests/rules/test_invalid_abstract_method.py
+++ b/dev/clint/tests/rules/test_invalid_abstract_method.py
@@ -14,6 +14,15 @@ import abc
 
 class AbstractExample(abc.ABC):
     @abc.abstractmethod
+    def bad_abstract_method_has_implementation(self) -> None:
+        return "This should not be here"
+
+    @abc.abstractmethod
+    def bad_abstract_method_multiple_statements(self) -> None:
+        pass
+        ...
+
+    @abc.abstractmethod
     def good_abstract_method_pass(self) -> None:
         pass
 
@@ -24,20 +33,11 @@ class AbstractExample(abc.ABC):
     @abc.abstractmethod
     def good_abstract_method_docstring(self) -> None:
         '''This is a valid docstring'''
-
-    @abc.abstractmethod
-    def bad_abstract_method_implemented(self) -> None:
-        return "This should not be here"
-
-    @abc.abstractmethod
-    def bad_abstract_method_mulitple_statements(self) -> None:
-        pass
-        ...
 """
     )
 
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 2
     assert all(isinstance(v.rule, InvalidAbstractMethod) for v in violations)
-    assert violations[0].loc == Location(17, 4)
-    assert violations[1].loc == Location(21, 4)
+    assert violations[0].loc == Location(5, 4)
+    assert violations[1].loc == Location(9, 4)

--- a/dev/clint/tests/rules/test_missing_docstring_param.py
+++ b/dev/clint/tests/rules/test_missing_docstring_param.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules.missing_docstring_param import MissingDocstringParam
+
+
+def test_missing_docstring_param(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text(
+        '''
+def bad_function(param1: str, param2: int, param3: bool) -> None:
+    """
+    Example function with missing parameters in docstring.
+
+    Args:
+        param1: First parameter described
+    """
+
+def good_function(param1: str, param2: int) -> None:
+    """
+    Good function with all parameters documented.
+
+    Args:
+        param1: First parameter
+        param2: Second parameter
+    """
+'''
+    )
+
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, MissingDocstringParam) for v in violations)
+    assert violations[0].loc == Location(2, 4)

--- a/dev/clint/tests/rules/test_missing_docstring_param.py
+++ b/dev/clint/tests/rules/test_missing_docstring_param.py
@@ -32,4 +32,4 @@ def good_function(param1: str, param2: int) -> None:
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, MissingDocstringParam) for v in violations)
-    assert violations[0].loc == Location(2, 4)
+    assert violations[0].loc == Location(1, 0)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16704?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16704/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16704/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16704/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds comprehensive test coverage for 5 clint rules that were previously missing tests:

- `test_extraneous_docstring_param.py`: Tests detection of parameters in docstrings that don't exist in function signatures
- `test_forbidden_trace_ui_in_notebook.py`: Tests detection of MLflow Trace UI iframes in notebook outputs  
- `test_incorrect_type_annotation.py`: Tests detection of incorrect type annotations like 'callable' instead of 'Callable'
- `test_invalid_abstract_method.py`: Tests detection of invalid abstract method implementations
- `test_missing_docstring_param.py`: Tests detection of missing parameters in function docstrings

All tests follow existing patterns in the codebase and verify both positive and negative cases.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

All new tests pass when run individually and follow the existing test patterns. Each test creates temporary files with sample code that should trigger rule violations and verifies the correct violations are detected.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)