### PR TITLE
Bug fix: Databricks GenAI evaluation dataset source returns string, instead of DatasetSource instance

### DIFF
--- a/mlflow/data/dataset_source_registry.py
+++ b/mlflow/data/dataset_source_registry.py
@@ -217,3 +217,11 @@ try:
     _dataset_source_registry.register(UCVolumeDatasetSource)
 except ImportError:
     pass
+try:
+    from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
+        DatabricksEvaluationDatasetSource,
+    )
+
+    _dataset_source_registry.register(DatabricksEvaluationDatasetSource)
+except ImportError:
+    pass

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -13,7 +13,7 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
     def __init__(self, table_name: str, dataset_id: str):
         """
         Args:
-            table_name: The UC table name of the dataset
+            table_name: The three-level UC table name of the dataset
             dataset_id: The unique identifier of the dataset
         """
         self._table_name = table_name

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any
 
 from mlflow.data.dataset_source import DatasetSource
 
@@ -10,24 +10,22 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
     This source is used for datasets managed by the Databricks agents SDK.
     """
 
-    def __init__(self, table_name: Optional[str] = None, dataset_id: Optional[str] = None):
+    def __init__(self, table_name: str, dataset_id: str):
         """
         Args:
             table_name: The UC table name of the dataset
             dataset_id: The unique identifier of the dataset
         """
-        if not table_name and not dataset_id:
-            raise ValueError("Either table_name or dataset_id must be provided")
         self._table_name = table_name
         self._dataset_id = dataset_id
 
     @property
-    def table_name(self) -> Optional[str]:
+    def table_name(self) -> str:
         """The UC table name of the dataset."""
         return self._table_name
 
     @property
-    def dataset_id(self) -> Optional[str]:
+    def dataset_id(self) -> str:
         """The unique identifier of the dataset."""
         return self._dataset_id
 
@@ -66,18 +64,14 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
         """
         Returns a dictionary representation of the source.
         """
-        result = {}
-        if self._table_name is not None:
-            result["table_name"] = self._table_name
-        if self._dataset_id is not None:
-            result["dataset_id"] = self._dataset_id
-        return result
+        return {
+            "table_name": self._table_name,
+            "dataset_id": self._dataset_id,
+        }
 
     @classmethod
     def from_dict(cls, source_dict: dict[str, Any]) -> "DatabricksEvaluationDatasetSource":
         """
         Creates an instance from a dictionary representation.
         """
-        return cls(
-            table_name=source_dict.get("table_name"), dataset_id=source_dict.get("dataset_id")
-        )
+        return cls(table_name=source_dict["table_name"], dataset_id=source_dict["dataset_id"])

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -1,0 +1,84 @@
+from typing import Any, Optional
+
+from mlflow.data.dataset_source import DatasetSource
+
+
+class DatabricksEvaluationDatasetSource(DatasetSource):
+    """
+    Represents a Databricks Evaluation Dataset source.
+
+    This source is used for datasets managed by the Databricks agents SDK.
+    """
+
+    def __init__(self, table_name: Optional[str] = None, dataset_id: Optional[str] = None):
+        """
+        Args:
+            table_name: The UC table name of the dataset
+            dataset_id: The unique identifier of the dataset
+        """
+        if not table_name and not dataset_id:
+            raise ValueError("Either table_name or dataset_id must be provided")
+        self._table_name = table_name
+        self._dataset_id = dataset_id
+
+    @property
+    def table_name(self) -> Optional[str]:
+        """The UC table name of the dataset."""
+        return self._table_name
+
+    @property
+    def dataset_id(self) -> Optional[str]:
+        """The unique identifier of the dataset."""
+        return self._dataset_id
+
+    @staticmethod
+    def _get_source_type() -> str:
+        return "databricks_evaluation_dataset"
+
+    def load(self, **kwargs) -> Any:
+        """
+        Loads the dataset from the source.
+
+        This method is not implemented as the dataset should be loaded through
+        the databricks.agents.datasets API.
+        """
+        raise NotImplementedError(
+            "DatabricksEvaluationDatasetSource.load() is not implemented. "
+            "Please use the databricks.agents.datasets API to load the dataset."
+        )
+
+    @staticmethod
+    def _can_resolve(raw_source: dict[str, Any]) -> bool:
+        """
+        Determines whether the source can be resolved from a dictionary representation.
+        """
+        # Resolution from a dictionary representation is not supported for Databricks Evaluation
+        # Datasets
+        return False
+
+    @classmethod
+    def _resolve(cls, raw_source: dict[str, Any]):
+        """
+        Resolves the source from a dictionary representation.
+        """
+        raise NotImplementedError
+
+    def to_dict(self) -> dict[str, Any]:
+        """
+        Returns a dictionary representation of the source.
+        """
+        result = {}
+        if self._table_name is not None:
+            result["table_name"] = self._table_name
+        if self._dataset_id is not None:
+            result["dataset_id"] = self._dataset_id
+        return result
+
+    @classmethod
+    def from_dict(cls, source_dict: dict[str, Any]) -> "DatabricksEvaluationDatasetSource":
+        """
+        Creates an instance from a dictionary representation.
+        """
+        return cls(
+            table_name=source_dict.get("table_name"), dataset_id=source_dict.get("dataset_id")
+        )

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -61,7 +61,9 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
         """
         Resolves the source from a dictionary representation.
         """
-        raise NotImplementedError
+        raise NotImplementedError(
+            "DatabricksEvaluationDatasetSource._resolve() is not implemented."
+        )
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -61,7 +61,7 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
         """
         Resolves the source from a dictionary representation.
         """
-        raise NotImplementedError("Resolution from a source dataset is not supported")
+        raise NotImplementedError("Resolution from a source dictionary is not supported")
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -43,8 +43,7 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
         the databricks.agents.datasets API.
         """
         raise NotImplementedError(
-            "DatabricksEvaluationDatasetSource.load() is not implemented. "
-            "Please use the databricks.agents.datasets API to load the dataset."
+            "Loading a Databricks Evaluation Dataset from source is not supported"
         )
 
     @staticmethod

--- a/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
+++ b/mlflow/genai/datasets/databricks_evaluation_dataset_source.py
@@ -61,9 +61,7 @@ class DatabricksEvaluationDatasetSource(DatasetSource):
         """
         Resolves the source from a dictionary representation.
         """
-        raise NotImplementedError(
-            "DatabricksEvaluationDatasetSource._resolve() is not implemented."
-        )
+        raise NotImplementedError("Resolution from a source dataset is not supported")
 
     def to_dict(self) -> dict[str, Any]:
         """

--- a/mlflow/genai/datasets/evaluation_dataset.py
+++ b/mlflow/genai/datasets/evaluation_dataset.py
@@ -1,4 +1,3 @@
-import json
 from typing import TYPE_CHECKING, Any, Optional, Union
 
 from mlflow.data import Dataset
@@ -6,7 +5,6 @@ from mlflow.data.dataset_source import DatasetSource
 from mlflow.data.digest_utils import compute_pandas_digest
 from mlflow.data.evaluation_dataset import EvaluationDataset as LegacyEvaluationDataset
 from mlflow.data.pyfunc_dataset_mixin import PyFuncConvertibleDatasetMixin
-from mlflow.data.spark_dataset_source import SparkDatasetSource
 from mlflow.entities import Dataset as DatasetEntity
 from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
     DatabricksEvaluationDatasetSource,
@@ -63,23 +61,9 @@ class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
     @property
     def source(self) -> DatasetSource:
         """Source information for the dataset."""
-        # NB: The managed Dataset entity in Agent SDK doesn't propagate the source
-        # information. So we use the table name as the fallback source.
-        if self._dataset.source:
-            # If source is a string, it's a JSON string with table_name
-            if isinstance(self._dataset.source, str):
-                try:
-                    source_dict = json.loads(self._dataset.source)
-                    table_name = source_dict.get("table_name", self.name)
-                except (json.JSONDecodeError, AttributeError):
-                    # If it's not valid JSON, use the string as table name
-                    table_name = self._dataset.source
-                return DatabricksEvaluationDatasetSource(
-                    table_name=table_name, dataset_id=self.dataset_id
-                )
+        if isinstance(self._dataset.source, DatasetSource):
             return self._dataset.source
-        # Fallback to SparkDatasetSource for backward compatibility
-        return SparkDatasetSource(table_name=self.name)
+        return DatabricksEvaluationDatasetSource(table_name=self.name, dataset_id=self.dataset_id)
 
     @property
     def source_type(self) -> Optional[str]:

--- a/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
+++ b/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
@@ -103,6 +103,6 @@ def test_databricks_evaluation_dataset_source_can_resolve():
 
 def test_databricks_evaluation_dataset_source_resolve_not_implemented():
     with pytest.raises(
-        NotImplementedError, match="Resolution from a source dataset is not supported"
+        NotImplementedError, match="Resolution from a source dictionary is not supported"
     ):
         DatabricksEvaluationDatasetSource._resolve({})

--- a/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
+++ b/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
@@ -102,5 +102,7 @@ def test_databricks_evaluation_dataset_source_can_resolve():
 
 
 def test_databricks_evaluation_dataset_source_resolve_not_implemented():
-    with pytest.raises(NotImplementedError, match="_resolve\\(\\) is not implemented"):
+    with pytest.raises(
+        NotImplementedError, match="Resolution from a source dataset is not supported"
+    ):
         DatabricksEvaluationDatasetSource._resolve({})

--- a/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
+++ b/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
@@ -8,7 +8,6 @@ from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
 
 
 def test_databricks_evaluation_dataset_source_init():
-    # Test with both table_name and dataset_id (required)
     source = DatabricksEvaluationDatasetSource(
         table_name="catalog.schema.table", dataset_id="12345"
     )

--- a/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
+++ b/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
@@ -1,0 +1,106 @@
+import json
+
+import pytest
+
+from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
+    DatabricksEvaluationDatasetSource,
+)
+
+
+def test_databricks_evaluation_dataset_source_init():
+    # Test with table_name
+    source = DatabricksEvaluationDatasetSource(table_name="catalog.schema.table")
+    assert source.table_name == "catalog.schema.table"
+    assert source.dataset_id is None
+
+    # Test with dataset_id
+    source = DatabricksEvaluationDatasetSource(dataset_id="12345")
+    assert source.table_name is None
+    assert source.dataset_id == "12345"
+
+    # Test with both
+    source = DatabricksEvaluationDatasetSource(
+        table_name="catalog.schema.table", dataset_id="12345"
+    )
+    assert source.table_name == "catalog.schema.table"
+    assert source.dataset_id == "12345"
+
+    # Test without either should raise ValueError
+    with pytest.raises(ValueError, match="Either table_name or dataset_id must be provided"):
+        DatabricksEvaluationDatasetSource()
+
+
+def test_databricks_evaluation_dataset_source_get_source_type():
+    assert DatabricksEvaluationDatasetSource._get_source_type() == "databricks_evaluation_dataset"
+
+
+def test_databricks_evaluation_dataset_source_to_dict():
+    # Test with table_name only
+    source = DatabricksEvaluationDatasetSource(table_name="catalog.schema.table")
+    assert source.to_dict() == {"table_name": "catalog.schema.table"}
+
+    # Test with dataset_id only
+    source = DatabricksEvaluationDatasetSource(dataset_id="12345")
+    assert source.to_dict() == {"dataset_id": "12345"}
+
+    # Test with both
+    source = DatabricksEvaluationDatasetSource(
+        table_name="catalog.schema.table", dataset_id="12345"
+    )
+    assert source.to_dict() == {
+        "table_name": "catalog.schema.table",
+        "dataset_id": "12345",
+    }
+
+
+def test_databricks_evaluation_dataset_source_from_dict():
+    # Test with table_name only
+    source_dict = {"table_name": "catalog.schema.table"}
+    source = DatabricksEvaluationDatasetSource.from_dict(source_dict)
+    assert source.table_name == "catalog.schema.table"
+    assert source.dataset_id is None
+
+    # Test with dataset_id only
+    source_dict = {"dataset_id": "12345"}
+    source = DatabricksEvaluationDatasetSource.from_dict(source_dict)
+    assert source.table_name is None
+    assert source.dataset_id == "12345"
+
+    # Test with both
+    source_dict = {"table_name": "catalog.schema.table", "dataset_id": "12345"}
+    source = DatabricksEvaluationDatasetSource.from_dict(source_dict)
+    assert source.table_name == "catalog.schema.table"
+    assert source.dataset_id == "12345"
+
+
+def test_databricks_evaluation_dataset_source_to_json():
+    source = DatabricksEvaluationDatasetSource(
+        table_name="catalog.schema.table", dataset_id="12345"
+    )
+    json_str = source.to_json()
+    parsed = json.loads(json_str)
+    assert parsed == {"table_name": "catalog.schema.table", "dataset_id": "12345"}
+
+
+def test_databricks_evaluation_dataset_source_from_json():
+    json_str = json.dumps({"table_name": "catalog.schema.table", "dataset_id": "12345"})
+    source = DatabricksEvaluationDatasetSource.from_json(json_str)
+    assert source.table_name == "catalog.schema.table"
+    assert source.dataset_id == "12345"
+
+
+def test_databricks_evaluation_dataset_source_load_not_implemented():
+    source = DatabricksEvaluationDatasetSource(table_name="catalog.schema.table")
+    with pytest.raises(NotImplementedError, match="load\\(\\) is not implemented"):
+        source.load()
+
+
+def test_databricks_evaluation_dataset_source_can_resolve():
+    # _can_resolve should return False for all inputs
+    assert DatabricksEvaluationDatasetSource._can_resolve({}) is False
+    assert DatabricksEvaluationDatasetSource._can_resolve({"table_name": "test"}) is False
+
+
+def test_databricks_evaluation_dataset_source_resolve_not_implemented():
+    with pytest.raises(NotImplementedError, match="_resolve\\(\\) is not implemented"):
+        DatabricksEvaluationDatasetSource._resolve({})

--- a/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
+++ b/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
@@ -8,26 +8,12 @@ from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
 
 
 def test_databricks_evaluation_dataset_source_init():
-    # Test with table_name
-    source = DatabricksEvaluationDatasetSource(table_name="catalog.schema.table")
-    assert source.table_name == "catalog.schema.table"
-    assert source.dataset_id is None
-
-    # Test with dataset_id
-    source = DatabricksEvaluationDatasetSource(dataset_id="12345")
-    assert source.table_name is None
-    assert source.dataset_id == "12345"
-
-    # Test with both
+    # Test with both table_name and dataset_id (required)
     source = DatabricksEvaluationDatasetSource(
         table_name="catalog.schema.table", dataset_id="12345"
     )
     assert source.table_name == "catalog.schema.table"
     assert source.dataset_id == "12345"
-
-    # Test without either should raise ValueError
-    with pytest.raises(ValueError, match="Either table_name or dataset_id must be provided"):
-        DatabricksEvaluationDatasetSource()
 
 
 def test_databricks_evaluation_dataset_source_get_source_type():
@@ -35,15 +21,6 @@ def test_databricks_evaluation_dataset_source_get_source_type():
 
 
 def test_databricks_evaluation_dataset_source_to_dict():
-    # Test with table_name only
-    source = DatabricksEvaluationDatasetSource(table_name="catalog.schema.table")
-    assert source.to_dict() == {"table_name": "catalog.schema.table"}
-
-    # Test with dataset_id only
-    source = DatabricksEvaluationDatasetSource(dataset_id="12345")
-    assert source.to_dict() == {"dataset_id": "12345"}
-
-    # Test with both
     source = DatabricksEvaluationDatasetSource(
         table_name="catalog.schema.table", dataset_id="12345"
     )
@@ -54,19 +31,6 @@ def test_databricks_evaluation_dataset_source_to_dict():
 
 
 def test_databricks_evaluation_dataset_source_from_dict():
-    # Test with table_name only
-    source_dict = {"table_name": "catalog.schema.table"}
-    source = DatabricksEvaluationDatasetSource.from_dict(source_dict)
-    assert source.table_name == "catalog.schema.table"
-    assert source.dataset_id is None
-
-    # Test with dataset_id only
-    source_dict = {"dataset_id": "12345"}
-    source = DatabricksEvaluationDatasetSource.from_dict(source_dict)
-    assert source.table_name is None
-    assert source.dataset_id == "12345"
-
-    # Test with both
     source_dict = {"table_name": "catalog.schema.table", "dataset_id": "12345"}
     source = DatabricksEvaluationDatasetSource.from_dict(source_dict)
     assert source.table_name == "catalog.schema.table"
@@ -90,7 +54,9 @@ def test_databricks_evaluation_dataset_source_from_json():
 
 
 def test_databricks_evaluation_dataset_source_load_not_implemented():
-    source = DatabricksEvaluationDatasetSource(table_name="catalog.schema.table")
+    source = DatabricksEvaluationDatasetSource(
+        table_name="catalog.schema.table", dataset_id="12345"
+    )
     with pytest.raises(
         NotImplementedError,
         match="Loading a Databricks Evaluation Dataset from source is not supported",

--- a/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
+++ b/tests/genai/datasets/test_databricks_evaluation_dataset_source.py
@@ -91,7 +91,10 @@ def test_databricks_evaluation_dataset_source_from_json():
 
 def test_databricks_evaluation_dataset_source_load_not_implemented():
     source = DatabricksEvaluationDatasetSource(table_name="catalog.schema.table")
-    with pytest.raises(NotImplementedError, match="load\\(\\) is not implemented"):
+    with pytest.raises(
+        NotImplementedError,
+        match="Loading a Databricks Evaluation Dataset from source is not supported",
+    ):
         source.load()
 
 

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -105,16 +105,10 @@ def test_evaluation_dataset_source_with_spark_dataset_source():
 def test_evaluation_dataset_to_df(mock_managed_dataset):
     dataset = EvaluationDataset(mock_managed_dataset)
 
-    # First call should fetch from managed dataset
     df = dataset.to_df()
     assert isinstance(df, pd.DataFrame)
     assert len(df) == 3
     mock_managed_dataset.to_df.assert_called_once()
-
-    # Second call should use cached version
-    df2 = dataset.to_df()
-    assert df2 is df
-    assert mock_managed_dataset.to_df.call_count == 1  # Still only called once
 
 
 def test_evaluation_dataset_to_mlflow_entity(mock_managed_dataset):

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -55,8 +55,8 @@ def create_dataset_with_source(source_value: Any) -> EvaluationDataset:
     return EvaluationDataset(mock_dataset)
 
 
-def test_evaluation_dataset_properties():
-    dataset = create_dataset_with_source(create_test_source_json())
+def test_evaluation_dataset_properties(mock_managed_dataset):
+    dataset = EvaluationDataset(mock_managed_dataset)
 
     assert dataset.dataset_id == "test-dataset-id"
     assert dataset.name == "catalog.schema.table"

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -55,13 +55,6 @@ def create_dataset_with_source(source_value: Any) -> EvaluationDataset:
     return EvaluationDataset(mock_dataset)
 
 
-def test_evaluation_dataset_init(mock_managed_dataset):
-    dataset = EvaluationDataset(mock_managed_dataset)
-    assert dataset._dataset is mock_managed_dataset
-    assert dataset._df is None
-    assert dataset._digest is None
-
-
 def test_evaluation_dataset_properties():
     dataset = create_dataset_with_source(create_test_source_json())
 

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -1,0 +1,208 @@
+import json
+from typing import Any
+from unittest.mock import Mock, patch
+
+import pandas as pd
+
+from mlflow.data.spark_dataset_source import SparkDatasetSource
+from mlflow.genai.datasets.databricks_evaluation_dataset_source import (
+    DatabricksEvaluationDatasetSource,
+)
+from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
+
+
+def create_mock_managed_dataset(source_value: Any = "test-digest") -> Mock:
+    """Create a mock Databricks Agent Evaluation ManagedDataset for testing"""
+    mock_dataset = Mock()
+    mock_dataset.dataset_id = "test-dataset-id"
+    mock_dataset.name = "catalog.schema.table"
+    mock_dataset.digest = "test-digest"
+    mock_dataset.schema = "test-schema"
+    mock_dataset.profile = "test-profile"
+    mock_dataset.source = source_value
+    mock_dataset.source_type = "databricks-uc-table"
+    mock_dataset.create_time = "2024-01-01T00:00:00"
+    mock_dataset.created_by = "test-user"
+    mock_dataset.last_update_time = "2024-01-02T00:00:00"
+    mock_dataset.last_updated_by = "test-user-2"
+
+    # Mock methods
+    mock_dataset.to_df.return_value = pd.DataFrame({"col1": [1, 2, 3], "col2": ["a", "b", "c"]})
+    mock_dataset.set_profile.return_value = mock_dataset
+    mock_dataset.merge_records.return_value = mock_dataset
+
+    return mock_dataset
+
+
+def create_dataset_with_source(source_value: Any) -> EvaluationDataset:
+    """Factory function to create EvaluationDataset with specific source value."""
+    mock_dataset = create_mock_managed_dataset(source_value)
+    return EvaluationDataset(mock_dataset)
+
+
+def test_evaluation_dataset_init():
+    mock_managed_dataset = create_mock_managed_dataset()
+    dataset = EvaluationDataset(mock_managed_dataset)
+    assert dataset._dataset is mock_managed_dataset
+    assert dataset._df is None
+    assert dataset._digest is None
+
+
+def test_evaluation_dataset_properties():
+    dataset = create_dataset_with_source("test-digest")
+
+    assert dataset.dataset_id == "test-dataset-id"
+    assert dataset.name == "catalog.schema.table"
+    assert dataset.digest == "test-digest"
+    assert dataset.schema == "test-schema"
+    assert dataset.profile == "test-profile"
+    assert dataset.source_type == "databricks-uc-table"
+    assert dataset.create_time == "2024-01-01T00:00:00"
+    assert dataset.created_by == "test-user"
+    assert dataset.last_update_time == "2024-01-02T00:00:00"
+    assert dataset.last_updated_by == "test-user-2"
+
+
+def test_evaluation_dataset_source_default():
+    # Test that source returns DatabricksEvaluationDatasetSource with table name and dataset ID
+    # when the managed dataset source is not a DatasetSource
+    dataset = create_dataset_with_source("string-value")
+
+    source = dataset.source
+    assert isinstance(source, DatabricksEvaluationDatasetSource)
+    assert source.table_name == "catalog.schema.table"  # Uses dataset.name
+    assert source.dataset_id == "test-dataset-id"
+
+
+def test_evaluation_dataset_source_with_none():
+    # Test that source returns DatabricksEvaluationDatasetSource when managed dataset source is None
+    dataset = create_dataset_with_source(None)
+
+    source = dataset.source
+    assert isinstance(source, DatabricksEvaluationDatasetSource)
+    assert source.table_name == "catalog.schema.table"  # Uses dataset.name
+    assert source.dataset_id == "test-dataset-id"
+
+
+def test_evaluation_dataset_source_with_existing_dataset_source():
+    # Test when source is already a DatasetSource object - should return it directly
+    existing_source = DatabricksEvaluationDatasetSource(table_name="existing.table")
+    dataset = create_dataset_with_source(existing_source)
+
+    source = dataset.source
+    assert source is existing_source
+
+
+def test_evaluation_dataset_source_with_spark_dataset_source():
+    # Test when source is a SparkDatasetSource - should return it directly
+    spark_source = SparkDatasetSource(table_name="spark.table")
+    dataset = create_dataset_with_source(spark_source)
+
+    source = dataset.source
+    assert source is spark_source
+
+
+def test_evaluation_dataset_to_df():
+    mock_managed_dataset = create_mock_managed_dataset()
+    dataset = EvaluationDataset(mock_managed_dataset)
+
+    # First call should fetch from managed dataset
+    df = dataset.to_df()
+    assert isinstance(df, pd.DataFrame)
+    assert len(df) == 3
+    mock_managed_dataset.to_df.assert_called_once()
+
+    # Second call should use cached version
+    df2 = dataset.to_df()
+    assert df2 is df
+    assert mock_managed_dataset.to_df.call_count == 1  # Still only called once
+
+
+def test_evaluation_dataset_to_mlflow_entity():
+    # Test that _to_mlflow_entity properly serializes the source to JSON
+    dataset = create_dataset_with_source("any-value")
+
+    entity = dataset._to_mlflow_entity()
+    assert entity.name == "catalog.schema.table"
+    assert entity.digest == "test-digest"
+    assert entity.source_type == "databricks-uc-table"
+
+    # Check that source is properly serialized to JSON
+    source_dict = json.loads(entity.source)
+    assert source_dict["table_name"] == "catalog.schema.table"
+    assert source_dict["dataset_id"] == "test-dataset-id"
+    assert entity.schema == "test-schema"
+    assert entity.profile == "test-profile"
+
+
+def test_evaluation_dataset_to_mlflow_entity_with_existing_source():
+    # Test that _to_mlflow_entity works with an existing DatasetSource
+    existing_source = DatabricksEvaluationDatasetSource(
+        table_name="existing.table", dataset_id="existing-id"
+    )
+    dataset = create_dataset_with_source(existing_source)
+
+    entity = dataset._to_mlflow_entity()
+    assert entity.name == "catalog.schema.table"
+    assert entity.digest == "test-digest"
+    assert entity.source_type == "databricks-uc-table"
+
+    # Check that the existing source is properly serialized to JSON
+    source_dict = json.loads(entity.source)
+    assert source_dict["table_name"] == "existing.table"
+    assert source_dict["dataset_id"] == "existing-id"
+    assert entity.schema == "test-schema"
+    assert entity.profile == "test-profile"
+
+
+def test_evaluation_dataset_set_profile():
+    mock_managed_dataset = create_mock_managed_dataset()
+    dataset = EvaluationDataset(mock_managed_dataset)
+
+    new_dataset = dataset.set_profile("new-profile")
+    assert isinstance(new_dataset, EvaluationDataset)
+    mock_managed_dataset.set_profile.assert_called_once_with("new-profile")
+
+
+def test_evaluation_dataset_merge_records():
+    mock_managed_dataset = create_mock_managed_dataset()
+    dataset = EvaluationDataset(mock_managed_dataset)
+
+    new_records = [{"col1": 4, "col2": "d"}]
+    new_dataset = dataset.merge_records(new_records)
+    assert isinstance(new_dataset, EvaluationDataset)
+    mock_managed_dataset.merge_records.assert_called_once_with(new_records)
+
+
+@patch("mlflow.genai.datasets.evaluation_dataset.compute_pandas_digest")
+def test_evaluation_dataset_digest_computation(mock_compute_digest):
+    # Test when managed dataset has no digest
+    mock_managed_dataset = create_mock_managed_dataset()
+    mock_managed_dataset.digest = None
+    mock_compute_digest.return_value = "computed-digest"
+
+    dataset = EvaluationDataset(mock_managed_dataset)
+    digest = dataset.digest
+
+    assert digest == "computed-digest"
+    mock_compute_digest.assert_called_once()
+
+    # Subsequent calls should use cached digest
+    digest2 = dataset.digest
+    assert digest2 == "computed-digest"
+    assert mock_compute_digest.call_count == 1
+
+
+def test_evaluation_dataset_to_evaluation_dataset():
+    dataset = create_dataset_with_source("test-digest")
+
+    legacy_dataset = dataset.to_evaluation_dataset(
+        path="/path/to/data", feature_names=["col1", "col2"]
+    )
+
+    # Legacy EvaluationDataset stores data as _features_data
+    assert legacy_dataset._features_data.equals(dataset.to_df())
+    assert legacy_dataset._path == "/path/to/data"
+    assert legacy_dataset._feature_names == ["col1", "col2"]
+    assert legacy_dataset.name == "catalog.schema.table"
+    assert legacy_dataset.digest == "test-digest"

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -68,6 +68,9 @@ def test_evaluation_dataset_properties(mock_managed_dataset):
     assert dataset.created_by == "test-user"
     assert dataset.last_update_time == "2024-01-02T00:00:00"
     assert dataset.last_updated_by == "test-user-2"
+    assert isinstance(dataset.source, DatabricksEvaluationDatasetSource)
+    assert dataset.source.table_name == "catalog.schema.table"
+    assert dataset.source.dataset_id == "test-dataset-id"
 
 
 def test_evaluation_dataset_source_with_string_source():

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -80,7 +80,9 @@ def test_evaluation_dataset_source_with_none():
 
 
 def test_evaluation_dataset_source_with_existing_dataset_source():
-    existing_source = DatabricksEvaluationDatasetSource(table_name="existing.table")
+    existing_source = DatabricksEvaluationDatasetSource(
+        table_name="existing.table", dataset_id="existing-id"
+    )
     dataset = create_dataset_with_source(existing_source)
 
     assert dataset.source is existing_source

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -173,11 +173,6 @@ def test_evaluation_dataset_digest_computation(mock_compute_digest, mock_managed
     assert digest == "computed-digest"
     mock_compute_digest.assert_called_once()
 
-    # Subsequent calls should use cached digest
-    digest2 = dataset.digest
-    assert digest2 == "computed-digest"
-    assert mock_compute_digest.call_count == 1
-
 
 def test_evaluation_dataset_to_evaluation_dataset(mock_managed_dataset):
     dataset = EvaluationDataset(mock_managed_dataset)

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -49,7 +49,7 @@ def test_evaluation_dataset_init():
 
 
 def test_evaluation_dataset_properties():
-    dataset = create_dataset_with_source("test-digest")
+    dataset = create_dataset_with_source("any-value")
 
     assert dataset.dataset_id == "test-dataset-id"
     assert dataset.name == "catalog.schema.table"
@@ -64,42 +64,33 @@ def test_evaluation_dataset_properties():
 
 
 def test_evaluation_dataset_source_default():
-    # Test that source returns DatabricksEvaluationDatasetSource with table name and dataset ID
-    # when the managed dataset source is not a DatasetSource
     dataset = create_dataset_with_source("string-value")
 
-    source = dataset.source
-    assert isinstance(source, DatabricksEvaluationDatasetSource)
-    assert source.table_name == "catalog.schema.table"  # Uses dataset.name
-    assert source.dataset_id == "test-dataset-id"
+    assert isinstance(dataset.source, DatabricksEvaluationDatasetSource)
+    assert dataset.source.table_name == "catalog.schema.table"
+    assert dataset.source.dataset_id == "test-dataset-id"
 
 
 def test_evaluation_dataset_source_with_none():
-    # Test that source returns DatabricksEvaluationDatasetSource when managed dataset source is None
     dataset = create_dataset_with_source(None)
 
-    source = dataset.source
-    assert isinstance(source, DatabricksEvaluationDatasetSource)
-    assert source.table_name == "catalog.schema.table"  # Uses dataset.name
-    assert source.dataset_id == "test-dataset-id"
+    assert isinstance(dataset.source, DatabricksEvaluationDatasetSource)
+    assert dataset.source.table_name == "catalog.schema.table"
+    assert dataset.source.dataset_id == "test-dataset-id"
 
 
 def test_evaluation_dataset_source_with_existing_dataset_source():
-    # Test when source is already a DatasetSource object - should return it directly
     existing_source = DatabricksEvaluationDatasetSource(table_name="existing.table")
     dataset = create_dataset_with_source(existing_source)
 
-    source = dataset.source
-    assert source is existing_source
+    assert dataset.source is existing_source
 
 
 def test_evaluation_dataset_source_with_spark_dataset_source():
-    # Test when source is a SparkDatasetSource - should return it directly
     spark_source = SparkDatasetSource(table_name="spark.table")
     dataset = create_dataset_with_source(spark_source)
 
-    source = dataset.source
-    assert source is spark_source
+    assert dataset.source is spark_source
 
 
 def test_evaluation_dataset_to_df():
@@ -119,7 +110,6 @@ def test_evaluation_dataset_to_df():
 
 
 def test_evaluation_dataset_to_mlflow_entity():
-    # Test that _to_mlflow_entity properly serializes the source to JSON
     dataset = create_dataset_with_source("any-value")
 
     entity = dataset._to_mlflow_entity()
@@ -127,7 +117,6 @@ def test_evaluation_dataset_to_mlflow_entity():
     assert entity.digest == "test-digest"
     assert entity.source_type == "databricks-uc-table"
 
-    # Check that source is properly serialized to JSON
     source_dict = json.loads(entity.source)
     assert source_dict["table_name"] == "catalog.schema.table"
     assert source_dict["dataset_id"] == "test-dataset-id"
@@ -136,7 +125,6 @@ def test_evaluation_dataset_to_mlflow_entity():
 
 
 def test_evaluation_dataset_to_mlflow_entity_with_existing_source():
-    # Test that _to_mlflow_entity works with an existing DatasetSource
     existing_source = DatabricksEvaluationDatasetSource(
         table_name="existing.table", dataset_id="existing-id"
     )
@@ -147,7 +135,6 @@ def test_evaluation_dataset_to_mlflow_entity_with_existing_source():
     assert entity.digest == "test-digest"
     assert entity.source_type == "databricks-uc-table"
 
-    # Check that the existing source is properly serialized to JSON
     source_dict = json.loads(entity.source)
     assert source_dict["table_name"] == "existing.table"
     assert source_dict["dataset_id"] == "existing-id"
@@ -194,13 +181,12 @@ def test_evaluation_dataset_digest_computation(mock_compute_digest):
 
 
 def test_evaluation_dataset_to_evaluation_dataset():
-    dataset = create_dataset_with_source("test-digest")
+    dataset = create_dataset_with_source("any-value")
 
     legacy_dataset = dataset.to_evaluation_dataset(
         path="/path/to/data", feature_names=["col1", "col2"]
     )
 
-    # Legacy EvaluationDataset stores data as _features_data
     assert legacy_dataset._features_data.equals(dataset.to_df())
     assert legacy_dataset._path == "/path/to/data"
     assert legacy_dataset._feature_names == ["col1", "col2"]

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -1,6 +1,6 @@
 import json
 from typing import Any
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pandas as pd
 import pytest
@@ -161,17 +161,14 @@ def test_evaluation_dataset_merge_records(mock_managed_dataset):
     mock_managed_dataset.merge_records.assert_called_once_with(new_records)
 
 
-@patch("mlflow.genai.datasets.evaluation_dataset.compute_pandas_digest")
-def test_evaluation_dataset_digest_computation(mock_compute_digest, mock_managed_dataset):
+def test_evaluation_dataset_digest_computation(mock_managed_dataset):
     # Test when managed dataset has no digest
     mock_managed_dataset.digest = None
-    mock_compute_digest.return_value = "computed-digest"
 
     dataset = EvaluationDataset(mock_managed_dataset)
     digest = dataset.digest
 
-    assert digest == "computed-digest"
-    mock_compute_digest.assert_called_once()
+    assert digest is not None
 
 
 def test_evaluation_dataset_to_evaluation_dataset(mock_managed_dataset):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/16712?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16712/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16712/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16712/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Bug fix: Databricks GenAI evaluation dataset source returns string, instead of DatasetSource instance. Before this change, https://docs.databricks.com/aws/en/mlflow3/genai/eval-monitor/evaluate-app fails.

Stacktrace demonstrating the issue:

```
mlflow.genai.evaluate(
  File "/Users/corey.zumar/mlflow/mlflow/genai/evaluation/base.py", line 279, in evaluate
    result = mlflow.models.evaluate(
  File "/Users/corey.zumar/mlflow/mlflow/models/evaluation/base.py", line 1773, in evaluate
    dataset_input = DatasetInput(dataset=data._to_mlflow_entity(), tags=tags)
  File "/Users/corey.zumar/mlflow/mlflow/genai/datasets/evaluation_dataset.py", line 131, in _to_mlflow_entity
    source=self.source.to_json(),
AttributeError: 'str' object has no attribute 'to_json'
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

Fix a type mismatch error preventing `mlflow.genai.evaluate()` from being used with Databricks Managed Evaluation datasets

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
