### PR TITLE
Update schema inference tests for upcoming PEP 604 changes

### DIFF
--- a/mlflow/types/type_hints.py
+++ b/mlflow/types/type_hints.py
@@ -2,6 +2,7 @@ import base64
 import logging
 from datetime import datetime
 from functools import lru_cache
+from types import UnionType
 from typing import Any, NamedTuple, Optional, TypeVar, Union, get_args, get_origin
 
 import pydantic
@@ -25,17 +26,10 @@ from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER, model_dump_comp
 from mlflow.utils.warnings_utils import color_warning
 
 FIELD_TYPE = pydantic.fields.FieldInfo if IS_PYDANTIC_V2_OR_NEWER else pydantic.fields.ModelField
-_logger = logging.getLogger(__name__)
 NONE_TYPE = type(None)
-UNION_TYPES = (Union,)
-try:
-    # this import is only available in Python 3.10+
-    from types import UnionType
+UNION_TYPES = (Union, UnionType)
 
-    UNION_TYPES += (UnionType,)
-except ImportError:
-    pass
-
+_logger = logging.getLogger(__name__)
 # special type hint that can be used to convert data to
 # the input example type after data validation
 TypeFromExample = TypeVar("TypeFromExample")

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -28,7 +28,7 @@ def test_infer_primitive_types(input_value, expected_type):
         (["a", "b", "c"], list[str]),
         ([1.0, 2.0, 3.0], list[float]),
         ([True, False, True], list[bool]),
-        ([1, "hello", True], list[Union[int, str, bool]]),  # noqa_: UP007
+        ([1, "hello", True], list[Union[int, str, bool]]),  # _noqa: UP007
         ([1, "hello", True], list[int | str | bool]),
         ([1, 2.0], list[Union[int, float]]),
         ([[1, 2], [3, 4]], list[list[int]]),

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -52,7 +52,8 @@ class CustomExample(pydantic.BaseModel):
     bool_field: bool
     double_field: float
     any_field: Any
-    optional_str: Optional[str] = None
+    optional_str: Optional[str] = None  # _noqa: UP045
+    str_or_none: str | None = None
 
 
 class Message(pydantic.BaseModel):
@@ -63,7 +64,8 @@ class Message(pydantic.BaseModel):
 class CustomExample2(pydantic.BaseModel):
     custom_field: dict[str, Any]
     messages: list[Message]
-    optional_int: Optional[int] = None
+    optional_int: Optional[int] = None  # _noqa: UP045
+    int_or_none: int | None = None
 
 
 @pytest.mark.parametrize(
@@ -138,6 +140,7 @@ class CustomExample2(pydantic.BaseModel):
                                 Property(
                                     name="optional_str", dtype=DataType.string, required=False
                                 ),
+                                Property(name="str_or_none", dtype=DataType.string, required=False),
                             ]
                         )
                     ),
@@ -151,6 +154,7 @@ class CustomExample2(pydantic.BaseModel):
                     "double_field": 1.23,
                     "any_field": ["any", 123],
                     "optional_str": "optional",
+                    "str_or_none": "str_or_none",
                 }
             ],
         ),
@@ -174,6 +178,7 @@ class CustomExample2(pydantic.BaseModel):
                                     ),
                                 ),
                                 Property(name="optional_int", dtype=DataType.long, required=False),
+                                Property(name="int_or_none", dtype=DataType.long, required=False),
                             ]
                         )
                     )
@@ -184,6 +189,7 @@ class CustomExample2(pydantic.BaseModel):
                     "custom_field": {"a": 1},
                     "messages": [{"role": "admin", "content": "hello"}],
                     "optional_int": 123,
+                    "int_or_none": 456,
                 }
             ],
         ),
@@ -256,7 +262,8 @@ def test_pyfunc_model_infer_signature_from_type_hints(
 class CustomExample3(pydantic.BaseModel):
     custom_field: dict[str, list[str]]
     messages: list[Message]
-    optional_int: Optional[int] = None
+    optional_int: Optional[int] = None  # _noqa: UP045
+    int_or_none: int | None = None
 
 
 @pytest.mark.parametrize(
@@ -303,6 +310,7 @@ class CustomExample3(pydantic.BaseModel):
                         ),
                     ),
                     StructField("optional_int", IntegerType()),
+                    StructField("int_or_none", IntegerType()),
                 ]
             ),
             [
@@ -313,6 +321,7 @@ class CustomExample3(pydantic.BaseModel):
                         {"role": "user", "content": "hi"},
                     ],
                     "optional_int": 123,
+                    "int_or_none": 456,
                 },
                 {
                     "custom_field": {"a": ["a", "b", "c"]},
@@ -320,6 +329,7 @@ class CustomExample3(pydantic.BaseModel):
                         {"role": "admin", "content": "hello"},
                     ],
                     "optional_int": None,
+                    "int_or_none": None,
                 },
             ],
         ),

--- a/tests/pyfunc/test_pyfunc_model_with_type_hints.py
+++ b/tests/pyfunc/test_pyfunc_model_with_type_hints.py
@@ -117,7 +117,7 @@ class CustomExample2(pydantic.BaseModel):
             [{"a": ["a", "b"]}],
         ),
         # Union
-        (list[Union[int, str]], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),  # noqa_: UP007
+        (list[Union[int, str]], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),  # _noqa: UP007
         (list[int | str], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),
         # Any
         (list[Any], Schema([ColSpec(type=AnyType())]), [1, "a", 234]),

--- a/tests/types/test_schema.py
+++ b/tests/types/test_schema.py
@@ -1832,7 +1832,7 @@ def test_convert_dataclass_to_schema_for_rag():
 def test_convert_dataclass_to_schema_complex():
     @dataclass
     class Settings:
-        baz: Optional[bool] = True  # noqa_: UP045
+        baz: Optional[bool] = True  # _noqa: UP045
         qux: bool | None = None
 
     @dataclass

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -153,7 +153,7 @@ def test_infer_schema_from_pydantic_model(type_hint, expected_schema):
         (list[dict[str, list[str]]], Schema([ColSpec(type=Map(Array(DataType.string)))])),
         (list[Dict[str, List[str]]], Schema([ColSpec(type=Map(Array(DataType.string)))])),  # noqa: UP006
         # Union
-        (list[Union[int, str]], Schema([ColSpec(type=AnyType())])),  # noqa_: UP007
+        (list[Union[int, str]], Schema([ColSpec(type=AnyType())])),  # _noqa: UP007
         (list[int | str], Schema([ColSpec(type=AnyType())])),
         (list[list[int | str]], Schema([ColSpec(type=Array(AnyType()))])),
         # Any
@@ -214,7 +214,7 @@ def test_infer_schema_from_type_hints_errors():
         _infer_schema_from_list_type_hint(list[Optional[str]])
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])  # noqa_: UP007
+        _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])  # _noqa: UP007
 
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[str | int | type(None)])
@@ -358,12 +358,12 @@ def test_pydantic_model_validation(type_hint, example):
         (list[list[str]], [["a", "b"], ["c", "d"]]),
         (dict[str, int], {"a": 1, "b": 2}),
         (dict[str, list[str]], {"a": ["a", "b"], "b": ["c", "d"]}),
-        (Union[int, str], 1),  # noqa_: UP007
-        (Union[int, str], "a"),  # noqa_: UP007
+        (Union[int, str], 1),  # _noqa: UP007
+        (Union[int, str], "a"),  # _noqa: UP007
         (int | str, 1),
         (int | str, "a"),
         # Union type is inferred as AnyType, so it accepts double here as well
-        (Union[int, str], 1.2),  # noqa_: UP007
+        (Union[int, str], 1.2),  # _noqa: UP007
         (int | str, 1.2),
         (list[Any], [1, "a"]),
     ],

--- a/tests/types/test_type_hints.py
+++ b/tests/types/test_type_hints.py
@@ -208,10 +208,16 @@ def test_infer_schema_from_type_hints_errors():
 
     message = r"Input cannot be Optional type"
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_list_type_hint(Optional[list[str]])
+        _infer_schema_from_list_type_hint(Optional[list[str]])  # _noqa: UP045
 
     with pytest.raises(MlflowException, match=message):
-        _infer_schema_from_list_type_hint(list[Optional[str]])
+        _infer_schema_from_list_type_hint(list[str] | None)
+
+    with pytest.raises(MlflowException, match=message):
+        _infer_schema_from_list_type_hint(list[Optional[str]])  # _noqa: UP045
+
+    with pytest.raises(MlflowException, match=message):
+        _infer_schema_from_list_type_hint(list[str | None])
 
     with pytest.raises(MlflowException, match=message):
         _infer_schema_from_list_type_hint(list[Union[str, int, type(None)]])  # _noqa: UP007
@@ -419,8 +425,10 @@ def test_type_hints_validation_errors():
         ("a", str, "a"),
         (["a", "b"], list[str], ["a", "b"]),
         ({"a": 1, "b": 2}, dict[str, int], {"a": 1, "b": 2}),
-        (1, Optional[int], 1),
-        (None, Optional[int], None),
+        (1, Optional[int], 1),  # _noqa: UP045
+        (1, int | None, 1),
+        (None, Optional[int], None),  # _noqa: UP045
+        (None, int | None, None),
         (pd.DataFrame({"a": ["a", "b"]}), list[str], ["a", "b"]),
         (pd.DataFrame({"a": [{"x": "x"}]}), list[dict[str, str]], [{"x": "x"}]),
         # This is a temp workaround for evaluate


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16898?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16898/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16898/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16898/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

To prepare for #16872, 

- For union or optional, ensure both `Union[X, Y]` and `X | Y` are tested.
- Mark `Union[X, Y]` with a `noqa` comment to prevent ruff from auto-fixing them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
