### PR TITLE
Add a job to upload snapshots

### DIFF
--- a/.github/scripts/snapshots.js
+++ b/.github/scripts/snapshots.js
@@ -108,6 +108,8 @@ function getContentType(filename) {
     case ".whl":
     case ".zip":
       return "application/zip";
+    case ".tar.gz":
+      return "application/gzip";
     case ".jar":
       return "application/java-archive";
     default:

--- a/.github/scripts/snapshots.js
+++ b/.github/scripts/snapshots.js
@@ -1,0 +1,108 @@
+const fs = require("fs");
+const path = require("path");
+
+/**
+ * Upload artifacts to a GitHub release
+ * @param {Object} params
+ * @param {Object} params.github - GitHub API client
+ * @param {Object} params.context - GitHub context
+ * @param {string|string[]} params.artifacts - Path(s) to artifact file(s)
+ */
+module.exports = async ({ github, context, artifacts }) => {
+  const { owner, repo } = context.repo;
+
+  // Normalize to array
+  const artifactPaths = Array.isArray(artifacts) ? artifacts : [artifacts];
+
+  // Validate all artifacts exist
+  for (const artifactPath of artifactPaths) {
+    if (!fs.existsSync(artifactPath)) {
+      throw new Error(`Artifact not found: ${artifactPath}`);
+    }
+  }
+
+  // First, try to get existing release
+  let release;
+  let releaseExists = false;
+  try {
+    const { data } = await github.rest.repos.getReleaseByTag({
+      owner,
+      repo,
+      tag: "nightly",
+    });
+    release = data;
+    releaseExists = true;
+    console.log(`Found existing release: ${release.id}`);
+  } catch (error) {
+    if (error.status !== 404) {
+      throw error;
+    }
+  }
+
+  // If release exists, delete it (this also deletes the tag)
+  if (releaseExists) {
+    console.log("Deleting existing nightly release and tag...");
+    await github.rest.repos.deleteRelease({
+      owner,
+      repo,
+      release_id: release.id,
+    });
+  }
+
+  // Create a new release (this will also create the tag)
+  console.log("Creating new nightly release...");
+  const { data: newRelease } = await github.rest.repos.createRelease({
+    owner,
+    repo,
+    tag_name: "nightly",
+    target_commitish: context.sha, // Use the current commit SHA
+    name: `Nightly Build ${new Date().toISOString().split("T")[0]}`,
+    body: `This is an automated nightly build of MLflow.\n\n**Last updated:** ${new Date().toUTCString()}\n\n**Note:** This release is automatically updated daily with the latest changes from the master branch.`,
+    prerelease: true,
+    make_latest: false,
+  });
+  release = newRelease;
+  console.log(`Created new release: ${release.id}`);
+
+  // Upload all artifacts
+  for (const artifactPath of artifactPaths) {
+    const artifactName = path.basename(artifactPath);
+    const contentType = getContentType(artifactName);
+
+    console.log(`Uploading ${artifactName}...`);
+    const artifactData = fs.readFileSync(artifactPath);
+    await github.rest.repos.uploadReleaseAsset({
+      owner,
+      repo,
+      release_id: release.id,
+      name: artifactName,
+      data: artifactData,
+      headers: {
+        "content-type": contentType,
+        "content-length": artifactData.length,
+      },
+    });
+
+    console.log(`Successfully uploaded ${artifactName}`);
+  }
+
+  console.log("All artifacts uploaded successfully");
+};
+
+/**
+ * Get content type based on file extension
+ * @param {string} filename
+ * @returns {string} Content type
+ */
+function getContentType(filename) {
+  const ext = path.extname(filename).toLowerCase();
+  switch (ext) {
+    case ".whl":
+    case ".zip":
+      return "application/zip";
+    case ".jar":
+      return "application/java-archive";
+    default:
+      return "application/octet-stream";
+  }
+}

--- a/.github/scripts/snapshots.js
+++ b/.github/scripts/snapshots.js
@@ -6,12 +6,22 @@ const path = require("path");
  * @param {Object} params
  * @param {Object} params.github - GitHub API client
  * @param {Object} params.context - GitHub context
- * @param {string[]} params.artifactPaths - Path(s) to artifact file(s)
+ * @param {string} params.artifactPathsFile - Path to the file containing artifact paths
  */
-module.exports = async ({ github, context, artifactPaths }) => {
-  const { owner, repo } = context.repo;
+module.exports = async ({ github, context, artifactPathsFile }) => {
+  if (!fs.existsSync(artifactPathsFile)) {
+    throw new Error(`Artifacts file not found: ${artifactPathsFile}`);
+  }
 
-  // Validate all artifacts exist
+  const artifactPaths = fs
+    .readFileSync(artifactPathsFile, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim() !== "");
+
+  if (artifactPaths.length === 0) {
+    throw new Error(`No artifacts found in ${artifactPathsFile}`);
+  }
+
   for (const artifactPath of artifactPaths) {
     if (!fs.existsSync(artifactPath)) {
       throw new Error(`Artifact not found: ${artifactPath}`);
@@ -19,6 +29,7 @@ module.exports = async ({ github, context, artifactPaths }) => {
   }
 
   // First, try to get existing release
+  const { owner, repo } = context.repo;
   let release;
   let releaseExists = false;
   try {

--- a/.github/scripts/snapshots.js
+++ b/.github/scripts/snapshots.js
@@ -6,13 +6,10 @@ const path = require("path");
  * @param {Object} params
  * @param {Object} params.github - GitHub API client
  * @param {Object} params.context - GitHub context
- * @param {string|string[]} params.artifacts - Path(s) to artifact file(s)
+ * @param {string[]} params.artifactPaths - Path(s) to artifact file(s)
  */
-module.exports = async ({ github, context, artifacts }) => {
+module.exports = async ({ github, context, artifactPaths }) => {
   const { owner, repo } = context.repo;
-
-  // Normalize to array
-  const artifactPaths = Array.isArray(artifacts) ? artifacts : [artifacts];
 
   // Validate all artifacts exist
   for (const artifactPath of artifactPaths) {

--- a/.github/scripts/snapshots.js
+++ b/.github/scripts/snapshots.js
@@ -59,7 +59,7 @@ module.exports = async ({ github, context, artifacts }) => {
     name: `Nightly Build ${new Date().toISOString().split("T")[0]}`,
     body: `This is an automated nightly build of MLflow.\n\n**Last updated:** ${new Date().toUTCString()}\n\n**Note:** This release is automatically updated daily with the latest changes from the master branch.`,
     prerelease: true,
-    make_latest: false,
+    make_latest: "false",
   });
   release = newRelease;
   console.log(`Created new release: ${release.id}`);

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -1,10 +1,14 @@
 name: snapshots
+description: Daily uploads package snapshots to https://github.com/mlflow/mlflow/releases/tag/nightly.
 
 on:
   schedule:
     - cron: "0 0 * * *" # Runs daily at midnight UTC
   workflow_dispatch: # Allows manual triggering
   pull_request: # To test updates
+    paths:
+      - ".github/workflows/snapshots.yml"
+      - ".github/scripts/snapshots.js"
 
 defaults:
   run:
@@ -18,8 +22,6 @@ jobs:
       contents: write # Needed to push tags and create releases
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          fetch-depth: 0 # Fetch all history for tags
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-node
@@ -38,6 +40,7 @@ jobs:
           find $PWD/dist -type f -name "*.whl" -exec cp {} $ARTIFACT_DIR/ \;
           python dev/build.py --package-type skinny
           find $PWD/dist -type f -name "*.whl" -exec cp {} $ARTIFACT_DIR/ \;
+          ls $ARTIFACT_DIR
 
       - name: Build R package
         working-directory: mlflow/R/mlflow
@@ -45,6 +48,7 @@ jobs:
           Rscript -e 'install.packages("devtools")'
           Rscript -e 'devtools::build(path = ".")'
           find $PWD -name "*.tar.gz" -type f -exec cp {} $ARTIFACT_DIR/ \;
+          ls $ARTIFACT_DIR
 
       - name: Build Java packages
         working-directory: mlflow/java
@@ -55,8 +59,11 @@ jobs:
               ! -name "*javadoc.jar" \
               ! -name "original-*.jar" \
               -exec cp {} $ARTIFACT_DIR/ \;
+          ls $ARTIFACT_DIR
 
       - name: Upload artifacts to nightly release
+        # This step requires contents write permission, but pull requests filed from forks do not have this permission.
+        if: github.event_name != 'pull_request' || github.event.pull_request.base.repo.full_name == 'mlflow/mlflow'
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 0 * * *" # Runs daily at midnight UTC
   workflow_dispatch: # Allows manual triggering
-  pull_request: # for testing
+  pull_request: # To test updates
 
 defaults:
   run:

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -24,15 +24,17 @@ jobs:
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-node
 
-      - name: Install dependencies
+      - name: Create artifacts file
         run: |
-          pip install build
+          ARTIFACT_PATHS_FILE=$(mktemp)
+          echo "ARTIFACT_PATHS_FILE=$ARTIFACT_PATHS_FILE" >> $GITHUB_ENV
 
       - name: Build distribution files
         id: build-dist
         run: |
+          pip install build
           python dev/build.py
-          find $PWD/dist -type f -name "*.whl" >> /tmp/artifact_paths.txt
+          find $PWD/dist -type f -name "*.whl" >> $ARTIFACT_PATHS_FILE
 
       - name: Build Java distribution
         working-directory: mlflow/java
@@ -42,7 +44,8 @@ jobs:
             -exec find {} -name "*.jar" \
               ! -name "*sources.jar" \
               ! -name "*javadoc.jar" \
-              ! -name "original-*.jar" \; >> /tmp/artifact_paths.txt
+              ! -name "original-*.jar" \; >> $ARTIFACT_PATHS_FILE
+
       - name: Upload artifacts to nightly release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -51,5 +54,5 @@ jobs:
             await script({
               github,
               context,
-              artifactPathsFile: '/tmp/artifact_paths.txt'
+              artifactPathsFile: process.env.ARTIFACT_PATHS_FILE
             });

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -34,7 +34,7 @@ jobs:
           wheel_path=$(find dist -type f -name "*.whl")
           echo "wheel_path=${wheel_path}" >> $GITHUB_OUTPUT
 
-      - name: Upload wheel to nightly release
+      - name: Upload artifacts to nightly release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
@@ -42,5 +42,5 @@ jobs:
             await script({
               github,
               context,
-              artifacts: ['${{ steps.build-dist.outputs.wheel_path }}']
+              artifactPaths: ['${{ steps.build-dist.outputs.wheel_path }}']
             });

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -50,12 +50,11 @@ jobs:
         working-directory: mlflow/java
         run: |
           mvn -B -DskipTests clean package
-          find $PWD -name "target" -type d \
-            -exec find {} -name "*.jar" \
+          find $PWD -name "target" -type d -exec find {} -name "*.jar" \
               ! -name "*sources.jar" \
               ! -name "*javadoc.jar" \
               ! -name "original-*.jar" \
-              -exec cp {} $ARTIFACT_DIR/ \;
+              -exec cp {} $ARTIFACT_DIR/ \; \;
 
       - name: Upload artifacts to nightly release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -25,26 +25,26 @@ jobs:
       - uses: ./.github/actions/setup-node
       - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
 
-      - name: Create artifacts file
+      - name: Create artifacts directory
         run: |
-          ARTIFACT_PATHS_FILE=$(mktemp)
-          echo "ARTIFACT_PATHS_FILE=$ARTIFACT_PATHS_FILE" >> $GITHUB_ENV
+          ARTIFACT_DIR=$(mktemp -d)
+          echo "ARTIFACT_DIR=$ARTIFACT_DIR" >> $GITHUB_ENV
 
       - name: Build Python packages
         id: build-dist
         run: |
           pip install build
           python dev/build.py
-          find $PWD/dist -type f -name "*.whl" >> $ARTIFACT_PATHS_FILE
+          find $PWD/dist -type f -name "*.whl" -exec cp {} $ARTIFACT_DIR/ \;
           python dev/build.py --package-type skinny
-          find $PWD/dist -type f -name "*.whl" >> $ARTIFACT_PATHS_FILE
+          find $PWD/dist -type f -name "*.whl" -exec cp {} $ARTIFACT_DIR/ \;
 
       - name: Build R package
         working-directory: mlflow/R/mlflow
         run: |
           Rscript -e 'install.packages("devtools")'
           Rscript -e 'devtools::build()'
-          find $PWD -name "*.tar.gz" >> $ARTIFACT_PATHS_FILE
+          find $PWD -name "*.tar.gz" -exec cp {} $ARTIFACT_DIR/ \;
 
       - name: Build Java packages
         working-directory: mlflow/java
@@ -54,7 +54,8 @@ jobs:
             -exec find {} -name "*.jar" \
               ! -name "*sources.jar" \
               ! -name "*javadoc.jar" \
-              ! -name "original-*.jar" \; >> $ARTIFACT_PATHS_FILE
+              ! -name "original-*.jar" \
+              -exec cp {} $ARTIFACT_DIR/ \;
 
       - name: Upload artifacts to nightly release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
@@ -64,5 +65,5 @@ jobs:
             await script({
               github,
               context,
-              artifactPathsFile: process.env.ARTIFACT_PATHS_FILE
+              artifactDir: process.env.ARTIFACT_DIR
             });

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -1,0 +1,46 @@
+name: snapshots
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Runs daily at midnight UTC
+  workflow_dispatch: # Allows manual triggering
+  pull_request: # for testing
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: write # Needed to push tags and create releases
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0 # Fetch all history for tags
+      - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-node
+
+      - name: Install dependencies
+        run: |
+          pip install build
+
+      - name: Build distribution files
+        id: build-dist
+        run: |
+          python dev/build.py --sha $(git rev-parse HEAD)
+          wheel_path=$(find dist -type f -name "*.whl")
+          echo "wheel_path=${wheel_path}" >> $GITHUB_OUTPUT
+
+      - name: Upload wheel to nightly release
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const script = require('./.github/scripts/snapshots.js');
+            await script({
+              github,
+              context,
+              artifacts: ['${{ steps.build-dist.outputs.wheel_path }}']
+            });

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -43,8 +43,8 @@ jobs:
         working-directory: mlflow/R/mlflow
         run: |
           Rscript -e 'install.packages("devtools")'
-          Rscript -e 'devtools::build()'
-          find $PWD -name "*.tar.gz" -exec cp {} $ARTIFACT_DIR/ \;
+          Rscript -e 'devtools::build(path = ".")'
+          find $PWD -name "*.tar.gz" -type f -exec cp {} $ARTIFACT_DIR/ \;
 
       - name: Build Java packages
         working-directory: mlflow/java

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -23,20 +23,28 @@ jobs:
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-node
+      - uses: r-lib/actions/setup-r@bd49c52ffe281809afa6f0fecbf37483c5dd0b93 # v2.11.3
 
       - name: Create artifacts file
         run: |
           ARTIFACT_PATHS_FILE=$(mktemp)
           echo "ARTIFACT_PATHS_FILE=$ARTIFACT_PATHS_FILE" >> $GITHUB_ENV
 
-      - name: Build distribution files
+      - name: Build Python package
         id: build-dist
         run: |
           pip install build
           python dev/build.py
           find $PWD/dist -type f -name "*.whl" >> $ARTIFACT_PATHS_FILE
 
-      - name: Build Java distribution
+      - name: Build R package
+        working-directory: mlflow/R/mlflow
+        run: |
+          Rscript -e 'install.packages("devtools")'
+          Rscript -e 'devtools::build()'
+          find $PWD -name "*.tar.gz" >> $ARTIFACT_PATHS_FILE
+
+      - name: Build Java packages
         working-directory: mlflow/java
         run: |
           mvn -B -DskipTests clean package

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -50,11 +50,11 @@ jobs:
         working-directory: mlflow/java
         run: |
           mvn -B -DskipTests clean package
-          find $PWD -name "target" -type d -exec find {} -name "*.jar" \
+          find $PWD -path "*/target/*.jar" \
               ! -name "*sources.jar" \
               ! -name "*javadoc.jar" \
               ! -name "original-*.jar" \
-              -exec cp {} $ARTIFACT_DIR/ \; \;
+              -exec cp {} $ARTIFACT_DIR/ \;
 
       - name: Upload artifacts to nightly release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           fetch-depth: 0 # Fetch all history for tags
       - uses: ./.github/actions/setup-python
+      - uses: ./.github/actions/setup-java
       - uses: ./.github/actions/setup-node
 
       - name: Install dependencies
@@ -31,9 +32,17 @@ jobs:
         id: build-dist
         run: |
           python dev/build.py
-          wheel_path=$(find dist -type f -name "*.whl")
-          echo "wheel_path=${wheel_path}" >> $GITHUB_OUTPUT
+          find $PWD/dist -type f -name "*.whl" >> /tmp/artifact_paths.txt
 
+      - name: Build Java distribution
+        working-directory: mlflow/java
+        run: |
+          mvn -B -DskipTests clean package
+          find $PWD -name "target" -type d \
+            -exec find {} -name "*.jar" \
+              ! -name "*sources.jar" \
+              ! -name "*javadoc.jar" \
+              ! -name "original-*.jar" \; >> /tmp/artifact_paths.txt
       - name: Upload artifacts to nightly release
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
@@ -42,5 +51,5 @@ jobs:
             await script({
               github,
               context,
-              artifactPaths: ['${{ steps.build-dist.outputs.wheel_path }}']
+              artifactPathsFile: '/tmp/artifact_paths.txt'
             });

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -30,11 +30,13 @@ jobs:
           ARTIFACT_PATHS_FILE=$(mktemp)
           echo "ARTIFACT_PATHS_FILE=$ARTIFACT_PATHS_FILE" >> $GITHUB_ENV
 
-      - name: Build Python package
+      - name: Build Python packages
         id: build-dist
         run: |
           pip install build
           python dev/build.py
+          find $PWD/dist -type f -name "*.whl" >> $ARTIFACT_PATHS_FILE
+          python dev/build.py --package-type skinny
           find $PWD/dist -type f -name "*.whl" >> $ARTIFACT_PATHS_FILE
 
       - name: Build R package

--- a/.github/workflows/snapshots.yml
+++ b/.github/workflows/snapshots.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build distribution files
         id: build-dist
         run: |
-          python dev/build.py --sha $(git rev-parse HEAD)
+          python dev/build.py
           wheel_path=$(find dist -type f -name "*.whl")
           echo "wheel_path=${wheel_path}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16735?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16735/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16735/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16735/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This PR adds a cron job to upload package snapshots as a github release to sunset our internal s3 bucket that currently hosts snapshots.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
