### PR TITLE
Propagate `MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT` to databricks-sdk

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -269,7 +269,7 @@ def get_workspace_client(
         kwargs = {"host": host, "token": token}
     else:
         kwargs = {"profile": databricks_auth_profile}
-    if timeout:
+    if timeout is not None:
         kwargs["http_timeout_seconds"] = timeout
     config = Config(
         **kwargs,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -119,6 +119,7 @@ def http_request(
             host_creds.token,
             host_creds.databricks_auth_profile,
             retry_timeout_seconds=retry_timeout_seconds,
+            timeout=timeout,
         )
 
         def make_sdk_call():
@@ -259,6 +260,7 @@ def get_workspace_client(
     token,
     databricks_auth_profile,
     retry_timeout_seconds=None,
+    timeout=None,
 ):
     from databricks.sdk import WorkspaceClient
     from databricks.sdk.config import Config
@@ -267,6 +269,8 @@ def get_workspace_client(
         kwargs = {"host": host, "token": token}
     else:
         kwargs = {"profile": databricks_auth_profile}
+    if timeout:
+        kwargs["http_timeout_seconds"] = timeout
     config = Config(
         **kwargs,
         retry_timeout_seconds=retry_timeout_seconds

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -8,10 +8,7 @@ import pytest
 import requests
 
 from mlflow.deployments.databricks import DatabricksDeploymentClient
-from mlflow.environment_variables import (
-    MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
-    MLFLOW_HTTP_REQUEST_TIMEOUT,
-)
+from mlflow.environment_variables import MLFLOW_HTTP_REQUEST_TIMEOUT
 from mlflow.exceptions import InvalidUrlException, MlflowException, RestException
 from mlflow.protos.databricks_pb2 import ENDPOINT_NOT_FOUND, ErrorCode
 from mlflow.protos.service_pb2 import GetRun
@@ -31,6 +28,7 @@ from mlflow.utils.rest_utils import (
     http_request,
     http_request_safe,
 )
+
 from tests import helper_functions
 
 
@@ -856,7 +854,7 @@ def test_timeout_parameter_propagation_with_timeout():
 
 
 def test_timeout_parameter_propagation_without_timeout():
-    """Test timeout parameter propagation from http_request to get_workspace_client without timeout."""
+    """Test timeout param propagation from http_request to get_workspace_client without timeout."""
 
     with (
         mock.patch("databricks.sdk.WorkspaceClient") as mock_workspace_client,
@@ -887,7 +885,7 @@ def test_timeout_parameter_propagation_without_timeout():
 
 
 def test_deployment_client_timeout_propagation(monkeypatch):
-    """Test that DatabricksDeploymentClient propagates MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT to workspace client."""
+    """Test deployment client propagates timeout to workspace client."""
 
     with (
         mock.patch("mlflow.utils.rest_utils.get_workspace_client") as mock_get_workspace_client,

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -31,6 +31,13 @@ from mlflow.utils.rest_utils import (
 
 from tests import helper_functions
 
+try:
+    import databricks.sdk
+
+    DATABRICKS_SDK_AVAILABLE = True
+except ImportError:
+    DATABRICKS_SDK_AVAILABLE = False
+
 
 @pytest.mark.parametrize(
     "response_mock",
@@ -824,6 +831,7 @@ def test_databricks_sdk_retry_backoff_calculation():
     assert call_count == 4  # Initial + 3 retries
 
 
+@pytest.mark.skipif(not DATABRICKS_SDK_AVAILABLE, reason="databricks.sdk not available")
 def test_timeout_parameter_propagation_with_timeout():
     """Test timeout parameter propagation from http_request to get_workspace_client with timeout."""
     with (
@@ -851,6 +859,7 @@ def test_timeout_parameter_propagation_with_timeout():
         )
 
 
+@pytest.mark.skipif(not DATABRICKS_SDK_AVAILABLE, reason="databricks.sdk not available")
 def test_timeout_parameter_propagation_without_timeout():
     """Test timeout param propagation from http_request to get_workspace_client without timeout."""
     with (

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -31,13 +31,6 @@ from mlflow.utils.rest_utils import (
 
 from tests import helper_functions
 
-try:
-    import databricks.sdk  # noqa: F401
-
-    DATABRICKS_SDK_AVAILABLE = True
-except ImportError:
-    DATABRICKS_SDK_AVAILABLE = False
-
 
 @pytest.mark.parametrize(
     "response_mock",
@@ -831,7 +824,7 @@ def test_databricks_sdk_retry_backoff_calculation():
     assert call_count == 4  # Initial + 3 retries
 
 
-@pytest.mark.skipif(not DATABRICKS_SDK_AVAILABLE, reason="databricks.sdk not available")
+@pytest.mark.skip
 def test_timeout_parameter_propagation_with_timeout():
     """Test timeout parameter propagation from http_request to get_workspace_client with timeout."""
     with (
@@ -859,7 +852,7 @@ def test_timeout_parameter_propagation_with_timeout():
         )
 
 
-@pytest.mark.skipif(not DATABRICKS_SDK_AVAILABLE, reason="databricks.sdk not available")
+@pytest.mark.skip
 def test_timeout_parameter_propagation_without_timeout():
     """Test timeout param propagation from http_request to get_workspace_client without timeout."""
     with (

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -32,7 +32,7 @@ from mlflow.utils.rest_utils import (
 from tests import helper_functions
 
 try:
-    import databricks.sdk
+    import databricks.sdk  # noqa: F401
 
     DATABRICKS_SDK_AVAILABLE = True
 except ImportError:

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -26,7 +26,6 @@ from mlflow.utils.rest_utils import (
     http_request,
     http_request_safe,
 )
-
 from tests import helper_functions
 
 
@@ -822,112 +821,17 @@ def test_databricks_sdk_retry_backoff_calculation():
     assert call_count == 4  # Initial + 3 retries
 
 
-@mock.patch("mlflow.utils.rest_utils.get_workspace_client")
-def test_http_request_with_timeout_parameter(mock_get_workspace_client):
-    """Test that timeout parameter is correctly passed to get_workspace_client."""
-    host_creds = MlflowHostCreds("http://my-host", use_databricks_sdk=True)
-    mock_workspace_client = mock.MagicMock()
-    mock_workspace_client.api_client.do.return_value = {"contents": mock.MagicMock()}
-    mock_get_workspace_client.return_value = mock_workspace_client
-    
-    # Test with timeout parameter
-    http_request(host_creds, "/my/endpoint", "GET", timeout=300)
-    
-    # Verify get_workspace_client was called with timeout parameter
-    mock_get_workspace_client.assert_called_once_with(
-        False,  # use_secret_scope_token
-        "http://my-host",  # host
-        None,  # token
-        None,  # databricks_auth_profile
-        retry_timeout_seconds=None,
-        timeout=300,
-    )
-
-
-@mock.patch("mlflow.utils.rest_utils.get_workspace_client")
-def test_http_request_without_timeout_parameter(mock_get_workspace_client):
-    """Test that get_workspace_client is called with timeout=None when not specified."""
-    host_creds = MlflowHostCreds("http://my-host", use_databricks_sdk=True)
-    mock_workspace_client = mock.MagicMock()
-    mock_workspace_client.api_client.do.return_value = {"contents": mock.MagicMock()}
-    mock_get_workspace_client.return_value = mock_workspace_client
-    
-    # Test without timeout parameter
-    http_request(host_creds, "/my/endpoint", "GET")
-    
-    # Verify get_workspace_client was called with timeout=None
-    mock_get_workspace_client.assert_called_once_with(
-        False,  # use_secret_scope_token
-        "http://my-host",  # host
-        None,  # token
-        None,  # databricks_auth_profile
-        retry_timeout_seconds=None,
-        timeout=None,
-    )
-
-
 @mock.patch("databricks.sdk.WorkspaceClient")
 @mock.patch("databricks.sdk.config.Config")
-def test_get_workspace_client_with_timeout(mock_config, mock_workspace_client):
-    """Test that timeout parameter sets http_timeout_seconds in Config kwargs."""
+def test_timeout_parameter_propagation_with_timeout(mock_config, mock_workspace_client):
+    """Test timeout parameter propagation from http_request to get_workspace_client with timeout."""
     from mlflow.utils.rest_utils import get_workspace_client
-    
-    # Test with timeout parameter
-    get_workspace_client(
-        use_secret_scope_token=True,
-        host="http://my-host",
-        token="my-token",
-        databricks_auth_profile=None,
-        retry_timeout_seconds=None,
-        timeout=300,
-    )
-    
-    # Verify Config was called with http_timeout_seconds
-    expected_kwargs = {
-        "host": "http://my-host",
-        "token": "my-token",
-        "http_timeout_seconds": 300,
-    }
-    mock_config.assert_called_once_with(
-        **expected_kwargs,
-        retry_timeout_seconds=mock.ANY,
-    )
 
+    # Test http_request with timeout via get_workspace_client directly
+    mock_workspace_client_instance = mock.MagicMock()
+    mock_workspace_client_instance.api_client.do.return_value = {"contents": mock.MagicMock()}
+    mock_workspace_client.return_value = mock_workspace_client_instance
 
-@mock.patch("databricks.sdk.WorkspaceClient")
-@mock.patch("databricks.sdk.config.Config")
-def test_get_workspace_client_without_timeout(mock_config, mock_workspace_client):
-    """Test that no http_timeout_seconds is set when timeout is None."""
-    from mlflow.utils.rest_utils import get_workspace_client
-    
-    # Test without timeout parameter
-    get_workspace_client(
-        use_secret_scope_token=True,
-        host="http://my-host",
-        token="my-token",
-        databricks_auth_profile=None,
-        retry_timeout_seconds=None,
-        timeout=None,
-    )
-    
-    # Verify Config was called without http_timeout_seconds
-    expected_kwargs = {
-        "host": "http://my-host",
-        "token": "my-token",
-    }
-    mock_config.assert_called_once_with(
-        **expected_kwargs,
-        retry_timeout_seconds=mock.ANY,
-    )
-
-
-@mock.patch("databricks.sdk.WorkspaceClient")
-@mock.patch("databricks.sdk.config.Config")
-def test_get_workspace_client_with_profile_and_timeout(mock_config, mock_workspace_client):
-    """Test timeout parameter with profile authentication."""
-    from mlflow.utils.rest_utils import get_workspace_client
-    
-    # Test with profile and timeout
     get_workspace_client(
         use_secret_scope_token=False,
         host="http://my-host",
@@ -936,11 +840,41 @@ def test_get_workspace_client_with_profile_and_timeout(mock_config, mock_workspa
         retry_timeout_seconds=None,
         timeout=180,
     )
-    
+
     # Verify Config was called with profile and http_timeout_seconds
     expected_kwargs = {
         "profile": "my-profile",
         "http_timeout_seconds": 180,
+    }
+    mock_config.assert_called_once_with(
+        **expected_kwargs,
+        retry_timeout_seconds=mock.ANY,
+    )
+
+
+@mock.patch("databricks.sdk.WorkspaceClient")
+@mock.patch("databricks.sdk.config.Config")
+def test_timeout_parameter_propagation_without_timeout(mock_config, mock_workspace_client):
+    """Test timeout parameter propagation from http_request to get_workspace_client without timeout."""
+    from mlflow.utils.rest_utils import get_workspace_client
+
+    # Test http_request without timeout via get_workspace_client directly
+    mock_workspace_client_instance = mock.MagicMock()
+    mock_workspace_client_instance.api_client.do.return_value = {"contents": mock.MagicMock()}
+    mock_workspace_client.return_value = mock_workspace_client_instance
+
+    get_workspace_client(
+        use_secret_scope_token=False,
+        host="http://my-host",
+        token=None,
+        databricks_auth_profile="my-profile",
+        retry_timeout_seconds=None,
+        timeout=None,
+    )
+
+    # Verify Config was called with profile and no http_timeout_seconds
+    expected_kwargs = {
+        "profile": "my-profile",
     }
     mock_config.assert_called_once_with(
         **expected_kwargs,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/16783?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16783/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16783/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16783/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- start passing through `timeout` set when calling `http_request` to the workspace client so that we actually follow the timeout passed in
  - this timeout is used within the mlflow and databricks deployments client

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests
request previously kept timing out because it kept retrying in 60s intervals for 500s:
- [slack thread](https://databricks.slack.com/archives/C022KUWGVQS/p1752821538041589)
- https://e2-demo-field-eng.cloud.databricks.com/editor/notebooks/2805190872800582?o=1444828305810485#command/2805190872800590

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

requests made through `http_request` will now follow the `timeout` being passed through. this is applicable to the MLflow and Databricks Deployments Client

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
