### PR TITLE
Replace dict with WebhookLogEntry dataclass in webhook tests

### DIFF
--- a/tests/webhooks/app.py
+++ b/tests/webhooks/app.py
@@ -24,9 +24,10 @@ async def health_check():
 async def insecure_webhook(request: Request):
     webhook_data = {
         "endpoint": "/insecure-webhook",
-        "payload": await request.json(),
         "headers": dict(request.headers),
         "status_code": 200,
+        "payload": await request.json(),
+        "error": None,
     }
     with LOG_FILE.open("a") as f:
         f.write(json.dumps(webhook_data) + "\n")
@@ -75,9 +76,10 @@ async def secure_webhook(request: Request):
     if not signature:
         error_data = {
             "endpoint": "/secure-webhook",
-            "error": "Missing signature header",
-            "status_code": 400,
             "headers": dict(request.headers),
+            "status_code": 400,
+            "payload": None,
+            "error": "Missing signature header",
         }
         with LOG_FILE.open("a") as f:
             f.write(json.dumps(error_data) + "\n")
@@ -86,9 +88,10 @@ async def secure_webhook(request: Request):
     if not verify_signature(body, signature):
         error_data = {
             "endpoint": "/secure-webhook",
-            "error": "Invalid signature",
-            "status_code": 401,
             "headers": dict(request.headers),
+            "status_code": 401,
+            "payload": None,
+            "error": "Invalid signature",
         }
         with LOG_FILE.open("a") as f:
             f.write(json.dumps(error_data) + "\n")
@@ -97,9 +100,10 @@ async def secure_webhook(request: Request):
     payload = json.loads(body)
     webhook_data = {
         "endpoint": "/secure-webhook",
-        "payload": payload,
         "headers": dict(request.headers),
         "status_code": 200,
+        "payload": payload,
+        "error": None,
     }
 
     with LOG_FILE.open("a") as f:

--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -24,7 +24,7 @@ class WebhookLogEntry:
     endpoint: str
     headers: dict[str, str]
     status_code: int
-    payload: dict[str, Any] | None = None
+    payload: dict[str, Any]
     error: str | None = None
 
 

--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Generator
 
@@ -16,6 +17,15 @@ from mlflow.entities.webhook import WebhookEvent
 
 from tests.helper_functions import get_safe_port
 from tests.webhooks.app import WEBHOOK_SECRET
+
+
+@dataclass
+class WebhookLogEntry:
+    endpoint: str
+    headers: dict[str, str]
+    status_code: int
+    payload: dict[str, Any] | None = None
+    error: str | None = None
 
 
 def wait_until_ready(health_endpoint: str, max_attempts: int = 10) -> None:
@@ -83,10 +93,11 @@ class AppClient:
         resp = requests.delete(self.get_url("/logs"))
         resp.raise_for_status()
 
-    def get_logs(self) -> list[dict[str, Any]]:
+    def get_logs(self) -> list[WebhookLogEntry]:
         response = requests.get(self.get_url("/logs"))
         response.raise_for_status()
-        return response.json().get("logs", [])
+        logs_data = response.json().get("logs", [])
+        return [WebhookLogEntry(**log_data) for log_data in logs_data]
 
 
 @contextlib.contextmanager
@@ -156,8 +167,8 @@ def test_registered_model_created(mlflow_client: MlflowClient, app_client: AppCl
     )
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": registered_model.name,
         "description": registered_model.description,
         "tags": registered_model.tags,
@@ -180,8 +191,8 @@ def test_model_version_created(mlflow_client: MlflowClient, app_client: AppClien
     )
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": registered_model.name,
         "version": model_version.version,
         "source": "s3://bucket/path/to/model",
@@ -211,8 +222,8 @@ def test_model_version_tag_set(mlflow_client: MlflowClient, app_client: AppClien
     )
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": "model_version_tag_set",
         "version": model_version.version,
         "key": "test_tag_key",
@@ -244,8 +255,8 @@ def test_model_version_tag_deleted(mlflow_client: MlflowClient, app_client: AppC
     )
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": registered_model.name,
         "version": model_version.version,
         "key": "test_tag_key",
@@ -271,8 +282,8 @@ def test_model_version_alias_created(mlflow_client: MlflowClient, app_client: Ap
     )
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": registered_model.name,
         "version": model_version.version,
         "alias": "test_alias",
@@ -299,8 +310,8 @@ def test_model_version_alias_deleted(mlflow_client: MlflowClient, app_client: Ap
     mlflow_client.delete_registered_model_alias(name=model_version.name, alias="test_alias")
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": registered_model.name,
         "alias": "test_alias",
     }
@@ -323,16 +334,16 @@ def test_webhook_with_secret(mlflow_client: MlflowClient, app_client: AppClient)
 
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/secure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/secure-webhook"
+    assert logs[0].payload == {
         "name": registered_model.name,
         "description": registered_model.description,
         "tags": registered_model.tags,
     }
-    assert logs[0]["status_code"] == 200
+    assert logs[0].status_code == 200
     # HTTP headers are case-insensitive and FastAPI normalizes them to lowercase
-    assert "x-mlflow-signature" in logs[0]["headers"]
-    assert logs[0]["headers"]["x-mlflow-signature"].startswith("sha256=")
+    assert "x-mlflow-signature" in logs[0].headers
+    assert logs[0].headers["x-mlflow-signature"].startswith("sha256=")
 
 
 def test_webhook_with_wrong_secret(mlflow_client: MlflowClient, app_client: AppClient) -> None:
@@ -354,9 +365,9 @@ def test_webhook_with_wrong_secret(mlflow_client: MlflowClient, app_client: AppC
     # The webhook request should have failed, but error should be logged
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/secure-webhook"
-    assert logs[0]["error"] == "Invalid signature"
-    assert logs[0]["status_code"] == 401
+    assert logs[0].endpoint == "/secure-webhook"
+    assert logs[0].error == "Invalid signature"
+    assert logs[0].status_code == 401
 
 
 def test_webhook_without_secret_to_secure_endpoint(
@@ -378,9 +389,9 @@ def test_webhook_without_secret_to_secure_endpoint(
     # The webhook request should fail due to missing signature, but error should be logged
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/secure-webhook"
-    assert logs[0]["error"] == "Missing signature header"
-    assert logs[0]["status_code"] == 400
+    assert logs[0].endpoint == "/secure-webhook"
+    assert logs[0].error == "Missing signature header"
+    assert logs[0].status_code == 400
 
 
 def test_webhook_test_insecure_endpoint(mlflow_client: MlflowClient, app_client: AppClient) -> None:
@@ -402,8 +413,8 @@ def test_webhook_test_insecure_endpoint(mlflow_client: MlflowClient, app_client:
     # Check that the test payload was received
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": "example_model",
         "version": "1",
         "source": "models:/123",
@@ -433,15 +444,15 @@ def test_webhook_test_secure_endpoint(mlflow_client: MlflowClient, app_client: A
     # Check that the test payload was received with proper signature
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/secure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/secure-webhook"
+    assert logs[0].payload == {
         "name": "example_model",
         "tags": {"example_key": "example_value"},
         "description": "An example registered model",
     }
-    assert logs[0]["status_code"] == 200
-    assert "x-mlflow-signature" in logs[0]["headers"]
-    assert logs[0]["headers"]["x-mlflow-signature"].startswith("sha256=")
+    assert logs[0].status_code == 200
+    assert "x-mlflow-signature" in logs[0].headers
+    assert logs[0].headers["x-mlflow-signature"].startswith("sha256=")
 
 
 def test_webhook_test_with_specific_event(
@@ -471,8 +482,8 @@ def test_webhook_test_with_specific_event(
     # Check that the correct payload was sent
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/insecure-webhook"
-    assert logs[0]["payload"] == {
+    assert logs[0].endpoint == "/insecure-webhook"
+    assert logs[0].payload == {
         "name": "example_model",
         "version": "1",
         "key": "example_key",
@@ -518,6 +529,6 @@ def test_webhook_test_with_wrong_secret(mlflow_client: MlflowClient, app_client:
     # Check that error was logged
     logs = app_client.get_logs()
     assert len(logs) == 1
-    assert logs[0]["endpoint"] == "/secure-webhook"
-    assert logs[0]["error"] == "Invalid signature"
-    assert logs[0]["status_code"] == 401
+    assert logs[0].endpoint == "/secure-webhook"
+    assert logs[0].error == "Invalid signature"
+    assert logs[0].status_code == 401


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16869?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16869/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16869/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16869/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR refactors the webhook testing code to replace `list[dict[str, Any]]` return type with a properly typed `WebhookLogEntry` dataclass for better type safety and code maintainability.

**Changes:**
- Added `WebhookLogEntry` dataclass with typed fields: `endpoint`, `headers`, `status_code`, `payload`, and `error`
- Updated `AppClient.get_logs()` method to return `list[WebhookLogEntry]` instead of `list[dict[str, Any]]`
- Updated all test assertions to use dataclass field access instead of dictionary key access

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

All existing webhook tests pass with the new dataclass implementation.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)