### PR TITLE
Remove experimental decorators

### DIFF
--- a/mlflow/anthropic/__init__.py
+++ b/mlflow/anthropic/__init__.py
@@ -1,11 +1,9 @@
 from mlflow.anthropic.autolog import async_patched_class_call, patched_class_call
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "anthropic"
 
 
-@experimental(version="2.19.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -8,7 +8,6 @@ from mlflow.autogen.chat import log_tools
 from mlflow.entities import SpanType
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.utils import construct_full_inputs
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     get_autologging_config,
@@ -19,7 +18,6 @@ _logger = logging.getLogger(__name__)
 FLAVOR_NAME = "autogen"
 
 
-@experimental(version="2.16.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/bedrock/__init__.py
+++ b/mlflow/bedrock/__init__.py
@@ -1,6 +1,5 @@
 import logging
 
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 _logger = logging.getLogger(__name__)
@@ -8,7 +7,6 @@ _logger = logging.getLogger(__name__)
 FLAVOR_NAME = "bedrock"
 
 
-@experimental(version="2.20.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/crewai/__init__.py
+++ b/mlflow/crewai/__init__.py
@@ -10,7 +10,6 @@ from packaging.version import Version
 from mlflow.crewai.autolog import (
     patched_class_call,
 )
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 _logger = logging.getLogger(__name__)
@@ -18,7 +17,6 @@ _logger = logging.getLogger(__name__)
 FLAVOR_NAME = "crewai"
 
 
-@experimental(version="2.19.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -13,7 +13,7 @@ from mlflow.environment_variables import (
 )
 from mlflow.exceptions import MlflowException
 from mlflow.utils import AttrDict
-from mlflow.utils.annotations import deprecated, experimental
+from mlflow.utils.annotations import deprecated
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.rest_utils import augmented_raise_for_status, http_request
 
@@ -556,7 +556,6 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
                 method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
             )
 
-    @experimental(version="2.19.0")
     def update_endpoint_config(self, endpoint, config):
         """
         Update the configuration of a specified serving endpoint. See
@@ -616,7 +615,6 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             method="PUT", route=posixpath.join(endpoint, "config"), json_body=config
         )
 
-    @experimental(version="2.19.0")
     def update_endpoint_tags(self, endpoint, config):
         """
         Update the tags of a specified serving endpoint. See
@@ -646,7 +644,6 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             method="PATCH", route=posixpath.join(endpoint, "tags"), json_body=config
         )
 
-    @experimental(version="2.19.0")
     def update_endpoint_rate_limits(self, endpoint, config):
         """
         Update the rate limits of a specified serving endpoint.
@@ -682,7 +679,6 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             method="PUT", route=posixpath.join(endpoint, "rate-limits"), json_body=config
         )
 
-    @experimental(version="2.19.0")
     def update_endpoint_ai_gateway(self, endpoint, config):
         """
         Update the AI Gateway configuration of a specified serving endpoint.

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -6,7 +6,6 @@ import mlflow
 from mlflow.dspy.constant import FLAVOR_NAME
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracing.utils import construct_full_inputs
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     get_autologging_config,
@@ -14,7 +13,6 @@ from mlflow.utils.autologging_utils import (
 )
 
 
-@experimental(version="2.18.0")
 def autolog(
     log_traces: bool = True,
     log_traces_from_compile: bool = False,

--- a/mlflow/dspy/load.py
+++ b/mlflow/dspy/load.py
@@ -8,7 +8,6 @@ from mlflow.models.dependencies_schemas import _get_dependencies_schema_from_mod
 from mlflow.models.model import _update_active_model_id_based_on_mlflow_model
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils.annotations import experimental
 from mlflow.utils.model_utils import (
     _add_code_from_conf_to_system_path,
     _get_flavor_configuration,
@@ -48,7 +47,6 @@ def _load_model(model_uri, dst_path=None):
     return loaded_wrapper
 
 
-@experimental(version="2.18.0")
 @trace_disabled  # Suppress traces for internal calls while loading model
 def load_model(model_uri, dst_path=None):
     """

--- a/mlflow/dspy/save.py
+++ b/mlflow/dspy/save.py
@@ -28,7 +28,6 @@ from mlflow.models.utils import _save_example
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.types.schema import DataType
-from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -70,7 +69,6 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-@experimental(version="2.18.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces for internal predict calls while logging model
 def save_model(
@@ -262,7 +260,6 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental(version="2.18.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces for internal predict calls while logging model
 def log_model(

--- a/mlflow/gemini/__init__.py
+++ b/mlflow/gemini/__init__.py
@@ -7,13 +7,11 @@ from mlflow.gemini.autolog import (
     patched_class_call,
     patched_module_call,
 )
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "gemini"
 
 
-@experimental(version="2.19.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/groq/__init__.py
+++ b/mlflow/groq/__init__.py
@@ -3,13 +3,11 @@ The ``mlflow.groq`` module provides an API for logging and loading Groq models.
 """
 
 from mlflow.groq._groq_autolog import patched_call
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "groq"
 
 
-@experimental(version="2.20.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     log_traces: bool = True,

--- a/mlflow/langchain/autolog.py
+++ b/mlflow/langchain/autolog.py
@@ -1,7 +1,6 @@
 import logging
 
 from mlflow.langchain.constant import FLAVOR_NAME
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 from mlflow.utils.autologging_utils.safety import safe_patch
@@ -9,7 +8,6 @@ from mlflow.utils.autologging_utils.safety import safe_patch
 logger = logging.getLogger(__name__)
 
 
-@experimental(version="2.10.0")
 @autologging_integration(FLAVOR_NAME)
 def autolog(
     disable=False,

--- a/mlflow/langchain/model.py
+++ b/mlflow/langchain/model.py
@@ -66,7 +66,6 @@ from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types.schema import ColSpec, DataType, Schema
-from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
     _get_databricks_serverless_env_vars,
     is_in_databricks_model_serving_environment,
@@ -126,7 +125,6 @@ def get_default_conda_env():
     return _mlflow_conda_env(additional_pip_deps=get_default_pip_requirements())
 
 
-@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces for internal predict calls while saving model
@@ -414,7 +412,6 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces for internal predict calls while logging model
@@ -709,7 +706,6 @@ class _LangChainModelWrapper:
                 context.update(**schema)
             return context
 
-    @experimental(version="2.10.0")
     def _predict_with_callbacks(
         self,
         data: Union[pd.DataFrame, list[Union[str, dict[str, Any]]], Any],
@@ -889,7 +885,6 @@ def _load_model_from_local_fs(local_model_path, model_config_overrides=None):
     return model
 
 
-@experimental(version="2.3.0")
 @docstring_version_compatibility_warning(FLAVOR_NAME)
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):

--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -5,7 +5,6 @@ from threading import Thread
 
 from packaging.version import Version
 
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import (
     autologging_integration,
     safe_patch,
@@ -17,7 +16,6 @@ FLAVOR_NAME = "litellm"
 _logger = logging.getLogger(__name__)
 
 
-@experimental(version="2.19.0")
 def autolog(
     log_traces: bool = True,
     disable: bool = False,

--- a/mlflow/llama_index/autolog.py
+++ b/mlflow/llama_index/autolog.py
@@ -1,9 +1,7 @@
 from mlflow.llama_index.constant import FLAVOR_NAME
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration
 
 
-@experimental(version="2.15.0")
 def autolog(
     log_traces: bool = True,
     disable: bool = False,

--- a/mlflow/llama_index/model.py
+++ b/mlflow/llama_index/model.py
@@ -27,7 +27,6 @@ from mlflow.models.utils import (
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
-from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import LOG_MODEL_PARAM_DOCS, format_docstring
 from mlflow.utils.environment import (
     _CONDA_ENV_FILE_NAME,
@@ -118,7 +117,6 @@ def _supported_classes():
     return supported
 
 
-@experimental(version="2.15.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def save_model(
@@ -312,7 +310,6 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental(version="2.15.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 @trace_disabled  # Suppress traces while loading model
 def log_model(
@@ -527,7 +524,6 @@ def _load_llama_model(path, flavor_conf):
         return load_index_from_storage(storage_context)
 
 
-@experimental(version="2.15.0")
 @trace_disabled  # Suppress traces while loading model
 def load_model(model_uri, dst_path=None):
     """

--- a/mlflow/metrics/__init__.py
+++ b/mlflow/metrics/__init__.py
@@ -30,7 +30,6 @@ from mlflow.models import (
     EvaluationMetric,
     make_metric,
 )
-from mlflow.utils.annotations import experimental
 
 
 def latency() -> EvaluationMetric:
@@ -426,7 +425,6 @@ def f1_score() -> EvaluationMetric:
     return make_metric(eval_fn=_f1_score_eval_fn, greater_is_better=True, name="f1_score")
 
 
-@experimental(version="2.18.0")
 def bleu() -> EvaluationMetric:
     """
     This function will create a metric for evaluating `bleu`_.

--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -25,7 +25,6 @@ from mlflow.protos.databricks_pb2 import (
     UNAUTHENTICATED,
     ErrorCode,
 )
-from mlflow.utils.annotations import experimental
 from mlflow.utils.class_utils import _get_class_from_string
 from mlflow.version import VERSION
 
@@ -195,7 +194,6 @@ def _get_aggregate_results(scores, aggregations):
     )
 
 
-@experimental(version="2.13.0")
 def make_genai_metric_from_prompt(
     name: str,
     judge_prompt: Optional[str] = None,

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Optional
 
-from mlflow.utils.annotations import experimental
-
 if TYPE_CHECKING:
     from mlflow.models.model import Model
 
@@ -22,7 +20,6 @@ class DependenciesSchemasType(Enum):
     RETRIEVERS = "retrievers"
 
 
-@experimental(version="2.13.0")
 def set_retriever_schema(
     *,
     primary_key: str,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -619,7 +619,6 @@ class Model:
     def model_size_bytes(self, value: Optional[int]) -> None:
         self._model_size_bytes = value
 
-    @experimental(version="2.13.0")
     @property
     def resources(self) -> dict[str, dict[ResourceType, list[dict[str, Any]]]]:
         """
@@ -631,7 +630,6 @@ class Model:
         """
         return self._resources
 
-    @experimental(version="2.13.0")
     @resources.setter
     def resources(self, value: Optional[Union[str, list[Resource]]]) -> None:
         if isinstance(value, (Path, str)):
@@ -1598,7 +1596,6 @@ def _validate_llama_index_model(model):
     return _validate_and_prepare_llama_index_model_or_path(model, None)
 
 
-@experimental(version="2.13.0")
 def set_model(model) -> None:
     """
     When logging model as code, this function can be used to set the model object

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -7,7 +7,6 @@ from typing import ForwardRef, get_args, get_origin
 from mlflow.exceptions import MlflowException
 from mlflow.models.flavor_backend_registry import get_flavor_backend
 from mlflow.utils import env_manager as _EnvManager
-from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import is_databricks_connect
 from mlflow.utils.file_utils import TempDir
 
@@ -98,7 +97,6 @@ _CONTENT_TYPE_CSV = "csv"
 _CONTENT_TYPE_JSON = "json"
 
 
-@experimental(version="2.18.0")
 def predict(
     model_uri,
     input_data=None,

--- a/mlflow/models/utils.py
+++ b/mlflow/models/utils.py
@@ -36,7 +36,6 @@ from mlflow.types.utils import (
     clean_tensor_type,
 )
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
-from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.file_utils import create_tmp_dir, get_local_path_or_none
 from mlflow.utils.mlflow_tags import MLFLOW_MODEL_IS_EXTERNAL
@@ -469,7 +468,6 @@ def _split_input_data_and_params(input_example):
     return input_example, None
 
 
-@experimental(version="2.16.0")
 def convert_input_example_to_serving_input(input_example) -> Optional[str]:
     """
     Helper function to convert a model's input example to a serving input example that
@@ -1994,7 +1992,6 @@ def _flatten_nested_params(
 
 # NB: this function should always be kept in sync with the serving
 # process in scoring_server invocations.
-@experimental(version="2.16.0")
 def validate_serving_input(model_uri: str, serving_input: Union[str, dict[str, Any]]):
     """
     Helper function to validate the model can be served and provided input is valid

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -25,7 +25,6 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import TraceJSONEncoder
-from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 from mlflow.utils.autologging_utils.safety import safe_patch
@@ -37,7 +36,6 @@ _MESSAGE_FORMAT_CHAT = "openai.chat.completions"
 _MESSAGE_FORMAT_RESPONSES = "openai.responses"
 
 
-@experimental(version="2.14.0")
 def autolog(
     disable=False,
     exclusive=False,

--- a/mlflow/openai/model.py
+++ b/mlflow/openai/model.py
@@ -24,7 +24,6 @@ from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking.artifact_utils import _download_artifact_from_uri
 from mlflow.types import ColSpec, Schema, TensorSpec
-from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
     check_databricks_secret_scope_access,
     is_in_databricks_runtime,
@@ -62,7 +61,6 @@ _PYFUNC_SUPPORTED_TASKS = ("chat.completions", "embeddings", "completions")
 _logger = logging.getLogger(__name__)
 
 
-@experimental(version="2.3.0")
 def get_default_pip_requirements():
     """
     Returns:
@@ -73,7 +71,6 @@ def get_default_pip_requirements():
     return list(map(_get_pinned_requirement, ["openai", "tiktoken", "tenacity"]))
 
 
-@experimental(version="2.3.0")
 def get_default_conda_env():
     """
     Returns:
@@ -231,7 +228,6 @@ def _get_input_schema(task, content):
         return Schema([ColSpec(type="string")])
 
 
-@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def save_model(
     model,
@@ -430,7 +426,6 @@ def save_model(
     _PythonEnv.current().to_yaml(os.path.join(path, _PYTHON_ENV_FILE_NAME))
 
 
-@experimental(version="2.3.0")
 @format_docstring(LOG_MODEL_PARAM_DOCS.format(package_name=FLAVOR_NAME))
 def log_model(
     model,
@@ -838,7 +833,6 @@ def _load_pyfunc(path):
     return _OpenAIWrapper(_load_model(path))
 
 
-@experimental(version="2.3.0")
 def load_model(model_uri, dst_path=None):
     """
     Load an OpenAI model from a local file or a run.

--- a/mlflow/pyfunc/__init__.py
+++ b/mlflow/pyfunc/__init__.py
@@ -545,7 +545,7 @@ from mlflow.utils import (
 )
 from mlflow.utils import env_manager as _EnvManager
 from mlflow.utils._spark_utils import modified_environ
-from mlflow.utils.annotations import deprecated, developer_stable, experimental
+from mlflow.utils.annotations import deprecated, developer_stable
 from mlflow.utils.databricks_utils import (
     _get_databricks_serverless_env_vars,
     get_dbconnect_udf_sandbox_info,
@@ -1053,7 +1053,6 @@ class PyFuncModel:
             info["flavor"] = self._model_meta.flavors[FLAVOR_NAME]["loader_module"]
         return yaml.safe_dump({"mlflow.pyfunc.loaded_model": info}, default_flow_style=False)
 
-    @experimental(version="2.16.0")
     def get_raw_model(self):
         """
         Get the underlying raw model if the model wrapper implemented `get_raw_model` function.

--- a/mlflow/pyfunc/loaders/chat_agent.py
+++ b/mlflow/pyfunc/loaders/chat_agent.py
@@ -15,7 +15,6 @@ from mlflow.types.agent import (
     ChatContext,
 )
 from mlflow.types.type_hints import model_validate
-from mlflow.utils.annotations import experimental
 
 
 def _load_pyfunc(model_path: str, model_config: Optional[dict[str, Any]] = None):
@@ -23,7 +22,6 @@ def _load_pyfunc(model_path: str, model_config: Optional[dict[str, Any]] = None)
     return _ChatAgentPyfuncWrapper(chat_agent)
 
 
-@experimental(version="2.20.0")
 class _ChatAgentPyfuncWrapper:
     """
     Wrapper class that converts dict inputs to pydantic objects accepted by :class:`~ChatAgent`.

--- a/mlflow/pyfunc/utils/input_converter.py
+++ b/mlflow/pyfunc/utils/input_converter.py
@@ -1,8 +1,6 @@
 from dataclasses import fields, is_dataclass
 from typing import Union, get_args, get_origin
 
-from mlflow.utils.annotations import experimental
-
 
 def _is_optional_dataclass(field_type) -> bool:
     """
@@ -18,7 +16,6 @@ def _is_optional_dataclass(field_type) -> bool:
     return False
 
 
-@experimental(version="2.18.0")
 def _hydrate_dataclass(dataclass_type, data):
     """Recursively create an instance of the dataclass_type from data."""
     if not (is_dataclass(dataclass_type) or _is_optional_dataclass(dataclass_type)):

--- a/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
@@ -39,7 +39,6 @@ from mlflow.utils._unity_catalog_utils import (
     get_artifact_repo_from_storage_info,
     get_full_name_from_sc,
 )
-from mlflow.utils.annotations import experimental
 from mlflow.utils.oss_registry_utils import get_oss_host_creds
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.rest_utils import (
@@ -71,7 +70,6 @@ def _require_arg_unspecified(arg_name, arg_value, default_values=None, message=N
         _raise_unsupported_arg(arg_name, message)
 
 
-@experimental(version="2.17.0")
 class UnityCatalogOssStore(BaseRestStore):
     """
     Client for an Open Source Unity Catalog Server accessed via REST API calls.

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1164,7 +1164,6 @@ def delete_trace_tag(trace_id: str, key: str) -> None:
     TracingClient().delete_trace_tag(trace_id, key)
 
 
-@experimental(version="2.17.0")
 def add_trace(trace: Union[Trace, dict[str, Any]], target: Optional[LiveSpan] = None):
     """
     Add a completed trace object into another trace.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1263,7 +1263,6 @@ class MlflowClient:
         if root_span:
             root_span.end(outputs, attributes, status, end_time_ns)
 
-    @experimental(version="2.20.0")
     def _log_trace(self, trace: Trace) -> str:
         """
         Log the complete Trace object to the backend store.

--- a/mlflow/types/schema.py
+++ b/mlflow/types/schema.py
@@ -14,7 +14,6 @@ from typing import Any, Optional, TypedDict, Union, get_args, get_origin
 import numpy as np
 
 from mlflow.exceptions import MlflowException
-from mlflow.utils.annotations import experimental
 
 ARRAY_TYPE = "array"
 OBJECT_TYPE = "object"
@@ -677,7 +676,6 @@ class Map(BaseType):
         raise MlflowException(f"Map type {self!r} and {other!r} are incompatible")
 
 
-@experimental(version="2.19.0")
 class AnyType(BaseType):
     def __init__(self):
         """
@@ -1398,7 +1396,6 @@ def _is_union(t: type) -> bool:
     return get_origin(t) in [Union, UnionType]
 
 
-@experimental(version="2.13.0")
 def convert_dataclass_to_schema(dataclass):
     """
     Converts a given dataclass into a Schema object. The dataclass must include type hints


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/16930?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16930/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16930/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16930/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Remove experimental decorators that are too old.
https://runbot.cloud.databricks.com/build/MlflowOssRunCommand/run-logs/8787756 fails due to python version incompatibility, we can fix it later.

python dev/remove_experimental_decorators.py 
Cutoff date: 2025-01-30 06:34:40 UTC
mlflow/anthropic/__init__.py:8:2: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/autogen/__init__.py:22:2: Removed experimental(version='2.16.0') (age: 332 days)
mlflow/bedrock/__init__.py:11:2: Removed experimental(version='2.20.0') (age: 186 days)
mlflow/crewai/__init__.py:21:2: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/deployments/databricks/__init__.py:559:6: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/deployments/databricks/__init__.py:619:6: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/deployments/databricks/__init__.py:649:6: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/deployments/databricks/__init__.py:685:6: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/dspy/autolog.py:17:2: Removed experimental(version='2.18.0') (age: 252 days)
mlflow/dspy/load.py:51:2: Removed experimental(version='2.18.0') (age: 252 days)
mlflow/dspy/save.py:73:2: Removed experimental(version='2.18.0') (age: 252 days)
mlflow/dspy/save.py:265:2: Removed experimental(version='2.18.0') (age: 252 days)
mlflow/gemini/__init__.py:16:2: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/groq/__init__.py:12:2: Removed experimental(version='2.20.0') (age: 186 days)
mlflow/langchain/autolog.py:12:2: Removed experimental(version='2.10.0') (age: 550 days)
mlflow/langchain/model.py:129:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/langchain/model.py:417:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/langchain/model.py:892:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/langchain/model.py:712:6: Removed experimental(version='2.10.0') (age: 550 days)
mlflow/litellm/__init__.py:20:2: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/llama_index/autolog.py:6:2: Removed experimental(version='2.15.0') (age: 364 days)
mlflow/llama_index/model.py:121:2: Removed experimental(version='2.15.0') (age: 364 days)
mlflow/llama_index/model.py:315:2: Removed experimental(version='2.15.0') (age: 364 days)
mlflow/llama_index/model.py:530:2: Removed experimental(version='2.15.0') (age: 364 days)
mlflow/metrics/__init__.py:429:2: Removed experimental(version='2.18.0') (age: 252 days)
mlflow/metrics/genai/genai_metric.py:198:2: Removed experimental(version='2.13.0') (age: 435 days)
mlflow/models/dependencies_schemas.py:25:2: Removed experimental(version='2.13.0') (age: 435 days)
mlflow/models/model.py:1601:2: Removed experimental(version='2.13.0') (age: 435 days)
mlflow/models/model.py:622:6: Removed experimental(version='2.13.0') (age: 435 days)
mlflow/models/model.py:634:6: Removed experimental(version='2.13.0') (age: 435 days)
mlflow/models/python_api.py:101:2: Removed experimental(version='2.18.0') (age: 252 days)
mlflow/models/utils.py:472:2: Removed experimental(version='2.16.0') (age: 332 days)
mlflow/models/utils.py:1997:2: Removed experimental(version='2.16.0') (age: 332 days)
mlflow/openai/autolog.py:40:2: Removed experimental(version='2.14.0') (age: 406 days)
mlflow/openai/model.py:65:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/openai/model.py:76:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/openai/model.py:234:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/openai/model.py:433:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/openai/model.py:841:2: Removed experimental(version='2.3.0') (age: 832 days)
mlflow/pyfunc/__init__.py:1056:6: Removed experimental(version='2.16.0') (age: 332 days)
mlflow/pyfunc/loaders/chat_agent.py:26:2: Removed experimental(version='2.20.0') (age: 186 days)
mlflow/pyfunc/utils/input_converter.py:21:2: Removed experimental(version='2.18.0') (age: 252 days)
mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py:74:2: Removed experimental(version='2.17.0') (age: 290 days)
mlflow/tracing/fluent.py:1167:2: Removed experimental(version='2.17.0') (age: 290 days)
mlflow/tracking/client.py:1266:6: Removed experimental(version='2.20.0') (age: 186 days)
mlflow/types/schema.py:680:2: Removed experimental(version='2.19.0') (age: 229 days)
mlflow/types/schema.py:1401:2: Removed experimental(version='2.13.0') (age: 435 days)

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
