### PR TITLE
[OSS GenAI Eval #2] Add evaluation harness that support static dataset evaluation.

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Callable, Optional
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset
-from mlflow.genai.evaluation import harness
 from mlflow.genai.evaluation.constant import InputDatasetColumn
 from mlflow.genai.evaluation.utils import (
     _convert_scorer_to_legacy_metric,
@@ -16,10 +15,7 @@ from mlflow.genai.evaluation.utils import (
 from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, BuiltInScorer
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
-from mlflow.genai.utils.trace_utils import (
-    clean_up_extra_traces,
-    convert_predict_fn,
-)
+from mlflow.genai.utils.trace_utils import clean_up_extra_traces, convert_predict_fn
 from mlflow.models.evaluation.base import (
     EvaluationResult,
     _is_model_deployment_endpoint_uri,
@@ -269,6 +265,8 @@ def evaluate(
 
 
 def _evaluate_oss(data, scorers, predict_fn, model_id):
+    from mlflow.genai.evaluation import harness
+
     # Rename 'request' / 'response' column back to 'inputs' / 'outputs'.
     # This is a temporary hack to avoid branching _convert_to_eval_set()
     # into OSS and DBX implementation.

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -1,14 +1,17 @@
 import logging
 import time
 import warnings
+from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import mlflow
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset
+from mlflow.genai.evaluation import harness
+from mlflow.genai.evaluation.constant import InputDatasetColumn
 from mlflow.genai.evaluation.utils import (
     _convert_scorer_to_legacy_metric,
-    _convert_to_legacy_eval_set,
+    _convert_to_eval_set,
 )
 from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers.builtin_scorers import GENAI_CONFIG_NAME, BuiltInScorer
@@ -20,6 +23,7 @@ from mlflow.genai.utils.trace_utils import (
 from mlflow.models.evaluation.base import (
     EvaluationResult,
     _is_model_deployment_endpoint_uri,
+    _start_run_or_reuse_active_run,
 )
 from mlflow.tracing.constant import (
     DATABRICKS_OPTIONS_KEY,
@@ -27,6 +31,7 @@ from mlflow.tracing.constant import (
     RETURN_TRACE_OPTION_KEY,
 )
 from mlflow.tracing.utils.copy import copy_trace_to_experiment
+from mlflow.tracking.fluent import _set_active_model
 from mlflow.utils.annotations import experimental
 from mlflow.utils.uri import is_databricks_uri
 
@@ -223,25 +228,11 @@ def evaluate(
         This function is not thread-safe. Please do not use it in multi-threaded
         environments.
     """
-    try:
-        import databricks.agents  # noqa: F401
-    except ImportError:
-        raise ImportError(
-            "The `databricks-agents` package is required to use mlflow.genai.evaluate() "
-            "Please install it with `pip install databricks-agents`."
-        )
-
-    if not is_databricks_uri(mlflow.get_tracking_uri()):
-        raise ValueError(
-            "The genai evaluation function is only supported on Databricks. "
-            "Please set the tracking URI to Databricks."
-        )
-
     is_managed_dataset = isinstance(data, EvaluationDataset)
 
     scorers = validate_scorers(scorers)
-    # convert into a pandas dataframe with current evaluation set schema
-    df = data.to_df() if is_managed_dataset else _convert_to_legacy_eval_set(data)
+    # convert into a pandas dataframe with expected evaluation set schema
+    df = data.to_df() if is_managed_dataset else _convert_to_eval_set(data)
 
     builtin_scorers = [scorer for scorer in scorers if isinstance(scorer, BuiltInScorer)]
     valid_data_for_builtin_scorers(df, builtin_scorers, predict_fn)
@@ -257,9 +248,56 @@ def evaluate(
             "For example: {'query': 'What is MLflow?'}"
         )
 
+    # If the input dataset is a managed dataset, we pass the original dataset
+    # to the evaluate function to preserve metadata like dataset name.
+    data = data if is_managed_dataset else df
+
     if predict_fn:
         predict_fn = convert_predict_fn(predict_fn=predict_fn, sample_input=sample_input)
 
+    eval_start_time = int(time.time() * 1000)
+
+    if is_databricks_uri(mlflow.get_tracking_uri()):
+        result = _evaluate_dbx(data, scorers, predict_fn, model_id)
+    else:
+        result = _evaluate_oss(data, scorers, predict_fn, model_id)
+
+    # Clean up noisy traces generated during evaluation
+    clean_up_extra_traces(result.run_id, eval_start_time)
+
+    return result
+
+
+def _evaluate_oss(data, scorers, predict_fn, model_id):
+    # Rename 'request' / 'response' column back to 'inputs' / 'outputs'.
+    # This is a temporary hack to avoid branching _convert_to_eval_set()
+    # into OSS and DBX implementation.
+    data = data.rename(
+        columns={
+            "request": InputDatasetColumn.INPUTS,
+            "response": InputDatasetColumn.OUTPUTS,
+        }
+    )
+
+    # TODO: Log input dataset to the run
+    with (
+        _start_run_or_reuse_active_run() as run_id,
+        _set_active_model(model_id=model_id) if model_id else nullcontext(),
+    ):
+        return harness.run(
+            predict_fn=predict_fn,
+            dataset=data,
+            scorers=scorers,
+            run_id=run_id,
+        )
+        # TODO: Support logging aggregated metrics to the logged model
+
+
+def _evaluate_dbx(data, scorers, predict_fn, model_id):
+    """In Databricks, we run GenAI evaluation using databricks-agents package and
+    the mlflow.evaluate() function. This is a temporary migration state and we will
+    eventually unify this into OSS flow.
+    """
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",
@@ -275,12 +313,9 @@ def evaluate(
             module="mlflow.data.evaluation_dataset",
         )
 
-        eval_start_time = int(time.time() * 1000)
-        result = mlflow.models.evaluate(
+        return mlflow.models.evaluate(
             model=predict_fn,
-            # If the input dataset is a managed dataset, we pass the original dataset
-            # to the evaluate function to preserve metadata like dataset name.
-            data=data if is_managed_dataset else df,
+            data=data,
             evaluator_config={GENAI_CONFIG_NAME: {"metrics": []}},  # Turn off the default metrics
             # Scorers are passed to the eval harness as extra metrics
             extra_metrics=[_convert_scorer_to_legacy_metric(_scorer) for _scorer in scorers],
@@ -288,10 +323,6 @@ def evaluate(
             model_id=model_id,
             _called_from_genai_evaluate=True,
         )
-
-        # Clean up noisy traces generated during evaluation
-        clean_up_extra_traces(result.run_id, eval_start_time)
-        return result
 
 
 @experimental(version="3.0.0")

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -279,14 +279,13 @@ def _evaluate_oss(data, scorers, predict_fn, model_id):
 
     # TODO: Log input dataset to the run
     with (
-        _start_run_or_reuse_active_run() as run_id,
+        _start_run_or_reuse_active_run(),
         _set_active_model(model_id=model_id) if model_id else nullcontext(),
     ):
         return harness.run(
             predict_fn=predict_fn,
             dataset=data,
             scorers=scorers,
-            run_id=run_id,
         )
         # TODO: Support logging aggregated metrics to the logged model
 

--- a/mlflow/genai/evaluation/constant.py
+++ b/mlflow/genai/evaluation/constant.py
@@ -21,3 +21,24 @@ class AgentEvaluationReserverKey:
 
 # A column name for storing custom expectations dictionary in Agent Evaluation.
 AGENT_EVAL_CUSTOM_EXPECTATION_KEY = "custom_expected"
+
+
+# Input dataset column names
+class InputDatasetColumn:
+    REQUEST_ID = "request_id"
+    INPUTS = "inputs"
+    REQUEST = "request"
+    RESPONSE = "response"
+    OUTPUTS = "outputs"
+    EXPECTATIONS = "expectations"
+    TRACE = "trace"
+
+
+# Result Dataframe column names
+class ResultDataFrameColumn:
+    REQUEST_ID = "request_id"
+    INPUTS = "inputs"
+    OUTPUTS = "outputs"
+    EXPECTATIONS = "expectations"
+    TRACE = "trace"
+    ERROR_MESSAGE = "error_message"

--- a/mlflow/genai/evaluation/context.py
+++ b/mlflow/genai/evaluation/context.py
@@ -1,0 +1,161 @@
+"""
+Introduces main Context class and the framework to specify different specialized
+contexts.
+"""
+
+import functools
+from abc import ABC, abstractmethod
+from typing import Optional
+
+import mlflow
+
+
+class Context(ABC):
+    """
+    Abstract class for execution context.
+    Context is stateless and should NOT be used to store information related to specific eval run.
+    """
+
+    @abstractmethod
+    def get_mlflow_experiment_id(self) -> Optional[str]:
+        """
+        Get the current MLflow experiment ID, or None if not running within an MLflow experiment.
+        """
+
+    @abstractmethod
+    def get_mlflow_run_id(self) -> Optional[str]:
+        """
+        Gets the MLflow RunId, or None if not running within an MLflow run.
+        """
+
+    @abstractmethod
+    def get_user_name(self) -> Optional[str]:
+        """
+        Get the current user's name.
+        """
+
+
+class NoneContext(Context):
+    """
+    A context that does nothing.
+    """
+
+    def get_mlflow_experiment_id(self) -> Optional[str]:
+        raise AssertionError("Context is not set")
+
+    def get_mlflow_run_id(self) -> Optional[str]:
+        raise AssertionError("Context is not set")
+
+    def get_user_name(self) -> Optional[str]:
+        raise AssertionError("Context is not set")
+
+
+class RealContext(Context):
+    """
+    Context for eval execution.
+
+    NOTE: This class is not covered by unit tests and is meant to be tested through
+    smoke tests that run this code on an actual Databricks cluster.
+    """
+
+    @classmethod
+    def _get_dbutils(cls):
+        """
+        Returns an instance of dbutils.
+        """
+        try:
+            from databricks.sdk.runtime import dbutils
+
+            return dbutils
+        except ImportError:
+            import IPython
+
+            dbutils = IPython.get_ipython().user_ns["dbutils"]
+        return dbutils
+
+    def __init__(self):
+        self._dbutils = self._get_dbutils()
+        try:
+            self._notebook_context = self._dbutils.entry_point.getDbutils().notebook().getContext()
+        except Exception:
+            self._notebook_context = None
+
+    def get_mlflow_experiment_id(self) -> Optional[str]:
+        # Note `_get_experiment_id` is thread-safe
+        return mlflow.tracking.fluent._get_experiment_id()
+
+    def get_mlflow_run_id(self) -> Optional[str]:
+        """
+        Gets the MLflow run_id the evaluation harness is running under.
+
+        Warning: This run_id may not be active. This happens when `get_mlflow_run_id` is called from
+        a different thread than the one that started the MLflow run.
+        """
+        # First check if we have a thread-local override
+        if hasattr(self, "_thread_local_mlflow_run_id") and self._thread_local_mlflow_run_id:
+            return self._thread_local_mlflow_run_id
+
+        # Otherwise fall back to the active run
+        if mlflow.active_run():
+            return mlflow.active_run().info.run_id
+
+        return None
+
+    def set_mlflow_run_id(self, run_id: str) -> None:
+        """
+        Set the MLflow run ID explicitly.
+
+        This method should be called when running code in a different thread than the one that
+        started the MLflow run. It sets the run ID in a thread-local variable so that it can be
+        accessed from the thread.
+        """
+        # Since we can't directly set mlflow.active_run() in a thread,
+        # we'll store the run_id in a thread-local attribute
+        if not hasattr(self, "_thread_local_mlflow_run_id"):
+            self._thread_local_mlflow_run_id = None
+        self._thread_local_mlflow_run_id = run_id
+
+    def get_user_name(self) -> Optional[str]:
+        try:
+            return self._notebook_context.userName().get()
+        except Exception:
+            return None
+
+
+# Context is a singleton.
+_context_singleton = NoneContext()
+
+
+def context_is_active() -> bool:
+    """
+    Check if a context is active.
+    """
+    return not isinstance(get_context(), NoneContext)
+
+
+def get_context() -> Context:
+    """
+    Get the context.
+    """
+    return _context_singleton or NoneContext()
+
+
+def eval_context(func):
+    """
+    Decorator for wrapping all eval APIs with setup and closure logic.
+
+    Sets up a context singleton with RealContext if there isn't one already.
+    Initializes the session for the current thread. Clears the session after
+    the function is executed.
+    """
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        # Set up the context singleton if it doesn't exist
+        if not context_is_active():
+            global _context_singleton
+            _context_singleton = RealContext()
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/mlflow/genai/evaluation/context.py
+++ b/mlflow/genai/evaluation/context.py
@@ -5,9 +5,12 @@ contexts.
 
 import functools
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Optional
+from typing import Callable, Optional, ParamSpec, TypeVar
 
 import mlflow
+
+P = ParamSpec("P")
+R = TypeVar("R")
 
 
 class Context(ABC):
@@ -134,10 +137,10 @@ def get_context() -> Context:
     """
     Get the context.
     """
-    return _context_singleton or NoneContext()
+    return _context_singleton
 
 
-def eval_context(func: Callable[..., Any]) -> Callable[..., Any]:
+def eval_context(func: Callable[P, R]) -> Callable[P, R]:
     """
     Decorator for wrapping all eval APIs with setup and closure logic.
 
@@ -145,7 +148,7 @@ def eval_context(func: Callable[..., Any]) -> Callable[..., Any]:
     """
 
     @functools.wraps(func)
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> R:
         # Set up the context singleton if it doesn't exist
         if not context_is_active():
             global _context_singleton

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -134,12 +134,7 @@ class EvalResult:
         assessments = self.get_assessments_dict()
 
         # Merge dictionaries and convert to pd.Series
-        combined_data = {
-            **inputs,
-            # **metrics,
-            **assessments,
-        }
-        return pd.Series(combined_data)
+        return pd.Series(inputs | assessments)
 
     def get_assessments_dict(self) -> dict[str, Any]:
         result = {}
@@ -147,10 +142,12 @@ class EvalResult:
             if not isinstance(assessment, Feedback):
                 continue
 
-            result[f"{assessment.name}/value"] = assessment.value
-            result[f"{assessment.name}/rationale"] = assessment.rationale
-            result[f"{assessment.name}/error_message"] = assessment.error_message
-            result[f"{assessment.name}/error_code"] = assessment.error_code
+            result |= {
+                f"{assessment.name}/value": assessment.value,
+                f"{assessment.name}/rationale": assessment.rationale,
+                f"{assessment.name}/error_message": assessment.error_message,
+                f"{assessment.name}/error_code": assessment.error_code,
+            }
 
         return result
 

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -1,0 +1,162 @@
+"""Entities for evaluation."""
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import pandas as pd
+
+from mlflow.entities.assessment import Expectation, Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.entities.trace import Trace
+from mlflow.exceptions import MlflowException
+from mlflow.genai.evaluation.constant import InputDatasetColumn, ResultDataFrameColumn
+from mlflow.genai.evaluation.context import get_context
+from mlflow.genai.evaluation.utils import is_none_or_nan
+
+
+@dataclass
+class EvalItem:
+    """Represents a row in the evaluation dataset."""
+
+    """Unique identifier for the eval item."""
+    request_id: str
+
+    """Raw input to the model/application when `evaluate` is called."""
+    inputs: dict[str, Any]
+
+    """Raw output from the model/application."""
+    outputs: Any
+
+    """Expectations from the eval item."""
+    expectations: dict[str, Any]
+
+    """Trace of the model invocation."""
+    trace: Optional[Trace] = None
+
+    """Error message if the model invocation fails."""
+    error_message: Optional[str] = None
+
+    @classmethod
+    def from_dataset_row(cls, row: dict[str, Any]) -> "EvalItem":
+        """
+        Create an EvalItem from a row of input Pandas Dataframe row.
+        """
+        inputs = cls._parse_inputs(row.get(InputDatasetColumn.INPUTS))
+        outputs = row.get(InputDatasetColumn.OUTPUTS)
+
+        # Get the request ID from the row, or generate a new unique ID if not present.
+        request_id = row.get(InputDatasetColumn.REQUEST_ID)
+        if is_none_or_nan(request_id):
+            request_id = hashlib.sha256(str(inputs).encode()).hexdigest()
+
+        # Extract trace column from the dataset.
+        trace = row.get(InputDatasetColumn.TRACE)
+        if is_none_or_nan(trace):
+            trace = None
+        else:
+            trace = trace if isinstance(trace, Trace) else Trace.from_json(trace)
+
+        # Extract expectations column from the dataset.
+        expectations = row.get(InputDatasetColumn.EXPECTATIONS)
+
+        return cls(
+            request_id=request_id,
+            inputs=inputs,
+            outputs=outputs,
+            expectations=expectations,
+            trace=trace,
+        )
+
+    @classmethod
+    def _parse_inputs(cls, data: str | dict[str, Any]) -> dict[str, Any]:
+        # The inputs can be either a dictionary or JSON-serialized version of it.
+        if isinstance(data, dict):
+            return data
+        elif isinstance(data, str):  # JSON-serialized string
+            try:
+                return json.loads(data)
+            except Exception as e:
+                raise MlflowException.invalid_parameter_value(
+                    "Failed to parse inputs as JSON."
+                ) from e
+
+        raise MlflowException.invalid_parameter_value(
+            f"inputs must be a dictionary or JSON serializable: {type(data)}"
+        )
+
+    def get_expectation_assessments(self) -> list[Expectation]:
+        """Get the expectations as a list of Expectation objects."""
+        expectations = []
+        for name, value in self.expectations.items():
+            source_id = get_context().get_user_name()
+            expectations.append(
+                Expectation(
+                    trace_id=self.trace.info.trace_id,
+                    name=name,
+                    source=AssessmentSource(
+                        source_type=AssessmentSourceType.HUMAN,
+                        source_id=source_id or "unknown",
+                    ),
+                    value=value,
+                )
+            )
+        return expectations
+
+    def to_dict(self) -> dict[str, Any]:
+        inputs = {
+            ResultDataFrameColumn.REQUEST_ID: self.request_id,
+            ResultDataFrameColumn.INPUTS: self.inputs,
+            ResultDataFrameColumn.OUTPUTS: self.outputs,
+            ResultDataFrameColumn.TRACE: self.trace.to_json(),
+            ResultDataFrameColumn.EXPECTATIONS: self.expectations,
+            ResultDataFrameColumn.ERROR_MESSAGE: self.error_message,
+        }
+        return {k: v for k, v in inputs.items() if v is not None}
+
+
+@dataclass
+class EvalResult:
+    """Holds the result of the evaluation for an eval item."""
+
+    eval_item: EvalItem
+    """A collection of assessments from scorers."""
+    assessments: list[Feedback] = field(default_factory=list)
+    """Error message encountered in processing the eval item."""
+    eval_error: Optional[str] = None
+
+    def to_pd_series(self) -> pd.Series:
+        """Converts the EvalResult to a flattened pd.Series."""
+        inputs = self.eval_item.to_dict()
+        # TODO: Uncomment once we support aggregating metrics
+        # metrics = self.get_metrics_dict()
+        assessments = self.get_assessments_dict()
+
+        # Merge dictionaries and convert to pd.Series
+        combined_data = {
+            **inputs,
+            # **metrics,
+            **assessments,
+        }
+        return pd.Series(combined_data)
+
+    def get_assessments_dict(self) -> dict[str, Any]:
+        result = {}
+        for assessment in self.assessments:
+            if not isinstance(assessment, Feedback):
+                continue
+
+            result[f"{assessment.name}/value"] = assessment.value
+            result[f"{assessment.name}/rationale"] = assessment.rationale
+            result[f"{assessment.name}/error_message"] = assessment.error_message
+            result[f"{assessment.name}/error_code"] = assessment.error_code
+
+        return result
+
+
+@dataclass
+class EvaluationResult:
+    run_id: str
+    metrics: dict[str, float]
+    result_df: pd.DataFrame

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -29,8 +29,7 @@ def run(
     dataset: pd.DataFrame,
     predict_fn=None,
     scorers=None,
-    run_id,
-):
+) -> EvaluationResult:
     """
     Runs GenAI evaluation harness to the given dataset.
 
@@ -158,8 +157,8 @@ def _compute_eval_scores(
         try:
             results = [future.result() for future in as_completed(futures)]
         except KeyboardInterrupt:
-            for future in futures:
-                future.cancel()
+            # Cancel pending futures
+            executor.shutdown(cancel_futures=True)
             raise
 
     # Flatten list[list[Assessment]] into a single list[Assessment]

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -1,0 +1,186 @@
+"""Entry point to the evaluation harness"""
+
+from __future__ import annotations
+
+import logging
+import traceback
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Callable, Optional
+
+import pandas as pd
+
+import mlflow
+import mlflow.tracing.constant as tracing_constant
+from mlflow.entities.assessment import Assessment, Feedback
+from mlflow.entities.assessment_error import AssessmentError
+from mlflow.entities.trace import Trace
+from mlflow.genai.evaluation import context
+from mlflow.genai.evaluation.entities import EvalItem, EvalResult, EvaluationResult
+from mlflow.genai.evaluation.utils import make_code_type_assessment_source, standardize_scorer_value
+from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.utils.trace_utils import create_minimal_trace
+
+_logger = logging.getLogger(__name__)
+
+
+@context.eval_context
+def run(
+    *,
+    dataset: pd.DataFrame,
+    predict_fn=None,
+    scorers=None,
+    run_id,
+):
+    """
+    Runs GenAI evaluation harness to the given dataset.
+
+    The overall flow is:
+
+    1. Convert the dataset to a list of EvalItem objects
+    2. Run the prediction and scoring for each EvalItem in parallel
+        a. If predict_fn is provided, invoke the predict_fn for the EvalItem
+        b. If predict_fn is not provided, create a dummy trace for the EvalItem
+        c. Execute the scorers to compute assessments.
+        d. Log the assessments to the trace.
+    3. Compute the aggregated metrics from the assessments.
+    """
+    eval_items = [EvalItem.from_dataset_row(row) for row in dataset.to_dict(orient="records")]
+
+    ctx = context.get_context()
+    run_id = ctx.get_mlflow_run_id()
+
+    with ThreadPoolExecutor(
+        # TODO: Add new MLflow environment variable for this
+        max_workers=10,  # env_vars.RAG_EVAL_MAX_WORKERS.get()
+        thread_name_prefix="MlflowGenAIEvalHarness",
+    ) as executor:
+        futures = [
+            executor.submit(
+                _run_single,
+                eval_item=eval_item,
+                scorers=scorers,
+                predict_fn=predict_fn,
+                run_id=run_id,
+            )
+            for eval_item in eval_items
+        ]
+        # TODO: Port the fancy tqdm progress bar from the DBX agent harness.
+        eval_results = [future.result() for future in as_completed(futures)]
+
+    eval_results_df = pd.DataFrame([result.to_pd_series() for result in eval_results])
+    return EvaluationResult(
+        run_id=run_id,
+        result_df=eval_results_df,
+        # TODO: Support metrics aggregation
+        metrics={},
+    )
+
+
+def _run_single(
+    eval_item: EvalItem,
+    scorers: list[Scorer],
+    run_id: Optional[str],
+    predict_fn: Optional[Callable[..., Any]] = None,
+) -> EvalResult:
+    """Run the logic of the eval harness for a single eval item."""
+    # Set the MLflow run ID in the context for this thread
+    if run_id:
+        # Manually set the mlflow_run_id for this context to be the same as was set in
+        # the parent thread. This is required because MLflow runs are thread-local.
+        ctx = context.get_context()
+        ctx.set_mlflow_run_id(run_id)
+
+    # When static dataset (a pair of inputs and outputs) is given, we create a minimal trace
+    # with root span only, to log the assessments on it.
+    #
+    # TODO: Support two more patterns that are currently supported in the DBX agent harness.
+    #  1. predict_fn is given
+    #  2. traces are given as dataset
+    minimal_trace = create_minimal_trace(eval_item)
+    eval_item.trace = minimal_trace
+
+    # Execute the scorers
+    assessments = _compute_eval_scores(eval_item=eval_item, scorers=scorers)
+    assessments.extend(eval_item.get_expectation_assessments())
+    eval_result = EvalResult(eval_item=eval_item, assessments=assessments)
+
+    try:
+        logged_trace = _log_assessments(
+            run_id=run_id,
+            trace=eval_item.trace,
+            assessments=eval_result.assessments,
+        )
+        eval_result.eval_item.trace = logged_trace
+    except Exception as e:
+        # Failures in logging to MLflow should not fail the entire harness run
+        _logger.warning(f"Failed to log trace and assessments to MLflow: {e}")
+
+    return eval_result
+
+
+def _compute_eval_scores(
+    *,
+    eval_item: EvalItem,
+    scorers: list[Scorer],
+) -> list[Feedback]:
+    """Compute the per-eval-item scores."""
+    if not scorers:
+        return []
+
+    def run_scorer(scorer):
+        try:
+            value = scorer.run(
+                inputs=eval_item.inputs,
+                outputs=eval_item.outputs,
+                expectations=eval_item.expectations,
+                trace=eval_item.trace,
+            )
+            return standardize_scorer_value(scorer.name, value)
+        except Exception as e:
+            error_assessment = Feedback(
+                name=scorer.name,
+                source=make_code_type_assessment_source(scorer.name),
+                error=AssessmentError(
+                    error_code="SCORER_ERROR",
+                    error_message=str(e),
+                    stack_trace=traceback.format_exc(),
+                ),
+            )
+            return [error_assessment]
+
+    # Use a thread pool to run scorers in parallel
+    with ThreadPoolExecutor(
+        max_workers=len(scorers),
+        thread_name_prefix="MlflowGenAIEvalScorer",
+    ) as executor:
+        futures = [executor.submit(run_scorer, scorer) for scorer in scorers]
+
+        try:
+            results = [future.result() for future in as_completed(futures)]
+        except KeyboardInterrupt:
+            for future in futures:
+                future.cancel()
+            raise
+
+    # Flatten list[list[Assessment]] into a single list[Assessment]
+    return [assessment for sublist in results for assessment in sublist]
+
+
+def _log_assessments(
+    run_id: Optional[str],
+    trace: Trace,
+    assessments: list[Assessment],
+) -> Trace:
+    for assessment in assessments:
+        # Ensure that if we created a new trace, that the updated trace_id is reflected in
+        # the assessments.
+        assessment.trace_id = trace.info.trace_id
+        if run_id is not None:
+            assessment.metadata = {
+                **(assessment.metadata or {}),
+                tracing_constant.AssessmentMetadataKey.SOURCE_RUN_ID: run_id,
+            }
+        mlflow.log_assessment(trace_id=assessment.trace_id, assessment=assessment)
+
+    # Get the trace to fetch newly created assessments.
+    return mlflow.get_trace(trace.info.trace_id)

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,8 +1,10 @@
 import json
 import logging
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Collection, Optional, Union
 
 from mlflow.entities import Assessment, Trace
+from mlflow.entities.assessment import DEFAULT_FEEDBACK_NAME, Feedback
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.exceptions import MlflowException
 from mlflow.genai.evaluation.constant import (
     AgentEvaluationReserverKey,
@@ -30,6 +32,8 @@ if TYPE_CHECKING:
 
 
 _logger = logging.getLogger(__name__)
+
+USER_DEFINED_ASSESSMENT_NAME_KEY = "_user_defined_assessment_name"
 
 
 def _convert_eval_set_to_df(data: "EvaluationDatasetTypes") -> "pd.DataFrame":
@@ -79,11 +83,10 @@ def _convert_eval_set_to_df(data: "EvaluationDatasetTypes") -> "pd.DataFrame":
     return df
 
 
-def _convert_to_legacy_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame":
+def _convert_to_eval_set(data: "EvaluationDatasetTypes") -> "pd.DataFrame":
     """
-    Takes in a dataset in the format that mlflow.genai.evaluate() expects and converts it into
-    to the current eval-set schema that Agent Evaluation takes in. The transformed schema should
-    be accepted by mlflow.evaluate().
+    Takes in a dataset in the multiple format that mlflow.genai.evaluate() expects and converts it
+    into standardized Pandas DataFrame.
     The expected schema can be found at:
     https://docs.databricks.com/aws/en/generative-ai/agent-evaluation/evaluation-schema
 
@@ -242,3 +245,86 @@ def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
         eval_fn=eval_fn,
         name=scorer.name,
     )
+
+
+def standardize_scorer_value(scorer_name: str, value: Any) -> list[Feedback]:
+    """
+    Convert the scorer return value to a list of MLflow Assessment (Feedback) objects.
+
+    Scorer can return:
+    - A number, boolean, or string, a list of them.
+    - An Feedback object
+    - A list of Feedback objects
+
+    All of the above will be converted to a list of Feedback objects.
+    """
+    # None is a valid metric value, return an empty list
+    if value is None:
+        return []
+
+    # Primitives are valid metric values
+    if isinstance(value, (int, float, bool, str)):
+        return [
+            Feedback(
+                name=scorer_name,
+                source=make_code_type_assessment_source(scorer_name),
+                value=value,
+            )
+        ]
+
+    if isinstance(value, Feedback):
+        value.name = _get_custom_assessment_name(value, scorer_name)
+        return [value]
+
+    if isinstance(value, Collection):
+        assessments = []
+        for item in value:
+            if isinstance(item, Feedback):
+                # Scorer returns multiple assessments as a list.
+                item.name = _get_custom_assessment_name(item, scorer_name)
+                assessments.append(item)
+            else:
+                # If the item is not assessment, the list represents a single assessment
+                # value of list type. Convert it to a Feedback object.
+                assessments.append(
+                    Feedback(
+                        name=scorer_name,
+                        source=make_code_type_assessment_source(scorer_name),
+                        value=item,
+                    )
+                )
+        return assessments
+
+    raise MlflowException.invalid_parameter_value(
+        f"Got unsupported result from scorer '{scorer_name}'. "
+        f"Expected the metric value to be a number, or a boolean, or a string, "
+        "or an Feedback, or a list of Feedbacks. "
+        f"Got {value}.",
+    )
+
+
+def _get_custom_assessment_name(assessment: Feedback, scorer_name: str) -> str:
+    """Get the name of the custom assessment. Use assessment name if present and not a builtin judge
+    name, otherwise use the scorer name.
+
+    Args:
+        assessment: The assessment to get the name for.
+        scorer_name: The name of the scprer.
+    """
+    # If the user didn't provide a name, use the scorer name
+    if assessment.name == DEFAULT_FEEDBACK_NAME or (
+        assessment.metadata is not None
+        and assessment.metadata.get(USER_DEFINED_ASSESSMENT_NAME_KEY) == "false"
+    ):
+        return scorer_name
+    return assessment.name
+
+
+def make_code_type_assessment_source(scorer_name: str) -> AssessmentSource:
+    return AssessmentSource(source_type=AssessmentSourceType.CODE, source_id=scorer_name)
+
+
+def is_none_or_nan(value: Any) -> bool:
+    """Checks whether a value is None or NaN."""
+    # isinstance(value, float) check is needed to ensure that pd.isna is not called on an array.
+    return value is None or (isinstance(value, float) and pd.isna(value))

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import math
 from typing import TYPE_CHECKING, Any, Collection, Optional, Union
 
 from mlflow.entities import Assessment, Trace
@@ -325,6 +326,10 @@ def make_code_type_assessment_source(scorer_name: str) -> AssessmentSource:
 
 
 def is_none_or_nan(value: Any) -> bool:
-    """Checks whether a value is None or NaN."""
-    # isinstance(value, float) check is needed to ensure that pd.isna is not called on an array.
-    return value is None or (isinstance(value, float) and pd.isna(value))
+    """
+    Checks whether a value is None or NaN.
+
+    NB: This function does not handle pandas.NA.
+    """
+    # isinstance(value, float) check is needed to ensure that math.isnan is not called on an array.
+    return value is None or (isinstance(value, float) and math.isnan(value))

--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -99,7 +99,7 @@ def valid_data_for_builtin_scorers(
 
     Args:
         data: The data to validate. This must be a pandas DataFrame converted to
-            the legacy evaluation set schema via `_convert_to_legacy_eval_set`.
+            the legacy evaluation set schema via `_convert_to_eval_set`.
         builtin_scorers: The list of builtin scorers to validate the data for.
         predict_fn: The predict function to validate the data for.
     """

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -18,13 +18,13 @@ def mock_init_auth():
         yield
 
 
-@pytest.fixture(autouse=True)
-def spoof_tracking_uri_check():
+@pytest.fixture(params=[True, False], ids=["databricks", "oss"])
+def is_in_databricks(request):
     # NB: The mlflow.genai.evaluate() API is only runnable when the tracking URI is set
     # to Databricks. However, we cannot test against real Databricks server in CI, so
     # we spoof the check by patching the is_databricks_uri() function.
-    with mock.patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=True):
-        yield
+    with mock.patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=request.param):
+        yield request.param
 
 
 @pytest.fixture

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -12,7 +12,7 @@ from mlflow.entities.span import SpanType
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai import scorer
-from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
+from mlflow.genai.evaluation.utils import _convert_to_eval_set
 from mlflow.genai.scorers.builtin_scorers import Safety
 from mlflow.utils.spark_utils import is_spark_connect_mode
 
@@ -197,7 +197,7 @@ def get_test_traces(type=Literal["pandas", "list"]):
 @pytest.mark.parametrize("input_type", ["list", "pandas"])
 def test_convert_to_legacy_eval_traces(input_type):
     sample_data = get_test_traces(type=input_type)
-    data = _convert_to_legacy_eval_set(sample_data)
+    data = _convert_to_eval_set(sample_data)
 
     assert "trace" in data.columns
 
@@ -215,10 +215,10 @@ def test_convert_to_legacy_eval_traces(input_type):
 
 
 @pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)
-def test_convert_to_legacy_eval_set_has_no_errors(data_fixture, request):
+def test_convert_to_eval_set_has_no_errors(data_fixture, request):
     sample_data = request.getfixturevalue(data_fixture)
 
-    transformed_data = _convert_to_legacy_eval_set(sample_data)
+    transformed_data = _convert_to_eval_set(sample_data)
 
     assert "request" in transformed_data.columns
     assert "response" in transformed_data.columns
@@ -234,7 +234,7 @@ def test_convert_to_legacy_eval_raise_for_invalid_json_columns(spark):
         ]
     )
     with pytest.raises(MlflowException, match="Failed to parse `inputs` column."):
-        _convert_to_legacy_eval_set(df)
+        _convert_to_eval_set(df)
 
     # Data with invalid `expectations` column
     df = spark.createDataFrame(
@@ -250,7 +250,7 @@ def test_convert_to_legacy_eval_raise_for_invalid_json_columns(spark):
         ]
     )
     with pytest.raises(MlflowException, match="Failed to parse `expectations` column."):
-        _convert_to_legacy_eval_set(df)
+        _convert_to_eval_set(df)
 
 
 @pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -309,7 +309,7 @@ def test_scorer_receives_correct_data(data_fixture, request):
 
 def test_input_is_required_if_trace_is_not_provided(is_in_databricks):
     mock_module = (
-        "mlflow.models.evaluate" if is_in_databricks else "mlflow.genai.evaluation.base.harness.run"
+        "mlflow.models.evaluate" if is_in_databricks else "mlflow.genai.evaluation.harness.run"
     )
 
     with patch(mock_module) as mock_evaluate:
@@ -332,7 +332,7 @@ def test_input_is_required_if_trace_is_not_provided(is_in_databricks):
 
 def test_input_is_optional_if_trace_is_provided(is_in_databricks):
     mock_module = (
-        "mlflow.models.evaluate" if is_in_databricks else "mlflow.genai.evaluation.base.harness.run"
+        "mlflow.models.evaluate" if is_in_databricks else "mlflow.genai.evaluation.harness.run"
     )
 
     with mlflow.start_span() as span:

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -74,6 +74,9 @@ def test_scorer_name_works(sample_data, dummy_scorer, is_in_databricks):
 
 
 def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace, is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support passing traces yet")
+
     with (
         patch(
             "databricks.agents.evals.judges.correctness",

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -53,7 +53,10 @@ def sample_data():
 
 
 @pytest.mark.parametrize("dummy_scorer", [AlwaysYesScorer(name="always_yes"), scorer(always_yes)])
-def test_scorer_existence_in_metrics(sample_data, dummy_scorer):
+def test_scorer_existence_in_metrics(sample_data, dummy_scorer, is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support metrics aggregation yet")
+
     result = mlflow.genai.evaluate(data=sample_data, scorers=[dummy_scorer])
     assert any("always_yes" in metric for metric in result.metrics.keys())
 
@@ -61,13 +64,16 @@ def test_scorer_existence_in_metrics(sample_data, dummy_scorer):
 @pytest.mark.parametrize(
     "dummy_scorer", [AlwaysYesScorer(name="always_no"), scorer(name="always_no")(always_yes)]
 )
-def test_scorer_name_works(sample_data, dummy_scorer):
+def test_scorer_name_works(sample_data, dummy_scorer, is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support metrics aggregation yet")
+
     _SCORER_NAME = "always_no"
     result = mlflow.genai.evaluate(data=sample_data, scorers=[dummy_scorer])
     assert any(_SCORER_NAME in metric for metric in result.metrics.keys())
 
 
-def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
+def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace, is_in_databricks):
     with (
         patch(
             "databricks.agents.evals.judges.correctness",
@@ -132,7 +138,10 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
     )
 
 
-def test_trace_passed_to_custom_scorer_correctly(sample_data):
+def test_trace_passed_to_custom_scorer_correctly(sample_data, is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support passing traces yet")
+
     actual_call_args_list = []
 
     @scorer
@@ -171,7 +180,10 @@ def test_trace_passed_to_custom_scorer_correctly(sample_data):
         )
 
 
-def test_trace_passed_correctly():
+def test_trace_passed_correctly(is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support passing traces yet")
+
     @mlflow.trace
     def predict_fn(question):
         return "output: " + str(question)
@@ -233,7 +245,10 @@ def test_trace_passed_correctly():
         ),
     ],
 )
-def test_scorer_on_genai_evaluate(sample_data, scorer_return):
+def test_scorer_on_genai_evaluate(sample_data, scorer_return, is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support metrics aggregation yet")
+
     @scorer
     def dummy_scorer(inputs, outputs):
         return scorer_return
@@ -262,7 +277,7 @@ def test_custom_scorer_allow_none_return():
     assert dummy_scorer.run(inputs={"question": "query"}, outputs="answer") is None
 
 
-def test_scorer_returns_feedback_with_error(sample_data):
+def test_scorer_returns_feedback_with_error(sample_data, is_in_databricks):
     @scorer
     def dummy_scorer(inputs):
         return Feedback(
@@ -272,11 +287,10 @@ def test_scorer_returns_feedback_with_error(sample_data):
             metadata={"index": 0},
         )
 
-    with patch("mlflow.get_tracking_uri", return_value="databricks"):
-        results = mlflow.genai.evaluate(
-            data=sample_data,
-            scorers=[dummy_scorer],
-        )
+    results = mlflow.genai.evaluate(
+        data=sample_data,
+        scorers=[dummy_scorer],
+    )
 
     # Scorer should not be in result when it returns an error
     assert all("dummy_scorer" not in metric for metric in results.metrics.keys())
@@ -320,7 +334,10 @@ def test_custom_scorer_does_not_overwrite_feedback_name_when_returning_list():
     assert feedbacks[1].name == "small_question"
 
 
-def test_extra_traces_from_customer_scorer_should_be_cleaned_up():
+def test_extra_traces_from_customer_scorer_should_be_cleaned_up(is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support predict_fn yet")
+
     @scorer
     def my_scorer_1(inputs, outputs):
         with mlflow.start_span(name="scorer_trace_1") as span:
@@ -361,7 +378,10 @@ def test_extra_traces_from_customer_scorer_should_be_cleaned_up():
     assert len(get_traces()) == 1
 
 
-def test_extra_traces_before_evaluation_execution_should_not_be_cleaned_up():
+def test_extra_traces_before_evaluation_execution_should_not_be_cleaned_up(is_in_databricks):
+    if not is_in_databricks:
+        pytest.skip("OSS GenAI evaluator doesn't support predict_fn yet")
+
     def predict(question: str) -> str:
         return "output: " + str(question)
 

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -5,7 +5,7 @@ import pytest
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.genai.evaluation.utils import _convert_to_legacy_eval_set
+from mlflow.genai.evaluation.utils import _convert_to_eval_set
 from mlflow.genai.scorers.base import Scorer, scorer
 from mlflow.genai.scorers.builtin_scorers import (
     Correctness,
@@ -97,7 +97,7 @@ def test_validate_data(mock_logger, sample_rag_trace):
         }
     )
 
-    converted_date = _convert_to_legacy_eval_set(data)
+    converted_date = _convert_to_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
@@ -123,7 +123,7 @@ def test_validate_data_with_expectations(mock_logger, sample_rag_trace):
         }
     )
 
-    converted_date = _convert_to_legacy_eval_set(data)
+    converted_date = _convert_to_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
@@ -143,7 +143,7 @@ def test_global_guideline_adherence_does_not_require_expectations(mock_logger):
             "outputs": ["output1", "output2"],
         }
     )
-    converted_date = _convert_to_legacy_eval_set(data)
+    converted_date = _convert_to_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[Guidelines(guidelines=["Be polite", "Be kind"])],
@@ -168,7 +168,7 @@ def test_validate_data_with_correctness(expectations, mock_logger):
         }
     )
 
-    converted_date = _convert_to_legacy_eval_set(data)
+    converted_date = _convert_to_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[Correctness()],
@@ -187,7 +187,7 @@ def test_validate_data_with_correctness(expectations, mock_logger):
 def test_validate_data_missing_columns(mock_logger):
     data = pd.DataFrame({"inputs": [{"question": "input1"}, {"question": "input2"}]})
 
-    converted_date = _convert_to_legacy_eval_set(data)
+    converted_date = _convert_to_eval_set(data)
 
     valid_data_for_builtin_scorers(
         data=converted_date,
@@ -214,7 +214,7 @@ def test_validate_data_with_trace(mock_logger):
     trace = mlflow.get_trace(span.trace_id)
     data = [{"trace": trace}, {"trace": trace}]
 
-    converted_date = _convert_to_legacy_eval_set(data)
+    converted_date = _convert_to_eval_set(data)
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
@@ -229,7 +229,7 @@ def test_validate_data_with_trace(mock_logger):
 def test_validate_data_with_predict_fn(mock_logger):
     data = pd.DataFrame({"inputs": [{"question": "input1"}, {"question": "input2"}]})
 
-    converted_date = _convert_to_legacy_eval_set(data)
+    converted_date = _convert_to_eval_set(data)
 
     valid_data_for_builtin_scorers(
         data=converted_date,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16732?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16732/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16732/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16732/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This PR depends on https://github.com/mlflow/mlflow/pull/16731

The initial bootstrap of evaluation harness implementation. It only support passing static dataset. It omits several core functionalities from the existing Databricks evaluator, which will be covered in follow-ups:

* Support for `predict_fn` argument.
* Passing traces as evaluation dataset.
* Aggregating assessments into metrics and log them to the Run.
* Showing nice tqdm progress bar.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
