### PR TITLE
Add `skip_removal`  parameter to experimental decorator

### DIFF
--- a/dev/remove_experimental_decorators.py
+++ b/dev/remove_experimental_decorators.py
@@ -73,6 +73,10 @@ def find_experimental_decorators(
             if not (isinstance(decorator.func, ast.Name) and decorator.func.id == "experimental"):
                 continue
 
+            # Skip decorators with `skip_removal=True` flag
+            if _has_skip_removal_flag(decorator):
+                continue
+
             version = _extract_version_from_ast_decorator(decorator)
             if not version or version not in release_dates:
                 continue
@@ -99,6 +103,14 @@ def _extract_version_from_ast_decorator(decorator: ast.Call) -> Optional[str]:
         if keyword.arg == "version" and isinstance(keyword.value, ast.Constant):
             return str(keyword.value.value)
     return None
+
+
+def _has_skip_removal_flag(decorator: ast.Call) -> bool:
+    """Check if decorator has skip_removal=True flag."""
+    for keyword in decorator.keywords:
+        if keyword.arg == "skip_removal" and isinstance(keyword.value, ast.Constant):
+            return keyword.value.value is True
+    return False
 
 
 def remove_decorators_from_file(

--- a/mlflow/utils/annotations.py
+++ b/mlflow/utils/annotations.py
@@ -46,7 +46,9 @@ def experimental(
 
 def experimental(
     f: Optional[Callable[P, R]] = None,
+    *,
     version: Optional[str] = None,
+    skip_removal: bool = False,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """Decorator / decorator creator for marking APIs experimental in the docstring.
 
@@ -55,6 +57,8 @@ def experimental(
         version: The version in which the API was introduced as experimental.
             The version is used to determine whether the API should be considered
             as stable or not when releasing a new version of MLflow.
+        skip_removal: If True, prevents automatic removal by `dev/remove_experimental_decorators.py`
+            even after the 6-month experimental period has elapsed.
 
     Returns:
         A decorator that adds a note to the docstring of the decorated API,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/16934?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16934/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16934/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16934/merge
```

</p>
</details>


### What changes are proposed in this pull request?

Address https://github.com/mlflow/mlflow/pull/16930#issuecomment-3131093152

This PR adds a `skip_removal` parameter to the `@experimental` decorator that prevents automatic removal by `dev/remove_experimental_decorators.py` even after the 6-month experimental period has elapsed.

**Changes:**
- Add `skip_removal: bool = False` parameter to `@experimental` decorator
- Update `dev/remove_experimental_decorators.py` to check for and respect `skip_removal=True` flag
- Rename internal functions and comments from "ignore" to "skip_removal" for clarity
- Improve parameter documentation to specify the exact script and time period

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Tested the updated script with `--dry-run` to verify it correctly identifies and skips decorators with `skip_removal=True`.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `skip_removal` parameter to `@experimental` decorator to prevent automatic removal after 6-month experimental period.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)