### PR TITLE
Fix autologging slowness on databricks

### DIFF
--- a/mlflow/tracking/context/databricks_job_context.py
+++ b/mlflow/tracking/context/databricks_job_context.py
@@ -23,7 +23,7 @@ class DatabricksJobRunContext(RunContextProvider):
         job_type = databricks_utils.get_job_type()
         webapp_url = databricks_utils.get_webapp_url()
         workspace_url = databricks_utils.get_workspace_url()
-        workspace_url_fallback, workspace_id = databricks_utils.get_workspace_info_from_dbutils()
+        workspace_id = databricks_utils.get_workspace_id()
         tags = {
             MLFLOW_SOURCE_NAME: (
                 f"jobs/{job_id}/run/{job_run_id}"
@@ -42,8 +42,10 @@ class DatabricksJobRunContext(RunContextProvider):
             tags[MLFLOW_DATABRICKS_WEBAPP_URL] = webapp_url
         if workspace_url is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url
-        elif workspace_url_fallback is not None:
-            tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url_fallback
+        else:
+            workspace_url_fallback, _ = databricks_utils.get_workspace_info_from_dbutils()
+            if workspace_url_fallback is not None:
+                tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url_fallback
         if workspace_id is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_ID] = workspace_id
         return tags

--- a/mlflow/tracking/context/databricks_notebook_context.py
+++ b/mlflow/tracking/context/databricks_notebook_context.py
@@ -21,7 +21,7 @@ class DatabricksNotebookRunContext(RunContextProvider):
         notebook_path = databricks_utils.get_notebook_path()
         webapp_url = databricks_utils.get_webapp_url()
         workspace_url = databricks_utils.get_workspace_url()
-        workspace_url_fallback, workspace_id = databricks_utils.get_workspace_info_from_dbutils()
+        workspace_id = databricks_utils.get_workspace_id()
         tags = {
             MLFLOW_SOURCE_NAME: notebook_path,
             MLFLOW_SOURCE_TYPE: SourceType.to_string(SourceType.NOTEBOOK),
@@ -34,8 +34,10 @@ class DatabricksNotebookRunContext(RunContextProvider):
             tags[MLFLOW_DATABRICKS_WEBAPP_URL] = webapp_url
         if workspace_url is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url
-        elif workspace_url_fallback is not None:
-            tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url_fallback
+        else:
+            workspace_url_fallback, _ = databricks_utils.get_workspace_info_from_dbutils()
+            if workspace_url_fallback is not None:
+                tags[MLFLOW_DATABRICKS_WORKSPACE_URL] = workspace_url_fallback
         if workspace_id is not None:
             tags[MLFLOW_DATABRICKS_WORKSPACE_ID] = workspace_id
         return tags

--- a/mlflow/tracking/default_experiment/databricks_notebook_experiment_provider.py
+++ b/mlflow/tracking/default_experiment/databricks_notebook_experiment_provider.py
@@ -8,12 +8,13 @@ from mlflow.utils.mlflow_tags import MLFLOW_EXPERIMENT_SOURCE_ID, MLFLOW_EXPERIM
 
 class DatabricksNotebookExperimentProvider(DefaultExperimentProvider):
     _resolved_notebook_experiment_id = None
+    _resolved = False
 
     def in_context(self):
         return databricks_utils.is_in_databricks_notebook()
 
     def get_experiment_id(self):
-        if DatabricksNotebookExperimentProvider._resolved_notebook_experiment_id:
+        if DatabricksNotebookExperimentProvider._resolved:
             return DatabricksNotebookExperimentProvider._resolved_notebook_experiment_id
 
         source_notebook_id = databricks_utils.get_notebook_id()
@@ -38,6 +39,8 @@ class DatabricksNotebookExperimentProvider(DefaultExperimentProvider):
                 experiment_id = source_notebook_id
             else:
                 raise e
+        finally:
+            DatabricksNotebookExperimentProvider._resolved = True
 
         DatabricksNotebookExperimentProvider._resolved_notebook_experiment_id = experiment_id
 

--- a/mlflow/tracking/default_experiment/databricks_notebook_experiment_provider.py
+++ b/mlflow/tracking/default_experiment/databricks_notebook_experiment_provider.py
@@ -1,3 +1,5 @@
+from functools import lru_cache
+
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
 from mlflow.tracking.client import MlflowClient
@@ -7,16 +9,12 @@ from mlflow.utils.mlflow_tags import MLFLOW_EXPERIMENT_SOURCE_ID, MLFLOW_EXPERIM
 
 
 class DatabricksNotebookExperimentProvider(DefaultExperimentProvider):
-    _resolved_notebook_experiment_id = None
-    _resolved = False
-
     def in_context(self):
         return databricks_utils.is_in_databricks_notebook()
 
-    def get_experiment_id(self):
-        if DatabricksNotebookExperimentProvider._resolved:
-            return DatabricksNotebookExperimentProvider._resolved_notebook_experiment_id
-
+    @lru_cache(maxsize=1)
+    @staticmethod
+    def _resolve_notebook_experiment_id():
         source_notebook_id = databricks_utils.get_notebook_id()
         source_notebook_name = databricks_utils.get_notebook_path()
         tags = {
@@ -39,9 +37,8 @@ class DatabricksNotebookExperimentProvider(DefaultExperimentProvider):
                 experiment_id = source_notebook_id
             else:
                 raise e
-        finally:
-            DatabricksNotebookExperimentProvider._resolved = True
-
-        DatabricksNotebookExperimentProvider._resolved_notebook_experiment_id = experiment_id
 
         return experiment_id
+
+    def get_experiment_id(self):
+        return DatabricksNotebookExperimentProvider._resolve_notebook_experiment_id()

--- a/tests/tracing/utils/test_environment.py
+++ b/tests/tracing/utils/test_environment.py
@@ -50,6 +50,7 @@ def test_resolve_env_metadata_in_databricks_notebook():
         mock_db_utils.get_notebook_path.return_value = "/Users/bob/test.py"
         mock_db_utils.get_webapp_url.return_value = None
         mock_db_utils.get_workspace_url.return_value = None
+        mock_db_utils.get_workspace_id.return_value = None
         mock_db_utils.get_workspace_info_from_dbutils.return_value = (None, None)
 
         assert resolve_env_metadata() == {

--- a/tests/tracking/context/test_databricks_job_context.py
+++ b/tests/tracking/context/test_databricks_job_context.py
@@ -28,6 +28,9 @@ def test_databricks_job_run_context_tags():
         "mlflow.utils.databricks_utils.get_workspace_url",
         return_value="https://dev.databricks.com",
     )
+    patch_workspace_id = mock.patch(
+        "mlflow.utils.databricks_utils.get_workspace_id", return_value="123456"
+    )
     patch_workspace_url_none = mock.patch(
         "mlflow.utils.databricks_utils.get_workspace_url", return_value=None
     )
@@ -43,6 +46,7 @@ def test_databricks_job_run_context_tags():
         patch_webapp_url as webapp_url_mock,
         patch_workspace_url as workspace_url_mock,
         patch_workspace_info as workspace_info_mock,
+        patch_workspace_id as workspace_id_mock,
     ):
         assert DatabricksJobRunContext().tags() == {
             MLFLOW_SOURCE_NAME: (
@@ -54,7 +58,7 @@ def test_databricks_job_run_context_tags():
             MLFLOW_DATABRICKS_JOB_TYPE: job_type_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
             MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_url_mock.return_value,
-            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
+            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_id_mock.return_value,
         }
 
     with (
@@ -64,6 +68,7 @@ def test_databricks_job_run_context_tags():
         patch_webapp_url as webapp_url_mock,
         patch_workspace_url_none as workspace_url_mock,
         patch_workspace_info as workspace_info_mock,
+        patch_workspace_id as workspace_id_mock,
     ):
         assert DatabricksJobRunContext().tags() == {
             MLFLOW_SOURCE_NAME: (
@@ -75,7 +80,7 @@ def test_databricks_job_run_context_tags():
             MLFLOW_DATABRICKS_JOB_TYPE: job_type_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
             MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_info_mock.return_value[0],  # fallback value
-            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
+            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_id_mock.return_value,
         }
 
 

--- a/tests/tracking/context/test_databricks_notebook_context.py
+++ b/tests/tracking/context/test_databricks_notebook_context.py
@@ -26,6 +26,9 @@ def test_databricks_notebook_run_context_tags():
         "mlflow.utils.databricks_utils.get_workspace_url",
         return_value="https://dev.databricks.com",
     )
+    patch_workspace_id = mock.patch(
+        "mlflow.utils.databricks_utils.get_workspace_id", return_value="123456"
+    )
     patch_workspace_url_none = mock.patch(
         "mlflow.utils.databricks_utils.get_workspace_url", return_value=None
     )
@@ -40,6 +43,7 @@ def test_databricks_notebook_run_context_tags():
         patch_webapp_url as webapp_url_mock,
         patch_workspace_url as workspace_url_mock,
         patch_workspace_info as workspace_info_mock,
+        patch_workspace_id as workspace_id_mock,
     ):
         assert DatabricksNotebookRunContext().tags() == {
             MLFLOW_SOURCE_NAME: notebook_path_mock.return_value,
@@ -48,7 +52,7 @@ def test_databricks_notebook_run_context_tags():
             MLFLOW_DATABRICKS_NOTEBOOK_PATH: notebook_path_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
             MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_url_mock.return_value,
-            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
+            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_id_mock.return_value,
         }
 
     with (
@@ -57,6 +61,7 @@ def test_databricks_notebook_run_context_tags():
         patch_webapp_url as webapp_url_mock,
         patch_workspace_url_none as workspace_url_mock,
         patch_workspace_info as workspace_info_mock,
+        patch_workspace_id as workspace_id_mock,
     ):
         assert DatabricksNotebookRunContext().tags() == {
             MLFLOW_SOURCE_NAME: notebook_path_mock.return_value,
@@ -65,7 +70,7 @@ def test_databricks_notebook_run_context_tags():
             MLFLOW_DATABRICKS_NOTEBOOK_PATH: notebook_path_mock.return_value,
             MLFLOW_DATABRICKS_WEBAPP_URL: webapp_url_mock.return_value,
             MLFLOW_DATABRICKS_WORKSPACE_URL: workspace_info_mock.return_value[0],  # fallback value
-            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_info_mock.return_value[1],
+            MLFLOW_DATABRICKS_WORKSPACE_ID: workspace_id_mock.return_value,
         }
 
 

--- a/tests/tracking/default_experiment/test_databricks_notebook_experiment_provider.py
+++ b/tests/tracking/default_experiment/test_databricks_notebook_experiment_provider.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+import pytest
+
 from mlflow import MlflowClient
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
@@ -7,6 +9,11 @@ from mlflow.tracking.default_experiment.databricks_notebook_experiment_provider 
     DatabricksNotebookExperimentProvider,
 )
 from mlflow.utils.mlflow_tags import MLFLOW_EXPERIMENT_SOURCE_ID, MLFLOW_EXPERIMENT_SOURCE_TYPE
+
+
+@pytest.fixture(autouse=True)
+def reset_resolved_notebook_experiment_id():
+    DatabricksNotebookExperimentProvider._resolved = False
 
 
 def test_databricks_notebook_default_experiment_in_context():

--- a/tests/tracking/default_experiment/test_databricks_notebook_experiment_provider.py
+++ b/tests/tracking/default_experiment/test_databricks_notebook_experiment_provider.py
@@ -13,7 +13,7 @@ from mlflow.utils.mlflow_tags import MLFLOW_EXPERIMENT_SOURCE_ID, MLFLOW_EXPERIM
 
 @pytest.fixture(autouse=True)
 def reset_resolved_notebook_experiment_id():
-    DatabricksNotebookExperimentProvider._resolved = False
+    DatabricksNotebookExperimentProvider._resolve_notebook_experiment_id.cache_clear()
 
 
 def test_databricks_notebook_default_experiment_in_context():

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -621,8 +621,8 @@ def test_start_run_defaults_databricks_notebook(
     )
     mock_workspace_id = mock.Mock()
     workspace_info_patch = mock.patch(
-        "mlflow.utils.databricks_utils.get_workspace_info_from_dbutils",
-        return_value=(mock_webapp_url, mock_workspace_id),
+        "mlflow.utils.databricks_utils.get_workspace_id",
+        return_value=mock_workspace_id,
     )
 
     expected_tags = {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/16870?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16870/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16870/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16870/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix autologging slowness that's reported by a user
- `get_experiment_id` was called repeatedly in `databricks_notebook_experiment_provider` during autologging patch, and this process is a bit slow, we should only check it once
- `resolve_tags` is super slow (get_workspace_info_from_dbutils), mostly spent on connection with java gateway, while this call is not necessary

Pending on customer verification on this fix.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
