### PR TITLE
Fix predict with pre-releases

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,6 +32,7 @@ env:
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
   PYTHONUTF8: "1"
   _MLFLOW_TESTING_TELEMETRY: "true"
+  UV_PRERELEASE: "allow"
 
 jobs:
   # python-skinny tests cover a subset of mlflow functionality

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -32,7 +32,6 @@ env:
   PIP_CONSTRAINT: ${{ github.workspace }}/requirements/constraints.txt
   PYTHONUTF8: "1"
   _MLFLOW_TESTING_TELEMETRY: "true"
-  UV_PRERELEASE: "allow"
 
 jobs:
   # python-skinny tests cover a subset of mlflow functionality

--- a/docs/docs/classic-ml/model/dependencies/index.mdx
+++ b/docs/docs/classic-ml/model/dependencies/index.mdx
@@ -739,6 +739,27 @@ mlflow.pyfunc.log_model(
 )
 ```
 
+### How to enable installing pre-releases when using `mlflow.models.predict`
+
+If you use mlflow.models.predict to validate a model before serving and encounter an error like:
+
+```
+hint: `mlflow-skinny` was requested with a pre-release marker (e.g.,
+      mlflow-skinny==3.2.0rc0), but pre-releases weren't enabled (try:
+      `--prerelease=allow`)
+```
+
+You can resolve it by setting the environment variable `UV_PRERELEASE=allow` through the `extra_envs` field. This enables uv to install pre-release packages during environment setup.
+
+```python
+mlflow.models.predict(
+    model_uri=model_info.model_uri,
+    input_data=["a", "b", "c"],
+    extra_envs={"UV_PRERELEASE": "allow"},
+)
+```
+
+
 ### How to Migrate Anaconda Dependency for License Change
 
 Anaconda Inc. updated their [terms of service](https://www.anaconda.com/terms-of-service) for anaconda.org channels. Based on the new terms of service you may require a commercial license if you rely on Anaconda’s packaging and distribution. See [Anaconda Commercial Edition FAQ](https://www.anaconda.com/blog/anaconda-commercial-edition-faq) for more information. Your use of any Anaconda channels is governed by their terms of service.

--- a/docs/docs/classic-ml/model/dependencies/index.mdx
+++ b/docs/docs/classic-ml/model/dependencies/index.mdx
@@ -759,7 +759,6 @@ mlflow.models.predict(
 )
 ```
 
-
 ### How to Migrate Anaconda Dependency for License Change
 
 Anaconda Inc. updated their [terms of service](https://www.anaconda.com/terms-of-service) for anaconda.org channels. Based on the new terms of service you may require a commercial license if you rely on Anaconda’s packaging and distribution. See [Anaconda Commercial Edition FAQ](https://www.anaconda.com/blog/anaconda-commercial-edition-faq) for more information. Your use of any Anaconda channels is governed by their terms of service.

--- a/docs/docs/classic-ml/model/index.mdx
+++ b/docs/docs/classic-ml/model/index.mdx
@@ -1837,6 +1837,16 @@ mlflow.models.predict(
 )
 ```
 
+If your model dependencies (see the model artifact’s requirements.txt) include **pre-release packages** (e.g., mlflow==3.2.0rc0), set the environment variable `UV_PRERELEASE=allow` via the `extra_envs` field.
+
+```python
+mlflow.models.predict(
+    model_uri=model_info.model_uri,
+    input_data=["a", "b", "c"],
+    extra_envs={"UV_PRERELEASE": "allow"},
+)
+```
+
 ### Environment managers
 
 The <APILink fn="mlflow.models.predict" /> API supports the following environment managers to create the virtual environment for prediction:

--- a/docs/docs/classic-ml/model/python_model.mdx
+++ b/docs/docs/classic-ml/model/python_model.mdx
@@ -102,6 +102,8 @@ mlflow.models.predict(
     model_uri=model_info.model_uri,
     input_data=["a", "b", "c"],
     env_manager="uv",
+    # ONLY SET THIS if your model dependencies include pre-release packages (e.g. mlflow==3.2.0rc0)
+    extra_envs={"UV_PRERELEASE": "allow"},
 )
 ```
 

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -176,7 +176,8 @@ def predict(
 
         enable_prerelease: If specified, allow pre-release versions of dependencies to be installed.
             Set this to True if your model dependencies include pre-release versions such as
-            `mlflow==3.2.0rc0`. Default to False.
+            `mlflow==3.2.0rc0`. When this is set to True, the `UV_PRERELEASE` environment variable
+            is set to "allow" automatically. Default to False.
 
             .. note::
                 This parameter is only supported when `env_manager` is set to "uv".

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -217,6 +217,14 @@ def predict(
             output_path="output.json",
         )
 
+        # Run prediction with pre-release versions
+        mlflow.models.predict(
+            model_uri=f"runs:/{run_id}/model",
+            input_data={"x": 1, "y": 2},
+            env_manager="uv",
+            extra_envs={"UV_PRERELEASE": "allow"},
+        )
+
     """
     # to avoid circular imports
     from mlflow.pyfunc import _PREBUILD_ENV_ROOT_LOCATION

--- a/mlflow/models/python_api.py
+++ b/mlflow/models/python_api.py
@@ -107,7 +107,6 @@ def predict(
     install_mlflow=False,
     pip_requirements_override=None,
     extra_envs=None,
-    enable_prerelease=False,
     # TODO: add an option to force recreating the env
 ):
     """
@@ -171,16 +170,14 @@ def predict(
             current os.environ are passed, and this parameter can be used to override them.
 
             .. note::
-                This parameter is only supported when `env_manager` is set to "virtualenv",
-                "conda" or "uv".
-
-        enable_prerelease: If specified, allow pre-release versions of dependencies to be installed.
-            Set this to True if your model dependencies include pre-release versions such as
-            `mlflow==3.2.0rc0`. When this is set to True, the `UV_PRERELEASE` environment variable
-            is set to "allow" automatically. Default to False.
+                If your model dependencies include pre-release versions such as `mlflow==3.2.0rc0`
+                and you are using `uv` as the environment manager, set `UV_PRERELEASE` environment
+                variable to "allow" in `extra_envs` to allow installing pre-release versions.
+                e.g. `extra_envs={"UV_PRERELEASE": "allow"}`.
 
             .. note::
-                This parameter is only supported when `env_manager` is set to "uv".
+                This parameter is only supported when `env_manager` is set to "virtualenv",
+                "conda" or "uv".
 
     Code example:
 
@@ -265,19 +262,6 @@ def predict(
         }
     else:
         pyfunc_backend_env_root_config = {"create_env_root_dir": True}
-
-    if enable_prerelease:
-        if "UV_PRERELEASE" in os.environ:
-            _logger.info("Prerelease is already enabled via UV_PRERELEASE environment variable.")
-        elif extra_envs and "UV_PRERELEASE" in extra_envs:
-            _logger.warning(
-                "UV_PRERELEASE is set in `extra_envs`; using its value for prerelease and "
-                "ignoring `enable_prerelease`."
-            )
-        else:
-            extra_envs = extra_envs or {}
-            extra_envs["UV_PRERELEASE"] = "allow"
-            _logger.info("Prerelease enabled via `enable_prerelease`.")
 
     def _predict(_input_path: str):
         return get_flavor_backend(

--- a/mlflow/pyfunc/backend.py
+++ b/mlflow/pyfunc/backend.py
@@ -139,6 +139,7 @@ class PyFuncBackend(FlavorBackend):
                 capture_output=capture_output,
                 pip_requirements_override=pip_requirements_override,
                 env_manager=self._env_manager,
+                extra_envs=extra_envs,
             )
             self._environment = Environment(activate_cmd, extra_env=extra_envs)
         elif self._env_manager == em.CONDA:

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -446,9 +446,8 @@ def _get_or_create_virtualenv(
             )
             raise
 
-    env_vars = _get_virtualenv_extra_env_vars(env_root_dir)
-    if extra_envs:
-        env_vars.update(extra_envs)
+    extra_envs = extra_envs or {}
+    extra_envs |= _get_virtualenv_extra_env_vars(env_root_dir)
 
     # Create an environment
     return _create_virtualenv(
@@ -457,7 +456,7 @@ def _get_or_create_virtualenv(
         env_dir=env_dir,
         pyenv_root_dir=pyenv_root_dir,
         env_manager=env_manager,
-        extra_env=env_vars,
+        extra_env=extra_envs,
         capture_output=capture_output,
         pip_requirements_override=pip_requirements_override,
     )

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -281,7 +281,7 @@ def _create_virtualenv(
             f"version {python_env.python} using uv"
         )
         env_creation_cmd = ["uv", "venv", env_dir, f"--python={python_env.python}"]
-        install_deps_cmd_prefix = "uv pip install --prerelease=allow"
+        install_deps_cmd_prefix = "uv pip install"
         if _MLFLOW_TESTING.get():
             os.environ["RUST_LOG"] = "uv=debug"
     with remove_on_error(
@@ -379,6 +379,7 @@ def _get_or_create_virtualenv(
     capture_output=False,
     pip_requirements_override: Optional[list[str]] = None,
     env_manager: Literal["virtualenv", "uv"] = em.UV,
+    extra_envs: Optional[dict[str, str]] = None,
 ):
     """Restores an MLflow model's environment in a virtual environment and returns a command
     to activate it.
@@ -394,6 +395,8 @@ def _get_or_create_virtualenv(
             the environment (upgrade if already installed).
         env_manager: Specifies the environment manager to use to create the environment.
             Defaults to "uv".
+        extra_envs: If specified, a dictionary of extra environment variables will be passed to the
+            environment creation command.
 
             .. tip::
                 It is highly recommended to use "uv" as it has significant performance improvements
@@ -443,7 +446,9 @@ def _get_or_create_virtualenv(
             )
             raise
 
-    extra_env = _get_virtualenv_extra_env_vars(env_root_dir)
+    env_vars = _get_virtualenv_extra_env_vars(env_root_dir)
+    if extra_envs:
+        env_vars.update(extra_envs)
 
     # Create an environment
     return _create_virtualenv(
@@ -452,7 +457,7 @@ def _get_or_create_virtualenv(
         env_dir=env_dir,
         pyenv_root_dir=pyenv_root_dir,
         env_manager=env_manager,
-        extra_env=extra_env,
+        extra_env=env_vars,
         capture_output=capture_output,
         pip_requirements_override=pip_requirements_override,
     )

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -112,7 +112,8 @@ def test_run_local_conda_env():
 
 
 @skip_if_skinny
-def test_run_uv_python_env():
+def test_run_uv_python_env(monkeypatch):
+    monkeypatch.setenv("UV_PRERELEASE", "allow")
     python_env_path = os.path.join(TEST_VIRTUALENV_PROJECT_DIR, "python_env.yaml")
     python_env_contents = _PythonEnv.from_yaml(python_env_path)
 

--- a/tests/projects/test_projects_cli.py
+++ b/tests/projects/test_projects_cli.py
@@ -112,8 +112,7 @@ def test_run_local_conda_env():
 
 
 @skip_if_skinny
-def test_run_uv_python_env(monkeypatch):
-    monkeypatch.setenv("UV_PRERELEASE", "allow")
+def test_run_uv_python_env():
     python_env_path = os.path.join(TEST_VIRTUALENV_PROJECT_DIR, "python_env.yaml")
     python_env_contents = _PythonEnv.from_yaml(python_env_path)
 
@@ -128,6 +127,7 @@ def test_run_uv_python_env(monkeypatch):
     invoke_cli_runner(
         cli.run,
         [TEST_VIRTUALENV_PROJECT_DIR, "-e", "test", "--env-manager", "uv"],
+        env={"UV_PRERELEASE": "allow"},
     )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/16998?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16998/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/16998/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/16998/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Introduce `enable_prerelease` parameter in `predict` API and convert default behavior to not installing pre-releases.

Test:
<img width="895" height="647" alt="image" src="https://github.com/user-attachments/assets/b85d12ad-4999-4634-9cd1-4aedb9abd429" />

Verified the original issue reporting this error was fixed.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?
Verified the behavior manually.

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
