### PR TITLE
Fix check run deduplication in protect.js to use check_suite.id

### DIFF
--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -34,6 +34,7 @@ module.exports = async ({ github, context }) => {
         owner,
         repo,
         ref,
+        filter: 'latest',
       })
     ).filter(({ name }) => name !== "protect");
 

--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -47,7 +47,7 @@ module.exports = async ({ github, context }) => {
       }
     }
     const runs = Object.values(latestRuns).map(({ name, status, conclusion, check_suite }) => ({
-      name: `${name} / ${check_suite.id}`,
+      name: `${name} (${check_suite.id})`,
       status:
         status !== "completed"
           ? STATE.pending

--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -46,8 +46,8 @@ module.exports = async ({ github, context }) => {
         latestRuns[key] = run;
       }
     }
-    const runs = Object.values(latestRuns).map(({ name, status, conclusion }) => ({
-      name,
+    const runs = Object.values(latestRuns).map(({ name, status, conclusion, check_suite }) => ({
+      name: `${name} / ${check_suite.id}`,
       status:
         status !== "completed"
           ? STATE.pending

--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -39,9 +39,10 @@ module.exports = async ({ github, context }) => {
 
     const latestRuns = {};
     for (const run of checkRuns) {
-      const { name } = run;
-      if (!latestRuns[name] || new Date(run.started_at) > new Date(latestRuns[name].started_at)) {
-        latestRuns[name] = run;
+      const { name, check_suite } = run;
+      const key = `${name}-${check_suite.id}`;
+      if (!latestRuns[key] || new Date(run.started_at) > new Date(latestRuns[key].started_at)) {
+        latestRuns[key] = run;
       }
     }
     const runs = Object.values(latestRuns).map(({ name, status, conclusion }) => ({

--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -80,7 +80,7 @@ module.exports = async ({ github, context }) => {
         state === "pending" ? STATE.pending : state === "success" ? STATE.success : STATE.failure,
     }));
 
-    return [...runs, ...statuses];
+    return [...runs, ...statuses].sort((a, b) => a.name.localeCompare(b.name));
   }
 
   const start = new Date();

--- a/.github/workflows/protect.js
+++ b/.github/workflows/protect.js
@@ -34,7 +34,7 @@ module.exports = async ({ github, context }) => {
         owner,
         repo,
         ref,
-        filter: 'latest',
+        filter: "latest",
       })
     ).filter(({ name }) => name !== "protect");
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16794?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16794/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16794/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16794/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR updates the deduplication logic in the protect workflow script (`.github/workflows/protect.js`) to use `check_suite.id` along with the check run name when identifying unique check runs.

Previously, check runs were deduplicated only by name, which could cause issues when multiple check suites contain runs with the same name. This could lead to incorrect status reporting as runs from different suites would overwrite each other.

The fix:
- Modified the deduplication key to include both the check run name and `check_suite.id`
- This ensures that check runs from different check suites are properly distinguished

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)