### PR TITLE
Implement HMAC signature verification for webhooks

### DIFF
--- a/mlflow/webhooks/__init__.py
+++ b/mlflow/webhooks/__init__.py
@@ -3,6 +3,7 @@
 This module provides webhook functionality for MLflow model registry events.
 """
 
+from mlflow.webhooks.constants import WEBHOOK_SIGNATURE_HEADER
 from mlflow.webhooks.types import (
     ModelVersionAliasCreatedPayload,
     ModelVersionAliasDeletedPayload,
@@ -21,4 +22,5 @@ __all__ = [
     "ModelVersionAliasCreatedPayload",
     "ModelVersionAliasDeletedPayload",
     "WebhookPayload",
+    "WEBHOOK_SIGNATURE_HEADER",
 ]

--- a/mlflow/webhooks/constants.py
+++ b/mlflow/webhooks/constants.py
@@ -1,0 +1,2 @@
+# Webhook HTTP headers
+WEBHOOK_SIGNATURE_HEADER = "X-MLflow-Signature"

--- a/mlflow/webhooks/dispatch.py
+++ b/mlflow/webhooks/dispatch.py
@@ -1,3 +1,6 @@
+import hashlib
+import hmac
+import json
 import logging
 
 import requests
@@ -9,6 +12,20 @@ from mlflow.webhooks.types import WebhookPayload
 _logger = logging.getLogger(__name__)
 
 
+def _generate_hmac_signature(secret: str, payload_bytes: bytes) -> str:
+    """Generate HMAC-SHA256 signature for webhook payload.
+
+    Args:
+        secret: The webhook secret key
+        payload_bytes: The serialized payload bytes
+
+    Returns:
+        The HMAC signature in the format "sha256=<hex_digest>"
+    """
+    signature = hmac.new(secret.encode("utf-8"), payload_bytes, hashlib.sha256).hexdigest()
+    return f"sha256={signature}"
+
+
 def _dispatch_webhook_impl(
     *,
     event: WebhookEvent,
@@ -18,8 +35,14 @@ def _dispatch_webhook_impl(
     # TODO: Make this non-blocking
     for webhook in store.list_webhooks():
         if event in webhook.events:
-            # TODO: Implement HMAC signature verification
-            requests.post(webhook.url, json=payload)
+            payload_bytes = json.dumps(payload).encode("utf-8")
+            headers = {"Content-Type": "application/json"}
+            # Add HMAC signature if secret is configured
+            if webhook.secret:
+                signature = _generate_hmac_signature(webhook.secret, payload_bytes)
+                headers["X-MLflow-Signature"] = signature
+
+            requests.post(webhook.url, data=payload_bytes, headers=headers)
 
 
 def dispatch_webhook(

--- a/mlflow/webhooks/dispatch.py
+++ b/mlflow/webhooks/dispatch.py
@@ -7,6 +7,7 @@ import requests
 
 from mlflow.entities.webhook import WebhookEvent
 from mlflow.store.model_registry.abstract_store import AbstractStore
+from mlflow.webhooks.constants import WEBHOOK_SIGNATURE_HEADER
 from mlflow.webhooks.types import WebhookPayload
 
 _logger = logging.getLogger(__name__)
@@ -40,7 +41,7 @@ def _dispatch_webhook_impl(
             # Add HMAC signature if secret is configured
             if webhook.secret:
                 signature = _generate_hmac_signature(webhook.secret, payload_bytes)
-                headers["X-MLflow-Signature"] = signature
+                headers[WEBHOOK_SIGNATURE_HEADER] = signature
 
             requests.post(webhook.url, data=payload_bytes, headers=headers)
 

--- a/tests/webhooks/app.py
+++ b/tests/webhooks/app.py
@@ -1,10 +1,12 @@
+import hashlib
+import hmac
 import json
 import sys
 from pathlib import Path
 
 import fastapi
 import uvicorn
-from fastapi import Request
+from fastapi import HTTPException, Request
 
 LOG_FILE = Path("logs.jsonl")
 
@@ -22,6 +24,7 @@ async def insecure_webhook(request: Request):
         "endpoint": "/insecure-webhook",
         "payload": await request.json(),
         "headers": dict(request.headers),
+        "status_code": 200,
     }
     with LOG_FILE.open("a") as f:
         f.write(json.dumps(webhook_data) + "\n")
@@ -45,6 +48,62 @@ async def get_logs():
     with LOG_FILE.open("r") as f:
         logs = [json.loads(s) for line in f if (s := line.strip())]
         return {"logs": logs}
+
+
+# Secret key for HMAC verification (in real world, this would be stored securely)
+WEBHOOK_SECRET = "test-secret-key"
+
+
+def verify_signature(payload: bytes, signature: str) -> bool:
+    if not signature or not signature.startswith("sha256="):
+        return False
+
+    expected_signature = hmac.new(
+        WEBHOOK_SECRET.encode("utf-8"), payload, hashlib.sha256
+    ).hexdigest()
+    provided_digest = signature.removeprefix("sha256=")
+    return hmac.compare_digest(expected_signature, provided_digest)
+
+
+@app.post("/secure-webhook")
+async def secure_webhook(request: Request):
+    body = await request.body()
+    signature = request.headers.get("X-MLflow-Signature")
+
+    if not signature:
+        error_data = {
+            "endpoint": "/secure-webhook",
+            "error": "Missing signature header",
+            "status_code": 400,
+            "headers": dict(request.headers),
+        }
+        with LOG_FILE.open("a") as f:
+            f.write(json.dumps(error_data) + "\n")
+        raise HTTPException(status_code=400, detail="Missing signature header")
+
+    if not verify_signature(body, signature):
+        error_data = {
+            "endpoint": "/secure-webhook",
+            "error": "Invalid signature",
+            "status_code": 401,
+            "headers": dict(request.headers),
+        }
+        with LOG_FILE.open("a") as f:
+            f.write(json.dumps(error_data) + "\n")
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    payload = json.loads(body)
+    webhook_data = {
+        "endpoint": "/secure-webhook",
+        "payload": payload,
+        "headers": dict(request.headers),
+        "status_code": 200,
+    }
+
+    with LOG_FILE.open("a") as f:
+        f.write(json.dumps(webhook_data) + "\n")
+
+    return {"status": "received", "signature": "verified"}
 
 
 if __name__ == "__main__":

--- a/tests/webhooks/app.py
+++ b/tests/webhooks/app.py
@@ -8,6 +8,8 @@ import fastapi
 import uvicorn
 from fastapi import HTTPException, Request
 
+from mlflow.webhooks.constants import WEBHOOK_SIGNATURE_HEADER
+
 LOG_FILE = Path("logs.jsonl")
 
 app = fastapi.FastAPI()
@@ -68,7 +70,7 @@ def verify_signature(payload: bytes, signature: str) -> bool:
 @app.post("/secure-webhook")
 async def secure_webhook(request: Request):
     body = await request.body()
-    signature = request.headers.get("X-MLflow-Signature")
+    signature = request.headers.get(WEBHOOK_SIGNATURE_HEADER)
 
     if not signature:
         error_data = {

--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -15,6 +15,7 @@ from mlflow import MlflowClient
 from mlflow.entities.webhook import WebhookEvent
 
 from tests.helper_functions import get_safe_port
+from tests.webhooks.app import WEBHOOK_SECRET
 
 
 def wait_until_ready(health_endpoint: str, max_attempts: int = 10) -> None:
@@ -311,7 +312,7 @@ def test_webhook_with_secret(mlflow_client: MlflowClient, app_client: AppClient)
         name="secure_webhook",
         url=app_client.get_url("/secure-webhook"),
         events=[WebhookEvent.REGISTERED_MODEL_CREATED],
-        secret="test-secret-key",  # This matches WEBHOOK_SECRET in app.py
+        secret=WEBHOOK_SECRET,
     )
 
     registered_model = mlflow_client.create_registered_model(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16739?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16739/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16739/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16739/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR implements HMAC signature verification for MLflow webhooks to enhance security by ensuring webhook payloads are authentic and haven't been tampered with.

**Key Changes:**
- Added `_generate_hmac_signature()` function in `mlflow/webhooks/dispatch.py` using HMAC-SHA256
- Modified webhook dispatch to include `X-MLflow-Signature` header when webhook has a secret configured
- Enhanced test infrastructure with secure webhook endpoint that verifies signatures
- Added comprehensive tests covering successful authentication, wrong secrets, and missing signatures
- Maintains backward compatibility - webhooks without secrets continue to work as before

**Implementation Details:**
- Uses industry-standard `sha256=<hex_digest>` format (similar to GitHub webhooks)  
- Employs constant-time comparison for security
- Only computes signatures when webhook secret is provided
- Logs both successful and failed webhook requests for debugging

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

**New Tests Added:**
- `test_webhook_with_secret`: Verifies successful HMAC authentication with correct secret
- `test_webhook_with_wrong_secret`: Tests rejection of invalid signatures (401 error)
- `test_webhook_without_secret_to_secure_endpoint`: Tests rejection when no signature provided (400 error)
- Enhanced test app with `/secure-webhook` endpoint that validates HMAC signatures

All 9 webhook tests pass, ensuring both new security features and existing functionality work correctly.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow webhooks now support HMAC signature verification for enhanced security. When a webhook is configured with a secret, MLflow will generate and include an `X-MLflow-Signature` header containing an HMAC-SHA256 signature that webhook receivers can use to verify payload authenticity. This feature is backward compatible - existing webhooks without secrets continue to work unchanged.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)