### PR TITLE
Fix LiteLLM tracing issue

### DIFF
--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -1,8 +1,5 @@
-import importlib.metadata
 import logging
 from typing import Callable
-
-from packaging.version import Version
 
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 

--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -1,15 +1,10 @@
 import importlib.metadata
 import logging
-from contextlib import contextmanager
-from threading import Thread
+from typing import Callable
 
 from packaging.version import Version
 
-from mlflow.utils.autologging_utils import (
-    autologging_integration,
-    safe_patch,
-)
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
+from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "litellm"
 
@@ -53,38 +48,16 @@ def autolog(
         litellm.failure_callback = _append_mlflow_callbacks(litellm.failure_callback)
 
         # Workaround for https://github.com/BerriAI/litellm/issues/8013
-        # TODO: Add upper bound version check when the issue is fixed.
-        if Version(importlib.metadata.version("litellm")) >= Version("1.59.4"):
+        if Version(importlib.metadata.version("litellm")) >= Version("1.59.4") and Version(
+            importlib.metadata.version("litellm")
+        ) < Version("1.60.0"):
             litellm.failure_callback = [
                 cb if cb != "mlflow" else MlflowLogger() for cb in litellm.failure_callback
             ]
 
-        if is_in_databricks_runtime():
-            # Patch main APIs e.g. completion to inject custom handling for threading.
-            # By default, those API will start a new thread when calling log_success_event()
-            # handler of the logging callbacks and never wait for it to finish. This is
-            # problematic in Databricks notebook, because the inline trace UI display
-            # assumes that the trace is generated synchronously. If the trace is generated
-            # asynchronously, it will be displayed in different later cells.
-            # To workaround this issue, we monkey-patch these APIs to wait for the logging
-            # threads to finish before returning the result.
-            # This is not required for OSS environment where we don't show inline trace UI.
-            for func in [
-                "completion",
-                "embedding",
-                "text_completion",
-                "image_generation",
-                "transcription",
-                "speech",
-            ]:
-                _patch_threading_in_function(litellm, func)
+        # Patch thread pool executor to bypass non-blocking behavior of success_handler
+        _patch_thread_pool()
 
-            # For streaming case, we need to patch the iterator because traces are generated
-            # when consuming the generator, not when calling the main APIs.
-            _patch_threading_in_function(litellm.utils.CustomStreamWrapper, "__next__")
-
-            # NB: We don't need to patch async function because Databricks notebook waits
-            # for the async task to finish before finishing the cell.
     else:
         litellm.success_callback = _remove_mlflow_callbacks(litellm.success_callback)
         litellm.failure_callback = _remove_mlflow_callbacks(litellm.failure_callback)
@@ -110,51 +83,23 @@ def _autolog(
     pass
 
 
-def _patch_threading_in_function(target, function_name: str):
+def _patch_thread_pool():
     """
     Apply the threading patch to a synchronous function.
 
     We capture the threads started by the function using the _patch_thread_start context manager,
     then join them to ensure they are finished before the notebook cell finishes executing.
     """
+    from litellm.litellm_core_utils.thread_pool_executor import executor
 
-    def _patch_fn(original, *args, **kwargs):
-        with _patch_thread_start() as logging_threads:
-            result = original(*args, **kwargs)
-        for thread in logging_threads:
-            thread.join()
-        return result
+    def _patched_submit(original, *args, **kwargs):
+        if isinstance(args[0], Callable) and "success_handler" in args[0].__name__:
+            # Immediately run the callback handler instead of submitting it to the thread pool
+            args[0](*args[1:], **kwargs)
+            return
+        return original(*args, **kwargs)
 
-    safe_patch(FLAVOR_NAME, target, function_name, _patch_fn)
-
-
-@contextmanager
-def _patch_thread_start():
-    """
-    A context manager to collect threads started for logging handlers.
-    This is done by monkey-patching the start() method of threading.Thread.
-    Note that failure handlers are executed synchronously, so we don't need to patch them.
-    """
-    original = Thread.start
-    logging_threads = []
-
-    def patched_thread(self, *args, **kwargs):
-        target = getattr(self, "_target", None)
-        # success_handler is for normal request, and run_success_... is for streaming
-        # - https://github.com/BerriAI/litellm/blob/4f8a3fd4cfc20cf43b38379928b41c2691c85d36/litellm/utils.py#L946
-        # - https://github.com/BerriAI/litellm/blob/4f8a3fd4cfc20cf43b38379928b41c2691c85d36/litellm/utils.py#L7526
-        if target and target.__name__ in [
-            "success_handler",
-            "run_success_logging_and_cache_storage",
-        ]:
-            logging_threads.append(self)
-        return original(self, *args, **kwargs)
-
-    Thread.start = patched_thread
-    try:
-        yield logging_threads
-    finally:
-        Thread.start = original
+    safe_patch(FLAVOR_NAME, executor, "submit", _patched_submit)
 
 
 def _append_mlflow_callbacks(callbacks):

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -990,7 +990,7 @@ litellm:
     #   pip install git+https://github.com/BerriAI/litellm.git
   autologging:
     minimum: "1.52.9"
-    maximum: "1.74.12"
+    maximum: "1.74.9"
     requirements:
       ">= 0.0.0": [
           "openai",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -985,11 +985,10 @@ promptflow:
 litellm:
   package_info:
     pip_release: "litellm"
-    # TODO: Uncomment this once https://github.com/BerriAI/litellm/issues/9656 is fixed
-    # install_dev: |
-    #   pip install git+https://github.com/BerriAI/litellm.git
+    install_dev: |
+      pip install git+https://github.com/BerriAI/litellm.git
   autologging:
-    minimum: "1.52.9"
+    minimum: "1.63.0"
     maximum: "1.74.9"
     requirements:
       ">= 0.0.0": [

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -990,9 +990,7 @@ litellm:
     #   pip install git+https://github.com/BerriAI/litellm.git
   autologging:
     minimum: "1.52.9"
-    maximum: "1.58.4"
-    # TODO: Remove this once https://github.com/BerriAI/litellm/issues/9656 is fixed
-    unsupported: [">=1.59"]
+    maximum: "1.74.12"
     requirements:
       ">= 0.0.0": [
           "openai",

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -988,7 +988,7 @@ litellm:
     install_dev: |
       pip install git+https://github.com/BerriAI/litellm.git
   autologging:
-    minimum: "1.63.0"
+    minimum: "1.63.14"
     maximum: "1.74.9"
     requirements:
       ">= 0.0.0": [

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -402,7 +402,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "litellm"
         },
         "autologging": {
-            "minimum": "1.52.9",
+            "minimum": "1.63.14",
             "maximum": "1.74.9"
         }
     },

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -403,7 +403,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "1.52.9",
-            "maximum": "1.58.4"
+            "maximum": "1.74.12"
         }
     },
     "groq": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -403,7 +403,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "1.52.9",
-            "maximum": "1.74.12"
+            "maximum": "1.74.9"
         }
     },
     "groq": {

--- a/tests/litellm/test_litellm_autolog.py
+++ b/tests/litellm/test_litellm_autolog.py
@@ -1,30 +1,13 @@
 import asyncio
-import time
 from typing import Optional
-from unittest import mock
 
 import litellm
 import pytest
 
 import mlflow
 from mlflow.entities.span import SpanType
-from mlflow.utils.databricks_utils import is_in_databricks_runtime
 
 from tests.tracing.helper import get_traces
-
-
-# fixture to run test twice, one for in databricks and one for not in databricks
-@pytest.fixture(params=[True, False])
-def is_in_databricks(request):
-    with mock.patch(
-        "mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=request.param
-    ):
-        yield request.param
-
-
-def _wait_if_not_in_databricks():
-    if not is_in_databricks_runtime():
-        time.sleep(1)
 
 
 @pytest.fixture(autouse=True)
@@ -34,19 +17,14 @@ def cleanup_callbacks():
     litellm.failure_callbacks = []
 
 
-def test_litellm_tracing_success(is_in_databricks):
+def test_litellm_tracing_success():
     mlflow.litellm.autolog()
 
     response = litellm.completion(
         model="gpt-4o-mini",
         messages=[{"role": "system", "content": "Hello"}],
     )
-
     assert response.choices[0].message.content == '[{"role": "system", "content": "Hello"}]'
-
-    # Success logging is asynchronous by default, but in Databricks, we patch it to be synchronous
-    # to ensure that the trace is rendered correctly in notebook.
-    _wait_if_not_in_databricks()
 
     traces = get_traces()
     assert len(traces) == 1
@@ -63,10 +41,19 @@ def test_litellm_tracing_success(is_in_databricks):
     assert spans[0].attributes["call_type"] == "completion"
     assert spans[0].attributes["cache_hit"] is None
     assert spans[0].attributes["response_cost"] > 0
-    assert spans[0].attributes["usage"] is not None
+    assert spans[0].attributes["usage"] == {
+        "completion_tokens": 12,
+        "prompt_tokens": 9,
+        "total_tokens": 21,
+    }
+    assert traces[0].info.token_usage == {
+        "input_tokens": 9,
+        "output_tokens": 12,
+        "total_tokens": 21,
+    }
 
 
-def test_litellm_tracing_failure(is_in_databricks):
+def test_litellm_tracing_failure():
     mlflow.litellm.autolog()
 
     with pytest.raises(litellm.exceptions.BadRequestError, match="LLM Provider"):
@@ -90,7 +77,7 @@ def test_litellm_tracing_failure(is_in_databricks):
     assert spans[0].events[0].name == "exception"
 
 
-def test_litellm_tracing_streaming(is_in_databricks):
+def test_litellm_tracing_streaming():
     mlflow.litellm.autolog()
 
     response = litellm.completion(
@@ -101,8 +88,6 @@ def test_litellm_tracing_streaming(is_in_databricks):
 
     chunks = [c.choices[0].delta.content for c in response]
     assert chunks == ["Hello", " world", None]
-
-    _wait_if_not_in_databricks()
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace.info.status == "OK"
@@ -118,10 +103,20 @@ def test_litellm_tracing_streaming(is_in_databricks):
     }
     assert spans[0].outputs["choices"][0]["message"]["content"] == "Hello world"
     assert spans[0].attributes["model"] == "gpt-4o-mini"
+    assert spans[0].attributes["usage"] == {
+        "prompt_tokens": 8,
+        "completion_tokens": 2,
+        "total_tokens": 10,
+    }
+    assert trace.info.token_usage == {
+        "input_tokens": 8,
+        "output_tokens": 2,
+        "total_tokens": 10,
+    }
 
 
 @pytest.mark.asyncio
-async def test_litellm_tracing_async(is_in_databricks):
+async def test_litellm_tracing_async():
     mlflow.litellm.autolog()
 
     response = await litellm.acompletion(
@@ -151,7 +146,7 @@ async def test_litellm_tracing_async(is_in_databricks):
 
 
 @pytest.mark.asyncio
-async def test_litellm_tracing_async_streaming(is_in_databricks):
+async def test_litellm_tracing_async_streaming():
     mlflow.litellm.autolog()
 
     response = await litellm.acompletion(
@@ -186,22 +181,34 @@ async def test_litellm_tracing_async_streaming(is_in_databricks):
     assert spans[0].outputs["choices"][0]["message"]["content"] == "Hello world"
 
 
-def test_litellm_tracing_disable(is_in_databricks):
+def test_litellm_tracing_with_parent_span():
+    mlflow.litellm.autolog()
+
+    with mlflow.start_span(name="parent"):
+        litellm.completion(model="gpt-4o-mini", messages=[{"role": "system", "content": "Hello"}])
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace.info.status == "OK"
+
+    spans = trace.data.spans
+    assert len(spans) == 2
+    assert spans[0].name == "parent"
+    assert spans[1].name == "litellm-completion"
+
+
+def test_litellm_tracing_disable():
     mlflow.litellm.autolog()
 
     litellm.completion("gpt-4o-mini", [{"role": "system", "content": "Hello"}])
-    _wait_if_not_in_databricks()
     assert mlflow.get_trace(mlflow.get_last_active_trace_id()) is not None
     assert len(get_traces()) == 1
 
     mlflow.litellm.autolog(disable=True)
     litellm.completion("gpt-4o-mini", [{"role": "system", "content": "Hello"}])
-    _wait_if_not_in_databricks()
     # no additional trace should be created
     assert len(get_traces()) == 1
 
     mlflow.litellm.autolog(log_traces=False)
     litellm.completion("gpt-4o-mini", [{"role": "system", "content": "Hello"}])
-    _wait_if_not_in_databricks()
     # no additional trace should be created
     assert len(get_traces()) == 1

--- a/tests/litellm/test_litellm_autolog.py
+++ b/tests/litellm/test_litellm_autolog.py
@@ -46,11 +46,6 @@ def test_litellm_tracing_success():
         "prompt_tokens": 9,
         "total_tokens": 21,
     }
-    assert traces[0].info.token_usage == {
-        "input_tokens": 9,
-        "output_tokens": 12,
-        "total_tokens": 21,
-    }
 
 
 def test_litellm_tracing_failure():
@@ -106,11 +101,6 @@ def test_litellm_tracing_streaming():
     assert spans[0].attributes["usage"] == {
         "prompt_tokens": 8,
         "completion_tokens": 2,
-        "total_tokens": 10,
-    }
-    assert trace.info.token_usage == {
-        "input_tokens": 8,
-        "output_tokens": 2,
         "total_tokens": 10,
     }
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/16982?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16982/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16982/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16982/merge
```

</p>
</details>

### Related Issues/PRs

Fix https://github.com/mlflow/mlflow/issues/16697

### What changes are proposed in this pull request?


#### Problem

The LiteLLM callback is invoked in a non-blocking way in background thread. Due to this behavior, the span created by litellm callback is sometimes not associated with the manually-created parent span.

For example, the following example should create a trace with `parent` as root span and `litellm.completion` as a child.
```
with mlflow.start_span(name="parent") as span:
    litellm.completion(model=..., ...)
```

Here the expected order of events is like:

1. Start `parent` span.
2. Start `litellm.completion` span.
3. End `litellm.completion` span.
4. End `parent` span.

However, the span creation for the LiteLLM call is triggered in background thread, so the order is non-deterministic. It can be even like this:
2. End `parent` span.
3. Start `litellm.completion` span. 
4. End `litellm.completion` span.

In this case, the LiteLLM span is not associated with the parent.

### Solution

We once proposed LiteLLM to allow configuring the callback to blocking. However, it was abandoned after several months of wait. Therefore, this PR tries to address it within MLflow side.

There is one good change recently. Previously, the background thread is randomly created via `Thread.start` in different modules. Therefore, in order to change the behavior, we need to patch the `Thread` class itself, which is super scary.

However, recently LiteLLM moved the logic to use the singleton [threadpool](https://github.com/BerriAI/litellm/blob/65ca4f66f654343382a713e680500d8d47313a94/litellm/litellm_core_utils/thread_pool_executor.py#L5). This thread pool is used for every non-blocking logging call. Therefore, we can safely patch this object and change it to blocking.

The impact to the main application is still minimum if user configure MLflow to do async logging.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix parent-child span association issue for LiteLLM auto-tracing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
