### PR TITLE
Add _MLFLOW_TESTING_TELEMETRY env var to all pipelines

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -51,6 +51,7 @@ env:
   MLFLOW_HOME: ${{ github.workspace }}
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   set-matrix:

--- a/.github/workflows/deployments.yml
+++ b/.github/workflows/deployments.yml
@@ -20,6 +20,9 @@ defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
 
+env:
+  _MLFLOW_TESTING_TELEMETRY: "true"
+
 jobs:
   deployments:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/devcontainer.yml
+++ b/.github/workflows/devcontainer.yml
@@ -21,6 +21,9 @@ defaults:
   run:
     shell: bash --noprofile --norc -exo pipefail {0}
 
+env:
+  _MLFLOW_TESTING_TELEMETRY: "true"
+
 jobs:
   devcontainer:
     runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -28,6 +28,9 @@ defaults:
   run:
     working-directory: docs
 
+env:
+  _MLFLOW_TESTING_TELEMETRY: "true"
+
 jobs:
   check:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -38,6 +38,7 @@ env:
   MLFLOW_HOME: ${{ github.workspace }}
   MLFLOW_CONDA_HOME: /usr/share/miniconda
   PYTHONFAULTHANDLER: "1"
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   examples:

--- a/.github/workflows/gateway.yml
+++ b/.github/workflows/gateway.yml
@@ -23,6 +23,7 @@ defaults:
 env:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   gateway:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,7 @@ defaults:
 env:
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   lint:

--- a/.github/workflows/mlflow-3.yaml
+++ b/.github/workflows/mlflow-3.yaml
@@ -26,6 +26,7 @@ env:
   MLFLOW_HOME: /home/runner/work/mlflow/mlflow
   MLFLOW_CONDA_HOME: /usr/share/miniconda
   PYTHONUTF8: "1"
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   mlflow-3:

--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -36,6 +36,7 @@ env:
   SPARK_LOCAL_IP: localhost
   PYTHONUTF8: "1"
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   core_tests:

--- a/.github/workflows/protos.yml
+++ b/.github/workflows/protos.yml
@@ -19,6 +19,7 @@ on:
 
 env:
   MLFLOW_HOME: ${{ github.workspace }}
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}

--- a/.github/workflows/r.yml
+++ b/.github/workflows/r.yml
@@ -21,6 +21,7 @@ concurrency:
 
 env:
   MLFLOW_HOME: ${{ github.workspace }}
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   r:

--- a/.github/workflows/slow-tests.yml
+++ b/.github/workflows/slow-tests.yml
@@ -39,6 +39,7 @@ env:
   MLFLOW_HOME: ${{ github.workspace }}
   PIP_EXTRA_INDEX_URL: https://download.pytorch.org/whl/cpu
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   docker-build:

--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -26,6 +26,7 @@ env:
   MLFLOW_HOME: /home/runner/work/mlflow/mlflow
   MLFLOW_CONDA_HOME: /usr/share/miniconda
   PYTHONUTF8: "1"
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   core:

--- a/.github/workflows/uc-oss.yml
+++ b/.github/workflows/uc-oss.yml
@@ -25,6 +25,7 @@ defaults:
 
 env:
   MLFLOW_HOME: ${{ github.workspace }}
+  _MLFLOW_TESTING_TELEMETRY: "true"
 
 jobs:
   uc-oss-integration-test:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/16937?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16937/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16937/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16937/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
We use _MLFLOW_TESTING_TELEMETRY to determine which config to use, so we should always set this to true in MLflow CIs to avoid sending telemetry to prod resources.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
