### PR TITLE
[TS#22] Set inputs/outputs trace metadata to render request and response column in the current UI

### DIFF
--- a/libs/typescript/core/src/core/constants.ts
+++ b/libs/typescript/core/src/core/constants.ts
@@ -40,7 +40,13 @@ export const TraceMetadataKey = {
   MODEL_ID: 'mlflow.modelId',
   SIZE_BYTES: 'mlflow.trace.sizeBytes',
   SCHEMA_VERSION: 'mlflow.traceSchemaVersion',
-  TOKEN_USAGE: 'mlflow.trace.tokenUsage'
+  TOKEN_USAGE: 'mlflow.trace.tokenUsage',
+  // Deprecated, do not use. These fields are used for storing trace request and response
+  // in MLflow 2.x. In MLflow 3.x, these are replaced in favor of the request_preview and
+  // response_preview fields in the trace info.
+  // TODO: Remove this once the new trace table UI is available that is based on MLflow V3 trace.
+  INPUTS: 'mlflow.traceInputs',
+  OUTPUTS: 'mlflow.traceOutputs'
 };
 
 /**
@@ -78,3 +84,8 @@ export const TokenUsageKey = {
   OUTPUT_TOKENS: 'output_tokens',
   TOTAL_TOKENS: 'total_tokens'
 };
+
+/**
+ * Max length of the request/response preview in the trace info.
+ */
+export const REQUEST_RESPONSE_PREVIEW_MAX_LENGTH = 1000;

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -173,6 +173,9 @@ class BaseMlflowSpanProcessor(SimpleSpanProcessor):
         # Update trace state from span status, but only if the user hasn't explicitly set
         # a different trace status
         update_trace_state_from_span_conditionally(trace, root_span)
+
+        # TODO: Remove this once the new trace table UI is available that is based on MLflow V3 trace.
+        # Until then, these two metadata are still used to render the "request" and "response" columns.
         trace.info.trace_metadata.update(
             {
                 TraceMetadataKey.INPUTS: self._truncate_metadata(

--- a/mlflow/tracing/processor/base_mlflow.py
+++ b/mlflow/tracing/processor/base_mlflow.py
@@ -174,8 +174,8 @@ class BaseMlflowSpanProcessor(SimpleSpanProcessor):
         # a different trace status
         update_trace_state_from_span_conditionally(trace, root_span)
 
-        # TODO: Remove this once the new trace table UI is available that is based on MLflow V3 trace.
-        # Until then, these two metadata are still used to render the "request" and "response" columns.
+        # TODO: Remove this once the new trace table UI is available that is based on V3 trace.
+        # Until then, these two are still used to render the "request" and "response" columns.
         trace.info.trace_metadata.update(
             {
                 TraceMetadataKey.INPUTS: self._truncate_metadata(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16868?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16868/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16868/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16868/merge
```

</p>
</details>

### What changes are proposed in this pull request?

In MLflow 3., the `request_preview` and `response_preview` fields in the trace info is used for rendering the `request` and `response` columns in the trace table, respectively.

Typescript SDK sets them accordingly, however, I realized that OSS UI doesn't render these columns. The reason is it still look at the legacy `mlflow.traceInputs` and `mlflow.traceOutputs` keys stored in the trace metadata instead. 

This problem will disappear soon when we upgrade the trace table UI via UI sync, but it is still empty in MLflow 3.2, the latest version when we release TS SDK. Therefore, this PR update the SDK to set these two legacy fields as a workaround.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1044" height="169" alt="Screenshot 2025-07-24 at 19 34 31" src="https://github.com/user-attachments/assets/3604f325-eed7-4f9a-a14f-2ad35e48d16c" />

- First trace is the one generated after the fix.
- Second one is generated before the fix (empty columns).

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
