### PR TITLE
Fix the doc strings for legacy genai eval classes

### DIFF
--- a/mlflow/metrics/genai/genai_metric.py
+++ b/mlflow/metrics/genai/genai_metric.py
@@ -725,7 +725,7 @@ def retrieve_custom_metrics(
                 ],
             )
             custom_metric = make_genai_metric_from_prompt(
-                name="custom llm judge",
+                name="custom_llm_judge",
                 judge_prompt="This is a custom judge prompt.",
                 greater_is_better=False,
                 parameters={"temperature": 0.0},
@@ -740,7 +740,7 @@ def retrieve_custom_metrics(
             )
         metrics = retrieve_custom_metrics(
             run_id=run.info.run_id,
-            name="custom llm judge",
+            name="custom_llm_judge",
         )
     """
     client = mlflow.MlflowClient()

--- a/mlflow/models/evaluation/utils/metric.py
+++ b/mlflow/models/evaluation/utils/metric.py
@@ -13,11 +13,16 @@ _logger = logging.getLogger(__name__)
 @dataclass
 class MetricDefinition:
     """
-    A namedtuple representing a metric function and its properties.
+    A dataclass representing a metric definition used in model evaluation.
 
-    function : the metric function
-    name : the name of the metric function
-    index : the index of the function in the ``extra_metrics`` argument of mlflow.evaluate
+    Attributes:
+        function: The metric function to be called for evaluation.
+        name: The name of the metric.
+        index: The index of the metric in the ``extra_metrics`` argument of ``mlflow.evaluate``.
+        version: (Optional) The metric version. For example v1.
+        genai_metric_args: (Optional) A dictionary containing arguments specified by users when 
+            calling make_genai_metric or make_genai_metric_from_prompt. 
+            Those args are persisted so that we can deserialize the same metric object later.
     """
 
     function: Callable[..., Any]

--- a/mlflow/models/evaluation/utils/metric.py
+++ b/mlflow/models/evaluation/utils/metric.py
@@ -20,8 +20,8 @@ class MetricDefinition:
         name: The name of the metric.
         index: The index of the metric in the ``extra_metrics`` argument of ``mlflow.evaluate``.
         version: (Optional) The metric version. For example v1.
-        genai_metric_args: (Optional) A dictionary containing arguments specified by users when 
-            calling make_genai_metric or make_genai_metric_from_prompt. 
+        genai_metric_args: (Optional) A dictionary containing arguments specified by users when
+            calling make_genai_metric or make_genai_metric_from_prompt.
             Those args are persisted so that we can deserialize the same metric object later.
     """
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/16957?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16957/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16957/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16957/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

This PR fixes several incorrect docstrings for legacy genai eval functionalities. Concretely,
- Update the example for retrieve_custom_metrics to avoid the warning below
- The docstring of MetricDefinition class was incorrect

```
2025/07/30 16:06:46 WARNING mlflow.models.evaluation.base: The metric name 'custom llm judge' provided is not a valid Python identifier, which will prevent its use as a base metric for derived metrics. Please use a valid identifier to enable creation of derived metrics that use the given metric.
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [x] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
