### PR TITLE
Make preinstall versions optional for uv package manager in mlflow.models.predict

### DIFF
--- a/docs/docs/classic-ml/model/dependencies/index.mdx
+++ b/docs/docs/classic-ml/model/dependencies/index.mdx
@@ -586,6 +586,41 @@ The Python API is available since MLflow 2.10.0. If you are using an older versi
   </TabItem>
 </Tabs>
 
+#### Using UV for faster environment creation
+
+You can use `uv` as the environment manager for significantly faster environment creation:
+
+```python
+import mlflow
+
+mlflow.models.predict(
+    model_uri="runs:/<run_id>/model",
+    input_data="<input_data>",
+    env_manager="uv",  # Use uv for faster environment creation
+)
+```
+
+:::warning
+When using `uv` as the environment manager, MLflow only installs stable release versions of dependencies by default.
+If your model requires pre-release dependencies (alpha, beta, or release candidate versions), you must explicitly enable them:
+
+```python
+import os
+import mlflow
+
+# Enable pre-release dependencies for uv (not recommended for production)
+os.environ["MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE"] = "true"
+
+mlflow.models.predict(
+    model_uri="runs:/<run_id>/model",
+    input_data="<input_data>",
+    env_manager="uv",
+)
+```
+
+Pre-release versions may contain breaking changes and should be avoided in production environments.
+:::
+
 Using the <APILink fn="mlflow.models.predict" /> API is convenient for testing your model and inference environment quickly.
 However, it may not be a perfect simulation of the serving because it does not start the online inference server. That
 said, it's a great way to test whether your prediction inputs are correctly formatted.

--- a/docs/docs/classic-ml/model/index.mdx
+++ b/docs/docs/classic-ml/model/index.mdx
@@ -1852,8 +1852,8 @@ Run `pip install uv` to install uv, or refer to [uv installation guidance](https
 :::
 
 :::warning
-When using `uv` as the environment manager, MLflow by default only installs stable release versions of dependencies. 
-Pre-release versions (alpha, beta, release candidates) are excluded to ensure stability. If you need to test with 
+When using `uv` as the environment manager, MLflow by default only installs stable release versions of dependencies.
+Pre-release versions (alpha, beta, release candidates) are excluded to ensure stability. If you need to test with
 pre-release versions, you can enable them by setting the environment variable `MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE=true`.
 This is not recommended for production use as pre-release versions may contain breaking changes or unstable states of package code.
 :::

--- a/docs/docs/classic-ml/model/index.mdx
+++ b/docs/docs/classic-ml/model/index.mdx
@@ -1851,10 +1851,33 @@ Starting from MLflow 2.20.0, `uv` is available, and **it is extremely fast**.
 Run `pip install uv` to install uv, or refer to [uv installation guidance](https://docs.astral.sh/uv/getting-started/installation) for other installation methods.
 :::
 
+:::warning
+When using `uv` as the environment manager, MLflow by default only installs stable release versions of dependencies. 
+Pre-release versions (alpha, beta, release candidates) are excluded to ensure stability. If you need to test with 
+pre-release versions, you can enable them by setting the environment variable `MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE=true`.
+This is not recommended for production use as pre-release versions may contain breaking changes or unstable states of package code.
+:::
+
 Example of using `uv` to create a virtual environment for prediction:
 
 ```python
 import mlflow
+
+mlflow.models.predict(
+    model_uri="models:/<model_id>",
+    input_data="your_data",
+    env_manager="uv",
+)
+```
+
+Example of using `uv` with pre-release dependencies enabled:
+
+```python
+import os
+import mlflow
+
+# Enable pre-release dependencies (use with caution)
+os.environ["MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE"] = "true"
 
 mlflow.models.predict(
     model_uri="models:/<model_id>",

--- a/docs/docs/classic-ml/model/python_model.mdx
+++ b/docs/docs/classic-ml/model/python_model.mdx
@@ -106,8 +106,8 @@ mlflow.models.predict(
 ```
 
 :::note
-When using `uv` as the environment manager, MLflow only installs stable release versions of dependencies by default. 
-If you encounter issues with missing pre-release dependencies, see the [environment managers documentation](/ml/model#environment-managers) 
+When using `uv` as the environment manager, MLflow only installs stable release versions of dependencies by default.
+If you encounter issues with missing pre-release dependencies, see the [environment managers documentation](/ml/model#environment-managers)
 for how to enable pre-release versions.
 :::
 

--- a/docs/docs/classic-ml/model/python_model.mdx
+++ b/docs/docs/classic-ml/model/python_model.mdx
@@ -105,6 +105,12 @@ mlflow.models.predict(
 )
 ```
 
+:::note
+When using `uv` as the environment manager, MLflow only installs stable release versions of dependencies by default. 
+If you encounter issues with missing pre-release dependencies, see the [environment managers documentation](/ml/model#environment-managers) 
+for how to enable pre-release versions.
+:::
+
 In addition, you can load the model locally and validate it by running predictions.
 
 ```python

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -887,3 +887,16 @@ _MLFLOW_TESTING_TELEMETRY = _BooleanEnvironmentVariable("_MLFLOW_TESTING_TELEMET
 MLFLOW_ENABLE_THREAD_LOCAL_TRACING_DESTINATION = _BooleanEnvironmentVariable(
     "MLFLOW_ENABLE_THREAD_LOCAL_TRACING_DESTINATION", False
 )
+
+#: Whether to allow pre-release versions when installing dependencies in UV-managed
+#: virtual environments created by MLflow. When set to True, UV will use the
+#: --prerelease=allow flag during pip install operations, which may install alpha,
+#: beta, or release candidate versions of packages.
+#: NOTE: Pre-release versions are also automatically allowed when MLFLOW_TESTING is set,
+#: to support testing with development versions of MLflow and its dependencies.
+#: WARNING: Pre-release versions may contain breaking changes and are not recommended
+#: for production use.
+#: (default: ``False``)
+MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE = _BooleanEnvironmentVariable(
+    "MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE", False
+)

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -152,6 +152,13 @@ def predict(
             - "local": use the local environment
             - "conda": use conda
 
+            .. note::
+                When using "uv" as the environment manager, MLflow will by default only install
+                stable release versions of dependencies. To allow pre-release versions (alpha, beta,
+                release candidates), set the environment variable
+                ``MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE=true``. This is not recommended for
+                production use as pre-release versions may contain breaking changes.
+
         install_mlflow: If specified and there is a conda or virtualenv environment to be activated
             mlflow will be installed into the environment after it has been activated. The version
             of installed mlflow will be the same as the one used to invoke this command.

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -11,7 +11,11 @@ from typing import Literal, Optional
 from packaging.version import Version
 
 import mlflow
-from mlflow.environment_variables import _MLFLOW_TESTING, MLFLOW_ENV_ROOT
+from mlflow.environment_variables import (
+    _MLFLOW_TESTING,
+    MLFLOW_ENV_ROOT,
+    MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.models.model import MLMODEL_FILE_NAME, Model
 from mlflow.utils import env_manager as em
@@ -281,7 +285,11 @@ def _create_virtualenv(
             f"version {python_env.python} using uv"
         )
         env_creation_cmd = ["uv", "venv", env_dir, f"--python={python_env.python}"]
-        install_deps_cmd_prefix = "uv pip install --prerelease=allow"
+        # Allow pre-release versions if explicitly enabled via environment variable or during testing
+        if MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE.get() or _MLFLOW_TESTING.get():
+            install_deps_cmd_prefix = "uv pip install --prerelease=allow"
+        else:
+            install_deps_cmd_prefix = "uv pip install"
         if _MLFLOW_TESTING.get():
             os.environ["RUST_LOG"] = "uv=debug"
     with remove_on_error(

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -285,7 +285,8 @@ def _create_virtualenv(
             f"version {python_env.python} using uv"
         )
         env_creation_cmd = ["uv", "venv", env_dir, f"--python={python_env.python}"]
-        # Allow pre-release versions if explicitly enabled via environment variable or during testing
+        # Allow pre-release versions if explicitly enabled via environment variable
+        # or during testing
         if MLFLOW_VIRTUALENV_UV_ALLOW_PRERELEASE.get() or _MLFLOW_TESTING.get():
             install_deps_cmd_prefix = "uv pip install --prerelease=allow"
         else:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/16988?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16988/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16988/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16988/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The current behavior for the `uv` environment manager within mlflow.models.predict is to enable installing pre-release / alpha / beta versions of packages, which creates a high risk for breaking changes in dependent libraries to be installed, leading to user confusion about their model compatibility for transitive dependencies that may not be stable. 
The recent alpha release of pydantic has a bug in it that causes input validation for Agent based models using a Pydantic interface to throw an exception for a moved API in the alpha build. 

Making this option opt-in for users and enabled by default for CI can minimize the chances of pre-release buggy versions from affecting users.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [X] Examples
  - [X] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/prompt`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
