### PR TITLE
Update DatabricksTraceExporter to ingest span immediately rather than batching them at trace-level

### DIFF
--- a/mlflow/genai/experimental/databricks_trace_exporter.py
+++ b/mlflow/genai/experimental/databricks_trace_exporter.py
@@ -7,9 +7,9 @@ from typing import Optional, Sequence
 
 from cachetools import TTLCache
 from ingest_api_sdk import TableProperties
+from opentelemetry.sdk.trace import ReadableSpan
 
-from mlflow.entities.model_registry import PromptVersion
-from mlflow.entities.trace import Trace
+from mlflow.entities.span import Span
 from mlflow.environment_variables import (
     MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL,
 )
@@ -18,7 +18,10 @@ from mlflow.genai.experimental.databricks_trace_exporter_utils import (
     create_archival_ingest_sdk,
 )
 from mlflow.genai.experimental.databricks_trace_otel_pb2 import Span as DeltaProtoSpan
+from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+from mlflow.tracing.utils import encode_span_id
 from mlflow.utils.annotations import experimental
 
 _logger = logging.getLogger(__name__)
@@ -42,18 +45,37 @@ class MlflowV3DeltaSpanExporter(MlflowV3SpanExporter):
         # Delta archiver for Databricks archiving functionality
         self._delta_archiver = DatabricksTraceDeltaArchiver()
 
-    def _log_trace(self, trace: Trace, prompts: Sequence[PromptVersion]):
+    def export(self, spans: Sequence[ReadableSpan]):
         """
-        Handles exporting a trace via the MlflowV3SpanExporter with additional archiving to
-        Databricks Delta tables.
+        Export the spans to the destination.
         """
-        # Call parent implementation for existing MlflowV3SpanExporter functionality
-        super()._log_trace(trace, prompts)
+        # Export the spans to Databricks Delta if archival is enabled
+        # NB: Call this before super().export() is called , so that
+        # the trace is still in InMemoryTraceManager
+        for span in spans:
+            if mlflow_span := self._get_mlflow_spans(span):
+                try:
+                    self._delta_archiver.archive(mlflow_span)
+                except Exception as e:
+                    _logger.warning(f"Failed to archive trace to Databricks Delta: {e}")
 
+        # Export the spans to MLflow backend as usual
+        super().export(spans)
+
+    def _get_mlflow_spans(self, span: ReadableSpan) -> Optional[Span]:
+        """
+        Get the MLflow spans for the given OpenTelemetry spans.
+        """
         try:
-            self._delta_archiver.archive(trace)
+            return InMemoryTraceManager.get_instance().get_span_from_id(
+                # use MLflow trace ID instead of OTel trace ID
+                trace_id=json.loads(span.attributes.get(SpanAttributeKey.REQUEST_ID)),
+                # MLflow span ID is encoded version of OTel span ID
+                span_id=encode_span_id(span.context.span_id),
+            )
         except Exception as e:
-            _logger.warning(f"Failed to archive trace to Databricks Delta: {e}")
+            _logger.warning(f"Failed to get MLflow span for span {span.context.span_id}: {e}")
+            return None
 
 
 class DatabricksTraceDeltaArchiver:
@@ -66,13 +88,13 @@ class DatabricksTraceDeltaArchiver:
     _config_cache = TTLCache(maxsize=100, ttl=TRACE_STORAGE_CONFIG_CACHE_TTL_SECONDS)
     _config_cache_lock = threading.Lock()
 
-    def archive(self, trace: Trace):
+    def archive(self, span: Span):
         """
         Try to export a trace to Databricks Delta if archival is configured for the experiment.
         This method handles all enablement checking, configuration resolution, and authentication.
 
         Args:
-            trace: MLflow Trace object containing spans data.
+            span: MLflow Span object containing spans data.
         """
         # Check if delta archival is globally enabled
         if not MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL.get():
@@ -82,12 +104,13 @@ class DatabricksTraceDeltaArchiver:
         try:
             # Extract experiment ID from trace location
             experiment_id = None
-            if (
-                trace.info.trace_location
-                and trace.info.trace_location.type == "MLFLOW_EXPERIMENT"
-                and trace.info.trace_location.mlflow_experiment
-            ):
-                experiment_id = trace.info.trace_location.mlflow_experiment.experiment_id
+            with InMemoryTraceManager.get_instance().get_trace(span.trace_id) as trace:
+                if (
+                    trace.info.trace_location
+                    and trace.info.trace_location.type == "MLFLOW_EXPERIMENT"
+                    and trace.info.trace_location.mlflow_experiment
+                ):
+                    experiment_id = trace.info.trace_location.mlflow_experiment.experiment_id
 
             if not experiment_id:
                 _logger.debug("No experiment ID found in trace, skipping delta archival")
@@ -108,8 +131,8 @@ class DatabricksTraceDeltaArchiver:
                 config.spans_table_name, DeltaProtoSpan.DESCRIPTOR
             )
 
-            # Run the trace logging
-            self._archive_trace(trace, experiment_id, config.spans_table_name)
+            # Run the async trace logging and wait for completion
+            self._archive(span, experiment_id, config.spans_table_name)
 
         except Exception as e:
             _logger.warning(f"Failed to export trace to Databricks Delta: {e}")
@@ -131,23 +154,18 @@ class DatabricksTraceDeltaArchiver:
                 _logger.debug(f"Cached config for experiment {experiment_id}: {config is not None}")
             return self._config_cache[experiment_id]
 
-    def _archive_trace(self, trace: Trace, experiment_id: str, spans_table_name: str):
+    def _archive(self, span: Span, experiment_id: str, spans_table_name: str):
         """
-        Handles exporting a trace to Databricks Delta using the IngestApi.
+        Handles exporting a span to Databricks Delta using the IngestApi.
 
         Args:
-            trace: MLflow Trace object containing spans data.
+            span: MLflow Span object containing spans data.
             experiment_id: ID of the experiment for logging.
             spans_table_name: Name of the spans table for logging.
         """
         try:
             # Convert MLflow trace to OTel proto spans
-            proto_spans = self._convert_trace_to_proto_spans(trace)
-
-            if not proto_spans or len(proto_spans) == 0:
-                _logger.debug("No proto spans to export")
-                return
-
+            proto_span = self._convert_span_to_proto(span)
             # Get stream factory singleton for this table
             factory = IngestStreamFactory.get_instance(self._spans_table_properties)
 
@@ -156,11 +174,10 @@ class DatabricksTraceDeltaArchiver:
 
             # Ingest all spans for the trace
             _logger.debug(
-                f"Ingesting {len(proto_spans)} spans for trace {trace.info.request_id} to table "
+                f"Ingesting span {span.span_id} for trace {span.trace_id} to table "
                 f"{spans_table_name}"
             )
-            for proto_span in proto_spans:
-                stream.ingest_record(proto_span)
+            stream.ingest_record(proto_span)
 
             # Always flush() to ensure data durability.  In sync logging mode, this is ok.
             # For async mode, the flush will be handled by the async queue
@@ -170,93 +187,85 @@ class DatabricksTraceDeltaArchiver:
         except Exception as e:
             _logger.warning(f"Failed to send trace to Databricks Delta: {e}")
 
-    def _convert_trace_to_proto_spans(self, trace: Trace) -> "list[DeltaProtoSpan]":
+    def _convert_span_to_proto(self, span: Span) -> "DeltaProtoSpan":
         """
-        Convert an MLflow trace to a list of Delta Proto Spans.
+        Convert an MLflow span to a Delta Proto Span.
         Direct conversion from MLflow Span to Delta format.
 
         Args:
-            trace: MLflow Trace object containing spans data.
+            span: MLflow Span object containing spans data.
 
         TODO: move this to Span.to_proto() once the legacy trace server span are fully repcated
 
         Returns:
-            List of DeltaProtoSpan objects.
+            DeltaProtoSpan object.
         """
-        delta_proto_spans = []
+        delta_proto = DeltaProtoSpan()
 
-        for span in trace.data.spans:
-            # Skip spans that have no span ID since it will break parent-child relationships
-            if span.span_id is None:
-                _logger.debug(f"Span {span.name} has no span ID, skipping")
-                continue
+        # Skip spans that have no span ID since it will break parent-child relationships
+        if span.span_id is None:
+            _logger.debug(f"Span {span.name} has no span ID, skipping")
+            return
 
-            delta_proto = DeltaProtoSpan()
+        delta_proto = DeltaProtoSpan()
 
-            # Use raw OpenTelemetry trace ID instead of the one from the trace
-            # (without "tr-" prefix) for full OTel compliance
-            delta_proto.trace_id = span._trace_id
-            delta_proto.span_id = span.span_id
-            delta_proto.parent_span_id = span.parent_id or ""
-            delta_proto.trace_state = ""
-            delta_proto.flags = 0
-            delta_proto.name = span.name
+        # Use raw OpenTelemetry trace ID instead of the one from the trace
+        # (without "tr-" prefix) for full OTel compliance
+        delta_proto.trace_id = span._trace_id
+        delta_proto.span_id = span.span_id
+        delta_proto.parent_span_id = span.parent_id or ""
+        delta_proto.trace_state = ""
+        delta_proto.flags = 0
+        delta_proto.name = span.name
 
-            # Map span kind to string
-            kind_mapping = {
-                "internal": "SPAN_KIND_INTERNAL",
-                "server": "SPAN_KIND_SERVER",
-                "client": "SPAN_KIND_CLIENT",
-                "producer": "SPAN_KIND_PRODUCER",
-                "consumer": "SPAN_KIND_CONSUMER",
+        # Map span kind to string
+        kind_mapping = {
+            "internal": "SPAN_KIND_INTERNAL",
+            "server": "SPAN_KIND_SERVER",
+            "client": "SPAN_KIND_CLIENT",
+            "producer": "SPAN_KIND_PRODUCER",
+            "consumer": "SPAN_KIND_CONSUMER",
+        }
+        delta_proto.kind = kind_mapping.get(
+            getattr(span, "kind", "internal").lower(), "SPAN_KIND_INTERNAL"
+        )
+
+        # Set timestamps (convert to nanoseconds if needed)
+        current_time_ns = int(time.time() * 1e9)
+        delta_proto.start_time_unix_nano = getattr(span, "start_time_ns", current_time_ns)
+        end_time_ns = getattr(span, "end_time_ns", None)
+        if end_time_ns is None:
+            end_time_ns = delta_proto.start_time_unix_nano + 1000000000  # fallback: 1s after start
+        delta_proto.end_time_unix_nano = end_time_ns
+
+        # the raw otel span attributes are already json serialized
+        attributes = dict(span._span.attributes)
+
+        for key, value in attributes.items():
+            delta_proto.attributes[str(key)] = value
+
+        # Convert events directly
+        events = getattr(span, "events", []) or []
+        for event in events:
+            event_dict = {
+                "time_unix_nano": getattr(event, "timestamp_ns", current_time_ns),
+                "name": getattr(event, "name", "event"),
+                "attributes": getattr(event, "attributes", {}) or {},
+                "dropped_attributes_count": 0,
             }
-            delta_proto.kind = kind_mapping.get(
-                getattr(span, "kind", "internal").lower(), "SPAN_KIND_INTERNAL"
-            )
+            delta_proto.events.append(json.dumps(event_dict))
+        delta_proto.dropped_events_count = 0
 
-            # Set timestamps (convert to nanoseconds if needed)
-            current_time_ns = int(time.time() * 1e9)
-            delta_proto.start_time_unix_nano = getattr(span, "start_time_ns", current_time_ns)
-            end_time_ns = getattr(span, "end_time_ns", None)
-            if end_time_ns is None:
-                end_time_ns = (
-                    delta_proto.start_time_unix_nano + 1000000000
-                )  # fallback: 1s after start
-            delta_proto.end_time_unix_nano = end_time_ns
+        # Links are rarely used in MLflow, set to empty
+        delta_proto.dropped_links_count = 0
 
-            # the raw otel span attributes are already json serialized
-            attributes = dict(span._span.attributes)
-
-            for key, value in attributes.items():
-                delta_proto.attributes[str(key)] = value
-
-            delta_proto.dropped_attributes_count = 0
-
-            # Convert events directly
-            events = getattr(span, "events", []) or []
-            for event in events:
-                event_dict = {
-                    "time_unix_nano": getattr(event, "timestamp_ns", current_time_ns),
-                    "name": getattr(event, "name", "event"),
-                    "attributes": getattr(event, "attributes", {}) or {},
-                    "dropped_attributes_count": 0,
-                }
-                delta_proto.events.append(json.dumps(event_dict))
-            delta_proto.dropped_events_count = 0
-
-            # Links are rarely used in MLflow, set to empty
-            delta_proto.dropped_links_count = 0
-
-            # Convert status directly
-            status_dict = {
-                "code": getattr(span.status, "status_code", "STATUS_CODE_UNSET"),
-                "message": getattr(span.status, "description", "") or "",
-            }
-            delta_proto.status = json.dumps(status_dict)
-
-            delta_proto_spans.append(delta_proto)
-
-        return delta_proto_spans
+        # Convert status directly
+        status_dict = {
+            "code": getattr(span.status, "status_code", "STATUS_CODE_UNSET"),
+            "message": getattr(span.status, "description", "") or "",
+        }
+        delta_proto.status = json.dumps(status_dict)
+        return delta_proto
 
     def shutdown(self):
         """

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -48,7 +48,7 @@ class MlflowV3SpanExporter(SpanExporter):
         """
         for span in spans:
             if span._parent is not None:
-                _logger.debug("Received a non-root span. Skipping export.")
+                # Skip non-root spans
                 continue
 
             manager_trace = InMemoryTraceManager.get_instance().pop_trace(span.context.trace_id)
@@ -135,3 +135,10 @@ class MlflowV3SpanExporter(SpanExporter):
             return False
 
         return self._is_async_enabled
+
+    def force_flush(self):
+        """
+        Force the exporter to flush any pending traces.
+        """
+        if self._is_async_enabled:
+            self._async_queue.flush()

--- a/tests/genai/experimental/test_databricks_trace_exporter.py
+++ b/tests/genai/experimental/test_databricks_trace_exporter.py
@@ -7,12 +7,14 @@ from unittest import mock
 
 import pytest
 
-from mlflow.entities.span import Span
+import mlflow
+from mlflow.entities.span import LiveSpan, Span, SpanType
 from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
+from mlflow.entities.trace_status import TraceStatus
 from mlflow.genai.experimental.databricks_trace_exporter import (
     DatabricksTraceDeltaArchiver,
     IngestStreamFactory,
@@ -21,34 +23,24 @@ from mlflow.genai.experimental.databricks_trace_exporter import (
 from mlflow.genai.experimental.databricks_trace_storage_config import (
     DatabricksTraceDeltaStorageConfig,
 )
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+
+from tests.tracing.helper import get_traces
 
 _EXPERIMENT_ID = "dummy-experiment-id"
 
 
 @pytest.fixture
-def sample_trace_without_spans():
-    """Fixture providing a sample trace for testing."""
-    trace_info = TraceInfo(
-        trace_id="test-trace-id",
-        trace_location=TraceLocation.from_experiment_id(_EXPERIMENT_ID),
-        request_time=0,
-        execution_duration=1,
-        state=TraceState.OK,
-        trace_metadata={},
-        tags={},
-    )
-    trace_data = TraceData(spans=[])
-    return Trace(info=trace_info, data=trace_data)
-
-
-@pytest.fixture
-def sample_trace_with_spans():
+def sample_trace():
     """Fixture providing a trace with sample spans for testing."""
     from tests.tracing.helper import create_mock_otel_span
 
+    otel_trace_id = 0x1234567890ABCDEF
+    mlflow_trace_id = "test-trace-id"
+
     # Create real OpenTelemetry spans using the helper function
     otel_span1 = create_mock_otel_span(
-        trace_id=0x1234567890ABCDEF,  # Use proper hex trace ID
+        trace_id=otel_trace_id,  # Use proper hex trace ID
         span_id=0x123456789ABCDEF0,
         name="root_span",
         parent_id=None,
@@ -57,7 +49,7 @@ def sample_trace_with_spans():
     )
 
     otel_span2 = create_mock_otel_span(
-        trace_id=0x1234567890ABCDEF,  # Same trace ID
+        trace_id=otel_trace_id,  # Same trace ID
         span_id=0x123456789ABCDEF1,
         name="child_span",
         parent_id=0x123456789ABCDEF0,
@@ -66,8 +58,8 @@ def sample_trace_with_spans():
     )
 
     # Create real MLflow Span objects
-    span1 = Span(otel_span1)
-    span2 = Span(otel_span2)
+    span1 = LiveSpan(otel_span1, mlflow_trace_id)
+    span2 = LiveSpan(otel_span2, mlflow_trace_id)
 
     # Set attributes using the proper span methods
     # Note: We need to set attributes through the underlying otel span for testing
@@ -77,7 +69,7 @@ def sample_trace_with_spans():
     spans = [span1, span2]
 
     trace_info = TraceInfo(
-        trace_id="test-trace-id",
+        trace_id=mlflow_trace_id,
         trace_location=TraceLocation.from_experiment_id(_EXPERIMENT_ID),
         request_time=0,
         execution_duration=1,
@@ -86,6 +78,11 @@ def sample_trace_with_spans():
         tags={},
     )
     trace_data = TraceData(spans=spans)
+
+    trace_manager = InMemoryTraceManager.get_instance()
+    trace_manager.register_trace(otel_trace_id, trace_info)
+    trace_manager.register_span(span1)
+    trace_manager.register_span(span2)
     return Trace(info=trace_info, data=trace_data)
 
 
@@ -106,7 +103,63 @@ def sample_config():
 # =============================================================================
 
 
-def test_mlflow_v3_delta_span_exporter_delegates_to_archiver(sample_trace_without_spans):
+def test_mlflow_delta_export_integration(monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "true")
+
+    class TestModel:
+        @mlflow.trace()
+        def predict(self, x, y):
+            z = x + y
+            z = self.add_one(z)
+            z = self.square(z)
+            return z  # noqa: RET504
+
+        @mlflow.trace(span_type=SpanType.TOOL, attributes={"delta": 1})
+        def add_one(self, z):
+            return z + 1
+
+        @mlflow.trace(span_type=SpanType.TOOL)
+        def square(self, t):
+            res = t**2
+            time.sleep(0.1)
+            return res
+
+    model = TestModel()
+
+    mock_ingest_sdk = mock.Mock()
+    with (
+        mock.patch(
+            "mlflow.genai.experimental.databricks_trace_exporter.DatabricksTraceServerClient"
+        ),
+        mock.patch(
+            "mlflow.genai.experimental.databricks_trace_exporter.create_archival_ingest_sdk",
+            return_value=mock_ingest_sdk,
+        ),
+    ):
+        model.predict(1, 2)
+
+    # Validate if the trace is exported via the normal MLflow backend path
+    traces = get_traces()
+    assert len(traces) == 1
+    assert traces[0].info.status == TraceStatus.OK
+    assert len(traces[0].data.spans) == 3
+    assert traces[0].data.spans[0].name == "predict"
+    assert traces[0].data.spans[1].name == "add_one"
+    assert traces[0].data.spans[2].name == "square"
+
+    # Verify archiver was called for each span
+    mock_stream = mock_ingest_sdk.create_stream.return_value
+    assert mock_stream.ingest_record.call_count == 3
+    proto_spans = mock_stream.ingest_record.call_args_list
+    span_names = {span[0][0].name for span in proto_spans}
+    assert "predict" in span_names
+    assert "add_one" in span_names
+    assert "square" in span_names
+    # Flush for every ingest
+    assert mock_stream.flush.call_count == 3
+
+
+def test_mlflow_v3_delta_span_exporter_delegates_to_archiver(sample_trace):
     """Test that MlflowV3DeltaSpanExporter properly delegates to the archiver."""
     exporter = MlflowV3DeltaSpanExporter(tracking_uri="databricks")
 
@@ -116,17 +169,28 @@ def test_mlflow_v3_delta_span_exporter_delegates_to_archiver(sample_trace_withou
         # Mock delta archiver
         mock.patch.object(exporter._delta_archiver, "archive") as mock_archive,
     ):
-        # Call _log_trace - should delegate to both parent and archiver
-        exporter._log_trace(sample_trace_without_spans, prompts=[])
+        # Export spans - should delegate to both parent and archiver
+        otel_spans = [s._span for s in sample_trace.data.spans]
+        exporter.export(otel_spans)
+        exporter.force_flush()
 
         # Verify parent _log_trace was called
-        mock_parent_log_trace.assert_called_once_with(sample_trace_without_spans, [])
+        mock_parent_log_trace.assert_called_once()
+        trace, prompts = mock_parent_log_trace.call_args[0]
+        assert trace.info.trace_id == sample_trace.info.trace_id
+        assert prompts == []
 
-        # Verify archiver was called
-        mock_archive.assert_called_once_with(sample_trace_without_spans)
+        # Verify archiver was called for each span
+        assert mock_archive.call_count == 2
+        assert mock_archive.has_calls(
+            [
+                mock.call(sample_trace.data.spans[0]),
+                mock.call(sample_trace.data.spans[1]),
+            ]
+        )
 
 
-def test_mlflow_v3_delta_span_exporter_error_isolation(sample_trace_without_spans):
+def test_mlflow_v3_delta_span_exporter_error_isolation(sample_trace):
     """Test that delta archiver errors don't affect base MLflow export functionality."""
     exporter = MlflowV3DeltaSpanExporter(tracking_uri="databricks")
 
@@ -139,14 +203,25 @@ def test_mlflow_v3_delta_span_exporter_error_isolation(sample_trace_without_span
         ) as mock_archive,
         mock.patch("mlflow.genai.experimental.databricks_trace_exporter._logger") as mock_logger,
     ):
-        # Call _log_trace - should succeed despite archiver error
-        exporter._log_trace(sample_trace_without_spans, prompts=[])
+        # Call export - should succeed despite archiver error
+        otel_spans = [s._span for s in sample_trace.data.spans]
+        exporter.export(otel_spans)
+        exporter.force_flush()
 
         # Verify parent _log_trace was called successfully
-        mock_parent_log_trace.assert_called_once_with(sample_trace_without_spans, [])
+        mock_parent_log_trace.assert_called_once()
+        trace, prompts = mock_parent_log_trace.call_args[0]
+        assert trace.info.trace_id == sample_trace.info.trace_id
+        assert prompts == []
 
         # Verify archiver was called
-        mock_archive.assert_called_once_with(sample_trace_without_spans)
+        assert mock_archive.call_count == 2
+        assert mock_archive.has_calls(
+            [
+                mock.call(sample_trace.data.spans[0]),
+                mock.call(sample_trace.data.spans[1]),
+            ]
+        )
 
         # Verify error was logged but didn't crash the export
         mock_logger.warning.assert_called()
@@ -159,7 +234,7 @@ def test_mlflow_v3_delta_span_exporter_error_isolation(sample_trace_without_span
 # =============================================================================
 
 
-def test_archive_with_delta_disabled(sample_trace_without_spans, monkeypatch):
+def test_archive_with_delta_disabled(sample_trace, monkeypatch):
     """Test archive method when delta archiving is disabled."""
     monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "false")
 
@@ -169,7 +244,7 @@ def test_archive_with_delta_disabled(sample_trace_without_spans, monkeypatch):
         "mlflow.genai.experimental.databricks_trace_exporter.DatabricksTraceServerClient"
     ) as mock_client_class:
         # Archive should return early without calling the client
-        archiver.archive(sample_trace_without_spans)
+        archiver.archive(sample_trace.data.spans[0])
         mock_client_class.assert_not_called()
 
 
@@ -200,7 +275,7 @@ def test_archive_with_no_experiment_id(monkeypatch):
         mock_client_class.assert_not_called()
 
 
-def test_archive_with_missing_archival_config(sample_trace_without_spans, monkeypatch):
+def test_archive_with_missing_archival_config(sample_trace, monkeypatch):
     """Test that archiver handles gracefully when no configuration is available."""
     monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "true")
 
@@ -219,7 +294,7 @@ def test_archive_with_missing_archival_config(sample_trace_without_spans, monkey
         mock_client.get_trace_destination.return_value = None
 
         # Archive should return early without error
-        archiver.archive(sample_trace_without_spans)
+        archiver.archive(sample_trace.data.spans[0])
 
         # Verify that the client was called to check for config
         mock_client.get_trace_destination.assert_called_once_with(_EXPERIMENT_ID)
@@ -230,9 +305,7 @@ def test_archive_with_missing_archival_config(sample_trace_without_spans, monkey
         assert any("not enabled for experiment" in msg for msg in debug_calls)
 
 
-def test_delta_archiver_archive_archival_config_error_handling(
-    sample_trace_without_spans, monkeypatch
-):
+def test_delta_archiver_archive_archival_config_error_handling(sample_trace, monkeypatch):
     """Test that DatabricksTraceDeltaArchiver handles errors gracefully."""
     monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "true")
 
@@ -251,7 +324,7 @@ def test_delta_archiver_archive_archival_config_error_handling(
         mock_client.get_trace_destination.side_effect = Exception("Config fetch failed")
 
         # Archive should handle the error gracefully without crashing
-        archiver.archive(sample_trace_without_spans)
+        archiver.archive(sample_trace.data.spans[0])
 
         # Verify that the error was logged as a warning (since an exception was raised)
         mock_logger.warning.assert_called()
@@ -260,7 +333,7 @@ def test_delta_archiver_archive_archival_config_error_handling(
 
 
 def test_delta_archiver_archive_with_valid_archival_config(
-    sample_trace_without_spans, sample_config, monkeypatch
+    sample_trace, sample_config, monkeypatch
 ):
     """Test successful archival when valid configuration is available."""
     monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "true")
@@ -274,26 +347,26 @@ def test_delta_archiver_archive_with_valid_archival_config(
             "mlflow.genai.experimental.databricks_trace_exporter.DatabricksTraceServerClient"
         ) as mock_client_class,
         mock.patch(
-            "mlflow.genai.experimental.databricks_trace_exporter.DatabricksTraceDeltaArchiver._archive_trace"
-        ) as mock_archive_trace,
+            "mlflow.genai.experimental.databricks_trace_exporter.DatabricksTraceDeltaArchiver._archive"
+        ) as mock_archive,
     ):
         # Mock client to return valid config
         mock_client = mock_client_class.return_value
         mock_client.get_trace_destination.return_value = sample_config
 
         # Archive should proceed with archival
-        archiver.archive(sample_trace_without_spans)
+        archiver.archive(sample_trace.data.spans[0])
 
         # Verify that the client was called
         mock_client.get_trace_destination.assert_called_once_with(_EXPERIMENT_ID)
 
         # Verify that archival was initiated
-        mock_archive_trace.assert_called_once_with(
-            sample_trace_without_spans, _EXPERIMENT_ID, sample_config.spans_table_name
+        mock_archive.assert_called_once_with(
+            sample_trace.data.spans[0], _EXPERIMENT_ID, sample_config.spans_table_name
         )
 
 
-def test_archive_trace_integration_flow(sample_trace_with_spans, sample_config, monkeypatch):
+def test_archive_trace_integration_flow(sample_trace, sample_config, monkeypatch):
     """Test the complete _archive_trace integration flow with IngestStreamFactory."""
     monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "true")
 
@@ -320,66 +393,21 @@ def test_archive_trace_integration_flow(sample_trace_with_spans, sample_config, 
         mock_get_instance.return_value = mock_factory
 
         # Call archive - this will run the async _archive_trace method
-        archiver.archive(sample_trace_with_spans)
+        archiver.archive(sample_trace.data.spans[0])
 
         # Verify the integration flow
         mock_client.get_trace_destination.assert_called_once_with(_EXPERIMENT_ID)
         mock_get_instance.assert_called_once()
         mock_factory.get_or_create_stream.assert_called_once()
 
-        # Verify that proto spans were ingested (2 spans in the test trace)
-        assert mock_stream.ingest_record.call_count == 2
+        # Verify that proto span was ingested
+        assert mock_stream.ingest_record.call_count == 1
 
         # Verify stream was flushed
         mock_stream.flush.assert_called_once()
 
 
-def test_archive_trace_with_empty_spans(sample_trace_without_spans, sample_config, monkeypatch):
-    """Test _archive_trace with a trace containing no spans."""
-    monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "true")
-
-    # Clear cache to avoid interference from other tests
-    DatabricksTraceDeltaArchiver._config_cache.clear()
-    archiver = DatabricksTraceDeltaArchiver()
-
-    # Mock stream and factory
-    mock_stream = mock.Mock()
-    mock_factory = mock.Mock()
-    mock_factory.get_or_create_stream.return_value = mock_stream
-
-    with (
-        mock.patch(
-            "mlflow.genai.experimental.databricks_trace_exporter.DatabricksTraceServerClient"
-        ) as mock_client_class,
-        mock.patch(
-            "mlflow.genai.experimental.databricks_trace_exporter.IngestStreamFactory.get_instance"
-        ) as mock_get_instance,
-        mock.patch("mlflow.genai.experimental.databricks_trace_exporter._logger") as mock_logger,
-    ):
-        # Setup mocks
-        mock_client = mock_client_class.return_value
-        mock_client.get_trace_destination.return_value = sample_config
-        mock_get_instance.return_value = mock_factory
-
-        # Call archive with empty trace
-        archiver.archive(sample_trace_without_spans)
-
-        # Verify config was fetched
-        mock_client.get_trace_destination.assert_called_once_with(_EXPERIMENT_ID)
-
-        # Should have logged debug message about no spans
-        mock_logger.debug.assert_called()
-        debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
-        assert any("No proto spans to export" in msg for msg in debug_calls)
-
-        # Stream operations should not be called since there are no spans
-        mock_get_instance.assert_not_called()
-        mock_stream.ingest_record.assert_not_called()
-
-
-def test_archive_trace_ingest_stream_error_handling(
-    sample_trace_with_spans, sample_config, monkeypatch
-):
+def test_archive_trace_ingest_stream_error_handling(sample_trace, sample_config, monkeypatch):
     """Test error handling when stream operations fail."""
     monkeypatch.setenv("MLFLOW_TRACING_ENABLE_DELTA_ARCHIVAL", "true")
 
@@ -408,7 +436,7 @@ def test_archive_trace_ingest_stream_error_handling(
         mock_get_instance.return_value = mock_factory
 
         # Call archive - should handle stream error gracefully
-        archiver.archive(sample_trace_with_spans)
+        archiver.archive(sample_trace.data.spans[0])
 
         # Verify that the error was caught and logged
         mock_logger.warning.assert_called()
@@ -713,20 +741,16 @@ def test_ingest_stream_factory_thread_safety():
 # =============================================================================
 
 
-def test_convert_trace_to_proto_spans_basic(sample_trace_with_spans):
+def test_convert_trace_to_proto_spans_basic(sample_trace):
     """Test basic conversion of trace to proto spans."""
     archiver = DatabricksTraceDeltaArchiver()
 
-    proto_spans = archiver._convert_trace_to_proto_spans(sample_trace_with_spans)
-
-    # Should convert 2 spans from the fixture
-    assert len(proto_spans) == 2
+    proto_span = archiver._convert_span_to_proto(sample_trace.data.spans[0])
 
     # Verify basic fields are populated
-    for proto_span in proto_spans:
-        assert proto_span.name in ["root_span", "child_span"]
-        assert proto_span.trace_id  # Should have trace ID
-        assert proto_span.span_id  # Should have span ID
+    assert proto_span.name == "root_span"
+    assert proto_span.trace_id  # Should have trace ID
+    assert proto_span.span_id  # Should have span ID
 
 
 def test_convert_trace_to_proto_spans_with_complex_data():
@@ -764,26 +788,10 @@ def test_convert_trace_to_proto_spans_with_complex_data():
     otel_span.set_status(OTelStatus(StatusCode.ERROR, "Test error"))
 
     # Create real MLflow Span object
-    span = Span(otel_span)
-    spans = [span]
-
-    trace_info = TraceInfo(
-        trace_id="test-trace-id",
-        trace_location=TraceLocation.from_experiment_id(_EXPERIMENT_ID),
-        request_time=0,
-        execution_duration=1,
-        state=TraceState.OK,
-        trace_metadata={},
-        tags={},
-    )
-    trace_data = TraceData(spans=spans)
-    trace = Trace(info=trace_info, data=trace_data)
+    mlflow_span = Span(otel_span)
 
     archiver = DatabricksTraceDeltaArchiver()
-    proto_spans = archiver._convert_trace_to_proto_spans(trace)
-
-    assert len(proto_spans) == 1
-    proto_span = proto_spans[0]
+    proto_span = archiver._convert_span_to_proto(mlflow_span)
 
     # Verify basic proto span structure
     assert proto_span.trace_id == "00000000000000001234567890abcdef"
@@ -834,134 +842,13 @@ def test_convert_trace_to_proto_spans_with_complex_data():
     assert status["message"] == "Test error"
 
 
-def test_convert_trace_to_proto_spans_empty_trace(sample_trace_without_spans):
-    """Test conversion with a trace containing no spans."""
-    archiver = DatabricksTraceDeltaArchiver()
-
-    proto_spans = archiver._convert_trace_to_proto_spans(sample_trace_without_spans)
-
-    # Empty trace should return empty list
-    assert proto_spans == []
-
-
-def test_convert_trace_to_proto_spans_otel_compliance(sample_trace_with_spans):
+def test_convert_trace_to_proto_spans_otel_compliance(sample_trace):
     """Test that trace_id format complies with OTel spec (no tr- prefix)."""
     archiver = DatabricksTraceDeltaArchiver()
 
-    proto_spans = archiver._convert_trace_to_proto_spans(sample_trace_with_spans)
+    proto_span = archiver._convert_span_to_proto(sample_trace.data.spans[0])
 
     # Verify trace IDs don't have "tr-" prefix (OTel compliance)
-    for proto_span in proto_spans:
-        assert not proto_span.trace_id.startswith("tr-")
-        # Should use the raw _trace_id from the span
-        assert (
-            proto_span.trace_id == "00000000000000001234567890abcdef"
-        )  # From the fixture hex value
-
-
-def test_convert_trace_to_proto_spans_filters_spans_without_id():
-    """Test that spans without span_id (None) are filtered out during conversion."""
-    from mlflow.entities.span import NoOpSpan
-
-    from tests.tracing.helper import create_mock_otel_span
-
-    # Create a mix of valid spans and a NoOpSpan
-    otel_span1 = create_mock_otel_span(
-        trace_id=0x1234567890ABCDEF,
-        span_id=0x123456789ABCDEF0,
-        name="valid_span_1",
-        parent_id=None,
-        start_time=1000,
-        end_time=2000,
-    )
-
-    otel_span2 = create_mock_otel_span(
-        trace_id=0x1234567890ABCDEF,
-        span_id=0x123456789ABCDEF1,
-        name="valid_span_2",
-        parent_id=0x123456789ABCDEF0,
-        start_time=1100,
-        end_time=1900,
-    )
-
-    # Create real MLflow Span objects
-    span1 = Span(otel_span1)
-    span2 = Span(otel_span2)
-    no_op_span = NoOpSpan()  # This returns None for span_id
-
-    # Set a name for the NoOpSpan for testing (normally it returns None)
-    # We'll override just for this test to make the log message testable
-    no_op_span._name = "no_op_span_test"
-
-    spans = [span1, no_op_span, span2]
-
-    trace_info = TraceInfo(
-        trace_id="test-trace-id",
-        trace_location=TraceLocation.from_experiment_id(_EXPERIMENT_ID),
-        request_time=0,
-        execution_duration=1,
-        state=TraceState.OK,
-        trace_metadata={},
-        tags={},
-    )
-    trace_data = TraceData(spans=spans)
-    trace = Trace(info=trace_info, data=trace_data)
-
-    archiver = DatabricksTraceDeltaArchiver()
-
-    # Mock the logger to verify debug message
-    # Also mock the line that's causing the AttributeError to skip it for this test
-    with mock.patch("mlflow.genai.experimental.databricks_trace_exporter._logger") as mock_logger:
-
-        def patched_convert(trace):
-            """Patched version that skips the problematic attributes line"""
-            from mlflow.genai.experimental.databricks_trace_otel_pb2 import Span as DeltaProtoSpan
-
-            delta_proto_spans = []
-
-            for span in trace.data.spans:
-                # Skip spans that have no span ID
-                if span.span_id is None:
-                    mock_logger.debug(f"Span {span.name} has no span ID, skipping")
-                    continue
-
-                # Create a basic proto span without the problematic attributes assignment
-                delta_proto = DeltaProtoSpan()
-                delta_proto.trace_id = span._trace_id
-                delta_proto.span_id = span.span_id
-                delta_proto.parent_span_id = span.parent_id or ""
-                delta_proto.trace_state = ""
-                delta_proto.flags = 0
-                delta_proto.name = span.name
-                delta_proto.kind = "SPAN_KIND_INTERNAL"
-                delta_proto.start_time_unix_nano = getattr(span, "start_time_ns", 1000)
-                delta_proto.end_time_unix_nano = getattr(span, "end_time_ns", 2000)
-                # Skip attributes assignment that causes error
-                delta_proto.dropped_attributes_count = 0
-                delta_proto.dropped_events_count = 0
-                delta_proto.dropped_links_count = 0
-                delta_proto.status = json.dumps({"code": "STATUS_CODE_UNSET", "message": ""})
-
-                delta_proto_spans.append(delta_proto)
-
-            return delta_proto_spans
-
-        with mock.patch.object(archiver, "_convert_trace_to_proto_spans", patched_convert):
-            proto_spans = archiver._convert_trace_to_proto_spans(trace)
-
-            # Should only convert 2 valid spans (NoOpSpan filtered out)
-            assert len(proto_spans) == 2
-
-            # Verify the correct spans were converted
-            assert proto_spans[0].name == "valid_span_1"
-            assert proto_spans[1].name == "valid_span_2"
-
-            # Verify that both spans have valid span IDs
-            assert proto_spans[0].span_id == "123456789abcdef0"
-            assert proto_spans[1].span_id == "123456789abcdef1"
-
-            # Verify debug logging occurred for the filtered span
-            mock_logger.debug.assert_called()
-            debug_calls = [call[0][0] for call in mock_logger.debug.call_args_list]
-            # The NoOpSpan.name returns None, verify the debug message as "Span None has no span ID"
-            assert any("has no span ID, skipping" in msg for msg in debug_calls)
+    assert not proto_span.trace_id.startswith("tr-")
+    # Should use the raw _trace_id from the span
+    assert proto_span.trace_id == "00000000000000001234567890abcdef"  # From the fixture hex value

--- a/tests/tracing/processor/test_mlflow_v3_processor.py
+++ b/tests/tracing/processor/test_mlflow_v3_processor.py
@@ -134,9 +134,3 @@ def test_on_end():
     assert trace_info.status == TraceStatus.OK
     assert trace_info.execution_time_ms == 4
     assert trace_info.tags == {}
-
-    # Non-root span should not be exported
-    mock_exporter.reset_mock()
-    child_span = create_mock_otel_span(trace_id="trace_id", span_id=2, parent_id=1)
-    processor.on_end(child_span)
-    mock_exporter.export.assert_not_called()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16843?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16843/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16843/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16843/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Follow-up for https://github.com/mlflow/mlflow/pull/16781#discussion_r2223090065. The Delta Ingestion accepts a stream of span, so it is straight-forward to export each span immediately, rather than batching them to a trace.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested E2E on notebok:

<img width="1296" height="145" alt="Screenshot 2025-07-23 at 16 45 30" src="https://github.com/user-attachments/assets/5539ea83-e446-429a-914a-43153d378e38" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
