### PR TITLE
[TS #18] Implement decorator

### DIFF
--- a/libs/typescript/core/src/core/api.ts
+++ b/libs/typescript/core/src/core/api.ts
@@ -278,7 +278,7 @@ export function trace<T extends (...args: any[]) => any>(
           name: decoratorOptions?.name || originalMethod.name || String(propertyKey),
           spanType: decoratorOptions?.spanType,
           attributes: decoratorOptions?.attributes,
-          inputs: inputs
+          inputs,
         };
 
         return withSpan((_span) => {

--- a/libs/typescript/core/src/core/api.ts
+++ b/libs/typescript/core/src/core/api.ts
@@ -205,32 +205,109 @@ function createAndRegisterMlflowSpan(
 }
 
 /**
- * Create a traced version of a function.
+ * Create a traced version of a function or decorator for tracing class methods.
  *
- * When the function is called, the span will automatically capture:
+ * When used as a function wrapper, the span will automatically capture:
  * - The function inputs
  * - The function outputs
  * - The function name as the span name
  * - The function execution time
  * - Any exception thrown by the function
  *
- * @param func The function to trace
+ * When used as a decorator, it preserves the `this` context for class methods.
+ *
+ * @param func The function to trace (when used as function wrapper)
  * @param options Optional trace options including name, spanType, and attributes
- * @returns The traced function
+ * @returns The traced function or method decorator
  *
  * @example
- * // With no options (uses function name as span name)
+ * // Function wrapper with no options
  * const tracedFunc = trace(myFunc);
  *
  * @example
- * // With options
+ * // Function wrapper with options
  * const tracedFunc = trace(myFunc, { name: 'custom_span_name', spanType: 'LLM' });
-
+ *
  * @example
- * // Inline declaration
- * const myFunc = trace(async (a: number, b: number) => a + b, { spanType: 'TOOL' });
+ * // Decorator with no options
+ * class MyService {
+ *   @trace()
+ *   async processData(data: any) {
+ *     return processedData;
+ *   }
+ * }
+ *
+ * @example
+ * // Decorator with options
+ * class MyService {
+ *   @trace({ name: 'custom_span', spanType: SpanType.LLM })
+ *   async generateText(prompt: string) {
+ *     return generatedText;
+ *   }
+ * }
  */
-export function trace<T extends (...args: any[]) => any>(func: T, options?: TraceOptions): T {
+export function trace(options?: TraceOptions): MethodDecorator;
+export function trace<T extends (...args: any[]) => any>(func: T, options?: TraceOptions): T;
+export function trace<T extends (...args: any[]) => any>(
+  funcOrOptions?: T | TraceOptions,
+  options?: TraceOptions
+): T | MethodDecorator {
+  // Check if this is being used as a decorator (no function provided, or options provided)
+  if (typeof funcOrOptions !== 'function') {
+    const decoratorOptions = funcOrOptions as TraceOptions | undefined;
+    
+    // Return a method decorator
+    return function (_target: any, propertyKey: string | symbol, descriptor: PropertyDescriptor) {
+      const originalMethod = descriptor.value;
+      
+      if (typeof originalMethod !== 'function') {
+        throw new Error('@trace decorator can only be applied to methods');
+      }
+      
+      // Create the traced method wrapper
+      descriptor.value = function (this: any, ...args: any[]) {
+        let inputs: any;
+        try {
+          inputs = mapArgsToObject(originalMethod, args);
+        } catch (error) {
+          console.debug('Failed to map arguments values to names', error);
+          inputs = args;
+        }
+
+        const spanOptions: Omit<SpanOptions, 'parent'> = {
+          name: decoratorOptions?.name || originalMethod.name || String(propertyKey),
+          spanType: decoratorOptions?.spanType,
+          attributes: decoratorOptions?.attributes,
+          inputs: inputs
+        };
+
+        // The key insight: preserve the original `this` context
+        const originalThis = this;
+        
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+        return withSpan((_span) => {
+          // Call the original method with the preserved `this` context
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+          return originalMethod.apply(originalThis, args);
+        }, spanOptions);
+      };
+      
+      // Preserve the original method's properties
+      Object.defineProperty(descriptor.value, 'length', { value: originalMethod.length });
+      Object.defineProperty(descriptor.value, 'name', { value: originalMethod.name });
+      
+      return descriptor;
+    };
+  } else {
+    // This is the function-based usage (existing behavior)
+    return traceFunction(funcOrOptions, options);
+  }
+}
+
+/**
+ * Internal function to handle function-based tracing (non-decorator usage)
+ */
+function traceFunction<T extends (...args: any[]) => any>(func: T, options?: TraceOptions): T {
   // Create a wrapper function that preserves the original function's properties
   const wrapper = function (this: any, ...args: Parameters<T>): ReturnType<T> {
     let inputs: any;

--- a/libs/typescript/core/src/core/api.ts
+++ b/libs/typescript/core/src/core/api.ts
@@ -278,7 +278,7 @@ export function trace<T extends (...args: any[]) => any>(
           name: decoratorOptions?.name || originalMethod.name || String(propertyKey),
           spanType: decoratorOptions?.spanType,
           attributes: decoratorOptions?.attributes,
-          inputs,
+          inputs
         };
 
         return withSpan((_span) => {

--- a/libs/typescript/core/tests/core/api.test.ts
+++ b/libs/typescript/core/tests/core/api.test.ts
@@ -802,7 +802,7 @@ describe('API', () => {
 
       // Async method
       async asyncMultiply(x: number): Promise<number> {
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 10));
         return this.value * x;
       }
 
@@ -824,7 +824,7 @@ describe('API', () => {
       // Async method with decorator
       @mlflow.trace({ name: 'async_multiply_decorated', spanType: SpanType.TOOL })
       async asyncMultiply(x: number): Promise<number> {
-        await new Promise(resolve => setTimeout(resolve, 10));
+        await new Promise((resolve) => setTimeout(resolve, 10));
         return this.value * x;
       }
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16791?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16791/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16791/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16791/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.trace` wrapper doesn't work with class method. As a workaround, support decorating methods to allow users trace methods easily. The usage is very similar to Python one.

```
    class DecoratedTestClass {
      private value = 42;

      @mlflow.trace({ spanType: 'TOOL' })
      multiply(x: number): number {
        return this.value * x;
      }
    }
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Will update https://github.com/mlflow/mlflow/pull/16755 once this PR is merged.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
