### PR TITLE
Allow setting thread-local tracing destination via `mlflow.tracing.set_destination`

### DIFF
--- a/mlflow/entities/trace_location.py
+++ b/mlflow/entities/trace_location.py
@@ -14,11 +14,9 @@ class MlflowExperimentLocation(_MlflowObject):
 
     Args:
         experiment_id: The ID of the MLflow experiment where the trace is stored.
-        tracking_uri: The MLflow tracking URI.
     """
 
     experiment_id: str
-    tracking_uri: str
 
     def to_proto(self):
         return pb.TraceLocation.MlflowExperimentLocation(experiment_id=self.experiment_id)

--- a/mlflow/entities/trace_location.py
+++ b/mlflow/entities/trace_location.py
@@ -14,9 +14,11 @@ class MlflowExperimentLocation(_MlflowObject):
 
     Args:
         experiment_id: The ID of the MLflow experiment where the trace is stored.
+        tracking_uri: The MLflow tracking URI.
     """
 
     experiment_id: str
+    tracking_uri: str
 
     def to_proto(self):
         return pb.TraceLocation.MlflowExperimentLocation(experiment_id=self.experiment_id)

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -4,6 +4,7 @@ from typing import Optional, Sequence
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
+import mlflow
 from mlflow.entities.model_registry import PromptVersion
 from mlflow.entities.trace import Trace
 from mlflow.environment_variables import (
@@ -67,7 +68,7 @@ class MlflowV3SpanExporter(SpanExporter):
 
             tracking_uri = InMemoryTraceManager.get_instance().get_trace_tracking_uri(
                 trace.info.trace_id
-            )
+            ) or mlflow.get_tracking_uri()
             if self._should_log_async(tracking_uri):
                 self._async_queue.put(
                     task=Task(

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -43,6 +43,7 @@ class MlflowV3SpanExporter(SpanExporter):
             spans: A sequence of OpenTelemetry ReadableSpan objects passed from
                 a span processor. Only root spans for each trace should be exported.
         """
+
         for span in spans:
             if span._parent is not None:
                 _logger.debug("Received a non-root span. Skipping export.")

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -7,6 +7,7 @@ from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 from opentelemetry.sdk.trace import Span as OTelSpan
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
 
+import mlflow
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_METADATA,
@@ -59,12 +60,14 @@ class BaseMlflowSpanProcessor(SimpleSpanProcessor):
         """
         from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
         from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
+        from mlflow.tracing.destination import MlflowExperiment
         
         # Initialize the span exporter using thread-local tracing destination settings.
         tracking_uri = None
         if destination := _MLFLOW_TRACE_USER_DESTINATION.get():
-            if destination.type == "experiment":
+            if isinstance(destination, MlflowExperiment):
                 tracking_uri = destination.tracking_uri
+        tracking_uri = tracking_uri or mlflow.get_tracking_uri()
         self.span_exporter = MlflowV3SpanExporter(tracking_uri)
 
         trace_id = self._trace_manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -42,8 +42,11 @@ class BaseMlflowSpanProcessor(SimpleSpanProcessor):
 
     """
 
-    def __init__(self):
-        self.span_exporter = None
+    def __init__(
+        self,
+        span_exporter: SpanExporter,
+    ):
+        self.span_exporter = span_exporter
         self._trace_manager = InMemoryTraceManager.get_instance()
         self._env_metadata = resolve_env_metadata()
 
@@ -58,18 +61,6 @@ class BaseMlflowSpanProcessor(SimpleSpanProcessor):
                 is obtained from the global context, it won't be passed here so we should not rely
                 on it.
         """
-        from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
-        from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
-        from mlflow.tracing.destination import MlflowExperiment
-        
-        # Initialize the span exporter using thread-local tracing destination settings.
-        tracking_uri = None
-        if destination := _MLFLOW_TRACE_USER_DESTINATION.get():
-            if isinstance(destination, MlflowExperiment):
-                tracking_uri = destination.tracking_uri
-        tracking_uri = tracking_uri or mlflow.get_tracking_uri()
-        self.span_exporter = MlflowV3SpanExporter(tracking_uri)
-
         trace_id = self._trace_manager.get_mlflow_trace_id_from_otel_id(span.context.trace_id)
 
         if not trace_id and span.parent is not None:

--- a/mlflow/tracing/processor/mlflow_v3.py
+++ b/mlflow/tracing/processor/mlflow_v3.py
@@ -19,8 +19,11 @@ class MlflowV3SpanProcessor(BaseMlflowSpanProcessor):
     using the V3 trace schema and API.
     """
 
-    def __init__(self):
-        super().__init__()
+    def __init__(
+        self,
+        span_exporter: SpanExporter,
+    ):
+        super().__init__(span_exporter)
 
     def _start_trace(self, root_span: OTelSpan) -> TraceInfo:
         """
@@ -45,7 +48,8 @@ class MlflowV3SpanProcessor(BaseMlflowSpanProcessor):
 
         tracking_uri = None
         if isinstance(_MLFLOW_TRACE_USER_DESTINATION.get(), MlflowExperiment):
-            tracking_uri = _MLFLOW_TRACE_USER_DESTINATION.get().tracking_uri or mlflow.get_tracking_uri()
+            tracking_uri = _MLFLOW_TRACE_USER_DESTINATION.get().tracking_uri
+        tracking_uri = tracking_uri or mlflow.get_tracking_uri()
 
         self._trace_manager.register_trace(root_span.context.trace_id, trace_info, tracking_uri)
 

--- a/mlflow/tracing/processor/mlflow_v3.py
+++ b/mlflow/tracing/processor/mlflow_v3.py
@@ -18,12 +18,8 @@ class MlflowV3SpanProcessor(BaseMlflowSpanProcessor):
     using the V3 trace schema and API.
     """
 
-    def __init__(
-        self,
-        span_exporter: SpanExporter,
-        experiment_id: Optional[str] = None,
-    ):
-        super().__init__(span_exporter, experiment_id)
+    def __init__(self):
+        super().__init__()
 
     def _start_trace(self, root_span: OTelSpan) -> TraceInfo:
         """

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -34,6 +34,7 @@ from mlflow.utils.databricks_utils import (
     is_in_databricks_model_serving_environment,
     is_mlflow_tracing_enabled_in_model_serving,
 )
+from mlflow.utils.thread_utils import ThreadLocalVariable
 
 if TYPE_CHECKING:
     from mlflow.entities import Span
@@ -48,7 +49,7 @@ _MLFLOW_TRACER_PROVIDER_INITIALIZED = Once()
 
 # A trace destination specified by the user via the `set_destination` function.
 # This destination, when set, will take precedence over other configurations.
-_MLFLOW_TRACE_USER_DESTINATION = None
+_MLFLOW_TRACE_USER_DESTINATION = ThreadLocalVariable(lambda: None)
 
 _logger = logging.getLogger(__name__)
 
@@ -199,8 +200,7 @@ def set_destination(destination: TraceDestination):
 
     # The destination needs to be persisted because the tracer setup can be re-initialized
     # e.g. when the tracing is disabled and re-enabled, or tracking URI is changed, etc.
-    global _MLFLOW_TRACE_USER_DESTINATION
-    _MLFLOW_TRACE_USER_DESTINATION = destination
+    _MLFLOW_TRACE_USER_DESTINATION.set(destination)
 
     _setup_tracer_provider()
 
@@ -246,18 +246,7 @@ def _setup_tracer_provider(disabled=False):
     #  1. Partners can implement span processor/exporter and destination class.
     #  2. They can register their implementation to the registry via entry points.
     #  3. MLflow will pick the implementation based on given destination id.
-    if _MLFLOW_TRACE_USER_DESTINATION is not None:
-        experiment_id = _MLFLOW_TRACE_USER_DESTINATION.experiment_id
-
-        tracking_uri = None
-        if isinstance(_MLFLOW_TRACE_USER_DESTINATION, MlflowExperiment):
-            tracking_uri = _MLFLOW_TRACE_USER_DESTINATION.tracking_uri
-
-        processor = _get_mlflow_span_processor(
-            tracking_uri=tracking_uri or mlflow.get_tracking_uri(), experiment_id=experiment_id
-        )
-
-    elif should_use_otlp_exporter():
+    if should_use_otlp_exporter():
         # Export to OpenTelemetry Collector when configured
         from mlflow.tracing.processor.otel import OtelSpanProcessor
 
@@ -278,7 +267,7 @@ def _setup_tracer_provider(disabled=False):
 
     else:
         # Default to MLflow Tracking Server
-        processor = _get_mlflow_span_processor(tracking_uri=mlflow.get_tracking_uri())
+        processor = _get_mlflow_span_processor()
 
     # Configure sampling based on environment variable
     sampling_ratio = MLFLOW_TRACE_SAMPLING_RATIO.get()
@@ -316,7 +305,7 @@ def _setup_tracer_provider(disabled=False):
     suppress_warning("opentelemetry.sdk.trace", "Calling end() on an ended span")
 
 
-def _get_mlflow_span_processor(tracking_uri: str, experiment_id: Optional[str] = None):
+def _get_mlflow_span_processor():
     """
     Get the MLflow span processor instance that is used by the current tracer provider.
     """
@@ -325,7 +314,7 @@ def _get_mlflow_span_processor(tracking_uri: str, experiment_id: Optional[str] =
     from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 
     exporter = MlflowV3SpanExporter(tracking_uri=tracking_uri)
-    return MlflowV3SpanProcessor(exporter, experiment_id=experiment_id)
+    return MlflowV3SpanProcessor(exporter)
 
 
 @raise_as_trace_exception
@@ -478,8 +467,7 @@ def reset():
     _MLFLOW_TRACER_PROVIDER_INITIALIZED.done = False
 
     # Reset the custom destination set by the user
-    global _MLFLOW_TRACE_USER_DESTINATION
-    _MLFLOW_TRACE_USER_DESTINATION = None
+    _MLFLOW_TRACE_USER_DESTINATION.set(None)
 
     # Reset the tracing configuration to defaults
     reset_config()

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -313,7 +313,7 @@ def _get_mlflow_span_processor():
     from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
     from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 
-    exporter = MlflowV3SpanExporter(tracking_uri=tracking_uri)
+    exporter = MlflowV3SpanExporter()
     return MlflowV3SpanProcessor(exporter)
 
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -73,7 +73,7 @@ class InMemoryTraceManager:
         self._trace_id_to_tracking_uri_map = {}
         self._lock = threading.Lock()  # Lock for _traces
 
-    def register_trace(self, otel_trace_id: int, trace_info: TraceInfo, tracking_uri: Optional[str]):
+    def register_trace(self, otel_trace_id: int, trace_info: TraceInfo, tracking_uri: Optional[str] = None):
         """
         Register a new trace info object to the in-memory trace registry.
 

--- a/mlflow/tracing/trace_manager.py
+++ b/mlflow/tracing/trace_manager.py
@@ -86,8 +86,7 @@ class InMemoryTraceManager:
         with self._lock:
             self._traces[trace_info.trace_id] = _Trace(trace_info)
             self._otel_id_to_mlflow_trace_id[otel_trace_id] = trace_info.trace_id
-            if tracking_uri:
-                self._trace_id_to_tracking_uri_map[trace_info.trace_id] = tracking_uri
+            self._trace_id_to_tracking_uri_map[trace_info.trace_id] = tracking_uri
 
     def register_span(self, span: LiveSpan):
         """

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -134,9 +134,9 @@ def create_test_trace_info(
     )
 
 
-def get_traces(experiment_id=None) -> list[Trace]:
+def get_traces(experiment_id=None, tracking_uri=None) -> list[Trace]:
     # Get all traces from the backend
-    return TracingClient().search_traces(
+    return TracingClient(tracking_uri).search_traces(
         experiment_ids=[experiment_id or _get_experiment_id()],
     )
 

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -155,15 +155,14 @@ def purge_traces(experiment_id=None):
 
 def get_tracer_tracking_uri() -> Optional[str]:
     """Get current tracking URI configured as the trace export destination."""
-    from opentelemetry import trace
+    from mlflow.tracing.provider import _MLFLOW_TRACE_USER_DESTINATION
+    from mlflow.tracing.destination import MlflowExperiment
 
-    tracer = _get_tracer(__name__)
-    if isinstance(tracer, trace.ProxyTracer):
-        tracer = tracer._tracer
-    span_processor = tracer.span_processor._span_processors[0]
+    tracking_uri = None
+    if isinstance(_MLFLOW_TRACE_USER_DESTINATION.get(), MlflowExperiment):
+        tracking_uri = _MLFLOW_TRACE_USER_DESTINATION.get().tracking_uri
 
-    if isinstance(span_processor, MlflowV3SpanProcessor):
-        return span_processor.span_exporter._client.tracking_uri
+    return tracking_uri or mlflow.get_tracking_uri()
 
 
 @pytest.fixture

--- a/tests/tracing/processor/test_mlflow_v3_processor.py
+++ b/tests/tracing/processor/test_mlflow_v3_processor.py
@@ -88,20 +88,6 @@ def test_on_start_during_run(monkeypatch):
         assert trace.info.request_metadata[TraceMetadataKey.SOURCE_RUN] == run.info.run_id
 
 
-def test_on_start_with_experiment_id_override(monkeypatch):
-    mlflow.set_experiment(experiment_id=DEFAULT_EXPERIMENT_ID)
-    processor = MlflowV3SpanProcessor(
-        span_exporter=mock.MagicMock(), experiment_id="another_experiment"
-    )
-
-    span = create_mock_otel_span(trace_id=123, span_id=1)
-    processor.on_start(span)
-
-    trace_id = "tr-" + encode_trace_id(span.context.trace_id)
-    trace = InMemoryTraceManager.get_instance()._traces[trace_id]
-    assert trace.info.experiment_id == "another_experiment"
-
-
 def test_on_end():
     trace_info = create_test_trace_info("request_id", 0)
     trace_manager = InMemoryTraceManager.get_instance()

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -120,7 +120,6 @@ def test_set_destination_databricks(monkeypatch):
     processors = tracer.span_processor._span_processors
     assert len(processors) == 1
     assert isinstance(processors[0], MlflowV3SpanProcessor)
-    assert processors[0]._experiment_id == "123"
     assert isinstance(processors[0].span_exporter, MlflowV3SpanExporter)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/16854?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16854/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16854/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16854/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Allow setting thread-local tracing destination via `mlflow.tracing.set_destination`.

To achieve the goal, in this PR, I update:

* Decouple `MlflowV3SpanProcessor` and MLflow-experiment / tracking URI,  `MlflowV3SpanProcessor` instance fetches thread-local MLflow-experiment / tracking URI values from tracing destination during `on_start` invocation.

* Save `trace_id => tracking URI` mapping info in `trace_manager` (the `MlflowV3SpanExporter` need to use it)

* Decouple `MlflowV3SpanExporter` and tracking URI, the `MlflowV3SpanExporter` gets the tracking URI by querying the `_trace_id_to_tracking_uri_map` in `trace_manager` instance.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Allow setting thread-local tracing destination via mlflow.tracing.set_destination
#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
