### PR TITLE
Fix: genai testa failed in `databricks-agents` 1.2.0

### DIFF
--- a/tests/genai/test_genai_import_without_agent_sdk.py
+++ b/tests/genai/test_genai_import_without_agent_sdk.py
@@ -1,6 +1,16 @@
 import pytest
 
 from mlflow.genai.datasets import create_dataset, delete_dataset, get_dataset
+from mlflow.genai.scheduled_scorers import (
+    ScorerScheduleConfig,
+    add_scheduled_scorer,
+    delete_scheduled_scorer,
+    get_scheduled_scorer,
+    list_scheduled_scorers,
+    set_scheduled_scorers,
+    update_scheduled_scorer,
+)
+from mlflow.genai.scorers.base import Scorer
 
 
 # Test `mlflow.genai` namespace
@@ -41,3 +51,65 @@ def test_get_dataset_raises_when_agents_not_installed():
 def test_delete_dataset_raises_when_agents_not_installed():
     with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
         delete_dataset("test_dataset")
+
+
+class MockScorer(Scorer):
+    """Mock scorer for testing purposes."""
+
+    name: str = "mock_scorer"
+
+    def __call__(self, *, outputs=None, **kwargs):
+        return {"score": 1.0}
+
+
+def test_add_scheduled_scorer_raises_when_agents_not_installed():
+    mock_scorer = MockScorer()
+
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        add_scheduled_scorer(
+            experiment_id="test_experiment",
+            scheduled_scorer_name="test_scorer",
+            scorer=mock_scorer,
+            sample_rate=0.5,
+            filter_string="test_filter",
+        )
+
+
+def test_update_scheduled_scorer_raises_when_agents_not_installed():
+    mock_scorer = MockScorer()
+
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        update_scheduled_scorer(
+            experiment_id="test_experiment",
+            scheduled_scorer_name="test_scorer",
+            scorer=mock_scorer,
+            sample_rate=0.5,
+            filter_string="test_filter",
+        )
+
+
+def test_delete_scheduled_scorer_raises_when_agents_not_installed():
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        delete_scheduled_scorer(
+            experiment_id="test_experiment", scheduled_scorer_name="test_scorer"
+        )
+
+
+def test_get_scheduled_scorer_raises_when_agents_not_installed():
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        get_scheduled_scorer(experiment_id="test_experiment", scheduled_scorer_name="test_scorer")
+
+
+def test_list_scheduled_scorers_raises_when_agents_not_installed():
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        list_scheduled_scorers(experiment_id="test_experiment")
+
+
+def test_set_scheduled_scorers_raises_when_agents_not_installed():
+    mock_scorer = MockScorer()
+    scheduled_scorer = ScorerScheduleConfig(
+        scorer=mock_scorer, scheduled_scorer_name="test_scorer", sample_rate=0.5
+    )
+
+    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
+        set_scheduled_scorers(experiment_id="test_experiment", scheduled_scorers=[scheduled_scorer])

--- a/tests/genai/test_scheduled_scorers.py
+++ b/tests/genai/test_scheduled_scorers.py
@@ -1,13 +1,5 @@
-import pytest
-
 from mlflow.genai.scheduled_scorers import (
     ScorerScheduleConfig,
-    add_scheduled_scorer,
-    delete_scheduled_scorer,
-    get_scheduled_scorer,
-    list_scheduled_scorers,
-    set_scheduled_scorers,
-    update_scheduled_scorer,
 )
 from mlflow.genai.scorers.base import Scorer
 
@@ -35,56 +27,3 @@ def test_scheduled_scorer_class_instantiation():
     assert scheduled_scorer.scheduled_scorer_name == "test_scorer"
     assert scheduled_scorer.sample_rate == 0.5
     assert scheduled_scorer.filter_string == "test_filter"
-
-
-def test_add_scheduled_scorer_raises_when_agents_not_installed():
-    mock_scorer = MockScorer()
-
-    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        add_scheduled_scorer(
-            experiment_id="test_experiment",
-            scheduled_scorer_name="test_scorer",
-            scorer=mock_scorer,
-            sample_rate=0.5,
-            filter_string="test_filter",
-        )
-
-
-def test_update_scheduled_scorer_raises_when_agents_not_installed():
-    mock_scorer = MockScorer()
-
-    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        update_scheduled_scorer(
-            experiment_id="test_experiment",
-            scheduled_scorer_name="test_scorer",
-            scorer=mock_scorer,
-            sample_rate=0.5,
-            filter_string="test_filter",
-        )
-
-
-def test_delete_scheduled_scorer_raises_when_agents_not_installed():
-    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        delete_scheduled_scorer(
-            experiment_id="test_experiment", scheduled_scorer_name="test_scorer"
-        )
-
-
-def test_get_scheduled_scorer_raises_when_agents_not_installed():
-    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        get_scheduled_scorer(experiment_id="test_experiment", scheduled_scorer_name="test_scorer")
-
-
-def test_list_scheduled_scorers_raises_when_agents_not_installed():
-    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        list_scheduled_scorers(experiment_id="test_experiment")
-
-
-def test_set_scheduled_scorers_raises_when_agents_not_installed():
-    mock_scorer = MockScorer()
-    scheduled_scorer = ScorerScheduleConfig(
-        scorer=mock_scorer, scheduled_scorer_name="test_scorer", sample_rate=0.5
-    )
-
-    with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
-        set_scheduled_scorers(experiment_id="test_experiment", scheduled_scorers=[scheduled_scorer])


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16751?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16751/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16751/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16751/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for https://github.com/mlflow/mlflow/actions/runs/16309375896/job/46061849191?pr=16748

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
