### PR TITLE
Fix OpenAI multimodal message logging support

### DIFF
--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -192,9 +192,29 @@ def _log_secrets_yaml(local_model_dir, scope):
         yaml.safe_dump({e.value: f"{scope}:{e.secret_key}" for e in _OpenAIEnvVar}, f)
 
 
-def _parse_format_fields(s) -> set[str]:
-    """Parses format fields from a given string, e.g. "Hello {name}" -> ["name"]."""
-    return {fn for _, fn, _, _ in Formatter().parse(s) if fn is not None}
+def _parse_format_fields(content) -> set[str]:
+    """Parses format fields from content (string, list, or dict)."""
+    if isinstance(content, str):
+        return {fn for _, fn, _, _ in Formatter().parse(content) if fn is not None}
+    elif isinstance(content, list):
+        # Handle multimodal content (list of objects)
+        fields = set()
+        for item in content:
+            if isinstance(item, dict):
+                for value in item.values():
+                    fields.update(_parse_format_fields(value))  # Recursive call
+            elif isinstance(item, str):
+                fields.update(_parse_format_fields(item))
+        return fields
+    elif isinstance(content, dict):
+        # Handle dict content (recursively)
+        fields = set()
+        for value in content.values():
+            fields.update(_parse_format_fields(value))  # Recursive call
+        return fields
+    else:
+        # For other types (e.g., None), return empty set
+        return set()
 
 
 def _get_input_schema(task, content):
@@ -605,13 +625,36 @@ class _ContentFormatter:
 
     def format_chat(self, **params):
         format_args = {v: params[v] for v in self.variables}
-        return [
-            {
-                "role": message.get("role").format(**format_args),
-                "content": message.get("content").format(**format_args),
-            }
-            for message in self.template
-        ]
+
+        def format_value(value):
+            """Recursively format a value (string, list, dict, or other)."""
+            if isinstance(value, str):
+                return value.format(**format_args)
+            elif isinstance(value, list):
+                return [format_value(item) for item in value]
+            elif isinstance(value, dict):
+                return {key: format_value(val) for key, val in value.items()}
+            else:
+                return value
+
+        formatted_messages = []
+
+        for message in self.template:
+            role = message.get("role")
+            content = message.get("content")
+
+            # Format role and content recursively
+            formatted_role = format_value(role)
+            formatted_content = format_value(content)
+
+            formatted_messages.append(
+                {
+                    "role": formatted_role,
+                    "content": formatted_content,
+                }
+            )
+
+        return formatted_messages
 
 
 def _first_string_column(pdf):

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -192,7 +192,7 @@ def _log_secrets_yaml(local_model_dir, scope):
         yaml.safe_dump({e.value: f"{scope}:{e.secret_key}" for e in _OpenAIEnvVar}, f)
 
 
-def _parse_format_fields(content) -> set[str]:
+def _parse_format_fields(content: Union[str, list[Any], dict[str, Any], Any]) -> set[str]:
     """Recursively parse format fields from content of various types.
 
     Extracts template variable names (e.g., {variable}) from content that can be
@@ -687,7 +687,9 @@ class _ContentFormatter:
         """
         format_args = {v: params[v] for v in self.variables}
 
-        def format_value(value):
+        def format_value(
+            value: Union[str, list[Any], dict[str, Any], Any],
+        ) -> Union[str, list[Any], dict[str, Any], Any]:
             """Recursively format a value with template variable substitution.
 
             Args:

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -193,31 +193,7 @@ def _log_secrets_yaml(local_model_dir, scope):
 
 
 def _parse_format_fields(content: Union[str, list[Any], dict[str, Any], Any]) -> set[str]:
-    """Recursively parse format fields from content of various types.
-
-    Extracts template variable names (e.g., {variable}) from content that can be
-    a string, list, dictionary, or other types. This function handles multimodal
-    content structures used in OpenAI chat completions.
-
-    Args:
-        content: The content to parse. Can be:
-            - str: A string potentially containing format fields like "Hello {name}"
-            - list: A list of items (e.g., multimodal content with text and images)
-            - dict: A dictionary with values to parse recursively
-            - other: Any other type (returns empty set)
-
-    Returns:
-        A set of format field names found in the content. For example,
-        "Hello {name}, your {item} is ready" returns {"name", "item"}.
-
-    Examples:
-        >>> _parse_format_fields("Hello {name}")
-        {'name'}
-        >>> _parse_format_fields([{"type": "text", "text": "Hello {user}"}])
-        {'user'}
-        >>> _parse_format_fields({"message": "Welcome {name}", "data": "{value}"})
-        {'name', 'value'}
-    """
+    """Parse format fields from content recursively."""
     if isinstance(content, str):
         return {fn for _, fn, _, _ in Formatter().parse(content) if fn is not None}
     elif isinstance(content, list):
@@ -648,57 +624,11 @@ class _ContentFormatter:
         return self.template.format(**{v: params[v] for v in self.variables})
 
     def format_chat(self, **params):
-        """Format chat completion messages with parameter substitution.
-
-        Formats chat messages by recursively substituting template variables with
-        provided parameter values. Handles both simple string-based content and
-        complex multimodal content structures (lists and dictionaries).
-
-        Args:
-            **params: Template variable values to substitute. Keys should match
-                the variable names found in the template (e.g., 'name', 'content').
-
-        Returns:
-            A list of formatted message dictionaries, each containing 'role' and
-            'content' keys with template variables substituted.
-
-        Examples:
-            >>> formatter = _ContentFormatter(
-            ...     "chat.completions", [{"role": "user", "content": "Hello {name}"}]
-            ... )
-            >>> formatter.format_chat(name="Alice")
-            [{"role": "user", "content": "Hello Alice"}]
-
-            >>> # Multimodal content
-            >>> formatter = _ContentFormatter(
-            ...     "chat.completions",
-            ...     [
-            ...         {
-            ...             "role": "user",
-            ...             "content": [
-            ...                 {"type": "text", "text": "Analyze {item}"},
-            ...                 {"type": "image_url", "image_url": {"url": "{image}"}},
-            ...             ],
-            ...         }
-            ...     ],
-            ... )
-            >>> formatter.format_chat(item="this image", image="data:image/png;base64,...")
-            [{"role": "user", "content": [...]}]  # With substituted values
-        """
         format_args = {v: params[v] for v in self.variables}
 
         def format_value(
             value: Union[str, list[Any], dict[str, Any], Any],
         ) -> Union[str, list[Any], dict[str, Any], Any]:
-            """Recursively format a value with template variable substitution.
-
-            Args:
-                value: The value to format. Can be string, list, dict, or other type.
-
-            Returns:
-                The formatted value with template variables substituted. Non-string
-                types are processed recursively to handle nested structures.
-            """
             if isinstance(value, str):
                 return value.format(**format_args)
             elif isinstance(value, list):

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -618,7 +618,21 @@ def test_inference_params_overlap(tmp_path):
 
 
 def test_multimodal_messages(tmp_path):
-    """Test that multimodal messages (text + image) work correctly."""
+    """Test multimodal OpenAI messages with template variables.
+
+    Verifies that MLflow correctly handles OpenAI chat completion messages
+    containing both text and image content (multimodal) with template variables
+    for dynamic content substitution.
+
+    Args:
+        tmp_path: Pytest fixture providing a temporary directory path.
+
+    Tests:
+        - Model saving with multimodal content and template variables
+        - Correct signature inference from multimodal templates
+        - Model loading and prediction with multimodal data
+        - Template variable substitution in complex nested structures
+    """
     # Test multimodal content with variable placeholders
     mlflow.openai.save_model(
         model="gpt-4o-mini",
@@ -685,7 +699,21 @@ def test_multimodal_messages(tmp_path):
 
 
 def test_multimodal_messages_no_variables(tmp_path):
-    """Test that multimodal messages without variables work correctly."""
+    """Test that multimodal messages without variables work correctly.
+
+    Verifies that MLflow correctly handles OpenAI multimodal messages that contain
+    no template variables, ensuring the default content parameter is added and
+    the model can process additional user input alongside static multimodal content.
+
+    Args:
+        tmp_path: Pytest fixture providing a temporary directory path.
+
+    Tests:
+        - Model saving with static multimodal content (no template variables)
+        - Default signature inference when no variables are found
+        - Model loading and prediction with additional user content
+        - Proper message composition with both static and dynamic content
+    """
     mlflow.openai.save_model(
         model="gpt-4o-mini",
         task=chat_completions(),

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -618,21 +618,6 @@ def test_inference_params_overlap(tmp_path):
 
 
 def test_multimodal_messages(tmp_path):
-    """Test multimodal OpenAI messages with template variables.
-
-    Verifies that MLflow correctly handles OpenAI chat completion messages
-    containing both text and image content (multimodal) with template variables
-    for dynamic content substitution.
-
-    Args:
-        tmp_path: Pytest fixture providing a temporary directory path.
-
-    Tests:
-        - Model saving with multimodal content and template variables
-        - Correct signature inference from multimodal templates
-        - Model loading and prediction with multimodal data
-        - Template variable substitution in complex nested structures
-    """
     # Test multimodal content with variable placeholders
     mlflow.openai.save_model(
         model="gpt-4o-mini",
@@ -699,21 +684,6 @@ def test_multimodal_messages(tmp_path):
 
 
 def test_multimodal_messages_no_variables(tmp_path):
-    """Test that multimodal messages without variables work correctly.
-
-    Verifies that MLflow correctly handles OpenAI multimodal messages that contain
-    no template variables, ensuring the default content parameter is added and
-    the model can process additional user input alongside static multimodal content.
-
-    Args:
-        tmp_path: Pytest fixture providing a temporary directory path.
-
-    Tests:
-        - Model saving with static multimodal content (no template variables)
-        - Default signature inference when no variables are found
-        - Model loading and prediction with additional user content
-        - Proper message composition with both static and dynamic content
-    """
     mlflow.openai.save_model(
         model="gpt-4o-mini",
         task=chat_completions(),

--- a/tests/openai/test_openai_model_export.py
+++ b/tests/openai/test_openai_model_export.py
@@ -615,3 +615,118 @@ def test_inference_params_overlap(tmp_path):
                 params=ParamSchema([ParamSpec(name="prefix", default=None, dtype="string")]),
             ),
         )
+
+
+def test_multimodal_messages(tmp_path):
+    """Test that multimodal messages (text + image) work correctly."""
+    # Test multimodal content with variable placeholders
+    mlflow.openai.save_model(
+        model="gpt-4o-mini",
+        task=chat_completions(),
+        path=tmp_path,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "{system_prompt}"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/jpeg;base64,{image_base64}",
+                            "detail": "low",
+                        },
+                    },
+                ],
+            }
+        ],
+    )
+
+    model = mlflow.models.Model.load(tmp_path)
+    assert model.signature.inputs.to_dict() == [
+        {"name": "image_base64", "type": "string", "required": True},
+        {"name": "system_prompt", "type": "string", "required": True},
+    ]
+    assert model.signature.outputs.to_dict() == [
+        {"type": "string", "required": True},
+    ]
+
+    model = mlflow.pyfunc.load_model(tmp_path)
+    data = pd.DataFrame(
+        {
+            "system_prompt": ["Analyze this image"],
+            "image_base64": [
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+            ],
+        }
+    )
+
+    expected_output = [
+        [
+            {
+                "content": [
+                    {"type": "text", "text": "Analyze this image"},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": (
+                                "data:image/jpeg;base64,"
+                                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+                            ),
+                            "detail": "low",
+                        },
+                    },
+                ],
+                "role": "user",
+            }
+        ]
+    ]
+
+    assert list(map(json.loads, model.predict(data))) == expected_output
+
+
+def test_multimodal_messages_no_variables(tmp_path):
+    """Test that multimodal messages without variables work correctly."""
+    mlflow.openai.save_model(
+        model="gpt-4o-mini",
+        task=chat_completions(),
+        path=tmp_path,
+        messages=[
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/jpeg;base64,abc123", "detail": "low"},
+                    },
+                ],
+            }
+        ],
+    )
+
+    model = mlflow.models.Model.load(tmp_path)
+    # Should add default content variable since no variables found
+    assert model.signature.inputs.to_dict() == [
+        {"type": "string", "required": True},
+    ]
+
+    model = mlflow.pyfunc.load_model(tmp_path)
+    data = pd.DataFrame({"content": ["Additional context"]})
+
+    expected_output = [
+        [
+            {
+                "content": [
+                    {"type": "text", "text": "What's in this image?"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/jpeg;base64,abc123", "detail": "low"},
+                    },
+                ],
+                "role": "user",
+            },
+            {"content": "Additional context", "role": "user"},
+        ]
+    ]
+
+    assert list(map(json.loads, model.predict(data))) == expected_output


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mohammadsubhani/mlflow/pull/16795?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16795/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16795/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16795/merge
```

</p>
</details>

  ### Related Issues/PRs

  <!-- Uncomment 'Resolve' if this PR can close the linked items. -->
  Resolve #16707

  ### What changes are proposed in this pull request?

  This PR fixes a TypeError that occurs when logging OpenAI models with multimodal
   message content (text + images). Previously, MLflow only supported string-based
   message content. When users attempted to log models with list-based multimodal
  content, the `_parse_format_fields` function would crash with "TypeError:
  expected str, got list".

  The fix implements recursive parsing logic to handle complex nested structures
  while maintaining full backward compatibility with existing string-based message
   templates.

  ### How is this PR tested?

  - [x] Existing unit/integration tests
  - [x] New unit/integration tests
  - [x] Manual tests

  **New Tests Added:**
  - `test_multimodal_messages()` - Tests multimodal content with template
  variables
  - `test_multimodal_messages_no_variables()` - Tests multimodal content without
  template variables
  - Both tests validate model saving, loading, and template variable extraction

  **Manual Testing:**
  - Validated fix works with real multimodal OpenAI message structures
  - Confirmed models can be saved and loaded successfully in MLflow UI
  - Tested with both Vision API format and custom multimodal formats

<img width="909" height="752" alt="Screenshot 2025-07-19 at 5 05 26 PM" src="https://github.com/user-attachments/assets/fdaa35e5-3782-4bb1-9a82-5da10fe6a0cb" />

<img width="2337" height="485" alt="Screenshot 2025-07-19 at 5 05 50 PM" src="https://github.com/user-attachments/assets/a79ef83c-83b2-443f-a5ad-f98c7aa6d35b" />


  ### Does this PR require documentation update?

  - [x] No. You can skip the rest of this section.

  ### Release Notes

  #### Is this a user-facing change?

  - [x] Yes. Give a description of this change to be included in the release notes
   for MLflow users.

  **Description:** MLflow now supports logging OpenAI models with multimodal
  messages containing both text and image content. Previously, attempting to log
  such models would result in a TypeError. This enhancement enables users to work
  with OpenAI's Vision API and other multimodal chat completion models while
  maintaining full backward compatibility.

  #### What component(s), interfaces, languages, and integrations does this PR
  affect?

  Components:
- [x] `area/models`: MLmodel format, model
  serialization/deserialization, flavors

  Interface:

  - [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript,
  JavaScript dev server
  - [ ] `area/docker`: Docker use across MLflow's components, such as
  MLflow Projects and MLflow Models
  - [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or
   Model Registry
  - [ ] `area/windows`: Windows support

  Language:

  - [ ] `language/r`: R APIs and clients
  - [ ] `language/java`: Java APIs and clients
  - [ ] `language/new`: Proposals for new client languages

  Integrations:

  - [ ] `integrations/azure`: Azure and Azure ML integrations
  - [ ] `integrations/sagemaker`: SageMaker integrations
  - [ ] `integrations/databricks`: Databricks integrations

  <a name="release-note-category"></a>

  #### How should the PR be classified in the release notes? Choose one:

  - [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

  #### Should this PR be included in the next patch release?

  - [x] Yes (this PR will be cherry-picked and included in the next patch release)