### PR TITLE
Support multi-turn message and response format in uc prompt registry

### DIFF
--- a/mlflow/prompt/constants.py
+++ b/mlflow/prompt/constants.py
@@ -7,12 +7,9 @@ PROMPT_TEXT_TAG_KEY = "mlflow.prompt.text"
 
 LINKED_PROMPTS_TAG_KEY = "mlflow.linkedPrompts"
 
-# New tag keys for enhanced prompt features
-PROMPT_TYPE_TAG_KEY = "mlflow.prompt.type"
-RESPONSE_FORMAT_TAG_KEY = "mlflow.prompt.response_format"
 # Unity Catalog tags cannot contain dots
-PROMPT_TYPE_TAG_KEY_UC = "_mlflow_prompt_type"
-RESPONSE_FORMAT_TAG_KEY_UC = "_mlflow_prompt_response_format"
+PROMPT_TYPE_TAG_KEY = "_mlflow_prompt_type"
+RESPONSE_FORMAT_TAG_KEY = "_mlflow_prompt_response_format"
 
 # Prompt types
 PROMPT_TYPE_TEXT = "text"

--- a/mlflow/prompt/constants.py
+++ b/mlflow/prompt/constants.py
@@ -10,6 +10,9 @@ LINKED_PROMPTS_TAG_KEY = "mlflow.linkedPrompts"
 # New tag keys for enhanced prompt features
 PROMPT_TYPE_TAG_KEY = "mlflow.prompt.type"
 RESPONSE_FORMAT_TAG_KEY = "mlflow.prompt.response_format"
+# Unity Catalog tags cannot contain dots
+PROMPT_TYPE_TAG_KEY_UC = "_mlflow_prompt_type"
+RESPONSE_FORMAT_TAG_KEY_UC = "_mlflow_prompt_response_format"
 
 # Prompt types
 PROMPT_TYPE_TEXT = "text"

--- a/mlflow/server/js/src/common/utils/TagUtils.ts
+++ b/mlflow/server/js/src/common/utils/TagUtils.ts
@@ -11,8 +11,10 @@ import { RunLoggedArtifactType } from '@mlflow/mlflow/src/experiment-tracking/ty
 import { KeyValueEntity } from '../types';
 
 export const MLFLOW_INTERNAL_PREFIX = 'mlflow.';
+const MLFLOW_INTERNAL_PREFIX_UC = '_mlflow_';
 
-export const isUserFacingTag = (tagKey: string) => !tagKey.startsWith(MLFLOW_INTERNAL_PREFIX);
+export const isUserFacingTag = (tagKey: string) =>
+  !tagKey.startsWith(MLFLOW_INTERNAL_PREFIX) && !tagKey.startsWith(MLFLOW_INTERNAL_PREFIX_UC);
 
 export const diffCurrentAndNewTags = (
   currentTags: KeyValueEntity[],

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -18,7 +18,12 @@ from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.exceptions import MlflowException, RestException
-from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY
+from mlflow.prompt.constants import (
+    PROMPT_TYPE_CHAT,
+    PROMPT_TYPE_TAG_KEY_UC,
+    PROMPT_TYPE_TEXT,
+    RESPONSE_FORMAT_TAG_KEY_UC,
+)
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
@@ -1442,9 +1447,13 @@ class UcModelRegistryStore(BaseRestStore):
 
         final_tags = tags.copy() if tags else {}
         if response_format:
-            final_tags[RESPONSE_FORMAT_TAG_KEY] = json.dumps(
+            final_tags[RESPONSE_FORMAT_TAG_KEY_UC] = json.dumps(
                 PromptVersion.convert_response_format_to_dict(response_format)
             )
+        if isinstance(template, str):
+            final_tags[PROMPT_TYPE_TAG_KEY_UC] = PROMPT_TYPE_TEXT
+        else:
+            final_tags[PROMPT_TYPE_TAG_KEY_UC] = PROMPT_TYPE_CHAT
 
         if final_tags:
             prompt_version_proto.tags.extend(mlflow_tags_to_proto_version_tags(final_tags))

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -20,9 +20,9 @@ from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.prompt.constants import (
     PROMPT_TYPE_CHAT,
-    PROMPT_TYPE_TAG_KEY_UC,
+    PROMPT_TYPE_TAG_KEY,
     PROMPT_TYPE_TEXT,
-    RESPONSE_FORMAT_TAG_KEY_UC,
+    RESPONSE_FORMAT_TAG_KEY,
 )
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
@@ -1447,13 +1447,13 @@ class UcModelRegistryStore(BaseRestStore):
 
         final_tags = tags.copy() if tags else {}
         if response_format:
-            final_tags[RESPONSE_FORMAT_TAG_KEY_UC] = json.dumps(
+            final_tags[RESPONSE_FORMAT_TAG_KEY] = json.dumps(
                 PromptVersion.convert_response_format_to_dict(response_format)
             )
         if isinstance(template, str):
-            final_tags[PROMPT_TYPE_TAG_KEY_UC] = PROMPT_TYPE_TEXT
+            final_tags[PROMPT_TYPE_TAG_KEY] = PROMPT_TYPE_TEXT
         else:
-            final_tags[PROMPT_TYPE_TAG_KEY_UC] = PROMPT_TYPE_CHAT
+            final_tags[PROMPT_TYPE_TAG_KEY] = PROMPT_TYPE_CHAT
 
         if final_tags:
             prompt_version_proto.tags.extend(mlflow_tags_to_proto_version_tags(final_tags))

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -7,9 +7,10 @@ import re
 import shutil
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import google.protobuf.empty_pb2
+from pydantic import BaseModel
 
 import mlflow
 from mlflow.entities import Run
@@ -17,6 +18,7 @@ from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.exceptions import MlflowException, RestException
+from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
     INVALID_PARAMETER_VALUE,
@@ -160,6 +162,9 @@ from mlflow.utils.rest_utils import (
     verify_rest_response,
 )
 from mlflow.utils.uri import is_fuse_or_uc_volumes_uri
+
+if TYPE_CHECKING:
+    from mlflow.types.chat import ContentType
 
 _TRACKING_METHOD_TO_INFO = extract_api_info_for_service(MlflowService, _REST_API_PATH_PREFIX)
 _METHOD_TO_INFO = {
@@ -1416,9 +1421,10 @@ class UcModelRegistryStore(BaseRestStore):
     def create_prompt_version(
         self,
         name: str,
-        template: str,
+        template: Union[str, list[dict[str, "ContentType"]]],
         description: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     ) -> PromptVersion:
         """
         Create a new prompt version in Unity Catalog.
@@ -1433,8 +1439,15 @@ class UcModelRegistryStore(BaseRestStore):
         # We don't set it here as it's generated server-side
         if description:
             prompt_version_proto.description = description
-        if tags:
-            prompt_version_proto.tags.extend(mlflow_tags_to_proto_version_tags(tags))
+
+        final_tags = tags.copy() if tags else {}
+        if response_format:
+            final_tags[RESPONSE_FORMAT_TAG_KEY] = json.dumps(
+                PromptVersion.convert_response_format_to_dict(response_format)
+            )
+
+        if final_tags:
+            prompt_version_proto.tags.extend(mlflow_tags_to_proto_version_tags(final_tags))
 
         req_body = message_to_json(
             CreatePromptVersionRequest(

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -7,6 +7,7 @@ from typing import Optional
 
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
+from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY_UC
 from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
     PromptAlias as ProtoPromptAlias,
 )
@@ -75,6 +76,11 @@ def proto_to_mlflow_prompt(
     version_tags = (
         proto_version_tags_to_mlflow_tags(proto_version.tags) if proto_version.tags else {}
     )
+    if RESPONSE_FORMAT_TAG_KEY_UC in version_tags:
+        response_format = json.loads(version_tags[RESPONSE_FORMAT_TAG_KEY_UC])
+    else:
+        response_format = None
+
     version_tags = {
         key: value for key, value in version_tags.items() if not key.startswith("_mlflow")
     }
@@ -96,6 +102,7 @@ def proto_to_mlflow_prompt(
         creation_timestamp=proto_version.creation_timestamp,
         tags=version_tags,
         aliases=aliases,
+        response_format=response_format,
     )
 
 

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -2,6 +2,7 @@
 Utility functions for converting between Unity Catalog proto and MLflow entities.
 """
 
+import json
 from typing import Optional
 
 from mlflow.entities.model_registry.prompt import Prompt
@@ -74,6 +75,9 @@ def proto_to_mlflow_prompt(
     version_tags = (
         proto_version_tags_to_mlflow_tags(proto_version.tags) if proto_version.tags else {}
     )
+    version_tags = {
+        key: value for key, value in version_tags.items() if not key.startswith("_mlflow")
+    }
 
     # Extract aliases
     aliases = []
@@ -87,7 +91,7 @@ def proto_to_mlflow_prompt(
     return PromptVersion(
         name=proto_version.name,
         version=version,
-        template=proto_version.template,
+        template=json.loads(proto_version.template),
         commit_message=proto_version.description,
         creation_timestamp=proto_version.creation_timestamp,
         tags=version_tags,

--- a/mlflow/store/_unity_catalog/registry/utils.py
+++ b/mlflow/store/_unity_catalog/registry/utils.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
-from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY_UC
+from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY
 from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
     PromptAlias as ProtoPromptAlias,
 )
@@ -76,8 +76,8 @@ def proto_to_mlflow_prompt(
     version_tags = (
         proto_version_tags_to_mlflow_tags(proto_version.tags) if proto_version.tags else {}
     )
-    if RESPONSE_FORMAT_TAG_KEY_UC in version_tags:
-        response_format = json.loads(version_tags[RESPONSE_FORMAT_TAG_KEY_UC])
+    if RESPONSE_FORMAT_TAG_KEY in version_tags:
+        response_format = json.loads(version_tags[RESPONSE_FORMAT_TAG_KEY])
     else:
         response_format = None
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5640,17 +5640,12 @@ class MlflowClient:
 
         Args:
             name: Name of the prompt.
-            template: The prompt template content for this version. Can be either:
-                - A string containing text with variables enclosed in double curly braces,
-                  e.g. {{variable}}, which will be replaced with actual values by the `format`
-                  method.
-                - A list of dictionaries representing chat messages, where each message has
-                  'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
+            template: The prompt template content for this version.
             description: Optional description of the prompt version.
             tags: Optional dictionary of prompt version tags.
             response_format: Optional Pydantic class or dictionary defining the expected response
-                structure. This can be used to specify the schema for structured outputs from LLM
-                calls.
+                structure. This can be used to specify the schema for structured
+                outputs from LLM calls.
 
         Returns:
             A PromptVersion object.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -5627,9 +5627,10 @@ class MlflowClient:
     def create_prompt_version(
         self,
         name: str,
-        template: str,
+        template: Union[str, list[dict[str, "ContentType"]]],
         description: Optional[str] = None,
         tags: Optional[dict[str, str]] = None,
+        response_format: Optional[Union[BaseModel, dict[str, Any]]] = None,
     ) -> PromptVersion:
         """
         Create a new version of an existing prompt.
@@ -5639,9 +5640,17 @@ class MlflowClient:
 
         Args:
             name: Name of the prompt.
-            template: Template text of the prompt version.
+            template: The prompt template content for this version. Can be either:
+                - A string containing text with variables enclosed in double curly braces,
+                  e.g. {{variable}}, which will be replaced with actual values by the `format`
+                  method.
+                - A list of dictionaries representing chat messages, where each message has
+                  'role' and 'content' keys (e.g., [{"role": "user", "content": "Hello {{name}}"}])
             description: Optional description of the prompt version.
             tags: Optional dictionary of prompt version tags.
+            response_format: Optional Pydantic class or dictionary defining the expected response
+                structure. This can be used to specify the schema for structured outputs from LLM
+                calls.
 
         Returns:
             A PromptVersion object.
@@ -5661,7 +5670,9 @@ class MlflowClient:
             )
         """
         registry_client = self._get_registry_client()
-        return registry_client.create_prompt_version(name, template, description, tags)
+        return registry_client.create_prompt_version(
+            name, template, description, tags, response_format
+        )
 
     @experimental(version="3.0.0")
     @require_prompt_registry

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -29,7 +29,13 @@ from mlflow.entities.run_tag import RunTag
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.models.model import MLMODEL_FILE_NAME
 from mlflow.models.signature import ModelSignature, Schema
-from mlflow.prompt.constants import LINKED_PROMPTS_TAG_KEY
+from mlflow.prompt.constants import (
+    LINKED_PROMPTS_TAG_KEY,
+    PROMPT_TYPE_CHAT,
+    PROMPT_TYPE_TAG_KEY_UC,
+    PROMPT_TYPE_TEXT,
+    RESPONSE_FORMAT_TAG_KEY_UC,
+)
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     MODEL_VERSION_OPERATION_READ_WRITE,
     AwsCredentials,
@@ -2343,8 +2349,6 @@ def test_create_prompt_version_uc(mock_http, store, monkeypatch):
 
 @mock_http_200
 def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeypatch):
-    from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY
-
     name = "prompt1"
     template = "Generate a response for {query}"
     description = "A response generation prompt"
@@ -2390,11 +2394,12 @@ def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeyp
     prompt_version = request_body["prompt_version"]
 
     tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
-    assert RESPONSE_FORMAT_TAG_KEY in tags_in_request
+    assert RESPONSE_FORMAT_TAG_KEY_UC in tags_in_request
 
     expected_response_format = json.dumps(response_format)
-    assert tags_in_request[RESPONSE_FORMAT_TAG_KEY] == expected_response_format
+    assert tags_in_request[RESPONSE_FORMAT_TAG_KEY_UC] == expected_response_format
     assert tags_in_request["env"] == "test"
+    assert tags_in_request[PROMPT_TYPE_TAG_KEY_UC] == PROMPT_TYPE_TEXT
 
 
 @mock_http_200
@@ -2445,6 +2450,7 @@ def test_create_prompt_version_with_multi_turn_template_uc(mock_http, store, mon
     tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
     assert tags_in_request["type"] == "conversation"
     assert tags_in_request["env"] == "test"
+    assert tags_in_request[PROMPT_TYPE_TAG_KEY_UC] == PROMPT_TYPE_CHAT
 
 
 @mock_http_200

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -2347,7 +2347,7 @@ def test_create_prompt_version_uc(mock_http, store, monkeypatch):
         proto_to_prompt.assert_called()
 
 
-@mock_http_200
+@mock.patch("mlflow.utils.rest_utils.http_request")
 def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeypatch):
     name = "prompt1"
     template = "Generate a response for {query}"
@@ -2355,32 +2355,34 @@ def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeyp
     tags = {"env": "test"}
     response_format = {"type": "object", "properties": {"answer": {"type": "string"}}}
 
-    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
-    with mock.patch(
-        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
-        return_value=PromptVersion(
-            name=name,
-            version=1,
-            template=template,
-            commit_message=description,
-            tags=tags,
-            response_format=response_format,
-        ),
-    ) as proto_to_prompt:
-        store.create_prompt_version(
-            name=name,
-            template=template,
-            description=description,
-            tags=tags,
-            response_format=response_format,
-        )
+    # Mock the HTTP response to simulate Unity Catalog server response
+    mock_response_data = {
+        "name": name,
+        "version": "1",
+        "template": json.dumps(template),
+        "description": description,
+        "tags": [
+            {"key": "env", "value": "test"},
+            {"key": RESPONSE_FORMAT_TAG_KEY_UC, "value": json.dumps(response_format)},
+            {"key": PROMPT_TYPE_TAG_KEY_UC, "value": PROMPT_TYPE_TEXT},
+        ],
+    }
+
+    mock_http.return_value = mock.MagicMock(status_code=200, text=json.dumps(mock_response_data))
+
+    result = store.create_prompt_version(
+        name=name,
+        template=template,
+        description=description,
+        tags=tags,
+        response_format=response_format,
+    )
 
     # Verify the correct endpoint is called
     assert any(
         "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
         for c in mock_http.call_args_list
     )
-    proto_to_prompt.assert_called()
 
     # Verify the HTTP request body contains the response_format in tags
     http_call_args = [
@@ -2394,12 +2396,14 @@ def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeyp
     prompt_version = request_body["prompt_version"]
 
     tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
-    assert RESPONSE_FORMAT_TAG_KEY_UC in tags_in_request
-
     expected_response_format = json.dumps(response_format)
     assert tags_in_request[RESPONSE_FORMAT_TAG_KEY_UC] == expected_response_format
-    assert tags_in_request["env"] == "test"
     assert tags_in_request[PROMPT_TYPE_TAG_KEY_UC] == PROMPT_TYPE_TEXT
+    assert tags_in_request["env"] == "test"
+
+    assert isinstance(result, PromptVersion)
+    assert result.name == name
+    assert result.response_format == response_format
 
 
 @mock_http_200

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -2342,6 +2342,112 @@ def test_create_prompt_version_uc(mock_http, store, monkeypatch):
 
 
 @mock_http_200
+def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeypatch):
+    from mlflow.prompt.constants import RESPONSE_FORMAT_TAG_KEY
+
+    name = "prompt1"
+    template = "Generate a response for {query}"
+    description = "A response generation prompt"
+    tags = {"env": "test"}
+    response_format = {"type": "object", "properties": {"answer": {"type": "string"}}}
+
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(
+            name=name,
+            version=1,
+            template=template,
+            commit_message=description,
+            tags=tags,
+            response_format=response_format,
+        ),
+    ) as proto_to_prompt:
+        store.create_prompt_version(
+            name=name,
+            template=template,
+            description=description,
+            tags=tags,
+            response_format=response_format,
+        )
+
+    # Verify the correct endpoint is called
+    assert any(
+        "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+        for c in mock_http.call_args_list
+    )
+    proto_to_prompt.assert_called()
+
+    # Verify the HTTP request body contains the response_format in tags
+    http_call_args = [
+        c
+        for c in mock_http.call_args_list
+        if "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+    ]
+    assert len(http_call_args) == 1
+
+    request_body = http_call_args[0][1]["json"]
+    prompt_version = request_body["prompt_version"]
+
+    tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
+    assert RESPONSE_FORMAT_TAG_KEY in tags_in_request
+
+    expected_response_format = json.dumps(response_format)
+    assert tags_in_request[RESPONSE_FORMAT_TAG_KEY] == expected_response_format
+    assert tags_in_request["env"] == "test"
+
+
+@mock_http_200
+def test_create_prompt_version_with_multi_turn_template_uc(mock_http, store, monkeypatch):
+    name = "prompt1"
+    template = [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Hello, can you help me with {task}?"},
+        {"role": "assistant", "content": "Of course! I'd be happy to help you with {task}."},
+        {"role": "user", "content": "Please provide a detailed explanation."},
+    ]
+    description = "A multi-turn conversation prompt"
+    tags = {"type": "conversation", "env": "test"}
+
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(
+            name=name, version=1, template=template, commit_message=description, tags=tags
+        ),
+    ) as proto_to_prompt:
+        store.create_prompt_version(
+            name=name, template=template, description=description, tags=tags
+        )
+
+    # Verify the correct endpoint is called
+    assert any(
+        "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+        for c in mock_http.call_args_list
+    )
+    proto_to_prompt.assert_called()
+
+    # Verify the HTTP request body contains the multi-turn template
+    http_call_args = [
+        c
+        for c in mock_http.call_args_list
+        if "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
+    ]
+    assert len(http_call_args) == 1
+
+    request_body = http_call_args[0][1]["json"]
+    prompt_version = request_body["prompt_version"]
+
+    # Verify template was JSON-encoded properly
+    template_in_request = json.loads(prompt_version["template"])
+    assert template_in_request == template
+
+    tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
+    assert tags_in_request["type"] == "conversation"
+    assert tags_in_request["env"] == "test"
+
+
+@mock_http_200
 def test_get_prompt_uc(mock_http, store, monkeypatch):
     name = "prompt1"
     # Patch proto_info_to_mlflow_prompt_info to return a dummy Prompt

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -32,9 +32,9 @@ from mlflow.models.signature import ModelSignature, Schema
 from mlflow.prompt.constants import (
     LINKED_PROMPTS_TAG_KEY,
     PROMPT_TYPE_CHAT,
-    PROMPT_TYPE_TAG_KEY_UC,
+    PROMPT_TYPE_TAG_KEY,
     PROMPT_TYPE_TEXT,
-    RESPONSE_FORMAT_TAG_KEY_UC,
+    RESPONSE_FORMAT_TAG_KEY,
 )
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     MODEL_VERSION_OPERATION_READ_WRITE,
@@ -2347,7 +2347,7 @@ def test_create_prompt_version_uc(mock_http, store, monkeypatch):
         proto_to_prompt.assert_called()
 
 
-@mock.patch("mlflow.utils.rest_utils.http_request")
+@mock_http_200
 def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeypatch):
     name = "prompt1"
     template = "Generate a response for {query}"
@@ -2355,34 +2355,32 @@ def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeyp
     tags = {"env": "test"}
     response_format = {"type": "object", "properties": {"answer": {"type": "string"}}}
 
-    # Mock the HTTP response to simulate Unity Catalog server response
-    mock_response_data = {
-        "name": name,
-        "version": "1",
-        "template": json.dumps(template),
-        "description": description,
-        "tags": [
-            {"key": "env", "value": "test"},
-            {"key": RESPONSE_FORMAT_TAG_KEY_UC, "value": json.dumps(response_format)},
-            {"key": PROMPT_TYPE_TAG_KEY_UC, "value": PROMPT_TYPE_TEXT},
-        ],
-    }
-
-    mock_http.return_value = mock.MagicMock(status_code=200, text=json.dumps(mock_response_data))
-
-    result = store.create_prompt_version(
-        name=name,
-        template=template,
-        description=description,
-        tags=tags,
-        response_format=response_format,
-    )
+    # Patch proto_to_mlflow_prompt to return a dummy PromptVersion
+    with mock.patch(
+        "mlflow.store._unity_catalog.registry.rest_store.proto_to_mlflow_prompt",
+        return_value=PromptVersion(
+            name=name,
+            version=1,
+            template=template,
+            commit_message=description,
+            tags=tags,
+            response_format=response_format,
+        ),
+    ) as proto_to_prompt:
+        store.create_prompt_version(
+            name=name,
+            template=template,
+            description=description,
+            tags=tags,
+            response_format=response_format,
+        )
 
     # Verify the correct endpoint is called
     assert any(
         "/prompts/" in c[1]["endpoint"] and "/versions" in c[1]["endpoint"]
         for c in mock_http.call_args_list
     )
+    proto_to_prompt.assert_called()
 
     # Verify the HTTP request body contains the response_format in tags
     http_call_args = [
@@ -2396,14 +2394,12 @@ def test_create_prompt_version_with_response_format_uc(mock_http, store, monkeyp
     prompt_version = request_body["prompt_version"]
 
     tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
-    expected_response_format = json.dumps(response_format)
-    assert tags_in_request[RESPONSE_FORMAT_TAG_KEY_UC] == expected_response_format
-    assert tags_in_request[PROMPT_TYPE_TAG_KEY_UC] == PROMPT_TYPE_TEXT
-    assert tags_in_request["env"] == "test"
+    assert RESPONSE_FORMAT_TAG_KEY in tags_in_request
 
-    assert isinstance(result, PromptVersion)
-    assert result.name == name
-    assert result.response_format == response_format
+    expected_response_format = json.dumps(response_format)
+    assert tags_in_request[RESPONSE_FORMAT_TAG_KEY] == expected_response_format
+    assert tags_in_request["env"] == "test"
+    assert tags_in_request[PROMPT_TYPE_TAG_KEY] == PROMPT_TYPE_TEXT
 
 
 @mock_http_200
@@ -2454,7 +2450,7 @@ def test_create_prompt_version_with_multi_turn_template_uc(mock_http, store, mon
     tags_in_request = {tag["key"]: tag["value"] for tag in prompt_version.get("tags", [])}
     assert tags_in_request["type"] == "conversation"
     assert tags_in_request["env"] == "test"
-    assert tags_in_request[PROMPT_TYPE_TAG_KEY_UC] == PROMPT_TYPE_CHAT
+    assert tags_in_request[PROMPT_TYPE_TAG_KEY] == PROMPT_TYPE_CHAT
 
 
 @mock_http_200

--- a/tests/store/_unity_catalog/registry/test_uc_prompt_utils.py
+++ b/tests/store/_unity_catalog/registry/test_uc_prompt_utils.py
@@ -1,5 +1,12 @@
+import json
+
 from mlflow.entities.model_registry.prompt import Prompt
 from mlflow.entities.model_registry.prompt_version import PromptVersion
+from mlflow.prompt.constants import (
+    PROMPT_TYPE_TAG_KEY,
+    PROMPT_TYPE_TEXT,
+    RESPONSE_FORMAT_TAG_KEY,
+)
 from mlflow.protos.unity_catalog_prompt_messages_pb2 import (
     Prompt as ProtoPrompt,
 )
@@ -91,7 +98,7 @@ def test_proto_to_mlflow_prompt():
     proto_version = ProtoPromptVersion()
     proto_version.name = "test_prompt"
     proto_version.version = "1"
-    proto_version.template = "Hello {{name}}!"
+    proto_version.template = json.dumps("Hello {{name}}!")
     proto_version.description = "Test description"
 
     # Add version tags
@@ -99,6 +106,22 @@ def test_proto_to_mlflow_prompt():
         [
             ProtoPromptVersionTag(key="env", value="production"),
             ProtoPromptVersionTag(key="author", value="alice"),
+            ProtoPromptVersionTag(key=PROMPT_TYPE_TAG_KEY, value=PROMPT_TYPE_TEXT),
+            ProtoPromptVersionTag(
+                key=RESPONSE_FORMAT_TAG_KEY,
+                value=json.dumps(
+                    {
+                        "type": "json_schema",
+                        "json_schema": {
+                            "name": "test_schema",
+                            "schema": {
+                                "type": "object",
+                                "properties": {"name": {"type": "string"}},
+                            },
+                        },
+                    }
+                ),
+            ),
         ]
     )
 
@@ -106,13 +129,21 @@ def test_proto_to_mlflow_prompt():
 
     # The critical test: version tags should go to tags
     expected_tags = {"env": "production", "author": "alice"}
+    assert result.template == "Hello {{name}}!"
+    assert result.response_format == {
+        "type": "json_schema",
+        "json_schema": {
+            "name": "test_schema",
+            "schema": {"type": "object", "properties": {"name": {"type": "string"}}},
+        },
+    }
     assert result.tags == expected_tags
 
     # Test with no tags
     proto_no_tags = ProtoPromptVersion()
     proto_no_tags.name = "no_tags_prompt"
     proto_no_tags.version = "2"
-    proto_no_tags.template = "Simple template"
+    proto_no_tags.template = json.dumps("Simple template")
 
     result_no_tags = proto_to_mlflow_prompt(proto_no_tags)
     assert result_no_tags.tags == {}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16808?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16808/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16808/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16808/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Support multi-turn message and response format in uc prompt registry

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
