### PR TITLE
Track APIs

### DIFF
--- a/mlflow/models/evaluation/base.py
+++ b/mlflow/models/evaluation/base.py
@@ -27,6 +27,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.models.evaluation.utils.trace import configure_autologging_for_evaluation
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.artifact.utils.models import _parse_model_id_if_present
+from mlflow.telemetry.track import track_api_usage
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import _set_active_model
@@ -990,6 +991,7 @@ def _get_last_failed_evaluator():
 # DO NOT CHANGE THE ORDER OF THE ARGUMENTS
 # The order of the arguments need to be preserved. You can add new arguments at the end
 # of the argument list, but do not change the order of the existing arguments.
+@track_api_usage
 def _evaluate(
     *,
     model,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -32,7 +32,9 @@ from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri, _upload_artifact_to_uri
 from mlflow.tracking.fluent import (
+    _create_logged_model,
     _get_active_model_context,
+    _last_logged_model_id,
     _set_active_model_id,
     _use_logged_model,
 )
@@ -1163,7 +1165,7 @@ class Model:
                     **(params or {}),
                     **(client.get_run(run_id).data.params if run_id else {}),
                 }
-                model = mlflow.initialize_logged_model(
+                model = _create_logged_model(
                     # TODO: Update model name
                     name=name,
                     source_run_id=run_id,
@@ -1172,7 +1174,9 @@ class Model:
                     tags={key: str(value) for key, value in tags.items()}
                     if tags is not None
                     else None,
+                    flavor=flavor.__name__,
                 )
+                _last_logged_model_id.set(model.model_id)
                 if (
                     MLFLOW_PRINT_MODEL_URLS_ON_CREATION.get()
                     and is_databricks_uri(tracking_uri)

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1174,7 +1174,7 @@ class Model:
                     tags={key: str(value) for key, value in tags.items()}
                     if tags is not None
                     else None,
-                    flavor=flavor.__name__,
+                    flavor=flavor.__name__ if hasattr(flavor, "__name__") else "custom",
                 )
                 _last_logged_model_id.set(model.model_id)
                 if (

--- a/mlflow/telemetry/parser.py
+++ b/mlflow/telemetry/parser.py
@@ -27,7 +27,7 @@ class LoggedModelParser(TelemetryParser):
     @classmethod
     def extract_params(cls, arguments: dict[str, Any]) -> Optional[LoggedModelParams]:
         flavor = arguments.get("flavor")
-        flavor = flavor.replace("mlflow.", "") if flavor else "custom"
+        flavor = flavor.removeprefix("mlflow.") if flavor else "custom"
         return LoggedModelParams(flavor=flavor)
 
 

--- a/mlflow/telemetry/parser.py
+++ b/mlflow/telemetry/parser.py
@@ -26,7 +26,8 @@ class TelemetryParser(ABC):
 class LoggedModelParser(TelemetryParser):
     @classmethod
     def extract_params(cls, arguments: dict[str, Any]) -> Optional[LoggedModelParams]:
-        flavor = arguments.get("flavor") or "custom"
+        flavor = arguments.get("flavor")
+        flavor = flavor.replace("mlflow.", "") if flavor else "custom"
         return LoggedModelParams(flavor=flavor)
 
 

--- a/mlflow/telemetry/parser.py
+++ b/mlflow/telemetry/parser.py
@@ -26,9 +26,9 @@ class TelemetryParser(ABC):
 class LoggedModelParser(TelemetryParser):
     @classmethod
     def extract_params(cls, arguments: dict[str, Any]) -> Optional[LoggedModelParams]:
-        flavor = arguments.get("flavor")
-        flavor = flavor.removeprefix("mlflow.") if flavor else "custom"
-        return LoggedModelParams(flavor=flavor)
+        if flavor := arguments.get("flavor"):
+            return LoggedModelParams(flavor=flavor.removeprefix("mlflow."))
+        return None
 
 
 class RegisteredModelParser(TelemetryParser):

--- a/mlflow/telemetry/parser.py
+++ b/mlflow/telemetry/parser.py
@@ -1,32 +1,21 @@
-import logging
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Callable, Optional
+from typing import Any, Optional
 
 from mlflow.telemetry.schemas import (
-    AutologParams,
     BaseParams,
-    GenaiEvaluateParams,
-    LogModelParams,
-    ModelType,
+    LoggedModelParams,
+    RegisteredModelParams,
 )
-
-if TYPE_CHECKING:
-    from mlflow.genai.scorers import Scorer
-
-_logger = logging.getLogger(__name__)
 
 
 class TelemetryParser(ABC):
     @classmethod
     @abstractmethod
-    def extract_params(
-        cls, func: Callable[..., Any], arguments: dict[str, Any]
-    ) -> Optional[BaseParams]:
+    def extract_params(cls, arguments: dict[str, Any]) -> Optional[BaseParams]:
         """
         Extract the parameters from the function call.
 
         Args:
-            func: The function.
             arguments: The arguments passed to the function.
 
         Returns:
@@ -34,121 +23,28 @@ class TelemetryParser(ABC):
         """
 
 
-def _parse_flavor_from_module_name(module_name: str) -> Optional[str]:
-    if module_name.startswith("mlflow."):
-        return module_name.split(".")[1]
-
-
-class LogModelParser(TelemetryParser):
+class LoggedModelParser(TelemetryParser):
     @classmethod
-    def extract_params(
-        cls, func: Callable[..., Any], arguments: dict[str, Any]
-    ) -> Optional[LogModelParams]:
-        flavor = _parse_flavor_from_module_name(func.__module__)
-        if flavor is None:
-            _logger.debug(f"Failed to extract log model params for function {func.__name__}")
-            return
+    def extract_params(cls, arguments: dict[str, Any]) -> Optional[LoggedModelParams]:
+        flavor = arguments.get("flavor") or "custom"
+        return LoggedModelParams(flavor=flavor)
 
-        model_type = cls.parse_model_type(flavor, arguments)
-        record_params = {"flavor": flavor, "model": model_type.value}
-        for param in [
-            "pip_requirements",
-            "extra_pip_requirements",
-            "code_paths",
-            "params",
-            "metadata",
-        ]:
-            record_params[f"is_{param}_set"] = arguments.get(param) is not None
 
-        return LogModelParams(**record_params)
-
+class RegisteredModelParser(TelemetryParser):
     @classmethod
-    def parse_model_type(cls, flavor: str, arguments: dict[str, Any]) -> ModelType:
-        if flavor == "pyfunc":
-            model = arguments.get("python_model")
-            # either python_model or loader_module must be specified
-            if model is None and arguments.get("loader_module"):
-                return ModelType.LOADER_MODULE
-
-            try:
-                from mlflow.pyfunc.model import ResponsesAgent
-            except ImportError:
-                pass
-            else:
-                if isinstance(model, ResponsesAgent):
-                    return ModelType.RESPONSES_AGENT
-
-            try:
-                from mlflow.pyfunc.model import ChatAgent, ChatModel, PythonModel
-            except ImportError:
-                pass
-            else:
-                if isinstance(model, ChatModel):
-                    return ModelType.CHAT_MODEL
-                elif isinstance(model, ChatAgent):
-                    return ModelType.CHAT_AGENT
-                # This check should be at the end because it's the most generic model type
-                elif isinstance(model, PythonModel):
-                    return ModelType.PYTHON_MODEL
-
-            return ModelType.PYTHON_FUNCTION if callable(model) else ModelType.MODEL_OBJECT
-        else:
-            # model parameter is the first positional argument
-            model = next(iter(arguments.values()), None)
-            return ModelType.MODEL_PATH if isinstance(model, str) else ModelType.MODEL_OBJECT
-
-
-class AutologParser(TelemetryParser):
-    @classmethod
-    def extract_params(
-        cls, func: Callable[..., Any], arguments: dict[str, Any]
-    ) -> Optional[AutologParams]:
-        # autolog functions decorated with @autologging_integration have integration_name attribute
-        flavor = getattr(func, "integration_name", _parse_flavor_from_module_name(func.__module__))
-        if flavor is None:
-            _logger.debug(f"Failed to extract autolog params for function {func.__name__}")
-            return
-        record_params = {"flavor": flavor}
-        for param in ["disable", "log_traces", "log_models"]:
-            record_params[param] = arguments.get(param, False) or False
-        return AutologParams(**record_params)
-
-
-class GenaiEvaluateParser(TelemetryParser):
-    @classmethod
-    def extract_params(
-        cls, func: Callable[..., Any], arguments: dict[str, Any]
-    ) -> Optional[GenaiEvaluateParams]:
+    def extract_params(cls, arguments: dict[str, Any]) -> Optional[RegisteredModelParams]:
+        tags = arguments.get("tags") or {}
+        is_prompt = False
         try:
-            from mlflow.genai.evaluation import evaluate
-        except ImportError:
-            return None
-        if func.__module__ != evaluate.__module__:
-            return None
-
-        scorers = arguments.get("scorers", [])
-        scorers = [cls.sanitize_scorer_name(scorer) for scorer in scorers]
-        is_predict_fn_set = arguments.get("predict_fn") is not None
-        return GenaiEvaluateParams(scorers=scorers, is_predict_fn_set=is_predict_fn_set)
-
-    @classmethod
-    def sanitize_scorer_name(cls, scorer: "Scorer") -> str:
-        """
-        Sanitize the scorer name to remove user-customized scorers.
-        """
-        try:
-            from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
+            from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
         except ImportError:
             pass
         else:
-            if isinstance(scorer, BuiltInScorer):
-                return scorer.name
-
-        return "CustomScorer"
+            is_prompt = tags.get(IS_PROMPT_TAG_KEY, "false").lower() == "true"
+        return RegisteredModelParams(is_prompt=is_prompt)
 
 
 API_PARSER_MAPPING: dict[str, TelemetryParser] = {
-    "log_model": LogModelParser,
-    "autolog": AutologParser,
-    "evaluate": GenaiEvaluateParser,
+    "create_logged_model": LoggedModelParser,
+    "create_registered_model": RegisteredModelParser,
 }

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -27,7 +27,7 @@ class BaseParams:
 
 @dataclass
 class LoggedModelParams(BaseParams):
-    flavor: str
+    flavor: Optional[str] = None
 
 
 @dataclass

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -15,19 +15,6 @@ class APIStatus(str, Enum):
     FAILURE = "failure"
 
 
-class ModelType(str, Enum):
-    MODEL_PATH = "model_path"
-    MODEL_OBJECT = "model_object"
-    PYTHON_FUNCTION = "python_function"
-    PYTHON_MODEL = "python_model"
-    CHAT_MODEL = "chat_model"
-    CHAT_AGENT = "chat_agent"
-    RESPONSES_AGENT = "responses_agent"
-    # pyfunc log_model can accept either python_model or loader_module,
-    # we set model type to LOADER_MODULE if loader_module is specified
-    LOADER_MODULE = "loader_module"
-
-
 @dataclass
 class BaseParams:
     """
@@ -39,28 +26,13 @@ class BaseParams:
 
 
 @dataclass
-class LogModelParams(BaseParams):
+class LoggedModelParams(BaseParams):
     flavor: str
-    model: ModelType
-    is_pip_requirements_set: bool = False
-    is_extra_pip_requirements_set: bool = False
-    is_code_paths_set: bool = False
-    is_params_set: bool = False
-    is_metadata_set: bool = False
 
 
 @dataclass
-class AutologParams(BaseParams):
-    flavor: str
-    disable: bool
-    log_traces: bool
-    log_models: bool
-
-
-@dataclass
-class GenaiEvaluateParams(BaseParams):
-    scorers: list[str]
-    is_predict_fn_set: bool = False
+class RegisteredModelParams(BaseParams):
+    is_prompt: bool
 
 
 @dataclass

--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -27,7 +27,7 @@ class BaseParams:
 
 @dataclass
 class LoggedModelParams(BaseParams):
-    flavor: Optional[str] = None
+    flavor: str
 
 
 @dataclass

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -1,8 +1,4 @@
-import inspect
 import os
-from collections import defaultdict
-from contextlib import contextmanager
-from contextvars import ContextVar
 
 from mlflow.environment_variables import MLFLOW_DISABLE_TELEMETRY
 from mlflow.version import VERSION
@@ -69,62 +65,3 @@ def is_telemetry_disabled() -> bool:
         or _IS_IN_DATABRICKS
         or _IS_MLFLOW_DEV_VERSION
     )
-
-
-def _get_whitelist() -> dict[str, set[str]]:
-    """
-    Whitelist for APIs that are only invoked by MLflow but should be tracked.
-    """
-    whitelist = defaultdict(set)
-    try:
-        from mlflow.pyfunc.utils.data_validation import _infer_schema_from_list_type_hint
-
-        whitelist[_infer_schema_from_list_type_hint.__module__].add(
-            _infer_schema_from_list_type_hint.__qualname__
-        )
-    except ImportError:
-        pass
-
-    return whitelist
-
-
-def should_skip_telemetry(func) -> bool:
-    # If the function is in whitelist, we should always track it
-    if func.__qualname__ in _get_whitelist().get(func.__module__, set()):
-        return False
-
-    if _disable_telemetry_tracking_var.get():
-        return True
-
-    frame = inspect.currentframe()
-    try:
-        # skip the current frame and the API call frames
-        frame = frame.f_back.f_back if frame and frame.f_back else None
-        module = inspect.getmodule(frame)
-        # TODO: consider recording if this comes from databricks modules
-        return module and module.__name__.startswith("mlflow")
-    finally:
-        del frame
-
-
-# ContextVar to disable telemetry tracking in the current thread.
-# This is thread-local to avoid race conditions when multiple threads are running in parallel.
-# NB: this doesn't work if a nested function spawns a new thread (e.g. mlflow.genai.evaluate)
-_disable_telemetry_tracking_var = ContextVar("disable_telemetry_tracking", default=False)
-
-
-@contextmanager
-def _disable_telemetry():
-    """
-    Context manager to disable telemetry tracking in the following scenarios:
-    1. Circular API calls: When MLflow invokes `databricks-agents` APIs, which in turn call back
-        into MLflow APIs. This prevents telemetry from tracking internal, nested invocations.
-    2. Code-based model logging: During model logging, the model file may be executed directly,
-        potentially triggering additional telemetry logging inside model file. This context
-        suppresses such telemetry during model loading and logging.
-    """
-    token = _disable_telemetry_tracking_var.set(True)
-    try:
-        yield
-    finally:
-        _disable_telemetry_tracking_var.reset(token)

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -26,6 +26,7 @@ from mlflow.protos.databricks_pb2 import (
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
+from mlflow.telemetry.track import track_api_usage
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import TraceJSONEncoder, exclude_immutable_tags
@@ -59,6 +60,7 @@ class TracingClient:
     def store(self):
         return _get_store(self.tracking_uri)
 
+    @track_api_usage
     def start_trace(self, trace_info: TraceInfo) -> TraceInfo:
         """
         Create a new trace in the backend.
@@ -412,6 +414,7 @@ class TracingClient:
 
         return self.store.get_assessment(trace_id, assessment_id)
 
+    @track_api_usage
     def log_assessment(self, trace_id: str, assessment: Assessment) -> Assessment:
         """
         Log an assessment to a trace.

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -26,6 +26,7 @@ from mlflow.store.model_registry import (
     SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT,
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
 )
+from mlflow.telemetry.track import track_api_usage
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS, utils
 from mlflow.utils.arguments_utils import _get_arg_names
 
@@ -61,6 +62,7 @@ class ModelRegistryClient:
 
     # Registered Model Methods
 
+    @track_api_usage
     def create_registered_model(self, name, tags=None, description=None, deployment_job_id=None):
         """Create a new registered model in backend store.
 
@@ -205,6 +207,7 @@ class ModelRegistryClient:
 
     # Model Version Methods
 
+    @track_api_usage
     def create_model_version(
         self,
         name,
@@ -456,6 +459,7 @@ class ModelRegistryClient:
         """
         return self.store.get_model_version_by_alias(name, alias)
 
+    @track_api_usage
     def create_prompt(
         self,
         name: str,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -36,6 +36,7 @@ from mlflow.store.tracking import (
     SEARCH_MAX_RESULTS_DEFAULT,
 )
 from mlflow.store.tracking.rest_store import RestStore
+from mlflow.telemetry.track import track_api_usage
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking.metric_value_conversion_utils import convert_metric_value_to_float_if_possible
 from mlflow.utils import chunk_list
@@ -132,6 +133,7 @@ class TrackingServiceClient:
             token = paged_history.token
         return history
 
+    @track_api_usage
     def create_run(self, experiment_id, start_time=None, tags=None, run_name=None):
         """Create a :py:class:`mlflow.entities.Run` object that can be associated with
         metrics, parameters, artifacts, etc.
@@ -257,6 +259,7 @@ class TrackingServiceClient:
         """
         return self.store.get_experiment_by_name(name)
 
+    @track_api_usage
     def create_experiment(self, name, artifact_location=None, tags=None):
         """Create an experiment.
 
@@ -821,6 +824,7 @@ class TrackingServiceClient:
             page_token=page_token,
         )
 
+    @track_api_usage
     def create_logged_model(
         self,
         experiment_id: str,
@@ -829,6 +833,7 @@ class TrackingServiceClient:
         tags: Optional[dict[str, str]] = None,
         params: Optional[dict[str, str]] = None,
         model_type: Optional[str] = None,
+        flavor: Optional[str] = None,
     ) -> LoggedModel:
         return self.store.create_logged_model(
             experiment_id=experiment_id,

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -833,6 +833,8 @@ class TrackingServiceClient:
         tags: Optional[dict[str, str]] = None,
         params: Optional[dict[str, str]] = None,
         model_type: Optional[str] = None,
+        # This parameter is only used for telemetry purposes, and
+        # does not affect the logged model.
         flavor: Optional[str] = None,
     ) -> LoggedModel:
         return self.store.create_logged_model(

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5365,8 +5365,22 @@ class MlflowClient:
         Returns:
             The created model.
         """
-        return self._tracking_client.create_logged_model(
+        return self._create_logged_model(
             experiment_id, name, source_run_id, tags, params, model_type
+        )
+
+    def _create_logged_model(
+        self,
+        experiment_id: str,
+        name: Optional[str] = None,
+        source_run_id: Optional[str] = None,
+        tags: Optional[dict[str, str]] = None,
+        params: Optional[dict[str, str]] = None,
+        model_type: Optional[str] = None,
+        flavor: Optional[str] = None,
+    ) -> LoggedModel:
+        return self._tracking_client.create_logged_model(
+            experiment_id, name, source_run_id, tags, params, model_type, flavor
         )
 
     @experimental(version="3.0.0")

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -2248,6 +2248,7 @@ def _create_logged_model(
     params: Optional[dict[str, str]] = None,
     model_type: Optional[str] = None,
     experiment_id: Optional[str] = None,
+    flavor: Optional[str] = None,
 ) -> LoggedModel:
     """
     Create a new LoggedModel in the ``PENDING`` state.
@@ -2263,6 +2264,7 @@ def _create_logged_model(
                     enables you to easily search for this model and compare it to other models of
                     type ``"agent"`` in the future.
         experiment_id: The experiment ID of the experiment to which the model belongs.
+        flavor: The flavor of the model.
 
     Returns:
         A new LoggedModel in the ``PENDING`` state.
@@ -2277,13 +2279,14 @@ def _create_logged_model(
             get_run(source_run_id).info.experiment_id if source_run_id else None
         )
     resolved_tags = context_registry.resolve_tags(tags)
-    return MlflowClient().create_logged_model(
+    return MlflowClient()._create_logged_model(
         experiment_id=experiment_id,
         name=name,
         source_run_id=source_run_id,
         tags=resolved_tags,
         params=params,
         model_type=model_type,
+        flavor=flavor,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ from mlflow.utils.os import is_windows
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 from tests.autologging.fixtures import enable_test_mode
-from tests.helper_functions import avoid_telemetry_tracking, get_safe_port
+from tests.helper_functions import get_safe_port
 from tests.tracing.helper import purge_traces
 
 if not IS_TRACING_SDK_ONLY:
@@ -335,8 +335,7 @@ def mock_is_in_databricks(request):
 @pytest.fixture(autouse=not IS_TRACING_SDK_ONLY)
 def reset_active_model_context():
     yield
-    with avoid_telemetry_tracking():
-        clear_active_model()
+    clear_active_model()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/genai/optimize/test_base.py
+++ b/tests/genai/optimize/test_base.py
@@ -14,16 +14,13 @@ from mlflow.genai.scorers import scorer
 from mlflow.tracking import MlflowClient
 from mlflow.tracking._model_registry.fluent import register_prompt
 
-from tests.helper_functions import avoid_telemetry_tracking
-
 
 @pytest.fixture
 def sample_prompt():
-    with avoid_telemetry_tracking():
-        return register_prompt(
-            name="test_translation_prompt",
-            template="Translate the following text to {{language}}: {{input_text}}",
-        )
+    return register_prompt(
+        name="test_translation_prompt",
+        template="Translate the following text to {{language}}: {{input_text}}",
+    )
 
 
 @pytest.fixture

--- a/tests/helper_functions.py
+++ b/tests/helper_functions.py
@@ -821,17 +821,8 @@ def get_logged_model_by_name(name: str) -> Optional[LoggedModel]:
     return logged_models[0] if len(logged_models) >= 1 else None
 
 
-@contextmanager
-def avoid_telemetry_tracking():
-    """
-    Context manager to disable telemetry, this avoids side effects of telemetry on tests.
-    """
-    with mock.patch("mlflow.telemetry.track.should_skip_telemetry", return_value=True):
-        yield
-
-
 def validate_telemetry_record(
-    mock_requests, func, *, params=None, status="success", search_index=False
+    mock_requests, func, params=None, *, status="success", search_index=False
 ) -> dict[str, Any]:
     """
     Validate the telemetry record at the given index.

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -5,7 +5,7 @@ import time
 import pytest
 
 from mlflow.telemetry.client import MAX_QUEUE_SIZE, MAX_WORKERS, TelemetryClient
-from mlflow.telemetry.schemas import APIRecord, APIStatus, LogModelParams, ModelType
+from mlflow.telemetry.schemas import APIRecord, APIStatus
 
 
 @pytest.fixture
@@ -33,7 +33,6 @@ def test_add_record_and_send(telemetry_client: TelemetryClient, mock_requests):
         api_name="test_api",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
 
     # Add record and wait for processing
@@ -61,7 +60,6 @@ def test_batch_processing(telemetry_client: TelemetryClient, mock_requests):
             api_name=f"test_api_{i}",
             timestamp_ns=time.time_ns(),
             status=APIStatus.SUCCESS,
-            params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
         )
         telemetry_client.add_record(record)
 
@@ -77,7 +75,6 @@ def test_flush_functionality(telemetry_client: TelemetryClient, mock_requests):
         api_name="test_api",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record)
 
@@ -93,7 +90,6 @@ def test_client_shutdown(telemetry_client: TelemetryClient, mock_requests):
             api_name="test_api",
             timestamp_ns=time.time_ns(),
             status=APIStatus.SUCCESS,
-            params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
         )
         telemetry_client.add_record(record)
     assert len(mock_requests) == 0
@@ -121,7 +117,6 @@ def test_error_handling(mock_requests, telemetry_client):
         api_name="test_api",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record)
 
@@ -141,7 +136,6 @@ def test_stop_event(telemetry_client: TelemetryClient, mock_requests):
         api_name="test_api",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record)
 
@@ -162,7 +156,6 @@ def test_concurrent_record_addition(telemetry_client: TelemetryClient, mock_requ
                 api_name=f"thread_{thread_id}_api_{i}",
                 timestamp_ns=time.time_ns(),
                 status=APIStatus.SUCCESS,
-                params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
             )
             telemetry_client.add_record(record)
             time.sleep(0.1)
@@ -191,7 +184,6 @@ def test_telemetry_info_inclusion(telemetry_client: TelemetryClient, mock_reques
         api_name="test_api",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record)
 
@@ -216,7 +208,6 @@ def test_partition_key(telemetry_client: TelemetryClient, mock_requests):
         api_name="test_api",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record)
     telemetry_client.add_record(record)
@@ -265,7 +256,6 @@ def test_log_suppression_in_consumer_thread(mock_requests, capsys, telemetry_cli
         api_name="test_api",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record)
 
@@ -298,7 +288,6 @@ def test_consumer_thread_no_stderr_output(mock_requests, capsys, telemetry_clien
             api_name=f"test_api_{i}",
             timestamp_ns=time.time_ns(),
             status=APIStatus.SUCCESS,
-            params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
         )
         telemetry_client.add_record(record)
 
@@ -330,7 +319,6 @@ def test_batch_time_interval(mock_requests, telemetry_client: TelemetryClient):
         api_name="test_api_1",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record1)
 
@@ -343,7 +331,6 @@ def test_batch_time_interval(mock_requests, telemetry_client: TelemetryClient):
         api_name="test_api_2",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record2)
 
@@ -360,7 +347,6 @@ def test_batch_time_interval(mock_requests, telemetry_client: TelemetryClient):
         api_name="test_api_3",
         timestamp_ns=time.time_ns(),
         status=APIStatus.SUCCESS,
-        params=LogModelParams(flavor="test_flavor", model=ModelType.PYTHON_FUNCTION),
     )
     telemetry_client.add_record(record3)
     assert len(mock_requests) == 2

--- a/tests/telemetry/test_parser.py
+++ b/tests/telemetry/test_parser.py
@@ -1,150 +1,48 @@
 import pytest
 
-import mlflow
-from mlflow.genai.scorers import Scorer, scorer
-from mlflow.genai.scorers.builtin_scorers import Correctness, Safety, get_all_scorers
-from mlflow.pyfunc.model import PythonModel
-from mlflow.telemetry.parser import (
-    AutologParser,
-    GenaiEvaluateParser,
-    LogModelParser,
-)
-from mlflow.telemetry.schemas import AutologParams, GenaiEvaluateParams, LogModelParams, ModelType
+from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
+from mlflow.telemetry.parser import LoggedModelParser, RegisteredModelParser
+from mlflow.telemetry.schemas import LoggedModelParams, RegisteredModelParams
 
 
 @pytest.mark.parametrize(
-    ("func", "arguments", "expected_params"),
+    ("arguments", "expected_params"),
     [
         (
-            mlflow.autolog,
-            {"log_models": True, "log_traces": True, "disable": False},
-            AutologParams(flavor="mlflow", disable=False, log_traces=True, log_models=True),
-        ),
-        (
-            mlflow.langchain.autolog,
-            {"disable": True},
-            AutologParams(flavor="langchain", disable=True, log_traces=False, log_models=False),
-        ),
-        (
-            mlflow.langchain.autolog,
-            {"disable": False, "log_traces": True},
-            AutologParams(flavor="langchain", disable=False, log_traces=True, log_models=False),
-        ),
-        (
-            mlflow.sklearn.autolog,
-            {"log_models": True},
-            AutologParams(flavor="sklearn", disable=False, log_traces=False, log_models=True),
-        ),
-    ],
-)
-def test_autolog_parser(func, arguments, expected_params):
-    assert AutologParser.extract_params(func, arguments) == expected_params
-
-
-@pytest.mark.parametrize(
-    ("func", "arguments", "expected_params"),
-    [
-        (
-            mlflow.langchain.log_model,
-            {"model": "model_path", "extra_pip_requirements": ["pandas", "numpy"]},
-            LogModelParams(
-                flavor="langchain",
-                model=ModelType.MODEL_PATH.value,
-                is_pip_requirements_set=False,
-                is_extra_pip_requirements_set=True,
-                is_code_paths_set=False,
-                is_params_set=False,
-                is_metadata_set=False,
-            ),
-        ),
-        (
-            mlflow.pyfunc.log_model,
-            {
-                "python_model": lambda x: x,
-                "pip_requirements": ["pandas"],
-                "code_paths": ["/path/to/code"],
-            },
-            LogModelParams(
+            {"flavor": "pyfunc"},
+            LoggedModelParams(
                 flavor="pyfunc",
-                model=ModelType.PYTHON_FUNCTION.value,
-                is_pip_requirements_set=True,
-                is_extra_pip_requirements_set=False,
-                is_code_paths_set=True,
-                is_params_set=False,
-                is_metadata_set=False,
             ),
         ),
         (
-            mlflow.pyfunc.log_model,
-            {"python_model": PythonModel(), "metadata": {"key": "value"}},
-            LogModelParams(
-                flavor="pyfunc",
-                model=ModelType.PYTHON_MODEL.value,
-                is_pip_requirements_set=False,
-                is_extra_pip_requirements_set=False,
-                is_code_paths_set=False,
-                is_params_set=False,
-                is_metadata_set=True,
+            {
+                "flavor": None,
+            },
+            LoggedModelParams(
+                flavor="custom",
             ),
         ),
         (
-            mlflow.sklearn.log_model,
-            {"model": object(), "params": {"key": "value"}},
-            LogModelParams(
-                flavor="sklearn",
-                model=ModelType.MODEL_OBJECT.value,
-                is_pip_requirements_set=False,
-                is_extra_pip_requirements_set=False,
-                is_code_paths_set=False,
-                is_params_set=True,
-                is_metadata_set=False,
+            {},
+            LoggedModelParams(
+                flavor="custom",
             ),
         ),
     ],
 )
-def test_log_model_parser(func, arguments, expected_params):
-    assert LogModelParser.extract_params(func, arguments) == expected_params
-
-
-@scorer
-def not_empty(outputs) -> bool:
-    return outputs != ""
-
-
-def test_sanitize_scorer_name():
-    parser = GenaiEvaluateParser()
-    built_in_scorers = get_all_scorers()
-    for built_in_scorer in built_in_scorers:
-        assert parser.sanitize_scorer_name(built_in_scorer) == built_in_scorer.name
-
-    custom_scorer = Scorer(name="test_scorer")
-    assert parser.sanitize_scorer_name(custom_scorer) == "CustomScorer"
-    assert parser.sanitize_scorer_name(not_empty) == "CustomScorer"
+def test_logged_model_parser(arguments, expected_params):
+    assert LoggedModelParser.extract_params(arguments) == expected_params
 
 
 @pytest.mark.parametrize(
-    ("func", "arguments", "expected_params"),
+    ("arguments", "expected_params"),
     [
-        (
-            mlflow.genai.evaluate,
-            {"data": ["a", "b", "c"], "scorers": [Safety(), not_empty]},
-            GenaiEvaluateParams(scorers=["safety", "CustomScorer"], is_predict_fn_set=False),
-        ),
-        (
-            mlflow.genai.evaluate,
-            {"scorers": [Safety(), Correctness()], "predict_fn": lambda x: x},
-            GenaiEvaluateParams(scorers=["safety", "correctness"], is_predict_fn_set=True),
-        ),
-        (
-            mlflow.genai.evaluate,
-            {
-                "data": ["a", "b", "c"],
-                "scorers": [Scorer(name="test_scorer"), not_empty],
-                "predict_fn": lambda x: x,
-            },
-            GenaiEvaluateParams(scorers=["CustomScorer", "CustomScorer"], is_predict_fn_set=True),
-        ),
+        ({"tags": None}, RegisteredModelParams(is_prompt=False)),
+        ({"tags": {}}, RegisteredModelParams(is_prompt=False)),
+        ({"tags": {IS_PROMPT_TAG_KEY: "true"}}, RegisteredModelParams(is_prompt=True)),
+        ({"tags": {IS_PROMPT_TAG_KEY: "false"}}, RegisteredModelParams(is_prompt=False)),
+        ({}, RegisteredModelParams(is_prompt=False)),
     ],
 )
-def test_genai_evaluate_parser(func, arguments, expected_params):
-    assert GenaiEvaluateParser.extract_params(func, arguments) == expected_params
+def test_registered_model_parser(arguments, expected_params):
+    assert RegisteredModelParser.extract_params(arguments) == expected_params

--- a/tests/telemetry/test_parser.py
+++ b/tests/telemetry/test_parser.py
@@ -24,16 +24,9 @@ from mlflow.telemetry.schemas import LoggedModelParams, RegisteredModelParams
             {
                 "flavor": None,
             },
-            LoggedModelParams(
-                flavor="custom",
-            ),
+            None,
         ),
-        (
-            {},
-            LoggedModelParams(
-                flavor="custom",
-            ),
-        ),
+        ({}, None),
     ],
 )
 def test_logged_model_parser(arguments, expected_params):

--- a/tests/telemetry/test_parser.py
+++ b/tests/telemetry/test_parser.py
@@ -9,9 +9,15 @@ from mlflow.telemetry.schemas import LoggedModelParams, RegisteredModelParams
     ("arguments", "expected_params"),
     [
         (
-            {"flavor": "pyfunc"},
+            {"flavor": "mlflow.pyfunc"},
             LoggedModelParams(
                 flavor="pyfunc",
+            ),
+        ),
+        (
+            {"flavor": "sklearn"},
+            LoggedModelParams(
+                flavor="sklearn",
             ),
         ),
         (

--- a/tests/telemetry/test_track.py
+++ b/tests/telemetry/test_track.py
@@ -13,8 +13,6 @@ from mlflow.telemetry.schemas import APIStatus
 from mlflow.telemetry.track import track_api_usage
 from mlflow.telemetry.utils import is_telemetry_disabled
 
-from tests.helper_functions import validate_telemetry_record
-
 
 def test_track_api_usage(mock_requests):
     assert len(mock_requests) == 0
@@ -116,19 +114,3 @@ def test_track_api_usage_update_env_var_after_import(monkeypatch, mock_requests)
     test_func()
     # no new record should be added
     assert len(mock_requests) == 1
-
-
-def test_track_api_usage_do_not_track_internal_api_complex(mock_requests):
-    @track_api_usage
-    def test_func_1():
-        test_func_2()
-
-    def test_func_2():
-        test_func_3()
-
-    @track_api_usage
-    def test_func_3():
-        pass
-
-    test_func_1()
-    validate_telemetry_record(mock_requests, test_func_1)

--- a/tests/telemetry/test_tracked_apis.py
+++ b/tests/telemetry/test_tracked_apis.py
@@ -28,10 +28,10 @@ def test_create_logged_model(mock_requests):
     func = TrackingServiceClient.create_logged_model
 
     mlflow.create_external_model(name="model")
-    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="custom"))
+    validate_telemetry_record(mock_requests, func)
 
     mlflow.initialize_logged_model(name="model", tags={"key": "value"})
-    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="custom"))
+    validate_telemetry_record(mock_requests, func)
 
     mlflow.pyfunc.log_model(
         name="model",

--- a/tests/telemetry/test_tracked_apis.py
+++ b/tests/telemetry/test_tracked_apis.py
@@ -1,0 +1,162 @@
+import pandas as pd
+import pytest
+import sklearn.neighbors as knn
+
+import mlflow
+from mlflow import MlflowClient
+from mlflow.entities import Feedback
+from mlflow.models.evaluation.base import _evaluate
+from mlflow.telemetry.schemas import LoggedModelParams, RegisteredModelParams
+from mlflow.tracing.client import TracingClient
+from mlflow.tracking._model_registry.client import ModelRegistryClient
+from mlflow.tracking._tracking_service.client import TrackingServiceClient
+
+from tests.helper_functions import validate_telemetry_record
+
+
+class TestModel(mlflow.pyfunc.PythonModel):
+    def predict(self, model_input: list[str]) -> list[str]:
+        return model_input
+
+
+@pytest.fixture
+def mlflow_client():
+    return MlflowClient()
+
+
+def test_create_logged_model(mock_requests):
+    func = TrackingServiceClient.create_logged_model
+
+    mlflow.create_external_model(name="model")
+    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="custom"))
+
+    mlflow.initialize_logged_model(name="model", tags={"key": "value"})
+    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="custom"))
+
+    mlflow.pyfunc.log_model(
+        name="model",
+        python_model=TestModel(),
+    )
+    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="mlflow.pyfunc"))
+
+    mlflow.sklearn.log_model(
+        knn.KNeighborsClassifier(),
+        name="model",
+    )
+    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="mlflow.sklearn"))
+
+
+def test_create_experiment(mock_requests, mlflow_client):
+    mlflow.create_experiment(name="test_experiment")
+    validate_telemetry_record(mock_requests, TrackingServiceClient.create_experiment)
+
+    mlflow_client.create_experiment(name="test_experiment1")
+    validate_telemetry_record(mock_requests, TrackingServiceClient.create_experiment)
+
+
+def test_create_run(mock_requests, mlflow_client):
+    exp_id = mlflow.create_experiment(name="test_experiment")
+    with mlflow.start_run(experiment_id=exp_id):
+        validate_telemetry_record(
+            mock_requests, TrackingServiceClient.create_run, search_index=True
+        )
+
+    mlflow_client.create_run(experiment_id=exp_id)
+    validate_telemetry_record(mock_requests, TrackingServiceClient.create_run)
+
+
+def test_create_registered_model(mock_requests, mlflow_client):
+    mlflow_client.create_registered_model(name="test_model1")
+    validate_telemetry_record(
+        mock_requests,
+        ModelRegistryClient.create_registered_model,
+        RegisteredModelParams(is_prompt=False),
+    )
+
+    mlflow.pyfunc.log_model(
+        name="model",
+        python_model=TestModel(),
+        registered_model_name="test_model",
+    )
+    validate_telemetry_record(
+        mock_requests,
+        ModelRegistryClient.create_registered_model,
+        RegisteredModelParams(is_prompt=False),
+        search_index=True,
+    )
+
+
+def test_create_model_version(mock_requests, mlflow_client):
+    mlflow_client.create_registered_model(name="test_model")
+    mlflow_client.create_model_version(
+        name="test_model", source="test_source", run_id="test_run_id"
+    )
+    validate_telemetry_record(
+        mock_requests, ModelRegistryClient.create_model_version, search_index=True
+    )
+
+    mlflow.pyfunc.log_model(
+        name="model",
+        python_model=TestModel(),
+        registered_model_name="test_model",
+    )
+    validate_telemetry_record(
+        mock_requests, ModelRegistryClient.create_model_version, search_index=True
+    )
+
+
+def test_start_trace(mock_requests, mlflow_client):
+    with mlflow.start_span(name="test_span"):
+        pass
+    validate_telemetry_record(mock_requests, TracingClient.start_trace)
+
+    @mlflow.trace
+    def test_func():
+        pass
+
+    test_func()
+    validate_telemetry_record(mock_requests, TracingClient.start_trace)
+
+    trace_id = mlflow_client.start_trace(name="test_trace").trace_id
+    mlflow_client.end_trace(trace_id=trace_id)
+    validate_telemetry_record(mock_requests, TracingClient.start_trace)
+
+
+def test_create_prompt(mock_requests, mlflow_client):
+    mlflow_client.create_prompt(name="test_prompt")
+    validate_telemetry_record(mock_requests, ModelRegistryClient.create_prompt, search_index=True)
+
+    # OSS prompt registry uses create_registered_model with a special tag
+    mlflow.genai.register_prompt(
+        name="greeting_prompt",
+        template="Respond to the user's message as a {{style}} AI. {{greeting}}",
+    )
+    expected_params = RegisteredModelParams(is_prompt=True)
+    validate_telemetry_record(
+        mock_requests,
+        ModelRegistryClient.create_registered_model,
+        expected_params,
+        search_index=True,
+    )
+
+
+def test_log_assessment(mock_requests):
+    with mlflow.start_span(name="test_span") as span:
+        feedback = Feedback(
+            name="faithfulness",
+            value=0.9,
+            rationale="The model is faithful to the input.",
+            metadata={"model": "gpt-4o-mini"},
+        )
+
+        mlflow.log_assessment(trace_id=span.trace_id, assessment=feedback)
+    validate_telemetry_record(mock_requests, TracingClient.log_assessment)
+
+
+def test_evaluate(mock_requests):
+    mlflow.models.evaluate(
+        data=pd.DataFrame({"x": [1, 2, 3], "y": [4, 5, 6]}),
+        model=lambda x: x["x"] * 2,
+        extra_metrics=[mlflow.metrics.latency()],
+    )
+    validate_telemetry_record(mock_requests, _evaluate, search_index=True)

--- a/tests/telemetry/test_tracked_apis.py
+++ b/tests/telemetry/test_tracked_apis.py
@@ -37,13 +37,13 @@ def test_create_logged_model(mock_requests):
         name="model",
         python_model=TestModel(),
     )
-    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="mlflow.pyfunc"))
+    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="pyfunc"))
 
     mlflow.sklearn.log_model(
         knn.KNeighborsClassifier(),
         name="model",
     )
-    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="mlflow.sklearn"))
+    validate_telemetry_record(mock_requests, func, LoggedModelParams(flavor="sklearn"))
 
 
 def test_create_experiment(mock_requests, mlflow_client):

--- a/tests/telemetry/test_utils.py
+++ b/tests/telemetry/test_utils.py
@@ -1,13 +1,6 @@
-from concurrent.futures import ThreadPoolExecutor
-
-from mlflow.telemetry.client import get_telemetry_client
-from mlflow.telemetry.track import track_api_usage
 from mlflow.telemetry.utils import (
-    _disable_telemetry,
     is_telemetry_disabled,
 )
-
-from tests.helper_functions import validate_telemetry_record
 
 
 def test_is_telemetry_disabled(monkeypatch):
@@ -22,42 +15,3 @@ def test_is_telemetry_disabled(monkeypatch):
     with monkeypatch.context() as m:
         m.setenv("DO_NOT_TRACK", "true")
         assert is_telemetry_disabled() is True
-
-
-def test_disable_telemetry(mock_requests):
-    @track_api_usage
-    def test_func():
-        pass
-
-    with _disable_telemetry():
-        test_func()
-        get_telemetry_client().flush()
-    assert len(mock_requests) == 0
-
-    test_func()
-    get_telemetry_client().flush()
-    assert len(mock_requests) == 1
-    validate_telemetry_record(mock_requests, test_func)
-
-
-def test_disable_telemetry_multiple_threads(mock_requests):
-    @track_api_usage
-    def test_func():
-        pass
-
-    def thread_target(x):
-        if x % 2 == 0:
-            with _disable_telemetry():
-                test_func()
-        else:
-            test_func()
-
-    with ThreadPoolExecutor(max_workers=10) as executor:
-        futures = [executor.submit(thread_target, i) for i in range(10)]
-        for f in futures:
-            f.result()
-
-    get_telemetry_client().flush()
-    assert len(mock_requests) == 5
-    for i in range(len(mock_requests)):
-        assert mock_requests[i]["data"]["api_name"] == test_func.__qualname__

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -65,7 +65,6 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_USER,
 )
 
-from tests.helper_functions import avoid_telemetry_tracking
 from tests.tracing.conftest import async_logging_enabled  # noqa: F401
 from tests.tracing.helper import create_test_trace_info, get_traces
 
@@ -404,10 +403,9 @@ def tracking_uri(request, tmp_path, monkeypatch):
 
     # NB: MLflow tracer does not handle the change of tracking URI well,
     # so we need to reset the tracer to switch the tracking URI during testing.
-    with avoid_telemetry_tracking():
-        mlflow.tracing.disable()
-        mlflow.set_tracking_uri(tracking_uri)
-        mlflow.tracing.enable()
+    mlflow.tracing.disable()
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.tracing.enable()
 
     yield tracking_uri
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/16784?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16784/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16784/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16784/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
- track APIs
  - create_logged_model
  - create_experiment
  - create_run
  - create_registered_model
  - create_model_version
  - start_trace
  - create_prompt
  - log_assessment
  - _evaluate
- Now we track internal APIs, remove the useless variables and functions
- Added `flavor` param in `_create_logged_model` so that we can know the flavor of the logged model without changing the public facing API



<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
