### PR TITLE
Enforce PEP 604 union type syntax 

### DIFF
--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -2586,7 +2586,7 @@ e.g., struct<a:int, b:array<int>>.
 
     @pandas_udf(result_type)
     def udf(
-        iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]],  # noqa: UP006
+        iterator: Iterator[Tuple[Union[pandas.Series, pandas.DataFrame], ...]],  # noqa: UP006,UP007
     ) -> Iterator[result_type_hint]:
         # importing here to prevent circular import
         from mlflow.pyfunc.scoring_server.client import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -232,6 +232,7 @@ select = [
   "TRY203",  # useless-try-except
   "UP004",   # useless-object-inheritance
   "UP006",   # non-pep585-annotation
+  "UP007",   # non-pep604-annotation-union
   "UP008",   # super-call-with-parameters
   "UP011",   # lru-cache-without-parameters
   "UP012",   # unnecessary-encode-utf8
@@ -239,6 +240,7 @@ select = [
   "UP030",   # format-literals
   "UP031",   # printf-string-format
   "UP034",   # extraneous-parenthesis
+  "UP045",   # non-pep604-annotation-optional
   "W",       # warning
 ]
 ignore = [
@@ -253,6 +255,11 @@ ignore = [
 "examples/*" = ["T20", "RET504", "E501"]
 "docs/*" = ["T20", "RET504", "E501"]
 "mlflow/*" = ["PT018"]
+# TODO: Consider enabling UP007 and UP045 in the following files.
+# Note: Switching to the new union syntax may introduce behavior changes.
+"mlflow/types/type_hints.py" = ["UP007", "UP045"]
+"tests/types/test_type_hints.py" = ["UP007", "UP045"]
+"tests/pyfunc/test_pyfunc_model_with_type_hints.py" = ["UP007", "UP045"]
 
 [tool.ruff.lint.flake8-pytest-style]
 mark-parentheses = false

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -28,9 +28,10 @@ def test_infer_primitive_types(input_value, expected_type):
         (["a", "b", "c"], list[str]),
         ([1.0, 2.0, 3.0], list[float]),
         ([True, False, True], list[bool]),
-        ([1, "hello", True], list[Union[int, str, bool]]),  # _noqa: UP007
+        ([1, "hello", True], list[Union[int, str, bool]]),  # noqa: UP007
         ([1, "hello", True], list[int | str | bool]),
-        ([1, 2.0], list[Union[int, float]]),
+        ([1, 2.0], list[Union[int, float]]),  # noqa: UP007
+        ([1, 2.0], list[int | float]),
         ([[1, 2], [3, 4]], list[list[int]]),
         ([["a"], ["b", "c"]], list[list[str]]),
     ],

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -52,7 +52,7 @@ class CustomExample(pydantic.BaseModel):
     bool_field: bool
     double_field: float
     any_field: Any
-    optional_str: Optional[str] = None  # _noqa: UP045
+    optional_str: Optional[str] = None  # noqa: UP045
     str_or_none: str | None = None
 
 
@@ -64,7 +64,7 @@ class Message(pydantic.BaseModel):
 class CustomExample2(pydantic.BaseModel):
     custom_field: dict[str, Any]
     messages: list[Message]
-    optional_int: Optional[int] = None  # _noqa: UP045
+    optional_int: Optional[int] = None  # noqa: UP045
     int_or_none: int | None = None
 
 
@@ -119,7 +119,7 @@ class CustomExample2(pydantic.BaseModel):
             [{"a": ["a", "b"]}],
         ),
         # Union
-        (list[Union[int, str]], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),  # _noqa: UP007
+        (list[Union[int, str]], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),  # noqa: UP007
         (list[int | str], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),
         # Any
         (list[Any], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),
@@ -262,7 +262,7 @@ def test_pyfunc_model_infer_signature_from_type_hints(
 class CustomExample3(pydantic.BaseModel):
     custom_field: dict[str, list[str]]
     messages: list[Message]
-    optional_int: Optional[int] = None  # _noqa: UP045
+    optional_int: Optional[int] = None  # noqa: UP045
     int_or_none: int | None = None
 
 

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1832,7 +1832,7 @@ def test_convert_dataclass_to_schema_for_rag():
 def test_convert_dataclass_to_schema_complex():
     @dataclass
     class Settings:
-        baz: Optional[bool] = True  # _noqa: UP045
+        baz: Optional[bool] = True  # noqa: UP045
         qux: bool | None = None
 
     @dataclass

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -153,7 +153,7 @@ def test_infer_schema_from_pydantic_model(type_hint, expected_schema):
         (list[dict[str, list[str]]], Schema([ColSpec(type=Map(Array(DataType.string)))])),
         (list[Dict[str, List[str]]], Schema([ColSpec(type=Map(Array(DataType.string)))])),  # noqa: UP006
         # Union
-        (list[Union[int, str]], Schema([ColSpec(type=AnyType())])),  # _noqa: UP007
+        (list[Union[int, str]], Schema([ColSpec(type=AnyType())])),  # noqa: UP007
         (list[int | str], Schema([ColSpec(type=AnyType())])),
         (list[list[int | str]], Schema([ColSpec(type=Array(AnyType()))])),
         # Any
@@ -208,19 +208,19 @@ def test_infer_schema_from_type_hints_errors():
 
     message = r"Input cannot be Optional type"
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_list_type_hint(Optional[list[str]])  # _noqa: UP045
+        _infer_schema_from_list_type_hint(Optional[list[str]])  # noqa: UP045
 
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[str] | None)
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_list_type_hint(list[Optional[str]])  # _noqa: UP045
+        _infer_schema_from_list_type_hint(list[Optional[str]])  # noqa: UP045
 
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[str | None])
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])  # _noqa: UP007
+        _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])  # noqa: UP007
 
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[str | int | type(None)])
@@ -364,12 +364,12 @@ def test_pydantic_model_validation(type_hint, example):
         (list[list[str]], [["a", "b"], ["c", "d"]]),
         (dict[str, int], {"a": 1, "b": 2}),
         (dict[str, list[str]], {"a": ["a", "b"], "b": ["c", "d"]}),
-        (Union[int, str], 1),  # _noqa: UP007
-        (Union[int, str], "a"),  # _noqa: UP007
+        (Union[int, str], 1),  # noqa: UP007
+        (Union[int, str], "a"),  # noqa: UP007
         (int | str, 1),
         (int | str, "a"),
         # Union type is inferred as AnyType, so it accepts double here as well
-        (Union[int, str], 1.2),  # _noqa: UP007
+        (Union[int, str], 1.2),  # noqa: UP007
         (int | str, 1.2),
         (list[Any], [1, "a"]),
     ],
@@ -425,9 +425,9 @@ def test_type_hints_validation_errors():
         ("a", str, "a"),
         (["a", "b"], list[str], ["a", "b"]),
         ({"a": 1, "b": 2}, dict[str, int], {"a": 1, "b": 2}),
-        (1, Optional[int], 1),  # _noqa: UP045
+        (1, Optional[int], 1),  # noqa: UP045
         (1, int | None, 1),
-        (None, Optional[int], None),  # _noqa: UP045
+        (None, Optional[int], None),  # noqa: UP045
         (None, int | None, None),
         (pd.DataFrame({"a": ["a", "b"]}), list[str], ["a", "b"]),
         (pd.DataFrame({"a": [{"x": "x"}]}), list[dict[str, str]], [{"x": "x"}]),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16872?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16872/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16872/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16872/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Resolve #xxx -->

### What changes are proposed in this pull request?

This PR enables two ruff rules to modernize our type annotations:
- UP045: Use PEP 604 uni types (`X | None`) instead of `Optional[X]`
- UP007: Use PEP 604 union types (`X | Y`) instead of `Union[X, Y]`

These changes improve code consistency and align with Python 3.10+ idioms.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)