### PR TITLE
Fix model_validator

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -1,4 +1,4 @@
-from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER, model_validator
+from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER
 
 if not IS_PYDANTIC_V2_OR_NEWER:
     raise ImportError(
@@ -8,7 +8,7 @@ if not IS_PYDANTIC_V2_OR_NEWER:
 import json
 from typing import Any, Optional, Union
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 
 from mlflow.types.agent import ChatContext
 from mlflow.types.chat import BaseModel

--- a/mlflow/types/responses_helpers.py
+++ b/mlflow/types/responses_helpers.py
@@ -1,4 +1,4 @@
-from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER, model_validator
+from mlflow.utils.pydantic_utils import IS_PYDANTIC_V2_OR_NEWER
 
 if not IS_PYDANTIC_V2_OR_NEWER:
     raise ImportError(
@@ -9,7 +9,7 @@ if not IS_PYDANTIC_V2_OR_NEWER:
 import warnings
 from typing import Any, Optional, Union
 
-from pydantic import ConfigDict
+from pydantic import ConfigDict, model_validator
 
 from mlflow.types.chat import BaseModel
 

--- a/mlflow/utils/pydantic_utils.py
+++ b/mlflow/utils/pydantic_utils.py
@@ -22,15 +22,30 @@ def field_validator(field: str, mode: str = "before"):
 
 
 def model_validator(mode: str, skip_on_failure: bool = False):
-    """A wrapper for Pydantic model validator that is compatible with Pydantic v1 and v2.
+    """
+    A wrapper for Pydantic model validator that is compatible with Pydantic v1 and v2.
     Note that the `skip_on_failure` argument is only available in Pydantic v1.
+
+    To use this decorator, the function must be of below signature:
+    def func(cls, values: Any) -> Any:
+        ...
+    where `cls` is the Pydantic model class and `values` is the dictionary of values.
+
+    For Pydantic v2 BaseModel, import `model_validator` from pydantic directly.
     """
 
     def decorator(func: Callable[..., Any]) -> Callable[..., Any]:
         if IS_PYDANTIC_V2_OR_NEWER:
             from pydantic import model_validator as pydantic_model_validator
 
-            return pydantic_model_validator(mode=mode)(func)
+            if mode == "after":
+
+                def wrapper(self):
+                    return func(type(self), self)
+
+                return pydantic_model_validator(mode=mode)(wrapper)
+            else:
+                return pydantic_model_validator(mode=mode)(func)
         else:
             from pydantic import root_validator
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/17026?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17026/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17026/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17026/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
@model_validator for pydantic v2 requires the function signature to be like:
```
def func(self) -> Self:
    ...
```
However, to preserve the compatibility between pydantic v1 and v2, we added this model_validator decorator. It worked fine on `def func(cls, values)` function signature, but the latest 2.12.0a1 release made a breaking change and this kind of signature is no longer supported (https://github.com/pydantic/pydantic/issues/12110)
This PR fixes the issue by wrapper the internal function.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
