### PR TITLE
Move API inventory check from Sphinx conf.py to GitHub Actions workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,6 +73,16 @@ jobs:
           API_REFERENCE_PREFIX: https://pr-${{ github.event.pull_request.number }}--mlflow-docs-preview.netlify.app/docs/
         run: |
           npm run build-all -- --no-r --use-npm
+      - name: Check API inventory
+        run: |
+          if [ -n "$(git status --porcelain api_reference/api_inventory.txt)" ]; then
+            echo "The API inventory file 'docs/api_reference/api_inventory.txt' is outdated (see the diff below)."
+            echo "Please update it by running 'make rsthtml' in the 'docs/api_reference' directory."
+            echo "If the new APIs should be marked as experimental, please decorate them with '@experimental'."
+            echo "Diff:"
+            git diff api_reference/api_inventory.txt
+            exit 1
+          fi
       - name: Test examples
         working-directory: docs/api_reference
         run: |

--- a/docs/api_reference/source/conf.py
+++ b/docs/api_reference/source/conf.py
@@ -418,18 +418,6 @@ def env_updated(app: Sphinx, env: BuildEnvironment) -> None:
         path.parent.mkdir(parents=True)
     path.write_text("\n".join(sorted(items)) + "\n")
 
-    # Check if the API inventory file is outdated
-    result = subprocess.run(
-        ["git", "diff", "--exit-code", path], text=True, capture_output=True, check=False
-    )
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"The API inventory file '{path.relative_to(repo_root)}' is outdated (see the diff below). "
-            "Please update it by running `make rsthtml` in the `docs/api_reference` directory. "
-            "If the new APIs should be marked as experimental, please decorate them with `@experimental`."
-            f"{result.stdout.strip()}\n\n"
-        )
-
 
 def setup(app):
     languagesections.setup(app)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17077?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17077/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17077/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17077/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Resolve --> #17036

### What changes are proposed in this pull request?

This PR moves the API inventory check from the Sphinx build process (`conf.py`) to a dedicated GitHub Actions step in the docs workflow. This change improves the development experience by:

1. Moving the API inventory check from the Sphinx build process to a dedicated GitHub Actions step
2. Making it easier to diagnose and fix API inventory issues without running the full docs build locally
3. Providing clearer error messages in the CI workflow when the API inventory is outdated

The check logic remains the same - it verifies that `api_inventory.txt` is up-to-date - but now runs as a separate CI step after the docs build completes.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The change is tested through the existing CI workflow that builds the documentation.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)