### PR TITLE
Fix `dev/install-skinny.sh` to checkout `libs/skinny` directory

### DIFF
--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -131,6 +131,13 @@ jobs:
 
           docker run --rm python:3.10 bash -c "pip install uv && uv pip install --system $URL && python -c 'import mlflow; print(mlflow.__version__)'"
 
+      - name: Test dev/install-skinny.sh
+        if: github.event_name == 'pull_request'
+        env:
+          PIP_DRY_RUN: "1"
+        run: |
+          dev/install-skinny.sh pull/${{ github.event.pull_request.number }}/merge
+
       # Anyone with read access can download the uploaded wheel on GitHub.
       - name: Upload wheel
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install build twine
+          pip install build setuptools twine wheel
 
       - name: Build distribution files
         id: build-dist

--- a/dev/install-skinny.sh
+++ b/dev/install-skinny.sh
@@ -14,7 +14,7 @@ TEMP_DIR=$(mktemp -d)
 git clone --filter=blob:none --no-checkout https://github.com/mlflow/mlflow.git $TEMP_DIR
 cd $TEMP_DIR
 # Exclude the mlflow/server/js folder as it contains frontend JavaScript files not needed for mlflow-skinny installation.
-git sparse-checkout set --no-cone /mlflow /skinny /pyproject.toml '!mlflow/server/js/*'
+git sparse-checkout set --no-cone /mlflow libs/skinny /pyproject.toml '!mlflow/server/js/*'
 git fetch origin "$REF"
 git config advice.detachedHead false
 git checkout FETCH_HEAD

--- a/dev/install-skinny.sh
+++ b/dev/install-skinny.sh
@@ -14,7 +14,7 @@ TEMP_DIR=$(mktemp -d)
 git clone --filter=blob:none --no-checkout https://github.com/mlflow/mlflow.git $TEMP_DIR
 cd $TEMP_DIR
 # Exclude the mlflow/server/js folder as it contains frontend JavaScript files not needed for mlflow-skinny installation.
-git sparse-checkout set --no-cone /mlflow libs/skinny /pyproject.toml '!mlflow/server/js/*'
+git sparse-checkout set --no-cone /mlflow /libs/skinny /pyproject.toml '!mlflow/server/js/*'
 git fetch origin "$REF"
 git config advice.detachedHead false
 git checkout FETCH_HEAD

--- a/dev/install-skinny.sh
+++ b/dev/install-skinny.sh
@@ -7,6 +7,8 @@
 #
 # Install from a specific PR:
 # curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/<pr_num>/merge
+set -euo pipefail
+
 REF=${1:-HEAD}
 
 # Fetching the entire repo is slow. Use sparse-checkout to only fetch the necessary files.

--- a/dev/install-skinny.sh
+++ b/dev/install-skinny.sh
@@ -14,7 +14,7 @@ TEMP_DIR=$(mktemp -d)
 git clone --filter=blob:none --no-checkout https://github.com/mlflow/mlflow.git $TEMP_DIR
 cd $TEMP_DIR
 # Exclude the mlflow/server/js folder as it contains frontend JavaScript files not needed for mlflow-skinny installation.
-git sparse-checkout set --no-cone /mlflow /libs/skinny /pyproject.toml '!mlflow/server/js/*'
+git sparse-checkout set --no-cone /mlflow /libs/skinny /pyproject.toml '!/mlflow/server/js/*'
 git fetch origin "$REF"
 git config advice.detachedHead false
 git checkout FETCH_HEAD


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16771?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16771/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16771/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16771/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Related to #15860. Fix `dev/install-skinny.sh` to checkout `libs/skinny` directory.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
