### PR TITLE
[OSS GenAI Eval #4] Support `predict_fn` argument in OSS GenAI eval

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -624,6 +624,10 @@ _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS = _BooleanEnvironmentVariable(
     "_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS", False
 )
 
+#: Maximum number of workers to use for the evaluation.
+#: (default: ``10``)
+MLFLOW_GENAI_EVAL_MAX_WORKERS = _EnvironmentVariable("MLFLOW_GENAI_EVAL_MAX_WORKERS", int, 10)
+
 #: Whether to warn (default) or raise (opt-in) for unresolvable requirements inference for
 #: a model's dependency inference. If set to True, an exception will be raised if requirements
 #: inference or the process of capturing imported modules encounters any errors.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -624,7 +624,8 @@ _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS = _BooleanEnvironmentVariable(
     "_MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS", False
 )
 
-#: Maximum number of workers to use for the evaluation.
+#: Maximum number of workers to use for running model prediction and scoring during
+# for each row in the dataset passed to the `mlflow.genai.evaluate` function.
 #: (default: ``10``)
 MLFLOW_GENAI_EVAL_MAX_WORKERS = _EnvironmentVariable("MLFLOW_GENAI_EVAL_MAX_WORKERS", int, 10)
 

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -301,12 +301,13 @@ def _evaluate_dbx(data, scorers, predict_fn, model_id):
     # NB: The "RAG_EVAL_MAX_WORKERS" env var is used in the DBX agent harness, but is
     # deprecated in favor of the new "MLFLOW_GENAI_EVAL_MAX_WORKERS" env var. The old
     # one is not publicly documented, but we keep it for backward compatibility.
-    if MLFLOW_GENAI_EVAL_MAX_WORKERS.is_set() and "RAG_EVAL_MAX_WORKERS" in os.environ:
+    if MLFLOW_GENAI_EVAL_MAX_WORKERS.is_set() and "RAG_EVAL_MAX_WORKERS" not in os.environ:
+        os.environ["RAG_EVAL_MAX_WORKERS"] = str(MLFLOW_GENAI_EVAL_MAX_WORKERS.get())
+    elif "RAG_EVAL_MAX_WORKERS" in os.environ:
         logger.warning(
             "The `RAG_EVAL_MAX_WORKERS` environment variable is deprecated. "
             "Please use `MLFLOW_GENAI_EVAL_MAX_WORKERS` instead."
         )
-        os.environ["RAG_EVAL_MAX_WORKERS"] = str(MLFLOW_GENAI_EVAL_MAX_WORKERS.get())
 
     with warnings.catch_warnings():
         warnings.filterwarnings(

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -1,10 +1,12 @@
 import logging
+import os
 import time
 import warnings
 from contextlib import nullcontext
 from typing import TYPE_CHECKING, Any, Callable, Optional
 
 import mlflow
+from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset
 from mlflow.genai.evaluation.constant import InputDatasetColumn
@@ -296,6 +298,17 @@ def _evaluate_dbx(data, scorers, predict_fn, model_id):
     the mlflow.evaluate() function. This is a temporary migration state and we will
     eventually unify this into OSS flow.
     """
+
+    # NB: The "RAG_EVAL_MAX_WORKERS" env var is used in the DBX agent harness, but is
+    # deprecated in favor of the new "MLFLOW_GENAI_EVAL_MAX_WORKERS" env var. The old
+    # one is not publicly documented, but we keep it for backward compatibility.
+    if MLFLOW_GENAI_EVAL_MAX_WORKERS.is_set() and os.environ.get("RAG_EVAL_MAX_WORKERS") is None:
+        logger.warning(
+            "The `RAG_EVAL_MAX_WORKERS` environment variable is deprecated. "
+            "Please use `MLFLOW_GENAI_EVAL_MAX_WORKERS` instead."
+        )
+        os.environ["RAG_EVAL_MAX_WORKERS"] = str(MLFLOW_GENAI_EVAL_MAX_WORKERS.get())
+
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -290,7 +290,6 @@ def _evaluate_oss(data, scorers, predict_fn, model_id):
             scorers=scorers,
             run_id=run_id,
         )
-        # TODO: Support logging aggregated metrics to the logged model
 
 
 def _evaluate_dbx(data, scorers, predict_fn, model_id):

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -301,7 +301,7 @@ def _evaluate_dbx(data, scorers, predict_fn, model_id):
     # NB: The "RAG_EVAL_MAX_WORKERS" env var is used in the DBX agent harness, but is
     # deprecated in favor of the new "MLFLOW_GENAI_EVAL_MAX_WORKERS" env var. The old
     # one is not publicly documented, but we keep it for backward compatibility.
-    if MLFLOW_GENAI_EVAL_MAX_WORKERS.is_set() and os.environ.get("RAG_EVAL_MAX_WORKERS") is None:
+    if MLFLOW_GENAI_EVAL_MAX_WORKERS.is_set() and "RAG_EVAL_MAX_WORKERS" in os.environ:
         logger.warning(
             "The `RAG_EVAL_MAX_WORKERS` environment variable is deprecated. "
             "Please use `MLFLOW_GENAI_EVAL_MAX_WORKERS` instead."

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -279,13 +279,14 @@ def _evaluate_oss(data, scorers, predict_fn, model_id):
 
     # TODO: Log input dataset to the run
     with (
-        _start_run_or_reuse_active_run(),
+        _start_run_or_reuse_active_run() as run_id,
         _set_active_model(model_id=model_id) if model_id else nullcontext(),
     ):
         return harness.run(
             predict_fn=predict_fn,
             dataset=data,
             scorers=scorers,
+            run_id=run_id,
         )
         # TODO: Support logging aggregated metrics to the logged model
 

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -59,7 +59,7 @@ class EvalItem:
             trace = trace if isinstance(trace, Trace) else Trace.from_json(trace)
 
         # Extract expectations column from the dataset.
-        expectations = row.get(InputDatasetColumn.EXPECTATIONS)
+        expectations = row.get(InputDatasetColumn.EXPECTATIONS, {})
 
         return cls(
             request_id=request_id,

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -6,7 +6,7 @@ import logging
 import traceback
 import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from typing import Any, Callable, Optional
+from typing import Any, Callable
 
 import pandas as pd
 
@@ -33,7 +33,7 @@ def run(
     dataset: pd.DataFrame,
     predict_fn=None,
     scorers=None,
-    run_id: Optional[str] = None,
+    run_id: str | None = None,
 ) -> EvaluationResult:
     """
     Runs GenAI evaluation harness to the given dataset.
@@ -83,8 +83,8 @@ def run(
 def _run_single(
     eval_item: EvalItem,
     scorers: list[Scorer],
-    run_id: Optional[str],
-    predict_fn: Optional[Callable[..., Any]] = None,
+    run_id: str | None,
+    predict_fn: Callable[..., Any] | None = None,
 ) -> EvalResult:
     """Run the logic of the eval harness for a single eval item."""
     # Set the MLflow run ID in the context for this thread
@@ -183,7 +183,7 @@ def _compute_eval_scores(
 
 
 def _log_assessments(
-    run_id: Optional[str],
+    run_id: str | None,
     trace: Trace,
     assessments: list[Assessment],
 ) -> Trace:

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -94,7 +94,7 @@ def _run_single(
         ctx = context.get_context()
         ctx.set_mlflow_run_id(run_id)
 
-    # TODO: Support another patten that are currently supported in the DBX agent harness,
+    # TODO: Support another pattern that are currently supported in the DBX agent harness,
     # which is when traces are given as dataset
     if predict_fn:
         # NB: Setting prediction context let us retrieve the trace by a custom ID. Setting

--- a/mlflow/genai/scorers/aggregation.py
+++ b/mlflow/genai/scorers/aggregation.py
@@ -84,7 +84,7 @@ def _cast_assessment_value_to_float(assessment: Feedback) -> float | None:
     ):
         return float(assessment.value.lower() == CategoricalRating.YES)
     else:
-        _logger.error(f"Invalid assessment value: {assessment.value}")
+        _logger.error(f"Invalid assessment value for {assessment.name}: {assessment.value}")
 
 
 def _compute_aggregations(

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -20,7 +20,7 @@ class TraceMetadataKey:
 
 class TraceTagKey:
     TRACE_NAME = "mlflow.traceName"
-    EVAL_REQUEST_ID = "eval.requestId"
+    EVAL_REQUEST_ID = "mlflow.eval.requestId"
 
 
 class TokenUsageKey:

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -587,7 +587,7 @@ def start_span_no_context(
 
 
 @request_id_backward_compatible
-def get_trace(trace_id: str) -> Optional[Trace]:
+def get_trace(trace_id: str, silent=False) -> Optional[Trace]:
     """
     Get a trace by the given request ID if it exists.
 
@@ -597,7 +597,8 @@ def get_trace(trace_id: str) -> Optional[Trace]:
 
     Args:
         trace_id: The ID of the trace.
-
+        silent: If True, suppress the warning message when the trace is not found. The API will
+            return None without any warning. Default to False.
 
     .. code-block:: python
         :test:
@@ -621,11 +622,12 @@ def get_trace(trace_id: str) -> Optional[Trace]:
     try:
         return TracingClient().get_trace(trace_id)
     except MlflowException as e:
-        _logger.warning(
-            f"Failed to get trace from the tracking store: {e}"
-            "For full traceback, set logging level to debug.",
-            exc_info=_logger.isEnabledFor(logging.DEBUG),
-        )
+        if not silent:
+            _logger.warning(
+                f"Failed to get trace from the tracking store: {e}"
+                "For full traceback, set logging level to debug.",
+                exc_info=_logger.isEnabledFor(logging.DEBUG),
+            )
         return None
 
 

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -178,6 +178,10 @@ def test_evaluate_with_predict_fn(is_predict_fn_traced, is_in_databricks):
     assert metrics["relevance/mean"] == 1.0
     assert metrics["has_trace/mean"] == 1.0
 
+    # Metrics should be logged to the model ID as well
+    model = mlflow.get_logged_model(model_id)
+    assert metrics == {m.key: m.value for m in model.metrics}
+
     # Exact number of traces should be generated
     traces = get_traces()
     assert len(traces) == len(data)

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -144,9 +144,6 @@ def test_evaluate_with_static_dataset(is_in_databricks):
 
 @pytest.mark.parametrize("is_predict_fn_traced", [True, False])
 def test_evaluate_with_predict_fn(is_predict_fn_traced, is_in_databricks):
-    if not is_in_databricks:
-        pytest.skip("OSS genai evaluator doesn't support predict_fn yet")
-
     model_id = mlflow.set_active_model(name="test-model-id").model_id
 
     data = [
@@ -383,11 +380,6 @@ def test_evaluate_with_managed_dataset(is_in_databricks):
 
 @mock.patch("mlflow.deployments.get_deploy_client")
 def test_model_from_deployment_endpoint(mock_get_deploy_client, is_in_databricks):
-    if not is_in_databricks:
-        pytest.skip(
-            "OSS genai evaluator doesn't support model from deployment endpoint evaluation yet"
-        )
-
     mock_client = mock_get_deploy_client.return_value
     mock_client.predict.return_value = _DUMMY_CHAT_RESPONSE
 

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -380,9 +380,6 @@ def test_scorer_receives_correct_data_with_trace_data(input_type):
 
 @pytest.mark.parametrize("data_fixture", _ALL_DATA_FIXTURES)
 def test_predict_fn_receives_correct_data(data_fixture, request, is_in_databricks):
-    if not is_in_databricks:
-        pytest.skip("The predict_fn arg is not supported in OSS MLflow yet")
-
     sample_data = request.getfixturevalue(data_fixture)
 
     received_args = []

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -352,7 +352,10 @@ def test_extra_traces_from_customer_scorer_should_be_cleaned_up(is_in_databricks
     # Traces should only be generated for predict_fn
     traces = get_traces()
     assert len(traces) == 100
-    assert all(trace.data.spans[0].name == "predict" for trace in traces)
+    trace_names = [trace.data.spans[0].name for trace in traces]
+    assert all(trace_name == "predict" for trace_name in trace_names), (
+        f"Traces include unexpected names: {[n for n in trace_names if n != 'predict']}"
+    )
     purge_traces()
 
     # When invoked directly, the scorer should generate traces

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -321,9 +321,6 @@ def test_custom_scorer_does_not_overwrite_feedback_name_when_returning_list():
 
 
 def test_extra_traces_from_customer_scorer_should_be_cleaned_up(is_in_databricks):
-    if not is_in_databricks:
-        pytest.skip("OSS GenAI evaluator doesn't support predict_fn yet")
-
     @scorer
     def my_scorer_1(inputs, outputs):
         with mlflow.start_span(name="scorer_trace_1") as span:
@@ -365,9 +362,6 @@ def test_extra_traces_from_customer_scorer_should_be_cleaned_up(is_in_databricks
 
 
 def test_extra_traces_before_evaluation_execution_should_not_be_cleaned_up(is_in_databricks):
-    if not is_in_databricks:
-        pytest.skip("OSS GenAI evaluator doesn't support predict_fn yet")
-
     def predict(question: str) -> str:
         return "output: " + str(question)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16919?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16919/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16919/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16919/merge
```

</p>
</details>

### What changes are proposed in this pull request?

- Support passing the`predict_fn` to `mlflow.genai.evaluate` in OSS. The logic is simple, we just run the given function, then treat the output and generated trace as if they are given in the dataset.
- Also addressing the minor TODO of adding mlflow environment variable.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
