### PR TITLE
Optimize clint performance by avoiding expensive serialization overhead

### DIFF
--- a/dev/clint/src/clint/__init__.py
+++ b/dev/clint/src/clint/__init__.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import sys
+import tempfile
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
@@ -38,16 +39,22 @@ def main():
         regex = re.compile("|".join(map(re.escape, config.exclude)))
         files = [f for f in files if not regex.match(f) and os.path.exists(f)]
 
-    index = SymbolIndex.build()
-    with ProcessPoolExecutor() as pool:
-        futures = [pool.submit(lint_file, Path(f), config, index) for f in files]
-        violations_iter = itertools.chain.from_iterable(f.result() for f in as_completed(futures))
-        if violations := list(violations_iter):
-            if args.output_format == "json":
-                sys.stdout.write(json.dumps([v.json() for v in violations]))
-            elif args.output_format == "text":
-                sys.stderr.write("\n".join(map(str, violations)) + "\n")
-            sys.exit(1)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Pickle `SymbolIndex` to avoid expensive serialization overhead when passing
+        # the large index object to multiple worker processes
+        index_path = Path(tmp_dir) / "symbol_index.pkl"
+        SymbolIndex.build().save(index_path)
+        with ProcessPoolExecutor() as pool:
+            futures = [pool.submit(lint_file, Path(f), config, index_path) for f in files]
+            violations_iter = itertools.chain.from_iterable(
+                f.result() for f in as_completed(futures)
+            )
+            if violations := list(violations_iter):
+                if args.output_format == "json":
+                    sys.stdout.write(json.dumps([v.json() for v in violations]))
+                elif args.output_format == "text":
+                    sys.stderr.write("\n".join(map(str, violations)) + "\n")
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/dev/clint/src/clint/index.py
+++ b/dev/clint/src/clint/index.py
@@ -22,6 +22,7 @@ print(f"Arguments: {func_info.args}")  # -> ['key, 'value', 'step', ...]
 
 import ast
 import multiprocessing
+import pickle
 import subprocess
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -149,6 +150,16 @@ class SymbolIndex:
     ) -> None:
         self.import_mapping = import_mapping
         self.func_mapping = func_mapping
+
+    def save(self, path: Path) -> None:
+        with path.open("wb") as f:
+            pickle.dump((self.import_mapping, self.func_mapping), f)
+
+    @classmethod
+    def load(cls, path: Path) -> Self:
+        with path.open("rb") as f:
+            import_mapping, func_mapping = pickle.load(f)
+        return cls(import_mapping, func_mapping)
 
     @classmethod
     def build(cls) -> Self:

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -799,8 +799,9 @@ def _has_h1_header(cells: list[dict[str, Any]]) -> bool:
     )
 
 
-def lint_file(path: Path, config: Config, index: SymbolIndex) -> list[Violation]:
+def lint_file(path: Path, config: Config, index_path: Path) -> list[Violation]:
     code = path.read_text()
+    index = SymbolIndex.load(index_path)
     if path.suffix == ".ipynb":
         violations = []
         if cells := json.loads(code).get("cells"):

--- a/dev/clint/tests/rules/conftest.py
+++ b/dev/clint/tests/rules/conftest.py
@@ -1,7 +1,12 @@
+from pathlib import Path
+
 import pytest
 from clint.index import SymbolIndex
 
 
 @pytest.fixture(scope="session")
-def index() -> SymbolIndex:
-    return SymbolIndex.build()
+def index_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    tmp_dir = tmp_path_factory.mktemp("clint_tests")
+    index_file = tmp_dir / "symbol_index.pkl"
+    SymbolIndex.build().save(index_file)
+    return index_file

--- a/dev/clint/tests/rules/test_do_not_disable.py
+++ b/dev/clint/tests/rules/test_do_not_disable.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.do_not_disable import DoNotDisable
 
 
-def test_do_not_disable(index: SymbolIndex, tmp_path: Path) -> None:
+def test_do_not_disable(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -19,7 +18,7 @@ def test_do_not_disable(index: SymbolIndex, tmp_path: Path) -> None:
     )
 
     config = Config(select={DoNotDisable.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, DoNotDisable) for v in violations)
     assert violations[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_docstring_param_order.py
+++ b/dev/clint/tests/rules/test_docstring_param_order.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.docstring_param_order import DocstringParamOrder
 
 
-def test_docstring_param_order(index: SymbolIndex, tmp_path: Path) -> None:
+def test_docstring_param_order(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -29,7 +28,7 @@ def f(a: int, b: str) -> None:
     )
 
     config = Config(select={DocstringParamOrder.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, DocstringParamOrder) for v in violations)
     assert violations[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_empty_notebook_cell.py
+++ b/dev/clint/tests/rules/test_empty_notebook_cell.py
@@ -2,12 +2,11 @@ import json
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import lint_file
 from clint.rules.empty_notebook_cell import EmptyNotebookCell
 
 
-def test_empty_notebook_cell(index: SymbolIndex, tmp_path: Path) -> None:
+def test_empty_notebook_cell(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test_notebook.ipynb"
     notebook_content = {
         "cells": [
@@ -41,7 +40,7 @@ def test_empty_notebook_cell(index: SymbolIndex, tmp_path: Path) -> None:
     }
     tmp_file.write_text(json.dumps(notebook_content))
     config = Config(select={EmptyNotebookCell.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 2
     assert all(isinstance(v.rule, EmptyNotebookCell) for v in violations)
     assert violations[0].cell == 1

--- a/dev/clint/tests/rules/test_example_syntax_error.py
+++ b/dev/clint/tests/rules/test_example_syntax_error.py
@@ -2,12 +2,11 @@ from pathlib import Path
 
 import pytest
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.example_syntax_error import ExampleSyntaxError
 
 
-def test_example_syntax_error(index: SymbolIndex, tmp_path: Path) -> None:
+def test_example_syntax_error(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -29,14 +28,14 @@ def good():
 '''
     )
     config = Config(select={ExampleSyntaxError.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, ExampleSyntaxError) for v in violations)
     assert violations[0].loc == Location(5, 8)
 
 
 @pytest.mark.parametrize("suffix", [".md", ".mdx"])
-def test_example_syntax_error_markdown(index: SymbolIndex, tmp_path: Path, suffix: str) -> None:
+def test_example_syntax_error_markdown(index_path: Path, tmp_path: Path, suffix: str) -> None:
     tmp_file = (tmp_path / "test").with_suffix(suffix)
     tmp_file.write_text(
         """
@@ -46,7 +45,7 @@ def g():
 """
     )
     config = Config(select={ExampleSyntaxError.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, ExampleSyntaxError) for v in violations)
     assert violations[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_extraneous_docstring_param.py
+++ b/dev/clint/tests/rules/test_extraneous_docstring_param.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.extraneous_docstring_param import ExtraneousDocstringParam
 
 
-def test_extraneous_docstring_param(index: SymbolIndex, tmp_path: Path) -> None:
+def test_extraneous_docstring_param(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -32,7 +31,7 @@ def good_function(param1: str, param2: int) -> None:
     )
 
     config = Config(select={ExtraneousDocstringParam.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, ExtraneousDocstringParam) for v in violations)
     assert violations[0].loc == Location(1, 0)

--- a/dev/clint/tests/rules/test_forbidden_set_active_model_usage.py
+++ b/dev/clint/tests/rules/test_forbidden_set_active_model_usage.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.forbidden_set_active_model_usage import ForbiddenSetActiveModelUsage
 
 
-def test_forbidden_set_active_model_usage(index: SymbolIndex, tmp_path: Path) -> None:
+def test_forbidden_set_active_model_usage(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -29,7 +28,7 @@ _set_active_model("model_name")
     )
 
     config = Config(select={ForbiddenSetActiveModelUsage.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 3
     assert all(isinstance(v.rule, ForbiddenSetActiveModelUsage) for v in violations)
     assert violations[0].loc == Location(4, 0)  # mlflow.set_active_model call

--- a/dev/clint/tests/rules/test_forbidden_top_level_import.py
+++ b/dev/clint/tests/rules/test_forbidden_top_level_import.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.forbidden_top_level_import import ForbiddenTopLevelImport
 
 
-def test_forbidden_top_level_import(index: SymbolIndex, tmp_path: Path) -> None:
+def test_forbidden_top_level_import(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -22,7 +21,7 @@ import baz
         select={ForbiddenTopLevelImport.name},
         forbidden_top_level_imports={"*": ["foo"]},
     )
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 2
     assert all(isinstance(v.rule, ForbiddenTopLevelImport) for v in violations)
     assert violations[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_forbidden_trace_ui_in_notebook.py
+++ b/dev/clint/tests/rules/test_forbidden_trace_ui_in_notebook.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import lint_file
 from clint.rules.forbidden_trace_ui_in_notebook import ForbiddenTraceUIInNotebook
 
 
-def test_forbidden_trace_ui_in_notebook(index: SymbolIndex, tmp_path: Path) -> None:
+def test_forbidden_trace_ui_in_notebook(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.ipynb"
     notebook_content = """
 {
@@ -62,7 +61,7 @@ def test_forbidden_trace_ui_in_notebook(index: SymbolIndex, tmp_path: Path) -> N
 """
     tmp_file.write_text(notebook_content)
     config = Config(select={ForbiddenTraceUIInNotebook.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, ForbiddenTraceUIInNotebook) for v in violations)
     assert violations[0].cell == 2

--- a/dev/clint/tests/rules/test_implicit_optional.py
+++ b/dev/clint/tests/rules/test_implicit_optional.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules import ImplicitOptional
 
 
-def test_implicit_optional(index: SymbolIndex, tmp_path: Path) -> None:
+def test_implicit_optional(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -24,7 +23,7 @@ class Good:
 """
     )
     config = Config(select={ImplicitOptional.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 2
     assert all(isinstance(r.rule, ImplicitOptional) for r in results)
     assert results[0].loc == Location(4, 5)

--- a/dev/clint/tests/rules/test_incorrect_type_annotation.py
+++ b/dev/clint/tests/rules/test_incorrect_type_annotation.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.incorrect_type_annotation import IncorrectTypeAnnotation
 
 
-def test_incorrect_type_annotation(index: SymbolIndex, tmp_path: Path) -> None:
+def test_incorrect_type_annotation(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -22,7 +21,7 @@ def good_function(param: Callable[[str], str]) -> Any:
     )
 
     config = Config(select={IncorrectTypeAnnotation.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 4
     assert all(isinstance(v.rule, IncorrectTypeAnnotation) for v in violations)
     assert violations[0].loc == Location(1, 33)  # callable

--- a/dev/clint/tests/rules/test_invalid_abstract_method.py
+++ b/dev/clint/tests/rules/test_invalid_abstract_method.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.invalid_abstract_method import InvalidAbstractMethod
 
 
-def test_invalid_abstract_method(index: SymbolIndex, tmp_path: Path) -> None:
+def test_invalid_abstract_method(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -37,7 +36,7 @@ class AbstractExample(abc.ABC):
     )
 
     config = Config(select={InvalidAbstractMethod.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 2
     assert all(isinstance(v.rule, InvalidAbstractMethod) for v in violations)
     assert violations[0].loc == Location(5, 4)

--- a/dev/clint/tests/rules/test_invalid_experimental_decorator.py
+++ b/dev/clint/tests/rules/test_invalid_experimental_decorator.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.invalid_experimental_decorator import InvalidExperimentalDecorator
 
 
-def test_invalid_experimental_decorator(index: SymbolIndex, tmp_path: Path) -> None:
+def test_invalid_experimental_decorator(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -50,7 +49,7 @@ def good_function2():
     )
 
     config = Config(select={InvalidExperimentalDecorator.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 5
     assert all(isinstance(v.rule, InvalidExperimentalDecorator) for v in violations)
     assert violations[0].loc == Location(4, 1)  # @experimental without args

--- a/dev/clint/tests/rules/test_lazy_builtin_import.py
+++ b/dev/clint/tests/rules/test_lazy_builtin_import.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules import LazyBuiltinImport
 
 
-def test_lazy_builtin_import(index: SymbolIndex, tmp_path: Path) -> None:
+def test_lazy_builtin_import(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -20,7 +19,7 @@ import os
 """
     )
     config = Config(select={LazyBuiltinImport.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 1
     assert isinstance(results[0].rule, LazyBuiltinImport)
     assert results[0].loc == Location(3, 4)

--- a/dev/clint/tests/rules/test_lazy_module.py
+++ b/dev/clint/tests/rules/test_lazy_module.py
@@ -2,12 +2,11 @@ from pathlib import Path
 
 import pytest
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.lazy_module import LazyModule
 
 
-def test_lazy_module(index: SymbolIndex, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_lazy_module(index_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Create a file that looks like mlflow/__init__.py for the rule to apply
 
     monkeypatch.chdir(tmp_path)
@@ -29,7 +28,7 @@ if TYPE_CHECKING:
 """
     )
     config = Config(select={LazyModule.name})
-    violations = lint_file(tmp_file.relative_to(tmp_path), config, index)
+    violations = lint_file(tmp_file.relative_to(tmp_path), config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, LazyModule) for v in violations)
     assert violations[0].loc == Location(5, 12)  # anthropic LazyLoader

--- a/dev/clint/tests/rules/test_log_model_artifact_path.py
+++ b/dev/clint/tests/rules/test_log_model_artifact_path.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.log_model_artifact_path import LogModelArtifactPath
 
 
-def test_log_model_artifact_path(index: SymbolIndex, tmp_path: Path) -> None:
+def test_log_model_artifact_path(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -30,7 +29,7 @@ mlflow.pytorch.log_model(model, artifact_path="pytorch_model")
     )
 
     config = Config(select={LogModelArtifactPath.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 3
     assert all(isinstance(v.rule, LogModelArtifactPath) for v in violations)
     assert violations[0].loc == Location(4, 0)

--- a/dev/clint/tests/rules/test_markdown_link.py
+++ b/dev/clint/tests/rules/test_markdown_link.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.markdown_link import MarkdownLink
 
 
-def test_markdown_link(index: SymbolIndex, tmp_path: Path) -> None:
+def test_markdown_link(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -35,7 +34,7 @@ def function_with_rest_link():
     )
 
     config = Config(select={MarkdownLink.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 3
     assert all(isinstance(v.rule, MarkdownLink) for v in violations)
     assert violations[0].loc == Location(3, 4)

--- a/dev/clint/tests/rules/test_missing_docstring_param.py
+++ b/dev/clint/tests/rules/test_missing_docstring_param.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.missing_docstring_param import MissingDocstringParam
 
 
-def test_missing_docstring_param(index: SymbolIndex, tmp_path: Path) -> None:
+def test_missing_docstring_param(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -30,7 +29,7 @@ def good_function(param1: str, param2: int) -> None:
     )
 
     config = Config(select={MissingDocstringParam.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, MissingDocstringParam) for v in violations)
     assert violations[0].loc == Location(1, 0)

--- a/dev/clint/tests/rules/test_missing_notebook_h1_header.py
+++ b/dev/clint/tests/rules/test_missing_notebook_h1_header.py
@@ -2,12 +2,11 @@ import json
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import lint_file
 from clint.rules import MissingNotebookH1Header
 
 
-def test_missing_notebook_h1_header(index: SymbolIndex, tmp_path: Path) -> None:
+def test_missing_notebook_h1_header(index_path: Path, tmp_path: Path) -> None:
     notebook = {
         "cells": [
             {
@@ -23,12 +22,12 @@ def test_missing_notebook_h1_header(index: SymbolIndex, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.ipynb"
     tmp_file.write_text(json.dumps(notebook))
     config = Config(select={MissingNotebookH1Header.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 1
     assert isinstance(results[0].rule, MissingNotebookH1Header)
 
 
-def test_missing_notebook_h1_header_positive(index: SymbolIndex, tmp_path: Path) -> None:
+def test_missing_notebook_h1_header_positive(index_path: Path, tmp_path: Path) -> None:
     notebook = {
         "cells": [
             {
@@ -44,5 +43,5 @@ def test_missing_notebook_h1_header_positive(index: SymbolIndex, tmp_path: Path)
     tmp_file = tmp_path / "test_positive.ipynb"
     tmp_file.write_text(json.dumps(notebook))
     config = Config(select={MissingNotebookH1Header.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 0

--- a/dev/clint/tests/rules/test_mlflow_class_name.py
+++ b/dev/clint/tests/rules/test_mlflow_class_name.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.mlflow_class_name import MlflowClassName
 
 
-def test_mlflow_class_name(index: SymbolIndex, tmp_path: Path) -> None:
+def test_mlflow_class_name(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -37,7 +36,7 @@ class DataHandler:
     )
 
     config = Config(select={MlflowClassName.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 4
     assert all(isinstance(v.rule, MlflowClassName) for v in violations)
     assert violations[0].loc == Location(2, 0)  # MLflowClient

--- a/dev/clint/tests/rules/test_multi_assign.py
+++ b/dev/clint/tests/rules/test_multi_assign.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules import MultiAssign
 
 
-def test_multi_assign(index: SymbolIndex, tmp_path: Path) -> None:
+def test_multi_assign(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -18,7 +17,7 @@ a, b = func()
 """
     )
     config = Config(select={MultiAssign.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 1
     assert all(isinstance(r.rule, MultiAssign) for r in results)
     assert results[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_no_rst.py
+++ b/dev/clint/tests/rules/test_no_rst.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.no_rst import NoRst
 
 
-def test_no_rst(index: SymbolIndex, tmp_path: Path) -> None:
+def test_no_rst(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -29,7 +28,7 @@ def good(x: int) -> str:
     )
 
     config = Config(select={NoRst.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, NoRst) for v in violations)
     assert violations[0].loc == Location(2, 4)

--- a/dev/clint/tests/rules/test_os_environ_delete_in_test.py
+++ b/dev/clint/tests/rules/test_os_environ_delete_in_test.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.os_environ_delete_in_test import OsEnvironDeleteInTest
 
 
-def test_os_environ_delete_in_test(index: SymbolIndex, tmp_path: Path) -> None:
+def test_os_environ_delete_in_test(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test_env.py"
     tmp_file.write_text(
         """
@@ -22,7 +21,7 @@ def test_something():
     )
 
     config = Config(select={OsEnvironDeleteInTest.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, OsEnvironDeleteInTest) for v in violations)
     assert violations[0].loc == Location(5, 4)

--- a/dev/clint/tests/rules/test_os_environ_set_in_test.py
+++ b/dev/clint/tests/rules/test_os_environ_set_in_test.py
@@ -2,13 +2,12 @@ from pathlib import Path
 
 import pytest
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.os_environ_set_in_test import OsEnvironSetInTest
 
 
 def test_os_environ_set_in_test(
-    index: SymbolIndex, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    index_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
     tmp_file = tmp_path / "test_file.py"
@@ -26,7 +25,7 @@ def non_test_func():
 """
     )
     config = Config(select={OsEnvironSetInTest.name})
-    violations = lint_file(tmp_file.relative_to(tmp_path), config, index)
+    violations = lint_file(tmp_file.relative_to(tmp_path), config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, OsEnvironSetInTest) for v in violations)
     assert violations[0].loc == Location(5, 4)

--- a/dev/clint/tests/rules/test_pytest_mark_repeat.py
+++ b/dev/clint/tests/rules/test_pytest_mark_repeat.py
@@ -2,13 +2,12 @@ from pathlib import Path
 
 import pytest
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.pytest_mark_repeat import PytestMarkRepeat
 
 
 def test_pytest_mark_repeat(
-    index: SymbolIndex, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    index_path: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     monkeypatch.chdir(tmp_path)
     tmp_file = tmp_path / "test_pytest_mark_repeat.py"
@@ -22,7 +21,7 @@ def test_flaky_function():
 """
     )
     config = Config(select={PytestMarkRepeat.name})
-    violations = lint_file(tmp_file.relative_to(tmp_path), config, index)
+    violations = lint_file(tmp_file.relative_to(tmp_path), config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, PytestMarkRepeat) for v in violations)
     assert violations[0].loc == Location(3, 1)

--- a/dev/clint/tests/rules/test_test_name_typo.py
+++ b/dev/clint/tests/rules/test_test_name_typo.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.test_name_typo import TestNameTypo
 
 
-def test_test_name_typo(index: SymbolIndex, tmp_path: Path) -> None:
+def test_test_name_typo(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test_something.py"
     tmp_file.write_text(
         """import pytest
@@ -34,7 +33,7 @@ def tset_something():
     )
 
     config = Config(select={TestNameTypo.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 2
     assert all(isinstance(v.rule, TestNameTypo) for v in violations)
     assert violations[0].loc == Location(3, 0)

--- a/dev/clint/tests/rules/test_thread_pool_executor_without_thread_name_prefix.py
+++ b/dev/clint/tests/rules/test_thread_pool_executor_without_thread_name_prefix.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules import ThreadPoolExecutorWithoutThreadNamePrefix
 
 
-def test_thread_pool_executor(index: SymbolIndex, tmp_path: Path) -> None:
+def test_thread_pool_executor(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -20,7 +19,7 @@ ThreadPoolExecutor(thread_name_prefix="worker")
 """
     )
     config = Config(select={ThreadPoolExecutorWithoutThreadNamePrefix.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 1
     assert isinstance(results[0].rule, ThreadPoolExecutorWithoutThreadNamePrefix)
     assert results[0].loc == Location(4, 0)

--- a/dev/clint/tests/rules/test_typing_extensions.py
+++ b/dev/clint/tests/rules/test_typing_extensions.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.typing_extensions import TypingExtensions
 
 
-def test_typing_extensions(index: SymbolIndex, tmp_path: Path) -> None:
+def test_typing_extensions(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -21,7 +20,7 @@ from typing_extensions import Self
     config = Config(
         select={TypingExtensions.name}, typing_extensions_allowlist=["typing_extensions.Self"]
     )
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, TypingExtensions) for v in violations)
     assert violations[0].loc == Location(2, 0)

--- a/dev/clint/tests/rules/test_unknown_mlflow_arguments.py
+++ b/dev/clint/tests/rules/test_unknown_mlflow_arguments.py
@@ -2,12 +2,11 @@ from pathlib import Path
 
 import pytest
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.unknown_mlflow_arguments import UnknownMlflowArguments
 
 
-def test_unknown_mlflow_arguments(index: SymbolIndex, tmp_path: Path) -> None:
+def test_unknown_mlflow_arguments(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -35,14 +34,14 @@ def good():
         select={UnknownMlflowArguments.name},
         example_rules=[UnknownMlflowArguments.name],
     )
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, UnknownMlflowArguments) for v in violations)
     assert violations[0].loc == Location(7, 8)
 
 
 @pytest.mark.parametrize("suffix", [".md", ".mdx"])
-def test_unknown_mlflow_arguments_markdown(index: SymbolIndex, tmp_path: Path, suffix: str) -> None:
+def test_unknown_mlflow_arguments_markdown(index_path: Path, tmp_path: Path, suffix: str) -> None:
     tmp_file = (tmp_path / "test").with_suffix(suffix)
     tmp_file.write_text(
         """
@@ -67,7 +66,7 @@ mlflow.log_param(key="k", value="v")
         select={UnknownMlflowArguments.name},
         example_rules=[UnknownMlflowArguments.name],
     )
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, UnknownMlflowArguments) for v in violations)
     assert violations[0].loc == Location(6, 0)

--- a/dev/clint/tests/rules/test_unknown_mlflow_function.py
+++ b/dev/clint/tests/rules/test_unknown_mlflow_function.py
@@ -2,12 +2,11 @@ from pathlib import Path
 
 import pytest
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.unknown_mlflow_function import UnknownMlflowFunction
 
 
-def test_unknown_mlflow_function(index: SymbolIndex, tmp_path: Path) -> None:
+def test_unknown_mlflow_function(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         '''
@@ -35,14 +34,14 @@ def good():
 '''
     )
     config = Config(select={UnknownMlflowFunction.name}, example_rules=[UnknownMlflowFunction.name])
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, UnknownMlflowFunction) for v in violations)
     assert violations[0].loc == Location(7, 8)
 
 
 @pytest.mark.parametrize("suffix", [".md", ".mdx"])
-def test_unknown_mlflow_function_markdown(index: SymbolIndex, tmp_path: Path, suffix: str) -> None:
+def test_unknown_mlflow_function_markdown(index_path: Path, tmp_path: Path, suffix: str) -> None:
     tmp_file = (tmp_path / "test").with_suffix(suffix)
     tmp_file.write_text(
         """
@@ -68,7 +67,7 @@ mlflow.log_param("k", "v")
         select={UnknownMlflowFunction.name},
         example_rules=[UnknownMlflowFunction.name],
     )
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 1
     assert all(isinstance(v.rule, UnknownMlflowFunction) for v in violations)
     assert violations[0].loc == Location(6, 0)

--- a/dev/clint/tests/rules/test_unnamed_thread.py
+++ b/dev/clint/tests/rules/test_unnamed_thread.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules import UnnamedThread
 
 
-def test_unnamed_thread(index: SymbolIndex, tmp_path: Path) -> None:
+def test_unnamed_thread(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -20,7 +19,7 @@ threading.Thread(target=lambda: None)
 """
     )
     config = Config(select={UnnamedThread.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 1
     assert isinstance(results[0].rule, UnnamedThread)
     assert results[0].loc == Location(4, 0)

--- a/dev/clint/tests/rules/test_unparameterized_generic_type.py
+++ b/dev/clint/tests/rules/test_unparameterized_generic_type.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules.unparameterized_generic_type import UnparameterizedGenericType
 
 
-def test_unparameterized_generic_type(index: SymbolIndex, tmp_path: Path) -> None:
+def test_unparameterized_generic_type(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -29,7 +28,7 @@ def good_dict() -> dict[str, int]:
     )
 
     config = Config(select={UnparameterizedGenericType.name})
-    violations = lint_file(tmp_file, config, index)
+    violations = lint_file(tmp_file, config, index_path)
     assert len(violations) == 2
     assert all(isinstance(v.rule, UnparameterizedGenericType) for v in violations)
     assert violations[0].loc == Location(4, 18)  # bad_list return type

--- a/dev/clint/tests/rules/test_use_sys_executable.py
+++ b/dev/clint/tests/rules/test_use_sys_executable.py
@@ -1,12 +1,11 @@
 from pathlib import Path
 
 from clint.config import Config
-from clint.index import SymbolIndex
 from clint.linter import Location, lint_file
 from clint.rules import UseSysExecutable
 
 
-def test_use_sys_executable(index: SymbolIndex, tmp_path: Path) -> None:
+def test_use_sys_executable(index_path: Path, tmp_path: Path) -> None:
     tmp_file = tmp_path / "test.py"
     tmp_file.write_text(
         """
@@ -23,7 +22,7 @@ subprocess.check_call([sys.executable, "-m", "mlflow", "ui"])
 """
     )
     config = Config(select={UseSysExecutable.name})
-    results = lint_file(tmp_file, config, index)
+    results = lint_file(tmp_file, config, index_path)
     assert len(results) == 2
     assert all(isinstance(r.rule, UseSysExecutable) for r in results)
     assert results[0].loc == Location(5, 0)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR optimizes the performance of the clint linter by eliminating expensive serialization overhead when passing the SymbolIndex to worker processes:

- **Replace direct object passing with file-based approach**: Instead of passing the large SymbolIndex object directly to worker processes (which requires expensive pickling for each worker), we now pickle it once to a temporary file and pass the file path
- **Add SymbolIndex serialization methods**: Added `save()` and `load()` methods with proper Path type hints for efficient file-based persistence
- **Use TemporaryDirectory for better resource management**: Use `tempfile.TemporaryDirectory` for automatic cleanup instead of manual file management
- **Update lint_file signature**: Modified to accept `index_path` parameter and load the index from disk in each worker process

**Performance Impact**: This change significantly improves performance when linting multiple files in parallel by avoiding repeated serialization of the large SymbolIndex object (containing ~4,915 import mappings and ~2,768 function mappings totaling ~775KB) across worker processes.

### Performance Benchmarks

Tested with `pre-commit run clint --all-files` on the entire MLflow codebase (~1,625 Python files):

| Branch        | Total Time | Improvement         |
| ------------- | ---------- | ------------------- |
| **Master**    | 9.237s     | -                   |
| **Optimized** | 5.000s     | **🔥 45.9% faster** |

The optimization delivers a **45.9% speed improvement** (4.2 seconds faster) with better CPU utilization, indicating much more efficient parallelization.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests  
- [x] Manual tests

Manually tested with `python3 -m dev.clint.src.clint mlflow/tracking/client.py` and comprehensive performance benchmarking with `pre-commit run clint --all-files` to verify functionality and performance improvements.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- This is an internal performance optimization for the clint linter, not user-facing -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)