### PR TITLE
Preserve the argument order of register_prompt

### DIFF
--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -32,9 +32,9 @@ def suppress_genai_migration_warning():
 def register_prompt(
     name: str,
     template: Union[str, list[dict[str, "ContentType"]]],
-    response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     commit_message: Optional[str] = None,
     tags: Optional[dict[str, str]] = None,
+    response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
 ) -> PromptVersion:
     """
     Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
@@ -67,13 +67,13 @@ def register_prompt(
                     prompt = client.load_prompt("my_prompt")
                     langchain_format = prompt.to_single_brace_format()
 
-        response_format: Optional Pydantic class or dictionary defining the expected response
-            structure. This can be used to specify the schema for structured outputs from LLM calls.
         commit_message: A message describing the changes made to the prompt, similar to a
             Git commit message. Optional.
         tags: A dictionary of tags associated with the **prompt version**.
             This is useful for storing version-specific information, such as the author of
             the changes. Optional.
+        response_format: Optional Pydantic class or dictionary defining the expected response
+            structure. This can be used to specify the schema for structured outputs from LLM calls.
 
     Returns:
         A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
@@ -128,9 +128,9 @@ def register_prompt(
         return registry_api.register_prompt(
             name=name,
             template=template,
-            response_format=response_format,
             commit_message=commit_message,
             tags=tags,
+            response_format=response_format,
         )
 
 

--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -58,13 +58,13 @@ def model_version_to_prompt_version(
         name=model_version.name,
         version=int(model_version.version),
         template=template,
-        response_format=response_format,
         commit_message=model_version.description,
         creation_timestamp=model_version.creation_timestamp,
         tags=model_version.tags,
         aliases=model_version.aliases,
         last_updated_timestamp=model_version.last_updated_timestamp,
         user_id=model_version.user_id,
+        response_format=response_format,
     )
 
 

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -689,9 +689,9 @@ class AbstractStore:
         self,
         name: str,
         template: Union[str, list[dict[str, "ContentType"]]],
-        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         description: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     ) -> PromptVersion:
         """
         Create a new version of an existing prompt.
@@ -707,11 +707,11 @@ class AbstractStore:
                   method.
                 - A list of dictionaries representing chat messages, where each message has
                   'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+            description: Optional description of the prompt version.
+            tags: Optional dictionary of version tags.
             response_format: Optional Pydantic class or dictionary defining the expected response
                 structure. This can be used to specify the schema for structured outputs from LLM
                 calls.
-            description: Optional description of the prompt version.
-            tags: Optional dictionary of version tags.
 
         Returns:
             A PromptVersion object representing the created version.

--- a/mlflow/tracking/_model_registry/client.py
+++ b/mlflow/tracking/_model_registry/client.py
@@ -547,9 +547,9 @@ class ModelRegistryClient:
         self,
         name: str,
         template: Union[str, list[dict[str, "ContentType"]]],
-        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         description: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     ) -> PromptVersion:
         """
         Create a new version of an existing prompt.
@@ -565,16 +565,16 @@ class ModelRegistryClient:
                   method.
                 - A list of dictionaries representing chat messages, where each message has
                   'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+            description: Optional description of this version.
+            tags: Optional dictionary of version tags.
             response_format: Optional Pydantic class or dictionary defining the expected response
                 structure. This can be used to specify the schema for structured outputs from LLM
                 calls.
-            description: Optional description of this version.
-            tags: Optional dictionary of version tags.
 
         Returns:
             A PromptVersion object representing the new version.
         """
-        return self.store.create_prompt_version(name, template, response_format, description, tags)
+        return self.store.create_prompt_version(name, template, description, tags, response_format)
 
     def get_prompt_version(self, name: str, version: str) -> PromptVersion:
         """

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -538,9 +538,9 @@ def set_model_version_tag(
 def register_prompt(
     name: str,
     template: Union[str, list[dict[str, "ContentType"]]],
-    response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     commit_message: Optional[str] = None,
     tags: Optional[dict[str, str]] = None,
+    response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
 ) -> PromptVersion:
     """
     Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
@@ -572,14 +572,13 @@ def register_prompt(
                     prompt = client.load_prompt("my_prompt")
                     langchain_format = prompt.to_single_brace_format()
 
-        response_format: Optional Pydantic class or dictionary defining the expected response
-            structure. This can be used to specify the schema for structured outputs from LLM calls.
-
         commit_message: A message describing the changes made to the prompt, similar to a
             Git commit message. Optional.
         tags: A dictionary of tags associated with the **prompt version**.
             This is useful for storing version-specific information, such as the author of
             the changes. Optional.
+        response_format: Optional Pydantic class or dictionary defining the expected response
+            structure. This can be used to specify the schema for structured outputs from LLM calls.
 
     Returns:
         A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
@@ -640,9 +639,9 @@ def register_prompt(
     return MlflowClient().register_prompt(
         name=name,
         template=template,
-        response_format=response_format,
         commit_message=commit_message,
         tags=tags,
+        response_format=response_format,
     )
 
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -445,9 +445,9 @@ class MlflowClient:
         self,
         name: str,
         template: Union[str, list[dict[str, "ContentType"]]],
-        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
         commit_message: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     ) -> PromptVersion:
         """
         Register a new :py:class:`Prompt <mlflow.entities.Prompt>` in the MLflow Prompt Registry.
@@ -519,14 +519,14 @@ class MlflowClient:
                 - A list of dictionaries representing chat messages, where each message has
                   'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
 
-            response_format: Optional Pydantic class or dictionary defining the expected response
-                structure. This can be used to specify the schema for structured outputs from LLM
-                calls.
             commit_message: A message describing the changes made to the prompt, similar to a
                 Git commit message. Optional.
             tags: A dictionary of tags associated with the **prompt version**.
                 This is useful for storing version-specific information, such as the author of
                 the changes. Optional.
+            response_format: Optional Pydantic class or dictionary defining the expected response
+                structure. This can be used to specify the schema for structured outputs from LLM
+                calls.
 
         Returns:
             A :py:class:`Prompt <mlflow.entities.Prompt>` object that was created.
@@ -551,9 +551,9 @@ class MlflowClient:
             prompt_version = registry_client.create_prompt_version(
                 name=name,
                 template=template,
-                response_format=response_format,
                 description=commit_message,
                 tags=tags or {},
+                response_format=response_format,
             )
 
             return registry_client.get_prompt_version(name, str(prompt_version.version))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16807?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16807/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16807/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16807/merge
```

</p>
</details>

### Related Issues/PRs
N/A

### What changes are proposed in this pull request?

Change the argument order of `register_prompt` to append the new argument as the last argument to preserve the positional order of existing arguments.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
