### PR TITLE
Add select configuration to clint linter with rule-specific test updates

### DIFF
--- a/dev/clint/src/clint/config.py
+++ b/dev/clint/src/clint/config.py
@@ -6,9 +6,12 @@ from pathlib import Path
 
 import tomli
 
+from clint.rules import ALL_RULES
+
 
 @dataclass
 class Config:
+    select: set[str] = field(default_factory=set)
     exclude: list[str] = field(default_factory=list)
     # Path -> List of modules that should not be imported globally under that path
     forbidden_top_level_imports: dict[str, list[str]] = field(default_factory=dict)
@@ -34,6 +37,13 @@ class Config:
         per_file_ignores: dict[re.Pattern[str], list[str]] = {}
         for pattern, rules in per_file_ignores_raw.items():
             per_file_ignores[re.compile(pattern)] = set(rules)
+
+        select = clint.get("select")
+        if select is None:
+            select = ALL_RULES
+        else:
+            if unknown_rules := set(select) - ALL_RULES:
+                raise ValueError(f"Unknown rules in 'select': {unknown_rules}")
 
         return cls(
             exclude=clint.get("exclude", []),

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -346,6 +346,9 @@ class Linter(ast.NodeVisitor):
         self.ignored_rules = get_ignored_rules_for_file(path, config.per_file_ignores)
 
     def _check(self, loc: Location, rule: rules.Rule) -> None:
+        # Skip rules that are not selected in the config
+        if rule.name not in self.config.select:
+            return
         # Check line-level ignores
         if (lines := self.ignore.get(rule.name)) and loc.lineno in lines:
             return
@@ -813,7 +816,7 @@ def lint_file(path: Path, config: Config, index: SymbolIndex) -> list[Violation]
                         cell_index=cell_idx,
                     )
                 )
-            if not _has_h1_header(cells):
+            if (rules.MissingNotebookH1Header.name in config.select) and not _has_h1_header(cells):
                 violations.append(
                     Violation(
                         rules.MissingNotebookH1Header(),

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -34,7 +34,11 @@ from clint.rules.unnamed_thread import UnnamedThread
 from clint.rules.unparameterized_generic_type import UnparameterizedGenericType
 from clint.rules.use_sys_executable import UseSysExecutable
 
+ALL_RULES = {rule.name for rule in Rule.__subclasses__()}
+
+
 __all__ = [
+    "ALL_RULES",
     "Rule",
     "DoNotDisable",
     "DocstringParamOrder",

--- a/dev/clint/src/clint/rules/base.py
+++ b/dev/clint/src/clint/rules/base.py
@@ -5,22 +5,21 @@ import itertools
 import re
 from abc import ABC, abstractmethod
 
+_id_counter = itertools.count(start=1)
+_CLASS_NAME_TO_RULE_NAME_REGEX = re.compile(r"(?<!^)(?=[A-Z])")
+
 
 class Rule(ABC):
-    _CLASS_NAME_TO_RULE_NAME_REGEX = re.compile(r"(?<!^)(?=[A-Z])")
-    _id_counter = itertools.count(start=1)
-    _generated_id: str
+    id: str
+    name: str
 
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         # Only generate ID for concrete classes
         if not inspect.isabstract(cls):
-            id_ = next(cls._id_counter)
-            cls._generated_id = f"MLF{id_:04d}"
-
-    @property
-    def id(self) -> str:
-        return self._generated_id
+            id_ = next(_id_counter)
+            cls.id = f"MLF{id_:04d}"
+            cls.name = _CLASS_NAME_TO_RULE_NAME_REGEX.sub("-", cls.__name__).lower()
 
     @abstractmethod
     def _message(self) -> str:
@@ -31,10 +30,3 @@ class Rule(ABC):
     @property
     def message(self) -> str:
         return self._message()
-
-    @property
-    def name(self) -> str:
-        """
-        The name of this rule.
-        """
-        return self._CLASS_NAME_TO_RULE_NAME_REGEX.sub("-", self.__class__.__name__).lower()

--- a/dev/clint/tests/rules/conftest.py
+++ b/dev/clint/tests/rules/conftest.py
@@ -1,13 +1,7 @@
 import pytest
-from clint.config import Config
 from clint.index import SymbolIndex
 
 
 @pytest.fixture(scope="session")
 def index() -> SymbolIndex:
     return SymbolIndex.build()
-
-
-@pytest.fixture(scope="session")
-def config() -> Config:
-    return Config()

--- a/dev/clint/tests/rules/test_do_not_disable.py
+++ b/dev/clint/tests/rules/test_do_not_disable.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.do_not_disable import DoNotDisable
 
 
-def test_do_not_disable(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_do_not_disable(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -18,6 +18,7 @@ def test_do_not_disable(index: SymbolIndex, config: Config, tmp_path: Path) -> N
 """
     )
 
+    config = Config(select={DoNotDisable.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, DoNotDisable) for v in violations)

--- a/dev/clint/tests/rules/test_docstring_param_order.py
+++ b/dev/clint/tests/rules/test_docstring_param_order.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.docstring_param_order import DocstringParamOrder
 
 
-def test_docstring_param_order(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_docstring_param_order(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -28,6 +28,7 @@ def f(a: int, b: str) -> None:
 """
     )
 
+    config = Config(select={DocstringParamOrder.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, DocstringParamOrder) for v in violations)

--- a/dev/clint/tests/rules/test_empty_notebook_cell.py
+++ b/dev/clint/tests/rules/test_empty_notebook_cell.py
@@ -7,17 +7,10 @@ from clint.linter import lint_file
 from clint.rules.empty_notebook_cell import EmptyNotebookCell
 
 
-def test_empty_notebook_cell(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_empty_notebook_cell(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test_notebook.ipynb"
     notebook_content = {
         "cells": [
-            {
-                "cell_type": "markdown",
-                "source": ["# Test"],
-                "metadata": {},
-                "execution_count": None,
-                "outputs": [],
-            },
             {
                 "cell_type": "code",
                 "source": [],  # Empty cell
@@ -47,8 +40,9 @@ def test_empty_notebook_cell(index: SymbolIndex, config: Config, tmp_path: Path)
         "nbformat_minor": 4,
     }
     tmp_file.write_text(json.dumps(notebook_content))
+    config = Config(select={EmptyNotebookCell.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 2
     assert all(isinstance(v.rule, EmptyNotebookCell) for v in violations)
-    assert violations[0].cell == 2
-    assert violations[1].cell == 4
+    assert violations[0].cell == 1
+    assert violations[1].cell == 3

--- a/dev/clint/tests/rules/test_extraneous_docstring_param.py
+++ b/dev/clint/tests/rules/test_extraneous_docstring_param.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.extraneous_docstring_param import ExtraneousDocstringParam
 
 
-def test_extraneous_docstring_param(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_extraneous_docstring_param(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -31,6 +31,7 @@ def good_function(param1: str, param2: int) -> None:
 '''
     )
 
+    config = Config(select={ExtraneousDocstringParam.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, ExtraneousDocstringParam) for v in violations)

--- a/dev/clint/tests/rules/test_forbidden_top_level_import.py
+++ b/dev/clint/tests/rules/test_forbidden_top_level_import.py
@@ -18,7 +18,10 @@ from foo import bar
 import baz
 """
     )
-    config = Config(forbidden_top_level_imports={"*": ["foo"]})
+    config = Config(
+        select={ForbiddenTopLevelImport.name},
+        forbidden_top_level_imports={"*": ["foo"]},
+    )
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 2
     assert all(isinstance(v.rule, ForbiddenTopLevelImport) for v in violations)

--- a/dev/clint/tests/rules/test_forbidden_trace_ui_in_notebook.py
+++ b/dev/clint/tests/rules/test_forbidden_trace_ui_in_notebook.py
@@ -6,7 +6,7 @@ from clint.linter import lint_file
 from clint.rules.forbidden_trace_ui_in_notebook import ForbiddenTraceUIInNotebook
 
 
-def test_forbidden_trace_ui_in_notebook(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_forbidden_trace_ui_in_notebook(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.ipynb"
     notebook_content = """
 {
@@ -61,6 +61,7 @@ def test_forbidden_trace_ui_in_notebook(index: SymbolIndex, config: Config, tmp_
 }
 """
     tmp_file.write_text(notebook_content)
+    config = Config(select={ForbiddenTraceUIInNotebook.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, ForbiddenTraceUIInNotebook) for v in violations)

--- a/dev/clint/tests/rules/test_implicit_optional.py
+++ b/dev/clint/tests/rules/test_implicit_optional.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules import ImplicitOptional
 
 
-def test_implicit_optional(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_implicit_optional(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -23,6 +23,7 @@ class Good:
     x: Optional[str] = None
 """
     )
+    config = Config(select={ImplicitOptional.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 2
     assert all(isinstance(r.rule, ImplicitOptional) for r in results)

--- a/dev/clint/tests/rules/test_incorrect_type_annotation.py
+++ b/dev/clint/tests/rules/test_incorrect_type_annotation.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.incorrect_type_annotation import IncorrectTypeAnnotation
 
 
-def test_incorrect_type_annotation(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_incorrect_type_annotation(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -21,6 +21,7 @@ def good_function(param: Callable[[str], str]) -> Any:
 """
     )
 
+    config = Config(select={IncorrectTypeAnnotation.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 4
     assert all(isinstance(v.rule, IncorrectTypeAnnotation) for v in violations)

--- a/dev/clint/tests/rules/test_invalid_abstract_method.py
+++ b/dev/clint/tests/rules/test_invalid_abstract_method.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.invalid_abstract_method import InvalidAbstractMethod
 
 
-def test_invalid_abstract_method(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_invalid_abstract_method(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -36,6 +36,7 @@ class AbstractExample(abc.ABC):
 """
     )
 
+    config = Config(select={InvalidAbstractMethod.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 2
     assert all(isinstance(v.rule, InvalidAbstractMethod) for v in violations)

--- a/dev/clint/tests/rules/test_lazy_builtin_import.py
+++ b/dev/clint/tests/rules/test_lazy_builtin_import.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules import LazyBuiltinImport
 
 
-def test_lazy_builtin_import(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_lazy_builtin_import(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -19,6 +19,7 @@ def f():
 import os
 """
     )
+    config = Config(select={LazyBuiltinImport.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 1
     assert isinstance(results[0].rule, LazyBuiltinImport)

--- a/dev/clint/tests/rules/test_log_model_artifact_path.py
+++ b/dev/clint/tests/rules/test_log_model_artifact_path.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.log_model_artifact_path import LogModelArtifactPath
 
 
-def test_log_model_artifact_path(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_log_model_artifact_path(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -29,6 +29,7 @@ mlflow.pytorch.log_model(model, artifact_path="pytorch_model")
 """
     )
 
+    config = Config(select={LogModelArtifactPath.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 3
     assert all(isinstance(v.rule, LogModelArtifactPath) for v in violations)

--- a/dev/clint/tests/rules/test_markdown_link.py
+++ b/dev/clint/tests/rules/test_markdown_link.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.markdown_link import MarkdownLink
 
 
-def test_markdown_link(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_markdown_link(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -34,6 +34,7 @@ def function_with_rest_link():
 '''
     )
 
+    config = Config(select={MarkdownLink.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 3
     assert all(isinstance(v.rule, MarkdownLink) for v in violations)

--- a/dev/clint/tests/rules/test_missing_docstring_param.py
+++ b/dev/clint/tests/rules/test_missing_docstring_param.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.missing_docstring_param import MissingDocstringParam
 
 
-def test_missing_docstring_param(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_missing_docstring_param(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -29,6 +29,7 @@ def good_function(param1: str, param2: int) -> None:
 '''
     )
 
+    config = Config(select={MissingDocstringParam.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, MissingDocstringParam) for v in violations)

--- a/dev/clint/tests/rules/test_missing_notebook_h1_header.py
+++ b/dev/clint/tests/rules/test_missing_notebook_h1_header.py
@@ -7,7 +7,7 @@ from clint.linter import lint_file
 from clint.rules import MissingNotebookH1Header
 
 
-def test_missing_notebook_h1_header(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_missing_notebook_h1_header(index: SymbolIndex, tmp_path: Path) -> None:
     notebook = {
         "cells": [
             {
@@ -22,14 +22,13 @@ def test_missing_notebook_h1_header(index: SymbolIndex, config: Config, tmp_path
     }
     tmp_file = tmp_path / "test.ipynb"
     tmp_file.write_text(json.dumps(notebook))
+    config = Config(select={MissingNotebookH1Header.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 1
     assert isinstance(results[0].rule, MissingNotebookH1Header)
 
 
-def test_missing_notebook_h1_header_positive(
-    index: SymbolIndex, config: Config, tmp_path: Path
-) -> None:
+def test_missing_notebook_h1_header_positive(index: SymbolIndex, tmp_path: Path) -> None:
     notebook = {
         "cells": [
             {
@@ -44,5 +43,6 @@ def test_missing_notebook_h1_header_positive(
     }
     tmp_file = tmp_path / "test_positive.ipynb"
     tmp_file.write_text(json.dumps(notebook))
+    config = Config(select={MissingNotebookH1Header.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 0

--- a/dev/clint/tests/rules/test_multi_assign.py
+++ b/dev/clint/tests/rules/test_multi_assign.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules import MultiAssign
 
 
-def test_multi_assign(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_multi_assign(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -17,6 +17,7 @@ x, y = 1, 2
 a, b = func()
 """
     )
+    config = Config(select={MultiAssign.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 1
     assert all(isinstance(r.rule, MultiAssign) for r in results)

--- a/dev/clint/tests/rules/test_no_rst.py
+++ b/dev/clint/tests/rules/test_no_rst.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.no_rst import NoRst
 
 
-def test_no_rst(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_no_rst(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -28,6 +28,7 @@ def good(x: int) -> str:
 """
     )
 
+    config = Config(select={NoRst.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, NoRst) for v in violations)

--- a/dev/clint/tests/rules/test_os_environ_delete_in_test.py
+++ b/dev/clint/tests/rules/test_os_environ_delete_in_test.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.os_environ_delete_in_test import OsEnvironDeleteInTest
 
 
-def test_os_environ_delete_in_test(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_os_environ_delete_in_test(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test_env.py"
     tmp_file.write_text(
         """
@@ -21,6 +21,7 @@ def test_something():
 """
     )
 
+    config = Config(select={OsEnvironDeleteInTest.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, OsEnvironDeleteInTest) for v in violations)

--- a/dev/clint/tests/rules/test_test_name_typo.py
+++ b/dev/clint/tests/rules/test_test_name_typo.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules.test_name_typo import TestNameTypo
 
 
-def test_test_name_typo(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_test_name_typo(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test_something.py"
     tmp_file.write_text(
         """import pytest
@@ -33,6 +33,7 @@ def tset_something():
 """
     )
 
+    config = Config(select={TestNameTypo.name})
     violations = lint_file(tmp_file, config, index)
     assert len(violations) == 2
     assert all(isinstance(v.rule, TestNameTypo) for v in violations)

--- a/dev/clint/tests/rules/test_thread_pool_executor_without_thread_name_prefix.py
+++ b/dev/clint/tests/rules/test_thread_pool_executor_without_thread_name_prefix.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules import ThreadPoolExecutorWithoutThreadNamePrefix
 
 
-def test_thread_pool_executor(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_thread_pool_executor(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -19,6 +19,7 @@ ThreadPoolExecutor()
 ThreadPoolExecutor(thread_name_prefix="worker")
 """
     )
+    config = Config(select={ThreadPoolExecutorWithoutThreadNamePrefix.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 1
     assert isinstance(results[0].rule, ThreadPoolExecutorWithoutThreadNamePrefix)

--- a/dev/clint/tests/rules/test_typing_extensions.py
+++ b/dev/clint/tests/rules/test_typing_extensions.py
@@ -18,11 +18,10 @@ from typing_extensions import Self
 """
     )
 
-    violations = lint_file(
-        tmp_file,
-        config=Config(typing_extensions_allowlist=["typing_extensions.Self"]),
-        index=index,
+    config = Config(
+        select={TypingExtensions.name}, typing_extensions_allowlist=["typing_extensions.Self"]
     )
+    violations = lint_file(tmp_file, config, index)
     assert len(violations) == 1
     assert all(isinstance(v.rule, TypingExtensions) for v in violations)
     assert violations[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_unnamed_thread.py
+++ b/dev/clint/tests/rules/test_unnamed_thread.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules import UnnamedThread
 
 
-def test_unnamed_thread(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_unnamed_thread(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -19,6 +19,7 @@ threading.Thread(target=lambda: None)
 # threading.Thread(target=lambda: None, name="worker")
 """
     )
+    config = Config(select={UnnamedThread.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 1
     assert isinstance(results[0].rule, UnnamedThread)

--- a/dev/clint/tests/rules/test_use_sys_executable.py
+++ b/dev/clint/tests/rules/test_use_sys_executable.py
@@ -6,7 +6,7 @@ from clint.linter import Location, lint_file
 from clint.rules import UseSysExecutable
 
 
-def test_use_sys_executable(index: SymbolIndex, config: Config, tmp_path: Path) -> None:
+def test_use_sys_executable(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -22,6 +22,7 @@ subprocess.run([sys.executable, "-m", "mlflow", "ui"])
 subprocess.check_call([sys.executable, "-m", "mlflow", "ui"])
 """
     )
+    config = Config(select={UseSysExecutable.name})
     results = lint_file(tmp_file, config, index)
     assert len(results) == 2
     assert all(isinstance(r.rule, UseSysExecutable) for r in results)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16705?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16705/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16705/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16705/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR introduces a 'select' configuration option to the clint linter that allows users to run only specific rules instead of all rules by default.

**Key changes:**
- Add `select` field to Config class with validation against ALL_RULES
- Update Rule base class to store id and name as class attributes for better performance
- Add rule selection logic in linter to skip unselected rules  
- Update all test files to use `Config(select={RuleClass.name})` for isolated testing
- Add ALL_RULES set containing all available rule names
- Clean up conftest.py by removing unused config fixture

This change improves linter performance by allowing users to run only the rules they need, and ensures test isolation by having each test only run its specific rule.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

All existing tests have been updated to use the new select configuration and continue to pass. The change maintains backward compatibility - when no select is specified, all rules run by default.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add select configuration option to clint linter allowing users to run specific rules instead of all rules, improving performance for targeted linting.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)