### PR TITLE
Add `remote_name` parameter to git versioning for repository URL extraction

### DIFF
--- a/mlflow/genai/git_versioning/__init__.py
+++ b/mlflow/genai/git_versioning/__init__.py
@@ -12,9 +12,9 @@ _logger = logging.getLogger(__name__)
 
 
 class GitContext:
-    def __init__(self) -> None:
+    def __init__(self, remote_name: str = "origin") -> None:
         try:
-            self.info = GitInfo.from_env()
+            self.info = GitInfo.from_env(remote_name=remote_name)
         except GitOperationError as e:
             warnings.warn(
                 (
@@ -63,12 +63,18 @@ _active_context: GitContext | None = None
 
 
 @experimental(version="3.3.0")
-def enable_git_model_versioning() -> GitContext:
+def enable_git_model_versioning(remote_name: str = "origin") -> GitContext:
     """
     Enable git model versioning and set the active context.
+
+    Args:
+        remote_name: The name of the git remote to use. Defaults to "origin".
+
+    Returns:
+        A GitContext instance containing the git information and active model.
     """
     global _active_context
-    context = GitContext()
+    context = GitContext(remote_name=remote_name)
     _active_context = context
     return context
 

--- a/mlflow/genai/git_versioning/git_info.py
+++ b/mlflow/genai/git_versioning/git_info.py
@@ -19,7 +19,7 @@ class GitInfo:
     branch: str
     commit: str
     dirty: bool = False
-    repo: str | None = None
+    repo_url: str | None = None
 
     @classmethod
     def from_env(cls, remote_name: str) -> Self:
@@ -48,7 +48,7 @@ class GitInfo:
             dirty = repo.is_dirty(untracked_files=False)
             # Get repository URL
             repo_url = next((r.url for r in repo.remotes if r.name == remote_name), None)
-            return cls(branch=branch, commit=commit, dirty=dirty, repo=repo_url)
+            return cls(branch=branch, commit=commit, dirty=dirty, repo_url=repo_url)
 
         except git.GitError as e:
             raise GitOperationError(f"Failed to get repository information: {e}") from e
@@ -59,6 +59,6 @@ class GitInfo:
             MLFLOW_GIT_COMMIT: self.commit,
             MLFLOW_GIT_DIRTY: str(self.dirty).lower(),
         }
-        if self.repo is not None:
-            tags[MLFLOW_GIT_REPO_URL] = self.repo
+        if self.repo_url is not None:
+            tags[MLFLOW_GIT_REPO_URL] = self.repo_url
         return tags

--- a/mlflow/genai/git_versioning/git_info.py
+++ b/mlflow/genai/git_versioning/git_info.py
@@ -6,6 +6,7 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_GIT_BRANCH,
     MLFLOW_GIT_COMMIT,
     MLFLOW_GIT_DIRTY,
+    MLFLOW_GIT_REPO_URL,
 )
 
 
@@ -18,9 +19,10 @@ class GitInfo:
     branch: str
     commit: str
     dirty: bool = False
+    repo: str | None = None
 
     @classmethod
-    def from_env(cls) -> Self:
+    def from_env(cls, remote_name: str) -> Self:
         try:
             import git
         except ImportError as e:
@@ -44,15 +46,19 @@ class GitInfo:
 
             # Check if repo is dirty
             dirty = repo.is_dirty(untracked_files=False)
-
-            return cls(branch=branch, commit=commit, dirty=dirty)
+            # Get repository URL
+            repo_url = next((r.url for r in repo.remotes if r.name == remote_name), None)
+            return cls(branch=branch, commit=commit, dirty=dirty, repo=repo_url)
 
         except git.GitError as e:
             raise GitOperationError(f"Failed to get repository information: {e}") from e
 
     def to_mlflow_tags(self) -> dict[str, str]:
-        return {
+        tags = {
             MLFLOW_GIT_BRANCH: self.branch,
             MLFLOW_GIT_COMMIT: self.commit,
             MLFLOW_GIT_DIRTY: str(self.dirty).lower(),
         }
+        if self.repo is not None:
+            tags[MLFLOW_GIT_REPO_URL] = self.repo
+        return tags

--- a/mlflow/genai/git_versioning/git_info.py
+++ b/mlflow/genai/git_versioning/git_info.py
@@ -1,3 +1,4 @@
+import logging
 from dataclasses import dataclass
 
 from typing_extensions import Self
@@ -8,6 +9,8 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_GIT_DIRTY,
     MLFLOW_GIT_REPO_URL,
 )
+
+_logger = logging.getLogger(__name__)
 
 
 class GitOperationError(Exception):
@@ -48,6 +51,10 @@ class GitInfo:
             dirty = repo.is_dirty(untracked_files=False)
             # Get repository URL
             repo_url = next((r.url for r in repo.remotes if r.name == remote_name), None)
+            if repo_url is None:
+                _logger.warning(
+                    f"No remote named '{remote_name}' found. Repository URL will not be set."
+                )
             return cls(branch=branch, commit=commit, dirty=dirty, repo_url=repo_url)
 
         except git.GitError as e:

--- a/tests/genai/test_git_versioning.py
+++ b/tests/genai/test_git_versioning.py
@@ -166,3 +166,31 @@ def test_enable_git_model_versioning_ignores_untracked_files(tmp_git_repo: Path)
         assert len(models) == 1
         assert models[0].model_id == initial_model_id
     assert mlflow.get_active_model_id() is None
+
+
+def test_enable_git_model_versioning_default_remote_name(tmp_git_repo: Path):
+    subprocess.check_call(
+        ["git", "remote", "add", "origin", "https://github.com/test/repo.git"], cwd=tmp_git_repo
+    )
+    context = enable_git_model_versioning()
+    assert context.info.repo == "https://github.com/test/repo.git"
+
+
+def test_enable_git_model_versioning_custom_remote_name(tmp_git_repo: Path):
+    # Add multiple remotes
+    subprocess.check_call(
+        ["git", "remote", "add", "origin", "https://github.com/test/repo.git"],
+        cwd=tmp_git_repo,
+    )
+    subprocess.check_call(
+        ["git", "remote", "add", "upstream", "https://github.com/upstream/repo.git"],
+        cwd=tmp_git_repo,
+    )
+    context = enable_git_model_versioning(remote_name="upstream")
+    assert context.info.repo == "https://github.com/upstream/repo.git"
+
+
+def test_enable_git_model_versioning_nonexistent_remote(tmp_git_repo: Path):
+    # No remotes added - repo should be None
+    context = enable_git_model_versioning(remote_name="nonexistent")
+    assert context.info.repo is None

--- a/tests/genai/test_git_versioning.py
+++ b/tests/genai/test_git_versioning.py
@@ -190,7 +190,7 @@ def test_enable_git_model_versioning_custom_remote_name(tmp_git_repo: Path):
     assert context.info.repo_url == "https://github.com/upstream/repo.git"
 
 
-def test_enable_git_model_versioning_nonexistent_remote(tmp_git_repo: Path):
-    # No remotes added - repo should be None
-    context = enable_git_model_versioning(remote_name="nonexistent")
+def test_enable_git_model_versioning_no_remote(tmp_git_repo: Path):
+    # No remote - repo_url should be None
+    context = enable_git_model_versioning()
     assert context.info.repo_url is None

--- a/tests/genai/test_git_versioning.py
+++ b/tests/genai/test_git_versioning.py
@@ -6,6 +6,7 @@ import pytest
 import mlflow
 from mlflow.genai import disable_git_model_versioning, enable_git_model_versioning
 from mlflow.genai.git_versioning import _get_active_git_context
+from mlflow.genai.git_versioning.git_info import GitInfo
 
 
 @pytest.fixture(autouse=True)
@@ -173,7 +174,7 @@ def test_enable_git_model_versioning_default_remote_name(tmp_git_repo: Path):
         ["git", "remote", "add", "origin", "https://github.com/test/repo.git"], cwd=tmp_git_repo
     )
     context = enable_git_model_versioning()
-    assert context.info.repo == "https://github.com/test/repo.git"
+    assert context.info.repo_url == "https://github.com/test/repo.git"
 
 
 def test_enable_git_model_versioning_custom_remote_name(tmp_git_repo: Path):
@@ -187,10 +188,32 @@ def test_enable_git_model_versioning_custom_remote_name(tmp_git_repo: Path):
         cwd=tmp_git_repo,
     )
     context = enable_git_model_versioning(remote_name="upstream")
-    assert context.info.repo == "https://github.com/upstream/repo.git"
+    assert context.info.repo_url == "https://github.com/upstream/repo.git"
 
 
 def test_enable_git_model_versioning_nonexistent_remote(tmp_git_repo: Path):
     # No remotes added - repo should be None
     context = enable_git_model_versioning(remote_name="nonexistent")
-    assert context.info.repo is None
+    assert context.info.repo_url is None
+
+
+def test_git_info_from_env_with_remote_name(tmp_git_repo: Path):
+    # Add remotes
+    subprocess.check_call(
+        ["git", "remote", "add", "origin", "https://github.com/test/repo.git"], cwd=tmp_git_repo
+    )
+    subprocess.check_call(
+        ["git", "remote", "add", "fork", "https://github.com/fork/repo.git"], cwd=tmp_git_repo
+    )
+
+    # Test origin
+    info = GitInfo.from_env(remote_name="origin")
+    assert info.repo_url == "https://github.com/test/repo.git"
+
+    # Test fork
+    info = GitInfo.from_env(remote_name="fork")
+    assert info.repo_url == "https://github.com/fork/repo.git"
+
+    # Test non-existent remote
+    info = GitInfo.from_env(remote_name="nonexistent")
+    assert info.repo_url is None

--- a/tests/genai/test_git_versioning.py
+++ b/tests/genai/test_git_versioning.py
@@ -6,7 +6,6 @@ import pytest
 import mlflow
 from mlflow.genai import disable_git_model_versioning, enable_git_model_versioning
 from mlflow.genai.git_versioning import _get_active_git_context
-from mlflow.genai.git_versioning.git_info import GitInfo
 
 
 @pytest.fixture(autouse=True)
@@ -195,25 +194,3 @@ def test_enable_git_model_versioning_nonexistent_remote(tmp_git_repo: Path):
     # No remotes added - repo should be None
     context = enable_git_model_versioning(remote_name="nonexistent")
     assert context.info.repo_url is None
-
-
-def test_git_info_from_env_with_remote_name(tmp_git_repo: Path):
-    # Add remotes
-    subprocess.check_call(
-        ["git", "remote", "add", "origin", "https://github.com/test/repo.git"], cwd=tmp_git_repo
-    )
-    subprocess.check_call(
-        ["git", "remote", "add", "fork", "https://github.com/fork/repo.git"], cwd=tmp_git_repo
-    )
-
-    # Test origin
-    info = GitInfo.from_env(remote_name="origin")
-    assert info.repo_url == "https://github.com/test/repo.git"
-
-    # Test fork
-    info = GitInfo.from_env(remote_name="fork")
-    assert info.repo_url == "https://github.com/fork/repo.git"
-
-    # Test non-existent remote
-    info = GitInfo.from_env(remote_name="nonexistent")
-    assert info.repo_url is None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17051?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17051/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17051/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17051/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Resolve --> #N/A

### What changes are proposed in this pull request?

This PR adds a `remote_name` parameter to the git versioning functionality to allow users to specify which git remote to use when extracting repository URL information.

Key changes:
- Added `remote_name` parameter (defaults to "origin") to `enable_git_model_versioning()` and `GitContext`
- Updated `GitInfo.from_env()` to accept `remote_name` parameter and extract repository URL from the specified remote
- Modified `GitInfo.to_mlflow_tags()` to only include `MLFLOW_GIT_REPO_URL` tag when the repo URL is not None
- Added comprehensive tests for the new functionality

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Added 4 new test cases:
- `test_enable_git_model_versioning_default_remote_name`: Tests default "origin" remote
- `test_enable_git_model_versioning_custom_remote_name`: Tests custom remote name
- `test_enable_git_model_versioning_nonexistent_remote`: Tests behavior with non-existent remote
- `test_git_info_from_env_with_remote_name`: Tests GitInfo.from_env() directly

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added `remote_name` parameter to `enable_git_model_versioning()` to allow specifying which git remote to use for repository URL extraction.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)