### PR TITLE
Automatically track git metadata for experiments

### DIFF
--- a/mlflow/tracking/context/git_context.py
+++ b/mlflow/tracking/context/git_context.py
@@ -2,8 +2,8 @@ import logging
 
 from mlflow.tracking.context.abstract_context import RunContextProvider
 from mlflow.tracking.context.default_context import _get_main_file
-from mlflow.utils.git_utils import get_git_commit
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
+from mlflow.utils.git_utils import get_git_commit, get_git_branch, get_git_repo_url
+from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT, MLFLOW_GIT_BRANCH, MLFLOW_GIT_REPO_URL
 
 _logger = logging.getLogger(__name__)
 
@@ -12,6 +12,20 @@ def _get_source_version():
     main_file = _get_main_file()
     if main_file is not None:
         return get_git_commit(main_file)
+    return None
+
+
+def _get_git_branch():
+    main_file = _get_main_file()
+    if main_file is not None:
+        return get_git_branch(main_file)
+    return None
+
+
+def _get_git_repo_url():
+    main_file = _get_main_file()
+    if main_file is not None:
+        return get_git_repo_url(main_file)
     return None
 
 
@@ -25,8 +39,34 @@ class GitRunContext(RunContextProvider):
             self._cache["source_version"] = _get_source_version()
         return self._cache["source_version"]
 
+    @property
+    def _git_branch(self):
+        if "git_branch" not in self._cache:
+            self._cache["git_branch"] = _get_git_branch()
+        return self._cache["git_branch"]
+
+    @property
+    def _git_repo_url(self):
+        if "git_repo_url" not in self._cache:
+            self._cache["git_repo_url"] = _get_git_repo_url()
+        return self._cache["git_repo_url"]
+
     def in_context(self):
         return self._source_version is not None
 
     def tags(self):
-        return {MLFLOW_GIT_COMMIT: self._source_version}
+        tags = {}
+        
+        # Add Git commit SHA if available
+        if self._source_version is not None:
+            tags[MLFLOW_GIT_COMMIT] = self._source_version
+        
+        # Add Git branch name if available
+        if self._git_branch is not None:
+            tags[MLFLOW_GIT_BRANCH] = self._git_branch
+        
+        # Add Git repository URL if available
+        if self._git_repo_url is not None:
+            tags[MLFLOW_GIT_REPO_URL] = self._git_repo_url
+        
+        return tags

--- a/tests/tracking/context/test_git_context.py
+++ b/tests/tracking/context/test_git_context.py
@@ -4,10 +4,12 @@ import git
 import pytest
 
 from mlflow.tracking.context.git_context import GitRunContext
-from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT
+from mlflow.utils.mlflow_tags import MLFLOW_GIT_COMMIT, MLFLOW_GIT_BRANCH, MLFLOW_GIT_REPO_URL
 
 MOCK_SCRIPT_NAME = "/path/to/script.py"
 MOCK_COMMIT_HASH = "commit-hash"
+MOCK_BRANCH_NAME = "main"
+MOCK_REPO_URL = "https://github.com/mlflow/mlflow.git"
 
 
 @pytest.fixture
@@ -23,6 +25,12 @@ def patch_git_repo():
     mock_repo = mock.Mock()
     mock_repo.head.commit.hexsha = MOCK_COMMIT_HASH
     mock_repo.ignored.return_value = []
+    # Mock branch
+    mock_repo.active_branch.name = MOCK_BRANCH_NAME
+    # Mock remotes for repo URL
+    mock_remote = mock.Mock()
+    mock_remote.url = MOCK_REPO_URL
+    mock_repo.remotes = [mock_remote]
     with mock.patch("git.Repo", return_value=mock_repo):
         yield mock_repo
 
@@ -37,15 +45,38 @@ def test_git_run_context_in_context_false(patch_script_name):
 
 
 def test_git_run_context_tags(patch_script_name, patch_git_repo):
-    assert GitRunContext().tags() == {MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH}
+    expected_tags = {
+        MLFLOW_GIT_COMMIT: MOCK_COMMIT_HASH,
+        MLFLOW_GIT_BRANCH: MOCK_BRANCH_NAME,
+        MLFLOW_GIT_REPO_URL: MOCK_REPO_URL
+    }
+    assert GitRunContext().tags() == expected_tags
 
 
 def test_git_run_context_caching(patch_script_name):
-    """Check that the git commit hash is only looked up once."""
+    """Check that git operations are cached properly."""
 
-    with mock.patch("git.Repo") as mock_repo:
+    with mock.patch("mlflow.tracking.context.git_context._get_source_version") as mock_commit, \
+         mock.patch("mlflow.tracking.context.git_context._get_git_branch") as mock_branch, \
+         mock.patch("mlflow.tracking.context.git_context._get_git_repo_url") as mock_repo_url:
+        
+        mock_commit.return_value = MOCK_COMMIT_HASH
+        mock_branch.return_value = MOCK_BRANCH_NAME
+        mock_repo_url.return_value = MOCK_REPO_URL
+        
         context = GitRunContext()
-        context.in_context()
-        context.tags()
-
-    mock_repo.assert_called_once()
+        
+        # First calls should invoke the git functions
+        assert context._source_version == MOCK_COMMIT_HASH
+        assert context._git_branch == MOCK_BRANCH_NAME
+        assert context._git_repo_url == MOCK_REPO_URL
+        
+        # Second calls should use cached values
+        assert context._source_version == MOCK_COMMIT_HASH
+        assert context._git_branch == MOCK_BRANCH_NAME
+        assert context._git_repo_url == MOCK_REPO_URL
+        
+        # Each function should only be called once (due to caching)
+        mock_commit.assert_called_once()
+        mock_branch.assert_called_once()
+        mock_repo_url.assert_called_once()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/blitzedNdun/mlflow/pull/16827?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16827/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16827/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16827/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #13201

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Git metadata (branch + repo URL) are tracked by default without requiring MLflow Projects or Recipe.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Git branch and repository URL are now tracked automatically via tags.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
