### PR TITLE
ChatAgent: allow empty string content

### DIFF
--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -60,7 +60,7 @@ class ChatAgentMessage(BaseModel):
             content = values.get("content")
             tool_calls = values.get("tool_calls")
 
-        if not content and not tool_calls:
+        if content is None and tool_calls is None:
             raise ValueError("Either 'content' or 'tool_calls' must be provided.")
         return values
 

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -192,7 +192,7 @@ class ChatAgentChunk(BaseModel):
         class Config:
             validate_assignment = True
 
-    delta: ChatAgentMessage
+    delta: Optional[ChatAgentMessage] = None
     finish_reason: Optional[str] = None
     # TODO: add finish_reason_metadata once we have a plan for usage
     custom_outputs: Optional[dict[str, Any]] = None
@@ -201,9 +201,12 @@ class ChatAgentChunk(BaseModel):
     @model_validator(mode="after")
     def check_message_id(cls, values):
         """
-        Ensure that the message ID is unique.
+        Ensure that the message ID is unique if delta is provided.
         """
-        message_id = values.delta.id if IS_PYDANTIC_V2_OR_NEWER else values.get("delta").get("id")
+        delta = values.delta if IS_PYDANTIC_V2_OR_NEWER else values.get("delta")
+        if not delta:
+            return values
+        message_id = delta.id if IS_PYDANTIC_V2_OR_NEWER else delta.get("id")
 
         if message_id is None:
             raise ValueError(

--- a/mlflow/types/agent.py
+++ b/mlflow/types/agent.py
@@ -192,7 +192,7 @@ class ChatAgentChunk(BaseModel):
         class Config:
             validate_assignment = True
 
-    delta: Optional[ChatAgentMessage] = None
+    delta: ChatAgentMessage
     finish_reason: Optional[str] = None
     # TODO: add finish_reason_metadata once we have a plan for usage
     custom_outputs: Optional[dict[str, Any]] = None
@@ -201,12 +201,9 @@ class ChatAgentChunk(BaseModel):
     @model_validator(mode="after")
     def check_message_id(cls, values):
         """
-        Ensure that the message ID is unique if delta is provided.
+        Ensure that the message ID is unique.
         """
-        delta = values.delta if IS_PYDANTIC_V2_OR_NEWER else values.get("delta")
-        if not delta:
-            return values
-        message_id = delta.id if IS_PYDANTIC_V2_OR_NEWER else delta.get("id")
+        message_id = values.delta.id if IS_PYDANTIC_V2_OR_NEWER else values.get("delta").get("id")
 
         if message_id is None:
             raise ValueError(

--- a/tests/pyfunc/test_chat_agent_validation.py
+++ b/tests/pyfunc/test_chat_agent_validation.py
@@ -25,6 +25,14 @@ def test_chat_agent_message_throws_on_invalid_data():
         ChatAgentMessage(**data)
 
 
+def test_chat_agent_message_allows_empty_content():
+    # Empty string content should be allowed (not None)
+    data = {"role": "assistant", "content": ""}
+    message = ChatAgentMessage(**data)
+    assert message.content == ""
+    assert message.tool_calls is None
+
+
 def test_chat_agent_response_throws_on_missing_id():
     data = {"messages": [{"role": "user", "content": "a"}]}
     with pytest.raises(ValueError, match="All ChatAgentMessage objects in field `messages`"):
@@ -68,3 +76,11 @@ def test_chat_agent_chunk_throws_on_updated_id():
     chunk = ChatAgentChunk(**data)
     with pytest.raises(ValueError, match="The field `delta` of ChatAgentChunk"):
         chunk.delta = ChatAgentMessage(**{"role": "user", "content": "b"})
+
+
+def test_chat_agent_chunk_allows_none_delta():
+    # ChatAgentChunk with delta=None should be allowed
+    # also ensure no validation errors are raised
+    chunk = ChatAgentChunk()
+    assert chunk.delta is None
+    assert chunk.finish_reason is None

--- a/tests/pyfunc/test_chat_agent_validation.py
+++ b/tests/pyfunc/test_chat_agent_validation.py
@@ -76,11 +76,3 @@ def test_chat_agent_chunk_throws_on_updated_id():
     chunk = ChatAgentChunk(**data)
     with pytest.raises(ValueError, match="The field `delta` of ChatAgentChunk"):
         chunk.delta = ChatAgentMessage(**{"role": "user", "content": "b"})
-
-
-def test_chat_agent_chunk_allows_none_delta():
-    # ChatAgentChunk with delta=None should be allowed
-    # also ensure no validation errors are raised
-    chunk = ChatAgentChunk()
-    assert chunk.delta is None
-    assert chunk.finish_reason is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/16877?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16877/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16877/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16877/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
