### PR TITLE
Remove `importlib_metadata`

### DIFF
--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "databricks-sdk<1,>=0.20.0",
   "fastapi<1",
   "gitpython<4,>=3.1.9",
-  "importlib_metadata<9,>=3.7.0,!=4.7.0",
   "opentelemetry-api<3,>=1.9.0",
   "opentelemetry-sdk<3,>=1.9.0",
   "packaging<26",

--- a/mlflow/deployments/plugin_manager.py
+++ b/mlflow/deployments/plugin_manager.py
@@ -2,8 +2,6 @@ import abc
 import importlib.metadata
 import inspect
 
-import importlib_metadata
-
 from mlflow.deployments.base import BaseDeploymentClient
 from mlflow.deployments.utils import parse_target_uri
 from mlflow.exceptions import MlflowException
@@ -98,7 +96,7 @@ class DeploymentPlugins(PluginManager):
             )
             raise MlflowException(msg, error_code=RESOURCE_DOES_NOT_EXIST)
 
-        if isinstance(plugin_like, (importlib_metadata.EntryPoint, importlib.metadata.EntryPoint)):
+        if isinstance(plugin_like, (importlib.metadata.EntryPoint, importlib.metadata.EntryPoint)):
             try:
                 plugin_obj = plugin_like.load()
             except (AttributeError, ImportError) as exc:

--- a/mlflow/utils/doctor.py
+++ b/mlflow/utils/doctor.py
@@ -1,8 +1,8 @@
+import importlib.metadata
 import os
 import platform
 
 import click
-import importlib_metadata
 import yaml
 from packaging.requirements import Requirement
 
@@ -105,16 +105,16 @@ def doctor(mask_envs=False):
         )
 
     try:
-        requires = importlib_metadata.requires("mlflow")
-    except importlib_metadata.PackageNotFoundError:
-        requires = importlib_metadata.requires("mlflow-skinny")
+        requires = importlib.metadata.requires("mlflow")
+    except importlib.metadata.PackageNotFoundError:
+        requires = importlib.metadata.requires("mlflow-skinny")
 
     mlflow_dependencies = {}
     for req in requires:
         req = Requirement(req)
         try:
-            dist = importlib_metadata.distribution(req.name)
-        except importlib_metadata.PackageNotFoundError:
+            dist = importlib.metadata.distribution(req.name)
+        except importlib.metadata.PackageNotFoundError:
             continue
         else:
             mlflow_dependencies[req.name] = dist.version

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -17,7 +17,6 @@ from pathlib import Path
 from threading import Timer
 from typing import NamedTuple, Optional
 
-import importlib_metadata
 from packaging.requirements import Requirement
 from packaging.version import InvalidVersion, Version
 
@@ -271,7 +270,7 @@ def _run_command(cmd, timeout_seconds, env=None):
 
 def _get_installed_version(package: str, module: Optional[str] = None) -> str:
     """
-    Obtains the installed package version using `importlib_metadata.version`. If it fails, use
+    Obtains the installed package version using `importlib.metadata.version`. If it fails, use
     `__import__(module or package).__version__`.
     """
     if package == "mlflow":
@@ -280,9 +279,9 @@ def _get_installed_version(package: str, module: Optional[str] = None) -> str:
         return mlflow.__version__
 
     try:
-        version = importlib_metadata.version(package)
-    except importlib_metadata.PackageNotFoundError:
-        # Note `importlib_metadata.version(package)` is not necessarily equal to
+        version = importlib.metadata.version(package)
+    except importlib.metadata.PackageNotFoundError:
+        # Note `importlib.metadata.version(package)` is not necessarily equal to
         # `__import__(package).__version__`. See the example for pytorch below.
         #
         # Example
@@ -290,7 +289,7 @@ def _get_installed_version(package: str, module: Optional[str] = None) -> str:
         # $ pip install torch==1.9.0
         # $ python -c "import torch; print(torch.__version__)"
         # 1.9.0+cu102
-        # $ python -c "import importlib_metadata; print(importlib_metadata.version('torch'))"
+        # $ python -c "import importlib.metadata; print(importlib.metadata.version('torch'))"
         # 1.9.0
         version = __import__(module or package).__version__
 
@@ -442,10 +441,10 @@ _PACKAGES_TO_MODULES = None
 def _init_modules_to_packages_map():
     global _MODULES_TO_PACKAGES
     if _MODULES_TO_PACKAGES is None:
-        # Note `importlib_metadata.packages_distributions` only captures packages installed into
+        # Note `importlib.metadata.packages_distributions` only captures packages installed into
         # Python's site-packages directory via tools such as pip:
         # https://importlib-metadata.readthedocs.io/en/latest/using.html#using-importlib-metadata
-        _MODULES_TO_PACKAGES = importlib_metadata.packages_distributions()
+        _MODULES_TO_PACKAGES = importlib.metadata.packages_distributions()
 
         # Add mapping for MLflow extras
         _MODULES_TO_PACKAGES.update(MLFLOW_MODULES_TO_PACKAGES)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
   "gitpython<4,>=3.1.9",
   "graphene<4",
   "gunicorn<24; platform_system != 'Windows'",
-  "importlib_metadata<9,>=3.7.0,!=4.7.0",
   "matplotlib<4",
   "numpy<3",
   "opentelemetry-api<3,>=1.9.0",

--- a/requirements/skinny-requirements.txt
+++ b/requirements/skinny-requirements.txt
@@ -9,7 +9,6 @@ pyyaml<7,>=5.1
 protobuf<7,>=3.12.0
 requests<3,>=2.17.3
 packaging<26
-importlib_metadata<9,>=3.7.0,!=4.7.0
 sqlparse<1,>=0.4.0
 cachetools<7,>=5.0.0
 opentelemetry-api<3,>=1.9.0

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -37,16 +37,6 @@ packaging:
   pip_release: packaging
   max_major_version: 25
 
-importlib_metadata:
-  pip_release: importlib_metadata
-  # Automated dependency detection in MLflow Models relies on
-  # `importlib_metadata.packages_distributions` to resolve a module name to its package name
-  # (e.g. 'sklearn' -> 'scikit-learn'). importlib_metadata 3.7.0 or newer supports this function:
-  # https://github.com/python/importlib_metadata/blob/main/CHANGES.rst#v370
-  minimum: "3.7.0"
-  max_major_version: 8
-  unsupported: ["4.7.0"]
-
 sqlparse:
   pip_release: sqlparse
   # Lower bound sqlparse for: https://github.com/andialbrecht/sqlparse/pull/567

--- a/tests/llama_index/test_llama_index_autolog.py
+++ b/tests/llama_index/test_llama_index_autolog.py
@@ -1,6 +1,6 @@
+import importlib.metadata
 from unittest import mock
 
-import importlib_metadata
 import pytest
 from llama_index.core.chat_engine.types import ChatMode
 from llama_index.core.instrumentation import get_dispatcher
@@ -14,7 +14,7 @@ from mlflow.tracing.constant import TraceMetadataKey
 
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
-llama_core_version = Version(importlib_metadata.version("llama-index-core"))
+llama_core_version = Version(importlib.metadata.version("llama-index-core"))
 
 
 def test_autolog_enable_tracing(multi_index):

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -1,12 +1,12 @@
 import asyncio
 import base64
+import importlib.metadata
 import inspect
 import random
 from dataclasses import asdict
 from pathlib import Path
 from unittest.mock import ANY
 
-import importlib_metadata
 import llama_index.core
 import openai
 import pytest
@@ -32,8 +32,8 @@ from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
-llama_core_version = Version(importlib_metadata.version("llama-index-core"))
-llama_oai_version = Version(importlib_metadata.version("llama-index-llms-openai"))
+llama_core_version = Version(importlib.metadata.version("llama-index-core"))
+llama_oai_version = Version(importlib.metadata.version("llama-index-llms-openai"))
 
 
 @pytest.fixture(autouse=True)

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -723,7 +723,7 @@ def test_pyspark_version_is_logged_without_dev_suffix(spark_model_iris):
     expected_mlflow_version = _mlflow_major_version_string()
     unsuffixed_version = "2.4.0"
     for dev_suffix in [".dev0", ".dev", ".dev1", "dev.a", ".devb"]:
-        with mock.patch("importlib_metadata.version", return_value=unsuffixed_version + dev_suffix):
+        with mock.patch("importlib.metadata.version", return_value=unsuffixed_version + dev_suffix):
             with mlflow.start_run():
                 model_info = mlflow.spark.log_model(spark_model_iris.model, artifact_path="model")
             _assert_pip_requirements(
@@ -731,7 +731,7 @@ def test_pyspark_version_is_logged_without_dev_suffix(spark_model_iris):
             )
 
     for unaffected_version in ["2.0", "2.3.4", "2"]:
-        with mock.patch("importlib_metadata.version", return_value=unaffected_version):
+        with mock.patch("importlib.metadata.version", return_value=unaffected_version):
             pip_deps = _get_pip_deps(mlflow.spark.get_default_conda_env())
             assert any(x == f"pyspark=={unaffected_version}" for x in pip_deps)
 

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -1,11 +1,11 @@
 import importlib
+import importlib.metadata
 import os
 import sys
 from importlib.metadata import version
 from unittest import mock
 
 import cloudpickle
-import importlib_metadata
 import pytest
 
 import mlflow
@@ -242,8 +242,8 @@ def test_get_installed_version(tmp_path, monkeypatch):
     not_found_package = tmp_path.joinpath("not_found.py")
     not_found_package.write_text("__version__ = '1.2.3'")
     monkeypatch.syspath_prepend(str(tmp_path))
-    with pytest.raises(importlib_metadata.PackageNotFoundError, match=r".+"):
-        importlib_metadata.version("not_found")
+    with pytest.raises(importlib.metadata.PackageNotFoundError, match=r".+"):
+        importlib.metadata.version("not_found")
     assert _get_installed_version("not_found") == "1.2.3"
 
 
@@ -263,8 +263,8 @@ def test_get_pinned_requirement(tmp_path, monkeypatch):
     not_found_package = tmp_path.joinpath("not_found.py")
     not_found_package.write_text("__version__ = '1.2.3'")
     monkeypatch.syspath_prepend(str(tmp_path))
-    with pytest.raises(importlib_metadata.PackageNotFoundError, match=r".+"):
-        importlib_metadata.version("not_found")
+    with pytest.raises(importlib.metadata.PackageNotFoundError, match=r".+"):
+        importlib.metadata.version("not_found")
     assert _get_pinned_requirement("not_found") == "not_found==1.2.3"
 
 
@@ -290,7 +290,7 @@ def test_infer_requirements_excludes_mlflow():
         return_value=["mlflow", "pytest"],
     ):
         mlflow_package = "mlflow-skinny" if "MLFLOW_SKINNY" in os.environ else "mlflow"
-        assert mlflow_package in importlib_metadata.packages_distributions()["mlflow"]
+        assert mlflow_package in importlib.metadata.packages_distributions()["mlflow"]
         assert _infer_requirements("path/to/model", "sklearn") == [f"pytest=={pytest.__version__}"]
 
 
@@ -359,7 +359,7 @@ def test_infer_pip_requirements_scopes_databricks_imports():
             return_value="1.0",
         ),
         mock.patch(
-            "importlib_metadata.packages_distributions",
+            "importlib.metadata.packages_distributions",
             return_value={
                 "databricks": [
                     "databricks-automl-runtime",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16769?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16769/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16769/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16769/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

In Python <= 3.9, we need `importlib_metadata` since the bundled version is old (1.4?) but in Python 3.10, we don't.

<img width="777" height="403" alt="image" src="https://github.com/user-attachments/assets/816eda61-962f-4ad6-89c3-78c429d7c45c" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
