### PR TITLE
remove api_key before log to fix security thread

### DIFF
--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -255,18 +255,18 @@ def _parse_tools(tools):
 def _sanitize_value(val):
     """
     Sanitize a value to remove sensitive information.
-    
+
     Args:
         val: The value to sanitize. Can be None, a dict, a list, or other types.
-        
+
     Returns:
         The sanitized value.
     """
     if val is None:
         return None
-    
+
     sensitive_keys = ["api_key", "secret", "password", "token"]
-    
+
     if isinstance(val, dict):
         sanitized = {}
         for k, v in val.items():
@@ -274,8 +274,8 @@ def _sanitize_value(val):
                 continue
             sanitized[k] = _sanitize_value(v)
         return sanitized
-    
+
     elif isinstance(val, list):
         return [_sanitize_value(item) for item in val]
-    
+
     return val

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -113,6 +113,8 @@ def _set_span_attributes(span: LiveSpan, instance):
                         value = _parse_tasks(value)
                     elif key == "agents":
                         value = _parse_agents(value)
+                    elif key == "embedder":
+                        value = _sanitize_value(value)
                     span.set_attribute(key, str(value) if isinstance(value, list) else value)
 
         elif isinstance(instance, Agent):
@@ -153,6 +155,8 @@ def _get_agent_attributes(instance):
     for key, value in instance.__dict__.items():
         if key == "tools":
             value = _parse_tools(value)
+        elif key == "embedder":
+            value = _sanitize_value(value)
         if value is None:
             continue
         agent[key] = str(value)
@@ -246,3 +250,32 @@ def _parse_tools(tools):
                 }
             )
     return result
+
+
+def _sanitize_value(val):
+    """
+    Sanitize a value to remove sensitive information.
+    
+    Args:
+        val: The value to sanitize. Can be None, a dict, a list, or other types.
+        
+    Returns:
+        The sanitized value.
+    """
+    if val is None:
+        return None
+    
+    sensitive_keys = ["api_key", "secret", "password", "token"]
+    
+    if isinstance(val, dict):
+        sanitized = {}
+        for k, v in val.items():
+            if any(sensitive in k.lower() for sensitive in sensitive_keys):
+                continue
+            sanitized[k] = _sanitize_value(v)
+        return sanitized
+    
+    elif isinstance(val, list):
+        return [_sanitize_value(item) for item in val]
+    
+    return val


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/diy2learn/mlflow/pull/17082?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17082/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17082/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17082/merge
```

</p>
</details>

### Related Issues/PRs

Close https://github.com/mlflow/mlflow/issues/17078

### What changes are proposed in this pull request?

This PR addresses a security concern in the MLflow tracing integration with CrewAI.

When using mlflow.crewai.autolog() to trace agent activities, sensitive information such as the api_key may be inadvertently logged and exposed in MLflow UI or logs.

To mitigate this risk, this PR introduces sanitization of logged content, ensuring that sensitive fields like api_key are removed before being recorded.

### How is this PR tested?

- [ x] Existing unit/integration tests
- [ x] Manual tests

<img width="782" height="321" alt="image" src="https://github.com/user-attachments/assets/35a4bba1-19cd-4e93-a2ef-1124e594e2c8" />

### Does this PR require documentation update?

- [x ] No. You can skip the rest of this section.


### Release Notes

#### Is this a user-facing change?

- [x ] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components
- [x ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?
- [x ] Yes (this PR will be cherry-picked and included in the next patch release)
