### PR TITLE
Pin `cmudict`

### DIFF
--- a/mlflow/utils/environment.py
+++ b/mlflow/utils/environment.py
@@ -530,6 +530,10 @@ def _lock_requirements(
             constraints_file = tmp_dir_path / "constraints.txt"
             constraints_file.write_text("\n".join(constraints))
             constraints_opt = [f"--constraints={constraints_file}"]
+        elif pip_constraint := os.environ.get("PIP_CONSTRAINT"):
+            # If PIP_CONSTRAINT is set, use it as a constraint file
+            constraints_opt = [f"--constraints={pip_constraint}"]
+
         try:
             uv_options, uv_envs = _get_uv_options_for_databricks()
             out = subprocess.check_output(

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -22,3 +22,5 @@ FLAML<2.3.5
 # `tests/tracing/test_fluent.py::test_mlflow_trace_isolated_from_other_otel_processors`
 # https://github.com/huggingface/transformers/commit/211f2b08751cdee4bd6b84892b91f4a18dbfe305
 transformers<4.53.0
+# TODO: Unpin once https://github.com/textstat/textstat/issues/212 is resolved.
+cmudict<1.1.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16809?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16809/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16809/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16809/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Pin `cmudict` for https://github.com/textstat/textstat/issues/212. Fixes https://github.com/mlflow/mlflow/actions/runs/16430875422/job/46431868375:

```
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/mlflow/models/evaluation/default_evaluator.py", line 713, in _test_first_row
    metric_value = metric.evaluate(eval_fn_args)
  File "/home/runner/work/mlflow/mlflow/mlflow/models/evaluation/utils/metric.py", line 59, in evaluate
    metric: MetricValue = self.function(*eval_fn_args)
  File "/home/runner/work/mlflow/mlflow/mlflow/metrics/metric_definitions.py", line 165, in _flesch_kincaid_eval_fn
    scores = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
  File "/home/runner/work/mlflow/mlflow/mlflow/metrics/metric_definitions.py", line 165, in <listcomp>
    scores = [textstat.flesch_kincaid_grade(prediction) for prediction in predictions]
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/textstat/textstat.py", line 584, in flesch_kincaid_grade
    return self._legacy_round(metrics.flesch_kincaid_grade(text, self.__lang))
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/textstat/backend/metrics/_flesch_kincaid_grade.py", line 34, in flesch_kincaid_grade
    syllables = syllables_per_word(text, lang)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/textstat/backend/metrics/_syllables_per_word.py", line 26, in syllables_per_word
    return count_syllables(text, lang) / count_words(text)
  File "/opt/hostedtoolcache/Python/3.10.16/x64/lib/python3.10/site-packages/textstat/backend/counts/_count_syllables.py", line 30, in count_syllables
    cmu_phones = cmu_dict[word][0]
KeyError: 'text_a'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
