### PR TITLE
Fix set_destination

### DIFF
--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -18,7 +18,6 @@ from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 from mlflow.tracing.provider import (
-    _MLFLOW_TRACE_USER_DESTINATION,
     _get_tracer,
     _setup_tracer_provider,
     is_tracing_enabled,
@@ -126,7 +125,6 @@ def test_set_destination_databricks_serving(mock_databricks_serving_with_tracing
     assert len(processors) == 1
     assert isinstance(processors[0], MlflowV3SpanProcessor)
     assert isinstance(processors[0].span_exporter, MlflowV3SpanExporter)
-    assert _MLFLOW_TRACE_USER_DESTINATION.get().experiment_id == "123"
 
 
 def test_disable_enable_tracing():

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -18,6 +18,7 @@ from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.processor.inference_table import InferenceTableSpanProcessor
 from mlflow.tracing.processor.mlflow_v3 import MlflowV3SpanProcessor
 from mlflow.tracing.provider import (
+    _MLFLOW_TRACE_USER_DESTINATION,
     _get_tracer,
     _setup_tracer_provider,
     is_tracing_enabled,
@@ -114,6 +115,17 @@ def test_set_destination_databricks(monkeypatch):
     assert len(processors) == 1
     assert isinstance(processors[0], MlflowV3SpanProcessor)
     assert isinstance(processors[0].span_exporter, MlflowV3SpanExporter)
+
+
+def test_set_destination_databricks_serving(mock_databricks_serving_with_tracing_env):
+    mlflow.tracing.set_destination(destination=Databricks(experiment_id="123"))
+
+    tracer = _get_tracer("test")
+    processors = tracer.span_processor._span_processors
+    assert len(processors) == 1
+    assert isinstance(processors[0], MlflowV3SpanProcessor)
+    assert isinstance(processors[0].span_exporter, MlflowV3SpanExporter)
+    assert _MLFLOW_TRACE_USER_DESTINATION.get().experiment_id == "123"
 
 
 def test_disable_enable_tracing():

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -117,7 +117,8 @@ def test_set_destination_databricks(monkeypatch):
     assert isinstance(processors[0].span_exporter, MlflowV3SpanExporter)
 
 
-def test_set_destination_databricks_serving(mock_databricks_serving_with_tracing_env):
+def test_set_destination_databricks_serving(mock_databricks_serving_with_tracing_env, monkeypatch):
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "databricks")
     mlflow.tracing.set_destination(destination=Databricks(experiment_id="123"))
 
     tracer = _get_tracer("test")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/16981?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16981/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16981/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16981/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix a regression in https://github.com/mlflow/mlflow/pull/16859
In databricks serving environment, the current set_destination doesn't correctly resolve the processor to be MlflowV3SpanProcessor but instead InferenceTableProcessor. However set_destination should take priority, this PR fixes this issue.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
