### PR TITLE
Always return managed source for genai eval dataset

### DIFF
--- a/mlflow/genai/datasets/evaluation_dataset.py
+++ b/mlflow/genai/datasets/evaluation_dataset.py
@@ -61,8 +61,6 @@ class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
     @property
     def source(self) -> DatasetSource:
         """Source information for the dataset."""
-        if isinstance(self._dataset.source, DatasetSource):
-            return self._dataset.source
         return DatabricksEvaluationDatasetSource(table_name=self.name, dataset_id=self.dataset_id)
 
     @property

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -583,7 +583,6 @@ class TrackingServiceClient:
         Returns:
             None
         """
-        print("@@@ logging inputs", datasets, models)
         self.store.log_inputs(run_id=run_id, datasets=datasets, models=models)
 
     def log_outputs(self, run_id: str, models: list[LoggedModelOutput]):

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -583,6 +583,7 @@ class TrackingServiceClient:
         Returns:
             None
         """
+        print("@@@ logging inputs", datasets, models)
         self.store.log_inputs(run_id=run_id, datasets=datasets, models=models)
 
     def log_outputs(self, run_id: str, models: list[LoggedModelOutput]):

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -89,22 +89,6 @@ def test_evaluation_dataset_source_with_none():
     assert dataset.source.dataset_id == "test-dataset-id"
 
 
-def test_evaluation_dataset_source_with_existing_dataset_source():
-    existing_source = DatabricksEvaluationDatasetSource(
-        table_name="existing.table", dataset_id="existing-id"
-    )
-    dataset = create_dataset_with_source(existing_source)
-
-    assert dataset.source is existing_source
-
-
-def test_evaluation_dataset_source_with_spark_dataset_source():
-    spark_source = SparkDatasetSource(table_name="spark.table")
-    dataset = create_dataset_with_source(spark_source)
-
-    assert dataset.source is spark_source
-
-
 def test_evaluation_dataset_to_df(mock_managed_dataset):
     dataset = EvaluationDataset(mock_managed_dataset)
 
@@ -125,24 +109,6 @@ def test_evaluation_dataset_to_mlflow_entity(mock_managed_dataset):
     source_dict = json.loads(entity.source)
     assert source_dict["table_name"] == "catalog.schema.table"
     assert source_dict["dataset_id"] == "test-dataset-id"
-    assert entity.schema == "test-schema"
-    assert entity.profile == "test-profile"
-
-
-def test_evaluation_dataset_to_mlflow_entity_with_existing_source():
-    existing_source = DatabricksEvaluationDatasetSource(
-        table_name="existing.table", dataset_id="existing-id"
-    )
-    dataset = create_dataset_with_source(existing_source)
-
-    entity = dataset._to_mlflow_entity()
-    assert entity.name == "catalog.schema.table"
-    assert entity.digest == "test-digest"
-    assert entity.source_type == "databricks-uc-table"
-
-    source_dict = json.loads(entity.source)
-    assert source_dict["table_name"] == "existing.table"
-    assert source_dict["dataset_id"] == "existing-id"
     assert entity.schema == "test-schema"
     assert entity.profile == "test-profile"
 

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -131,6 +131,24 @@ def test_evaluation_dataset_to_mlflow_entity(mock_managed_dataset):
     assert entity.profile == "test-profile"
 
 
+def test_evaluation_dataset_to_mlflow_entity_with_existing_source():
+    existing_source = DatabricksEvaluationDatasetSource(
+        table_name="existing.table", dataset_id="existing-id"
+    )
+    dataset = create_dataset_with_source(existing_source)
+
+    entity = dataset._to_mlflow_entity()
+    assert entity.name == "existing.table"
+    assert entity.digest == "test-digest"
+    assert entity.source_type == "databricks-uc-table"
+
+    source_dict = json.loads(entity.source)
+    assert source_dict["table_name"] == "existing.table"
+    assert source_dict["dataset_id"] == "existing-id"
+    assert entity.schema == "test-schema"
+    assert entity.profile == "test-profile"
+
+
 def test_evaluation_dataset_set_profile(mock_managed_dataset):
     dataset = EvaluationDataset(mock_managed_dataset)
 

--- a/tests/genai/datasets/test_evaluation_dataset.py
+++ b/tests/genai/datasets/test_evaluation_dataset.py
@@ -23,8 +23,8 @@ def create_test_source_json(table_name: str = "main.default.testtable") -> str:
 def create_mock_managed_dataset(source_value: Any) -> Mock:
     """Create a mock Databricks Agent Evaluation ManagedDataset for testing"""
     mock_dataset = Mock()
-    mock_dataset.dataset_id = "test-dataset-id"
-    mock_dataset.name = "catalog.schema.table"
+    mock_dataset.dataset_id = getattr(source_value, "dataset_id", "test-dataset-id")
+    mock_dataset.name = getattr(source_value, "_table_name", "catalog.schema.table")
     mock_dataset.digest = "test-digest"
     mock_dataset.schema = "test-schema"
     mock_dataset.profile = "test-profile"
@@ -86,6 +86,24 @@ def test_evaluation_dataset_source_with_none():
 
     assert isinstance(dataset.source, DatabricksEvaluationDatasetSource)
     assert dataset.source.table_name == "catalog.schema.table"
+    assert dataset.source.dataset_id == "test-dataset-id"
+
+
+def test_evaluation_dataset_source_always_returns_databricks_evaluation_dataset_source():
+    existing_source = DatabricksEvaluationDatasetSource(
+        table_name="existing.table", dataset_id="existing-id"
+    )
+    dataset = create_dataset_with_source(existing_source)
+
+    assert isinstance(dataset.source, DatabricksEvaluationDatasetSource)
+    assert dataset.source.table_name == "existing.table"
+    assert dataset.source.dataset_id == "existing-id"
+
+    spark_source = SparkDatasetSource(table_name="spark.table")
+    dataset = create_dataset_with_source(spark_source)
+
+    assert isinstance(dataset.source, DatabricksEvaluationDatasetSource)
+    assert dataset.source.table_name == "spark.table"
     assert dataset.source.dataset_id == "test-dataset-id"
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/16894?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16894/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16894/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16894/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This is to preserve the dataset id for linking in the MLflow UI. Currently it looks like the backing source for managed eval sets is typically `SparkDatasetSource` which does not contain the dataset id, only table name. 

The two implement the same interface (DatasetSource) so it should be safe, but I'd appreciate advice on which situations to test.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Edited existing unit tests

Manually tested on databricks, ran the following code in a notebook:

```
import mlflow
from mlflow.genai.scorers import (
    RelevanceToQuery,
)

eval_dataset = mlflow.genai.datasets.get_dataset("ml.daniel_lok.daniel_dataset_new")

def predict(inputs):
  return "You're absolutely right!"

# Run the evaluation.
mlflow.genai.evaluate(
  data=eval_dataset,
  predict_fn=predict,
  scorers=[RelevanceToQuery()]
)
```

<img width="785" height="151" alt="Screenshot 2025-07-28 at 11 20 15 AM" src="https://github.com/user-attachments/assets/0e1a7575-42f0-4048-b092-f2b9e8b6fb86" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
