### PR TITLE
Remove `MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING` env var.

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -643,12 +643,6 @@ MLFLOW_MAX_TRACES_TO_DISPLAY_IN_NOTEBOOK = _EnvironmentVariable(
 #: (default: ``1.0``)
 MLFLOW_TRACE_SAMPLING_RATIO = _EnvironmentVariable("MLFLOW_TRACE_SAMPLING_RATIO", float, 1.0)
 
-#: Whether to writing trace to the MLflow backend from a model running in a Databricks
-#: model serving endpoint. If true, the trace will be written to both the MLflow backend
-#: and the Inference Table.
-_MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING = _BooleanEnvironmentVariable(
-    "MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", False
-)
 
 # Default addressing style to use for boto client
 MLFLOW_BOTO_CLIENT_ADDRESSING_STYLE = _EnvironmentVariable(

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -86,7 +86,14 @@ class InferenceTableSpanExporter(SpanExporter):
             _TRACE_BUFFER[trace.info.client_request_id] = trace.to_dict()
 
             # Export to MLflow backend if experiment ID is set
-            if MLFLOW_EXPERIMENT_ID.get() and trace.info.experiment_id is not None:
+            if MLFLOW_EXPERIMENT_ID.get():
+                if trace.info.experiment_id is None:
+                    _logger.debug(
+                        f"{MLFLOW_EXPERIMENT_ID.name} is set, but trace {trace.info.trace_id} "
+                        "has no experiment ID. Skipping export."
+                    )
+                    continue
+
                 try:
                     # Log the trace to the MLflow backend asynchronously
                     self._async_queue.put(

--- a/mlflow/tracing/export/inference_table.py
+++ b/mlflow/tracing/export/inference_table.py
@@ -8,7 +8,7 @@ from opentelemetry.sdk.trace.export import SpanExporter
 from mlflow.entities.model_registry import PromptVersion
 from mlflow.entities.trace import Trace
 from mlflow.environment_variables import (
-    _MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING,
+    MLFLOW_EXPERIMENT_ID,
     MLFLOW_TRACE_BUFFER_MAX_SIZE,
     MLFLOW_TRACE_BUFFER_TTL_SECONDS,
 )
@@ -56,13 +56,7 @@ class InferenceTableSpanExporter(SpanExporter):
 
     def __init__(self):
         self._trace_manager = InMemoryTraceManager.get_instance()
-
-        # NB: When this env var is set to true, MLflow will export traces to both inference
-        #  table and the Databricks Tracing Server.
-        self._should_write_to_mlflow_backend = (
-            _MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING.get()
-        )
-        if self._should_write_to_mlflow_backend:
+        if MLFLOW_EXPERIMENT_ID.get():
             self._client = TracingClient("databricks")
             self._async_queue = AsyncTraceExportQueue()
 
@@ -91,18 +85,8 @@ class InferenceTableSpanExporter(SpanExporter):
             # The key is Databricks request ID.
             _TRACE_BUFFER[trace.info.client_request_id] = trace.to_dict()
 
-            if self._should_write_to_mlflow_backend:
-                if trace.info.experiment_id is None:
-                    # NB: The experiment ID is set based on the MLFLOW_EXPERIMENT_ID env var
-                    #   populated in the scoring server by Agent Framework. If the model is not
-                    #   deployed via agents.deploy(), the env var will not be set and the
-                    #   experiment will be empty, even if the dual write itself is enabled.
-                    _logger.warning(
-                        "Dual write to MLflow backend is enabled, but experiment ID is not set "
-                        "for the trace. Skipping trace export to MLflow backend."
-                    )
-                    continue
-
+            # Export to MLflow backend if experiment ID is set
+            if MLFLOW_EXPERIMENT_ID.get() and trace.info.experiment_id is not None:
                 try:
                     # Log the trace to the MLflow backend asynchronously
                     self._async_queue.put(

--- a/mlflow/tracing/processor/mlflow_v3.py
+++ b/mlflow/tracing/processor/mlflow_v3.py
@@ -1,3 +1,5 @@
+import logging
+
 from opentelemetry.sdk.trace import Span as OTelSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
@@ -6,6 +8,8 @@ from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.tracing.processor.base_mlflow import BaseMlflowSpanProcessor
 from mlflow.tracing.utils import generate_trace_id_v3
+
+_logger = logging.getLogger(__name__)
 
 
 class MlflowV3SpanProcessor(BaseMlflowSpanProcessor):
@@ -28,11 +32,15 @@ class MlflowV3SpanProcessor(BaseMlflowSpanProcessor):
 
         This method is called in the on_start method of the base class.
         """
+        experiment_id = self._get_experiment_id_for_trace(root_span)
+        if experiment_id is None:
+            _logger.debug(
+                "Experiment ID is not set for trace. It may not be exported to MLflow backend."
+            )
+
         trace_info = TraceInfo(
             trace_id=generate_trace_id_v3(root_span),
-            trace_location=TraceLocation.from_experiment_id(
-                self._get_experiment_id_for_trace(root_span)
-            ),
+            trace_location=TraceLocation.from_experiment_id(experiment_id),
             request_time=root_span.start_time // 1_000_000,  # nanosecond to millisecond
             execution_duration=None,
             state=TraceState.IN_PROGRESS,

--- a/tests/langchain/test_langchain_model_export.py
+++ b/tests/langchain/test_langchain_model_export.py
@@ -3687,8 +3687,6 @@ def test_predict_with_callbacks_with_tracing(monkeypatch):
     # Simulate the model serving environment
     monkeypatch.setenv("IS_IN_DB_MODEL_SERVING_ENV", "true")
     monkeypatch.setenv("ENABLE_MLFLOW_TRACING", "true")
-    # write to mlflow backend as well
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", "true")
     mlflow.tracing.reset()
 
     model_info = mlflow.langchain.log_model(

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -42,13 +42,17 @@ def test_export(experiment_id, monkeypatch):
     span = LiveSpan(otel_span, trace_id)
     span.set_inputs({"input1": "very long input" * 100})
     span.set_outputs("very long output" * 100)
-    _register_span_and_trace(span, client_request_id=_DATABRICKS_REQUEST_ID_1, experiment_id=experiment_id)
+    _register_span_and_trace(
+        span, client_request_id=_DATABRICKS_REQUEST_ID_1, experiment_id=experiment_id
+    )
 
     child_otel_span = create_mock_otel_span(
         name="child", trace_id=_OTEL_TRACE_ID, span_id=2, parent_id=1
     )
     child_span = LiveSpan(child_otel_span, trace_id)
-    _register_span_and_trace(child_span, client_request_id=_DATABRICKS_REQUEST_ID_1, experiment_id=experiment_id)
+    _register_span_and_trace(
+        child_span, client_request_id=_DATABRICKS_REQUEST_ID_1, experiment_id=experiment_id
+    )
 
     # Invalid span should be also ignored
     invalid_otel_span = create_mock_otel_span(trace_id=23456, span_id=1)
@@ -159,7 +163,10 @@ def test_export_trace_buffer_not_exceeds_max_size(monkeypatch):
 
 
 def test_size_bytes_in_trace_sent_to_mlflow_backend(monkeypatch):
-    """Test that SIZE_BYTES is correctly set in the trace sent to MLflow backend when experiment ID is set."""
+    """
+    Test that SIZE_BYTES is correctly set in the trace sent
+    to MLflow backend when experiment ID is set.
+    """
     # Set experiment ID to enable MLflow backend export
     experiment_id = "test-experiment-id"
     monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", experiment_id)
@@ -226,7 +233,7 @@ def test_size_bytes_in_trace_sent_to_mlflow_backend(monkeypatch):
 
 
 def test_prompt_linking_with_experiment_id(monkeypatch):
-    """Test that prompts are correctly linked when experiment ID is set for MLflow backend export."""
+    """Test that prompts are correctly linked when experiment ID is set."""
     # Set experiment ID to enable MLflow backend export
     experiment_id = "test-experiment-id"
     monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", experiment_id)

--- a/tests/tracing/export/test_inference_table_exporter.py
+++ b/tests/tracing/export/test_inference_table_exporter.py
@@ -25,9 +25,10 @@ _DATABRICKS_REQUEST_ID_1 = "databricks-request-id-1"
 _DATABRICKS_REQUEST_ID_2 = "databricks-request-id-2"
 
 
-@pytest.mark.parametrize("dual_write_enabled", [True, False])
-def test_export(dual_write_enabled, monkeypatch):
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", str(dual_write_enabled))
+@pytest.mark.parametrize("experiment_id", ["test-experiment-id", None])
+def test_export(experiment_id, monkeypatch):
+    if experiment_id:
+        monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", experiment_id)
 
     otel_span = create_mock_otel_span(
         name="root",
@@ -41,13 +42,13 @@ def test_export(dual_write_enabled, monkeypatch):
     span = LiveSpan(otel_span, trace_id)
     span.set_inputs({"input1": "very long input" * 100})
     span.set_outputs("very long output" * 100)
-    _register_span_and_trace(span, client_request_id=_DATABRICKS_REQUEST_ID_1)
+    _register_span_and_trace(span, client_request_id=_DATABRICKS_REQUEST_ID_1, experiment_id=experiment_id)
 
     child_otel_span = create_mock_otel_span(
         name="child", trace_id=_OTEL_TRACE_ID, span_id=2, parent_id=1
     )
     child_span = LiveSpan(child_otel_span, trace_id)
-    _register_span_and_trace(child_span, client_request_id=_DATABRICKS_REQUEST_ID_1)
+    _register_span_and_trace(child_span, client_request_id=_DATABRICKS_REQUEST_ID_1, experiment_id=experiment_id)
 
     # Invalid span should be also ignored
     invalid_otel_span = create_mock_otel_span(trace_id=23456, span_id=1)
@@ -80,7 +81,7 @@ def test_export(dual_write_enabled, monkeypatch):
     # Last active trace ID should be set
     assert mlflow.get_last_active_trace_id() == trace_id
 
-    if dual_write_enabled:
+    if experiment_id:
         exporter._async_queue.flush(terminate=True)
 
         assert mock_tracing_client.start_trace.call_count == 1
@@ -91,7 +92,8 @@ def test_export(dual_write_enabled, monkeypatch):
         # The databricks request ID should be set to the client request ID
         assert trace_info.client_request_id == _DATABRICKS_REQUEST_ID_1
     else:
-        assert mock_tracing_client.log_trace.call_count == 0
+        # When experiment_id is not set, trace should not be exported to MLflow backend
+        assert mock_tracing_client.start_trace.call_count == 0
 
 
 def test_export_warn_invalid_attributes():
@@ -157,9 +159,10 @@ def test_export_trace_buffer_not_exceeds_max_size(monkeypatch):
 
 
 def test_size_bytes_in_trace_sent_to_mlflow_backend(monkeypatch):
-    """Test that SIZE_BYTES is correctly set in the trace sent to MLflow backend via dual write."""
-    # Enable dual write
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", "True")
+    """Test that SIZE_BYTES is correctly set in the trace sent to MLflow backend when experiment ID is set."""
+    # Set experiment ID to enable MLflow backend export
+    experiment_id = "test-experiment-id"
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", experiment_id)
 
     # Create spans and trace
     otel_span = create_mock_otel_span(
@@ -222,10 +225,11 @@ def test_size_bytes_in_trace_sent_to_mlflow_backend(monkeypatch):
     )
 
 
-def test_prompt_linking_with_dual_write(monkeypatch):
-    """Test that prompts are correctly linked when dual write to MLflow backend is enabled."""
-    # Enable dual write
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", "True")
+def test_prompt_linking_with_experiment_id(monkeypatch):
+    """Test that prompts are correctly linked when experiment ID is set for MLflow backend export."""
+    # Set experiment ID to enable MLflow backend export
+    experiment_id = "test-experiment-id"
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", experiment_id)
 
     # Create span and trace
     otel_span = create_mock_otel_span(
@@ -306,10 +310,9 @@ def test_prompt_linking_with_dual_write(monkeypatch):
     assert captured_trace_id == trace_id
 
 
-def test_prompt_linking_disabled_without_dual_write(monkeypatch):
-    """Test that prompt linking is not attempted when dual write is disabled."""
-    # Disable dual write
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", "False")
+def test_prompt_linking_disabled_without_experiment_id(monkeypatch):
+    """Test that prompt linking is not attempted when experiment ID is not set."""
+    # Don't set MLFLOW_EXPERIMENT_ID to disable MLflow backend export
 
     # Create span and trace
     otel_span = create_mock_otel_span(
@@ -360,9 +363,10 @@ def test_prompt_linking_disabled_without_dual_write(monkeypatch):
 
 
 def test_prompt_linking_with_empty_prompts(monkeypatch):
-    """Test that empty prompts list doesn't cause issues with dual write."""
-    # Enable dual write
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", "True")
+    """Test that empty prompts list doesn't cause issues when exporting to MLflow backend."""
+    # Set experiment ID to enable MLflow backend export
+    experiment_id = "test-experiment-id"
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", experiment_id)
 
     # Create span and trace
     otel_span = create_mock_otel_span(
@@ -414,10 +418,11 @@ def test_prompt_linking_with_empty_prompts(monkeypatch):
     assert captured_trace_id is None  # No linking occurred, so trace_id was never captured
 
 
-def test_prompt_linking_error_handling_with_dual_write(monkeypatch):
-    """Test that prompt linking errors are handled gracefully with dual write enabled."""
-    # Enable dual write
-    monkeypatch.setenv("MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING", "True")
+def test_prompt_linking_error_handling_with_experiment_id(monkeypatch):
+    """Test that prompt linking errors are handled gracefully when exporting to MLflow backend."""
+    # Set experiment ID to enable MLflow backend export
+    experiment_id = "test-experiment-id"
+    monkeypatch.setenv("MLFLOW_EXPERIMENT_ID", experiment_id)
 
     # Create span and trace
     otel_span = create_mock_otel_span(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17017?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17017/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17017/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17017/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Remove `MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING`.

The env var was used to gate the new behavior of trace export in model serving.

1. By default, MLflow only export traces to inference table.
2. If `MLFLOW_ENABLE_TRACE_DUAL_WRITE_IN_MODEL_SERVING` **and** `MLFLOW_EXPERIMENT_ID` env var is set, MLflow exports to **both** MLflow backend and inference table.

We used the former env var to gradually ramp up (2) experience. Now we finished ramp up so this PR removes it.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
