### PR TITLE
Fix OpenAI autolog Pydantic validation for enum values

### DIFF
--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -124,8 +124,17 @@ class ParamType(BaseModel):
 
 
 class ParamProperty(ParamType):
+    """
+    OpenAI uses JSON Schema (https://json-schema.org/) for function parameters.
+    See OpenAI function calling reference:
+    https://platform.openai.com/docs/guides/function-calling?&api-mode=responses#defining-functions
+
+    JSON Schema enum supports any JSON type (str, int, float, bool, null, arrays, objects),
+    but we restrict to basic scalar types for practical use cases and API safety.
+    """
+
     description: Optional[str] = None
-    enum: Optional[list[str]] = None
+    enum: Optional[list[Union[str, int, float, bool]]] = None
     items: Optional[ParamType] = None
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mohammadsubhani/mlflow/pull/16862?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16862/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16862/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16862/merge
```

</p>
</details>

## Fix OpenAI autolog Pydantic validation for enum values

OpenAI function calling uses JSON Schema which allows enum arrays to contain integers, floats, and booleans, not just strings. MLflow was incorrectly restricting enum values to strings only, causing validation errors for valid OpenAI tool definitions.

### Related Issues/PRs

Resolve #16851

### What changes are proposed in this pull request?

This PR fixes a Pydantic validation error in MLflow's OpenAI autologging functionality. The issue occurs when users define OpenAI function tools with non-string enum values (e.g., `[3, 4, 5]` for a `top` parameter, `[True, False]` for boolean options, or `[1.1, 2.5, 3.7]` for float values), which are valid according to OpenAI's API specification but were being rejected by MLflow's overly restrictive validation.

**Changes:**
- Update `ParamProperty.enum` from `list[str]` to `list[Union[str, int, float, bool]]` to support all JSON Schema enum types
- Add comprehensive test coverage for integer, float, boolean, and mixed enum types
- Add documentation referencing OpenAI and JSON Schema specifications

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x ] Manual tests

**Test Coverage:**
- Added `test_openai_parse_tools_enum_validation` in `tests/tracing/utils/test_utils.py`
- Tests integer, string, float, boolean, and mixed enum types
- Tests the exact code path where GitHub issue #16851 occurred
- All existing tests continue to pass

<img width="1643" height="929" alt="Screenshot 2025-07-24 at 1 33 33 AM" src="https://github.com/user-attachments/assets/c5712a99-b3e6-4d8e-9909-677469a4b0c7" />


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

**Documentation Updates:**
- Added comprehensive docstring to `ParamProperty` class referencing OpenAI and JSON Schema specifications
- Updated type hints to reflect supported enum types

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

**Description:** Fixed Pydantic validation error in OpenAI autologging when using integer, float, or boolean enum values in function tool definitions. This change aligns MLflow's validation with OpenAI's API specification and JSON Schema standards.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)