### PR TITLE
Add version selector to docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -129,6 +129,10 @@ const config: Config = {
           label: 'API Reference',
         },
         {
+          type: 'custom-versionSelector',
+          position: 'right',
+        },
+        {
           href: 'https://github.com/mlflow/mlflow',
           label: 'GitHub',
           position: 'right',

--- a/docs/src/components/NavbarItems/VersionSelector.tsx
+++ b/docs/src/components/NavbarItems/VersionSelector.tsx
@@ -1,0 +1,67 @@
+import React, { useState, useEffect } from 'react';
+import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
+import BrowserOnly from '@docusaurus/BrowserOnly';
+import { LinkLikeNavbarItemProps } from '@theme/NavbarItem';
+
+interface VersionSelectorProps {
+  mobile?: boolean;
+  position?: 'left' | 'right';
+  label?: string;
+  [key: string]: any;
+}
+
+function getLabel(currentVersion: string, versions: string[]): string {
+  if (currentVersion === 'latest' && versions.length > 0) {
+    // version list is sorted in descending order, so the first one is the latest
+    return `Version: ${versions[0]} (latest)`;
+  }
+
+  return `Version: ${currentVersion}`;
+}
+
+function VersionSelectorImpl({ mobile, label = 'Version', ...props }: VersionSelectorProps): JSX.Element {
+  const [versions, setVersions] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const versionsUrl = window.location.origin + '/docs/versions.json';
+
+  // Determine current version from URL or default to latest
+  const docPath = window.location.pathname;
+  const currentVersion = docPath.match(/^\/docs\/([a-zA-Z0-9.]+)/)?.[1];
+
+  const versionItems: LinkLikeNavbarItemProps[] = versions?.map((version) => ({
+    type: 'default',
+    label: version,
+    to: window.location.origin + `/docs/${version}/`,
+    target: '_self',
+  }));
+
+  useEffect(() => {
+    const fetchVersions = async () => {
+      try {
+        const response = await fetch(versionsUrl);
+        const data = await response.json();
+        if (data['versions'] != null) {
+          setVersions(data['versions']);
+        }
+      } catch (error) {
+        // do nothing, this can happen in dev where the versions.json file is not available
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchVersions();
+  }, [versionsUrl]);
+
+  if (loading || versions == null || versions.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownNavbarItem {...props} mobile={mobile} label={getLabel(currentVersion, versions)} items={versionItems} />
+  );
+}
+
+export default function VersionSelector(props: VersionSelectorProps): JSX.Element {
+  return <BrowserOnly>{() => <VersionSelectorImpl {...props} />}</BrowserOnly>;
+}

--- a/docs/src/theme/NavbarItem/ComponentTypes.tsx
+++ b/docs/src/theme/NavbarItem/ComponentTypes.tsx
@@ -1,7 +1,9 @@
 import ComponentTypes from '@theme-original/NavbarItem/ComponentTypes';
 import DocsDropdown from '@site/src/components/NavbarItems/DocsDropdown';
+import VersionSelector from '@site/src/components/NavbarItems/VersionSelector';
 
 export default {
   ...ComponentTypes,
   'custom-docsDropdown': DocsDropdown,
+  'custom-versionSelector': VersionSelector,
 };


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/16955?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16955/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16955/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16955/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds the version selector to the docs.

Similar to the old version selector, it fetches the `/docs/versions.json` file via network request and renders. This is not very ideal, but it has to work like this at the moment because built docs are hosted at /mlflow/mlflow-legacy-website. there is no way to check the canonical list of versions from this repo without network request.

Also, since we build docs statically, if we include `versions.json` as part of the build, then older versions of the docs will not be able to link to newer versions of the docs.

**Note:** After this PR, the version selector will only be available in docs for version 3.2+. Older versions will not contain the version selector unless we cherry-pick this PR to each historical branch and rebuild the docs.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested by running: 

1. `DOCS_BASE_URL=/docs/latest yarn build` 
2. Copy `build` folder to `mlflow-website/website/static/docs/latest`
3. copying `versions.json` to `mlflow-website/website/static/docs/versions.json` (as it is in `mlflow-legacy-website`)
4. run `yarn build` in website folder

https://github.com/user-attachments/assets/f78dbca6-08e5-428a-94a8-bf9c20383478



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
