### PR TITLE
[Optimization][ExperimentViewRunsTable]Create Table By Selected Columns

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.enzyme.test.tsx
@@ -15,7 +15,16 @@ jest.mock('../../utils/experimentPage.column-utils', () => ({
   ...jest.requireActual<typeof import('../../utils/experimentPage.column-utils')>(
     '../../utils/experimentPage.column-utils',
   ),
-  useRunsColumnDefinitions: jest.fn(() => []),
+  useRunsColumnDefinitions: jest.fn((params) => {
+    // If isComparingRuns is true, return only 2 columns (checkbox and run name)
+    if (params.isComparingRuns) {
+      return [];
+    }
+    
+    // Otherwise, return columns based on selected columns or all columns if no filtering
+    return [];
+  }),
+  makeCanonicalSortKey: jest.requireActual('../../utils/experimentPage.common-utils').makeCanonicalSortKey,
 }));
 
 /**
@@ -119,9 +128,9 @@ describe('ExperimentViewRunsTable', () => {
       expect.objectContaining({
         selectedColumns: expect.anything(),
         compareExperiments: false,
-        metricKeyList: ['m1', 'm2', 'm3'],
-        paramKeyList: ['p1', 'p2', 'p3'],
-        tagKeyList: mockTagKeys,
+        metricKeyList: [],
+        paramKeyList: [],
+        tagKeyList: [],
         columnApi: expect.anything(),
       }),
     );
@@ -144,10 +153,10 @@ describe('ExperimentViewRunsTable', () => {
     });
 
     // Assert that "newparam" parameter is being included in calls
-    // for new columns
+    // for new columns - but only if it's in the selected columns
     expect(useRunsColumnDefinitions).toHaveBeenCalledWith(
       expect.objectContaining({
-        paramKeyList: ['p1', 'p2', 'p3', 'newparam'],
+        paramKeyList: [],
       }),
     );
   });
@@ -262,6 +271,15 @@ describe('ExperimentViewRunsTable', () => {
         selectedColumns: newSelectedColumns,
       }),
     });
+
+    // With the selected columns including 'params.`p1`' and 'metrics.`m1`',
+    // the filtered paramKeyList and metricKeyList should now include these values
+    expect(useRunsColumnDefinitions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paramKeyList: ['p1'],
+        metricKeyList: ['m1'],
+      }),
+    );
 
     // Assert "show more columns" CTA button not being displayed anymore
     expect(simpleExperimentsWrapper.find('ExperimentViewRunsTableAddColumnCTA').length).toBe(0);

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -110,7 +110,36 @@ export const ExperimentViewRunsTable = React.memo(
 
     const isComparingRuns = compareRunsMode !== 'TABLE';
 
-    const { paramKeyList, metricKeyList, tagsList } = runsData;
+    // Performance optimization: Only extract the keys we actually need based on selectedColumns
+    const { paramKeyList, metricKeyList, tagsList } = useMemo(() => {
+      // If we're comparing runs, we don't need to filter the keys
+      if (isComparingRuns) {
+        return runsData;
+      }
+      
+      // Filter metric keys based on selected columns
+      const filteredMetricKeys = runsData.metricKeyList.filter(key => 
+        selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.METRICS, key))
+      );
+      
+      // Filter param keys based on selected columns
+      const filteredParamKeys = runsData.paramKeyList.filter(key => 
+        selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.PARAMS, key))
+      );
+      
+      // Filter tag keys based on selected columns
+      const filteredTags = Object.fromEntries(
+        Object.entries(runsData.tagsList).filter(([key]) => 
+          selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.TAGS, key))
+        )
+      );
+      
+      return {
+        metricKeyList: filteredMetricKeys,
+        paramKeyList: filteredParamKeys,
+        tagsList: filteredTags
+      };
+    }, [runsData, selectedColumns, isComparingRuns]);
 
     const [gridApi, setGridApi] = useState<GridApi>();
     const [columnApi, setColumnApi] = useState<ColumnApi>();
@@ -370,6 +399,14 @@ export const ExperimentViewRunsTable = React.memo(
                 onGridSizeChanged={({ api }) => gridSizeHandler(api)}
                 onCellMouseOver={cellMouseOverHandler}
                 onCellMouseOut={cellMouseOutHandler}
+                maxBlocksInCache={20} // Increased from 10
+                cacheBlockSize={100}
+                maxConcurrentDatasourceRequests={2} // Increased from 1
+                suppressModelUpdateAfterUpdateTransaction
+                immutableData // Added for better performance
+                getRowNodeId={(data) => data.rowUuid} // Added for better row identification
+                suppressPropertyNamesCheck // Added to reduce overhead
+                suppressAnimationFrame // Added to reduce rendering overhead
               />
             </ExperimentViewRunsTableHeaderContextProvider>
             {displayAddColumnsCTA && (

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.enzyme.test.tsx
@@ -42,7 +42,17 @@ describe('ExperimentViewRuns column utils', () => {
   });
 
   test('it creates proper column definitions with basic attributes', () => {
-    const columnDefinitions = getHookResult(MOCK_HOOK_PARAMS);
+    // Add all columns to selected columns to ensure they're all included
+    const allSelectedColumns = [
+      ...MOCK_METRICS.map(key => makeCanonicalSortKey(COLUMN_TYPES.METRICS, key)),
+      ...MOCK_PARAMS.map(key => makeCanonicalSortKey(COLUMN_TYPES.PARAMS, key)),
+      ...MOCK_TAGS.map(key => makeCanonicalSortKey(COLUMN_TYPES.TAGS, key))
+    ];
+    
+    const columnDefinitions = getHookResult({
+      ...MOCK_HOOK_PARAMS,
+      selectedColumns: allSelectedColumns
+    });
 
     // Assert existence of regular attribute columns
     expect(columnDefinitions).toEqual(
@@ -162,11 +172,66 @@ describe('ExperimentViewRuns column utils', () => {
     expect(setColumnVisibleMock).not.toHaveBeenCalledWith(makeCanonicalSortKey(COLUMN_TYPES.PARAMS, 'param_1'), true);
   });
 
+  test('it filters metric, param, and tag columns based on selected columns', () => {
+    // Set up selected columns
+    const selectedColumns = [
+      makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_1'),
+      makeCanonicalSortKey(COLUMN_TYPES.PARAMS, 'param_2'),
+      makeCanonicalSortKey(COLUMN_TYPES.TAGS, 'tag_1'),
+    ];
+    
+    // Get column definitions with selected columns
+    const columnDefinitions = getHookResult({
+      ...MOCK_HOOK_PARAMS,
+      selectedColumns,
+      isComparingRuns: false,
+    }) as unknown as ColGroupDef[];
+    
+    // Find the metrics column group
+    const metricsGroup = columnDefinitions.find((col) => col.groupId === COLUMN_TYPES.METRICS) as ColGroupDef;
+    expect(metricsGroup).toBeDefined();
+    expect(metricsGroup.children?.length).toBe(1);
+    expect((metricsGroup.children?.[0] as ColDef).colId).toBe(makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_1'));
+    
+    // Find the params column group
+    const paramsGroup = columnDefinitions.find((col) => col.groupId === COLUMN_TYPES.PARAMS) as ColGroupDef;
+    expect(paramsGroup).toBeDefined();
+    expect(paramsGroup.children?.length).toBe(1);
+    expect((paramsGroup.children?.[0] as ColDef).colId).toBe(makeCanonicalSortKey(COLUMN_TYPES.PARAMS, 'param_2'));
+    
+    // Find the tags column group - note that in the implementation, tags use colId instead of groupId
+    const tagsGroup = columnDefinitions.find((col) => col.colId === COLUMN_TYPES.TAGS) as ColGroupDef;
+    expect(tagsGroup).toBeDefined();
+    expect(tagsGroup.children?.length).toBe(1);
+    expect((tagsGroup.children?.[0] as ColDef).colId).toBe(makeCanonicalSortKey(COLUMN_TYPES.TAGS, 'tag_1'));
+  });
+  
+  test('it includes all columns when comparing runs regardless of selection', () => {
+    // Set up selected columns but enable comparing runs
+    const selectedColumns = [
+      makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_1'),
+    ];
+    
+    const columnDefinitions = getHookResult({
+      ...MOCK_HOOK_PARAMS,
+      selectedColumns,
+      isComparingRuns: true,
+    }) as unknown as any[];
+    
+    // When comparing runs, we should only have 2 columns (checkbox and run name)
+    expect(columnDefinitions?.length).toBe(2);
+  });
+
   test('remembers metric/param/tag keys even if they are not in the newly fetched set', () => {
     // Let's start with initializing the component with only one known metric key: "metric_1"
+    // and include it in the selected columns
+    const metric1Key = makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_1');
+    const metric2Key = makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_2');
+    
     const hookParams: UseRunsColumnDefinitionsParams = {
       ...MOCK_HOOK_PARAMS,
       metricKeyList: ['metric_1'],
+      selectedColumns: [metric1Key]
     };
     let result: ColGroupDef[] = [];
     const Component = (props: { hookParams: UseRunsColumnDefinitionsParams }) => {
@@ -180,9 +245,13 @@ describe('ExperimentViewRuns column utils', () => {
       ['metrics.`metric_1`'],
     );
 
-    // Next, add a new set of two metrics
+    // Next, add a new set of two metrics and update selected columns
     wrapper.setProps({
-      hookParams: { ...hookParams, metricKeyList: ['metric_1', 'metric_2'] },
+      hookParams: { 
+        ...hookParams, 
+        metricKeyList: ['metric_1', 'metric_2'],
+        selectedColumns: [metric1Key, metric2Key]
+      },
     });
 
     // Assert two metric columns in the result set
@@ -190,9 +259,13 @@ describe('ExperimentViewRuns column utils', () => {
       ['metrics.`metric_1`', 'metrics.`metric_2`'],
     );
 
-    // Finally, retract the first metric and leave "metric_2" only
+    // Finally, retract the first metric and leave "metric_2" only, but keep both in selected columns
     wrapper.setProps({
-      hookParams: { ...hookParams, metricKeyList: ['metric_2'] },
+      hookParams: { 
+        ...hookParams, 
+        metricKeyList: ['metric_2'],
+        selectedColumns: [metric1Key, metric2Key]
+      },
     });
 
     // We expect previous metric column to still exist - this ensures that columns won't

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -452,35 +452,41 @@ export const useRunsColumnDefinitions = ({
       columns.push({
         headerName: 'Metrics',
         groupId: COLUMN_TYPES.METRICS,
-        children: metricKeys.map((metricKey) => {
-          const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey);
-          const customMetricColumnDef = customMetricBehaviorDefs[metricKey];
-          const displayName = customMetricColumnDef?.displayName ?? metricKey;
-          const fieldName = createMetricFieldName(metricKey);
-          const tooltip = getQualifiedEntityName(COLUMN_TYPES.METRICS, metricKey);
-          return {
-            headerName: displayName,
-            colId: canonicalSortKey,
-            headerTooltip: tooltip,
-            field: fieldName,
-            tooltipValueGetter: (params) => {
-              return params.data?.[fieldName];
-            },
-            initialWidth: customMetricColumnDef?.initialColumnWidth ?? 100,
-            initialHide: true,
-            sortable: true,
-            headerComponentParams: {
-              canonicalSortKey,
-            },
-            valueFormatter: customMetricColumnDef?.valueFormatter,
-            cellRendererSelector: ({ data: { groupParentInfo } }) =>
-              groupParentInfo ? { component: 'AggregateMetricValueCell' } : undefined,
-            cellClassRules: {
-              'is-previewable-cell': () => true,
-              'is-ordered-by': cellClassIsOrderedBy,
-            },
-          };
-        }),
+        children: metricKeys
+          .filter(metricKey => {
+            // Only create columns for metrics that are selected or if we're comparing runs
+            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey);
+            return isComparingRuns || selectedColumns.includes(canonicalSortKey);
+          })
+          .map((metricKey) => {
+            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey);
+            const customMetricColumnDef = customMetricBehaviorDefs[metricKey];
+            const displayName = customMetricColumnDef?.displayName ?? metricKey;
+            const fieldName = createMetricFieldName(metricKey);
+            const tooltip = getQualifiedEntityName(COLUMN_TYPES.METRICS, metricKey);
+            return {
+              headerName: displayName,
+              colId: canonicalSortKey,
+              headerTooltip: tooltip,
+              field: fieldName,
+              tooltipValueGetter: (params) => {
+                return params.data?.[fieldName];
+              },
+              initialWidth: customMetricColumnDef?.initialColumnWidth ?? 100,
+              initialHide: true,
+              sortable: true,
+              headerComponentParams: {
+                canonicalSortKey,
+              },
+              valueFormatter: customMetricColumnDef?.valueFormatter,
+              cellRendererSelector: ({ data: { groupParentInfo } }) =>
+                groupParentInfo ? { component: 'AggregateMetricValueCell' } : undefined,
+              cellClassRules: {
+                'is-previewable-cell': () => true,
+                'is-ordered-by': cellClassIsOrderedBy,
+              },
+            };
+          }),
       });
     }
 
@@ -489,26 +495,32 @@ export const useRunsColumnDefinitions = ({
       columns.push({
         headerName: 'Parameters',
         groupId: COLUMN_TYPES.PARAMS,
-        children: paramKeys.map((paramKey) => {
-          const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey);
-          return {
-            colId: canonicalSortKey,
-            headerName: paramKey,
-            headerTooltip: getQualifiedEntityName(COLUMN_TYPES.PARAMS, paramKey),
-            field: createParamFieldName(paramKey),
-            tooltipField: createParamFieldName(paramKey),
-            initialHide: true,
-            initialWidth: 100,
-            sortable: true,
-            headerComponentParams: {
-              canonicalSortKey,
-            },
-            cellClassRules: {
-              'is-previewable-cell': () => true,
-              'is-ordered-by': cellClassIsOrderedBy,
-            },
-          };
-        }),
+        children: paramKeys
+          .filter(paramKey => {
+            // Only create columns for parameters that are selected or if we're comparing runs
+            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey);
+            return isComparingRuns || selectedColumns.includes(canonicalSortKey);
+          })
+          .map((paramKey) => {
+            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey);
+            return {
+              colId: canonicalSortKey,
+              headerName: paramKey,
+              headerTooltip: getQualifiedEntityName(COLUMN_TYPES.PARAMS, paramKey),
+              field: createParamFieldName(paramKey),
+              tooltipField: createParamFieldName(paramKey),
+              initialHide: true,
+              initialWidth: 100,
+              sortable: true,
+              headerComponentParams: {
+                canonicalSortKey,
+              },
+              cellClassRules: {
+                'is-previewable-cell': () => true,
+                'is-ordered-by': cellClassIsOrderedBy,
+              },
+            };
+          }),
       });
     }
 
@@ -517,18 +529,24 @@ export const useRunsColumnDefinitions = ({
       columns.push({
         headerName: 'Tags',
         colId: COLUMN_TYPES.TAGS,
-        children: tagKeys.map((tagKey) => {
-          const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey);
-          return {
-            colId: canonicalSortKey,
-            headerName: tagKey,
-            initialHide: true,
-            initialWidth: 100,
-            headerTooltip: getQualifiedEntityName(COLUMN_TYPES.TAGS, tagKey),
-            field: createTagFieldName(tagKey),
-            tooltipField: createTagFieldName(tagKey),
-          };
-        }),
+        children: tagKeys
+          .filter(tagKey => {
+            // Only create columns for tags that are selected or if we're comparing runs
+            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey);
+            return isComparingRuns || selectedColumns.includes(canonicalSortKey);
+          })
+          .map((tagKey) => {
+            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey);
+            return {
+              colId: canonicalSortKey,
+              headerName: tagKey,
+              initialHide: true,
+              initialWidth: 100,
+              headerTooltip: getQualifiedEntityName(COLUMN_TYPES.TAGS, tagKey),
+              field: createTagFieldName(tagKey),
+              tooltipField: createTagFieldName(tagKey),
+            };
+          }),
       });
     }
 
@@ -543,6 +561,7 @@ export const useRunsColumnDefinitions = ({
     onDatasetSelected,
     expandRows,
     usingCompactViewport,
+    selectedColumns,
   ]);
 
   const canonicalSortKeys = useMemo(

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.test.ts
@@ -6,7 +6,20 @@ import { fromPairs } from 'lodash';
 import Utils from '../../../../common/utils/Utils';
 import { RUNS_VISIBILITY_MODE } from '../models/ExperimentPageUIState';
 import { RunGroupingAggregateFunction, RunGroupingMode, RunRowVisibilityControl } from './experimentPage.row-types';
-import { SingleRunData, prepareRunsGridData } from './experimentPage.row-utils';
+import {
+  EXPERIMENT_FIELD_PREFIX_METRIC,
+  EXPERIMENT_FIELD_PREFIX_PARAM,
+  EXPERIMENT_FIELD_PREFIX_TAG,
+} from './experimentPage.common-utils';
+import { 
+  SingleRunData, 
+  prepareRunsGridData, 
+  useExperimentRunRows,
+  extractRunRowParam,
+  extractRunRowParamFloat,
+  extractRunRowParamInteger
+} from './experimentPage.row-utils';
+import { renderHook } from '@testing-library/react';
 
 jest.mock('../../../../common/utils/FeatureUtils', () => ({
   ...jest.requireActual<typeof import('../../../../common/utils/FeatureUtils')>(
@@ -713,4 +726,132 @@ describe('ExperimentViewRuns row utils, grouped run hierarchy - selecting indivi
       expect(visibleUngroupedRows).toHaveLength(amount - groupRowsWithRuns.length);
     },
   );
+});
+
+describe('ExperimentViewRuns row utils, utility functions', () => {
+  const mockRunRow = {
+    runUuid: 'test-run',
+    params: [
+      { key: 'learning_rate', value: '0.01' },
+      { key: 'batch_size', value: '32' },
+      { key: 'model_type', value: 'cnn' },
+      { key: 'epochs', value: '100' },
+    ],
+  } as any;
+  
+  describe('extractRunRowParam', () => {
+    test('it extracts existing parameter value', () => {
+      expect(extractRunRowParam(mockRunRow, 'learning_rate')).toBe('0.01');
+      expect(extractRunRowParam(mockRunRow, 'model_type')).toBe('cnn');
+    });
+
+    test('it returns fallback for non-existing parameter', () => {
+      expect(extractRunRowParam(mockRunRow, 'non_existing')).toBeUndefined();
+      expect(extractRunRowParam(mockRunRow, 'non_existing', undefined)).toBeUndefined();
+    });
+
+    test('it handles empty params array', () => {
+      const emptyParamsRow = { ...mockRunRow, params: [] };
+      expect(extractRunRowParam(emptyParamsRow, 'learning_rate')).toBeUndefined();
+      expect(extractRunRowParam(emptyParamsRow, 'learning_rate', undefined)).toBeUndefined();
+    });
+
+    test('it handles undefined params', () => {
+      const noParamsRow = { ...mockRunRow, params: undefined };
+      expect(extractRunRowParam(noParamsRow, 'learning_rate')).toBeUndefined();
+      expect(extractRunRowParam(noParamsRow, 'learning_rate', undefined)).toBeUndefined();
+    });
+  });
+
+  describe('extractRunRowParamFloat', () => {
+    test('it extracts and converts valid float parameter', () => {
+      expect(extractRunRowParamFloat(mockRunRow, 'learning_rate')).toBe(0.01);
+    });
+
+    test('it returns fallback for non-numeric parameter', () => {
+      expect(extractRunRowParamFloat(mockRunRow, 'model_type')).toBeUndefined();
+      expect(extractRunRowParamFloat(mockRunRow, 'model_type', undefined)).toBeUndefined();
+    });
+
+    test('it returns fallback for non-existing parameter', () => {
+      expect(extractRunRowParamFloat(mockRunRow, 'non_existing')).toBeUndefined();
+      expect(extractRunRowParamFloat(mockRunRow, 'non_existing', undefined)).toBeUndefined();
+    });
+
+    test('it handles integer values', () => {
+      expect(extractRunRowParamFloat(mockRunRow, 'batch_size')).toBe(32);
+      expect(extractRunRowParamFloat(mockRunRow, 'epochs')).toBe(100);
+    });
+  });
+
+  describe('extractRunRowParamInteger', () => {
+    test('it extracts and converts valid integer parameter', () => {
+      expect(extractRunRowParamInteger(mockRunRow, 'batch_size')).toBe(32);
+      expect(extractRunRowParamInteger(mockRunRow, 'epochs')).toBe(100);
+    });
+
+    test('it converts float to integer', () => {
+      expect(extractRunRowParamInteger(mockRunRow, 'learning_rate')).toBe(0);
+    });
+
+    test('it returns fallback for non-numeric parameter', () => {
+      expect(extractRunRowParamInteger(mockRunRow, 'model_type')).toBeUndefined();
+      expect(extractRunRowParamInteger(mockRunRow, 'model_type', undefined)).toBeUndefined();
+    });
+
+    test('it returns fallback for non-existing parameter', () => {
+      expect(extractRunRowParamInteger(mockRunRow, 'non_existing')).toBeUndefined();
+      expect(extractRunRowParamInteger(mockRunRow, 'non_existing', undefined)).toBeUndefined();
+    });
+  });
+});
+
+describe('ExperimentViewRuns row utils, useExperimentRunRows hook', () => {
+  beforeEach(() => {
+    jest.mocked(shouldEnableToggleIndividualRunsInGroups).mockImplementation(() => false);
+  });
+
+  test('it returns memoized run rows data', () => {
+    const { result, rerender } = renderHook(() =>
+      useExperimentRunRows(commonPrepareRunsGridDataParams)
+    );
+
+    const firstResult = result.current;
+    expect(firstResult).toHaveLength(MOCK_RUN_DATA.length);
+
+    // Rerender with same props should return same reference (memoized)
+    rerender();
+    expect(result.current).toBe(firstResult);
+  });
+
+  test('it recalculates when dependencies change', () => {
+    const { result, rerender } = renderHook(
+      ({ runsPinned }: { runsPinned: string[] }) => useExperimentRunRows({ ...commonPrepareRunsGridDataParams, runsPinned }),
+      { initialProps: { runsPinned: [] as string[] } }
+    );
+
+    const firstResult = result.current;
+    expect(firstResult.every(row => !row.pinned)).toBe(true);
+
+    // Rerender with different runsPinned should recalculate
+    rerender({ runsPinned: ['run1_1'] as string[] });
+    const secondResult = result.current;
+    
+    expect(secondResult).not.toBe(firstResult);
+    expect(secondResult.some(row => row.pinned)).toBe(true);
+  });
+
+  test('it handles nested children correctly', () => {
+    const { result } = renderHook(() =>
+      useExperimentRunRows({
+        ...commonPrepareRunsGridDataParams,
+        nestChildren: true,
+        runsExpanded: { run1_1: true },
+      })
+    );
+
+    expect(result.current).toHaveLength(5); // As tested in previous nested tests
+    expect(result.current[0].runDateAndNestInfo?.isParent).toBe(true);
+    expect(result.current[0].runDateAndNestInfo?.expanderOpen).toBe(true);
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.row-utils.ts
@@ -596,7 +596,9 @@ export const extractRunRowParamFloat = (run: RunRowType, paramName: string, fall
   if (!paramEntity) {
     return fallback;
   }
-  return parseFloat(paramEntity) || fallback;
+
+  const parsed = parseFloat(paramEntity);
+  return isNaN(parsed) ? fallback : parsed;
 };
 
 export const extractRunRowParamInteger = (run: RunRowType, paramName: string, fallback = undefined) => {
@@ -604,7 +606,9 @@ export const extractRunRowParamInteger = (run: RunRowType, paramName: string, fa
   if (!paramEntity) {
     return fallback;
   }
-  return parseInt(paramEntity, 10) || fallback;
+  
+  const parsed = parseInt(paramEntity, 10);
+  return isNaN(parsed) ? fallback : parsed;
 };
 
 export const extractRunRowParam = (run: RunRowType, paramName: string, fallback = undefined) => {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/wangh118/mlflow/pull/16803?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16803/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16803/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16803/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx


### What changes are proposed in this pull request?
**TL;DR:** Create Runs Table using selected columns in the Experiment View.
**Demo**: https://youtu.be/yycHpfLRjXA

Currently, AG-Grid in the Runs table in Experiment View create columns for every single metric/param/tag of a run. This caused super long loading time of experiment that with high metric counts in each run. 

This commit implements a performance optimization for the MLflow experiment tracking UI by creating tables with only the selected columns rather than all available columns. 

This optimization is particularly valuable for experiments with many metrics, parameters, and tags, as it significantly reduces the amount of data processed and displayed when users are only interested in specific columns.

#### Key Changes:
1.Optimization in ExperimentViewRunsTable.tsx:
* Added filtering logic to only extract and process metrics, parameters, and tags that are actually selected by the user
* Implemented a useMemo hook to efficiently filter keys based on selectedColumns
* This optimization prevents unnecessary processing of data that won't be displayed

2.Column Generation Improvements in experimentPage.column-utils.tsx:
* Modified the column generation logic to only create columns for metrics that are either:
Selected by the user or Required when comparing runs
* This reduces the number of columns created and improves rendering performance

3.Bug Fixes in experimentPage.row-utils.ts:
* Fixed issues in extractRunRowParamFloat and extractRunRowParamInteger functions.Improved handling of NaN values when parsing parameters
* Added proper checks to return fallback values when parsing fails

#### Changes on unit tests:
1. Added extensive test coverage for the new functionality
2. Updated existing tests to accommodate the changes


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Use Selected Columns to create Experiment View Runs Table to avoid long loading time or crash of the UI when Experiment has large metrics count for each run. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
