### PR TITLE
Rename webhook dispatch to delivery for better terminology alignment

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -178,7 +178,7 @@ from mlflow.utils.validation import (
     invalid_value,
     missing_value,
 )
-from mlflow.webhooks.dispatch import dispatch_webhook, test_webhook
+from mlflow.webhooks.delivery import deliver_webhook, test_webhook
 from mlflow.webhooks.types import (
     ModelVersionAliasCreatedPayload,
     ModelVersionAliasDeletedPayload,
@@ -1795,7 +1795,7 @@ def _create_registered_model():
     )
     response_message = CreateRegisteredModel.Response(registered_model=registered_model.to_proto())
 
-    dispatch_webhook(
+    deliver_webhook(
         event=WebhookEvent.REGISTERED_MODEL_CREATED,
         payload=RegisteredModelCreatedPayload(
             name=request_message.name,
@@ -2087,7 +2087,7 @@ def _create_model_version():
     response_message = CreateModelVersion.Response(model_version=model_version.to_proto())
 
     if not is_prompt:
-        dispatch_webhook(
+        deliver_webhook(
             event=WebhookEvent.MODEL_VERSION_CREATED,
             payload=ModelVersionCreatedPayload(
                 name=request_message.name,
@@ -2274,7 +2274,7 @@ def _set_model_version_tag():
     store.set_model_version_tag(name=request_message.name, version=request_message.version, tag=tag)
 
     if not _is_prompt(request_message.name):
-        dispatch_webhook(
+        deliver_webhook(
             event=WebhookEvent.MODEL_VERSION_TAG_SET,
             payload=ModelVersionTagSetPayload(
                 name=request_message.name,
@@ -2307,7 +2307,7 @@ def _delete_model_version_tag():
     )
 
     if not _is_prompt(request_message.name):
-        dispatch_webhook(
+        deliver_webhook(
             event=WebhookEvent.MODEL_VERSION_TAG_DELETED,
             payload=ModelVersionTagDeletedPayload(
                 name=request_message.name,
@@ -2339,7 +2339,7 @@ def _set_registered_model_alias():
     )
 
     if not _is_prompt(request_message.name):
-        dispatch_webhook(
+        deliver_webhook(
             event=WebhookEvent.MODEL_VERSION_ALIAS_CREATED,
             payload=ModelVersionAliasCreatedPayload(
                 name=request_message.name,
@@ -2366,7 +2366,7 @@ def _delete_registered_model_alias():
     store.delete_registered_model_alias(name=request_message.name, alias=request_message.alias)
 
     if not _is_prompt(request_message.name):
-        dispatch_webhook(
+        deliver_webhook(
             event=WebhookEvent.MODEL_VERSION_ALIAS_DELETED,
             payload=ModelVersionAliasDeletedPayload(
                 name=request_message.name,

--- a/mlflow/webhooks/delivery.py
+++ b/mlflow/webhooks/delivery.py
@@ -1,4 +1,4 @@
-"""Webhook dispatch implementation following Standard Webhooks conventions.
+"""Webhook delivery implementation following Standard Webhooks conventions.
 
 This module implements webhook delivery patterns similar to the Standard Webhooks
 specification (https://www.standardwebhooks.com), providing consistent and secure
@@ -101,7 +101,7 @@ def _send_webhook_request(
     return requests.post(webhook.url, data=payload_bytes, headers=headers, timeout=timeout)
 
 
-def _dispatch_webhook_impl(
+def _deliver_webhook_impl(
     *,
     event: WebhookEvent,
     payload: WebhookPayload,
@@ -119,17 +119,17 @@ def _dispatch_webhook_impl(
                 )
 
 
-def dispatch_webhook(
+def deliver_webhook(
     *,
     event: WebhookEvent,
     payload: WebhookPayload,
     store: AbstractStore,
 ) -> None:
     try:
-        _dispatch_webhook_impl(event=event, payload=payload, store=store)
+        _deliver_webhook_impl(event=event, payload=payload, store=store)
     except Exception as e:
         _logger.error(
-            f"Failed to dispatch webhook for event {event}: {e}",
+            f"Failed to deliver webhook for event {event}: {e}",
             exc_info=True,
         )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16904?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16904/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16904/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16904/merge
```

</p>
</details>

## Summary
- Rename `mlflow/webhooks/dispatch.py` to `delivery.py`
- Update function names from `dispatch_webhook` to `deliver_webhook`
- Update all imports and function calls in server handlers

## Motivation
This change improves code clarity and consistency:
- Aligns with industry standard terminology (e.g., GitHub uses "webhook delivery")
- Consistent with existing `WEBHOOK_DELIVERY_ID_HEADER` constant
- Better matches the Standard Webhooks specification terminology

## Test Plan
- Existing webhook tests should continue to pass
- No functional changes, only naming improvements

🤖 Generated with [Claude Code](https://claude.ai/code)