### PR TITLE
Support base64 images in chat blocks

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentType, useMemo } from 'react';
-import type { Components, Options } from 'react-markdown-10';
-import ReactMarkdown from 'react-markdown-10';
+import type { Components, Options, UrlTransform } from 'react-markdown-10';
+import ReactMarkdown, { defaultUrlTransform } from 'react-markdown-10';
 import remarkGfm from 'remark-gfm-4';
 
 import { TableCell, Typography, useDesignSystemTheme } from '@databricks/design-system';
@@ -10,13 +10,20 @@ import { CodeSnippet, SnippetCopyAction } from '@databricks/web-shared/snippet';
 import { TableRenderer, VirtualizedTableCell, VirtualizedTableRow } from './TableRenderer';
 import type { ReactMarkdownComponent, ReactMarkdownComponents, ReactMarkdownProps } from './types';
 
+const urlTransform: UrlTransform = (value) => {
+  if (value.startsWith('data:image/png') || value.startsWith('data:image/jpeg')) {
+    return value;
+  }
+  return defaultUrlTransform(value);
+};
+
 export const GenAIMarkdownRenderer = (props: { children: string; components?: ExtendedComponents }) => {
   const components: Components = useMemo(
     () => getMarkdownComponents({ extensions: props.components }),
     [props.components],
   );
   return (
-    <ReactMarkdown components={components} remarkPlugins={RemarkPlugins}>
+    <ReactMarkdown components={components} remarkPlugins={RemarkPlugins} urlTransform={urlTransform}>
       {props.children}
     </ReactMarkdown>
   );

--- a/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-markdown-renderer/GenAIMarkdownRenderer.tsx
@@ -10,6 +10,11 @@ import { CodeSnippet, SnippetCopyAction } from '@databricks/web-shared/snippet';
 import { TableRenderer, VirtualizedTableCell, VirtualizedTableRow } from './TableRenderer';
 import type { ReactMarkdownComponent, ReactMarkdownComponents, ReactMarkdownProps } from './types';
 
+/**
+ * NOTE: react-markdown sanitizes urls by default, including `data:` urls, with the `urlTransform` prop, documented here: https://github.com/remarkjs/react-markdown?tab=readme-ov-file#defaulturltransformurl
+ * It uses `micromark-util-sanitize-uri` package under the hood to escape urls and prevent injection: https://github.com/micromark/micromark/tree/main/packages/micromark-util-sanitize-uri#readme
+ * We can allow jpeg and png data urls, and use the default transformer for everything else.
+ */
 const urlTransform: UrlTransform = (value) => {
   if (value.startsWith('data:image/png') || value.startsWith('data:image/jpeg')) {
     return value;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessage.tsx
@@ -80,9 +80,12 @@ export function ModelTraceExplorerChatMessage({
   // tool call responses can be JSON, and in these cases
   // it's more helpful to display the message as JSON
   const shouldDisplayCodeSnippet = isJson && (message.role === 'tool' || message.role === 'function');
+
+  const isImageContent = message.content?.startsWith('![');
+
   // if the content is JSON, truncation will be handled by the code
   // snippet. otherwise, we need to truncate the content manually.
-  const isExpandable = !shouldDisplayCodeSnippet && content.length > CONTENT_TRUNCATION_LIMIT;
+  const isExpandable = !shouldDisplayCodeSnippet && !isImageContent && content.length > CONTENT_TRUNCATION_LIMIT;
 
   const displayedContent = isExpandable && !expanded ? `${content.slice(0, CONTENT_TRUNCATION_LIMIT)}...` : content;
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/frontsideair/mlflow/pull/16761?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16761/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16761/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16761/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> Followup to #16736

### What changes are proposed in this pull request?

Handle base64 encoded images in chat messages. Also make them exempt from truncation.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
