### PR TITLE
Replace guideline_adherence to guidelines

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -184,7 +184,7 @@ def build(package_type: PackageType) -> None:
                     "google-cloud-storage>=1.30.0",
                     "boto3>1",
                     "botocore",
-                    "databricks-agents>=1.0.0,<2.0",
+                    "databricks-agents>=1.2.0,<2.0",
                 ],
                 "mlserver": [
                     # Required to serve models through MLServer

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -68,7 +68,7 @@ databricks = [
   "google-cloud-storage>=1.30.0",
   "boto3>1",
   "botocore",
-  "databricks-agents>=1.0.0,<2.0",
+  "databricks-agents>=1.2.0,<2.0",
 ]
 mlserver = [
   "mlserver>=1.2.0,!=1.3.1,<2.0.0",

--- a/mlflow/genai/judges/databricks.py
+++ b/mlflow/genai/judges/databricks.py
@@ -332,16 +332,12 @@ def meets_guidelines(
             )
             print(feedback.value)  # "no"
     """
-    from databricks.agents.evals.judges import guideline_adherence
-
-    # Ensure guidelines is a list, as the underlying databricks judge only accepts lists
-    if isinstance(guidelines, str):
-        guidelines = [guidelines]
+    from databricks.agents.evals.judges import guidelines as guidelines_judge
 
     return _sanitize_feedback(
-        guideline_adherence(
+        guidelines_judge(
             guidelines=guidelines,
-            guidelines_context=context,
+            context=context,
             assessment_name=name,
         )
     )

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -67,7 +67,7 @@ databricks = [
   "google-cloud-storage>=1.30.0",
   "boto3>1",
   "botocore",
-  "databricks-agents>=1.0.0,<2.0",
+  "databricks-agents>=1.2.0,<2.0",
 ]
 mlserver = [
   "mlserver>=1.2.0,!=1.3.1,<2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,7 +83,7 @@ databricks = [
   "google-cloud-storage>=1.30.0",
   "boto3>1",
   "botocore",
-  "databricks-agents>=1.0.0,<2.0",
+  "databricks-agents>=1.2.0,<2.0",
 ]
 mlserver = [
   "mlserver>=1.2.0,!=1.3.1,<2.0.0",

--- a/tests/genai/judges/test_judges.py
+++ b/tests/genai/judges/test_judges.py
@@ -74,7 +74,7 @@ def test_sanitize_feedback_error():
 
 
 def test_meets_guidelines_happy_path():
-    with patch("databricks.agents.evals.judges.guideline_adherence") as mock_judge:
+    with patch("databricks.agents.evals.judges.guidelines") as mock_judge:
         mock_judge.return_value = create_test_feedback("yes")
         result = judges.meets_guidelines(guidelines="test", context={"response": "test"})
 
@@ -113,7 +113,7 @@ def test_meets_guidelines_happy_path():
         ),
         (
             judges.meets_guidelines,
-            "guideline_adherence",
+            "guidelines",
             {"guidelines": "test", "context": {"response": "test"}},
         ),
     ],

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -226,16 +226,16 @@ def test_retrieval_sufficiency_with_custom_expectations(sample_rag_trace):
 
 def test_guidelines():
     # 1. Called with per-row guidelines
-    with patch("databricks.agents.evals.judges.guideline_adherence") as mock_guideline_adherence:
+    with patch("databricks.agents.evals.judges.guidelines") as mock_guidelines:
         ExpectationsGuidelines()(
             inputs={"question": "query"},
             outputs="answer",
             expectations={"guidelines": ["guideline1", "guideline2"]},
         )
 
-    mock_guideline_adherence.assert_called_once_with(
+    mock_guidelines.assert_called_once_with(
         guidelines=["guideline1", "guideline2"],
-        guidelines_context={"request": "{'question': 'query'}", "response": "answer"},
+        context={"request": "{'question': 'query'}", "response": "answer"},
         assessment_name="expectations_guidelines",
     )
 
@@ -245,28 +245,28 @@ def test_guidelines():
         guidelines=["The response should be in English."],
     )
 
-    with patch("databricks.agents.evals.judges.guideline_adherence") as mock_guideline_adherence:
+    with patch("databricks.agents.evals.judges.guidelines") as mock_guidelines:
         is_english(
             inputs={"question": "query"},
             outputs="answer",
         )
 
-    mock_guideline_adherence.assert_called_once_with(
+    mock_guidelines.assert_called_once_with(
         guidelines=["The response should be in English."],
-        guidelines_context={"request": "{'question': 'query'}", "response": "answer"},
+        context={"request": "{'question': 'query'}", "response": "answer"},
         assessment_name="is_english",
     )
 
     # 3. Test meets_guidelines judge with string input (should wrap in list)
-    with patch("databricks.agents.evals.judges.guideline_adherence") as mock_guideline_adherence:
+    with patch("databricks.agents.evals.judges.guidelines") as mock_guidelines:
         meets_guidelines(
             guidelines="Be polite and respectful.",
             context={"response": "Hello, how are you?"},
         )
 
-    mock_guideline_adherence.assert_called_once_with(
-        guidelines=["Be polite and respectful."],
-        guidelines_context={"response": "Hello, how are you?"},
+    mock_guidelines.assert_called_once_with(
+        guidelines="Be polite and respectful.",
+        context={"response": "Hello, how are you?"},
         assessment_name=None,
     )
 

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -74,9 +74,9 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
             return_value=Feedback(name="correctness", value=CategoricalRating.YES),
         ) as mock_correctness,
         patch(
-            "databricks.agents.evals.judges.guideline_adherence",
-            return_value=Feedback(name="guideline_adherence", value=CategoricalRating.YES),
-        ) as mock_guideline,
+            "databricks.agents.evals.judges.guidelines",
+            return_value=Feedback(name="guidelines", value=CategoricalRating.YES),
+        ) as mock_guidelines,
         patch(
             "databricks.agents.evals.judges.groundedness",
             return_value=Feedback(name="groundedness", value=CategoricalRating.YES),
@@ -94,7 +94,7 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
         )
 
     assert mock_correctness.call_count == 1
-    assert mock_guideline.call_count == 1
+    assert mock_guidelines.call_count == 1
     assert mock_groundedness.call_count == 2  # Called per retriever span
 
     mock_correctness.assert_called_once_with(
@@ -104,9 +104,9 @@ def test_trace_passed_to_builtin_scorers_correctly(sample_rag_trace):
         expected_response="expected answer",
         assessment_name="correctness",
     )
-    mock_guideline.assert_called_once_with(
+    mock_guidelines.assert_called_once_with(
         guidelines=["write in english"],
-        guidelines_context={"request": "{'question': 'query'}", "response": "answer"},
+        context={"request": "{'question': 'query'}", "response": "answer"},
         assessment_name="english",
     )
     mock_groundedness.assert_has_calls(

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -135,7 +135,7 @@ def test_validate_data_with_expectations(mock_logger, sample_rag_trace):
     mock_logger.info.assert_not_called()
 
 
-def test_global_guideline_adherence_does_not_require_expectations(mock_logger):
+def test_global_guidelines_do_not_require_expectations(mock_logger):
     """Test that expectations are unwrapped and validated properly"""
     data = pd.DataFrame(
         {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/16856?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16856/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16856/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16856/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Replaces the old `guideline_adherence` judge with the new `guidelines` judge introduced in `databricks-agents==1.2.0`

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

Improved the judge for `meets_guidelines` to work better with `context` inputs.

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
