### PR TITLE
Made enable_databricks_trace_archiva() idempotent, fix stream caching and optimized genai view definition

### DIFF
--- a/mlflow/genai/experimental/databricks_trace_archival.py
+++ b/mlflow/genai/experimental/databricks_trace_archival.py
@@ -157,7 +157,12 @@ def _create_genai_trace_view(view_name: str, spans_table: str, events_table: str
                     TIMESTAMP_MILLIS(
                         CAST(body:last_update_time::DOUBLE AS BIGINT)
                     ) AS last_update_time,
-                    FROM_JSON(body:expectation::STRING, 'STRUCT<value: STRING>') AS expectation,
+                    FROM_JSON(body:expectation::STRING,
+                        'STRUCT<
+                            value: STRING,
+                            serialized_value: STRUCT<serialization_format: STRING, value: STRING>
+                            >
+                        ') AS expectation,
                     FROM_JSON(
                         body:feedback::STRING,
                         'STRUCT<

--- a/mlflow/genai/experimental/databricks_trace_exporter.py
+++ b/mlflow/genai/experimental/databricks_trace_exporter.py
@@ -334,15 +334,11 @@ class IngestStreamFactory:
         if stream_cache and "stream" in stream_cache:
             stream = stream_cache["stream"]
 
-            # Check if stream is in a valid state
-            is_invalid_state = hasattr(stream, "state") and str(stream.state) in [
-                "CLOSED",
-                "FAILED",
-            ]
+            from ingest_api_sdk.shared.definitions import StreamState
 
-            if is_invalid_state:
-                _logger.debug(f"Stream in invalid state {stream.state}, creating new stream")
-                # Invalidate the bad stream from the cache
+            # Invalidate the bad stream from the cache if stream is in a valid state
+            if stream.get_state() not in [StreamState.OPENED, StreamState.FLUSHING]:
+                _logger.debug(f"Stream in invalid state {stream.get_state()}, creating new stream")
                 self._thread_local.stream_cache = None
 
         # Return the valid stream if it wasn't invalidated


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jamesbxwu/mlflow/pull/16842?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16842/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16842/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16842/merge
```

</p>
</details>

### What changes are proposed in this pull request?
This PR addresses two important issues in the databricks trace archival functionality:

1. Assessment Timestamp Handling
  - Updated the GenAI view definition to correctly handle create_time and last_update_time fields in assessment events
  - These fields are now parsed as DOUBLE (Unix timestamps in milliseconds) and converted to proper TIMESTAMP using TIMESTAMP_MILLIS(CAST(...AS BIGINT))
  - Optimize the definition by using VARIANT to parse the event body for the initial join and then converting to STRUCT in the final select

2. Idempotent Behavior
  - Removed the ALREADY_EXISTS error handling that was causing early returns
  - The function now properly recreates the view and resets the experiment tag on every call
  - DatabricksTraceServerClient().create_trace_destination() is now idempotent and only throws ALREADY_EXISTS when table schema versions change

3. Fixed bug with ingest stream caching to use the proper `StreamState` enum instead of raw string

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [x] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
