### PR TITLE
Fix `get_model_info` to provide logged model info

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -344,7 +344,7 @@ class ModelInfo:
 
         :getter: Gets the model ID of the logged model
         """
-        return self._logged_model and self._logged_model.model_id
+        return self._logged_model.model_id if self._logged_model else None
 
     @property
     def metrics(self) -> Optional[list[Metric]]:
@@ -353,7 +353,7 @@ class ModelInfo:
 
         :getter: Retrieves the metrics of the logged model
         """
-        return self._logged_model and self._logged_model.metrics
+        return self._logged_model.metrics if self._logged_model else None
 
     @property
     def params(self) -> dict[str, str]:
@@ -362,7 +362,7 @@ class ModelInfo:
 
         :getter: Retrieves the parameters of the logged model
         """
-        return self._logged_model and self._logged_model.params
+        return self._logged_model.params if self._logged_model else None
 
     @property
     def tags(self) -> dict[str, str]:
@@ -371,7 +371,7 @@ class ModelInfo:
 
         :getter: Retrieves the tags of the logged model
         """
-        return self._logged_model and self._logged_model.tags
+        return self._logged_model.tags if self._logged_model else None
 
     @property
     def creation_timestamp(self) -> int:
@@ -380,14 +380,14 @@ class ModelInfo:
 
         :getter:  the creation timestamp of the logged model
         """
-        return self._logged_model and self._logged_model.creation_timestamp
+        return self._logged_model.creation_timestamp if self._logged_model else None
 
     @property
     def name(self) -> str:
         """
         Returns the name of the logged model.
         """
-        return self._logged_model and self._logged_model.name
+        return self._logged_model.name if self._logged_model else None
 
 
 class Model:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -344,7 +344,7 @@ class ModelInfo:
 
         :getter: Gets the model ID of the logged model
         """
-        return self._logged_model.model_id
+        return self._logged_model and self._logged_model.model_id
 
     @property
     def metrics(self) -> Optional[list[Metric]]:
@@ -353,7 +353,7 @@ class ModelInfo:
 
         :getter: Retrieves the metrics of the logged model
         """
-        return self._logged_model.metrics
+        return self._logged_model and self._logged_model.metrics
 
     @property
     def params(self) -> dict[str, str]:
@@ -362,7 +362,7 @@ class ModelInfo:
 
         :getter: Retrieves the parameters of the logged model
         """
-        return self._logged_model.params
+        return self._logged_model and self._logged_model.params
 
     @property
     def tags(self) -> dict[str, str]:
@@ -371,7 +371,7 @@ class ModelInfo:
 
         :getter: Retrieves the tags of the logged model
         """
-        return self._logged_model.tags
+        return self._logged_model and self._logged_model.tags
 
     @property
     def creation_timestamp(self) -> int:
@@ -380,14 +380,14 @@ class ModelInfo:
 
         :getter:  the creation timestamp of the logged model
         """
-        return self._logged_model.creation_timestamp
+        return self._logged_model and self._logged_model.creation_timestamp
 
     @property
     def name(self) -> str:
         """
         Returns the name of the logged model.
         """
-        return self._logged_model.name
+        return self._logged_model and self._logged_model.name
 
 
 class Model:

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -679,8 +679,7 @@ class Model:
         model metadata.
         """
         if logged_model is None:
-            client = mlflow.MlflowClient()
-            logged_model = client.get_logged_model(model_id=self.model_id)
+            logged_model = mlflow.get_logged_model(model_id=self.model_id)
         return ModelInfo(
             artifact_path=self.artifact_path,
             flavors=self.flavors,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -678,6 +678,9 @@ class Model:
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
         model metadata.
         """
+        if logged_model is None:
+            client = mlflow.MlflowClient()
+            logged_model = client.get_logged_model(model_id=self.model_id)
         return ModelInfo(
             artifact_path=self.artifact_path,
             flavors=self.flavors,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -678,7 +678,8 @@ class Model:
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
         model metadata.
         """
-        logged_model = logged_model or mlflow.get_logged_model(model_id=self.model_id)
+        if logged_model is None and self.model_id is not None:
+            logged_model = mlflow.get_logged_model(model_id=self.model_id)
         return ModelInfo(
             artifact_path=self.artifact_path,
             flavors=self.flavors,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -678,8 +678,7 @@ class Model:
         Create a :py:class:`ModelInfo <mlflow.models.model.ModelInfo>` instance that contains the
         model metadata.
         """
-        if logged_model is None:
-            logged_model = mlflow.get_logged_model(model_id=self.model_id)
+        logged_model = logged_model or mlflow.get_logged_model(model_id=self.model_id)
         return ModelInfo(
             artifact_path=self.artifact_path,
             flavors=self.flavors,

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -719,8 +719,9 @@ def test_get_model_info_with_logged_model():
     def model(model_input: list[str]) -> list[str]:
         return model_input
 
-    model_info = mlflow.pyfunc.log_model(
+    model_info_log_model = mlflow.pyfunc.log_model(
         name="test_model", python_model=model, input_example=["a", "b", "c"]
     )
-    model_info = mlflow.models.get_model_info(model_info.model_uri)
-    assert model_info.model_id == model_info.model_id
+    model_info_get_model_info = mlflow.models.get_model_info(model_info_log_model.model_uri)
+    assert model_info_log_model.model_id == model_info_get_model_info.model_id
+    assert model_info_log_model.name == model_info_get_model_info.name

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -713,3 +713,14 @@ def test_logged_model_status():
             )
     logged_model = mlflow.last_logged_model()
     assert logged_model.status == "FAILED"
+
+
+def test_get_model_info_with_logged_model():
+    def model(model_input: list[str]) -> list[str]:
+        return model_input
+
+    model_info = mlflow.pyfunc.log_model(
+        name="test_model", python_model=model, input_example=["a", "b", "c"]
+    )
+    model_info = mlflow.models.get_model_info(model_info.model_uri)
+    assert model_info.model_id == model_info.model_id


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16713?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16713/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16713/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16713/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Fix #16706

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Minimum example to reproduce the error:

```python
import mlflow


def model(model_input: list[str]) -> list[str]:
    return model_input


model_info = mlflow.pyfunc.log_model(
    name="test_model", python_model=model, input_example=["a", "b", "c"]
)
model_info = mlflow.models.get_model_info(model_info.model_uri)
assert model_info.model_id == model_info.model_id
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

Fix `get_model_info` to include logged model info.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
