### PR TITLE
Persist Model Metadata for Register Model with env_pack 

### DIFF
--- a/mlflow/utils/env_pack.py
+++ b/mlflow/utils/env_pack.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import shutil
 import subprocess
 import sys
@@ -5,7 +7,7 @@ import tarfile
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Literal
+from typing import Any, Generator, Literal
 
 import yaml
 
@@ -20,6 +22,7 @@ EnvPackType = Literal["databricks_model_serving"]
 _ARTIFACT_PATH = "_databricks"
 _MODEL_VERSION_TAR = "model_version.tar"
 _MODEL_ENVIRONMENT_TAR = "model_environment.tar"
+_METADATA_DIR = "metadata"
 
 
 def _tar(root_path: Path, tar_path: Path) -> tarfile.TarFile:
@@ -39,6 +42,53 @@ def _tar(root_path: Path, tar_path: Path) -> tarfile.TarFile:
     with tarfile.open(tar_path, "w", dereference=True) as tar:
         tar.add(root_path, arcname=".", filter=exclude)
     return tar
+
+
+def _calculate_file_metadata(file_path: Path) -> dict[str, Any]:
+    """Calculate hash and content length for a file.
+
+    Args:
+        file_path: Path to the file.
+
+    Returns:
+        Dictionary containing hash and content_length.
+    """
+    sha256 = hashlib.sha256()
+    content_length = 0
+
+    with open(file_path, "rb") as f:
+        while chunk := f.read(8192):
+            sha256.update(chunk)
+            content_length += len(chunk)
+
+    return {"hash": sha256.hexdigest(), "content_length": content_length}
+
+
+def _store_tar_metadata(local_artifacts_dir: Path, tar_files: dict[str, Path]) -> None:
+    """Calculate and store metadata for tar files.
+
+    Args:
+        local_artifacts_dir: Path to the model artifacts directory.
+        tar_files: Dictionary mapping tar file names to their paths.
+    """
+    # Use existing metadata directory if it exists, otherwise create it
+    metadata_dir = local_artifacts_dir / _METADATA_DIR
+    metadata_dir.mkdir(exist_ok=True)
+
+    metadata = {}
+
+    # Calculate metadata for each tar file
+    for name, tar_path in tar_files.items():
+        if tar_path.exists():
+            if name == _MODEL_VERSION_TAR:
+                metadata["model_version"] = _calculate_file_metadata(tar_path)
+            elif name == _MODEL_ENVIRONMENT_TAR:
+                metadata["model_environment"] = _calculate_file_metadata(tar_path)
+
+    # Store metadata as JSON file
+    metadata_file = metadata_dir / "artifact_metadata.json"
+    with open(metadata_file, "w") as f:
+        json.dump(metadata, f, indent=2)
 
 
 # TODO: Check pip requirements using uv instead.
@@ -124,8 +174,21 @@ def pack_env_for_databricks_model_serving(
         # Package model artifacts and env into temp_dir/_databricks
         temp_artifacts_dir = Path(temp_dir) / _ARTIFACT_PATH
         temp_artifacts_dir.mkdir(exist_ok=False)
-        _tar(local_artifacts_dir, temp_artifacts_dir / _MODEL_VERSION_TAR)
-        _tar(Path(sys.prefix), temp_artifacts_dir / _MODEL_ENVIRONMENT_TAR)
+
+        # Create tar files
+        model_version_tar_path = temp_artifacts_dir / _MODEL_VERSION_TAR
+        model_environment_tar_path = temp_artifacts_dir / _MODEL_ENVIRONMENT_TAR
+        _tar(local_artifacts_dir, model_version_tar_path)
+        _tar(Path(sys.prefix), model_environment_tar_path)
+
+        # Calculate and store metadata for the tar files
+        tar_files = {
+            _MODEL_VERSION_TAR: model_version_tar_path,
+            _MODEL_ENVIRONMENT_TAR: model_environment_tar_path,
+        }
+        _store_tar_metadata(local_artifacts_dir, tar_files)
+
+        # Move the _databricks directory to the final location
         shutil.move(str(temp_artifacts_dir), local_artifacts_dir)
 
         yield str(local_artifacts_dir)

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -1,3 +1,5 @@
+import hashlib
+import json
 import subprocess
 import sys
 import tarfile
@@ -112,6 +114,16 @@ def test_pack_env_for_databricks_model_serving_pip_requirements(tmp_path, mock_d
                     )
 
                 assert expected_pip_path in member_names
+
+            # Verify metadata was created
+            metadata_file = artifacts_path / env_pack._METADATA_DIR / "artifact_metadata.json"
+            assert metadata_file.exists()
+
+            with open(metadata_file) as f:
+                metadata = json.load(f)
+
+            assert "model_version" in metadata
+            assert "model_environment" in metadata
 
             # Verify subprocess.run was called with correct arguments
             mock_run.assert_called_once()
@@ -271,3 +283,99 @@ def test_pack_env_for_databricks_model_serving_missing_runtime_version(tmp_path,
         ):
             with env_pack.pack_env_for_databricks_model_serving("models:/test-model/1"):
                 pass
+
+
+def test_store_tar_metadata(tmp_path):
+    """Test that _store_tar_metadata correctly calculates and stores metadata for tar files."""
+    # Create artifacts directory and mock tar files
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+
+    model_version_content = b"mock model version content"
+    model_environment_content = b"Hola!"
+
+    model_version_tar = tmp_path / "model_version.tar"
+    model_environment_tar = tmp_path / "model_environment.tar"
+
+    model_version_tar.write_bytes(model_version_content)
+    model_environment_tar.write_bytes(model_environment_content)
+
+    tar_files = {
+        env_pack._MODEL_VERSION_TAR: model_version_tar,
+        env_pack._MODEL_ENVIRONMENT_TAR: model_environment_tar,
+    }
+
+    env_pack._store_tar_metadata(artifacts_dir, tar_files)
+
+    # Verify metadata directory and file creation
+    metadata_dir = artifacts_dir / env_pack._METADATA_DIR
+    assert metadata_dir.exists()
+
+    metadata_file = metadata_dir / "artifact_metadata.json"
+    assert metadata_file.exists()
+
+    # Load and verify metadata content structure
+    with open(metadata_file) as f:
+        metadata = json.load(f)
+
+    assert "model_version" in metadata
+    assert "model_environment" in metadata
+
+    # Verify model_version metadata
+    model_version_meta = metadata["model_version"]
+    assert "hash" in model_version_meta
+    assert "content_length" in model_version_meta
+    assert model_version_meta["hash"] == hashlib.sha256(model_version_content).hexdigest()
+    assert model_version_meta["content_length"] == len(model_version_content)
+
+    # Verify model_environment metadata
+    model_environment_meta = metadata["model_environment"]
+    assert "hash" in model_environment_meta
+    assert "content_length" in model_environment_meta
+    assert model_environment_meta["hash"] == hashlib.sha256(model_environment_content).hexdigest()
+    assert model_environment_meta["content_length"] == len(model_environment_content)
+
+    # Verify different content produces different hashes
+    assert model_version_meta["hash"] != model_environment_meta["hash"]
+
+
+def test_calculate_file_metadata_empty_file(tmp_path):
+    """Test _calculate_file_metadata with an empty file."""
+    empty_file = tmp_path / "empty.txt"
+    empty_file.write_bytes(b"")
+
+    metadata = env_pack._calculate_file_metadata(empty_file)
+
+    assert metadata["content_length"] == 0
+    assert metadata["hash"] == hashlib.sha256().hexdigest()
+
+
+def test_store_tar_metadata_missing_files(tmp_path):
+    """Test that _store_tar_metadata handles missing tar files gracefully."""
+    artifacts_dir = tmp_path / "artifacts"
+    artifacts_dir.mkdir()
+
+    # Create only one of the two expected tar files
+    existing_tar = tmp_path / "model_version.tar"
+    missing_tar = tmp_path / "model_environment.tar"
+
+    existing_tar.write_bytes(b"existing content")
+
+    tar_files = {
+        env_pack._MODEL_VERSION_TAR: existing_tar,
+        env_pack._MODEL_ENVIRONMENT_TAR: missing_tar,
+    }
+
+    # Should not raise an error even with missing files
+    env_pack._store_tar_metadata(artifacts_dir, tar_files)
+
+    # Verify metadata was created for existing file only
+    metadata_file = artifacts_dir / env_pack._METADATA_DIR / "artifact_metadata.json"
+    assert metadata_file.exists()
+
+    with open(metadata_file) as f:
+        metadata = json.load(f)
+
+    # Should only contain metadata for the existing file
+    assert "model_version" in metadata
+    assert "model_environment" not in metadata


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bhavik-soni/mlflow/pull/17045?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17045/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17045/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17045/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- In order to create a Unity Catalog backed manifest, we must include layer metadata as part of the manifest. This must be pre-calculated when the model is registered and stored as metadata beside the tars.
- This PR stores the necessary information in `.../metadata/artifact_metadata.json`

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
