### PR TITLE
Add linting rule to prevent mlflow.get_artifact_uri usage in examples

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -244,11 +244,11 @@ class ExampleVisitor(ast.NodeVisitor):
         self.has_log_model = False
 
     def visit_Call(self, node: ast.Call) -> None:
-        if resolved := self.linter.resolver.resolve(node.func):
-            match resolved:
-                case ["mlflow", _, "log_model"]:
+        if names := self.linter.resolver.resolve(node.func):
+            match names:
+                case ["mlflow", *_, "log_model"]:
                     self.has_log_model = True
-                case ["mlflow", "get_artifact_uri"] if self.has_log_model:
+                case ["mlflow", "get_artifact_uri"] if self.has_log_model and len(node.args) == 1:
                     self.linter._check(Location.from_node(node), rules.GetArtifactUri())
 
         if (

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -7,6 +7,7 @@ from clint.rules.extraneous_docstring_param import ExtraneousDocstringParam
 from clint.rules.forbidden_set_active_model_usage import ForbiddenSetActiveModelUsage
 from clint.rules.forbidden_top_level_import import ForbiddenTopLevelImport
 from clint.rules.forbidden_trace_ui_in_notebook import ForbiddenTraceUIInNotebook
+from clint.rules.get_artifact_uri import GetArtifactUri
 from clint.rules.implicit_optional import ImplicitOptional
 from clint.rules.incorrect_type_annotation import IncorrectTypeAnnotation
 from clint.rules.invalid_abstract_method import InvalidAbstractMethod
@@ -45,6 +46,7 @@ __all__ = [
     "EmptyNotebookCell",
     "ExampleSyntaxError",
     "ExtraneousDocstringParam",
+    "GetArtifactUri",
     "ForbiddenSetActiveModelUsage",
     "ForbiddenTopLevelImport",
     "ForbiddenTraceUIInNotebook",

--- a/dev/clint/src/clint/rules/get_artifact_uri.py
+++ b/dev/clint/src/clint/rules/get_artifact_uri.py
@@ -1,0 +1,9 @@
+from clint.rules.base import Rule
+
+
+class GetArtifactUri(Rule):
+    def _message(self) -> str:
+        return (
+            "`mlflow.get_artifact_uri` should not be used in examples. "
+            "Use the return value of `log_model` instead."
+        )

--- a/dev/clint/tests/rules/test_get_artifact_uri.py
+++ b/dev/clint/tests/rules/test_get_artifact_uri.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+
+import pytest
+from clint.config import Config
+from clint.index import SymbolIndex
+from clint.linter import Location, lint_file
+from clint.rules import GetArtifactUri
+
+
+def test_get_artifact_uri_in_rst_example(index: SymbolIndex, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.rst"
+    tmp_file.write_text(
+        """
+Documentation
+=============
+
+Here's an example:
+
+.. code-block:: python
+
+    import mlflow
+
+    with mlflow.start_run():
+        mlflow.sklearn.log_model(model, "model")
+        model_uri = mlflow.get_artifact_uri("model")
+        print(model_uri)
+"""
+    )
+    config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 1
+    assert violations[0].rule.name == GetArtifactUri.name
+    assert violations[0].loc == Location(12, 20)
+
+
+@pytest.mark.parametrize("suffix", [".md", ".mdx"])
+def test_get_artifact_uri_in_markdown_example(
+    index: SymbolIndex, tmp_path: Path, suffix: str
+) -> None:
+    tmp_file = (tmp_path / "test").with_suffix(suffix)
+    tmp_file.write_text(
+        """
+# Documentation
+
+Here's an example:
+
+```python
+import mlflow
+
+with mlflow.start_run():
+    mlflow.sklearn.log_model(model, "model")
+    model_uri = mlflow.get_artifact_uri("model")
+    print(model_uri)
+```
+"""
+    )
+    config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 1
+    assert violations[0].rule.name == GetArtifactUri.name
+    assert violations[0].loc == Location(10, 16)
+
+
+def test_get_artifact_uri_not_in_regular_python_files(index: SymbolIndex, tmp_path: Path) -> None:
+    tmp_file = tmp_path / "test.py"
+    tmp_file.write_text(
+        """
+import mlflow
+
+with mlflow.start_run():
+    model_uri = mlflow.get_artifact_uri("model")
+    print(model_uri)
+"""
+    )
+    config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 0
+
+
+def test_get_artifact_uri_without_log_model_allowed(index: SymbolIndex, tmp_path: Path) -> None:
+    """Test that mlflow.get_artifact_uri is allowed when no log_model is present."""
+    tmp_file = tmp_path / "test.rst"
+    tmp_file.write_text(
+        """
+Documentation
+=============
+
+Here's an example:
+
+.. code-block:: python
+
+    import mlflow
+
+    # This should be allowed - no log_model in the example
+    model_uri = mlflow.get_artifact_uri("some_model")
+    loaded_model = mlflow.sklearn.load_model(model_uri)
+"""
+    )
+    config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
+    violations = lint_file(tmp_file, config, index)
+    assert len(violations) == 0

--- a/dev/clint/tests/rules/test_get_artifact_uri.py
+++ b/dev/clint/tests/rules/test_get_artifact_uri.py
@@ -2,12 +2,11 @@ from pathlib import Path
 
 import pytest
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules import GetArtifactUri
 
 
-def test_get_artifact_uri_in_rst_example(index: SymbolIndex, tmp_path: Path) -> None:
+def test_get_artifact_uri_in_rst_example(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.rst"
     tmp_file.write_text(
         """
@@ -27,7 +26,7 @@ Here's an example:
 """
     )
     config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert violations[0].rule.name == GetArtifactUri.name
     assert violations[0].loc == Location(12, 20)
@@ -35,7 +34,7 @@ Here's an example:
 
 @pytest.mark.parametrize("suffix", [".md", ".mdx"])
 def test_get_artifact_uri_in_markdown_example(
-    index: SymbolIndex, tmp_path: Path, suffix: str
+    index_path: Path, tmp_path: Path, suffix: str
 ) -> None:
     tmp_file = (tmp_path / "test").with_suffix(suffix)
     tmp_file.write_text(
@@ -55,13 +54,13 @@ with mlflow.start_run():
 """
     )
     config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert violations[0].rule.name == GetArtifactUri.name
     assert violations[0].loc == Location(10, 16)
 
 
-def test_get_artifact_uri_not_in_regular_python_files(index: SymbolIndex, tmp_path: Path) -> None:
+def test_get_artifact_uri_not_in_regular_python_files(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -73,11 +72,11 @@ with mlflow.start_run():
 """
     )
     config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 0
 
 
-def test_get_artifact_uri_without_log_model_allowed(index: SymbolIndex, tmp_path: Path) -> None:
+def test_get_artifact_uri_without_log_model_allowed(index_path: Path, tmp_path: Path) -> None:
     """Test that mlflow.get_artifact_uri is allowed when no log_model is present."""
     tmp_file = tmp_path / "test.rst"
     tmp_file.write_text(
@@ -97,5 +96,5 @@ Here's an example:
 """
     )
     config = Config(select={GetArtifactUri.name}, example_rules=[GetArtifactUri.name])
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 0

--- a/docs/docs/classic-ml/community-model-flavors/index.mdx
+++ b/docs/docs/classic-ml/community-model-flavors/index.mdx
@@ -566,17 +566,16 @@ forecaster.fit(y, X=X)
 
 # Log with custom flavor
 with mlflow.start_run():
-    custom_sktime_flavor.log_model(
+    model_info = custom_sktime_flavor.log_model(
         sktime_model=forecaster, artifact_path="custom_forecaster"
     )
-    model_uri = mlflow.get_artifact_uri("custom_forecaster")
 
 # Load and use natively
-loaded_model = custom_sktime_flavor.load_model(model_uri)
+loaded_model = custom_sktime_flavor.load_model(model_info.model_uri)
 native_predictions = loaded_model.predict(fh=[1, 2, 3])
 
 # Load as PyFunc for serving
-loaded_pyfunc = mlflow.pyfunc.load_model(model_uri)
+loaded_pyfunc = mlflow.pyfunc.load_model(model_info.model_uri)
 
 # Create configuration for PyFunc prediction
 config_df = pd.DataFrame(

--- a/docs/docs/classic-ml/evaluation/metrics-visualizations.mdx
+++ b/docs/docs/classic-ml/evaluation/metrics-visualizations.mdx
@@ -74,12 +74,11 @@ business_metric = make_metric(
 
 with mlflow.start_run():
     # Log model
-    mlflow.sklearn.log_model(model, name="model")
-    model_uri = mlflow.get_artifact_uri("model")
+    model_info = mlflow.sklearn.log_model(model, name="model")
 
     # Evaluate with custom metric
     result = mlflow.evaluate(
-        model_uri,
+        model_info.model_uri,
         eval_data,
         targets="target",
         model_type="classifier",

--- a/docs/docs/classic-ml/evaluation/model-eval.mdx
+++ b/docs/docs/classic-ml/evaluation/model-eval.mdx
@@ -40,12 +40,11 @@ eval_data["label"] = y_test
 with mlflow.start_run():
     # Log model with signature
     signature = infer_signature(X_test, model.predict(X_test))
-    mlflow.sklearn.log_model(model, name="model", signature=signature)
-    model_uri = mlflow.get_artifact_uri("model")
+    model_info = mlflow.sklearn.log_model(model, name="model", signature=signature)
 
     # Comprehensive evaluation
     result = mlflow.models.evaluate(
-        model_uri,
+        model_info.model_uri,
         eval_data,
         targets="label",
         model_type="classifier",

--- a/docs/docs/classic-ml/evaluation/shap.mdx
+++ b/docs/docs/classic-ml/evaluation/shap.mdx
@@ -33,12 +33,11 @@ eval_data["label"] = y_test
 with mlflow.start_run():
     # Log model
     signature = infer_signature(X_test, model.predict(X_test))
-    mlflow.sklearn.log_model(model, name="model", signature=signature)
-    model_uri = mlflow.get_artifact_uri("model")
+    model_info = mlflow.sklearn.log_model(model, name="model", signature=signature)
 
     # Evaluate with SHAP explanations enabled
     result = mlflow.evaluate(
-        model_uri,
+        model_info.model_uri,
         eval_data,
         targets="label",
         model_type="classifier",

--- a/docs/docs/classic-ml/traditional-ml/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/index.mdx
@@ -331,12 +331,11 @@ with mlflow.start_run():
     # Train and log model
     model = RandomForestClassifier(n_estimators=100)
     model.fit(X_train, y_train)
-    mlflow.sklearn.log_model(model, name="model")
-    model_uri = mlflow.get_artifact_uri("model")
+    model_info = mlflow.sklearn.log_model(model, name="model")
 
     # Evaluate with automatic SHAP explanations
     result = mlflow.evaluate(
-        model_uri,
+        model_info.model_uri,
         eval_data,
         targets="label",
         model_type="classifier",

--- a/docs/docs/classic-ml/traditional-ml/sklearn/guide/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/sklearn/guide/index.mdx
@@ -307,12 +307,11 @@ eval_data["label"] = y_test
 with mlflow.start_run():
     # Log model with signature
     signature = infer_signature(X_test, model.predict(X_test))
-    mlflow.sklearn.log_model(model, name="model", signature=signature)
-    model_uri = mlflow.get_artifact_uri("model")
+    model_info = mlflow.sklearn.log_model(model, name="model", signature=signature)
 
     # Comprehensive evaluation with MLflow
     result = mlflow.evaluate(
-        model_uri,
+        model_info.model_uri,
         eval_data,
         targets="label",
         model_type="classifier",  # or "regressor" for regression

--- a/docs/docs/classic-ml/traditional-ml/xgboost/guide/index.mdx
+++ b/docs/docs/classic-ml/traditional-ml/xgboost/guide/index.mdx
@@ -884,12 +884,11 @@ eval_data["label"] = y_test
 with mlflow.start_run():
     # Log model with signature
     signature = infer_signature(X_test, model.predict(X_test))
-    mlflow.sklearn.log_model(model, name="model", signature=signature)
-    model_uri = mlflow.get_artifact_uri("model")
+    model_info = mlflow.sklearn.log_model(model, name="model", signature=signature)
 
     # Comprehensive evaluation with MLflow
     result = mlflow.evaluate(
-        model_uri,
+        model_info.model_uri,
         eval_data,
         targets="label",
         model_type="classifier",  # or "regressor" for regression

--- a/examples/gateway/mlflow_models/README.md
+++ b/examples/gateway/mlflow_models/README.md
@@ -56,17 +56,16 @@ model = SentenceTransformer(model_name_or_path="all-MiniLM-L6-v2")
 artifact_path = "embeddings_model"
 
 with mlflow.start_run():
-    mlflow.sentence_transformers.log_model(
+    model_info = mlflow.sentence_transformers.log_model(
         model,
         name=artifact_path,
     )
-    model_uri = mlflow.get_artifact_uri(artifact_path)
 ```
 
 ## Generate the cli command for starting a local MLflow Model Serving endpoint for this embeddings model
 
 ```python
-print(f"mlflow models serve -m {model_uri} -h 127.0.0.1 -p 9020 --no-conda")
+print(f"mlflow models serve -m {model_info.model_uri} -h 127.0.0.1 -p 9020 --no-conda")
 ```
 
 Copy the output from the print statement to the clipboard.
@@ -132,17 +131,16 @@ model = AutoModelForMaskedLM.from_pretrained(lm_architecture)
 components = {"model": model, "tokenizer": tokenizer}
 
 with mlflow.start_run():
-    mlflow.transformers.log_model(
+    model_info = mlflow.transformers.log_model(
         transformers_model=components,
         name=artifact_path,
     )
-    model_uri = mlflow.get_artifact_uri(artifact_path)
 ```
 
 ## Generate the cli command for starting a local MLflow Model Serving endpoint for this fill mask model
 
 ```python
-print(f"mlflow models serve -m {model_uri} -h 127.0.0.1 -p 9010 --no-conda")
+print(f"mlflow models serve -m {model_info.model_uri} -h 127.0.0.1 -p 9010 --no-conda")
 ```
 
 ## Starting the model server for the fill mask model

--- a/mlflow/pmdarima/__init__.py
+++ b/mlflow/pmdarima/__init__.py
@@ -482,11 +482,8 @@ def load_model(model_uri, dst_path=None):
                 model, name=ARTIFACT_PATH, signature=signature, input_example=input_example
             )
 
-            # Get the model URI for loading
-            model_uri = model_info.model_uri
-
         # Load the model
-        loaded_model = mlflow.pmdarima.load_model(model_uri)
+        loaded_model = mlflow.pmdarima.load_model(model_info.model_uri)
         # Forecast for the next 60 days
         forecast = loaded_model.predict(n_periods=60)
         print(f"forecast: {forecast}")

--- a/mlflow/pmdarima/__init__.py
+++ b/mlflow/pmdarima/__init__.py
@@ -478,12 +478,12 @@ def load_model(model_uri, dst_path=None):
 
             # Log model
             input_example = input_sample.head()
-            mlflow.pmdarima.log_model(
+            model_info = mlflow.pmdarima.log_model(
                 model, name=ARTIFACT_PATH, signature=signature, input_example=input_example
             )
 
             # Get the model URI for loading
-            model_uri = mlflow.get_artifact_uri(ARTIFACT_PATH)
+            model_uri = model_info.model_uri
 
         # Load the model
         loaded_model = mlflow.pmdarima.load_model(model_uri)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -298,6 +298,7 @@ example-rules = [
   "unknown-mlflow-function",
   "unknown-mlflow-arguments",
   "multi-assign",
+  "get-artifact-uri",
 ]
 
 [tool.clint.per-file-ignores]
@@ -307,6 +308,8 @@ example-rules = [
   "unnamed-thread",
   "thread-pool-executor-without-thread-name-prefix",
 ]
+# This file intentionally shows problematic code as an example of what NOT to do
+"docs/docs/genai/mlflow-3/faqs.mdx" = ["get-artifact-uri"]
 
 [tool.clint.forbidden-top-level-imports]
 "mlflow/gateway/providers/*" = ["fastapi", "starlette", "aiohttp"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17018?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17018/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17018/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17018/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #17010

### What changes are proposed in this pull request?

This PR introduces a new clint rule `get-artifact-uri` that prevents the usage of `mlflow.get_artifact_uri()` in documentation examples and guides users to use the return value of `log_model()` instead.

The rule implements context-aware checking using match statement pattern matching to only flag violations when a `log_model` call has been encountered first, preventing false positives.

**Key features:**
- Context-aware violation detection (only flags `get_artifact_uri` when `log_model` has been called)
- Modern Python match statement pattern matching for clean code
- Comprehensive test coverage with location verification
- Integration with existing ExampleVisitor functionality

**Files changed:**
- **New rule**: `dev/clint/src/clint/rules/get_artifact_uri.py`
- **Linter integration**: Enhanced `ExampleVisitor` in `dev/clint/src/clint/linter.py`
- **Tests**: `dev/clint/tests/rules/test_get_artifact_uri.py`
- **Configuration**: Added rule to `pyproject.toml`
- **Documentation fixes**: Fixed 10+ examples across documentation to use recommended patterns

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New tests include:**
- Context-aware behavior verification (no violations when no `log_model` present)
- Location checking for RST and Markdown examples
- Integration with existing linting infrastructure

**Manual testing:**
- Verified pre-commit hooks pass with `pre-commit run clint --all-files`
- Tested context-aware behavior with custom test files
- Confirmed all existing documentation violations are fixed

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

This PR *fixes* documentation examples rather than requiring new documentation.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is a developer-facing linting improvement that helps maintain documentation quality.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)