### PR TITLE
Support non prediction outputs in DSPy log_model

### DIFF
--- a/mlflow/dspy/wrapper.py
+++ b/mlflow/dspy/wrapper.py
@@ -50,9 +50,14 @@ class DspyModelWrapper(PythonModel):
             if isinstance(converted_inputs, dict):
                 # We pass a dict as keyword args and don't allow DSPy models
                 # to receive a single dict.
-                return self.model(**converted_inputs).toDict()
+                result = self.model(**converted_inputs)
             else:
-                return self.model(converted_inputs).toDict()
+                result = self.model(converted_inputs)
+
+            if isinstance(result, dspy.Prediction):
+                return result.toDict()
+            else:
+                return result
 
     def predict_stream(self, inputs: Any, params=None):
         import dspy

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -517,7 +517,4 @@ def test_predict_output(dummy_model):
     result = loaded_model.predict("What is 2 + 2?")
 
     assert isinstance(result, dict)
-    assert "answer" in result
-    assert result["answer"] == "4"
-    assert "custom_field" in result
-    assert result["custom_field"] == "custom_value"
+    assert result == {"answer": "4", "custom_field": "custom_value"}

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -485,3 +485,39 @@ def test_predict_stream_success(dummy_model):
             "chunk": "reason",
         },
     ]
+
+
+def test_predict_output(dummy_model):
+    class MockModelReturningNonPrediction(dspy.Module):
+        def forward(self, question):
+            # Return a plain dict instead of dspy.Prediction
+            return {"answer": "4", "custom_field": "custom_value"}
+
+    class MockModelReturningPrediction(dspy.Module):
+        def forward(self, question):
+            # Return a dspy.Prediction
+            prediction = dspy.Prediction()
+            prediction.answer = "4"
+            prediction.custom_field = "custom_value"
+            return prediction
+
+    dspy.settings.configure(lm=dummy_model)
+
+    non_prediction_model = MockModelReturningNonPrediction()
+    model_info = mlflow.dspy.log_model(non_prediction_model, name="non_prediction_model")
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    result = loaded_model.predict("What is 2 + 2?")
+
+    assert isinstance(result, dict)
+    assert result == {"answer": "4", "custom_field": "custom_value"}
+
+    prediction_model = MockModelReturningPrediction()
+    model_info = mlflow.dspy.log_model(prediction_model, name="prediction_model")
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+    result = loaded_model.predict("What is 2 + 2?")
+
+    assert isinstance(result, dict)
+    assert "answer" in result
+    assert result["answer"] == "4"
+    assert "custom_field" in result
+    assert result["custom_field"] == "custom_value"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16931?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16931/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16931/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16931/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Currently, the DSPy flavor log_model assumes the output of the module is always dspy.Prediction. So when the output is not dspy.Prediction, the predict method fails with `toDict()` call.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
