### PR TITLE
Render multi-modal trace for LangChain

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -367,8 +367,10 @@ describe('normalizeConversation', () => {
 
     expect(normalizeConversation(MOCK_OPENAI_RESPONSES_OUTPUT)).toEqual([
       expect.objectContaining({
-        content: '![image](data:image/png;base64,<base64_encoded_image_data>)',
+        content: '![](data:image/png;base64,<base64_encoded_image_data>)',
         role: 'tool',
+        tool_calls: undefined,
+        type: 'message',
       }),
       expect.objectContaining({
         role: 'assistant',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -38,7 +38,12 @@ import { TEST_SPAN_FILTER_STATE } from './timeline-tree/TimelineTree.test-utils'
 import { MOCK_ANTHROPIC_INPUT, MOCK_ANTHROPIC_OUTPUT } from './chat-utils/anthropic.test-utils';
 import { MOCK_GEMINI_INPUT, MOCK_GEMINI_OUTPUT } from './chat-utils/gemini.test-utils';
 import { MOCK_DSPY_INPUT, MOCK_DSPY_OUTPUT } from './chat-utils/dspy.test-utils';
-import { MOCK_LANGCHAIN_INPUT, MOCK_LANGCHAIN_OUTPUT, MOCK_LANGCHAIN_IMAGE_INPUT, MOCK_LANGCHAIN_SINGLE_IMAGE_INPUT } from './chat-utils/langchain.test-utils';
+import {
+  MOCK_LANGCHAIN_INPUT,
+  MOCK_LANGCHAIN_OUTPUT,
+  MOCK_LANGCHAIN_IMAGE_INPUT,
+  MOCK_LANGCHAIN_SINGLE_IMAGE_INPUT,
+} from './chat-utils/langchain.test-utils';
 import { MOCK_LLAMAINDEX_INPUT, MOCK_LLAMAINDEX_OUTPUT } from './chat-utils/llamaindex.test-utils';
 
 describe('parseTraceToTree', () => {
@@ -441,7 +446,8 @@ it('should handle langchain input with image content', () => {
   expect(normalizeConversation(MOCK_LANGCHAIN_IMAGE_INPUT)).toEqual([
     expect.objectContaining({
       role: 'user',
-      content: 'Describe the weather in this image:\n\n![](https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png)',
+      content:
+        'Describe the weather in this image:\n\n![](https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png)',
     }),
   ]);
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -38,7 +38,7 @@ import { TEST_SPAN_FILTER_STATE } from './timeline-tree/TimelineTree.test-utils'
 import { MOCK_ANTHROPIC_INPUT, MOCK_ANTHROPIC_OUTPUT } from './chat-utils/anthropic.test-utils';
 import { MOCK_GEMINI_INPUT, MOCK_GEMINI_OUTPUT } from './chat-utils/gemini.test-utils';
 import { MOCK_DSPY_INPUT, MOCK_DSPY_OUTPUT } from './chat-utils/dspy.test-utils';
-import { MOCK_LANGCHAIN_INPUT, MOCK_LANGCHAIN_OUTPUT, MOCK_LANGCHAIN_IMAGE_INPUT } from './chat-utils/langchain.test-utils';
+import { MOCK_LANGCHAIN_INPUT, MOCK_LANGCHAIN_OUTPUT, MOCK_LANGCHAIN_IMAGE_INPUT, MOCK_LANGCHAIN_SINGLE_IMAGE_INPUT } from './chat-utils/langchain.test-utils';
 import { MOCK_LLAMAINDEX_INPUT, MOCK_LLAMAINDEX_OUTPUT } from './chat-utils/llamaindex.test-utils';
 
 describe('parseTraceToTree', () => {
@@ -441,7 +441,16 @@ it('should handle langchain input with image content', () => {
   expect(normalizeConversation(MOCK_LANGCHAIN_IMAGE_INPUT)).toEqual([
     expect.objectContaining({
       role: 'user',
-      content: 'Describe the weather in this image:\n![](https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png)',
+      content: 'Describe the weather in this image:\n\n![](https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png)',
+    }),
+  ]);
+});
+
+it('should handle langchain input with single image content (no separator)', () => {
+  expect(normalizeConversation(MOCK_LANGCHAIN_SINGLE_IMAGE_INPUT)).toEqual([
+    expect.objectContaining({
+      role: 'user',
+      content: '![](https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png)',
     }),
   ]);
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -38,7 +38,7 @@ import { TEST_SPAN_FILTER_STATE } from './timeline-tree/TimelineTree.test-utils'
 import { MOCK_ANTHROPIC_INPUT, MOCK_ANTHROPIC_OUTPUT } from './chat-utils/anthropic.test-utils';
 import { MOCK_GEMINI_INPUT, MOCK_GEMINI_OUTPUT } from './chat-utils/gemini.test-utils';
 import { MOCK_DSPY_INPUT, MOCK_DSPY_OUTPUT } from './chat-utils/dspy.test-utils';
-import { MOCK_LANGCHAIN_INPUT, MOCK_LANGCHAIN_OUTPUT } from './chat-utils/langchain.test-utils';
+import { MOCK_LANGCHAIN_INPUT, MOCK_LANGCHAIN_OUTPUT, MOCK_LANGCHAIN_IMAGE_INPUT } from './chat-utils/langchain.test-utils';
 import { MOCK_LLAMAINDEX_INPUT, MOCK_LLAMAINDEX_OUTPUT } from './chat-utils/llamaindex.test-utils';
 
 describe('parseTraceToTree', () => {
@@ -433,6 +433,15 @@ it('should handle langchain input and outputs', () => {
     expect.objectContaining({
       content: expect.stringMatching(/oh, for crying out loud, no! that's just asking for a disaster/i),
       role: 'assistant',
+    }),
+  ]);
+});
+
+it('should handle langchain input with image content', () => {
+  expect(normalizeConversation(MOCK_LANGCHAIN_IMAGE_INPUT)).toEqual([
+    expect.objectContaining({
+      role: 'user',
+      content: 'Describe the weather in this image:\n![](https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png)',
     }),
   ]);
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -991,25 +991,26 @@ const formatChatContent = (content?: ModelTraceContentType | null): string | und
     return content;
   }
 
-  return (
-    content
-      // eslint-disable-next-line array-callback-return
-      .map((part) => {
-        switch (part.type) {
-          case 'text':
-          case 'input_text':
-          case 'output_text':
-            return part.text;
-          case 'image_url':
-            const url = part?.image_url?.url;
-            return url ? `![image](${url})` : '[image]';
-          case 'input_audio':
-            // raw encoded audio content is not displayed in the UI
-            return '[audio]';
-        }
-      })
-      .join('\n')
-  );
+  const contentParts = content
+    // eslint-disable-next-line array-callback-return
+    .map((part) => {
+      switch (part.type) {
+        case 'text':
+        case 'input_text':
+        case 'output_text':
+          return part.text;
+        case 'image_url':
+          const url = part?.image_url?.url;
+          return url ? `![](${url})` : '[image]';
+        case 'input_audio':
+          // raw encoded audio content is not displayed in the UI
+          return '[audio]';
+      }
+    })
+    .filter((part) => part !== undefined);
+
+  // Join with double line breaks for better visual separation
+  return contentParts.join('\n\n');
 };
 
 export const prettyPrintChatMessage = (message: RawModelTraceChatMessage): ModelTraceChatMessage | null => {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.test-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.test-utils.ts
@@ -83,3 +83,28 @@ export const MOCK_LANGCHAIN_OUTPUT = {
   run: null,
   type: 'LLMResult',
 };
+
+export const MOCK_LANGCHAIN_IMAGE_INPUT = [
+  [
+    {
+      content: [
+        {
+          type: 'text',
+          text: 'Describe the weather in this image:',
+        },
+        {
+          type: 'image_url',
+          image_url: {
+            url: 'https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png',
+          },
+        },
+      ],
+      additional_kwargs: {},
+      response_metadata: {},
+      type: 'human',
+      name: null,
+      id: null,
+      example: false,
+    },
+  ],
+];

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.test-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.test-utils.ts
@@ -108,3 +108,24 @@ export const MOCK_LANGCHAIN_IMAGE_INPUT = [
     },
   ],
 ];
+
+export const MOCK_LANGCHAIN_SINGLE_IMAGE_INPUT = [
+  [
+    {
+      content: [
+        {
+          type: 'image_url',
+          image_url: {
+            url: 'https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png',
+          },
+        },
+      ],
+      additional_kwargs: {},
+      response_metadata: {},
+      type: 'human',
+      name: null,
+      id: null,
+      example: false,
+    },
+  ],
+];

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.ts
@@ -78,7 +78,7 @@ export const langchainMessageToModelTraceMessage = (message: LangchainBaseMessag
         return '';
       })
       .filter(Boolean);
-    
+
     // Join with double line breaks for better visual separation
     content = contentParts.join('\n\n');
   } else {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.ts
@@ -65,20 +65,22 @@ export const langchainMessageToModelTraceMessage = (message: LangchainBaseMessag
     content = message.content;
   } else if (Array.isArray(message.content)) {
     // Convert array of content parts to string representation
-    content = message.content
+    const contentParts = message.content
       .map((part: any) => {
         if (isString(part)) {
           return part;
         } else if (part.type === 'text' && part.text) {
           return part.text;
         } else if (part.type === 'image_url' && part.image_url?.url) {
-          // Convert to markdown image format
+          // Convert to markdown image format with spacing
           return `![](${part.image_url.url})`;
         }
         return '';
       })
-      .filter(Boolean)
-      .join('\n');
+      .filter(Boolean);
+    
+    // Join with double line breaks for better visual separation
+    content = contentParts.join('\n\n');
   } else {
     content = undefined;
   }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/langchain.ts
@@ -2,9 +2,17 @@ import { compact, has, isNil, isString } from 'lodash';
 import { ModelTraceChatMessage, ModelTraceToolCall } from '../ModelTrace.types';
 import { isModelTraceToolCall, prettyPrintToolCall } from '../ModelTraceExplorer.utils';
 
+type LangchainContentPart = {
+  type: 'text' | 'image_url';
+  text?: string;
+  image_url?: {
+    url: string;
+  };
+};
+
 // it has other fields, but we only care about these for now
 export type LangchainBaseMessage = {
-  content?: string;
+  content?: string | LangchainContentPart[];
   type: 'human' | 'user' | 'assistant' | 'ai' | 'system' | 'tool' | 'function';
   tool_calls?: LangchainToolCallMessage[];
   tool_call_id?: string;
@@ -51,8 +59,32 @@ export const langchainMessageToModelTraceMessage = (message: LangchainBaseMessag
       return null;
   }
 
+  // Handle content that could be a string or an array of content parts
+  let content: string | undefined;
+  if (isString(message.content)) {
+    content = message.content;
+  } else if (Array.isArray(message.content)) {
+    // Convert array of content parts to string representation
+    content = message.content
+      .map((part: any) => {
+        if (isString(part)) {
+          return part;
+        } else if (part.type === 'text' && part.text) {
+          return part.text;
+        } else if (part.type === 'image_url' && part.image_url?.url) {
+          // Convert to markdown image format
+          return `![](${part.image_url.url})`;
+        }
+        return '';
+      })
+      .filter(Boolean)
+      .join('\n');
+  } else {
+    content = undefined;
+  }
+
   const normalizedMessage: ModelTraceChatMessage = {
-    content: message.content,
+    content,
     role,
   };
 
@@ -101,8 +133,8 @@ export const isLangchainBaseMessage = (obj: any): obj is LangchainBaseMessage =>
     return false;
   }
 
-  // it's okay if it's undefined / null, but if present it must be a string
-  if (!isNil(obj.content) && !isString(obj.content)) {
+  // content can be undefined/null, string, or array of content parts
+  if (!isNil(obj.content) && !isString(obj.content) && !Array.isArray(obj.content)) {
     return false;
   }
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16799?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16799/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16799/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16799/merge
```

</p>
</details>

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/16710

### What changes are proposed in this pull request?

Follow-up for https://github.com/mlflow/mlflow/pull/16760. Updating the LangChain message parsing logic to handle multiple contents block including images.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
## URL
from langchain_core.messages import HumanMessage
from langchain_openai import ChatOpenAI

model = ChatOpenAI(model="gpt-4.1-mini")

message = HumanMessage(
    content=[
        {"type": "text", "text": "Describe the weather in this image:"},
        {
            "type": "image_url",
            "image_url": {"url": "https://mlflow.org/docs/latest/api_reference/_static/MLflow-logo-final-black.png"},
        },
    ],
)
model.invoke([message])
```

<img width="800" height="671" alt="Screenshot 2025-07-21 at 16 25 42" src="https://github.com/user-attachments/assets/f282bd35-6273-4b77-8146-a2b75f9e4773" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

Will update doc in a follow-up.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

Render multi-modal LangChain trace including images in the Trace UI.

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
