### PR TITLE
Add event validation to `test_webhook` function

### DIFF
--- a/mlflow/webhooks/dispatch.py
+++ b/mlflow/webhooks/dispatch.py
@@ -7,6 +7,8 @@ from typing import Optional
 import requests
 
 from mlflow.entities.webhook import Webhook, WebhookEvent, WebhookTestResult
+from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.store.model_registry.abstract_store import AbstractStore
 from mlflow.webhooks.constants import WEBHOOK_SIGNATURE_HEADER
 from mlflow.webhooks.types import WebhookPayload, get_example_payload_for_event
@@ -95,6 +97,13 @@ def test_webhook(webhook: Webhook, event: Optional[WebhookEvent] = None) -> Webh
     Returns:
         WebhookTestResult indicating success/failure and response details
     """
+    # Validate event if provided
+    if event is not None and event not in webhook.events:
+        raise MlflowException(
+            f"Event '{event}' is not in webhook's configured events: {webhook.events}",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
     # Use provided event or the first event type for testing
     test_event = event or webhook.events[0]
     try:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16861?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16861/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16861/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16861/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds validation to the `test_webhook` function in `mlflow/webhooks/dispatch.py` to check if the passed-in event is in the webhook's configured events list. Previously, the function would accept any event without validation, potentially leading to confusion or unexpected behavior.

**Changes:**
- Added validation in `test_webhook()` to raise `MlflowException` with `INVALID_PARAMETER_VALUE` error code when an invalid event is provided
- Added comprehensive test case `test_webhook_test_with_invalid_event()` in `tests/webhooks/test_e2e.py` to verify the validation works correctly

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added a new test case `test_webhook_test_with_invalid_event` that:
1. Creates a webhook with specific events (`REGISTERED_MODEL_CREATED`, `MODEL_VERSION_CREATED`)
2. Attempts to test the webhook with an event not in the configured list (`MODEL_VERSION_TAG_SET`)
3. Validates that `MlflowException` is raised with appropriate error message

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added validation to webhook testing functionality to ensure only configured events can be used when testing webhooks.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>