### PR TITLE
Replace `collections.namedtuple` with `typing.NamedTuple`

### DIFF
--- a/mlflow/models/evaluation/artifacts.py
+++ b/mlflow/models/evaluation/artifacts.py
@@ -1,8 +1,8 @@
 import json
 import pathlib
 import pickle
-from collections import namedtuple
 from json import JSONDecodeError
+from typing import NamedTuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -116,9 +116,11 @@ _TYPE_TO_ARTIFACT_MAP = {
     plt.Figure: ImageEvaluationArtifact,
 }
 
-_InferredArtifactProperties = namedtuple(
-    "_InferredArtifactProperties", ["from_path", "type", "ext"]
-)
+
+class _InferredArtifactProperties(NamedTuple):
+    from_path: bool
+    type: type[EvaluationArtifact]
+    ext: str
 
 
 def _infer_artifact_type_and_ext(artifact_name, raw_artifact, custom_metric_tuple):

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -573,12 +573,6 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels, sample_we
     return pd.DataFrame(per_class_metrics_list)
 
 
-class _Curve(NamedTuple):
-    plot_fn: Callable[..., Any]
-    plot_fn_args: dict[str, Any]
-    auc: float
-
-
 def _gen_classifier_curve(
     is_binomial,
     y,

--- a/mlflow/models/evaluation/evaluators/classifier.py
+++ b/mlflow/models/evaluation/evaluators/classifier.py
@@ -1,8 +1,7 @@
 import logging
 import math
-from collections import namedtuple
 from contextlib import contextmanager
-from typing import Optional
+from typing import Any, Callable, NamedTuple, Optional
 
 import numpy as np
 import pandas as pd
@@ -23,7 +22,10 @@ from mlflow.models.utils import plot_lines
 _logger = logging.getLogger(__name__)
 
 
-_Curve = namedtuple("_Curve", ["plot_fn", "plot_fn_args", "auc"])
+class _Curve(NamedTuple):
+    plot_fn: Callable[..., Any]
+    plot_fn_args: dict[str, Any]
+    auc: float
 
 
 class ClassifierEvaluator(BuiltInEvaluator):
@@ -571,7 +573,10 @@ def _get_classifier_per_class_metrics_collection_df(y, y_pred, labels, sample_we
     return pd.DataFrame(per_class_metrics_list)
 
 
-_Curve = namedtuple("_Curve", ["plot_fn", "plot_fn_args", "auc"])
+class _Curve(NamedTuple):
+    plot_fn: Callable[..., Any]
+    plot_fn_args: dict[str, Any]
+    auc: float
 
 
 def _gen_classifier_curve(

--- a/mlflow/pyspark/ml/__init__.py
+++ b/mlflow/pyspark/ml/__init__.py
@@ -4,8 +4,9 @@ import logging
 import os
 import traceback
 import weakref
-from collections import OrderedDict, defaultdict, namedtuple
+from collections import OrderedDict, defaultdict
 from itertools import zip_longest
+from typing import Any, NamedTuple
 from urllib.parse import urlparse
 
 import numpy as np
@@ -211,10 +212,10 @@ def _should_log_hierarchy(estimator):
     )
 
 
-_AutologgingEstimatorMetadata = namedtuple(
-    "_AutologgingEstimatorMetadata",
-    ["hierarchy", "uid_to_indexed_name_map", "param_search_estimators"],
-)
+class _AutologgingEstimatorMetadata(NamedTuple):
+    hierarchy: dict[str, Any]
+    uid_to_indexed_name_map: dict[str, str]
+    param_search_estimators: list[Any]
 
 
 def _traverse_stage(stage):

--- a/mlflow/sklearn/utils.py
+++ b/mlflow/sklearn/utils.py
@@ -1,4 +1,3 @@
-import collections
 import inspect
 import logging
 import pkgutil
@@ -8,6 +7,7 @@ from copy import deepcopy
 from importlib import import_module
 from numbers import Number
 from operator import itemgetter
+from typing import Any, Callable, NamedTuple
 
 import numpy as np
 from packaging.version import Version
@@ -28,15 +28,22 @@ _TRAINING_PREFIX = "training_"
 
 _SAMPLE_WEIGHT = "sample_weight"
 
+
 # _SklearnArtifact represents a artifact (e.g confusion matrix) that will be computed and
 # logged during the autologging routine for a particular model type (eg, classifier, regressor).
-_SklearnArtifact = collections.namedtuple(
-    "_SklearnArtifact", ["name", "function", "arguments", "title"]
-)
+class _SklearnArtifact(NamedTuple):
+    name: str
+    function: Callable[..., Any]
+    arguments: dict[str, Any]
+    title: str
+
 
 # _SklearnMetric represents a metric (e.g, precision_score) that will be computed and
 # logged during the autologging routine for a particular model type (eg, classifier, regressor).
-_SklearnMetric = collections.namedtuple("_SklearnMetric", ["name", "function", "arguments"])
+class _SklearnMetric(NamedTuple):
+    name: str
+    function: Callable[..., Any]
+    arguments: dict[str, Any]
 
 
 def _gen_xgboost_sklearn_estimators_to_patch():

--- a/mlflow/store/artifact/cloud_artifact_repo.py
+++ b/mlflow/store/artifact/cloud_artifact_repo.py
@@ -4,9 +4,8 @@ import os
 import posixpath
 import time
 from abc import abstractmethod
-from collections import namedtuple
 from concurrent.futures import as_completed
-from typing import Optional
+from typing import NamedTuple, Optional
 
 from mlflow.environment_variables import (
     _MLFLOW_MPD_NUM_RETRIES,
@@ -86,15 +85,11 @@ def _complete_futures(futures_dict, file):
     return results, errors
 
 
-StagedArtifactUpload = namedtuple(
-    "StagedArtifactUpload",
-    [
-        # Local filesystem path of the source file to upload
-        "src_file_path",
-        # Base artifact URI-relative path specifying the upload destination
-        "artifact_file_path",
-    ],
-)
+class StagedArtifactUpload(NamedTuple):
+    # Local filesystem path of the source file to upload
+    src_file_path: str
+    # Base artifact URI-relative path specifying the upload destination
+    artifact_file_path: str
 
 
 class CloudArtifactRepository(ArtifactRepository):

--- a/mlflow/store/artifact/gcs_artifact_repo.py
+++ b/mlflow/store/artifact/gcs_artifact_repo.py
@@ -3,8 +3,7 @@ import importlib.metadata
 import os
 import posixpath
 import urllib.parse
-from collections import namedtuple
-from typing import Optional
+from typing import Any, NamedTuple, Optional
 
 from packaging.version import Version
 
@@ -26,7 +25,12 @@ from mlflow.store.artifact.artifact_repo import (
 )
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 
-GCSMPUArguments = namedtuple("GCSMPUArguments", ["transport", "url", "headers", "content_type"])
+
+class GCSMPUArguments(NamedTuple):
+    transport: Any
+    url: str
+    headers: dict[str, str]
+    content_type: str
 
 
 class GCSArtifactRepository(ArtifactRepository, MultipartUploadMixin):

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -17,9 +17,8 @@ import re
 import shutil
 import string
 import sys
-from collections import namedtuple
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 from urllib.parse import urlparse
 
 import numpy as np
@@ -263,6 +262,15 @@ def get_default_conda_env(model):
         flavor, based on the model instance framework type of the model to be logged.
     """
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements(model))
+
+
+class _DummyModel(NamedTuple):
+    name_or_path: str
+
+
+class _DummyPipeline(NamedTuple):
+    task: str
+    model: _DummyModel
 
 
 @docstring_version_compatibility_warning(integration_name=FLAVOR_NAME)
@@ -517,9 +525,9 @@ def save_model(
             )
 
         # Create a dummy pipeline object to be used for saving the model
-        DummyModel = namedtuple("DummyModel", ["name_or_path"])
-        DummyPipeline = namedtuple("DummyPipeline", ["task", "model"])
-        built_pipeline = DummyPipeline(task=task, model=DummyModel(name_or_path=transformers_model))
+        built_pipeline = _DummyPipeline(
+            task=task, model=_DummyModel(name_or_path=transformers_model)
+        )
     else:
         raise MlflowException(
             "The `transformers_model` must be one of the following types: \n"

--- a/mlflow/utils/autologging_utils/client.py
+++ b/mlflow/utils/autologging_utils/client.py
@@ -10,10 +10,9 @@ Remove this developer API.
 
 import logging
 import os
-from collections import namedtuple
 from concurrent.futures import ThreadPoolExecutor
 from itertools import zip_longest
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 from mlflow.entities import Metric, Param, RunTag
 from mlflow.entities.dataset_input import DatasetInput
@@ -35,10 +34,17 @@ if TYPE_CHECKING:
 
 _logger = logging.getLogger(__name__)
 
-_PendingCreateRun = namedtuple(
-    "_PendingCreateRun", ["experiment_id", "start_time", "tags", "run_name"]
-)
-_PendingSetTerminated = namedtuple("_PendingSetTerminated", ["status", "end_time"])
+
+class _PendingCreateRun(NamedTuple):
+    experiment_id: str
+    start_time: Optional[int]
+    tags: list[RunTag]
+    run_name: Optional[str]
+
+
+class _PendingSetTerminated(NamedTuple):
+    status: Optional[str]
+    end_time: Optional[int]
 
 
 class PendingRunId:

--- a/mlflow/utils/requirements_utils.py
+++ b/mlflow/utils/requirements_utils.py
@@ -11,7 +11,6 @@ import re
 import subprocess
 import sys
 import tempfile
-from collections import namedtuple
 from itertools import chain, filterfalse
 from pathlib import Path
 from threading import Timer
@@ -80,11 +79,11 @@ def _join_continued_lines(lines):
         yield "".join(continued_lines)
 
 
-# Represents a pip requirement.
-#
-# :param req_str: A requirement string (e.g. "scikit-learn == 0.24.2").
-# :param is_constraint: A boolean indicating whether this requirement is a constraint.
-_Requirement = namedtuple("_Requirement", ["req_str", "is_constraint"])
+class _Requirement(NamedTuple):
+    # A string representation of the requirement.
+    req_str: str
+    # A boolean indicating whether this requirement is a constraint.
+    is_constraint: bool
 
 
 def _parse_requirements(requirements, is_constraint, base_dir=None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -211,6 +211,7 @@ select = [
   "PT027",   # pytest-unittest-raises-assertion
   "PT030",   # pytest-warns-too-broad
   "PT031",   # pytest-warns-with-multiple-statements
+  "PYI024",  # collections-named-tuple
   "RET504",  # unnecessary-assign
   "RUF002",  # ambiguous-unicode-character-docstring
   "RUF003",  # ambiguous-unicode-character-comment

--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -1,6 +1,5 @@
 import pathlib
 import uuid
-from collections import namedtuple
 from typing import NamedTuple
 from unittest import mock
 
@@ -11,7 +10,10 @@ from mlflow.exceptions import MlflowException
 from mlflow.utils.file_utils import mkdir, path_to_local_file_uri
 from mlflow.utils.os import is_windows
 
-Artifact = namedtuple("Artifact", ["uri", "content"])
+
+class Artifact(NamedTuple):
+    uri: str
+    content: str
 
 
 @pytest.fixture

--- a/tests/autologging/test_autologging_safety_unit.py
+++ b/tests/autologging/test_autologging_safety_unit.py
@@ -1,8 +1,8 @@
 import abc
 import copy
 import inspect
-from collections import namedtuple
 from contextlib import nullcontext as does_not_raise
+from typing import Any, NamedTuple
 from unittest import mock
 
 import pytest
@@ -67,18 +67,14 @@ def test_autologging_integration():
 
 
 class MockEventLogger(AutologgingEventLogger):
-    LoggerCall = namedtuple(
-        "LoggerCall",
-        [
-            "method",
-            "session",
-            "patch_obj",
-            "function_name",
-            "call_args",
-            "call_kwargs",
-            "exception",
-        ],
-    )
+    class LoggerCall(NamedTuple):
+        method: str
+        session: Any
+        patch_obj: Any
+        function_name: str
+        call_args: Any
+        call_kwargs: Any
+        exception: Any
 
     def __init__(self):
         self.calls = []

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -1,7 +1,7 @@
 import inspect
 import sys
 import time
-from collections import namedtuple
+from typing import Any, NamedTuple
 from unittest import mock
 
 import pytest
@@ -467,7 +467,10 @@ def test_autologging_integration_makes_expected_event_logging_calls():
         raise Exception("autolog failed")
 
     class TestLogger(AutologgingEventLogger):
-        LoggerCall = namedtuple("LoggerCall", ["integration", "call_args", "call_kwargs"])
+        class LoggerCall(NamedTuple):
+            integration: Any
+            call_args: Any
+            call_kwargs: Any
 
         def __init__(self):
             self.calls = []

--- a/tests/catboost/test_catboost_model_export.py
+++ b/tests/catboost/test_catboost_model_export.py
@@ -1,7 +1,7 @@
 import json
 import os
-from collections import namedtuple
 from pathlib import Path
+from typing import Any, NamedTuple
 from unittest import mock
 
 import catboost as cb
@@ -39,7 +39,10 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("catboost") else ["--env-manager", "local"]
 )
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
+
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_dataframe: Any
 
 
 def get_iris():

--- a/tests/db/test_schema.py
+++ b/tests/db/test_schema.py
@@ -1,7 +1,7 @@
 import difflib
 import re
-from collections import namedtuple
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 from sqlalchemy import create_engine
@@ -34,7 +34,9 @@ def dump_schema(db_uri):
     return "\n".join(lines)
 
 
-_CreateTable = namedtuple("_CreateTable", ["table", "columns"])
+class _CreateTable(NamedTuple):
+    table: str
+    columns: str
 
 
 _CREATE_TABLE_REGEX = re.compile(

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -6,7 +6,7 @@ import re
 import signal
 import subprocess
 import uuid
-from collections import namedtuple
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -87,7 +87,11 @@ def get_breast_cancer_dataset():
     return data.data, data.target
 
 
-RunData = namedtuple("RunData", ["params", "metrics", "tags", "artifacts"])
+class RunData(NamedTuple):
+    params: dict[str, Any]
+    metrics: dict[str, Any]
+    tags: dict[str, Any]
+    artifacts: list[str]
 
 
 def get_run_data(run_id):

--- a/tests/gateway/tools.py
+++ b/tests/gateway/tools.py
@@ -6,9 +6,8 @@ import subprocess
 import sys
 import threading
 import time
-from collections import namedtuple
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, NamedTuple, Optional, Union
 from unittest import mock
 
 import aiohttp
@@ -236,7 +235,9 @@ class UvicornGateway:
         self.thread.join()
 
 
-ServerInfo = namedtuple("ServerInfo", ["pid", "url"])
+class ServerInfo(NamedTuple):
+    pid: int
+    url: str
 
 
 def log_sentence_transformers_model():

--- a/tests/h2o/test_h2o_model_export.py
+++ b/tests/h2o/test_h2o_model_export.py
@@ -2,7 +2,7 @@
 
 import json
 import os
-from collections import namedtuple
+from typing import Any, NamedTuple
 from unittest import mock
 
 import h2o
@@ -34,7 +34,10 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
 )
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_data: Any
 
 
 @pytest.fixture

--- a/tests/lightgbm/test_lightgbm_model_export.py
+++ b/tests/lightgbm/test_lightgbm_model_export.py
@@ -1,7 +1,7 @@
 import json
 import os
-from collections import namedtuple
 from pathlib import Path
+from typing import NamedTuple
 from unittest import mock
 
 import lightgbm as lgb
@@ -40,7 +40,10 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("lightgbm") else ["--env-manager", "local"]
 )
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
+
+class ModelWithData(NamedTuple):
+    model: lgb.Booster
+    inference_dataframe: pd.DataFrame
 
 
 @pytest.fixture(scope="module")

--- a/tests/models/test_utils.py
+++ b/tests/models/test_utils.py
@@ -1,6 +1,6 @@
 import os
 import random
-from collections import namedtuple
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -31,7 +31,10 @@ from mlflow.pyfunc import _enforce_schema, _validate_prediction_input
 from mlflow.types import DataType, Schema
 from mlflow.types.schema import Array, ColSpec, Object, Property
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_data: Any
 
 
 @pytest.fixture(scope="module")

--- a/tests/models/test_wheeled_model.py
+++ b/tests/models/test_wheeled_model.py
@@ -1,7 +1,7 @@
 import os
 import random
 import re
-from collections import namedtuple
+from typing import Any, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -37,7 +37,9 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
 )
 
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_data: Any
 
 
 @pytest.fixture(scope="module")

--- a/tests/paddle/test_paddle_model_export.py
+++ b/tests/paddle/test_paddle_model_export.py
@@ -1,6 +1,6 @@
 import json
 import os
-from collections import namedtuple
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -37,7 +37,10 @@ from tests.helper_functions import (
     pyfunc_serve_and_score_model,
 )
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe"])
+
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_dataframe: Any
 
 
 def get_dataset():

--- a/tests/prophet/test_prophet_model_export.py
+++ b/tests/prophet/test_prophet_model_export.py
@@ -1,8 +1,8 @@
 import json
 import os
-from collections import namedtuple
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -67,7 +67,10 @@ class DataGeneration:
         )
 
     def _generate_linear_data(self):
-        DataStruct = namedtuple("DataStruct", "dates, series")
+        class DataStruct(NamedTuple):
+            dates: Any
+            series: Any
+
         series = self._generate_raw()
         date_ranges = np.arange(
             self.start, self.start + timedelta(days=self.size), timedelta(days=1)
@@ -75,7 +78,10 @@ class DataGeneration:
         return DataStruct(date_ranges, series)
 
     def _generate_shift_data(self):
-        DataStruct = namedtuple("DataStruct", "dates, series")
+        class DataStruct(NamedTuple):
+            dates: Any
+            series: Any
+
         raw = self._generate_raw()[: int(self.size * 0.6)]
         temperature = np.concatenate((raw, raw / 2.0)).ravel()[: self.size]
         date_ranges = np.arange(
@@ -112,7 +118,10 @@ TARGET_FIELD_NAME = "yhat"
 DS_FORMAT = "%Y-%m-%dT%H:%M:%S"
 INFER_FORMAT = "%Y-%m-%d %H:%M:%S"
 
-ModelWithSource = namedtuple("ModelWithSource", ["model", "data"])
+
+class ModelWithSource(NamedTuple):
+    model: Any
+    data: Any
 
 
 @pytest.fixture(scope="module")

--- a/tests/pyfunc/test_scoring_server.py
+++ b/tests/pyfunc/test_scoring_server.py
@@ -3,9 +3,8 @@ import math
 import os
 import random
 import signal
-from collections import namedtuple
 from io import StringIO
-from typing import Any
+from typing import Any, NamedTuple
 
 import keras
 import numpy as np
@@ -48,7 +47,9 @@ else:
     from keras.optimizers import SGD
 
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_data: Any
 
 
 def build_and_save_sklearn_model(model_path):

--- a/tests/pyfunc/test_spark.py
+++ b/tests/pyfunc/test_spark.py
@@ -6,9 +6,8 @@ import subprocess
 import sys
 import threading
 import time
-from collections import namedtuple
 from pathlib import Path
-from typing import Iterator
+from typing import Any, Iterator, NamedTuple
 from unittest import mock
 
 import cloudpickle
@@ -148,7 +147,9 @@ def model_path(tmp_path):
     return os.path.join(tmp_path, "model")
 
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_data: Any
 
 
 @pytest.fixture(scope="module")

--- a/tests/pyfunc/test_virtualenv.py
+++ b/tests/pyfunc/test_virtualenv.py
@@ -1,8 +1,8 @@
 import os
 import sys
-from collections import namedtuple
 from io import BytesIO
 from stat import S_IRGRP, S_IROTH, S_IRUSR, S_IXGRP, S_IXOTH, S_IXUSR
+from typing import NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -31,13 +31,19 @@ TEST_DIR = "tests"
 TEST_MLFLOW_1X_MODEL_DIR = os.path.join(TEST_DIR, "resources", "example_mlflow_1x_sklearn_model")
 
 
+class Model(NamedTuple):
+    model: LogisticRegression
+    X_pred: pd.DataFrame
+    y_pred: np.ndarray
+
+
 @pytest.fixture(scope="module")
 def sklearn_model():
     X, y = load_iris(return_X_y=True, as_frame=True)
     model = LogisticRegression().fit(X, y)
     X_pred = X.sample(frac=0.1, random_state=0)
     y_pred = model.predict(X_pred)
-    return namedtuple("Model", ["model", "X_pred", "y_pred"])(model, X_pred, y_pred)
+    return Model(model, X_pred, y_pred)
 
 
 def serve_and_score(model_uri, data, extra_args=None):

--- a/tests/sagemaker/mock/__init__.py
+++ b/tests/sagemaker/mock/__init__.py
@@ -1,13 +1,16 @@
 import json
 import time
-from collections import namedtuple
 from datetime import datetime
+from typing import Any, NamedTuple
 
 from moto.core import DEFAULT_ACCOUNT_ID, BackendDict, BaseBackend, BaseModel
 from moto.core.models import base_decorator
 from moto.core.responses import BaseResponse
 
-SageMakerResourceWithArn = namedtuple("SageMakerResourceWithArn", ["resource", "arn"])
+
+class SageMakerResourceWithArn(NamedTuple):
+    resource: Any
+    arn: str
 
 
 class SageMakerResponse(BaseResponse):

--- a/tests/sagemaker/test_batch_deployment.py
+++ b/tests/sagemaker/test_batch_deployment.py
@@ -1,7 +1,7 @@
 import os
 import time
-from collections import namedtuple
 from functools import wraps
+from typing import NamedTuple
 from unittest import mock
 
 import boto3
@@ -31,7 +31,11 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from tests.helper_functions import set_boto_credentials  # noqa: F401
 from tests.sagemaker.mock import TransformJob, TransformJobOperation, mock_sagemaker
 
-TrainedModel = namedtuple("TrainedModel", ["model_path", "run_id", "model_uri"])
+
+class TrainedModel(NamedTuple):
+    model_path: str
+    run_id: str
+    model_uri: str
 
 
 @pytest.fixture

--- a/tests/sagemaker/test_sagemaker_deployment_client.py
+++ b/tests/sagemaker/test_sagemaker_deployment_client.py
@@ -2,9 +2,9 @@ import json
 import os
 import re
 import time
-from collections import namedtuple
 from functools import wraps
 from io import BytesIO
+from typing import NamedTuple
 from unittest import mock
 
 import boto3
@@ -35,7 +35,11 @@ from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from tests.helper_functions import set_boto_credentials  # noqa: F401
 from tests.sagemaker.mock import Endpoint, EndpointOperation, mock_sagemaker
 
-TrainedModel = namedtuple("TrainedModel", ["model_path", "run_id", "model_uri"])
+
+class TrainedModel(NamedTuple):
+    model_path: str
+    run_id: str
+    model_uri: str
 
 
 @pytest.fixture

--- a/tests/shap/test_shap.py
+++ b/tests/shap/test_shap.py
@@ -1,5 +1,5 @@
 import os
-from collections import namedtuple
+from typing import Any, NamedTuple
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -12,9 +12,12 @@ from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor
 import mlflow
 from mlflow import MlflowClient
 
-ModelWithExplanation = namedtuple(
-    "ModelWithExplanation", ["model", "X", "shap_values", "base_values"]
-)
+
+class ModelWithExplanation(NamedTuple):
+    model: Any
+    X: Any
+    shap_values: Any
+    base_values: Any
 
 
 def yield_artifacts(run_id, path=None):

--- a/tests/sklearn/test_sklearn_model_export.py
+++ b/tests/sklearn/test_sklearn_model_export.py
@@ -2,8 +2,8 @@ import json
 import os
 import pickle
 import tempfile
-from collections import namedtuple
 from pathlib import Path
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -57,7 +57,10 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("scikit-learn", module="sklearn") else ["--env-manager", "local"]
 )
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_data: Any
 
 
 @pytest.fixture(scope="module")

--- a/tests/spacy/test_spacy_model_export.py
+++ b/tests/spacy/test_spacy_model_export.py
@@ -1,8 +1,8 @@
 import json
 import os
 import random
-from collections import namedtuple
 from pathlib import Path
+from typing import Any, NamedTuple
 from unittest import mock
 
 import pandas as pd
@@ -38,7 +38,11 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("spacy") else ["--env-manager", "local"]
 )
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_data"])
+
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_data: Any
+
 
 spacy_version = Version(spacy.__version__)
 IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = spacy_version >= Version("3.0.0")

--- a/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
+++ b/tests/spark/autologging/ml/test_pyspark_ml_autologging.py
@@ -2,7 +2,7 @@ import importlib
 import json
 import math
 import pathlib
-from collections import namedtuple
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -159,7 +159,12 @@ def get_run_data(run_id):
     tags = {k: v for k, v in data.tags.items() if not k.startswith("mlflow.")}
     artifacts = [f.path for f in client.list_artifacts(run_id)]
 
-    RunData = namedtuple("RunData", ["params", "metrics", "tags", "artifacts"])
+    class RunData(NamedTuple):
+        params: Any
+        metrics: Any
+        tags: Any
+        artifacts: Any
+
     return RunData(data.params, data.metrics, tags, artifacts)
 
 

--- a/tests/spark/test_spark_model_export.py
+++ b/tests/spark/test_spark_model_export.py
@@ -2,8 +2,8 @@ import inspect
 import json
 import logging
 import os
-from collections import namedtuple
 from pathlib import Path
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -73,9 +73,11 @@ def spark_custom_env(tmp_path):
     return conda_env
 
 
-SparkModelWithData = namedtuple(
-    "SparkModelWithData", ["model", "spark_df", "pandas_df", "predictions"]
-)
+class SparkModelWithData(NamedTuple):
+    model: Any
+    spark_df: Any
+    pandas_df: Any
+    predictions: Any
 
 
 def _get_spark_session_with_retry(max_tries=3):

--- a/tests/statsmodels/model_fixtures.py
+++ b/tests/statsmodels/model_fixtures.py
@@ -1,4 +1,4 @@
-from collections import namedtuple
+from typing import Any, NamedTuple
 
 import numpy as np
 import pandas as pd
@@ -10,7 +10,11 @@ from statsmodels.tsa.arima_process import arma_generate_sample
 from mlflow.models import ModelSignature
 from mlflow.types.schema import Schema, TensorSpec
 
-ModelWithResults = namedtuple("ModelWithResults", ["model", "alg", "inference_dataframe"])
+
+class ModelWithResults(NamedTuple):
+    model: Any
+    alg: Any
+    inference_dataframe: Any
 
 
 """

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -1,6 +1,5 @@
 # pep8: disable=E501
 
-import collections
 import functools
 import json
 import os
@@ -33,11 +32,6 @@ from mlflow.utils.autologging_utils import (
 from mlflow.utils.process import _exec_cmd
 
 np.random.seed(1337)
-
-SavedModelInfo = collections.namedtuple(
-    "SavedModelInfo",
-    ["path", "meta_graph_tags", "signature_def_key", "inference_df", "expected_results_df"],
-)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tensorflow/test_tensorflow2_core_model_export.py
+++ b/tests/tensorflow/test_tensorflow2_core_model_export.py
@@ -1,5 +1,5 @@
-import collections
 import os
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -21,14 +21,10 @@ class ToyModel(tf.Module):
         return tf.reshape(tf.add(tf.matmul(x, self.w), self.b), [-1])
 
 
-TF2ModelInfo = collections.namedtuple(
-    "TF2ModelInfo",
-    [
-        "model",
-        "inference_data",
-        "expected_results",
-    ],
-)
+class TF2ModelInfo(NamedTuple):
+    model: Any
+    inference_data: Any
+    expected_results: Any
 
 
 @pytest.fixture

--- a/tests/tracking/fluent/test_fluent_autolog.py
+++ b/tests/tracking/fluent/test_fluent_autolog.py
@@ -1,8 +1,8 @@
 import contextlib
 import inspect
 import sys
-from collections import namedtuple
 from io import StringIO
+from typing import Any, NamedTuple
 from unittest import mock
 
 import anthropic
@@ -253,7 +253,10 @@ def test_universal_autolog_attaches_pyspark_import_hook_in_non_databricks(config
 
 def test_universal_autolog_makes_expected_event_logging_calls():
     class TestLogger(AutologgingEventLogger):
-        LoggerCall = namedtuple("LoggerCall", ["integration", "call_args", "call_kwargs"])
+        class LoggerCall(NamedTuple):
+            integration: Any
+            call_args: Any
+            call_kwargs: Any
 
         def __init__(self):
             self.calls = []

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -3,8 +3,8 @@ import os
 import pathlib
 import subprocess
 import tempfile
-from collections import namedtuple
 from io import BytesIO
+from typing import Any, NamedTuple
 
 import pytest
 import requests
@@ -40,10 +40,12 @@ def _launch_server(host, port, backend_store_uri, default_artifact_root, artifac
     return process
 
 
-ArtifactsServer = namedtuple(
-    "ArtifactsServer",
-    ["backend_store_uri", "default_artifact_root", "artifacts_destination", "url", "process"],
-)
+class ArtifactsServer(NamedTuple):
+    backend_store_uri: str
+    default_artifact_root: str
+    artifacts_destination: str
+    url: str
+    process: subprocess.Popen
 
 
 @pytest.fixture(scope="module")

--- a/tests/tracking/test_mlflow_artifacts.py
+++ b/tests/tracking/test_mlflow_artifacts.py
@@ -4,7 +4,7 @@ import pathlib
 import subprocess
 import tempfile
 from io import BytesIO
-from typing import Any, NamedTuple
+from typing import NamedTuple
 
 import pytest
 import requests

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -5,8 +5,8 @@ import pathlib
 import posixpath
 import random
 import re
-from collections import namedtuple
 from datetime import datetime, timezone
+from typing import NamedTuple
 from unittest import mock
 
 import pytest
@@ -43,7 +43,10 @@ from mlflow.utils.validation import (
     MAX_PARAMS_TAGS_PER_BATCH,
 )
 
-MockExperiment = namedtuple("MockExperiment", ["experiment_id", "lifecycle_stage"])
+
+class MockExperiment(NamedTuple):
+    experiment_id: str
+    lifecycle_stage: str
 
 
 def test_create_experiment():

--- a/tests/transformers/test_transformers_llm_inference_utils.py
+++ b/tests/transformers/test_transformers_llm_inference_utils.py
@@ -1,5 +1,5 @@
 import uuid
-from collections import namedtuple
+from typing import Any, NamedTuple
 from unittest import mock
 
 import pandas as pd
@@ -70,7 +70,11 @@ def test_apply_chat_template():
         convert_messages_to_prompt([["one", "two"]], DummyTokenizer())
 
 
-_TestCase = namedtuple("_TestCase", ["data", "params", "expected_data", "expected_params"])
+class _TestCase(NamedTuple):
+    data: Any
+    params: Any
+    expected_data: Any
+    expected_params: Any
 
 
 @pytest.mark.parametrize(

--- a/tests/xgboost/test_xgboost_model_export.py
+++ b/tests/xgboost/test_xgboost_model_export.py
@@ -1,7 +1,7 @@
 import json
 import os
-from collections import namedtuple
 from pathlib import Path
+from typing import Any, NamedTuple
 from unittest import mock
 
 import numpy as np
@@ -42,7 +42,11 @@ EXTRA_PYFUNC_SERVING_TEST_ARGS = (
     [] if _is_available_on_pypi("xgboost") else ["--env-manager", "local"]
 )
 
-ModelWithData = namedtuple("ModelWithData", ["model", "inference_dataframe", "inference_dmatrix"])
+
+class ModelWithData(NamedTuple):
+    model: Any
+    inference_dataframe: pd.DataFrame
+    inference_dmatrix: xgb.DMatrix
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16793?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16793/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16793/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16793/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

This change converts all usages of `collections.namedtuple` to `typing.NamedTuple` throughout the MLflow codebase to follow modern Python typing conventions.

Changes:
- Replace namedtuple() calls with proper NamedTuple class definitions
- Add appropriate type hints for all fields based on usage context
- Import NamedTuple from typing module instead of using collections.namedtuple
- Apply changes consistently across both source code and test files

🤖 Generated with [Claude Code](https://claude.ai/code)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
