### PR TITLE
[1][Span logging] Introduce DB migrations for SqlAlchemyStore span logging

### DIFF
--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
@@ -37,6 +37,9 @@ def upgrade():
             sa.Computed("end_time_unix_nano - start_time_unix_nano", persisted=True),
             nullable=True,
         ),
+        # Use LONGTEXT for MySQL to support large span content (up to 4GB).
+        # Standard TEXT in MySQL is limited to 64KB which is insufficient for
+        # spans with extensive attributes, events, or nested data structures.
         sa.Column("content", sa.Text().with_variant(LONGTEXT, "mysql"), nullable=False),
         sa.ForeignKeyConstraint(
             ["trace_id"],

--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
@@ -28,7 +28,8 @@ def upgrade():
         sa.Column("parent_span_id", sa.String(length=50), nullable=True),
         sa.Column("name", sa.Text(), nullable=True),
         # Use String instead of Text for type column to support MSSQL indexes.
-        # MSSQL doesn't allow TEXT columns in indexes.
+        # MSSQL doesn't allow TEXT columns in indexes. 1000 chars should be
+        # plenty for most span types.
         sa.Column("type", sa.String(length=1000), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=False),
         sa.Column("start_time_unix_nano", sa.BigInteger(), nullable=False),

--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
@@ -27,7 +27,9 @@ def upgrade():
         sa.Column("span_id", sa.String(length=50), nullable=False),
         sa.Column("parent_span_id", sa.String(length=50), nullable=True),
         sa.Column("name", sa.Text(), nullable=True),
-        sa.Column("type", sa.Text(), nullable=True),
+        # Use String instead of Text for type column to support MSSQL indexes.
+        # MSSQL doesn't allow TEXT columns in indexes.
+        sa.Column("type", sa.String(length=200), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=False),
         sa.Column("start_time_unix_nano", sa.BigInteger(), nullable=False),
         sa.Column("end_time_unix_nano", sa.BigInteger(), nullable=True),

--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
@@ -29,7 +29,7 @@ def upgrade():
         sa.Column("name", sa.Text(), nullable=True),
         # Use String instead of Text for type column to support MSSQL indexes.
         # MSSQL doesn't allow TEXT columns in indexes.
-        sa.Column("type", sa.String(length=200), nullable=True),
+        sa.Column("type", sa.String(length=1000), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=False),
         sa.Column("start_time_unix_nano", sa.BigInteger(), nullable=False),
         sa.Column("end_time_unix_nano", sa.BigInteger(), nullable=True),

--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
@@ -28,9 +28,9 @@ def upgrade():
         sa.Column("parent_span_id", sa.String(length=50), nullable=True),
         sa.Column("name", sa.Text(), nullable=True),
         # Use String instead of Text for type column to support MSSQL indexes.
-        # MSSQL doesn't allow TEXT columns in indexes. 1000 chars should be
-        # plenty for most span types.
-        sa.Column("type", sa.String(length=1000), nullable=True),
+        # MSSQL doesn't allow TEXT columns in indexes. Limited to 500 chars
+        # to stay within MySQL's max index key length of 3072 bytes.
+        sa.Column("type", sa.String(length=500), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=False),
         sa.Column("start_time_unix_nano", sa.BigInteger(), nullable=False),
         sa.Column("end_time_unix_nano", sa.BigInteger(), nullable=True),

--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
@@ -1,0 +1,80 @@
+"""add spans table
+
+Revision ID: a1b2c3d4e5f6
+Revises: 770bee3ae1dd
+Create Date: 2025-08-03 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.mysql import LONGTEXT
+
+from mlflow.store.tracking.dbmodels.models import SqlSpan
+
+# revision identifiers, used by Alembic.
+revision = "a1b2c3d4e5f6"
+down_revision = "770bee3ae1dd"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        SqlSpan.__tablename__,
+        sa.Column("trace_id", sa.String(length=50), nullable=False),
+        sa.Column("experiment_id", sa.Integer(), nullable=False),
+        sa.Column("span_id", sa.String(length=50), nullable=False),
+        sa.Column("parent_span_id", sa.String(length=50), nullable=True),
+        sa.Column("name", sa.Text(), nullable=True),
+        sa.Column("type", sa.Text(), nullable=True),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("start_time_unix_nano", sa.BigInteger(), nullable=False),
+        sa.Column("end_time_unix_nano", sa.BigInteger(), nullable=True),
+        sa.Column(
+            "duration_ns",
+            sa.BigInteger(),
+            sa.Computed("end_time_unix_nano - start_time_unix_nano", persisted=True),
+            nullable=True,
+        ),
+        sa.Column("content", sa.Text().with_variant(LONGTEXT, "mysql"), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["trace_id"],
+            ["trace_info.request_id"],
+            name="fk_spans_trace_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["experiment_id"],
+            ["experiments.experiment_id"],
+            name="fk_spans_experiment_id",
+        ),
+        sa.PrimaryKeyConstraint("trace_id", "span_id", name="spans_pk"),
+    )
+
+    with op.batch_alter_table(SqlSpan.__tablename__, schema=None) as batch_op:
+        batch_op.create_index(
+            f"index_{SqlSpan.__tablename__}_experiment_id",
+            ["experiment_id"],
+            unique=False,
+        )
+        # Two indexes needed to support both filter patterns efficiently:
+        batch_op.create_index(
+            f"index_{SqlSpan.__tablename__}_experiment_id_status_type",
+            ["experiment_id", "status", "type"],
+            unique=False,
+        )  # For status-only and status+type filters
+        batch_op.create_index(
+            f"index_{SqlSpan.__tablename__}_experiment_id_type_status",
+            ["experiment_id", "type", "status"],
+            unique=False,
+        )  # For type-only and type+status filters
+        batch_op.create_index(
+            f"index_{SqlSpan.__tablename__}_experiment_id_duration",
+            ["experiment_id", "duration_ns"],
+            unique=False,
+        )
+
+
+def downgrade():
+    op.drop_table(SqlSpan.__tablename__)

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1309,6 +1309,7 @@ class SqlSpan(Base):
     """
     Span type: `String` (limit 1000 characters). Can be null.
     Uses String instead of Text to support MSSQL indexes.
+    1000 chars should be plenty for most span types.
     """
 
     status = Column(String(50), nullable=False)

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1305,9 +1305,10 @@ class SqlSpan(Base):
     Span name: `Text`. Can be null.
     """
 
-    type = Column(Text, nullable=True)
+    type = Column(String(200), nullable=True)
     """
-    Span type: `Text`. Can be null.
+    Span type: `String` (limit 200 characters). Can be null.
+    Uses String instead of Text to support MSSQL indexes.
     """
 
     status = Column(String(50), nullable=False)

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1305,11 +1305,11 @@ class SqlSpan(Base):
     Span name: `Text`. Can be null.
     """
 
-    type = Column(String(1000), nullable=True)
+    type = Column(String(500), nullable=True)
     """
-    Span type: `String` (limit 1000 characters). Can be null.
+    Span type: `String` (limit 500 characters). Can be null.
     Uses String instead of Text to support MSSQL indexes.
-    1000 chars should be plenty for most span types.
+    Limited to 500 chars to stay within MySQL's max index key length.
     """
 
     status = Column(String(50), nullable=False)

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1305,9 +1305,9 @@ class SqlSpan(Base):
     Span name: `Text`. Can be null.
     """
 
-    type = Column(String(200), nullable=True)
+    type = Column(String(1000), nullable=True)
     """
-    Span type: `String` (limit 200 characters). Can be null.
+    Span type: `String` (limit 1000 characters). Can be null.
     Uses String instead of Text to support MSSQL indexes.
     """
 

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -6,6 +6,7 @@ from sqlalchemy import (
     Boolean,
     CheckConstraint,
     Column,
+    Computed,
     ForeignKey,
     ForeignKeyConstraint,
     Index,
@@ -1271,3 +1272,90 @@ class SqlLoggedModelTag(Base):
 
     def to_mlflow_entity(self) -> LoggedModelTag:
         return LoggedModelTag(key=self.tag_key, value=self.tag_value)
+
+
+class SqlSpan(Base):
+    __tablename__ = "spans"
+
+    trace_id = Column(
+        String(50), ForeignKey("trace_info.request_id", ondelete="CASCADE"), nullable=False
+    )
+    """
+    Trace ID: `String` (limit 50 characters). Part of composite primary key.
+    Foreign key to trace_info table.
+    """
+
+    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"), nullable=False)
+    """
+    Experiment ID: `Integer`. Foreign key to experiments table.
+    """
+
+    span_id = Column(String(50), nullable=False)
+    """
+    Span ID: `String` (limit 50 characters). Part of composite primary key.
+    """
+
+    parent_span_id = Column(String(50), nullable=True)
+    """
+    Parent span ID: `String` (limit 50 characters). Can be null for root spans.
+    """
+
+    name = Column(Text, nullable=True)
+    """
+    Span name: `Text`. Can be null.
+    """
+
+    type = Column(Text, nullable=True)
+    """
+    Span type: `Text`. Can be null.
+    """
+
+    status = Column(String(50), nullable=False)
+    """
+    Span status: `String` (limit 50 characters).
+    """
+
+    start_time_unix_nano = Column(BigInteger, nullable=False)
+    """
+    Start time in nanoseconds since Unix epoch: `BigInteger`.
+    """
+
+    end_time_unix_nano = Column(BigInteger, nullable=True)
+    """
+    End time in nanoseconds since Unix epoch: `BigInteger`. Can be null if span is in progress.
+    """
+
+    duration_ns = Column(
+        BigInteger,
+        Computed("end_time_unix_nano - start_time_unix_nano", persisted=True),
+        nullable=True,
+    )
+    """
+    Duration in nanoseconds: `BigInteger`. Computed from end_time - start_time.
+    Stored as a persisted/stored generated column for efficient filtering.
+    Will be NULL for in-progress spans (where end_time is NULL).
+    """
+
+    content = Column(Text, nullable=False)
+    """
+    Full span content as JSON: `Text`.
+    Uses LONGTEXT in MySQL to support large spans (up to 4GB).
+    """
+
+    trace_info = relationship("SqlTraceInfo", backref=backref("spans", cascade="all"))
+    """
+    SQLAlchemy relationship (many:one) with :py:class:`mlflow.store.dbmodels.models.SqlTraceInfo`.
+    """
+
+    __table_args__ = (
+        PrimaryKeyConstraint("trace_id", "span_id", name="spans_pk"),
+        Index("index_spans_experiment_id", "experiment_id"),
+        # Two indexes needed to support both filter patterns efficiently:
+        Index(
+            "index_spans_experiment_id_status_type", "experiment_id", "status", "type"
+        ),  # For status-only and status+type filters
+        Index(
+            "index_spans_experiment_id_type_status", "experiment_id", "type", "status"
+        ),  # For type-only and type+status filters
+        Index("index_spans_experiment_id_duration", "experiment_id", "duration_ns"),
+    )

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -260,6 +260,24 @@ CREATE TABLE params (
 )
 
 
+CREATE TABLE spans (
+    trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    experiment_id INTEGER NOT NULL,
+    span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+    name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+    type VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+    status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    start_time_unix_nano BIGINT NOT NULL,
+    end_time_unix_nano BIGINT,
+    duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
+    content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+    CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+    CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+);
+
+
 CREATE TABLE tags (
 	key VARCHAR(250) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	value VARCHAR(8000) COLLATE "SQL_Latin1_General_CP1_CI_AS",

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -266,7 +266,7 @@ CREATE TABLE spans (
     span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
     parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
     name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
-    type VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+    type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
     status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
     start_time_unix_nano BIGINT NOT NULL,
     end_time_unix_nano BIGINT,
@@ -275,7 +275,7 @@ CREATE TABLE spans (
     CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
     CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
     CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
-);
+)
 
 
 CREATE TABLE tags (

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -261,20 +261,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-    trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    experiment_id INTEGER NOT NULL,
-    span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-    name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
-    type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-    status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    start_time_unix_nano BIGINT NOT NULL,
-    end_time_unix_nano BIGINT,
-    duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
-    content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-    CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-    CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+	trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	start_time_unix_nano BIGINT NOT NULL,
+	end_time_unix_nano BIGINT,
+	duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
+	content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -268,6 +268,24 @@ CREATE TABLE params (
 )
 
 
+CREATE TABLE spans (
+	trace_id VARCHAR(50) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	span_id VARCHAR(50) NOT NULL,
+	parent_span_id VARCHAR(50),
+	name TEXT,
+	type VARCHAR(500),
+	status VARCHAR(50) NOT NULL,
+	start_time_unix_nano BIGINT NOT NULL,
+	end_time_unix_nano BIGINT,
+	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED,
+	content TEXT NOT NULL,
+	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE,
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
 CREATE TABLE tags (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000),

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -269,20 +269,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-        trace_id VARCHAR(50) NOT NULL,
-        experiment_id INTEGER NOT NULL,
-        span_id VARCHAR(50) NOT NULL,
-        parent_span_id VARCHAR(50),
-        name TEXT,
-        type VARCHAR(500),
-        status VARCHAR(50) NOT NULL,
-        start_time_unix_nano BIGINT NOT NULL,
-        end_time_unix_nano BIGINT,
-        duration_ns BIGINT GENERATED ALWAYS AS (((`end_time_unix_nano` - `start_time_unix_nano`))) STORED,
-        content LONGTEXT NOT NULL,
-        PRIMARY KEY (trace_id, span_id),
-        CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-        CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+	trace_id VARCHAR(50) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	span_id VARCHAR(50) NOT NULL,
+	parent_span_id VARCHAR(50),
+	name TEXT,
+	type VARCHAR(500),
+	status VARCHAR(50) NOT NULL,
+	start_time_unix_nano BIGINT NOT NULL,
+	end_time_unix_nano BIGINT,
+	duration_ns BIGINT GENERATED ALWAYS AS (((`end_time_unix_nano` - `start_time_unix_nano`))) STORED,
+	content LONGTEXT NOT NULL,
+	PRIMARY KEY (trace_id, span_id),
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -269,20 +269,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-    trace_id VARCHAR(50) NOT NULL,
-    experiment_id INTEGER NOT NULL,
-    span_id VARCHAR(50) NOT NULL,
-    parent_span_id VARCHAR(50),
-    name TEXT,
-    type VARCHAR(500),
-    status VARCHAR(50) NOT NULL,
-    start_time_unix_nano BIGINT NOT NULL,
-    end_time_unix_nano BIGINT,
-    duration_ns BIGINT GENERATED ALWAYS AS (((`end_time_unix_nano` - `start_time_unix_nano`))) STORED,
-    content LONGTEXT NOT NULL,
-    PRIMARY KEY (trace_id, span_id),
-    CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-    CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+        trace_id VARCHAR(50) NOT NULL,
+        experiment_id INTEGER NOT NULL,
+        span_id VARCHAR(50) NOT NULL,
+        parent_span_id VARCHAR(50),
+        name TEXT,
+        type VARCHAR(500),
+        status VARCHAR(50) NOT NULL,
+        start_time_unix_nano BIGINT NOT NULL,
+        end_time_unix_nano BIGINT,
+        duration_ns BIGINT GENERATED ALWAYS AS (((`end_time_unix_nano` - `start_time_unix_nano`))) STORED,
+        content LONGTEXT NOT NULL,
+        PRIMARY KEY (trace_id, span_id),
+        CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+        CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -269,20 +269,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-	trace_id VARCHAR(50) NOT NULL,
-	experiment_id INTEGER NOT NULL,
-	span_id VARCHAR(50) NOT NULL,
-	parent_span_id VARCHAR(50),
-	name TEXT,
-	type VARCHAR(500),
-	status VARCHAR(50) NOT NULL,
-	start_time_unix_nano BIGINT NOT NULL,
-	end_time_unix_nano BIGINT,
-	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED,
-	content TEXT NOT NULL,
-	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE,
-	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+    trace_id VARCHAR(50) NOT NULL,
+    experiment_id INTEGER NOT NULL,
+    span_id VARCHAR(50) NOT NULL,
+    parent_span_id VARCHAR(50),
+    name TEXT,
+    type VARCHAR(500),
+    status VARCHAR(50) NOT NULL,
+    start_time_unix_nano BIGINT NOT NULL,
+    end_time_unix_nano BIGINT,
+    duration_ns BIGINT GENERATED ALWAYS AS (((`end_time_unix_nano` - `start_time_unix_nano`))) STORED,
+    content LONGTEXT NOT NULL,
+    PRIMARY KEY (trace_id, span_id),
+    CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+    CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -266,6 +266,24 @@ CREATE TABLE params (
 )
 
 
+CREATE TABLE spans (
+    trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    experiment_id INTEGER NOT NULL,
+    span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+    name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+    type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+    status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    start_time_unix_nano BIGINT NOT NULL,
+    end_time_unix_nano BIGINT,
+    duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
+    content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+    CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+    CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+    CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
 CREATE TABLE tags (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000),

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -267,20 +267,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-	trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	experiment_id INTEGER NOT NULL,
-	span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	start_time_unix_nano BIGINT NOT NULL,
-	end_time_unix_nano BIGINT,
-	duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
-	content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+  trace_id VARCHAR(50) NOT NULL,
+  experiment_id INTEGER NOT NULL,
+  span_id VARCHAR(50) NOT NULL,
+  parent_span_id VARCHAR(50),
+  name TEXT,
+  type VARCHAR(500),
+  status VARCHAR(50) NOT NULL,
+  start_time_unix_nano BIGINT NOT NULL,
+  end_time_unix_nano BIGINT,
+  duration_ns BIGINT GENERATED ALWAYS AS ((end_time_unix_nano - start_time_unix_nano)) STORED,
+  content TEXT NOT NULL,
+  CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+  CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+  CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -267,20 +267,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-        trace_id VARCHAR(50) NOT NULL,
-        experiment_id INTEGER NOT NULL,
-        span_id VARCHAR(50) NOT NULL,
-        parent_span_id VARCHAR(50),
-        name TEXT,
-        type VARCHAR(500),
-        status VARCHAR(50) NOT NULL,
-        start_time_unix_nano BIGINT NOT NULL,
-        end_time_unix_nano BIGINT,
-        duration_ns BIGINT GENERATED ALWAYS AS ((end_time_unix_nano - start_time_unix_nano)) STORED,
-        content TEXT NOT NULL,
-        CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-        CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-        CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+	trace_id VARCHAR(50) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	span_id VARCHAR(50) NOT NULL,
+	parent_span_id VARCHAR(50),
+	name TEXT,
+	type VARCHAR(500),
+	status VARCHAR(50) NOT NULL,
+	start_time_unix_nano BIGINT NOT NULL,
+	end_time_unix_nano BIGINT,
+	duration_ns BIGINT GENERATED ALWAYS AS ((end_time_unix_nano - start_time_unix_nano)) STORED,
+	content TEXT NOT NULL,
+	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -267,20 +267,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-  trace_id VARCHAR(50) NOT NULL,
-  experiment_id INTEGER NOT NULL,
-  span_id VARCHAR(50) NOT NULL,
-  parent_span_id VARCHAR(50),
-  name TEXT,
-  type VARCHAR(500),
-  status VARCHAR(50) NOT NULL,
-  start_time_unix_nano BIGINT NOT NULL,
-  end_time_unix_nano BIGINT,
-  duration_ns BIGINT GENERATED ALWAYS AS ((end_time_unix_nano - start_time_unix_nano)) STORED,
-  content TEXT NOT NULL,
-  CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-  CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-  CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+        trace_id VARCHAR(50) NOT NULL,
+        experiment_id INTEGER NOT NULL,
+        span_id VARCHAR(50) NOT NULL,
+        parent_span_id VARCHAR(50),
+        name TEXT,
+        type VARCHAR(500),
+        status VARCHAR(50) NOT NULL,
+        start_time_unix_nano BIGINT NOT NULL,
+        end_time_unix_nano BIGINT,
+        duration_ns BIGINT GENERATED ALWAYS AS ((end_time_unix_nano - start_time_unix_nano)) STORED,
+        content TEXT NOT NULL,
+        CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+        CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+        CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -267,20 +267,20 @@ CREATE TABLE params (
 
 
 CREATE TABLE spans (
-    trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    experiment_id INTEGER NOT NULL,
-    span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-    name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
-    type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
-    status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    start_time_unix_nano BIGINT NOT NULL,
-    end_time_unix_nano BIGINT,
-    duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
-    content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-    CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-    CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-    CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+	trace_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	parent_span_id VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	name VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	type VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	status VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	start_time_unix_nano BIGINT NOT NULL,
+	end_time_unix_nano BIGINT,
+	duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
+	content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -275,7 +275,7 @@ CREATE TABLE spans (
 	span_id VARCHAR(50) NOT NULL,
 	parent_span_id VARCHAR(50),
 	name TEXT,
-	type VARCHAR(1000),
+	type VARCHAR(500),
 	status VARCHAR(50) NOT NULL,
 	start_time_unix_nano BIGINT NOT NULL,
 	end_time_unix_nano BIGINT,

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -269,6 +269,24 @@ CREATE TABLE params (
 )
 
 
+CREATE TABLE spans (
+	trace_id VARCHAR(50) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	span_id VARCHAR(50) NOT NULL,
+	parent_span_id VARCHAR(50),
+	name TEXT,
+	type VARCHAR(1000),
+	status VARCHAR(50) NOT NULL,
+	start_time_unix_nano BIGINT NOT NULL,
+	end_time_unix_nano BIGINT,
+	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED,
+	content TEXT NOT NULL,
+	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE,
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
 CREATE TABLE tags (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000),

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -275,7 +275,7 @@ CREATE TABLE spans (
 	span_id VARCHAR(50) NOT NULL,
 	parent_span_id VARCHAR(50),
 	name TEXT,
-	type VARCHAR(1000),
+	type VARCHAR(500),
 	status VARCHAR(50) NOT NULL,
 	start_time_unix_nano BIGINT NOT NULL,
 	end_time_unix_nano BIGINT,

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -269,6 +269,24 @@ CREATE TABLE params (
 )
 
 
+CREATE TABLE spans (
+	trace_id VARCHAR(50) NOT NULL,
+	experiment_id INTEGER NOT NULL,
+	span_id VARCHAR(50) NOT NULL,
+	parent_span_id VARCHAR(50),
+	name TEXT,
+	type VARCHAR(1000),
+	status VARCHAR(50) NOT NULL,
+	start_time_unix_nano BIGINT NOT NULL,
+	end_time_unix_nano BIGINT,
+	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED,
+	content TEXT NOT NULL,
+	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
+	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE,
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+)
+
+
 CREATE TABLE tags (
 	key VARCHAR(250) NOT NULL,
 	value VARCHAR(8000),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/17073?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17073/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17073/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17073/merge
```

</p>
</details>

- Add migration a1b2c3d4e5f6 to create spans table
- Add SqlSpan model to dbmodels/models.py
- Include indexes for efficient querying by experiment_id, status, type, and duration
- Remove trace_state column from schema (never included in final migration)

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Introduce DB migrations for SqlAlchemyStore span logging

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
