### PR TITLE
Add configurable timeout for webhook HTTP requests

### DIFF
--- a/docs/docs/classic-ml/webhooks/index.mdx
+++ b/docs/docs/classic-ml/webhooks/index.mdx
@@ -232,6 +232,7 @@ To prevent replay attacks, it's recommended to verify that webhook timestamps ar
 ### Environment Variables
 
 - `MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY`: Encryption key for storing webhook secrets securely
+- `MLFLOW_WEBHOOK_REQUEST_TIMEOUT`: Timeout in seconds for webhook HTTP requests (default: 30)
 
 ## Example: FastAPI Webhook Receiver
 
@@ -422,8 +423,8 @@ if __name__ == "__main__":
    - Check that the secret matches exactly (no extra spaces)
 
 3. **Connection timeouts:**
-   - MLflow has a default timeout of 30 seconds for webhook requests
-   - Ensure your endpoint responds quickly
+   - MLflow has a default timeout of 30 seconds for webhook requests (configurable via `MLFLOW_WEBHOOK_REQUEST_TIMEOUT`)
+   - Ensure your endpoint responds quickly or increase the timeout if needed
 
 ## API Reference
 

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -890,3 +890,7 @@ _MLFLOW_WEBHOOK_ALLOWED_SCHEMES = _EnvironmentVariable(
 MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY = _EnvironmentVariable(
     "MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY", str, None
 )
+
+#: Specifies the timeout in seconds for webhook HTTP requests
+#: (default: ``30``)
+MLFLOW_WEBHOOK_REQUEST_TIMEOUT = _EnvironmentVariable("MLFLOW_WEBHOOK_REQUEST_TIMEOUT", int, 30)

--- a/mlflow/webhooks/dispatch.py
+++ b/mlflow/webhooks/dispatch.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 import requests
 
 from mlflow.entities.webhook import Webhook, WebhookEvent, WebhookTestResult
+from mlflow.environment_variables import MLFLOW_WEBHOOK_REQUEST_TIMEOUT
 from mlflow.store.model_registry.abstract_store import AbstractStore
 from mlflow.webhooks.constants import (
     WEBHOOK_DELIVERY_ID_HEADER,
@@ -96,7 +97,8 @@ def _send_webhook_request(
         )
         headers[WEBHOOK_SIGNATURE_HEADER] = signature
 
-    return requests.post(webhook.url, data=payload_bytes, headers=headers, timeout=30)
+    timeout = MLFLOW_WEBHOOK_REQUEST_TIMEOUT.get()
+    return requests.post(webhook.url, data=payload_bytes, headers=headers, timeout=timeout)
 
 
 def _dispatch_webhook_impl(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16886?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16886/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16886/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16886/merge
```

</p>
</details>

### Related Issues/PRs

<!-- No specific issue, this is an enhancement request -->

### What changes are proposed in this pull request?

This PR adds configurable timeout support for webhook HTTP requests by:

1. **Adding `MLFLOW_WEBHOOK_REQUEST_TIMEOUT` environment variable** in `environment_variables.py`:
   - Default value: 30 seconds (maintains current behavior)
   - Type: integer
   - Allows users to customize webhook request timeout as needed

2. **Updating `dispatch.py`** to use the configurable timeout:
   - Replaced hardcoded `timeout=30` with `timeout=MLFLOW_WEBHOOK_REQUEST_TIMEOUT.get()`
   - Added appropriate import for the new environment variable

3. **Updated documentation** in `docs/docs/classic-ml/webhooks/index.mdx`:
   - Added the new environment variable to the Environment Variables section
   - Updated troubleshooting section to mention the configurable timeout

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

**Manual testing performed:**
- Verified default timeout behavior (30 seconds)
- Tested custom timeout values via environment variable
- Confirmed proper import and usage in dispatch module
- Validated code formatting and linting

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

**Description:** Added `MLFLOW_WEBHOOK_REQUEST_TIMEOUT` environment variable to allow configurable timeout for webhook HTTP requests (default: 30 seconds). Users can now customize webhook timeout based on their endpoint response requirements.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/server-infra`: MLflow Tracking server backend
- [x] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)