### PR TITLE
fixed workspace_id resolution to use the standard databricks sdk

### DIFF
--- a/mlflow/genai/experimental/databricks_trace_exporter_utils.py
+++ b/mlflow/genai/experimental/databricks_trace_exporter_utils.py
@@ -69,7 +69,7 @@ def create_archival_ingest_sdk():
     return IngestApiSdk(ingest_url, workspace_url, token)
 
 
-def _resolve_ingest_url(workspace_id: Optional[str] = None) -> str:
+def _resolve_ingest_url() -> str:
     """
     Dynamically resolve Databricks ingest URL from workspace host pattern.
 
@@ -89,10 +89,6 @@ def _resolve_ingest_url(workspace_id: Optional[str] = None) -> str:
     Azure Patterns:
     - Staging: *.staging.azuredatabricks.net → <workspace_id>.ingest.staging.azuredatabricks.net
     - Prod: *.azuredatabricks.net → <workspace_id>.ingest.azuredatabricks.net
-
-    Args:
-        workspace_id: Optional workspace ID. If not provided, will be auto-detected
-            from Databricks context
 
     Returns:
         str: The resolved ingest URL
@@ -120,10 +116,9 @@ def _resolve_ingest_url(workspace_id: Optional[str] = None) -> str:
 
     try:
         # Get workspace ID if not provided
-        if workspace_id is None:
-            from mlflow.utils.databricks_utils import get_workspace_id
+        from databricks.sdk import WorkspaceClient
 
-            workspace_id = get_workspace_id()
+        workspace_id = WorkspaceClient().get_workspace_id()
 
         if not workspace_id:
             raise MlflowException(


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR fixes a bug on the workspace_id resolution needed to construct the ingestion_url.  The current code uses `mlflow.utils.databricks_utils.get_workspace_id()` which assumes we are in the notebook context but this does not work for model serving.  The recommendation is to use the standard databricks SDK via `databricks.sdk.WorkspaceClient().get_workspace_id()`

### How is this PR tested?
Need to verify this on model serving but blocked by other issues and fixed unit tests.

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
