### PR TITLE
Modify `mlflow/genai/optimize/util.py::infer_type_from_value` to avoid UP007

### DIFF
--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -1,4 +1,5 @@
-from typing import Any, Union
+import functools
+from typing import Any
 
 from pydantic import BaseModel, create_model
 
@@ -18,10 +19,7 @@ def infer_type_from_value(value: Any, model_name: str = "Output") -> type:
         element_types = set()
         for item in value:
             element_types.add(infer_type_from_value(item))
-        if len(element_types) == 1:
-            return list[element_types.pop()]
-        else:
-            return list[Union[tuple(element_types)]]
+        return list[functools.reduce(lambda x, y: x | y, element_types)]
     elif isinstance(value, dict):
         fields = {k: (infer_type_from_value(v, model_name=k), ...) for k, v in value.items()}
         return create_model(model_name, **fields)

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -29,6 +29,7 @@ def test_infer_primitive_types(input_value, expected_type):
         ([1.0, 2.0, 3.0], list[float]),
         ([True, False, True], list[bool]),
         ([1, "hello", True], list[Union[int, str, bool]]),
+        ([1, "hello", True], list[int | str | bool]),  # NO PEP 604
         ([1, 2.0], list[Union[int, float]]),
         ([[1, 2], [3, 4]], list[list[int]]),
         ([["a"], ["b", "c"]], list[list[str]]),

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -28,8 +28,8 @@ def test_infer_primitive_types(input_value, expected_type):
         (["a", "b", "c"], list[str]),
         ([1.0, 2.0, 3.0], list[float]),
         ([True, False, True], list[bool]),
-        ([1, "hello", True], list[Union[int, str, bool]]),
-        ([1, "hello", True], list[int | str | bool]),  # NO PEP 604
+        ([1, "hello", True], list[Union[int, str, bool]]),  # noqa_: UP007
+        ([1, "hello", True], list[int | str | bool]),
         ([1, 2.0], list[Union[int, float]]),
         ([[1, 2], [3, 4]], list[list[int]]),
         ([["a"], ["b", "c"]], list[list[str]]),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16881?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16881/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16881/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16881/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Discovered in #16872. This PR modifies mlflow/genai/optimize/util.py::infer_type_from_value to avoid `UP007` (rule to enforce the new union syntax).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The existing test suite covers this functionality, and a new test case has been added to verify the behavior with the union operator syntax.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)