### PR TITLE
Fix API reference links by removing extra slash before fragments

### DIFF
--- a/docs/src/components/APILink/index.tsx
+++ b/docs/src/components/APILink/index.tsx
@@ -23,7 +23,7 @@ export function APILink({ fn, children, hash }: { fn: string; children?: React.R
     return <>{children}</>;
   }
 
-  const docLink = useBaseUrl(`/${APIModules[module]}#${hash ?? fn}`);
+  const docLink = useBaseUrl(`/${APIModules[module]}`) + `#${hash ?? fn}`;
   return (
     <a href={docLink} target="_blank">
       {children ?? <code>{fn}()</code>}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mohammadsubhani/mlflow/pull/16935?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16935/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16935/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16935/merge
```

</p>
</details>

 ### Related Issues/PRs

  Resolve #16867

  ### What changes are proposed in this pull request?

  This PR fixes broken API reference documentation links in the MLflow dataset documentation. The APILink
   React component was generating malformed URLs with an extra slash before fragment identifiers, causing
   403 errors when users clicked on dataset type links (PandasDataset, SparkDataset, etc.).

  **Changes:**
  - Modified `/docs/src/components/APILink/index.tsx` to separate base URL construction from fragment
  concatenation
  - Fixed URL generation from `/api_reference/python_api/mlflow.data.html/#fragment` to
  `/api_reference/python_api/mlflow.data.html#fragment`

<img width="1733" height="927" alt="Screenshot 2025-07-29 at 3 31 26 AM" src="https://github.com/user-attachments/assets/02679661-0031-4939-a49b-7d3058f26ca5" />


  ### How is this PR tested?

  - [ ] Existing unit/integration tests
  - [ ] New unit/integration tests
  - [x] Manual tests

  **Manual testing performed:**
  - Built complete documentation with API reference using `python scripts/build-api-docs.py` and `yarn
  build`
  - Verified APILink component generates correct URLs without extra slash
  - Tested production build serving at localhost:3002
  - Confirmed API reference links work properly without 403 errors
  - Validated fragment anchors navigate to correct documentation sections

  ### Does this PR require documentation update?

  - [x] No. You can skip the rest of this section.
  - [ ] Yes. I've updated:
    - [ ] Examples
    - [ ] API references
    - [ ] Instructions

  ### Release Notes

  #### Is this a user-facing change?

  - [ ] No. You can skip the rest of this section.
  - [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

  Fixed broken API reference documentation links in dataset documentation that were returning 403 errors
  due to malformed URLs with extra slashes before fragment identifiers.

  #### What component(s), interfaces, languages, and integrations does this PR affect?

  Components

  - [ ] `area/artifacts`: Artifact stores and artifact logging
  - [ ] `area/build`: Build and test infrastructure for MLflow
  - [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments
  integrations
  - [x] `area/docs`: MLflow documentation pages
  - [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
  - [ ] `area/examples`: Example code
  - [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model
  Registry
  - [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
  - [ ] `area/projects`: MLproject format, project running backends
  - [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
  - [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
  - [ ] `area/server-infra`: MLflow Tracking server backend
  - [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
  - [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

  Interface

  - [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
  - [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
  - [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
  - [ ] `area/windows`: Windows support

  Language

  - [ ] `language/r`: R APIs and clients
  - [ ] `language/java`: Java APIs and clients
  - [ ] `language/new`: Proposals for new client languages

  Integrations

  - [ ] `integrations/azure`: Azure and Azure ML integrations
  - [ ] `integrations/sagemaker`: SageMaker integrations
  - [ ] `integrations/databricks`: Databricks integrations

  <a name="release-note-category"></a>

  #### How should the PR be classified in the release notes? Choose one:

  - [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in
  the "Small Bugfixes and Documentation Updates" section
  - [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
  - [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
  - [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
  - [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

  #### Should this PR be included in the next patch release?

  - [x] Yes (this PR will be cherry-picked and included in the next patch release)
  - [ ] No (this PR will be included in the next minor release)