### PR TITLE
Handle new Tool usage of Pydantic AI

### DIFF
--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -26,6 +26,7 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
     class_map = {
         "pydantic_ai.Agent": ["run", "run_sync"],
         "pydantic_ai.models.instrumented.InstrumentedModel": ["request"],
+        "pydantic_ai._tool_manager.ToolManager": ["handle_call"],
         "pydantic_ai.Tool": ["run"],
         "pydantic_ai.mcp.MCPServer": ["call_tool", "list_tools"],
     }

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -120,15 +120,6 @@ def _get_span_type(instance) -> str:
     except ImportError:
         pass
 
-
-    try:
-        from pydantic_ai._tool_manager import ToolManager
-    except ImportError:
-        return SpanType.UNKNOWN
-
-    if isinstance(instance, ToolManager):
-        return SpanType.TOOL
-
     return SpanType.UNKNOWN
 
 

--- a/mlflow/pydantic_ai/autolog.py
+++ b/mlflow/pydantic_ai/autolog.py
@@ -111,6 +111,24 @@ def _get_span_type(instance) -> str:
         return SpanType.TOOL
     if isinstance(instance, MCPServer):
         return SpanType.TOOL
+
+    try:
+        from pydantic_ai._tool_manager import ToolManager
+
+        if isinstance(instance, ToolManager):
+            return SpanType.TOOL
+    except ImportError:
+        pass
+
+
+    try:
+        from pydantic_ai._tool_manager import ToolManager
+    except ImportError:
+        return SpanType.UNKNOWN
+
+    if isinstance(instance, ToolManager):
+        return SpanType.TOOL
+
     return SpanType.UNKNOWN
 
 

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -177,7 +177,6 @@ def test_agent_run_sync_enable_disable_fluent_autolog_with_tool(agent_with_tool)
     assert span2.parent_id == spans[1].span_id
 
     span3 = spans[3]
-    assert span3.name == "Tool.run"
     assert span3.span_type == SpanType.TOOL
     assert span3.parent_id == spans[1].span_id
 
@@ -215,7 +214,6 @@ async def test_agent_run_enable_disable_fluent_autolog_with_tool(agent_with_tool
     assert span1.parent_id == spans[0].span_id
 
     span2 = spans[2]
-    assert span2.name == "Tool.run"
     assert span2.span_type == SpanType.TOOL
     assert span2.parent_id == spans[0].span_id
 

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -185,7 +185,6 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool):
     assert span2.parent_id == spans[1].span_id
 
     span3 = spans[3]
-    assert span3.name == "Tool.run"
     assert span3.span_type == SpanType.TOOL
     assert span3.parent_id == spans[1].span_id
 
@@ -225,7 +224,6 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool):
     assert span1.parent_id == spans[0].span_id
 
     span2 = spans[2]
-    assert span2.name == "Tool.run"
     assert span2.span_type == SpanType.TOOL
     assert span2.parent_id == spans[0].span_id
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16852?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16852/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16852/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16852/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

PydanticAI stop calling Tool.run
Fix https://github.com/mlflow/dev/actions/runs/16418106809/job/46415628664

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
