### PR TITLE
Replace `license.file` with `license-files` in `pyproject.toml`

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -138,6 +138,7 @@ def build(package_type: PackageType) -> None:
                 "MLflow is an open source platform for the complete machine learning lifecycle"
             ),
             "readme": "README_SKINNY.md" if package_type == PackageType.SKINNY else "README.md",
+            "license": "Apache-2.0",
             "license-files": ["LICENSE.txt"],
             "keywords": ["mlflow", "ai", "databricks"],
             "classifiers": [

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -138,9 +138,7 @@ def build(package_type: PackageType) -> None:
                 "MLflow is an open source platform for the complete machine learning lifecycle"
             ),
             "readme": "README_SKINNY.md" if package_type == PackageType.SKINNY else "README.md",
-            "license": {
-                "file": "LICENSE.txt",
-            },
+            "license-files": ["LICENSE.txt"],
             "keywords": ["mlflow", "ai", "databricks"],
             "classifiers": [
                 "Development Status :: 5 - Production/Stable",

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -148,7 +148,6 @@ def build(package_type: PackageType) -> None:
                 "Intended Audience :: Information Technology",
                 "Topic :: Scientific/Engineering :: Artificial Intelligence",
                 "Topic :: Software Development :: Libraries :: Python Modules",
-                "License :: OSI Approved :: Apache Software License",
                 "Operating System :: OS Independent",
                 f"Programming Language :: Python :: {python_version}",
             ],

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -10,6 +10,7 @@ name = "mlflow-skinny"
 version = "3.1.3.dev0"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README_SKINNY.md"
+license-files = ["LICENSE.txt"]
 keywords = ["mlflow", "ai", "databricks"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -46,9 +47,6 @@ dependencies = [
 [[project.maintainers]]
 name = "Databricks"
 email = "mlflow-oss-maintainers@googlegroups.com"
-
-[project.license]
-file = "LICENSE.txt"
 
 [project.optional-dependencies]
 extras = [

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -10,6 +10,7 @@ name = "mlflow-skinny"
 version = "3.1.3.dev0"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README_SKINNY.md"
+license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
 keywords = ["mlflow", "ai", "databricks"]
 classifiers = [

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -20,7 +20,6 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.10",
 ]

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.10",
 ]

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -12,6 +12,7 @@ name = "mlflow"
 version = "3.1.3.dev0"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README.md"
+license-files = ["LICENSE.txt"]
 keywords = ["mlflow", "ai", "databricks"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -45,9 +46,6 @@ dependencies = [
 [[project.maintainers]]
 name = "Databricks"
 email = "mlflow-oss-maintainers@googlegroups.com"
-
-[project.license]
-file = "LICENSE.txt"
 
 [project.optional-dependencies]
 extras = [

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -12,6 +12,7 @@ name = "mlflow"
 version = "3.1.3.dev0"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README.md"
+license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
 keywords = ["mlflow", "ai", "databricks"]
 classifiers = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,6 @@ classifiers = [
   "Intended Audience :: Information Technology",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Software Development :: Libraries :: Python Modules",
-  "License :: OSI Approved :: Apache Software License",
   "Operating System :: OS Independent",
   "Programming Language :: Python :: 3.10",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ name = "mlflow"
 version = "3.1.3.dev0"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README.md"
+license-files = ["LICENSE.txt"]
 keywords = ["mlflow", "ai", "databricks"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -61,9 +62,6 @@ dependencies = [
 [[project.maintainers]]
 name = "Databricks"
 email = "mlflow-oss-maintainers@googlegroups.com"
-
-[project.license]
-file = "LICENSE.txt"
 
 [project.optional-dependencies]
 extras = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ name = "mlflow"
 version = "3.1.3.dev0"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README.md"
+license = "Apache-2.0"
 license-files = ["LICENSE.txt"]
 keywords = ["mlflow", "ai", "databricks"]
 classifiers = [

--- a/tests/dev/test_update_mlflow_versions.py
+++ b/tests/dev/test_update_mlflow_versions.py
@@ -50,7 +50,7 @@ _PYPROJECT_TOML_FILES = {
     },
     "pyproject.release.toml": {
         12: 'version = "{new_version}"',
-        30: '  "mlflow-skinny=={new_version}",',
+        31: '  "mlflow-skinny=={new_version}",',
     },
     "libs/skinny/pyproject.toml": {
         10: 'version = "{new_version}"',


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16772?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16772/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16772/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16772/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix for the following warning:

https://github.com/mlflow/mlflow/actions/runs/16339826102/job/46159478561?pr=16771

```
/tmp/build-env-y9y2lr1f/lib/python3.10/site-packages/setuptools/config/_apply_pyprojecttoml.py:82: SetuptoolsDeprecationWarning: `project.license` as a TOML table is deprecated
!!
        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).
        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.
        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
!!
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
