### PR TITLE
Implement non-blocking webhook delivery with configurable thread pool

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -900,3 +900,9 @@ MLFLOW_WEBHOOK_SECRET_ENCRYPTION_KEY = _EnvironmentVariable(
 #: Specifies the timeout in seconds for webhook HTTP requests
 #: (default: ``30``)
 MLFLOW_WEBHOOK_REQUEST_TIMEOUT = _EnvironmentVariable("MLFLOW_WEBHOOK_REQUEST_TIMEOUT", int, 30)
+
+#: Specifies the maximum number of threads for webhook delivery thread pool
+#: (default: ``10``)
+MLFLOW_WEBHOOK_DELIVERY_MAX_WORKERS = _EnvironmentVariable(
+    "MLFLOW_WEBHOOK_DELIVERY_MAX_WORKERS", int, 10
+)

--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -107,8 +107,12 @@ class AppClient:
             if len(logs) >= expected_count:
                 return logs
             time.sleep(0.1)
-        # Return whatever we have after timeout
-        return self.get_logs()
+        # Raise timeout error if expected count not reached
+        logs = self.get_logs()
+        raise TimeoutError(
+            f"Timeout waiting for {expected_count} webhook logs. "
+            f"Got {len(logs)} logs after {timeout}s timeout."
+        )
 
 
 @contextlib.contextmanager
@@ -176,7 +180,6 @@ def test_registered_model_created(mlflow_client: MlflowClient, app_client: AppCl
         description="test_description",
         tags={"test_tag_key": "test_tag_value"},
     )
-    # Wait for async webhook delivery
     logs = app_client.wait_for_logs(expected_count=1)
     assert len(logs) == 1
     assert logs[0].endpoint == "/insecure-webhook"

--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -99,7 +99,7 @@ class AppClient:
         logs_data = response.json().get("logs", [])
         return [WebhookLogEntry(**log_data) for log_data in logs_data]
 
-    def wait_for_logs(self, expected_count: int, timeout: float = 2.0) -> list[WebhookLogEntry]:
+    def wait_for_logs(self, expected_count: int, timeout: float = 5.0) -> list[WebhookLogEntry]:
         """Wait for webhooks to be delivered with a timeout."""
         start_time = time.time()
         while time.time() - start_time < timeout:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16906?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16906/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16906/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16906/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR implements non-blocking webhook delivery to improve MLflow performance by:

- **Added configurable thread pool**: New `MLFLOW_WEBHOOK_DELIVERY_MAX_WORKERS` environment variable (default: 10) to control concurrency
- **Replaced blocking delivery**: `_deliver_webhook_impl` now uses `ThreadPoolExecutor.submit()` for parallel webhook execution
- **Improved error handling**: Added `_send_webhook_with_error_handling` wrapper to isolate errors between webhook calls
- **Updated tests**: Modified webhook e2e tests to handle asynchronous delivery with new `wait_for_logs` method

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

All 14 webhook e2e tests pass, confirming that the non-blocking implementation maintains the same functionality while improving performance.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Webhook delivery is now non-blocking, improving MLflow server performance when webhooks are configured. The number of webhook delivery threads can be configured via `MLFLOW_WEBHOOK_DELIVERY_MAX_WORKERS` environment variable.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)