### PR TITLE
Disable eslint `no-nonnull-assertion` in tests

### DIFF
--- a/mlflow/server/js/.eslintrc.js
+++ b/mlflow/server/js/.eslintrc.js
@@ -622,7 +622,7 @@ module.exports = {
       },
     },
     {
-      files: ['*.test.js', '*-test.js', '*-test.jsx', 'test/**'],
+      files: ['*.test.js', '*-test.js', '*-test.jsx', '*.test.ts', '*-test.ts', '*.test.tsx', '*-test.tsx', 'test/**'],
       plugins: ['jest', 'chai-expect', 'chai-friendly'],
       globals: {
         sinon: true,
@@ -639,6 +639,7 @@ module.exports = {
         'testing-library/no-debugging-utils': 'error',
         'testing-library/no-dom-import': 'error',
         'testing-library/await-async-utils': 'error',
+        '@typescript-eslint/no-non-null-assertion': 'off',
       },
     },
     {

--- a/mlflow/server/js/.eslintrc.js
+++ b/mlflow/server/js/.eslintrc.js
@@ -623,7 +623,7 @@ module.exports = {
     },
     {
       files: ['*.test.js', '*-test.js', '*-test.jsx', '*.test.ts', '*-test.ts', '*.test.tsx', '*-test.tsx', 'test/**'],
-      plugins: ['jest', 'chai-expect', 'chai-friendly'],
+      plugins: ['jest', 'chai-expect', 'chai-friendly', 'testing-library'],
       globals: {
         sinon: true,
         chai: true,

--- a/mlflow/server/js/src/common/components/error-boundaries/SectionErrorBoundary.test.tsx
+++ b/mlflow/server/js/src/common/components/error-boundaries/SectionErrorBoundary.test.tsx
@@ -48,6 +48,6 @@ describe('SectionErrorBoundary', () => {
       </SectionErrorBoundary>,
     );
 
-    expect(screen.getByText(/error message: some error message/i));
+    expect(screen.getByText(/error message: some error message/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/17048?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17048/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17048/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17048/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Frequently we want to mock items for certain nullable types, and it's annoying to have to specify a null coalesce / typecast. I think it's fine to disable this rule for tests

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manually ensured rule does not run

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
