### PR TITLE
Fix semantic kernel tracing

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -743,11 +743,10 @@ class _SpanAttributesRegistry:
         if serialized_value:
             try:
                 return json.loads(serialized_value)
-            except Exception as e:
-                _logger.warning(
-                    f"Failed to get value for key {key}, make sure you set the attribute "
-                    f"on mlflow Span class instead of directly to the OpenTelemetry span. {e}"
-                )
+            except Exception:
+                # If failed to deserialize (e.g., string value is directly set to OTel span),
+                # return the original value as is.
+                return serialized_value
 
     def set(self, key: str, value: Any):
         if not isinstance(key, str):

--- a/mlflow/semantic_kernel/autolog.py
+++ b/mlflow/semantic_kernel/autolog.py
@@ -15,15 +15,11 @@ from opentelemetry.trace import (
 )
 
 from mlflow.entities.span import create_mlflow_span
-from mlflow.semantic_kernel.tracing_utils import (
-    get_mlflow_span_for_otel_span,
-    set_span_type,
-    set_token_usage,
-)
+from mlflow.semantic_kernel.tracing_utils import set_span_type, set_token_usage
 from mlflow.tracing.constant import SpanAttributeKey
 from mlflow.tracing.provider import _get_tracer
 from mlflow.tracing.trace_manager import InMemoryTraceManager
-from mlflow.tracing.utils import get_otel_attribute
+from mlflow.tracing.utils import get_mlflow_span_for_otel_span, get_otel_attribute
 
 _logger = logging.getLogger(__name__)
 

--- a/mlflow/semantic_kernel/autolog.py
+++ b/mlflow/semantic_kernel/autolog.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Optional
+from contextlib import contextmanager
+from typing import Generator, Optional
 
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
@@ -13,14 +14,16 @@ from opentelemetry.trace import (
     set_tracer_provider,
 )
 
-from mlflow.entities import SpanType
+from mlflow.entities.span import create_mlflow_span
 from mlflow.semantic_kernel.tracing_utils import (
-    _OTEL_SPAN_ID_TO_MLFLOW_SPAN_AND_TOKEN,
-    _get_span_type,
-    _set_token_usage,
+    get_mlflow_span_for_otel_span,
+    set_span_type,
+    set_token_usage,
 )
-from mlflow.tracing.fluent import start_span_no_context
-from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
+from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.provider import _get_tracer
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+from mlflow.tracing.utils import get_otel_attribute
 
 _logger = logging.getLogger(__name__)
 
@@ -71,31 +74,45 @@ class SemanticKernelSpanProcessor(SimpleSpanProcessor):
         self.span_exporter = SpanExporter()
 
     def on_start(self, span: OTelSpan, parent_context: Optional[Context] = None):
-        otel_span_id = span.get_span_context().span_id
-        parent_span_id = span.parent.span_id if span.parent else None
-        parent_st = _OTEL_SPAN_ID_TO_MLFLOW_SPAN_AND_TOKEN.get(parent_span_id)
-        parent_span = parent_st[0] if parent_st else None
+        # Trigger MLflow's span processor
+        tracer = _get_tracer(__name__)
+        tracer.span_processor.on_start(span, parent_context)
 
-        mlflow_span = start_span_no_context(
-            name=span.name,
-            parent_span=parent_span,
-            attributes=dict(span.attributes) if span.attributes else None,
-        )
-        token = set_span_in_context(mlflow_span)
-        _OTEL_SPAN_ID_TO_MLFLOW_SPAN_AND_TOKEN[otel_span_id] = (mlflow_span, token)
+        trace_id = get_otel_attribute(span, SpanAttributeKey.REQUEST_ID)
+        mlflow_span = create_mlflow_span(span, trace_id)
+
+        # Register new span in the in-memory trace manager
+        InMemoryTraceManager.get_instance().register_span(mlflow_span)
 
     def on_end(self, span: OTelReadableSpan) -> None:
-        st = _OTEL_SPAN_ID_TO_MLFLOW_SPAN_AND_TOKEN.pop(span.get_span_context().span_id, None)
-        if st is None:
+        mlflow_span = get_mlflow_span_for_otel_span(span)
+        if mlflow_span is None:
             _logger.debug("Span not found in the map. Skipping end.")
             return
 
-        mlflow_span, token = st
-        mlflow_span.set_attributes(dict(span.attributes))
-        _set_token_usage(mlflow_span, span.attributes)
+        with _bypass_attribute_guard(mlflow_span._span):
+            set_span_type(mlflow_span)
+            set_token_usage(mlflow_span)
 
-        if not mlflow_span.span_type or mlflow_span.span_type == SpanType.UNKNOWN:
-            mlflow_span.set_span_type(_get_span_type(span))
+        # Export the span using MLflow's span processor
+        tracer = _get_tracer(__name__)
+        tracer.span_processor.on_end(span)
 
-        detach_span_from_context(token)
-        mlflow_span.end()
+
+@contextmanager
+def _bypass_attribute_guard(span: OTelSpan) -> Generator[None, None, None]:
+    """
+    OpenTelemetry does not allow setting attributes if the span has end time defined.
+    https://github.com/open-telemetry/opentelemetry-python/blob/d327927d0274a320466feec6fba6d6ddb287dc5a/opentelemetry-sdk/src/opentelemetry/sdk/trace/__init__.py#L849-L851
+
+    However, we need to set some attributes within `on_end` handler of the span processor,
+    where the span is already marked as ended. This context manager is a hacky workaround
+    to bypass the attribute guard.
+    """
+    original_end_time = span._end_time
+    span._end_time = None
+    try:
+        yield
+
+    finally:
+        span._end_time = original_end_time

--- a/mlflow/semantic_kernel/tracing_utils.py
+++ b/mlflow/semantic_kernel/tracing_utils.py
@@ -24,11 +24,8 @@ import mlflow
 from mlflow.entities import SpanType
 from mlflow.entities.span import LiveSpan
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
-from mlflow.tracing.utils import construct_full_inputs
-
-# NB: Use global variable instead of the instance variable of the processor, because sometimes
-# multiple span processor instances can be created and we need to share the same map.
-_OTEL_SPAN_ID_TO_MLFLOW_SPAN_AND_TOKEN = {}
+from mlflow.tracing.trace_manager import InMemoryTraceManager
+from mlflow.tracing.utils import construct_full_inputs, encode_span_id, get_otel_attribute
 
 _OPERATION_TO_SPAN_TYPE = {
     CHAT_COMPLETION_OPERATION: SpanType.CHAT_MODEL,
@@ -43,6 +40,12 @@ _OPERATION_TO_SPAN_TYPE = {
 _logger = logging.getLogger(__name__)
 
 
+def get_mlflow_span_for_otel_span(span: OTelSpan) -> Optional[LiveSpan]:
+    trace_id = get_otel_attribute(span, SpanAttributeKey.REQUEST_ID)
+    mlflow_span_id = encode_span_id(span.get_span_context().span_id)
+    return InMemoryTraceManager.get_instance().get_span_from_id(trace_id, mlflow_span_id)
+
+
 def semantic_kernel_diagnostics_wrapper(original, *args, **kwargs) -> None:
     """
     Wrapper for Semantic Kernel's model diagnostics decorators.
@@ -52,8 +55,7 @@ def semantic_kernel_diagnostics_wrapper(original, *args, **kwargs) -> None:
     """
     full_kwargs = construct_full_inputs(original, *args, **kwargs)
     current_span = full_kwargs.get("current_span") or get_current_span()
-    otel_span_id = current_span.get_span_context().span_id
-    mlflow_span = _get_live_span_from_otel_span_id(otel_span_id)
+    mlflow_span = get_mlflow_span_for_otel_span(current_span)
 
     if not mlflow_span:
         _logger.debug("Span is not found or recording. Skipping error handling.")
@@ -64,7 +66,8 @@ def semantic_kernel_diagnostics_wrapper(original, *args, **kwargs) -> None:
         # https://github.com/microsoft/semantic-kernel/blob/d5ee6aa1c176a4b860aba72edaa961570874661b/python/semantic_kernel/utils/telemetry/model_diagnostics/decorators.py#L369
         mlflow_span.set_inputs(_parse_content(prompt))
 
-    if completions := full_kwargs.get("completions"):
+    completions = full_kwargs.get("completions")
+    if completions:
         # Wrapping _set_completion_response
         # https://github.com/microsoft/semantic-kernel/blob/d5ee6aa1c176a4b860aba72edaa961570874661b/
         mlflow_span.set_outputs({"messages": [_parse_content(c) for c in completions]})
@@ -115,32 +118,19 @@ def _parse_content(value: Any) -> Any:
     return value
 
 
-def _get_live_span_from_otel_span_id(otel_span_id: str) -> Optional[LiveSpan]:
-    if span_and_token := _OTEL_SPAN_ID_TO_MLFLOW_SPAN_AND_TOKEN.get(otel_span_id):
-        return span_and_token[0]
-    else:
-        _logger.debug(
-            f"Live span not found for OTel span ID: {otel_span_id}. "
-            "Cannot map OTel span ID to MLflow span ID, so we will skip registering "
-            "additional attributes. "
-        )
-        return None
-
-
-def _get_span_type(span: OTelSpan) -> str:
+def set_span_type(mlflow_span: LiveSpan) -> str:
     """Determine the span type based on the operation."""
-    if hasattr(span, "attributes") and (
-        operation := span.attributes.get(model_gen_ai_attributes.OPERATION)
-    ):
-        return _OPERATION_TO_SPAN_TYPE.get(operation, SpanType.UNKNOWN)
+    span_type = SpanType.UNKNOWN
+    if operation := mlflow_span.get_attribute(model_gen_ai_attributes.OPERATION):
+        span_type = _OPERATION_TO_SPAN_TYPE.get(operation, SpanType.UNKNOWN)
 
-    return SpanType.UNKNOWN
+    mlflow_span.set_span_type(span_type)
 
 
-def _set_token_usage(mlflow_span: LiveSpan, sk_attributes: dict[str, Any]) -> None:
+def set_token_usage(mlflow_span: LiveSpan) -> None:
     """Set token usage attributes on the MLflow span."""
-    input_tokens = sk_attributes.get(model_gen_ai_attributes.INPUT_TOKENS)
-    output_tokens = sk_attributes.get(model_gen_ai_attributes.OUTPUT_TOKENS)
+    input_tokens = mlflow_span.get_attribute(model_gen_ai_attributes.INPUT_TOKENS)
+    output_tokens = mlflow_span.get_attribute(model_gen_ai_attributes.OUTPUT_TOKENS)
 
     usage_dict = {}
     if input_tokens is not None:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -161,6 +161,17 @@ def decode_id(span_or_trace_id: str) -> int:
     return int(span_or_trace_id, 16)
 
 
+def get_mlflow_span_for_otel_span(span: OTelSpan) -> Optional[LiveSpan]:
+    """
+    Get the active MLflow span for the given OpenTelemetry span.
+    """
+    from mlflow.tracing.trace_manager import InMemoryTraceManager
+
+    trace_id = get_otel_attribute(span, SpanAttributeKey.REQUEST_ID)
+    mlflow_span_id = encode_span_id(span.get_span_context().span_id)
+    return InMemoryTraceManager.get_instance().get_span_from_id(trace_id, mlflow_span_id)
+
+
 def build_otel_context(trace_id: int, span_id: int) -> trace_api.SpanContext:
     """
     Build an OpenTelemetry SpanContext object from the given trace and span IDs.

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -289,3 +289,12 @@ def test_from_dict_raises_when_trace_id_is_empty():
                 "events": [],
             }
         )
+
+
+def test_set_attribute_directly_to_otel_span():
+    with mlflow.start_span("test") as span:
+        span._span.set_attribute("int", 1)
+        span._span.set_attribute("str", "a")
+
+    assert span.get_attribute("int") == 1
+    assert span.get_attribute("str") == "a"

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -99,8 +99,6 @@ def test_export_warn_invalid_attributes():
     trace_id = generate_trace_id_v3(otel_span)
     span = LiveSpan(otel_span, trace_id)
     span.set_attribute("valid", "value")
-    # # Users may set attribute directly to the OpenTelemetry span
-    # otel_span.set_attribute("int", 1)
     span.set_attribute("str", "a")
     _register_span_and_trace(span, client_request_id=_DATABRICKS_REQUEST_ID_1)
 
@@ -116,15 +114,6 @@ def test_export_warn_invalid_attributes():
         "valid": "value",
         "str": "a",
     }
-
-    # Users shouldn't set attribute directly to the OTel span
-    otel_span.set_attribute("int", 1)
-    exporter.export([otel_span])
-    with mock.patch("mlflow.entities.span._logger.warning") as mock_warning:
-        span.attributes
-        mock_warning.assert_called_once()
-        msg = mock_warning.call_args[0][0]
-        assert msg.startswith("Failed to get value for key int")
 
 
 def test_export_trace_buffer_not_exceeds_max_size(monkeypatch):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17005?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17005/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17005/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17005/merge
```

</p>
</details>

### What changes are proposed in this pull request?

#### Problem

The Semantic Kernel tracing doesn't work when other autologging e.g. `mlflow.openai.autolog` is enabled. The direct root cause is the parent span ID set in OpenAI span points to a span ID does not exist in the trace, which causes the UI crush.

<img width="719" height="243" alt="image" src="https://github.com/user-attachments/assets/06bfce9e-6e4c-4f37-a84f-248c8f21484e" />

#### Root Cause

Semantic Kernel has some built-in instrumentation using OpenTelemetry, so we implement auto-tracing by converting their OTel spans into MLflow spans. Basically this is how we do it today:

1. Semantic kernel invokes LLM, function, kernel, etc.
2. Sementic kernel triggers OTel tracer to start a span.
3. Our `SemanticKernelSpanProcessor.on_start` is triggered upon the span start.
4. Within the handler, we call `mlflow.start_span_no_context()` to create MLflow span.
5. Semantic kernel ends the OTel span. This triggers `SemanticKernelSpanProcessor.on_end`, where we finished MLflow span.

The problem is that, `mlflow.start_span_no_context()` also creates an Otel span. So in this process, we actually create two OTel span:

A. The one created at (4), which is within MLflow trace
B. The other created at (2), which is NOT in MLflow trace.

Then when OpenAI span is created, it uses (B) as a parent span. As a result, the parent ID points to a non-existing span and crush.

#### Solution

Instead of calling `mlflow.start_span_no_context` at step (4), we should wrap the Otel span created at (2) within the MLflow span. This way, we don't create separate OTel spans and parent-child relationship becomes correct.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
