### PR TITLE
Add protobuf documentation generation to build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ outputs/
 mlruns.db
 mlflow.db
 **/basic_auth.db
+mlflow/protos/protos.json
 
 # Mac
 .DS_Store

--- a/dev/Dockerfile.protos
+++ b/dev/Dockerfile.protos
@@ -2,7 +2,9 @@ FROM python:3.10-slim
 
 WORKDIR /mlflow
 
+RUN pip install protobuf packaging
+
 # Copy only necessary files to compile protos
 COPY mlflow/protos ./mlflow/protos/
-COPY dev/generate_protos.py ./dev/generate_protos.py
+COPY dev ./dev/
 COPY tests/protos ./tests/protos/

--- a/dev/gen_rest_api.py
+++ b/dev/gen_rest_api.py
@@ -1,0 +1,864 @@
+"""
+TODO: Clena up this file.
+"""
+
+import argparse
+import json
+import logging
+import re
+from enum import Enum
+from textwrap import dedent
+
+from texttable import Texttable
+
+"""
+The functions in here are simple functions to help in managing RST from python
+"""
+
+
+def gen_break():
+    return "\n\n===========================\n\n"
+
+
+def gen_h1(link_id, title):
+    link = link_id
+    return """
+
+.. _{link}:
+
+{name}
+{name_header}
+
+""".format(name=title, link=link, name_header="=" * len(title))
+
+
+def gen_h2(link_id, title):
+    link = link_id
+    return """
+
+.. _{link}:
+
+{name}
+{name_header}
+
+""".format(name=title, link=link, name_header="-" * len(title))
+
+
+def gen_page_title(title):
+    link = title.lower().replace(" ", "-")
+    return """
+.. _{link}:
+
+{name_header}
+{name}
+{name_header}
+
+""".format(name=title, link=link, name_header="=" * len(title))
+
+
+def ErrorHelper(msg):
+    return "JSON Validation Error: {}".format(msg)
+
+
+def validate_doc_public_json(docjson):
+    logging.info("Validating doc_public.json file.")
+    if "files" not in docjson:
+        logging.error(docjson.keys())
+        raise Exception(ErrorHelper("No 'files' key"))
+    files = docjson["files"][0]
+    logging.info("Checking 'content'")
+    if "content" not in files:
+        logging.error(files.keys())
+        raise Exception(ErrorHelper("No 'content' key"))
+    content = files["content"][0]
+    logging.info("Checking 'message', 'service', 'enum'")
+    if "message" not in content:
+        logging.error(content.keys())
+        raise Exception(ErrorHelper("No 'message' key"))
+    if "service" not in content:
+        logging.error(content.keys())
+        raise Exception(ErrorHelper("No 'service' key"))
+    if "enum" not in content:
+        logging.error(content.keys())
+        raise Exception(ErrorHelper("No 'enum' key"))
+    logging.info("Structure Appears to be valid! Continuing...")
+
+
+class MsgType(Enum):
+    generic = 1
+    request = 2
+    response = 3
+
+
+def gen_id(full_path):
+    "Generates an ID from a proto path"
+    return "".join(full_path)
+
+
+class Field:
+    """
+    A Field is a sub part of a message. It declares the field names, types, and descriptions
+    for a given message.
+    """
+
+    def __init__(self, full_path, name, description, field_type):
+        logging.debug("Creating Field {}".format(name))
+        self.id = gen_id(full_path)
+        self.name = name
+        self.description = description
+        self.field_type = field_type
+
+    def __repr__(self):
+        return self.name
+
+    def __str__(self):
+        return self.__repr__()
+
+    @staticmethod
+    def table_header():
+        return ["Field Name", "Type", "Description"]
+
+    def to_table(self):
+        return [self.name, self.field_type, self.description]
+
+    @staticmethod
+    def _parse_name(field_details):
+        declared_type = field_details["field_type"]
+        if declared_type == "oneof":
+            names = ["``{}``".format(x["field_name"]) for x in field_details["oneof"]]
+            name = " OR ".join(names)
+        else:
+            name = field_details["field_name"]
+        return name
+
+    @staticmethod
+    def _parse_type(field_details):
+        """
+        Parses the Field Type from a field object.
+        as of 8/31/2016 this is either a 'oneof' or some generic type(int, string, etc)
+        """
+        declared_type = field_details["field_type"]
+        if declared_type == "oneof":
+            field_types = [Field._convert_to_link(x["field_type"]) for x in field_details["oneof"]]
+            return " OR ".join(field_types)
+        return Field._convert_to_link(field_details["field_type"])
+
+    @staticmethod
+    def _parse_description(field_details):
+        """
+        Parses the description from a field object.
+        The description structure depends explicitly on the field type.
+        """
+        declared_type = field_details["field_type"]
+        deprecated = "" if not field_details["deprecated"] else "\nThis field is deprecated.\n"
+        required = "" if not field_details["validate_required"] else "\nThis field is required.\n"
+        if declared_type == "oneof":
+            options = []
+
+            def to_lowercase_first_char(s):
+                return s[:1].lower() + s[1:] if s else ""
+
+            for name, obj in zip(
+                Field._parse_name(field_details).split(" OR "), field_details["oneof"]
+            ):
+                options.append(
+                    "\n\nIf {}, {}".format(name, to_lowercase_first_char(obj["description"]))
+                )
+            return "\n\n\n\n".join(options) + required + deprecated
+        return field_details["description"] + required + deprecated
+
+    @staticmethod
+    def _convert_to_link(raw_string):
+        "Optionally converts a raw string to an internal link"
+        if "." in raw_string:
+            return ":ref:`{}`".format(raw_string.replace(".", "").lower())
+        return "``{}``".format(raw_string)
+
+    @classmethod
+    def parse_all_from(cls, field_list):
+        """
+        Parses all fields from a field list inside of a message.
+        Returns an array of Field objects.
+        """
+        all_instances = []
+        for field in field_list:
+            full_path = field["full_path"]
+            name = Field._parse_name(field)
+            field_type = Field._parse_type(field)
+            description = Field._parse_description(field)
+            assert not field["deprecated"]
+            if field["repeated"]:
+                field_type = "An array of " + field_type
+            vis = field["visibility"]
+            if vis == "public":
+                all_instances.append(cls(full_path, name, description, field_type))
+        return all_instances
+
+
+class Value:
+    """
+    A value is a sub part of an ProtoEnum. It declares the potential values
+    that a given enum can take on.
+    """
+
+    def __init__(self, full_path, name, description):
+        self.id = gen_id(full_path)
+        self.name = name
+        self.description = description
+
+    def __repr__(self):
+        return "{}".format(self.name)
+
+    def __str__(self):
+        return self.__repr__()
+
+    @staticmethod
+    def table_header():
+        return ["Name", "Description"]
+
+    def to_table(self):
+        return [self.name, self.description]
+
+    @classmethod
+    def parse_all_from(cls, value_list):
+        """
+        Parses all values from a value list inside of an enumeration.
+        Returns a list of Value Objects.
+        """
+        all_instances = []
+        for value in value_list:
+            all_instances.append(cls(value["full_path"], value["value"], value["description"]))
+        return all_instances
+
+
+class ProtoEnum:
+    """
+    A ProtoEnum is an Enum defined by the Proto json. It has a series of Values.
+    """
+
+    def __init__(self, full_path, name, description, values):
+        self.id = gen_id(full_path)
+        self.name = name
+        self.description = description
+        self.values = values
+
+    def __repr__(self):
+        return "{}\n {}".format(self.id, self.name)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def _generate_values_table(self):
+        """
+        Each Enum can contain 0 or more values. This generates a plain text table
+        out of the value's information.
+        Returns a string.
+        """
+        tbl = Texttable(max_width=200)
+        header = Value.table_header()
+        tbl.add_rows([header] + [f.to_table() for f in self.values])
+        return tbl.draw()
+
+    def to_rst(self):
+        "Converts a ProtoEnum Instance into rst"
+        values = self._generate_values_table()
+        title = gen_h2(self.id, self.name)
+        section = "\n{description}\n\n{values}".format(description=self.description, values=values)
+        return title + section
+
+    @classmethod
+    def parse_all_from(cls, files):
+        """
+        Parses all ProtoEnums from the raw proto file json. (the top level `files` group).
+        Returns an array of ProtoEnums
+        """
+        all_instances = []
+        for proto_file in files:
+            # Top-level enums
+            enums = [x["enum"] for x in proto_file["content"] if x["enum"]]
+            # Enums inside of messages
+            for content in filter(lambda x: x["message"], proto_file["content"]):
+                enums += content["message"].get("enums") or []
+            for enum in enums:
+                values = Value.parse_all_from(enum["values"])
+                description = enum["description"]
+                name = enum["name"]
+                all_instances.append(cls(enum["full_path"], name, description, values))
+
+        return all_instances
+
+
+class Message:
+    """
+    Mirrors a Proto Message like those that we find inside of the proto definition files
+    """
+
+    def __init__(self, full_path, name, description, fields):
+        logging.debug("Creating Message: {}".format(name))
+        self.id = gen_id(full_path)
+        self.name = name
+        self.description = description
+        self.fields = fields
+        self.type = MsgType.generic
+
+    def __repr__(self):
+        return "{}".format(self.id)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def _generate_field_table(self):
+        tbl = Texttable(max_width=200)
+        header = [Field.table_header()]
+        non_empty_fields = [f for f in self.fields if len(f.name) != 0]
+        rows = [f.to_table() for f in non_empty_fields]
+        tbl.add_rows(header + rows)
+        return tbl.draw()
+
+    def _generate_rst_title(self):
+        if self.type == MsgType.request:
+            return gen_h2(self.id, "Request Structure")
+        elif self.type == MsgType.response:
+            return gen_h2(self.id, "Response Structure")
+        return gen_h2(self.id, self.name)
+
+    def to_rst(self):
+        if not self.fields:
+            return ""
+
+        fields = self._generate_field_table()
+        title = self._generate_rst_title()
+
+        section = "\n\n{description}\n\n\n{fields}".format(
+            description=self.description, fields=fields
+        )
+        return title + section
+
+    @classmethod
+    def parse_all_from_list(cls, message_list):
+        """
+        Parses all messages from a list of messages along with their associated sub messages
+        (recursively). Returns a list of messages
+        """
+        all_instances = []
+        for msg in message_list:
+            name = msg["name"]
+            description = msg["description"]
+            fields = Field.parse_all_from(msg["fields"])
+            full_path = msg["full_path"]
+            vis = msg["visibility"]
+            if vis == "public":
+                all_instances.append(cls(full_path, name, description, fields))
+                if msg["messages"]:
+                    sub_messages = Message.parse_all_from_list(msg["messages"])
+                    all_instances.extend(sub_messages)
+
+        return all_instances
+
+    @classmethod
+    def parse_all_from(cls, files):
+        """
+        Parses all messages from raw proto file list along with their associated sub messages
+        (recursively). Returns a list of messages.
+        """
+        all_instances = []
+        for proto_file in files:
+            for content in filter(lambda x: x["message"], proto_file["content"]):
+                message = content["message"]
+                fields = Field.parse_all_from(message["fields"])
+                description = message["description"]
+                full_path = message["full_path"]
+                name = message["name"]
+                vis = message["visibility"]
+                if vis == "public":
+                    all_instances.append(cls(full_path, name, description, fields))
+                    if message["messages"]:
+                        sub_messages = Message.parse_all_from_list(message["messages"])
+                        all_instances.extend(sub_messages)
+
+        return all_instances
+
+
+class Method:
+    """
+    A method belongs to a service and describes the methods that are
+    available to that given service. A method also contains messages
+    in the form of the request message and the response message.
+    """
+
+    def __init__(self, full_path, name, description, path, method, request, response, title):
+        self.id = gen_id(full_path)
+        self.name = name
+        self.description = description
+        self.path = path
+        self.method = method
+        self.request = gen_id(request)
+        self.response = gen_id(response)
+        self.request_message = None
+        self.response_message = None
+        self.API_VERSION = None
+        self.title = title
+
+    @classmethod
+    def parse_all_from(cls, method_list):
+        all_instances = []
+        for method in method_list:
+            fp = method["full_path"]
+            n = method["name"]
+            d = method["description"]
+            p = method["rpc_options"]["path"]
+            m = method["rpc_options"]["method"]
+            req = method["request_full_path"]
+            resp = method["response_full_path"]
+            vis = method["rpc_options"]["visibility"]
+            title = method["rpc_options"].get("rpc_doc_title", None)
+            if vis == "public":
+                all_instances.append(cls(fp, n, d, p, m, req, resp, title))
+
+        return all_instances
+
+    def __repr__(self):
+        reqm = "NoMsg"
+        if self.request_message:
+            reqm = "HasMsg"
+
+        resm = "NoMsg"
+        if self.response_message:
+            resm = "HasMsg"
+
+        return "{}, {} ({}) -> {} ({})".format(
+            self.name, "".join(self.request), reqm, "".join(self.response), resm
+        )
+
+    def __str__(self):
+        return self.__repr__()
+
+    def to_rst(self):
+        if not self.API_VERSION:
+            raise Exception("MUST SET API VERSION")
+        prepped_title = self.title or " ".join(re.split(r"\W+", self.path)[2:]).title().lstrip()
+        title = gen_h1(self.id, prepped_title)
+        tbl = Texttable(max_width=200)
+        tbl.add_rows(
+            [
+                ["Endpoint", "HTTP Method"],
+                ["``{}{}``".format(self.API_VERSION, self.path), "``{}``".format(self.method)],
+            ]
+        )
+        parameters = tbl.draw()
+        body = """
+{parameters}
+
+{description}
+""".format(parameters=parameters, description=self.description)
+        ret_value = gen_break() + title + body + "\n\n"
+        if self.request_message:
+            ret_value += self.request_message.to_rst()
+        if self.response_message:
+            ret_value += self.response_message.to_rst()
+        return ret_value
+
+
+class Service:
+    "A Service as defined in our Proto Files"
+
+    def __init__(self, full_path, name, description, methods):
+        self.id = gen_id(full_path)
+        self.name = name
+        self.description = description
+        self.methods = methods
+
+    @classmethod
+    def parse_all_from(cls, files):
+        """
+        Parses all Services from a list of proto files as found in doc_public.json
+        returns a list of services.
+        """
+        all_instances = []
+        for proto_file in files:
+            for content in filter(lambda x: x["service"], proto_file["content"]):
+                service = content["service"]
+                methods = Method.parse_all_from(service["methods"])
+                name = service["name"]
+                description = service["description"]
+                all_instances.append(cls(service["full_path"], name, description, methods))
+        return all_instances
+
+    def __repr__(self):
+        return "{}\n Methods: {}".format(self.name, "\n  ".join([str(m) for m in self.methods]))
+
+    def __str__(self):
+        return self.__repr__()
+
+    def to_rst(self, method_order=None):
+        sections = []
+        sorted_methods = sorted(self.methods, key=lambda x: x.name)
+        if method_order:
+            method_map = dict(zip(method_order, range(0, len(method_order))))
+            sorted_methods = sorted(self.methods, key=lambda x: method_map[x.request])
+        for method in sorted_methods:
+            sections.append(method.to_rst())
+        return "".join(sections)
+
+
+class API:
+    """
+    An API is the only user facing module inside of this library. We specify an API
+    along with a set of related endpoints.
+    """
+
+    def __init__(self, name, description, api_version, dstPath, valid_proto_files):
+        self.name = name
+        self.description = description
+        self.dstPath = dstPath
+        self.valid_proto_files = valid_proto_files
+        self.services = None
+        self.messages = None
+        self.enums = None
+        self.comments = None
+        self.API_VERSION = api_version
+        self.file_filter = lambda x: x["filename"] in self.valid_proto_files
+
+    def __repr__(self):
+        return "{}".format(self.name)
+
+    def __str__(self):
+        return self.__repr__()
+
+    def validate_messages(self, valid_messages):
+        logging.info("Validating Messages for {}".format(self))
+        valid = set(valid_messages)
+        actual = {m.id for m in self.messages}
+        diff = actual - valid
+        if diff:
+            logging.error(
+                """
+The Specified Messages {} are not specified as a valid message for the docs but
+visibility is not set to PUBLIC_UNDOCUMENTED or PRIVATE.
+Please add it docs/api_sphinx_build.py under the relevant API endpoint or set it
+to the correct visibility level.
+""".format(diff)
+            )
+            raise
+
+    def set_services(self, proto_file_list):
+        """Parses the relevant services from a generic proto file list"""
+        logging.debug("starting service generation")
+        logging.debug(f"Starts with total of: {len(proto_file_list)}")
+        services_proto_list = list(filter(self.file_filter, proto_file_list))
+        try:
+            assert len(services_proto_list) != 0
+            assert len(services_proto_list) == len(self.valid_proto_files), (
+                len(services_proto_list),
+                len(self.valid_proto_files),
+            )
+        except AssertionError:
+            logging.error("length cannot be 0. This is likely due to a name error")
+            for f in self.valid_proto_files:
+                logging.error("Valid Proto File: {}".format(f))
+            for f in services_proto_list:
+                logging.error("Actual Proto File: {}".format(f))
+            logging.error("Maybe someone changed the name/location of a proto file?")
+            raise
+        self.services = sorted(Service.parse_all_from(services_proto_list), key=lambda x: x.name)
+        logging.debug("completed service generation")
+
+    def set_messages(self, proto_file_list):
+        """Parses the relevant messages from a generic proto file list"""
+        logging.debug("starting message generation")
+        logging.debug(f"Starts with total of: {len(proto_file_list)}")
+        messages_proto_list = list(filter(self.file_filter, proto_file_list))
+        try:
+            assert len(messages_proto_list) != 0
+            assert len(messages_proto_list) == len(self.valid_proto_files)
+        except AssertionError:
+            logging.error("length cannot be 0. This is likely due to a name error")
+            for f in self.valid_proto_files:
+                logging.error("Valid Proto File: {}".format(f))
+            logging.error("Maybe someone changed the name/location of a proto file?")
+            raise
+            raise
+
+        self.messages = sorted(Message.parse_all_from(messages_proto_list), key=lambda x: x.name)
+        logging.debug("completed message generation")
+
+    def set_enums(self, proto_file_list):
+        """Parses the relevant enums from a generic proto file list"""
+        logging.debug("starting enum generation")
+        logging.debug(f"Starts with total of: {len(proto_file_list)}")
+        enums_proto_list = list(filter(self.file_filter, proto_file_list))
+        try:
+            assert len(enums_proto_list) != 0
+            assert len(enums_proto_list) == len(self.valid_proto_files)
+        except AssertionError:
+            logging.error("length cannot be 0. This is likely due to a name error")
+            for f in self.valid_proto_files:
+                logging.error("Valid Proto File: {}".format(f))
+            logging.error("Maybe someone changed the name/location of a proto file?")
+            raise
+        self.enums = sorted(ProtoEnum.parse_all_from(enums_proto_list), key=lambda x: x.name)
+        logging.debug("completed enum generation")
+
+    def connect_methods_messages(self):
+        """
+        Every service has an associated list of methods. Each of those methods have a request
+        message and a response message. This method connects those two and labels the messages as
+        such as well as adding them to the relevant methods.
+        """
+        for service in self.services:
+            for method in service.methods:
+                request_set = False
+                response_set = False
+                method.API_VERSION = self.API_VERSION
+                for message in self.messages:
+                    if message.id == method.request and not request_set:
+                        method.request_message = message
+                        message.type = MsgType.request
+                        request_set = True
+                        logging.debug("Set Request Message for {}".format(str(method)))
+                    elif message.id == method.response and not response_set:
+                        method.response_message = message
+                        response_set = True
+                        message.type = MsgType.response
+                        logging.debug("Set Response Message for {}".format(str(method)))
+
+                if not request_set:
+                    logging.warn("Request not set {} for {}".format(method, str(self)))
+
+                if not response_set:
+                    logging.warn("Response not set {} for {}".format(method, str(self)))
+
+    def set_all(self, proto_file_list):
+        "Wraps all the above set methods"
+        logging.info("Setting Services for {}".format(self.name))
+        self.set_services(proto_file_list)
+        logging.info("Finished Setting Services for {}".format(self.name))
+        logging.info("Setting Messages for {}".format(self.name))
+        self.set_messages(proto_file_list)
+        logging.info("Finished Setting Messages for {}".format(self.name))
+        logging.info("Setting Enums for {}".format(self.name))
+        self.set_enums(proto_file_list)
+        logging.info("Finished Setting Enums for {}".format(self.name))
+        logging.info("Connecting Messages -> Services for {}".format(self.name))
+        self.connect_methods_messages()
+        logging.info("Finished Connecting Messages -> Services under {} API".format(self.name))
+
+    def write_rst(self, method_order=None):
+        try:
+            assert (
+                self.services is not None and self.messages is not None and self.enums is not None
+            )
+        except AssertionError:
+            logging.error("We haven't parsed anything. You're using the module incorrectly")
+            raise
+        try:
+            assert len(self.services) != 0 and len(self.messages) != 0
+        except AssertionError:
+            logging.error("There was likely an error parsing the doc_public.json file.")
+            logging.error(
+                "Services: %i Messages: %i Enums: %i",
+                len(self.services),
+                len(self.messages),
+                len(self.enums),
+            )
+            raise
+        services = [s.to_rst() for s in self.services]
+        enums = [s.to_rst() for s in self.enums]
+        generic_messages = [s.to_rst() for s in self.messages if s.type == MsgType.generic]
+
+        with open(self.dstPath, "w") as f:
+            f.write(gen_page_title("{} API".format(self.name)))
+            f.write(self.description)
+            f.write("\n.. contents:: Table of Contents\n    :local:\n    :depth: 1")
+            f.write("".join(services))
+            f.write(gen_h1(self.name + "add", "Data Structures"))
+            f.write("".join(generic_messages))
+            f.write("".join(enums))
+
+
+logging.basicConfig(format="%(levelname)s:%(lineno)d:%(message)s", level=logging.INFO)
+
+
+def create_argparser():
+    parser = argparse.ArgumentParser(
+        description="""
+This module converts a doc_public.json file created from the API files into
+.rst files that can be integrated directly into the documentation.
+"""
+    )
+    parser.add_argument("src", type=str, help="Path the doc public json FILE")
+    parser.add_argument("dst", type=str, help="Destination FOLDER for the rst files")
+    return parser
+
+
+if __name__ == "__main__":
+    src = "mlflow/protos/protos.json"
+    dst = "docs/api_reference/source/rest-api.rst"
+
+    API_VERSION = "2.0"
+    logging.info(
+        "SETTING API VERSION TO: {} EDIT api-sphinx-build.py TO CHANGE THIS VERSION".format(
+            API_VERSION
+        )
+    )
+    logging.info("Reading Source: " + src)
+
+    with open(src) as f:
+        docjson = json.load(f)
+
+    validate_doc_public_json(docjson)
+
+    proto_files = docjson["files"]
+
+    mlflow_description = dedent("""
+    The MLflow REST API allows you to create, list, and get experiments and runs, and log
+    parameters, metrics, and artifacts. The API is hosted under the ``/api`` route on the MLflow
+    tracking server. For example, to search for experiments on a tracking server hosted at
+    ``http://localhost:5000``, make a POST request to ``http://localhost:5000/api/2.0/mlflow/experiments/search``.
+
+    .. important::
+        The MLflow REST API requires content type ``application/json`` for all POST requests.
+    """)
+
+    mlflow_protos = [
+        "service.proto",
+        "model_registry.proto",
+        "webhooks.proto",
+    ]
+    valid_mlflow_messages = [
+        # APIs
+        "mlflowCreateExperiment",
+        "mlflowListExperiments",
+        "mlflowSearchExperiments",
+        "mlflowGetExperiment",
+        "mlflowGetExperimentByName",
+        "mlflowDeleteExperiment",
+        "mlflowRestoreExperiment",
+        "mlflowUpdateExperiment",
+        "mlflowCreateRun",
+        "mlflowDeleteRun",
+        "mlflowDeleteRuns",
+        "mlflowRestoreRun",
+        "mlflowRestoreRuns",
+        "mlflowGetRun",
+        "mlflowLogMetric",
+        "mlflowLogBatch",
+        "mlflowLogModel",
+        "mlflowLogInputs",
+        "mlflowLogBatchResponse",
+        "mlflowSetExperimentTag",
+        "mlflowDeleteExperimentTag",
+        "mlflowSetTag",
+        "mlflowDeleteTag",
+        "mlflowLogParam",
+        "mlflowGetMetricHistory",
+        "mlflowSearchRuns",
+        "mlflowListArtifacts",
+        "mlflowUpdateRun",
+        "mlflowPurgeDeletedState",
+        "mlflowCreateRegisteredModel",
+        "mlflowGetRegisteredModel",
+        "mlflowRenameRegisteredModel",
+        "mlflowUpdateRegisteredModel",
+        "mlflowDeleteRegisteredModel",
+        "mlflowListRegisteredModels",
+        "mlflowGetLatestVersions",
+        "mlflowCreateModelVersion",
+        "mlflowGetModelVersion",
+        "mlflowUpdateModelVersion",
+        "mlflowDeleteModelVersion",
+        "mlflowSearchModelVersions",
+        "mlflowGetModelVersionDownloadUri",
+        "mlflowTransitionModelVersionStage",
+        "mlflowSearchRegisteredModels",
+        "mlflowSetRegisteredModelTag",
+        "mlflowSetModelVersionTag",
+        "mlflowDeleteRegisteredModelTag",
+        "mlflowDeleteModelVersionTag",
+        # Responses
+        "mlflowCreateExperimentResponse",
+        "mlflowListExperimentsResponse",
+        "mlflowSearchExperimentsResponse",
+        "mlflowGetExperimentResponse",
+        "mlflowGetExperimentByNameResponse",
+        "mlflowDeleteExperimentResponse",
+        "mlflowRestoreExperimentResponse",
+        "mlflowUpdateExperimentResponse",
+        "mlflowCreateRunResponse",
+        "mlflowDeleteRunResponse",
+        "mlflowDeleteRunsResponse",
+        "mlflowRestoreRunResponse",
+        "mlflowRestoreRunsResponse",
+        "mlflowGetRunResponse",
+        "mlflowLogMetricResponse",
+        "mlflowLogInputsResponse",
+        "mlflowLogParamResponse",
+        "mlflowSetExperimentTagResponse",
+        "mlflowSetTagResponse",
+        "mlflowDeleteTagResponse",
+        "mlflowGetMetricHistoryResponse",
+        "mlflowSearchRunsResponse",
+        "mlflowListArtifactsResponse",
+        "mlflowUpdateRunResponse",
+        "mlflowPurgeDeletedStateResponse",
+        "mlflowCreateRegisteredModelResponse",
+        "mlflowGetRegisteredModelResponse",
+        "mlflowRenameRegisteredModelResponse",
+        "mlflowUpdateRegisteredModelResponse",
+        "mlflowListRegisteredModelsResponse",
+        "mlflowGetLatestVersionsResponse",
+        "mlflowCreateModelVersionResponse",
+        "mlflowUpdateModelVersionResponse",
+        "mlflowGetModelVersionResponse",
+        "mlflowSearchModelVersionsResponse",
+        "mlflowGetModelVersionDownloadUriResponse",
+        "mlflowTransitionModelVersionStageResponse",
+        "mlflowSearchRegisteredModelsResponse",
+        "mlflowSetRegisteredModelTagResponse",
+        "mlflowSetModelVersionTagResponse",
+        "mlflowDeleteRegisteredModelTagResponse",
+        "mlflowDeleteModelVersionTagResponse",
+        "mlflowGetModelVersionByAliasResponse",
+        # Other messages
+        "mlflowExperiment",
+        "mlflowRun",
+        "mlflowRunInfo",
+        "mlflowRunTag",
+        "mlflowExperimentTag",
+        "mlflowRunData",
+        "mlflowRunInputs",
+        "mlflowMetric",
+        "mlflowParam",
+        "mlflowFileInfo",
+        "mlflowRegisteredModel",
+        "mlflowModelVersion",
+        "mlflowModelVersionDetailed",
+        "mlflowModelVersionStatus",
+        "mlflowRegisteredModelTag",
+        "mlflowModelVersionTag",
+        "mlflowDeleteRegisteredModelAlias",
+        "mlflowGetModelVersionByAlias",
+        "mlflowRegisteredModelAlias",
+        "mlflowSetRegisteredModelAlias",
+        "mlflowDatasetInput",
+        "mlflowDataset",
+        "mlflowInputTag",
+        "mlflowDeploymentJobConnection",
+        "mlflowModelVersionDeploymentJobState",
+        "mlflowModelMetric",
+        "mlflowModelOutput",
+        "mlflowModelInput",
+        "mlflowRunOutputs",
+        "mlflowModelParam",
+    ]
+
+    mlflowAPI = API(
+        "REST",
+        mlflow_description,
+        API_VERSION,
+        dst,
+        mlflow_protos,
+    )
+    mlflowAPI.set_all(proto_files)
+    # Sort the methods based on the order in `valid_mlflow_messages` list.
+    mlflowAPI.write_rst(valid_mlflow_messages)

--- a/dev/generate-protos.sh
+++ b/dev/generate-protos.sh
@@ -46,4 +46,7 @@ docker cp "$CONTAINER_NAME:/mlflow/mlflow/java/client/src/main/java/." "mlflow/j
 echo "Generating GraphQL schema from Protobuf files..."
 python ./dev/proto_to_graphql/code_generator.py
 
+echo "Generating REST API from Protobuf files..."
+python ./dev/gen_rest_api.py
+
 echo "Done!"

--- a/dev/generate_protos.py
+++ b/dev/generate_protos.py
@@ -67,8 +67,7 @@ def gen_proto_docs(
             protoc_bin,
             f"-I={protoc_include_path}",
             f"-I={proto_dir}",
-            f"--pyi_out={out_dir}",
-            f"--plugin=protos-gen-docs={plugin_path}",
+            f"--plugin=protoc-gen-doc={plugin_path}",
             f"--doc_out={out_dir}",
             *[proto_dir / pf for pf in proto_files],
         ]

--- a/dev/generate_protos.py
+++ b/dev/generate_protos.py
@@ -24,7 +24,6 @@ def gen_protos(
 ) -> None:
     assert lang in ["python", "java"]
     out_dir.mkdir(parents=True, exist_ok=True)
-
     subprocess.check_call(
         [
             protoc_bin,
@@ -43,12 +42,34 @@ def gen_stub_files(
     protoc_include_path: Path,
     out_dir: Path,
 ) -> None:
+    out_dir.mkdir(parents=True, exist_ok=True)
     subprocess.check_call(
         [
             protoc_bin,
             f"-I={protoc_include_path}",
             f"-I={proto_dir}",
             f"--pyi_out={out_dir}",
+            *[proto_dir / pf for pf in proto_files],
+        ]
+    )
+
+
+def gen_proto_docs(
+    proto_dir: Path,
+    proto_files: list[Path],
+    protoc_bin: Path,
+    protoc_include_path: Path,
+    out_dir: Path,
+) -> None:
+    plugin_path = Path("dev/proto-plugin.sh").resolve()
+    subprocess.check_call(
+        [
+            protoc_bin,
+            f"-I={protoc_include_path}",
+            f"-I={proto_dir}",
+            f"--pyi_out={out_dir}",
+            f"--plugin=protos-gen-docs={plugin_path}",
+            f"--doc_out={out_dir}",
             *[proto_dir / pf for pf in proto_files],
         ]
     )
@@ -259,6 +280,14 @@ def main() -> None:
         protoc5260,
         protoc5260_include,
         Path("mlflow/protos/"),
+    )
+
+    gen_proto_docs(
+        MLFLOW_PROTOS_DIR,
+        basic_proto_files,
+        protoc5260,
+        protoc5260_include,
+        Path("mlflow/protos"),
     )
 
 

--- a/dev/proto-plugin.sh
+++ b/dev/proto-plugin.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+export PYTHONPATH="$PWD:$PYTHONPATH"
+python dev/proto_plugin.py

--- a/dev/proto_plugin.py
+++ b/dev/proto_plugin.py
@@ -1,0 +1,564 @@
+import json
+import sys
+from dataclasses import asdict, dataclass
+from dataclasses import field as dataclass_field
+from enum import Enum
+
+from google.protobuf import descriptor_pb2
+from google.protobuf.compiler import plugin_pb2
+
+from mlflow.protos import databricks_pb2
+
+
+class Visibility(Enum):
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    PUBLIC_UNDOCUMENTED = "public_undocumented"
+    PUBLIC_UNDOCUMENTED_READ_ONLY = "public_undocumented_read_only"
+
+
+@dataclass
+class ProtoMessageField:
+    description: str
+    field_name: str
+    field_default: str | None
+    entity_type: str
+    field_type: str
+    full_path: list[str]
+    visibility: str
+    since: str
+    deprecated: bool
+    repeated: bool
+    validate_required: bool
+    oneof: list["ProtoMessageField"] = dataclass_field(default_factory=list)
+
+
+@dataclass
+class ProtoMessage:
+    name: str
+    full_path: list[str]
+    description: str
+    visibility: str
+    fields: list[ProtoMessageField]
+    enums: list["ProtoEnum"]
+    messages: list["ProtoMessage"]
+
+
+@dataclass
+class ProtoEnumValue:
+    value: str
+    full_path: list[str]
+    visibility: str
+    description: str
+
+
+@dataclass
+class ProtoEnum:
+    name: str
+    description: str
+    full_path: list[str]
+    values: list[ProtoEnumValue]
+    visibility: str
+
+
+@dataclass
+class DatabricksRpcOptionsDescription:
+    path: str | None = None
+    method: str | None = None
+    visibility: str = "internal"
+    since_major: int | None = None
+    since_minor: int | None = None
+    error_codes: list[int] | None = None
+    rpc_doc_title: str = ""
+
+    def __post_init__(self):
+        if self.error_codes is None:
+            self.error_codes = []
+
+
+@dataclass
+class ProtoServiceMethod:
+    name: str
+    full_path: list[str]
+    request_full_path: list[str]
+    response_full_path: list[str]
+    description: str
+    rpc_options: DatabricksRpcOptionsDescription | None
+
+
+@dataclass
+class ProtoService:
+    name: str
+    full_path: list[str]
+    description: str
+    visibility: str
+    methods: list[ProtoServiceMethod]
+
+
+@dataclass
+class ProtoTopComment:
+    content: str
+    visibility: str
+
+
+@dataclass
+class ProtoFileElement:
+    comment: ProtoTopComment | None = None
+    enum: ProtoEnum | None = None
+    message: ProtoMessage | None = None
+    service: ProtoService | None = None
+
+
+@dataclass
+class ProtoFile:
+    filename: str
+    requested_visibility: str
+    content: list[ProtoFileElement]
+
+
+@dataclass
+class ProtoAllContent:
+    requested_visibility: str
+    files: list[ProtoFile]
+
+
+class ProtobufDocGenerator:
+    """Generates documentation from protobuf file descriptors."""
+
+    # Databricks protobuf extension field numbers
+    VISIBILITY_FIELD = 50000
+    VALIDATE_REQUIRED_FIELD = 50001
+    JSON_INLINE_FIELD = 50002
+    JSON_MAP_FIELD = 50003
+    DOC_FIELD = 50004
+
+    def __init__(self):
+        self.type_map = {}
+
+    def get_field_type_name(self, field: descriptor_pb2.FieldDescriptorProto) -> str:
+        type_names = {
+            descriptor_pb2.FieldDescriptorProto.TYPE_DOUBLE: "DOUBLE",
+            descriptor_pb2.FieldDescriptorProto.TYPE_FLOAT: "FLOAT",
+            descriptor_pb2.FieldDescriptorProto.TYPE_INT64: "INT64",
+            descriptor_pb2.FieldDescriptorProto.TYPE_UINT64: "UINT64",
+            descriptor_pb2.FieldDescriptorProto.TYPE_INT32: "INT32",
+            descriptor_pb2.FieldDescriptorProto.TYPE_FIXED64: "FIXED64",
+            descriptor_pb2.FieldDescriptorProto.TYPE_FIXED32: "FIXED32",
+            descriptor_pb2.FieldDescriptorProto.TYPE_BOOL: "BOOL",
+            descriptor_pb2.FieldDescriptorProto.TYPE_STRING: "STRING",
+            descriptor_pb2.FieldDescriptorProto.TYPE_BYTES: "BYTES",
+            descriptor_pb2.FieldDescriptorProto.TYPE_UINT32: "UINT32",
+            descriptor_pb2.FieldDescriptorProto.TYPE_SFIXED32: "SFIXED32",
+            descriptor_pb2.FieldDescriptorProto.TYPE_SFIXED64: "SFIXED64",
+            descriptor_pb2.FieldDescriptorProto.TYPE_SINT32: "SINT32",
+            descriptor_pb2.FieldDescriptorProto.TYPE_SINT64: "SINT64",
+        }
+
+        if field.type in type_names:
+            return type_names[field.type]
+        elif (
+            field.type == descriptor_pb2.FieldDescriptorProto.TYPE_MESSAGE
+            or field.type == descriptor_pb2.FieldDescriptorProto.TYPE_ENUM
+        ):
+            # Remove leading dot if present
+            type_name = field.type_name
+            if type_name.startswith("."):
+                type_name = type_name[1:]
+            return type_name
+        else:
+            return "unknown"
+
+    def get_visibility(self, options) -> Visibility:
+        # For now, return PUBLIC as default
+        # In a real implementation, this would check custom options
+        return Visibility.PUBLIC
+
+    def extract_rpc_options(self, options) -> DatabricksRpcOptionsDescription | None:
+        """Extract RPC options from method options.
+
+        This requires databricks_pb2 to be available for full extraction.
+        When running as a protoc plugin, the extension data is present in the
+        file descriptors but needs the compiled extension definitions to parse.
+        """
+        # Check if the method has the Databricks RPC extension
+        if options.HasExtension(databricks_pb2.rpc):
+            # Extract the RPC options
+            rpc_ext = options.Extensions[databricks_pb2.rpc]
+
+            # Extract endpoint information
+            path = None
+            method = None
+            since_major = None
+            since_minor = None
+
+            if rpc_ext.endpoints:
+                # Use the first endpoint for now
+                endpoint = rpc_ext.endpoints[0]
+                path = endpoint.path if endpoint.HasField("path") else None
+                method = endpoint.method if endpoint.HasField("method") else None
+
+                if endpoint.HasField("since") and endpoint.since:
+                    since_major = endpoint.since.major if endpoint.since.HasField("major") else None
+                    since_minor = endpoint.since.minor if endpoint.since.HasField("minor") else None
+
+            # Extract visibility
+            visibility = "internal"  # default
+            if rpc_ext.HasField("visibility"):
+                visibility_enum = rpc_ext.visibility
+                # Map the enum value to string
+                if visibility_enum == databricks_pb2.PUBLIC:
+                    visibility = "public"
+                elif visibility_enum == databricks_pb2.INTERNAL:
+                    visibility = "internal"
+                elif visibility_enum == databricks_pb2.PUBLIC_UNDOCUMENTED:
+                    visibility = "public_undocumented"
+
+            # Extract error codes
+            error_codes = list(rpc_ext.error_codes) if rpc_ext.error_codes else []
+
+            # Extract RPC doc title
+            rpc_doc_title = rpc_ext.rpc_doc_title if rpc_ext.HasField("rpc_doc_title") else ""
+
+            return DatabricksRpcOptionsDescription(
+                path=path,
+                method=method,
+                visibility=visibility,
+                since_major=since_major,
+                since_minor=since_minor,
+                error_codes=error_codes,
+                rpc_doc_title=rpc_doc_title,
+            )
+
+    def get_full_path_for_file(
+        self, file: descriptor_pb2.FileDescriptorProto, name: str
+    ) -> list[str]:
+        path_parts = []
+        if file.package:
+            path_parts.extend(file.package.split("."))
+        path_parts.append(name)
+        return path_parts
+
+    def get_full_path_for_nested(self, parent_path: list[str], name: str) -> list[str]:
+        return parent_path + [name]
+
+    def get_documentation(self, source_location: descriptor_pb2.SourceCodeInfo.Location) -> str:
+        if source_location and source_location.leading_comments:
+            return source_location.leading_comments.strip()
+        return ""
+
+    def find_source_location(
+        self, source_info: descriptor_pb2.SourceCodeInfo, path: list[int]
+    ) -> descriptor_pb2.SourceCodeInfo.Location | None:
+        for location in source_info.location:
+            if list(location.path) == path:
+                return location
+        return None
+
+    def process_field(
+        self,
+        field: descriptor_pb2.FieldDescriptorProto,
+        parent_path: list[str],
+        field_index: int,
+        source_info: descriptor_pb2.SourceCodeInfo,
+        message_path: list[int],
+    ) -> ProtoMessageField:
+        # Build source location path for this field
+        field_path = message_path + [2, field_index]  # 2 = field in message
+        location = self.find_source_location(source_info, field_path)
+
+        field_type = self.get_field_type_name(field)
+
+        default_value = None
+        if field.HasField("default_value"):
+            default_value = field.default_value
+
+        return ProtoMessageField(
+            description=self.get_documentation(location) if location else "",
+            field_name=field.name,
+            field_default=default_value,
+            entity_type=str(field.type),
+            field_type=field_type,
+            full_path=self.get_full_path_for_nested(parent_path, field.name),
+            visibility=self.get_visibility(field.options).value,
+            since="",
+            deprecated=field.options.deprecated if field.options.HasField("deprecated") else False,
+            repeated=field.label == descriptor_pb2.FieldDescriptorProto.LABEL_REPEATED,
+            validate_required=False,  # Would check custom extension
+            oneof=[],
+        )
+
+    def process_enum_value(
+        self,
+        value: descriptor_pb2.EnumValueDescriptorProto,
+        parent_path: list[str],
+        value_index: int,
+        source_info: descriptor_pb2.SourceCodeInfo,
+        enum_path: list[int],
+    ) -> ProtoEnumValue:
+        # Build source location path for this enum value
+        value_path = enum_path + [2, value_index]  # 2 = value in enum
+        location = self.find_source_location(source_info, value_path)
+
+        return ProtoEnumValue(
+            value=value.name,
+            full_path=self.get_full_path_for_nested(parent_path, value.name),
+            visibility=self.get_visibility(value.options).value,
+            description=self.get_documentation(location) if location else "",
+        )
+
+    def process_enum(
+        self,
+        enum: descriptor_pb2.EnumDescriptorProto,
+        parent_path: list[str],
+        enum_index: int,
+        source_info: descriptor_pb2.SourceCodeInfo,
+        parent_path_numbers: list[int],
+        is_nested: bool = False,
+    ) -> ProtoEnum:
+        # Build source location path for this enum
+        enum_path = parent_path_numbers + [4, enum_index] if is_nested else [5, enum_index]
+
+        location = self.find_source_location(source_info, enum_path)
+
+        full_path = self.get_full_path_for_nested(parent_path, enum.name)
+
+        values = []
+        for i, value in enumerate(enum.value):
+            values.append(self.process_enum_value(value, full_path, i, source_info, enum_path))
+
+        return ProtoEnum(
+            name=enum.name,
+            description=self.get_documentation(location) if location else "",
+            full_path=full_path,
+            values=values,
+            visibility=self.get_visibility(enum.options).value,
+        )
+
+    def process_message(
+        self,
+        msg: descriptor_pb2.DescriptorProto,
+        parent_path: list[str],
+        msg_index: int,
+        source_info: descriptor_pb2.SourceCodeInfo,
+        parent_path_numbers: list[int] | None = None,
+        is_nested: bool = False,
+    ) -> ProtoMessage:
+        # Build source location path for this message
+        message_path = parent_path_numbers + [3, msg_index] if is_nested else [4, msg_index]
+
+        location = self.find_source_location(source_info, message_path)
+
+        full_path = self.get_full_path_for_nested(parent_path, msg.name)
+
+        fields = []
+        # Process regular fields
+        for i, proto_field in enumerate(msg.field):
+            if not proto_field.HasField("oneof_index"):  # Skip oneof fields for now
+                fields.append(
+                    self.process_field(proto_field, full_path, i, source_info, message_path)
+                )
+
+        # Process oneofs
+        for oneof_index, oneof in enumerate(msg.oneof_decl):
+            oneof_fields = []
+            for i, proto_field in enumerate(msg.field):
+                if proto_field.HasField("oneof_index") and proto_field.oneof_index == oneof_index:
+                    oneof_fields.append(
+                        self.process_field(proto_field, full_path, i, source_info, message_path)
+                    )
+
+            if oneof_fields:
+                oneof_field = ProtoMessageField(
+                    description="",
+                    field_name=oneof.name,
+                    field_default=None,
+                    entity_type="oneof",
+                    field_type="oneof",
+                    full_path=self.get_full_path_for_nested(full_path, oneof.name),
+                    visibility=self.get_visibility(oneof.options).value,
+                    since="",
+                    deprecated=False,
+                    repeated=False,
+                    validate_required=False,
+                    oneof=oneof_fields,
+                )
+                fields.append(oneof_field)
+
+        # Process nested enums
+        enums = []
+        for i, enum in enumerate(msg.enum_type):
+            enums.append(
+                self.process_enum(enum, full_path, i, source_info, message_path, is_nested=True)
+            )
+
+        # Process nested messages
+        messages = []
+        for i, nested in enumerate(msg.nested_type):
+            messages.append(
+                self.process_message(
+                    nested, full_path, i, source_info, message_path, is_nested=True
+                )
+            )
+
+        return ProtoMessage(
+            name=msg.name,
+            full_path=full_path,
+            description=self.get_documentation(location) if location else "",
+            visibility=self.get_visibility(msg.options).value,
+            fields=fields,
+            enums=enums,
+            messages=messages,
+        )
+
+    def process_method(
+        self,
+        method: descriptor_pb2.MethodDescriptorProto,
+        parent_path: list[str],
+        method_index: int,
+        source_info: descriptor_pb2.SourceCodeInfo,
+        service_path: list[int],
+    ) -> ProtoServiceMethod:
+        # Build source location path for this method
+        method_path = service_path + [2, method_index]  # 2 = method in service
+        location = self.find_source_location(source_info, method_path)
+
+        # Remove leading dots from type names
+        input_type = method.input_type
+        if input_type.startswith("."):
+            input_type = input_type[1:]
+        output_type = method.output_type
+        if output_type.startswith("."):
+            output_type = output_type[1:]
+
+        input_path = input_type.split(".")
+        output_path = output_type.split(".")
+
+        # Extract RPC options from custom extensions
+        rpc_options = self.extract_rpc_options(method.options)
+
+        return ProtoServiceMethod(
+            name=method.name,
+            full_path=self.get_full_path_for_nested(parent_path, method.name),
+            request_full_path=input_path,
+            response_full_path=output_path,
+            description=self.get_documentation(location) if location else "",
+            rpc_options=rpc_options,
+        )
+
+    def process_service(
+        self,
+        service: descriptor_pb2.ServiceDescriptorProto,
+        parent_path: list[str],
+        service_index: int,
+        source_info: descriptor_pb2.SourceCodeInfo,
+    ) -> ProtoService:
+        # Build source location path for this service
+        service_path = [6, service_index]  # 6 = service at file level
+        location = self.find_source_location(source_info, service_path)
+
+        full_path = self.get_full_path_for_nested(parent_path, service.name)
+
+        methods = []
+        for i, method in enumerate(service.method):
+            methods.append(self.process_method(method, full_path, i, source_info, service_path))
+
+        return ProtoService(
+            name=service.name,
+            full_path=full_path,
+            description=self.get_documentation(location) if location else "",
+            visibility=self.get_visibility(service.options).value,
+            methods=methods,
+        )
+
+    def process_file(
+        self, file: descriptor_pb2.FileDescriptorProto, requested_vis: Visibility
+    ) -> ProtoFile:
+        elements = []
+
+        # Base path from package
+        base_path = file.package.split(".") if file.package else []
+
+        # Get source code info for documentation
+        source_info = file.source_code_info if file.HasField("source_code_info") else None
+        if not source_info:
+            source_info = descriptor_pb2.SourceCodeInfo()
+
+        # Process top-level messages
+        for i, msg in enumerate(file.message_type):
+            elements.append(
+                ProtoFileElement(message=self.process_message(msg, base_path, i, source_info))
+            )
+
+        # Process top-level enums
+        for i, enum in enumerate(file.enum_type):
+            elements.append(
+                ProtoFileElement(
+                    enum=self.process_enum(enum, base_path, i, source_info, [], is_nested=False)
+                )
+            )
+
+        # Process services
+        for i, service in enumerate(file.service):
+            elements.append(
+                ProtoFileElement(service=self.process_service(service, base_path, i, source_info))
+            )
+
+        return ProtoFile(
+            filename=file.name, requested_visibility=requested_vis.value, content=elements
+        )
+
+
+class ProtocPlugin:
+    """Protoc plugin implementation."""
+
+    def __init__(self):
+        self.generator = ProtobufDocGenerator()
+
+    def process_request(
+        self, request: plugin_pb2.CodeGeneratorRequest
+    ) -> plugin_pb2.CodeGeneratorResponse:
+        response = plugin_pb2.CodeGeneratorResponse()
+
+        files = []
+
+        # Process each file that was requested to be generated
+        for file_name in request.file_to_generate:
+            # Find the file descriptor
+            file_descriptor = None
+            for proto_file in request.proto_file:
+                if proto_file.name == file_name:
+                    file_descriptor = proto_file
+                    break
+
+            if file_descriptor:
+                # Process the file
+                proto_file = self.generator.process_file(file_descriptor, Visibility.PUBLIC)
+                files.append(proto_file)
+
+        # Generate documentation
+        doc_content = ProtoAllContent(requested_visibility=Visibility.PUBLIC.value, files=files)
+
+        # Generate doc_public.json
+        doc_file = response.file.add()
+        doc_file.name = "protos.json"
+        doc_file.content = json.dumps(asdict(doc_content), indent=2)
+
+        return response
+
+
+def main():
+    # Protoc plugin mode
+    # Read CodeGeneratorRequest from stdin
+    data = sys.stdin.buffer.read()
+    request = plugin_pb2.CodeGeneratorRequest.FromString(data)
+
+    # Process request
+    plugin = ProtocPlugin()
+    response = plugin.process_request(request)
+
+    # Write response to stdout
+    sys.stdout.buffer.write(response.SerializeToString())
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/api_reference/source/rest-api.rst
+++ b/docs/api_reference/source/rest-api.rst
@@ -6,10 +6,10 @@ REST API
 ========
 
 
-The MLflow REST API allows you to create, list, and get experiments and runs, and log parameters, metrics, and artifacts.
-The API is hosted under the ``/api`` route on the MLflow tracking server. For example, to search for
-experiments on a tracking server hosted at ``http://localhost:5000``, make a POST request to
-``http://localhost:5000/api/2.0/mlflow/experiments/search``.
+The MLflow REST API allows you to create, list, and get experiments and runs, and log
+parameters, metrics, and artifacts. The API is hosted under the ``/api`` route on the MLflow
+tracking server. For example, to search for experiments on a tracking server hosted at
+``http://localhost:5000``, make a POST request to ``http://localhost:5000/api/2.0/mlflow/experiments/search``.
 
 .. important::
     The MLflow REST API requires content type ``application/json`` for all POST requests.
@@ -19,6 +19,7 @@ experiments on a tracking server hosted at ``http://localhost:5000``, make a POS
     :depth: 1
 
 ===========================
+
 
 
 .. _mlflowMlflowServicecreateExperiment:
@@ -89,24 +90,26 @@ Response Structure
 
 
 
-.. _mlflowMlflowServicesearchExperiments:
+.. _mlflowMlflowServicecreateRun:
 
-Search Experiments
-==================
-
-
-+-----------------------------------+-------------+
-|             Endpoint              | HTTP Method |
-+===================================+=============+
-| ``2.0/mlflow/experiments/search`` | ``POST``    |
-+-----------------------------------+-------------+
+Create Run
+==========
 
 
++----------------------------+-------------+
+|          Endpoint          | HTTP Method |
++============================+=============+
+| ``2.0/mlflow/runs/create`` | ``POST``    |
++----------------------------+-------------+
+
+Create a new run within an experiment. A run is usually a single execution of a
+machine learning or data ETL pipeline. MLflow uses runs to track :ref:`mlflowParam`,
+:ref:`mlflowMetric`, and :ref:`mlflowRunTag` associated with a single execution.
 
 
 
 
-.. _mlflowSearchExperiments:
+.. _mlflowCreateRun:
 
 Request Structure
 -----------------
@@ -116,39 +119,23 @@ Request Structure
 
 
 
-+-------------+------------------------+--------------------------------------------------------------------------------------------+
-| Field Name  |          Type          |                                        Description                                         |
-+=============+========================+============================================================================================+
-| max_results | ``INT64``              | Maximum number of experiments desired.                                                     |
-|             |                        | Servers may select a desired default `max_results` value. All servers are                  |
-|             |                        | guaranteed to support a `max_results` threshold of at least 1,000 but may                  |
-|             |                        | support more. Callers of this endpoint are encouraged to pass max_results                  |
-|             |                        | explicitly and leverage page_token to iterate through experiments.                         |
-+-------------+------------------------+--------------------------------------------------------------------------------------------+
-| page_token  | ``STRING``             | Token indicating the page of experiments to fetch                                          |
-+-------------+------------------------+--------------------------------------------------------------------------------------------+
-| filter      | ``STRING``             | A filter expression over experiment attributes and tags that allows returning a subset of  |
-|             |                        | experiments. The syntax is a subset of SQL that supports ANDing together binary operations |
-|             |                        | between an attribute or tag, and a constant.                                               |
-|             |                        |                                                                                            |
-|             |                        | Example: ``name LIKE 'test-%' AND tags.key = 'value'``                                     |
-|             |                        |                                                                                            |
-|             |                        | You can select columns with special characters (hyphen, space, period, etc.) by using      |
-|             |                        | double quotes or backticks.                                                                |
-|             |                        |                                                                                            |
-|             |                        | Example: ``tags."extra-key" = 'value'`` or ``tags.`extra-key` = 'value'``                  |
-|             |                        |                                                                                            |
-|             |                        | Supported operators are ``=``, ``!=``, ``LIKE``, and ``ILIKE``.                            |
-+-------------+------------------------+--------------------------------------------------------------------------------------------+
-| order_by    | An array of ``STRING`` | List of columns for ordering search results, which can include experiment name and id      |
-|             |                        | with an optional "DESC" or "ASC" annotation, where "ASC" is the default.                   |
-|             |                        | Tiebreaks are done by experiment id DESC.                                                  |
-+-------------+------------------------+--------------------------------------------------------------------------------------------+
-| view_type   | :ref:`mlflowviewtype`  | Qualifier for type of experiments to be returned.                                          |
-|             |                        | If unspecified, return only active experiments.                                            |
-+-------------+------------------------+--------------------------------------------------------------------------------------------+
++---------------+---------------------------------+----------------------------------------------------------------------------+
+|  Field Name   |              Type               |                                Description                                 |
++===============+=================================+============================================================================+
+| experiment_id | ``STRING``                      | ID of the associated experiment.                                           |
++---------------+---------------------------------+----------------------------------------------------------------------------+
+| user_id       | ``STRING``                      | ID of the user executing the run.                                          |
+|               |                                 | This field is deprecated as of MLflow 1.0, and will be removed in a future |
+|               |                                 | MLflow release. Use 'mlflow.user' tag instead.                             |
++---------------+---------------------------------+----------------------------------------------------------------------------+
+| run_name      | ``STRING``                      | Name of the run.                                                           |
++---------------+---------------------------------+----------------------------------------------------------------------------+
+| start_time    | ``INT64``                       | Unix timestamp in milliseconds of when the run started.                    |
++---------------+---------------------------------+----------------------------------------------------------------------------+
+| tags          | An array of :ref:`mlflowruntag` | Additional metadata for run.                                               |
++---------------+---------------------------------+----------------------------------------------------------------------------+
 
-.. _mlflowSearchExperimentsResponse:
+.. _mlflowCreateRunResponse:
 
 Response Structure
 ------------------
@@ -158,14 +145,177 @@ Response Structure
 
 
 
-+-----------------+-------------------------------------+----------------------------------------------------------------------------+
-|   Field Name    |                Type                 |                                Description                                 |
-+=================+=====================================+============================================================================+
-| experiments     | An array of :ref:`mlflowexperiment` | Experiments that match the search criteria                                 |
-+-----------------+-------------------------------------+----------------------------------------------------------------------------+
-| next_page_token | ``STRING``                          | Token that can be used to retrieve the next page of experiments.           |
-|                 |                                     | An empty token means that no more experiments are available for retrieval. |
-+-----------------+-------------------------------------+----------------------------------------------------------------------------+
++------------+------------------+------------------------+
+| Field Name |       Type       |      Description       |
++============+==================+========================+
+| run        | :ref:`mlflowrun` | The newly created run. |
++------------+------------------+------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicedeleteExperiment:
+
+Delete Experiment
+=================
+
+
++-----------------------------------+-------------+
+|             Endpoint              | HTTP Method |
++===================================+=============+
+| ``2.0/mlflow/experiments/delete`` | ``POST``    |
++-----------------------------------+-------------+
+
+Mark an experiment and associated metadata, runs, metrics, params, and tags for deletion.
+If the experiment uses FileStore, artifacts associated with experiment are also deleted.
+
+
+
+
+.. _mlflowDeleteExperiment:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++---------------+------------+----------------------------------+
+|  Field Name   |    Type    |           Description            |
++===============+============+==================================+
+| experiment_id | ``STRING`` | ID of the associated experiment. |
+|               |            | This field is required.          |
+|               |            |                                  |
++---------------+------------+----------------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicedeleteExperimentTag:
+
+Delete Experiment Tag
+=====================
+
+
++--------------------------------------------------+-------------+
+|                     Endpoint                     | HTTP Method |
++==================================================+=============+
+| ``2.0/mlflow/experiments/delete-experiment-tag`` | ``POST``    |
++--------------------------------------------------+-------------+
+
+Delete a tag on an experiment.
+
+
+
+
+.. _mlflowDeleteExperimentTag:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++---------------+------------+-----------------------------------------------------------------------+
+|  Field Name   |    Type    |                              Description                              |
++===============+============+=======================================================================+
+| experiment_id | ``STRING`` | ID of the experiment that the tag was logged under. Must be provided. |
+|               |            | This field is required.                                               |
+|               |            |                                                                       |
++---------------+------------+-----------------------------------------------------------------------+
+| key           | ``STRING`` | Name of the tag. Maximum size is 255 bytes. Must be provided.         |
+|               |            | This field is required.                                               |
+|               |            |                                                                       |
++---------------+------------+-----------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicedeleteRun:
+
+Delete Run
+==========
+
+
++----------------------------+-------------+
+|          Endpoint          | HTTP Method |
++============================+=============+
+| ``2.0/mlflow/runs/delete`` | ``POST``    |
++----------------------------+-------------+
+
+Mark a run for deletion.
+
+
+
+
+.. _mlflowDeleteRun:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+--------------------------+
+| Field Name |    Type    |       Description        |
++============+============+==========================+
+| run_id     | ``STRING`` | ID of the run to delete. |
+|            |            | This field is required.  |
+|            |            |                          |
++------------+------------+--------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicedeleteTag:
+
+Delete Tag
+==========
+
+
++--------------------------------+-------------+
+|            Endpoint            | HTTP Method |
++================================+=============+
+| ``2.0/mlflow/runs/delete-tag`` | ``POST``    |
++--------------------------------+-------------+
+
+Delete a tag on a run. Tags are run metadata that can be updated during a run and after
+a run completes.
+
+
+
+
+.. _mlflowDeleteTag:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+----------------------------------------------------------------+
+| Field Name |    Type    |                          Description                           |
++============+============+================================================================+
+| run_id     | ``STRING`` | ID of the run that the tag was logged under. Must be provided. |
+|            |            | This field is required.                                        |
+|            |            |                                                                |
++------------+------------+----------------------------------------------------------------+
+| key        | ``STRING`` | Name of the tag. Maximum size is 255 bytes. Must be provided.  |
+|            |            | This field is required.                                        |
+|            |            |                                                                |
++------------+------------+----------------------------------------------------------------+
 
 ===========================
 
@@ -287,68 +437,24 @@ Response Structure
 
 
 
-.. _mlflowMlflowServicedeleteExperiment:
+.. _mlflowMlflowServicegetMetricHistory:
 
-Delete Experiment
-=================
-
-
-+-----------------------------------+-------------+
-|             Endpoint              | HTTP Method |
-+===================================+=============+
-| ``2.0/mlflow/experiments/delete`` | ``POST``    |
-+-----------------------------------+-------------+
-
-Mark an experiment and associated metadata, runs, metrics, params, and tags for deletion.
-If the experiment uses FileStore, artifacts associated with experiment are also deleted.
-
-
-
-
-.. _mlflowDeleteExperiment:
-
-Request Structure
------------------
-
-
-
-
-
-
-+---------------+------------+----------------------------------+
-|  Field Name   |    Type    |           Description            |
-+===============+============+==================================+
-| experiment_id | ``STRING`` | ID of the associated experiment. |
-|               |            | This field is required.          |
-|               |            |                                  |
-+---------------+------------+----------------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicerestoreExperiment:
-
-Restore Experiment
+Get Metric History
 ==================
 
 
 +------------------------------------+-------------+
 |              Endpoint              | HTTP Method |
 +====================================+=============+
-| ``2.0/mlflow/experiments/restore`` | ``POST``    |
+| ``2.0/mlflow/metrics/get-history`` | ``GET``     |
 +------------------------------------+-------------+
 
-Restore an experiment marked for deletion. This also restores
-associated metadata, runs, metrics, params, and tags. If experiment uses FileStore, underlying
-artifacts associated with experiment are also restored.
-
-Throws ``RESOURCE_DOES_NOT_EXIST`` if experiment was never created or was permanently deleted.
+Get a list of all values for the specified metric for a given run.
 
 
 
 
-.. _mlflowRestoreExperiment:
+.. _mlflowGetMetricHistory:
 
 Request Structure
 -----------------
@@ -358,105 +464,27 @@ Request Structure
 
 
 
-+---------------+------------+----------------------------------+
-|  Field Name   |    Type    |           Description            |
-+===============+============+==================================+
-| experiment_id | ``STRING`` | ID of the associated experiment. |
-|               |            | This field is required.          |
-|               |            |                                  |
-+---------------+------------+----------------------------------+
++-------------+------------+------------------------------------------------------------------------------------------------+
+| Field Name  |    Type    |                                          Description                                           |
++=============+============+================================================================================================+
+| run_id      | ``STRING`` | ID of the run from which to fetch metric values. Must be provided.                             |
++-------------+------------+------------------------------------------------------------------------------------------------+
+| run_uuid    | ``STRING`` | [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field   |
+|             |            | will be removed in a future MLflow version.                                                    |
++-------------+------------+------------------------------------------------------------------------------------------------+
+| metric_key  | ``STRING`` | Name of the metric.                                                                            |
+|             |            | This field is required.                                                                        |
+|             |            |                                                                                                |
++-------------+------------+------------------------------------------------------------------------------------------------+
+| page_token  | ``STRING`` | Token indicating the page of metric history to fetch                                           |
++-------------+------------+------------------------------------------------------------------------------------------------+
+| max_results | ``INT32``  | Maximum number of logged instances of a metric for a run to return per call.                   |
+|             |            | Backend servers may restrict the value of `max_results` depending on performance requirements. |
+|             |            | Requests that do not specify this value will behave as non-paginated queries where all         |
+|             |            | metric history values for a given metric within a run are returned in a single response.       |
++-------------+------------+------------------------------------------------------------------------------------------------+
 
-===========================
-
-
-
-.. _mlflowMlflowServiceupdateExperiment:
-
-Update Experiment
-=================
-
-
-+-----------------------------------+-------------+
-|             Endpoint              | HTTP Method |
-+===================================+=============+
-| ``2.0/mlflow/experiments/update`` | ``POST``    |
-+-----------------------------------+-------------+
-
-Update experiment metadata.
-
-
-
-
-.. _mlflowUpdateExperiment:
-
-Request Structure
------------------
-
-
-
-
-
-
-+---------------+------------+---------------------------------------------------------------------------------------------+
-|  Field Name   |    Type    |                                         Description                                         |
-+===============+============+=============================================================================================+
-| experiment_id | ``STRING`` | ID of the associated experiment.                                                            |
-|               |            | This field is required.                                                                     |
-|               |            |                                                                                             |
-+---------------+------------+---------------------------------------------------------------------------------------------+
-| new_name      | ``STRING`` | If provided, the experiment's name is changed to the new name. The new name must be unique. |
-+---------------+------------+---------------------------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicecreateRun:
-
-Create Run
-==========
-
-
-+----------------------------+-------------+
-|          Endpoint          | HTTP Method |
-+============================+=============+
-| ``2.0/mlflow/runs/create`` | ``POST``    |
-+----------------------------+-------------+
-
-Create a new run within an experiment. A run is usually a single execution of a
-machine learning or data ETL pipeline. MLflow uses runs to track :ref:`mlflowParam`,
-:ref:`mlflowMetric`, and :ref:`mlflowRunTag` associated with a single execution.
-
-
-
-
-.. _mlflowCreateRun:
-
-Request Structure
------------------
-
-
-
-
-
-
-+---------------+---------------------------------+----------------------------------------------------------------------------+
-|  Field Name   |              Type               |                                Description                                 |
-+===============+=================================+============================================================================+
-| experiment_id | ``STRING``                      | ID of the associated experiment.                                           |
-+---------------+---------------------------------+----------------------------------------------------------------------------+
-| user_id       | ``STRING``                      | ID of the user executing the run.                                          |
-|               |                                 | This field is deprecated as of MLflow 1.0, and will be removed in a future |
-|               |                                 | MLflow release. Use 'mlflow.user' tag instead.                             |
-+---------------+---------------------------------+----------------------------------------------------------------------------+
-| run_name      | ``STRING``                      | Name of the run.                                                           |
-+---------------+---------------------------------+----------------------------------------------------------------------------+
-| start_time    | ``INT64``                       | Unix timestamp in milliseconds of when the run started.                    |
-+---------------+---------------------------------+----------------------------------------------------------------------------+
-| tags          | An array of :ref:`mlflowruntag` | Additional metadata for run.                                               |
-+---------------+---------------------------------+----------------------------------------------------------------------------+
-
-.. _mlflowCreateRunResponse:
+.. _mlflowGetMetricHistoryResponse:
 
 Response Structure
 ------------------
@@ -466,89 +494,14 @@ Response Structure
 
 
 
-+------------+------------------+------------------------+
-| Field Name |       Type       |      Description       |
-+============+==================+========================+
-| run        | :ref:`mlflowrun` | The newly created run. |
-+------------+------------------+------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicedeleteRun:
-
-Delete Run
-==========
-
-
-+----------------------------+-------------+
-|          Endpoint          | HTTP Method |
-+============================+=============+
-| ``2.0/mlflow/runs/delete`` | ``POST``    |
-+----------------------------+-------------+
-
-Mark a run for deletion.
-
-
-
-
-.. _mlflowDeleteRun:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+--------------------------+
-| Field Name |    Type    |       Description        |
-+============+============+==========================+
-| run_id     | ``STRING`` | ID of the run to delete. |
-|            |            | This field is required.  |
-|            |            |                          |
-+------------+------------+--------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicerestoreRun:
-
-Restore Run
-===========
-
-
-+-----------------------------+-------------+
-|          Endpoint           | HTTP Method |
-+=============================+=============+
-| ``2.0/mlflow/runs/restore`` | ``POST``    |
-+-----------------------------+-------------+
-
-Restore a deleted run.
-
-
-
-
-.. _mlflowRestoreRun:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+---------------------------+
-| Field Name |    Type    |        Description        |
-+============+============+===========================+
-| run_id     | ``STRING`` | ID of the run to restore. |
-|            |            | This field is required.   |
-|            |            |                           |
-+------------+------------+---------------------------+
++-----------------+---------------------------------+-------------------------------------------------------------------------------------+
+|   Field Name    |              Type               |                                     Description                                     |
++=================+=================================+=====================================================================================+
+| metrics         | An array of :ref:`mlflowmetric` | All logged values for this metric.                                                  |
++-----------------+---------------------------------+-------------------------------------------------------------------------------------+
+| next_page_token | ``STRING``                      | Token that can be used to issue a query for the next page of metric history values. |
+|                 |                                 | A missing token indicates that no additional metrics are available to fetch.        |
++-----------------+---------------------------------+-------------------------------------------------------------------------------------+
 
 ===========================
 
@@ -612,26 +565,25 @@ Response Structure
 
 
 
-.. _mlflowMlflowServicelogMetric:
+.. _mlflowMlflowServicelistArtifacts:
 
-Log Metric
-==========
+List Artifacts
+==============
 
 
-+--------------------------------+-------------+
-|            Endpoint            | HTTP Method |
-+================================+=============+
-| ``2.0/mlflow/runs/log-metric`` | ``POST``    |
-+--------------------------------+-------------+
++-------------------------------+-------------+
+|           Endpoint            | HTTP Method |
++===============================+=============+
+| ``2.0/mlflow/artifacts/list`` | ``GET``     |
++-------------------------------+-------------+
 
-Log a metric for a run. A metric is a key-value pair (string key, float value) with an
-associated timestamp. Examples include the various metrics that represent ML model accuracy.
-A metric can be logged multiple times.
-
+List artifacts for a run. Takes an optional ``artifact_path`` prefix which if specified,
+the response contains only artifacts with the specified prefix.
 
 
 
-.. _mlflowLogMetric:
+
+.. _mlflowListArtifacts:
 
 Request Structure
 -----------------
@@ -641,28 +593,38 @@ Request Structure
 
 
 
-+------------+------------+-----------------------------------------------------------------------------------------------+
-| Field Name |    Type    |                                          Description                                          |
-+============+============+===============================================================================================+
-| run_id     | ``STRING`` | ID of the run under which to log the metric. Must be provided.                                |
-+------------+------------+-----------------------------------------------------------------------------------------------+
-| run_uuid   | ``STRING`` | [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will |
-|            |            | be removed in a future MLflow version.                                                        |
-+------------+------------+-----------------------------------------------------------------------------------------------+
-| key        | ``STRING`` | Name of the metric.                                                                           |
-|            |            | This field is required.                                                                       |
-|            |            |                                                                                               |
-+------------+------------+-----------------------------------------------------------------------------------------------+
-| value      | ``DOUBLE`` | Double value of the metric being logged.                                                      |
-|            |            | This field is required.                                                                       |
-|            |            |                                                                                               |
-+------------+------------+-----------------------------------------------------------------------------------------------+
-| timestamp  | ``INT64``  | Unix timestamp in milliseconds at the time metric was logged.                                 |
-|            |            | This field is required.                                                                       |
-|            |            |                                                                                               |
-+------------+------------+-----------------------------------------------------------------------------------------------+
-| step       | ``INT64``  | Step at which to log the metric                                                               |
-+------------+------------+-----------------------------------------------------------------------------------------------+
++------------+------------+-----------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                       Description                                       |
++============+============+=========================================================================================+
+| run_id     | ``STRING`` | ID of the run whose artifacts to list. Must be provided.                                |
++------------+------------+-----------------------------------------------------------------------------------------+
+| run_uuid   | ``STRING`` | [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will |
+|            |            | be removed in a future MLflow version.                                                  |
++------------+------------+-----------------------------------------------------------------------------------------+
+| path       | ``STRING`` | Filter artifacts matching this path (a relative path from the root artifact directory). |
++------------+------------+-----------------------------------------------------------------------------------------+
+| page_token | ``STRING`` | Token indicating the page of artifact results to fetch                                  |
++------------+------------+-----------------------------------------------------------------------------------------+
+
+.. _mlflowListArtifactsResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++-----------------+-----------------------------------+----------------------------------------------------------------------+
+|   Field Name    |               Type                |                             Description                              |
++=================+===================================+======================================================================+
+| root_uri        | ``STRING``                        | Root artifact directory for the run.                                 |
++-----------------+-----------------------------------+----------------------------------------------------------------------+
+| files           | An array of :ref:`mlflowfileinfo` | File location and metadata for artifacts.                            |
++-----------------+-----------------------------------+----------------------------------------------------------------------+
+| next_page_token | ``STRING``                        | Token that can be used to retrieve the next page of artifact results |
++-----------------+-----------------------------------+----------------------------------------------------------------------+
 
 ===========================
 
@@ -761,6 +723,115 @@ Request Structure
 
 
 
+.. _mlflowMlflowServicelogInputs:
+
+Log Inputs
+==========
+
+
++--------------------------------+-------------+
+|            Endpoint            | HTTP Method |
++================================+=============+
+| ``2.0/mlflow/runs/log-inputs`` | ``POST``    |
++--------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowLogInputs:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+---------------------------------------+-----------------------------------------------------------+
+| Field Name |                 Type                  |                        Description                        |
++============+=======================================+===========================================================+
+| run_id     | ``STRING``                            | ID of the run to log under                                |
+|            |                                       | This field is required.                                   |
+|            |                                       |                                                           |
++------------+---------------------------------------+-----------------------------------------------------------+
+| datasets   | An array of :ref:`mlflowdatasetinput` | Dataset inputs                                            |
++------------+---------------------------------------+-----------------------------------------------------------+
+| models     | An array of :ref:`mlflowmodelinput`   | Model inputs                                              |
+|            |                                       | (Currently undocumented for LoggedModels private preview) |
++------------+---------------------------------------+-----------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicelogMetric:
+
+Log Metric
+==========
+
+
++--------------------------------+-------------+
+|            Endpoint            | HTTP Method |
++================================+=============+
+| ``2.0/mlflow/runs/log-metric`` | ``POST``    |
++--------------------------------+-------------+
+
+Log a metric for a run. A metric is a key-value pair (string key, float value) with an
+associated timestamp. Examples include the various metrics that represent ML model accuracy.
+A metric can be logged multiple times.
+
+
+
+
+.. _mlflowLogMetric:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++----------------+------------+-----------------------------------------------------------------------------------------------+
+|   Field Name   |    Type    |                                          Description                                          |
++================+============+===============================================================================================+
+| run_id         | ``STRING`` | ID of the run under which to log the metric. Must be provided.                                |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| run_uuid       | ``STRING`` | [Deprecated, use run_id instead] ID of the run under which to log the metric. This field will |
+|                |            | be removed in a future MLflow version.                                                        |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| key            | ``STRING`` | Name of the metric.                                                                           |
+|                |            | This field is required.                                                                       |
+|                |            |                                                                                               |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| value          | ``DOUBLE`` | Double value of the metric being logged.                                                      |
+|                |            | This field is required.                                                                       |
+|                |            |                                                                                               |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| timestamp      | ``INT64``  | Unix timestamp in milliseconds at the time metric was logged.                                 |
+|                |            | This field is required.                                                                       |
+|                |            |                                                                                               |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| step           | ``INT64``  | Step at which to log the metric                                                               |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| model_id       | ``STRING`` | ID of the logged model associated with the metric, if applicable                              |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| dataset_name   | ``STRING`` | The name of the dataset associated with the metric.                                           |
+|                |            | E.g. "my.uc.table@2" "nyc-taxi-dataset", "fantastic-elk-3"                                    |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+| dataset_digest | ``STRING`` | Dataset digest of the dataset associated with the metric,                                     |
+|                |            | e.g. an md5 hash of the dataset that uniquely identifies it                                   |
+|                |            | within datasets of the same name.                                                             |
++----------------+------------+-----------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
 .. _mlflowMlflowServicelogModel:
 
 Log Model
@@ -801,44 +872,298 @@ Request Structure
 
 
 
-.. _mlflowMlflowServicelogInputs:
+.. _mlflowMlflowServicelogParam:
 
-Log Inputs
-==========
-
-
-+--------------------------------+-------------+
-|            Endpoint            | HTTP Method |
-+================================+=============+
-| ``2.0/mlflow/runs/log-inputs`` | ``POST``    |
-+--------------------------------+-------------+
-
-.. note::
-    Experimental: This API may change or be removed in a future release without warning.
+Log Param
+=========
 
 
++-----------------------------------+-------------+
+|             Endpoint              | HTTP Method |
++===================================+=============+
+| ``2.0/mlflow/runs/log-parameter`` | ``POST``    |
++-----------------------------------+-------------+
+
+Log a param used for a run. A param is a key-value pair (string key,
+string value). Examples include hyperparameters used for ML model training and
+constant dates and values used in an ETL pipeline. A param can be logged only once for a run.
 
 
-.. _mlflowLogInputs:
+
+
+.. _mlflowLogParam:
 
 Request Structure
 -----------------
 
 
 
-.. note::
-    Experimental: This API may change or be removed in a future release without warning.
 
 
-+------------+---------------------------------------+----------------------------+
-| Field Name |                 Type                  |        Description         |
-+============+=======================================+============================+
-| run_id     | ``STRING``                            | ID of the run to log under |
-|            |                                       | This field is required.    |
-|            |                                       |                            |
-+------------+---------------------------------------+----------------------------+
-| datasets   | An array of :ref:`mlflowdatasetinput` | Dataset inputs             |
-+------------+---------------------------------------+----------------------------+
+
++------------+------------+----------------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                         Description                                          |
++============+============+==============================================================================================+
+| run_id     | ``STRING`` | ID of the run under which to log the param. Must be provided.                                |
++------------+------------+----------------------------------------------------------------------------------------------+
+| run_uuid   | ``STRING`` | [Deprecated, use run_id instead] ID of the run under which to log the param. This field will |
+|            |            | be removed in a future MLflow version.                                                       |
++------------+------------+----------------------------------------------------------------------------------------------+
+| key        | ``STRING`` | Name of the param. Maximum size is 255 bytes.                                                |
+|            |            | This field is required.                                                                      |
+|            |            |                                                                                              |
++------------+------------+----------------------------------------------------------------------------------------------+
+| value      | ``STRING`` | String value of the param being logged. Maximum size is 6000 bytes.                          |
+|            |            | This field is required.                                                                      |
+|            |            |                                                                                              |
++------------+------------+----------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicerestoreExperiment:
+
+Restore Experiment
+==================
+
+
++------------------------------------+-------------+
+|              Endpoint              | HTTP Method |
++====================================+=============+
+| ``2.0/mlflow/experiments/restore`` | ``POST``    |
++------------------------------------+-------------+
+
+Restore an experiment marked for deletion. This also restores
+associated metadata, runs, metrics, params, and tags. If experiment uses FileStore, underlying
+artifacts associated with experiment are also restored.
+
+Throws ``RESOURCE_DOES_NOT_EXIST`` if experiment was never created or was permanently deleted.
+
+
+
+
+.. _mlflowRestoreExperiment:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++---------------+------------+----------------------------------+
+|  Field Name   |    Type    |           Description            |
++===============+============+==================================+
+| experiment_id | ``STRING`` | ID of the associated experiment. |
+|               |            | This field is required.          |
+|               |            |                                  |
++---------------+------------+----------------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicerestoreRun:
+
+Restore Run
+===========
+
+
++-----------------------------+-------------+
+|          Endpoint           | HTTP Method |
++=============================+=============+
+| ``2.0/mlflow/runs/restore`` | ``POST``    |
++-----------------------------+-------------+
+
+Restore a deleted run.
+
+
+
+
+.. _mlflowRestoreRun:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+---------------------------+
+| Field Name |    Type    |        Description        |
++============+============+===========================+
+| run_id     | ``STRING`` | ID of the run to restore. |
+|            |            | This field is required.   |
+|            |            |                           |
++------------+------------+---------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicesearchExperiments:
+
+Search Experiments
+==================
+
+
++-----------------------------------+-------------+
+|             Endpoint              | HTTP Method |
++===================================+=============+
+| ``2.0/mlflow/experiments/search`` | ``POST``    |
++-----------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowSearchExperiments:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++-------------+------------------------+--------------------------------------------------------------------------------------------+
+| Field Name  |          Type          |                                        Description                                         |
++=============+========================+============================================================================================+
+| max_results | ``INT64``              | Maximum number of experiments desired.                                                     |
+|             |                        | Servers may select a desired default `max_results` value. All servers are                  |
+|             |                        | guaranteed to support a `max_results` threshold of at least 1,000 but may                  |
+|             |                        | support more. Callers of this endpoint are encouraged to pass max_results                  |
+|             |                        | explicitly and leverage page_token to iterate through experiments.                         |
++-------------+------------------------+--------------------------------------------------------------------------------------------+
+| page_token  | ``STRING``             | Token indicating the page of experiments to fetch                                          |
++-------------+------------------------+--------------------------------------------------------------------------------------------+
+| filter      | ``STRING``             | A filter expression over experiment attributes and tags that allows returning a subset of  |
+|             |                        | experiments. The syntax is a subset of SQL that supports ANDing together binary operations |
+|             |                        | between an attribute or tag, and a constant.                                               |
+|             |                        |                                                                                            |
+|             |                        | Example: ``name LIKE 'test-%' AND tags.key = 'value'``                                     |
+|             |                        |                                                                                            |
+|             |                        | You can select columns with special characters (hyphen, space, period, etc.) by using      |
+|             |                        | double quotes or backticks.                                                                |
+|             |                        |                                                                                            |
+|             |                        | Example: ``tags."extra-key" = 'value'`` or ``tags.`extra-key` = 'value'``                  |
+|             |                        |                                                                                            |
+|             |                        | Supported operators are ``=``, ``!=``, ``LIKE``, and ``ILIKE``.                            |
++-------------+------------------------+--------------------------------------------------------------------------------------------+
+| order_by    | An array of ``STRING`` | List of columns for ordering search results, which can include experiment name and id      |
+|             |                        | with an optional "DESC" or "ASC" annotation, where "ASC" is the default.                   |
+|             |                        | Tiebreaks are done by experiment id DESC.                                                  |
++-------------+------------------------+--------------------------------------------------------------------------------------------+
+| view_type   | :ref:`mlflowviewtype`  | Qualifier for type of experiments to be returned.                                          |
+|             |                        | If unspecified, return only active experiments.                                            |
++-------------+------------------------+--------------------------------------------------------------------------------------------+
+
+.. _mlflowSearchExperimentsResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++-----------------+-------------------------------------+----------------------------------------------------------------------------+
+|   Field Name    |                Type                 |                                Description                                 |
++=================+=====================================+============================================================================+
+| experiments     | An array of :ref:`mlflowexperiment` | Experiments that match the search criteria                                 |
++-----------------+-------------------------------------+----------------------------------------------------------------------------+
+| next_page_token | ``STRING``                          | Token that can be used to retrieve the next page of experiments.           |
+|                 |                                     | An empty token means that no more experiments are available for retrieval. |
++-----------------+-------------------------------------+----------------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowMlflowServicesearchRuns:
+
+Search Runs
+===========
+
+
++----------------------------+-------------+
+|          Endpoint          | HTTP Method |
++============================+=============+
+| ``2.0/mlflow/runs/search`` | ``POST``    |
++----------------------------+-------------+
+
+Search for runs that satisfy expressions. Search expressions can use :ref:`mlflowMetric` and
+:ref:`mlflowParam` keys.
+
+
+
+
+.. _mlflowSearchRuns:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++----------------+------------------------+------------------------------------------------------------------------------------------------------+
+|   Field Name   |          Type          |                                             Description                                              |
++================+========================+======================================================================================================+
+| experiment_ids | An array of ``STRING`` | List of experiment IDs to search over.                                                               |
++----------------+------------------------+------------------------------------------------------------------------------------------------------+
+| filter         | ``STRING``             | A filter expression over params, metrics, and tags, that allows returning a subset of                |
+|                |                        | runs. The syntax is a subset of SQL that supports ANDing together binary operations                  |
+|                |                        | between a param, metric, or tag and a constant.                                                      |
+|                |                        |                                                                                                      |
+|                |                        | Example: ``metrics.rmse < 1 and params.model_class = 'LogisticRegression'``                          |
+|                |                        |                                                                                                      |
+|                |                        | You can select columns with special characters (hyphen, space, period, etc.) by using double quotes: |
+|                |                        | ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``                        |
+|                |                        |                                                                                                      |
+|                |                        | Supported operators are ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.                             |
++----------------+------------------------+------------------------------------------------------------------------------------------------------+
+| run_view_type  | :ref:`mlflowviewtype`  | Whether to display only active, only deleted, or all runs.                                           |
+|                |                        | Defaults to only active runs.                                                                        |
++----------------+------------------------+------------------------------------------------------------------------------------------------------+
+| max_results    | ``INT32``              | Maximum number of runs desired. If unspecified, defaults to 1000.                                    |
+|                |                        | All servers are guaranteed to support a `max_results` threshold of at least 50,000                   |
+|                |                        | but may support more. Callers of this endpoint are encouraged to pass max_results                    |
+|                |                        | explicitly and leverage page_token to iterate through experiments.                                   |
++----------------+------------------------+------------------------------------------------------------------------------------------------------+
+| order_by       | An array of ``STRING`` | List of columns to be ordered by, including attributes, params, metrics, and tags with an            |
+|                |                        | optional "DESC" or "ASC" annotation, where "ASC" is the default.                                     |
+|                |                        | Example: ["params.input DESC", "metrics.alpha ASC", "metrics.rmse"]                                  |
+|                |                        | Tiebreaks are done by start_time DESC followed by run_id for runs with the same start time           |
+|                |                        | (and this is the default ordering criterion if order_by is not provided).                            |
++----------------+------------------------+------------------------------------------------------------------------------------------------------+
+| page_token     | ``STRING``             |                                                                                                      |
++----------------+------------------------+------------------------------------------------------------------------------------------------------+
+
+.. _mlflowSearchRunsResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++-----------------+------------------------------+--------------------------------------+
+|   Field Name    |             Type             |             Description              |
++=================+==============================+======================================+
+| runs            | An array of :ref:`mlflowrun` | Runs that match the search criteria. |
++-----------------+------------------------------+--------------------------------------+
+| next_page_token | ``STRING``                   |                                      |
++-----------------+------------------------------+--------------------------------------+
 
 ===========================
 
@@ -944,70 +1269,24 @@ Request Structure
 
 
 
-.. _mlflowMlflowServicedeleteTag:
+.. _mlflowMlflowServiceupdateExperiment:
 
-Delete Tag
-==========
-
-
-+--------------------------------+-------------+
-|            Endpoint            | HTTP Method |
-+================================+=============+
-| ``2.0/mlflow/runs/delete-tag`` | ``POST``    |
-+--------------------------------+-------------+
-
-Delete a tag on a run. Tags are run metadata that can be updated during a run and after
-a run completes.
-
-
-
-
-.. _mlflowDeleteTag:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+----------------------------------------------------------------+
-| Field Name |    Type    |                          Description                           |
-+============+============+================================================================+
-| run_id     | ``STRING`` | ID of the run that the tag was logged under. Must be provided. |
-|            |            | This field is required.                                        |
-|            |            |                                                                |
-+------------+------------+----------------------------------------------------------------+
-| key        | ``STRING`` | Name of the tag. Maximum size is 255 bytes. Must be provided.  |
-|            |            | This field is required.                                        |
-|            |            |                                                                |
-+------------+------------+----------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicelogParam:
-
-Log Param
-=========
+Update Experiment
+=================
 
 
 +-----------------------------------+-------------+
 |             Endpoint              | HTTP Method |
 +===================================+=============+
-| ``2.0/mlflow/runs/log-parameter`` | ``POST``    |
+| ``2.0/mlflow/experiments/update`` | ``POST``    |
 +-----------------------------------+-------------+
 
-Log a param used for a run. A param is a key-value pair (string key,
-string value). Examples include hyperparameters used for ML model training and
-constant dates and values used in an ETL pipeline. A param can be logged only once for a run.
+Update experiment metadata.
 
 
 
 
-.. _mlflowLogParam:
+.. _mlflowUpdateExperiment:
 
 Request Structure
 -----------------
@@ -1017,240 +1296,15 @@ Request Structure
 
 
 
-+------------+------------+----------------------------------------------------------------------------------------------+
-| Field Name |    Type    |                                         Description                                          |
-+============+============+==============================================================================================+
-| run_id     | ``STRING`` | ID of the run under which to log the param. Must be provided.                                |
-+------------+------------+----------------------------------------------------------------------------------------------+
-| run_uuid   | ``STRING`` | [Deprecated, use run_id instead] ID of the run under which to log the param. This field will |
-|            |            | be removed in a future MLflow version.                                                       |
-+------------+------------+----------------------------------------------------------------------------------------------+
-| key        | ``STRING`` | Name of the param. Maximum size is 255 bytes.                                                |
-|            |            | This field is required.                                                                      |
-|            |            |                                                                                              |
-+------------+------------+----------------------------------------------------------------------------------------------+
-| value      | ``STRING`` | String value of the param being logged. Maximum size is 500 bytes.                           |
-|            |            | This field is required.                                                                      |
-|            |            |                                                                                              |
-+------------+------------+----------------------------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicegetMetricHistory:
-
-Get Metric History
-==================
-
-
-+------------------------------------+-------------+
-|              Endpoint              | HTTP Method |
-+====================================+=============+
-| ``2.0/mlflow/metrics/get-history`` | ``GET``     |
-+------------------------------------+-------------+
-
-Get a list of all values for the specified metric for a given run.
-
-
-
-
-.. _mlflowGetMetricHistory:
-
-Request Structure
------------------
-
-
-
-
-
-
-+-------------+------------+------------------------------------------------------------------------------------------------+
-| Field Name  |    Type    |                                          Description                                           |
-+=============+============+================================================================================================+
-| run_id      | ``STRING`` | ID of the run from which to fetch metric values. Must be provided.                             |
-+-------------+------------+------------------------------------------------------------------------------------------------+
-| run_uuid    | ``STRING`` | [Deprecated, use run_id instead] ID of the run from which to fetch metric values. This field   |
-|             |            | will be removed in a future MLflow version.                                                    |
-+-------------+------------+------------------------------------------------------------------------------------------------+
-| metric_key  | ``STRING`` | Name of the metric.                                                                            |
-|             |            | This field is required.                                                                        |
-|             |            |                                                                                                |
-+-------------+------------+------------------------------------------------------------------------------------------------+
-| page_token  | ``STRING`` | Token indicating the page of metric history to fetch                                           |
-+-------------+------------+------------------------------------------------------------------------------------------------+
-| max_results | ``INT32``  | Maximum number of logged instances of a metric for a run to return per call.                   |
-|             |            | Backend servers may restrict the value of `max_results` depending on performance requirements. |
-|             |            | Requests that do not specify this value will behave as non-paginated queries where all         |
-|             |            | metric history values for a given metric within a run are returned in a single response.       |
-+-------------+------------+------------------------------------------------------------------------------------------------+
-
-.. _mlflowGetMetricHistoryResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+-----------------+---------------------------------+-------------------------------------------------------------------------------------+
-|   Field Name    |              Type               |                                     Description                                     |
-+=================+=================================+=====================================================================================+
-| metrics         | An array of :ref:`mlflowmetric` | All logged values for this metric.                                                  |
-+-----------------+---------------------------------+-------------------------------------------------------------------------------------+
-| next_page_token | ``STRING``                      | Token that can be used to issue a query for the next page of metric history values. |
-|                 |                                 | A missing token indicates that no additional metrics are available to fetch.        |
-+-----------------+---------------------------------+-------------------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicesearchRuns:
-
-Search Runs
-===========
-
-
-+----------------------------+-------------+
-|          Endpoint          | HTTP Method |
-+============================+=============+
-| ``2.0/mlflow/runs/search`` | ``POST``    |
-+----------------------------+-------------+
-
-Search for runs that satisfy expressions. Search expressions can use :ref:`mlflowMetric` and
-:ref:`mlflowParam` keys.
-
-
-
-
-.. _mlflowSearchRuns:
-
-Request Structure
------------------
-
-
-
-
-
-
-+----------------+------------------------+------------------------------------------------------------------------------------------------------+
-|   Field Name   |          Type          |                                             Description                                              |
-+================+========================+======================================================================================================+
-| experiment_ids | An array of ``STRING`` | List of experiment IDs to search over.                                                               |
-+----------------+------------------------+------------------------------------------------------------------------------------------------------+
-| filter         | ``STRING``             | A filter expression over params, metrics, and tags, that allows returning a subset of                |
-|                |                        | runs. The syntax is a subset of SQL that supports ANDing together binary operations                  |
-|                |                        | between a param, metric, or tag and a constant.                                                      |
-|                |                        |                                                                                                      |
-|                |                        | Example: ``metrics.rmse < 1 and params.model_class = 'LogisticRegression'``                          |
-|                |                        |                                                                                                      |
-|                |                        | You can select columns with special characters (hyphen, space, period, etc.) by using double quotes: |
-|                |                        | ``metrics."model class" = 'LinearRegression' and tags."user-name" = 'Tomas'``                        |
-|                |                        |                                                                                                      |
-|                |                        | Supported operators are ``=``, ``!=``, ``>``, ``>=``, ``<``, and ``<=``.                             |
-+----------------+------------------------+------------------------------------------------------------------------------------------------------+
-| run_view_type  | :ref:`mlflowviewtype`  | Whether to display only active, only deleted, or all runs.                                           |
-|                |                        | Defaults to only active runs.                                                                        |
-+----------------+------------------------+------------------------------------------------------------------------------------------------------+
-| max_results    | ``INT32``              | Maximum number of runs desired. If unspecified, defaults to 1000.                                    |
-|                |                        | All servers are guaranteed to support a `max_results` threshold of at least 50,000                   |
-|                |                        | but may support more. Callers of this endpoint are encouraged to pass max_results                    |
-|                |                        | explicitly and leverage page_token to iterate through experiments.                                   |
-+----------------+------------------------+------------------------------------------------------------------------------------------------------+
-| order_by       | An array of ``STRING`` | List of columns to be ordered by, including attributes, params, metrics, and tags with an            |
-|                |                        | optional "DESC" or "ASC" annotation, where "ASC" is the default.                                     |
-|                |                        | Example: ["params.input DESC", "metrics.alpha ASC", "metrics.rmse"]                                  |
-|                |                        | Tiebreaks are done by start_time DESC followed by run_id for runs with the same start time           |
-|                |                        | (and this is the default ordering criterion if order_by is not provided).                            |
-+----------------+------------------------+------------------------------------------------------------------------------------------------------+
-| page_token     | ``STRING``             |                                                                                                      |
-+----------------+------------------------+------------------------------------------------------------------------------------------------------+
-
-.. _mlflowSearchRunsResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+-----------------+------------------------------+--------------------------------------+
-|   Field Name    |             Type             |             Description              |
-+=================+==============================+======================================+
-| runs            | An array of :ref:`mlflowrun` | Runs that match the search criteria. |
-+-----------------+------------------------------+--------------------------------------+
-| next_page_token | ``STRING``                   |                                      |
-+-----------------+------------------------------+--------------------------------------+
-
-===========================
-
-
-
-.. _mlflowMlflowServicelistArtifacts:
-
-List Artifacts
-==============
-
-
-+-------------------------------+-------------+
-|           Endpoint            | HTTP Method |
-+===============================+=============+
-| ``2.0/mlflow/artifacts/list`` | ``GET``     |
-+-------------------------------+-------------+
-
-List artifacts for a run. Takes an optional ``artifact_path`` prefix which if specified,
-the response contains only artifacts with the specified prefix.
-
-
-
-
-.. _mlflowListArtifacts:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+-----------------------------------------------------------------------------------------+
-| Field Name |    Type    |                                       Description                                       |
-+============+============+=========================================================================================+
-| run_id     | ``STRING`` | ID of the run whose artifacts to list. Must be provided.                                |
-+------------+------------+-----------------------------------------------------------------------------------------+
-| run_uuid   | ``STRING`` | [Deprecated, use run_id instead] ID of the run whose artifacts to list. This field will |
-|            |            | be removed in a future MLflow version.                                                  |
-+------------+------------+-----------------------------------------------------------------------------------------+
-| path       | ``STRING`` | Filter artifacts matching this path (a relative path from the root artifact directory). |
-+------------+------------+-----------------------------------------------------------------------------------------+
-| page_token | ``STRING`` | Token indicating the page of artifact results to fetch                                  |
-+------------+------------+-----------------------------------------------------------------------------------------+
-
-.. _mlflowListArtifactsResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+-----------------+-----------------------------------+----------------------------------------------------------------------+
-|   Field Name    |               Type                |                             Description                              |
-+=================+===================================+======================================================================+
-| root_uri        | ``STRING``                        | Root artifact directory for the run.                                 |
-+-----------------+-----------------------------------+----------------------------------------------------------------------+
-| files           | An array of :ref:`mlflowfileinfo` | File location and metadata for artifacts.                            |
-+-----------------+-----------------------------------+----------------------------------------------------------------------+
-| next_page_token | ``STRING``                        | Token that can be used to retrieve the next page of artifact results |
-+-----------------+-----------------------------------+----------------------------------------------------------------------+
++---------------+------------+---------------------------------------------------------------------------------------------+
+|  Field Name   |    Type    |                                         Description                                         |
++===============+============+=============================================================================================+
+| experiment_id | ``STRING`` | ID of the associated experiment.                                                            |
+|               |            | This field is required.                                                                     |
+|               |            |                                                                                             |
++---------------+------------+---------------------------------------------------------------------------------------------+
+| new_name      | ``STRING`` | If provided, the experiment's name is changed to the new name. The new name must be unique. |
++---------------+------------+---------------------------------------------------------------------------------------------+
 
 ===========================
 
@@ -1318,6 +1372,77 @@ Response Structure
 
 
 
+.. _mlflowModelRegistryServicecreateModelVersion:
+
+Create ModelVersion
+===================
+
+
++--------------------------------------+-------------+
+|               Endpoint               | HTTP Method |
++======================================+=============+
+| ``2.0/mlflow/model-versions/create`` | ``POST``    |
++--------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowCreateModelVersion:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+| Field Name  |                   Type                   |                                                Description                                                 |
++=============+==========================================+============================================================================================================+
+| name        | ``STRING``                               | Register model under this name                                                                             |
+|             |                                          | This field is required.                                                                                    |
+|             |                                          |                                                                                                            |
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+| source      | ``STRING``                               | URI indicating the location of the model artifacts.                                                        |
+|             |                                          | This field is required.                                                                                    |
+|             |                                          |                                                                                                            |
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+| run_id      | ``STRING``                               | MLflow run ID for correlation, if ``source`` was generated by an experiment run in                         |
+|             |                                          | MLflow tracking server                                                                                     |
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+| tags        | An array of :ref:`mlflowmodelversiontag` | Additional metadata for model version.                                                                     |
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+| run_link    | ``STRING``                               | MLflow run link - this is the exact link of the run that generated this model version,                     |
+|             |                                          | potentially hosted at another instance of MLflow.                                                          |
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+| description | ``STRING``                               | Optional description for model version.                                                                    |
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+| model_id    | ``STRING``                               | Optional `model_id` for model version that is used to link the registered model to the source logged model |
++-------------+------------------------------------------+------------------------------------------------------------------------------------------------------------+
+
+.. _mlflowCreateModelVersionResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++---------------+---------------------------+-----------------------------------------------------------------+
+|  Field Name   |           Type            |                           Description                           |
++===============+===========================+=================================================================+
+| model_version | :ref:`mlflowmodelversion` | Return new version number generated for this model in registry. |
++---------------+---------------------------+-----------------------------------------------------------------+
+
+===========================
+
+
+
 .. _mlflowModelRegistryServicecreateRegisteredModel:
 
 Create RegisteredModel
@@ -1345,17 +1470,19 @@ Request Structure
 
 
 
-+-------------+---------------------------------------------+--------------------------------------------+
-| Field Name  |                    Type                     |                Description                 |
-+=============+=============================================+============================================+
-| name        | ``STRING``                                  | Register models under this name            |
-|             |                                             | This field is required.                    |
-|             |                                             |                                            |
-+-------------+---------------------------------------------+--------------------------------------------+
-| tags        | An array of :ref:`mlflowregisteredmodeltag` | Additional metadata for registered model.  |
-+-------------+---------------------------------------------+--------------------------------------------+
-| description | ``STRING``                                  | Optional description for registered model. |
-+-------------+---------------------------------------------+--------------------------------------------+
++-------------------+---------------------------------------------+--------------------------------------------+
+|    Field Name     |                    Type                     |                Description                 |
++===================+=============================================+============================================+
+| name              | ``STRING``                                  | Register models under this name            |
+|                   |                                             | This field is required.                    |
+|                   |                                             |                                            |
++-------------------+---------------------------------------------+--------------------------------------------+
+| tags              | An array of :ref:`mlflowregisteredmodeltag` | Additional metadata for registered model.  |
++-------------------+---------------------------------------------+--------------------------------------------+
+| description       | ``STRING``                                  | Optional description for registered model. |
++-------------------+---------------------------------------------+--------------------------------------------+
+| deployment_job_id | ``STRING``                                  | Deployment job id for this model.          |
++-------------------+---------------------------------------------+--------------------------------------------+
 
 .. _mlflowCreateRegisteredModelResponse:
 
@@ -1372,6 +1499,456 @@ Response Structure
 +==================+==============================+=============+
 | registered_model | :ref:`mlflowregisteredmodel` |             |
 +------------------+------------------------------+-------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicedeleteModelVersion:
+
+Delete ModelVersion
+===================
+
+
++--------------------------------------+-------------+
+|               Endpoint               | HTTP Method |
++======================================+=============+
+| ``2.0/mlflow/model-versions/delete`` | ``DELETE``  |
++--------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowDeleteModelVersion:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+------------------------------+
+| Field Name |    Type    |         Description          |
++============+============+==============================+
+| name       | ``STRING`` | Name of the registered model |
+|            |            | This field is required.      |
+|            |            |                              |
++------------+------------+------------------------------+
+| version    | ``STRING`` | Model version number         |
+|            |            | This field is required.      |
+|            |            |                              |
++------------+------------+------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicedeleteModelVersionTag:
+
+Delete Model Version Tag
+========================
+
+
++------------------------------------------+-------------+
+|                 Endpoint                 | HTTP Method |
++==========================================+=============+
+| ``2.0/mlflow/model-versions/delete-tag`` | ``DELETE``  |
++------------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowDeleteModelVersionTag:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+-------------------------------------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                                    Description                                                    |
++============+============+===================================================================================================================+
+| name       | ``STRING`` | Name of the registered model that the tag was logged under.                                                       |
+|            |            | This field is required.                                                                                           |
+|            |            |                                                                                                                   |
++------------+------------+-------------------------------------------------------------------------------------------------------------------+
+| version    | ``STRING`` | Model version number that the tag was logged under.                                                               |
+|            |            | This field is required.                                                                                           |
+|            |            |                                                                                                                   |
++------------+------------+-------------------------------------------------------------------------------------------------------------------+
+| key        | ``STRING`` | Name of the tag. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes. |
+|            |            | This field is required.                                                                                           |
+|            |            |                                                                                                                   |
++------------+------------+-------------------------------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicedeleteRegisteredModel:
+
+Delete RegisteredModel
+======================
+
+
++-----------------------------------------+-------------+
+|                Endpoint                 | HTTP Method |
++=========================================+=============+
+| ``2.0/mlflow/registered-models/delete`` | ``DELETE``  |
++-----------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowDeleteRegisteredModel:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+------------------------------------------+
+| Field Name |    Type    |               Description                |
++============+============+==========================================+
+| name       | ``STRING`` | Registered model unique name identifier. |
+|            |            | This field is required.                  |
+|            |            |                                          |
++------------+------------+------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicedeleteRegisteredModelAlias:
+
+Delete Registered Model Alias
+=============================
+
+
++----------------------------------------+-------------+
+|                Endpoint                | HTTP Method |
++========================================+=============+
+| ``2.0/mlflow/registered-models/alias`` | ``DELETE``  |
++----------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowDeleteRegisteredModelAlias:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+---------------------------------------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                                     Description                                                     |
++============+============+=====================================================================================================================+
+| name       | ``STRING`` | Name of the registered model.                                                                                       |
+|            |            | This field is required.                                                                                             |
+|            |            |                                                                                                                     |
++------------+------------+---------------------------------------------------------------------------------------------------------------------+
+| alias      | ``STRING`` | Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes. |
+|            |            | This field is required.                                                                                             |
+|            |            |                                                                                                                     |
++------------+------------+---------------------------------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicedeleteRegisteredModelTag:
+
+Delete Registered Model Tag
+===========================
+
+
++---------------------------------------------+-------------+
+|                  Endpoint                   | HTTP Method |
++=============================================+=============+
+| ``2.0/mlflow/registered-models/delete-tag`` | ``DELETE``  |
++---------------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowDeleteRegisteredModelTag:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+-------------------------------------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                                    Description                                                    |
++============+============+===================================================================================================================+
+| name       | ``STRING`` | Name of the registered model that the tag was logged under.                                                       |
+|            |            | This field is required.                                                                                           |
+|            |            |                                                                                                                   |
++------------+------------+-------------------------------------------------------------------------------------------------------------------+
+| key        | ``STRING`` | Name of the tag. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes. |
+|            |            | This field is required.                                                                                           |
+|            |            |                                                                                                                   |
++------------+------------+-------------------------------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicegetLatestVersions:
+
+Get Latest ModelVersions
+========================
+
+
++------------------------------------------------------+-------------+
+|                       Endpoint                       | HTTP Method |
++======================================================+=============+
+| ``2.0/mlflow/registered-models/get-latest-versions`` | ``POST``    |
++------------------------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowGetLatestVersions:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------------------+------------------------------------------+
+| Field Name |          Type          |               Description                |
++============+========================+==========================================+
+| name       | ``STRING``             | Registered model unique name identifier. |
+|            |                        | This field is required.                  |
+|            |                        |                                          |
++------------+------------------------+------------------------------------------+
+| stages     | An array of ``STRING`` | List of stages.                          |
++------------+------------------------+------------------------------------------+
+
+.. _mlflowGetLatestVersionsResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++----------------+---------------------------------------+--------------------------------------------------------------------------------------------------+
+|   Field Name   |                 Type                  |                                           Description                                            |
++================+=======================================+==================================================================================================+
+| model_versions | An array of :ref:`mlflowmodelversion` | Latest version models for each requests stage. Only return models with current ``READY`` status. |
+|                |                                       | If no ``stages`` provided, returns the latest version for each stage, including ``"None"``.      |
++----------------+---------------------------------------+--------------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicegetModelVersion:
+
+Get ModelVersion
+================
+
+
++-----------------------------------+-------------+
+|             Endpoint              | HTTP Method |
++===================================+=============+
+| ``2.0/mlflow/model-versions/get`` | ``GET``     |
++-----------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowGetModelVersion:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+------------------------------+
+| Field Name |    Type    |         Description          |
++============+============+==============================+
+| name       | ``STRING`` | Name of the registered model |
+|            |            | This field is required.      |
+|            |            |                              |
++------------+------------+------------------------------+
+| version    | ``STRING`` | Model version number         |
+|            |            | This field is required.      |
+|            |            |                              |
++------------+------------+------------------------------+
+
+.. _mlflowGetModelVersionResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++---------------+---------------------------+-------------+
+|  Field Name   |           Type            | Description |
++===============+===========================+=============+
+| model_version | :ref:`mlflowmodelversion` |             |
++---------------+---------------------------+-------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicegetModelVersionByAlias:
+
+Get Model Version by Alias
+==========================
+
+
++----------------------------------------+-------------+
+|                Endpoint                | HTTP Method |
++========================================+=============+
+| ``2.0/mlflow/registered-models/alias`` | ``GET``     |
++----------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowGetModelVersionByAlias:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+-----------------------------------------------+
+| Field Name |    Type    |                  Description                  |
++============+============+===============================================+
+| name       | ``STRING`` | Name of the registered model.                 |
+|            |            | This field is required.                       |
+|            |            |                                               |
++------------+------------+-----------------------------------------------+
+| alias      | ``STRING`` | Name of the alias. Maximum size is 256 bytes. |
+|            |            | This field is required.                       |
+|            |            |                                               |
++------------+------------+-----------------------------------------------+
+
+.. _mlflowGetModelVersionByAliasResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++---------------+---------------------------+-------------+
+|  Field Name   |           Type            | Description |
++===============+===========================+=============+
+| model_version | :ref:`mlflowmodelversion` |             |
++---------------+---------------------------+-------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicegetModelVersionDownloadUri:
+
+Get Download URI For ModelVersion Artifacts
+===========================================
+
+
++------------------------------------------------+-------------+
+|                    Endpoint                    | HTTP Method |
++================================================+=============+
+| ``2.0/mlflow/model-versions/get-download-uri`` | ``GET``     |
++------------------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowGetModelVersionDownloadUri:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+------------------------------+
+| Field Name |    Type    |         Description          |
++============+============+==============================+
+| name       | ``STRING`` | Name of the registered model |
+|            |            | This field is required.      |
+|            |            |                              |
++------------+------------+------------------------------+
+| version    | ``STRING`` | Model version number         |
+|            |            | This field is required.      |
+|            |            |                              |
++------------+------------+------------------------------+
+
+.. _mlflowGetModelVersionDownloadUriResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++--------------+------------+-------------------------------------------------------------------------+
+|  Field Name  |    Type    |                               Description                               |
++==============+============+=========================================================================+
+| artifact_uri | ``STRING`` | URI corresponding to where artifacts for this model version are stored. |
++--------------+------------+-------------------------------------------------------------------------+
 
 ===========================
 
@@ -1489,393 +2066,6 @@ Response Structure
 
 
 
-.. _mlflowModelRegistryServiceupdateRegisteredModel:
-
-Update RegisteredModel
-======================
-
-
-+-----------------------------------------+-------------+
-|                Endpoint                 | HTTP Method |
-+=========================================+=============+
-| ``2.0/mlflow/registered-models/update`` | ``PATCH``   |
-+-----------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowUpdateRegisteredModel:
-
-Request Structure
------------------
-
-
-
-
-
-
-+-------------+------------+---------------------------------------------------------------------+
-| Field Name  |    Type    |                             Description                             |
-+=============+============+=====================================================================+
-| name        | ``STRING`` | Registered model unique name identifier.                            |
-|             |            | This field is required.                                             |
-|             |            |                                                                     |
-+-------------+------------+---------------------------------------------------------------------+
-| description | ``STRING`` | If provided, updates the description for this ``registered_model``. |
-+-------------+------------+---------------------------------------------------------------------+
-
-.. _mlflowUpdateRegisteredModelResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+------------------+------------------------------+-------------+
-|    Field Name    |             Type             | Description |
-+==================+==============================+=============+
-| registered_model | :ref:`mlflowregisteredmodel` |             |
-+------------------+------------------------------+-------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicedeleteRegisteredModel:
-
-Delete RegisteredModel
-======================
-
-
-+-----------------------------------------+-------------+
-|                Endpoint                 | HTTP Method |
-+=========================================+=============+
-| ``2.0/mlflow/registered-models/delete`` | ``DELETE``  |
-+-----------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowDeleteRegisteredModel:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+------------------------------------------+
-| Field Name |    Type    |               Description                |
-+============+============+==========================================+
-| name       | ``STRING`` | Registered model unique name identifier. |
-|            |            | This field is required.                  |
-|            |            |                                          |
-+------------+------------+------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicegetLatestVersions:
-
-Get Latest ModelVersions
-========================
-
-.. warning:: Model Stages are deprecated and will be removed in a future major release. To learn more about this deprecation, see our `migration guide <../model-registry/index.html#migrating-from-stages>`_.
-
-+------------------------------------------------------+-------------+
-|                       Endpoint                       | HTTP Method |
-+======================================================+=============+
-| ``2.0/mlflow/registered-models/get-latest-versions`` | ``GET``     |
-+------------------------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowGetLatestVersions:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------------------+------------------------------------------+
-| Field Name |          Type          |               Description                |
-+============+========================+==========================================+
-| name       | ``STRING``             | Registered model unique name identifier. |
-|            |                        | This field is required.                  |
-|            |                        |                                          |
-+------------+------------------------+------------------------------------------+
-| stages     | An array of ``STRING`` | List of stages.                          |
-+------------+------------------------+------------------------------------------+
-
-.. _mlflowGetLatestVersionsResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+----------------+---------------------------------------+--------------------------------------------------------------------------------------------------+
-|   Field Name   |                 Type                  |                                           Description                                            |
-+================+=======================================+==================================================================================================+
-| model_versions | An array of :ref:`mlflowmodelversion` | Latest version models for each requests stage. Only return models with current ``READY`` status. |
-|                |                                       | If no ``stages`` provided, returns the latest version for each stage, including ``"None"``.      |
-+----------------+---------------------------------------+--------------------------------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicecreateModelVersion:
-
-Create ModelVersion
-===================
-
-
-+--------------------------------------+-------------+
-|               Endpoint               | HTTP Method |
-+======================================+=============+
-| ``2.0/mlflow/model-versions/create`` | ``POST``    |
-+--------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowCreateModelVersion:
-
-Request Structure
------------------
-
-
-
-
-
-
-+-------------+------------------------------------------+----------------------------------------------------------------------------------------+
-| Field Name  |                   Type                   |                                      Description                                       |
-+=============+==========================================+========================================================================================+
-| name        | ``STRING``                               | Register model under this name                                                         |
-|             |                                          | This field is required.                                                                |
-|             |                                          |                                                                                        |
-+-------------+------------------------------------------+----------------------------------------------------------------------------------------+
-| source      | ``STRING``                               | URI indicating the location of the model artifacts.                                    |
-|             |                                          | This field is required.                                                                |
-|             |                                          |                                                                                        |
-+-------------+------------------------------------------+----------------------------------------------------------------------------------------+
-| run_id      | ``STRING``                               | MLflow run ID for correlation, if ``source`` was generated by an experiment run in     |
-|             |                                          | MLflow tracking server                                                                 |
-+-------------+------------------------------------------+----------------------------------------------------------------------------------------+
-| tags        | An array of :ref:`mlflowmodelversiontag` | Additional metadata for model version.                                                 |
-+-------------+------------------------------------------+----------------------------------------------------------------------------------------+
-| run_link    | ``STRING``                               | MLflow run link - this is the exact link of the run that generated this model version, |
-|             |                                          | potentially hosted at another instance of MLflow.                                      |
-+-------------+------------------------------------------+----------------------------------------------------------------------------------------+
-| description | ``STRING``                               | Optional description for model version.                                                |
-+-------------+------------------------------------------+----------------------------------------------------------------------------------------+
-
-.. _mlflowCreateModelVersionResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+---------------+---------------------------+-----------------------------------------------------------------+
-|  Field Name   |           Type            |                           Description                           |
-+===============+===========================+=================================================================+
-| model_version | :ref:`mlflowmodelversion` | Return new version number generated for this model in registry. |
-+---------------+---------------------------+-----------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicegetModelVersion:
-
-Get ModelVersion
-================
-
-
-+-----------------------------------+-------------+
-|             Endpoint              | HTTP Method |
-+===================================+=============+
-| ``2.0/mlflow/model-versions/get`` | ``GET``     |
-+-----------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowGetModelVersion:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+------------------------------+
-| Field Name |    Type    |         Description          |
-+============+============+==============================+
-| name       | ``STRING`` | Name of the registered model |
-|            |            | This field is required.      |
-|            |            |                              |
-+------------+------------+------------------------------+
-| version    | ``STRING`` | Model version number         |
-|            |            | This field is required.      |
-|            |            |                              |
-+------------+------------+------------------------------+
-
-.. _mlflowGetModelVersionResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+---------------+---------------------------+-------------+
-|  Field Name   |           Type            | Description |
-+===============+===========================+=============+
-| model_version | :ref:`mlflowmodelversion` |             |
-+---------------+---------------------------+-------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServiceupdateModelVersion:
-
-Update ModelVersion
-===================
-
-
-+--------------------------------------+-------------+
-|               Endpoint               | HTTP Method |
-+======================================+=============+
-| ``2.0/mlflow/model-versions/update`` | ``PATCH``   |
-+--------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowUpdateModelVersion:
-
-Request Structure
------------------
-
-
-
-
-
-
-+-------------+------------+---------------------------------------------------------------------+
-| Field Name  |    Type    |                             Description                             |
-+=============+============+=====================================================================+
-| name        | ``STRING`` | Name of the registered model                                        |
-|             |            | This field is required.                                             |
-|             |            |                                                                     |
-+-------------+------------+---------------------------------------------------------------------+
-| version     | ``STRING`` | Model version number                                                |
-|             |            | This field is required.                                             |
-|             |            |                                                                     |
-+-------------+------------+---------------------------------------------------------------------+
-| description | ``STRING`` | If provided, updates the description for this ``registered_model``. |
-+-------------+------------+---------------------------------------------------------------------+
-
-.. _mlflowUpdateModelVersionResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+---------------+---------------------------+-----------------------------------------------------------------+
-|  Field Name   |           Type            |                           Description                           |
-+===============+===========================+=================================================================+
-| model_version | :ref:`mlflowmodelversion` | Return new version number generated for this model in registry. |
-+---------------+---------------------------+-----------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicedeleteModelVersion:
-
-Delete ModelVersion
-===================
-
-
-+--------------------------------------+-------------+
-|               Endpoint               | HTTP Method |
-+======================================+=============+
-| ``2.0/mlflow/model-versions/delete`` | ``DELETE``  |
-+--------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowDeleteModelVersion:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+------------------------------+
-| Field Name |    Type    |         Description          |
-+============+============+==============================+
-| name       | ``STRING`` | Name of the registered model |
-|            |            | This field is required.      |
-|            |            |                              |
-+------------+------------+------------------------------+
-| version    | ``STRING`` | Model version number         |
-|            |            | This field is required.      |
-|            |            |                              |
-+------------+------------+------------------------------+
-
-===========================
-
-
-
 .. _mlflowModelRegistryServicesearchModelVersions:
 
 Search ModelVersions
@@ -1937,136 +2127,6 @@ Response Structure
 +-----------------+---------------------------------------+----------------------------------------------------------------------------+
 | next_page_token | ``STRING``                            | Pagination token to request next page of models for the same search query. |
 +-----------------+---------------------------------------+----------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicegetModelVersionDownloadUri:
-
-Get Download URI For ModelVersion Artifacts
-===========================================
-
-
-+------------------------------------------------+-------------+
-|                    Endpoint                    | HTTP Method |
-+================================================+=============+
-| ``2.0/mlflow/model-versions/get-download-uri`` | ``GET``     |
-+------------------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowGetModelVersionDownloadUri:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+------------------------------+
-| Field Name |    Type    |         Description          |
-+============+============+==============================+
-| name       | ``STRING`` | Name of the registered model |
-|            |            | This field is required.      |
-|            |            |                              |
-+------------+------------+------------------------------+
-| version    | ``STRING`` | Model version number         |
-|            |            | This field is required.      |
-|            |            |                              |
-+------------+------------+------------------------------+
-
-.. _mlflowGetModelVersionDownloadUriResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+--------------+------------+-------------------------------------------------------------------------+
-|  Field Name  |    Type    |                               Description                               |
-+==============+============+=========================================================================+
-| artifact_uri | ``STRING`` | URI corresponding to where artifacts for this model version are stored. |
-+--------------+------------+-------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicetransitionModelVersionStage:
-
-Transition ModelVersion Stage
-=============================
-
-.. warning:: Model Stages are deprecated and will be removed in a future major release. To learn more about this deprecation, see our `migration guide <../model-registry/index.html#migrating-from-stages>`_.
-
-+------------------------------------------------+-------------+
-|                    Endpoint                    | HTTP Method |
-+================================================+=============+
-| ``2.0/mlflow/model-versions/transition-stage`` | ``POST``    |
-+------------------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowTransitionModelVersionStage:
-
-Request Structure
------------------
-
-
-
-
-
-
-+---------------------------+------------+-------------------------------------------------------------------------------------------+
-|        Field Name         |    Type    |                                        Description                                        |
-+===========================+============+===========================================================================================+
-| name                      | ``STRING`` | Name of the registered model                                                              |
-|                           |            | This field is required.                                                                   |
-|                           |            |                                                                                           |
-+---------------------------+------------+-------------------------------------------------------------------------------------------+
-| version                   | ``STRING`` | Model version number                                                                      |
-|                           |            | This field is required.                                                                   |
-|                           |            |                                                                                           |
-+---------------------------+------------+-------------------------------------------------------------------------------------------+
-| stage                     | ``STRING`` | Transition `model_version` to new stage.                                                  |
-|                           |            | This field is required.                                                                   |
-|                           |            |                                                                                           |
-+---------------------------+------------+-------------------------------------------------------------------------------------------+
-| archive_existing_versions | ``BOOL``   | When transitioning a model version to a particular stage, this flag dictates whether all  |
-|                           |            | existing model versions in that stage should be atomically moved to the "archived" stage. |
-|                           |            | This ensures that at-most-one model version exists in the target stage.                   |
-|                           |            | This field is *required* when transitioning a model versions's stage                      |
-|                           |            | This field is required.                                                                   |
-|                           |            |                                                                                           |
-+---------------------------+------------+-------------------------------------------------------------------------------------------+
-
-.. _mlflowTransitionModelVersionStageResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+---------------+---------------------------+-----------------------+
-|  Field Name   |           Type            |      Description      |
-+===============+===========================+=======================+
-| model_version | :ref:`mlflowmodelversion` | Updated model version |
-+---------------+---------------------------+-----------------------+
 
 ===========================
 
@@ -2137,55 +2197,6 @@ Response Structure
 
 
 
-.. _mlflowModelRegistryServicesetRegisteredModelTag:
-
-Set Registered Model Tag
-========================
-
-
-+------------------------------------------+-------------+
-|                 Endpoint                 | HTTP Method |
-+==========================================+=============+
-| ``2.0/mlflow/registered-models/set-tag`` | ``POST``    |
-+------------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowSetRegisteredModelTag:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+----------------------------------------------------------------------------------------------------------+
-| Field Name |    Type    |                                               Description                                                |
-+============+============+==========================================================================================================+
-| name       | ``STRING`` | Unique name of the model.                                                                                |
-|            |            | This field is required.                                                                                  |
-|            |            |                                                                                                          |
-+------------+------------+----------------------------------------------------------------------------------------------------------+
-| key        | ``STRING`` | Name of the tag. Maximum size depends on storage backend.                                                |
-|            |            | If a tag with this name already exists, its preexisting value will be replaced by the specified `value`. |
-|            |            | All storage backends are guaranteed to support key values up to 250 bytes in size.                       |
-|            |            | This field is required.                                                                                  |
-|            |            |                                                                                                          |
-+------------+------------+----------------------------------------------------------------------------------------------------------+
-| value      | ``STRING`` | String value of the tag being logged. Maximum size depends on storage backend.                           |
-|            |            | This field is required.                                                                                  |
-|            |            |                                                                                                          |
-+------------+------------+----------------------------------------------------------------------------------------------------------+
-
-===========================
-
-
-
 .. _mlflowModelRegistryServicesetModelVersionTag:
 
 Set Model Version Tag
@@ -2239,198 +2250,6 @@ Request Structure
 
 
 
-.. _mlflowModelRegistryServicedeleteRegisteredModelTag:
-
-Delete Registered Model Tag
-===========================
-
-
-+---------------------------------------------+-------------+
-|                  Endpoint                   | HTTP Method |
-+=============================================+=============+
-| ``2.0/mlflow/registered-models/delete-tag`` | ``DELETE``  |
-+---------------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowDeleteRegisteredModelTag:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+-------------------------------------------------------------------------------------------------------------------+
-| Field Name |    Type    |                                                    Description                                                    |
-+============+============+===================================================================================================================+
-| name       | ``STRING`` | Name of the registered model that the tag was logged under.                                                       |
-|            |            | This field is required.                                                                                           |
-|            |            |                                                                                                                   |
-+------------+------------+-------------------------------------------------------------------------------------------------------------------+
-| key        | ``STRING`` | Name of the tag. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes. |
-|            |            | This field is required.                                                                                           |
-|            |            |                                                                                                                   |
-+------------+------------+-------------------------------------------------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicedeleteModelVersionTag:
-
-Delete Model Version Tag
-========================
-
-
-+------------------------------------------+-------------+
-|                 Endpoint                 | HTTP Method |
-+==========================================+=============+
-| ``2.0/mlflow/model-versions/delete-tag`` | ``DELETE``  |
-+------------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowDeleteModelVersionTag:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+-------------------------------------------------------------------------------------------------------------------+
-| Field Name |    Type    |                                                    Description                                                    |
-+============+============+===================================================================================================================+
-| name       | ``STRING`` | Name of the registered model that the tag was logged under.                                                       |
-|            |            | This field is required.                                                                                           |
-|            |            |                                                                                                                   |
-+------------+------------+-------------------------------------------------------------------------------------------------------------------+
-| version    | ``STRING`` | Model version number that the tag was logged under.                                                               |
-|            |            | This field is required.                                                                                           |
-|            |            |                                                                                                                   |
-+------------+------------+-------------------------------------------------------------------------------------------------------------------+
-| key        | ``STRING`` | Name of the tag. The name must be an exact match; wild-card deletion is not supported. Maximum size is 250 bytes. |
-|            |            | This field is required.                                                                                           |
-|            |            |                                                                                                                   |
-+------------+------------+-------------------------------------------------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicedeleteRegisteredModelAlias:
-
-Delete Registered Model Alias
-=============================
-
-
-+----------------------------------------+-------------+
-|                Endpoint                | HTTP Method |
-+========================================+=============+
-| ``2.0/mlflow/registered-models/alias`` | ``DELETE``  |
-+----------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowDeleteRegisteredModelAlias:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+---------------------------------------------------------------------------------------------------------------------+
-| Field Name |    Type    |                                                     Description                                                     |
-+============+============+=====================================================================================================================+
-| name       | ``STRING`` | Name of the registered model.                                                                                       |
-|            |            | This field is required.                                                                                             |
-|            |            |                                                                                                                     |
-+------------+------------+---------------------------------------------------------------------------------------------------------------------+
-| alias      | ``STRING`` | Name of the alias. The name must be an exact match; wild-card deletion is not supported. Maximum size is 256 bytes. |
-|            |            | This field is required.                                                                                             |
-|            |            |                                                                                                                     |
-+------------+------------+---------------------------------------------------------------------------------------------------------------------+
-
-===========================
-
-
-
-.. _mlflowModelRegistryServicegetModelVersionByAlias:
-
-Get Model Version by Alias
-==========================
-
-
-+----------------------------------------+-------------+
-|                Endpoint                | HTTP Method |
-+========================================+=============+
-| ``2.0/mlflow/registered-models/alias`` | ``GET``     |
-+----------------------------------------+-------------+
-
-
-
-
-
-
-.. _mlflowGetModelVersionByAlias:
-
-Request Structure
------------------
-
-
-
-
-
-
-+------------+------------+-----------------------------------------------+
-| Field Name |    Type    |                  Description                  |
-+============+============+===============================================+
-| name       | ``STRING`` | Name of the registered model.                 |
-|            |            | This field is required.                       |
-|            |            |                                               |
-+------------+------------+-----------------------------------------------+
-| alias      | ``STRING`` | Name of the alias. Maximum size is 256 bytes. |
-|            |            | This field is required.                       |
-|            |            |                                               |
-+------------+------------+-----------------------------------------------+
-
-.. _mlflowGetModelVersionByAliasResponse:
-
-Response Structure
-------------------
-
-
-
-
-
-
-+---------------+---------------------------+-------------+
-|  Field Name   |           Type            | Description |
-+===============+===========================+=============+
-| model_version | :ref:`mlflowmodelversion` |             |
-+---------------+---------------------------+-------------+
-
-===========================
-
-
-
 .. _mlflowModelRegistryServicesetRegisteredModelAlias:
 
 Set Registered Model Alias
@@ -2476,12 +2295,642 @@ Request Structure
 |            |            |                                                                                                               |
 +------------+------------+---------------------------------------------------------------------------------------------------------------+
 
+===========================
+
+
+
+.. _mlflowModelRegistryServicesetRegisteredModelTag:
+
+Set Registered Model Tag
+========================
+
+
++------------------------------------------+-------------+
+|                 Endpoint                 | HTTP Method |
++==========================================+=============+
+| ``2.0/mlflow/registered-models/set-tag`` | ``POST``    |
++------------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowSetRegisteredModelTag:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++------------+------------+----------------------------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                               Description                                                |
++============+============+==========================================================================================================+
+| name       | ``STRING`` | Unique name of the model.                                                                                |
+|            |            | This field is required.                                                                                  |
+|            |            |                                                                                                          |
++------------+------------+----------------------------------------------------------------------------------------------------------+
+| key        | ``STRING`` | Name of the tag. Maximum size depends on storage backend.                                                |
+|            |            | If a tag with this name already exists, its preexisting value will be replaced by the specified `value`. |
+|            |            | All storage backends are guaranteed to support key values up to 250 bytes in size.                       |
+|            |            | This field is required.                                                                                  |
+|            |            |                                                                                                          |
++------------+------------+----------------------------------------------------------------------------------------------------------+
+| value      | ``STRING`` | String value of the tag being logged. Maximum size depends on storage backend.                           |
+|            |            | This field is required.                                                                                  |
+|            |            |                                                                                                          |
++------------+------------+----------------------------------------------------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServicetransitionModelVersionStage:
+
+Transition ModelVersion Stage
+=============================
+
+
++------------------------------------------------+-------------+
+|                    Endpoint                    | HTTP Method |
++================================================+=============+
+| ``2.0/mlflow/model-versions/transition-stage`` | ``POST``    |
++------------------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowTransitionModelVersionStage:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++---------------------------+------------+-------------------------------------------------------------------------------------------+
+|        Field Name         |    Type    |                                        Description                                        |
++===========================+============+===========================================================================================+
+| name                      | ``STRING`` | Name of the registered model                                                              |
+|                           |            | This field is required.                                                                   |
+|                           |            |                                                                                           |
++---------------------------+------------+-------------------------------------------------------------------------------------------+
+| version                   | ``STRING`` | Model version number                                                                      |
+|                           |            | This field is required.                                                                   |
+|                           |            |                                                                                           |
++---------------------------+------------+-------------------------------------------------------------------------------------------+
+| stage                     | ``STRING`` | Transition `model_version` to new stage.                                                  |
+|                           |            | This field is required.                                                                   |
+|                           |            |                                                                                           |
++---------------------------+------------+-------------------------------------------------------------------------------------------+
+| archive_existing_versions | ``BOOL``   | When transitioning a model version to a particular stage, this flag dictates whether all  |
+|                           |            | existing model versions in that stage should be atomically moved to the "archived" stage. |
+|                           |            | This ensures that at-most-one model version exists in the target stage.                   |
+|                           |            | This field is *required* when transitioning a model versions's stage                      |
+|                           |            | This field is required.                                                                   |
+|                           |            |                                                                                           |
++---------------------------+------------+-------------------------------------------------------------------------------------------+
+
+.. _mlflowTransitionModelVersionStageResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++---------------+---------------------------+-----------------------+
+|  Field Name   |           Type            |      Description      |
++===============+===========================+=======================+
+| model_version | :ref:`mlflowmodelversion` | Updated model version |
++---------------+---------------------------+-----------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServiceupdateModelVersion:
+
+Update ModelVersion
+===================
+
+
++--------------------------------------+-------------+
+|               Endpoint               | HTTP Method |
++======================================+=============+
+| ``2.0/mlflow/model-versions/update`` | ``PATCH``   |
++--------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowUpdateModelVersion:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++-------------+------------+---------------------------------------------------------------------+
+| Field Name  |    Type    |                             Description                             |
++=============+============+=====================================================================+
+| name        | ``STRING`` | Name of the registered model                                        |
+|             |            | This field is required.                                             |
+|             |            |                                                                     |
++-------------+------------+---------------------------------------------------------------------+
+| version     | ``STRING`` | Model version number                                                |
+|             |            | This field is required.                                             |
+|             |            |                                                                     |
++-------------+------------+---------------------------------------------------------------------+
+| description | ``STRING`` | If provided, updates the description for this ``registered_model``. |
++-------------+------------+---------------------------------------------------------------------+
+
+.. _mlflowUpdateModelVersionResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++---------------+---------------------------+-----------------------------------------------------------------+
+|  Field Name   |           Type            |                           Description                           |
++===============+===========================+=================================================================+
+| model_version | :ref:`mlflowmodelversion` | Return new version number generated for this model in registry. |
++---------------+---------------------------+-----------------------------------------------------------------+
+
+===========================
+
+
+
+.. _mlflowModelRegistryServiceupdateRegisteredModel:
+
+Update RegisteredModel
+======================
+
+
++-----------------------------------------+-------------+
+|                Endpoint                 | HTTP Method |
++=========================================+=============+
+| ``2.0/mlflow/registered-models/update`` | ``PATCH``   |
++-----------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowUpdateRegisteredModel:
+
+Request Structure
+-----------------
+
+
+
+
+
+
++-------------------+------------+---------------------------------------------------------------------+
+|    Field Name     |    Type    |                             Description                             |
++===================+============+=====================================================================+
+| name              | ``STRING`` | Registered model unique name identifier.                            |
+|                   |            | This field is required.                                             |
+|                   |            |                                                                     |
++-------------------+------------+---------------------------------------------------------------------+
+| description       | ``STRING`` | If provided, updates the description for this ``registered_model``. |
++-------------------+------------+---------------------------------------------------------------------+
+| deployment_job_id | ``STRING`` | Deployment job id for this model.                                   |
++-------------------+------------+---------------------------------------------------------------------+
+
+.. _mlflowUpdateRegisteredModelResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++------------------+------------------------------+-------------+
+|    Field Name    |             Type             | Description |
++==================+==============================+=============+
+| registered_model | :ref:`mlflowregisteredmodel` |             |
++------------------+------------------------------+-------------+
+
+===========================
+
+
+
+.. _mlflowWebhookServicecreateWebhook:
+
+Create Webhook
+==============
+
+
++-------------------------+-------------+
+|        Endpoint         | HTTP Method |
++=========================+=============+
+| ``2.0/mlflow/webhooks`` | ``POST``    |
++-------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowCreateWebhook:
+
+Request Structure
+-----------------
+
+
+
+Create webhook request
+
+
++-------------+---------------------------------------+------------------------------------------------------+
+| Field Name  |                 Type                  |                     Description                      |
++=============+=======================================+======================================================+
+| name        | ``STRING``                            | Name of the webhook                                  |
+|             |                                       | This field is required.                              |
+|             |                                       |                                                      |
++-------------+---------------------------------------+------------------------------------------------------+
+| description | ``STRING``                            | Optional description for the webhook                 |
++-------------+---------------------------------------+------------------------------------------------------+
+| url         | ``STRING``                            | URL to send webhook events to                        |
+|             |                                       | This field is required.                              |
+|             |                                       |                                                      |
++-------------+---------------------------------------+------------------------------------------------------+
+| events      | An array of :ref:`mlflowwebhookevent` | List of events to subscribe to                       |
+|             |                                       | This field is required.                              |
+|             |                                       |                                                      |
++-------------+---------------------------------------+------------------------------------------------------+
+| secret      | ``STRING``                            | Secret key for HMAC signature verification           |
++-------------+---------------------------------------+------------------------------------------------------+
+| status      | :ref:`mlflowwebhookstatus`            | Initial status (defaults to ACTIVE if not specified) |
++-------------+---------------------------------------+------------------------------------------------------+
+
+.. _mlflowCreateWebhookResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++------------+----------------------+-------------+
+| Field Name |         Type         | Description |
++============+======================+=============+
+| webhook    | :ref:`mlflowwebhook` |             |
++------------+----------------------+-------------+
+
+===========================
+
+
+
+.. _mlflowWebhookServicedeleteWebhook:
+
+Delete Webhook
+==============
+
+
++--------------------------------------+-------------+
+|               Endpoint               | HTTP Method |
++======================================+=============+
+| ``2.0/mlflow/webhooks/{webhook_id}`` | ``DELETE``  |
++--------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowDeleteWebhook:
+
+Request Structure
+-----------------
+
+
+
+Delete webhook request
+
+
++------------+------------+-----------------------------+
+| Field Name |    Type    |         Description         |
++============+============+=============================+
+| webhook_id | ``STRING`` | ID of the webhook to delete |
+|            |            | This field is required.     |
+|            |            |                             |
++------------+------------+-----------------------------+
+
+===========================
+
+
+
+.. _mlflowWebhookServicegetWebhook:
+
+Get Webhook
+===========
+
+
++--------------------------------------+-------------+
+|               Endpoint               | HTTP Method |
++======================================+=============+
+| ``2.0/mlflow/webhooks/{webhook_id}`` | ``GET``     |
++--------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowGetWebhook:
+
+Request Structure
+-----------------
+
+
+
+Get webhook request
+
+
++------------+------------+-------------------------------+
+| Field Name |    Type    |          Description          |
++============+============+===============================+
+| webhook_id | ``STRING`` | ID of the webhook to retrieve |
+|            |            | This field is required.       |
+|            |            |                               |
++------------+------------+-------------------------------+
+
+.. _mlflowGetWebhookResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++------------+----------------------+-------------+
+| Field Name |         Type         | Description |
++============+======================+=============+
+| webhook    | :ref:`mlflowwebhook` |             |
++------------+----------------------+-------------+
+
+===========================
+
+
+
+.. _mlflowWebhookServicelistWebhooks:
+
+List Webhooks
+=============
+
+
++-------------------------+-------------+
+|        Endpoint         | HTTP Method |
++=========================+=============+
+| ``2.0/mlflow/webhooks`` | ``GET``     |
++-------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowListWebhooks:
+
+Request Structure
+-----------------
+
+
+
+List webhooks request
+
+
++-------------+------------+----------------------------------------+
+| Field Name  |    Type    |              Description               |
++=============+============+========================================+
+| max_results | ``INT32``  | Maximum number of webhooks to return   |
++-------------+------------+----------------------------------------+
+| page_token  | ``STRING`` | Pagination token from previous request |
++-------------+------------+----------------------------------------+
+
+.. _mlflowListWebhooksResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++-----------------+----------------------------------+--------------------------------+
+|   Field Name    |               Type               |          Description           |
++=================+==================================+================================+
+| webhooks        | An array of :ref:`mlflowwebhook` | List of webhooks               |
++-----------------+----------------------------------+--------------------------------+
+| next_page_token | ``STRING``                       | Pagination token for next page |
++-----------------+----------------------------------+--------------------------------+
+
+===========================
+
+
+
+.. _mlflowWebhookServicetestWebhook:
+
+Test Webhook
+============
+
+
++-------------------------------------------+-------------+
+|                 Endpoint                  | HTTP Method |
++===========================================+=============+
+| ``2.0/mlflow/webhooks/{webhook_id}/test`` | ``POST``    |
++-------------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowTestWebhook:
+
+Request Structure
+-----------------
+
+
+
+Test webhook request
+
+
++------------+---------------------------+---------------------------------------------------------------------------------+
+| Field Name |           Type            |                                   Description                                   |
++============+===========================+=================================================================================+
+| webhook_id | ``STRING``                | ID of the webhook to test                                                       |
+|            |                           | This field is required.                                                         |
+|            |                           |                                                                                 |
++------------+---------------------------+---------------------------------------------------------------------------------+
+| event      | :ref:`mlflowwebhookevent` | Optional event type to test. If not specified, defaults to the first event type |
+|            |                           | in the webhook's subscribed events.                                             |
++------------+---------------------------+---------------------------------------------------------------------------------+
+
+.. _mlflowTestWebhookResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++------------+--------------------------------+-------------+
+| Field Name |              Type              | Description |
++============+================================+=============+
+| result     | :ref:`mlflowwebhooktestresult` |             |
++------------+--------------------------------+-------------+
+
+===========================
+
+
+
+.. _mlflowWebhookServiceupdateWebhook:
+
+Update Webhook
+==============
+
+
++--------------------------------------+-------------+
+|               Endpoint               | HTTP Method |
++======================================+=============+
+| ``2.0/mlflow/webhooks/{webhook_id}`` | ``PATCH``   |
++--------------------------------------+-------------+
+
+
+
+
+
+
+.. _mlflowUpdateWebhook:
+
+Request Structure
+-----------------
+
+
+
+Update webhook request
+
+
++-------------+---------------------------------------+------------------------------------+
+| Field Name  |                 Type                  |            Description             |
++=============+=======================================+====================================+
+| webhook_id  | ``STRING``                            | ID of the webhook to update        |
+|             |                                       | This field is required.            |
+|             |                                       |                                    |
++-------------+---------------------------------------+------------------------------------+
+| name        | ``STRING``                            | New name for the webhook           |
++-------------+---------------------------------------+------------------------------------+
+| description | ``STRING``                            | New description for the webhook    |
++-------------+---------------------------------------+------------------------------------+
+| url         | ``STRING``                            | New URL for the webhook            |
++-------------+---------------------------------------+------------------------------------+
+| events      | An array of :ref:`mlflowwebhookevent` | New list of events to subscribe to |
++-------------+---------------------------------------+------------------------------------+
+| secret      | ``STRING``                            | New secret key for HMAC signature  |
++-------------+---------------------------------------+------------------------------------+
+| status      | :ref:`mlflowwebhookstatus`            | New status for the webhook         |
++-------------+---------------------------------------+------------------------------------+
+
+.. _mlflowUpdateWebhookResponse:
+
+Response Structure
+------------------
+
+
+
+
+
+
++------------+----------------------+-------------+
+| Field Name |         Type         | Description |
++============+======================+=============+
+| webhook    | :ref:`mlflowwebhook` |             |
++------------+----------------------+-------------+
+
 .. _RESTadd:
 
 Data Structures
 ===============
 
 
+
+.. _mlflowCreateAssessment:
+
+CreateAssessment
+----------------
+
+
+
+
+
+
++------------+------------------------------------+---------------------------+
+| Field Name |                Type                |        Description        |
++============+====================================+===========================+
+| assessment | :ref:`mlflowassessmentsassessment` | The assessment to create. |
+|            |                                    | This field is required.   |
+|            |                                    |                           |
++------------+------------------------------------+---------------------------+
+
+.. _mlflowCreateLoggedModel:
+
+CreateLoggedModel
+-----------------
+
+
+
+
+
+
++---------------+-----------------------------------------------+-------------------------------------------------------------------------------+
+|  Field Name   |                     Type                      |                                  Description                                  |
++===============+===============================================+===============================================================================+
+| experiment_id | ``STRING``                                    | ID of the associated experiment.                                              |
+|               |                                               | This field is required.                                                       |
+|               |                                               |                                                                               |
++---------------+-----------------------------------------------+-------------------------------------------------------------------------------+
+| name          | ``STRING``                                    | Name of the model. Optional. If not specified, the backend will generate one. |
++---------------+-----------------------------------------------+-------------------------------------------------------------------------------+
+| model_type    | ``STRING``                                    | The type of model, such as "Agent", "Classifier", "LLM".                      |
++---------------+-----------------------------------------------+-------------------------------------------------------------------------------+
+| source_run_id | ``STRING``                                    | Run ID of the run that created this model.                                    |
++---------------+-----------------------------------------------+-------------------------------------------------------------------------------+
+| params        | An array of :ref:`mlflowloggedmodelparameter` | LoggedModel params.                                                           |
++---------------+-----------------------------------------------+-------------------------------------------------------------------------------+
+| tags          | An array of :ref:`mlflowloggedmodeltag`       | LoggedModel tags.                                                             |
++---------------+-----------------------------------------------+-------------------------------------------------------------------------------+
 
 .. _mlflowDataset:
 
@@ -2490,9 +2939,6 @@ Dataset
 
 
 
-.. note::
-    Experimental: This API may change or be removed in a future release without warning.
-
 Dataset. Represents a reference to data used for training, testing, or evaluation during
 the model development process.
 
@@ -2500,7 +2946,7 @@ the model development process.
 +-------------+------------+----------------------------------------------------------------------------------------------+
 | Field Name  |    Type    |                                         Description                                          |
 +=============+============+==============================================================================================+
-| name        | ``STRING`` | The name of the dataset. E.g. ?my.uc.table@2? ?nyc-taxi-dataset?, ?fantastic-elk-3?          |
+| name        | ``STRING`` | The name of the dataset. E.g. "my.uc.table@2" "nyc-taxi-dataset", "fantastic-elk-3"          |
 |             |            | This field is required.                                                                      |
 |             |            |                                                                                              |
 +-------------+------------+----------------------------------------------------------------------------------------------+
@@ -2509,12 +2955,12 @@ the model development process.
 |             |            | This field is required.                                                                      |
 |             |            |                                                                                              |
 +-------------+------------+----------------------------------------------------------------------------------------------+
-| source_type | ``STRING`` | Source information for the dataset. Note that the source may not exactly reproduce the       |
-|             |            | dataset if it was transformed / modified before use with MLflow.                             |
+| source_type | ``STRING`` | The type of the dataset source, e.g. 'databricks-uc-table', 'DBFS', 'S3', ...                |
 |             |            | This field is required.                                                                      |
 |             |            |                                                                                              |
 +-------------+------------+----------------------------------------------------------------------------------------------+
-| source      | ``STRING`` | The type of the dataset source, e.g. ?databricks-uc-table?, ?DBFS?, ?S3?, ...                |
+| source      | ``STRING`` | Source information for the dataset. Note that the source may not exactly reproduce the       |
+|             |            | dataset if it was transformed / modified before use with MLflow.                             |
 |             |            | This field is required.                                                                      |
 |             |            |                                                                                              |
 +-------------+------------+----------------------------------------------------------------------------------------------+
@@ -2526,6 +2972,26 @@ the model development process.
 |             |            | in an array.                                                                                 |
 +-------------+------------+----------------------------------------------------------------------------------------------+
 
+.. _mlflowSearchLoggedModelsDataset:
+
+Dataset
+-------
+
+
+
+
+
+
++----------------+------------+----------------------------+
+|   Field Name   |    Type    |        Description         |
++================+============+============================+
+| dataset_name   | ``STRING`` | The name of the dataset.   |
+|                |            | This field is required.    |
+|                |            |                            |
++----------------+------------+----------------------------+
+| dataset_digest | ``STRING`` | The digest of the dataset. |
++----------------+------------+----------------------------+
+
 .. _mlflowDatasetInput:
 
 DatasetInput
@@ -2533,21 +2999,222 @@ DatasetInput
 
 
 
-.. note::
-    Experimental: This API may change or be removed in a future release without warning.
-
 DatasetInput. Represents a dataset and input tags.
 
 
 +------------+-----------------------------------+----------------------------------------------------------------------------------+
 | Field Name |               Type                |                                   Description                                    |
 +============+===================================+==================================================================================+
-| tags       | An array of :ref:`mlflowinputtag` | A list of tags for the dataset input, e.g. a ?context? tag with value ?training? |
+| tags       | An array of :ref:`mlflowinputtag` | A list of tags for the dataset input, e.g. a "context" tag with value "training" |
 +------------+-----------------------------------+----------------------------------------------------------------------------------+
 | dataset    | :ref:`mlflowdataset`              | The dataset being used as a Run input.                                           |
 |            |                                   | This field is required.                                                          |
 |            |                                   |                                                                                  |
 +------------+-----------------------------------+----------------------------------------------------------------------------------+
+
+.. _mlflowDatasetSummary:
+
+DatasetSummary
+--------------
+
+
+
+DatasetSummary. Represents a summary of information about a dataset.
+
+
++---------------+------------+-------------------------------------------------------------------------------------+
+|  Field Name   |    Type    |                                     Description                                     |
++===============+============+=====================================================================================+
+| experiment_id | ``STRING`` | Unique identifier for the experiment.                                               |
+|               |            | This field is required.                                                             |
+|               |            |                                                                                     |
++---------------+------------+-------------------------------------------------------------------------------------+
+| name          | ``STRING`` | The name of the dataset. E.g. "my.uc.table@2" "nyc-taxi-dataset", "fantastic-elk-3" |
+|               |            | This field is required.                                                             |
+|               |            |                                                                                     |
++---------------+------------+-------------------------------------------------------------------------------------+
+| digest        | ``STRING`` | Dataset digest, e.g. an md5 hash of the dataset that uniquely identifies it         |
+|               |            | within datasets of the same name.                                                   |
+|               |            | This field is required.                                                             |
+|               |            |                                                                                     |
++---------------+------------+-------------------------------------------------------------------------------------+
+| context       | ``STRING`` | Value of "context" tag if set for the given dataset.                                |
++---------------+------------+-------------------------------------------------------------------------------------+
+
+.. _mlflowDeleteAssessment:
+
+DeleteAssessment
+----------------
+
+
+
+A request to delete an assessment identified by its trace_id and assessment_id.
+The response is empty on successful deletion.
+
+
++---------------+------------+---------------------------+
+|  Field Name   |    Type    |        Description        |
++===============+============+===========================+
+| trace_id      | ``STRING`` | The ID of the trace.      |
+|               |            | This field is required.   |
+|               |            |                           |
++---------------+------------+---------------------------+
+| assessment_id | ``STRING`` | The ID of the assessment. |
+|               |            | This field is required.   |
+|               |            |                           |
++---------------+------------+---------------------------+
+
+.. _mlflowDeleteLoggedModel:
+
+DeleteLoggedModel
+-----------------
+
+
+
+
+
+
++------------+------------+--------------------------------------+
+| Field Name |    Type    |             Description              |
++============+============+======================================+
+| model_id   | ``STRING`` | The ID of the LoggedModel to delete. |
+|            |            | This field is required.              |
+|            |            |                                      |
++------------+------------+--------------------------------------+
+
+.. _mlflowDeleteLoggedModelTag:
+
+DeleteLoggedModelTag
+--------------------
+
+
+
+
+
+
++------------+------------+---------------------------------------------------+
+| Field Name |    Type    |                    Description                    |
++============+============+===================================================+
+| model_id   | ``STRING`` | The ID of the LoggedModel to delete the tag from. |
+|            |            | This field is required.                           |
+|            |            |                                                   |
++------------+------------+---------------------------------------------------+
+| tag_key    | ``STRING`` | The tag key.                                      |
+|            |            | This field is required.                           |
+|            |            |                                                   |
++------------+------------+---------------------------------------------------+
+
+.. _mlflowDeleteTraceTag:
+
+DeleteTraceTag
+--------------
+
+
+
+
+
+
++------------+------------+-----------------------------------------------+
+| Field Name |    Type    |                  Description                  |
++============+============+===============================================+
+| trace_id   | ``STRING`` | ID of the trace from which to delete the tag. |
++------------+------------+-----------------------------------------------+
+| key        | ``STRING`` | Name of the tag to delete.                    |
++------------+------------+-----------------------------------------------+
+
+.. _mlflowDeleteTraceTagV3:
+
+DeleteTraceTagV3
+----------------
+
+
+
+
+
+
++------------+------------+-----------------------------------------------+
+| Field Name |    Type    |                  Description                  |
++============+============+===============================================+
+| request_id | ``STRING`` | ID of the trace from which to delete the tag. |
++------------+------------+-----------------------------------------------+
+| key        | ``STRING`` | Name of the tag to delete.                    |
++------------+------------+-----------------------------------------------+
+
+.. _mlflowDeleteTraces:
+
+DeleteTraces
+------------
+
+
+
+
+
+
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+|      Field Name      |          Type          |                                      Description                                      |
++======================+========================+=======================================================================================+
+| experiment_id        | ``STRING``             | ID of the associated experiment.                                                      |
+|                      |                        | This field is required.                                                               |
+|                      |                        |                                                                                       |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+| max_timestamp_millis | ``INT64``              | Case 1: max_timestamp_millis and max_traces must be specified for time-based deletion |
+|                      |                        | The maximum timestamp in milliseconds since the UNIX epoch for deleting traces.       |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+| max_traces           | ``INT32``              | The maximum number of traces to delete.                                               |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+| request_ids          | An array of ``STRING`` | Case 2: request_ids must be specified for ID-based deletion                           |
+|                      |                        | A set of request IDs to delete                                                        |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+
+.. _mlflowDeleteTracesV3:
+
+DeleteTracesV3
+--------------
+
+
+
+
+
+
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+|      Field Name      |          Type          |                                      Description                                      |
++======================+========================+=======================================================================================+
+| experiment_id        | ``STRING``             | ID of the associated experiment.                                                      |
+|                      |                        | This field is required.                                                               |
+|                      |                        |                                                                                       |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+| max_timestamp_millis | ``INT64``              | Case 1: max_timestamp_millis and max_traces must be specified for time-based deletion |
+|                      |                        | The maximum timestamp in milliseconds since the UNIX epoch for deleting traces.       |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+| max_traces           | ``INT32``              | The maximum number of traces to delete.                                               |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+| request_ids          | An array of ``STRING`` | Case 2: request_ids must be specified for ID-based deletion                           |
+|                      |                        | A set of request IDs to delete                                                        |
++----------------------+------------------------+---------------------------------------------------------------------------------------+
+
+.. _mlflowEndTrace:
+
+EndTrace
+--------
+
+
+
+
+
+
++------------------+-----------------------------------------------+----------------------------------------------------------------+
+|    Field Name    |                     Type                      |                          Description                           |
++==================+===============================================+================================================================+
+| request_id       | ``STRING``                                    | ID of the trace to end.                                        |
++------------------+-----------------------------------------------+----------------------------------------------------------------+
+| timestamp_ms     | ``INT64``                                     | Unix timestamp of when the trace ended in milliseconds.        |
++------------------+-----------------------------------------------+----------------------------------------------------------------+
+| status           | :ref:`mlflowtracestatus`                      | Overall status of the operation being traced (OK, error, etc). |
++------------------+-----------------------------------------------+----------------------------------------------------------------+
+| request_metadata | An array of :ref:`mlflowtracerequestmetadata` | Additional metadata about the operation being traced.          |
++------------------+-----------------------------------------------+----------------------------------------------------------------+
+| tags             | An array of :ref:`mlflowtracetag`             | Additional tags to add to the trace.                           |
++------------------+-----------------------------------------------+----------------------------------------------------------------+
 
 .. _mlflowExperiment:
 
@@ -2603,7 +3270,7 @@ FileInfo
 
 
 
-
+Metadata of a single artifact file or directory.
 
 
 +------------+------------+---------------------------------------------------+
@@ -2616,15 +3283,187 @@ FileInfo
 | file_size  | ``INT64``  | Size in bytes. Unset for directories.             |
 +------------+------------+---------------------------------------------------+
 
+.. _mlflowFinalizeLoggedModel:
+
+FinalizeLoggedModel
+-------------------
+
+
+
+
+
+
++------------+--------------------------------+------------------------------------------------------------------------------------+
+| Field Name |              Type              |                                    Description                                     |
++============+================================+====================================================================================+
+| model_id   | ``STRING``                     | The ID of the LoggedModel to finalize                                              |
+|            |                                | This field is required.                                                            |
+|            |                                |                                                                                    |
++------------+--------------------------------+------------------------------------------------------------------------------------+
+| status     | :ref:`mlflowloggedmodelstatus` | Whether or not the model is ready for use.                                         |
+|            |                                | Valid values in this message: ENUM<LOGGED_MODEL_READY, LOGGED_MODEL_UPLOAD_FAILED> |
+|            |                                | ("LOGGED_MODEL_UPLOAD_FAILED" indicates that something went wrong when logging     |
+|            |                                | the model weights / agent code)                                                    |
+|            |                                | This field is required.                                                            |
+|            |                                |                                                                                    |
++------------+--------------------------------+------------------------------------------------------------------------------------+
+
+.. _mlflowGetAssessmentRequest:
+
+GetAssessmentRequest
+--------------------
+
+
+
+
+
+
++---------------+------------+------------------------------------------------+
+|  Field Name   |    Type    |                  Description                   |
++===============+============+================================================+
+| trace_id      | ``STRING`` | The ID of the trace the assessment belongs to. |
+|               |            | This field is required.                        |
+|               |            |                                                |
++---------------+------------+------------------------------------------------+
+| assessment_id | ``STRING`` | The ID of the assessment.                      |
+|               |            | This field is required.                        |
+|               |            |                                                |
++---------------+------------+------------------------------------------------+
+
+.. _mlflowGetLoggedModel:
+
+GetLoggedModel
+--------------
+
+
+
+
+
+
++------------+------------+----------------------------------------+
+| Field Name |    Type    |              Description               |
++============+============+========================================+
+| model_id   | ``STRING`` | The ID of the LoggedModel to retrieve. |
+|            |            | This field is required.                |
+|            |            |                                        |
++------------+------------+----------------------------------------+
+
+.. _mlflowGetMetricHistoryBulkInterval:
+
+GetMetricHistoryBulkInterval
+----------------------------
+
+
+
+
+
+
++-------------+------------------------+---------------------------------------------------------------------------------------------+
+| Field Name  |          Type          |                                         Description                                         |
++=============+========================+=============================================================================================+
+| run_ids     | An array of ``STRING`` | ID(s) of the run(s) from which to fetch metric values. Must be provided.                    |
++-------------+------------------------+---------------------------------------------------------------------------------------------+
+| metric_key  | ``STRING``             | Name of the metric.                                                                         |
+|             |                        | This field is required.                                                                     |
+|             |                        |                                                                                             |
++-------------+------------------------+---------------------------------------------------------------------------------------------+
+| start_step  | ``INT32``              | Optional start step to only fetch metrics after the specified step. Must be defined if      |
+|             |                        | end_step is defined.                                                                        |
++-------------+------------------------+---------------------------------------------------------------------------------------------+
+| end_step    | ``INT32``              | Optional end step to only fetch metrics before the specified step. Must be defined if       |
+|             |                        | start_step is defined.                                                                      |
++-------------+------------------------+---------------------------------------------------------------------------------------------+
+| max_results | ``INT32``              | Maximum number of results to fetch per run specified. Must be set to a positive number.     |
+|             |                        | Note, in reality, the API returns at most (max_results + # of run IDs) x (# run IDs) metric |
+|             |                        | data points.                                                                                |
++-------------+------------------------+---------------------------------------------------------------------------------------------+
+
+.. _mlflowGetOnlineTraceDetails:
+
+GetOnlineTraceDetails
+---------------------
+
+
+
+
+
+
++------------------------------+------------+-----------------------------------------------+
+|          Field Name          |    Type    |                  Description                  |
++==============================+============+===============================================+
+| trace_id                     | ``STRING`` | Trace ID to retrieve                          |
+|                              |            | This field is required.                       |
+|                              |            |                                               |
++------------------------------+------------+-----------------------------------------------+
+| sql_warehouse_id             | ``STRING`` | SQL warehouse to use for query                |
+|                              |            | This field is required.                       |
+|                              |            |                                               |
++------------------------------+------------+-----------------------------------------------+
+| source_inference_table       | ``STRING`` | Source inference table to use for query       |
+|                              |            | ie. "ml.bbqiu.codegen_payload"                |
+|                              |            | This field is required.                       |
+|                              |            |                                               |
++------------------------------+------------+-----------------------------------------------+
+| source_databricks_request_id | ``STRING`` | Source databricks request id to use for query |
+|                              |            | ie. "8d1992ce-ba3d-49e9-9701-e9b323c5cc8c"    |
+|                              |            | This field is required.                       |
+|                              |            |                                               |
++------------------------------+------------+-----------------------------------------------+
+
+.. _mlflowGetTraceInfo:
+
+GetTraceInfo
+------------
+
+
+
+
+
+
++------------+------------+---------------------------------------------+
+| Field Name |    Type    |                 Description                 |
++============+============+=============================================+
+| request_id | ``STRING`` | ID of the trace to fetch. Must be provided. |
++------------+------------+---------------------------------------------+
+
+.. _mlflowGetTraceInfoV3:
+
+GetTraceInfoV3
+--------------
+
+
+
+
+
+
++------------+------------+---------------------------------------------+
+| Field Name |    Type    |                 Description                 |
++============+============+=============================================+
+| trace_id   | ``STRING`` | ID of the trace to fetch. Must be provided. |
++------------+------------+---------------------------------------------+
+
+.. _mlflowTraceLocationInferenceTableLocation:
+
+InferenceTableLocation
+----------------------
+
+
+
+
+
+
++-----------------+------------+--------------------------------------------------------------------+
+|   Field Name    |    Type    |                            Description                             |
++=================+============+====================================================================+
+| full_table_name | ``STRING`` | Full inference table name in the form of catalog.schema.table_name |
++-----------------+------------+--------------------------------------------------------------------+
+
 .. _mlflowInputTag:
 
 InputTag
 --------
 
 
-
-.. note::
-    Experimental: This API may change or be removed in a future release without warning.
 
 Tag for an input.
 
@@ -2641,6 +3480,222 @@ Tag for an input.
 |            |            |                         |
 +------------+------------+-------------------------+
 
+.. _mlflowLinkTracesToRun:
+
+LinkTracesToRun
+---------------
+
+
+
+
+
+
++------------+------------------------+--------------------------------------------------------------------------------+
+| Field Name |          Type          |                                  Description                                   |
++============+========================+================================================================================+
+| trace_ids  | An array of ``STRING`` | IDs of the traces to link to the run.                                          |
+|            |                        | The maximum number of trace IDs that can be linked in a single request is 100. |
++------------+------------------------+--------------------------------------------------------------------------------+
+| run_id     | ``STRING``             | ID of the run to link the traces to.                                           |
+|            |                        | This field is required.                                                        |
+|            |                        |                                                                                |
++------------+------------------------+--------------------------------------------------------------------------------+
+
+.. _mlflowListLoggedModelArtifacts:
+
+ListLoggedModelArtifacts
+------------------------
+
+
+
+
+
+
++-------------------------+------------+-----------------------------------------------------------------------------------------+
+|       Field Name        |    Type    |                                       Description                                       |
++=========================+============+=========================================================================================+
+| model_id                | ``STRING`` | The ID of the LoggedModel for which to list the artifacts                               |
+|                         |            | This field is required.                                                                 |
+|                         |            |                                                                                         |
++-------------------------+------------+-----------------------------------------------------------------------------------------+
+| artifact_directory_path | ``STRING`` | Filter artifacts matching this path (a relative path from the root artifact directory). |
++-------------------------+------------+-----------------------------------------------------------------------------------------+
+| page_token              | ``STRING`` | Token indicating the page of artifact results to fetch                                  |
++-------------------------+------------+-----------------------------------------------------------------------------------------+
+
+.. _mlflowLogLoggedModelParamsRequest:
+
+LogLoggedModelParamsRequest
+---------------------------
+
+
+
+
+
+
++------------+-----------------------------------------------+-----------------------------------------------+
+| Field Name |                     Type                      |                  Description                  |
++============+===============================================+===============================================+
+| model_id   | ``STRING``                                    | The ID of the logged model to log params for. |
+|            |                                               | This field is required.                       |
+|            |                                               |                                               |
++------------+-----------------------------------------------+-----------------------------------------------+
+| params     | An array of :ref:`mlflowloggedmodelparameter` | Parameters attached to the model.             |
++------------+-----------------------------------------------+-----------------------------------------------+
+
+.. _mlflowLogOutputs:
+
+LogOutputs
+----------
+
+
+
+
+
+
++------------+--------------------------------------+------------------------------------------+
+| Field Name |                 Type                 |               Description                |
++============+======================================+==========================================+
+| run_id     | ``STRING``                           | ID of the Run from which to log outputs. |
+|            |                                      | This field is required.                  |
+|            |                                      |                                          |
++------------+--------------------------------------+------------------------------------------+
+| models     | An array of :ref:`mlflowmodeloutput` | Model outputs from the Run.              |
++------------+--------------------------------------+------------------------------------------+
+
+.. _mlflowLoggedModel:
+
+LoggedModel
+-----------
+
+
+
+A LoggedModel message includes logged model attributes,
+tags, registration info, params, and linked run metrics.
+
+
++------------+------------------------------+-------------------------------------------------------------+
+| Field Name |             Type             |                         Description                         |
++============+==============================+=============================================================+
+| info       | :ref:`mlflowloggedmodelinfo` | LoggedModel attributes such as model ID, status, tags, etc. |
++------------+------------------------------+-------------------------------------------------------------+
+| data       | :ref:`mlflowloggedmodeldata` | LoggedModel params and metrics.                             |
++------------+------------------------------+-------------------------------------------------------------+
+
+.. _mlflowLoggedModelData:
+
+LoggedModelData
+---------------
+
+
+
+A LoggedModelData message includes logged model params and linked metrics.
+
+
++------------+-----------------------------------------------+------------------------------------------------+
+| Field Name |                     Type                      |                  Description                   |
++============+===============================================+================================================+
+| params     | An array of :ref:`mlflowloggedmodelparameter` | Immutable String key-value pairs of the model. |
++------------+-----------------------------------------------+------------------------------------------------+
+| metrics    | An array of :ref:`mlflowmetric`               | Performance metrics linked to the model.       |
++------------+-----------------------------------------------+------------------------------------------------+
+
+.. _mlflowLoggedModelInfo:
+
+LoggedModelInfo
+---------------
+
+
+
+A LoggedModelInfo includes logged model attributes,
+tags, and registration info.
+
+
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+|        Field Name         |                         Type                         |                                   Description                                   |
++===========================+======================================================+=================================================================================+
+| model_id                  | ``STRING``                                           | A unique identifier for the model.                                              |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| experiment_id             | ``STRING``                                           | The ID of the experiment that owns the model.                                   |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| name                      | ``STRING``                                           | Name of the model.                                                              |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| creation_timestamp_ms     | ``INT64``                                            | Timestamp when the model was created, in milliseconds since the UNIX epoch.     |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| last_updated_timestamp_ms | ``INT64``                                            | Timestamp when the model was last updated, in milliseconds since the UNIX epoch |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| artifact_uri              | ``STRING``                                           | URI of the directory where model artifacts are stored.                          |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| status                    | :ref:`mlflowloggedmodelstatus`                       | Whether or not the model is ready for use.                                      |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| creator_id                | ``INT64``                                            | The ID of the user or principal that created the model.                         |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| model_type                | ``STRING``                                           | The type of model, such as "Agent", "Classifier", "LLM".                        |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| source_run_id             | ``STRING``                                           | Run ID of the run that created the model.                                       |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| status_message            | ``STRING``                                           | Details on the current status.                                                  |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| tags                      | An array of :ref:`mlflowloggedmodeltag`              | Mutable String key-value pairs set on the model.                                |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+| registrations             | An array of :ref:`mlflowloggedmodelregistrationinfo` | If the model has been promoted to the Model Registry, this field includes       |
+|                           |                                                      | information like the Registered Model name, Model Version number, etc.          |
++---------------------------+------------------------------------------------------+---------------------------------------------------------------------------------+
+
+.. _mlflowLoggedModelParameter:
+
+LoggedModelParameter
+--------------------
+
+
+
+Parameter associated with a LoggedModel.
+
+
++------------+------------+-----------------------------------+
+| Field Name |    Type    |            Description            |
++============+============+===================================+
+| key        | ``STRING`` | Key identifying this param.       |
++------------+------------+-----------------------------------+
+| value      | ``STRING`` | Value associated with this param. |
++------------+------------+-----------------------------------+
+
+.. _mlflowLoggedModelRegistrationInfo:
+
+LoggedModelRegistrationInfo
+---------------------------
+
+
+
+RegistrationInfo for a LoggedModel.
+
+
++------------+------------+------------------------------------------------------------------------+
+| Field Name |    Type    |                              Description                               |
++============+============+========================================================================+
+| name       | ``STRING`` | The name of the Registered Model to which the model has been promoted. |
++------------+------------+------------------------------------------------------------------------+
+| version    | ``STRING`` | The version number of the promoted model.                              |
++------------+------------+------------------------------------------------------------------------+
+
+.. _mlflowLoggedModelTag:
+
+LoggedModelTag
+--------------
+
+
+
+Tag for a LoggedModel.
+
+
++------------+------------+----------------+
+| Field Name |    Type    |  Description   |
++============+============+================+
+| key        | ``STRING`` | The tag key.   |
++------------+------------+----------------+
+| value      | ``STRING`` | The tag value. |
++------------+------------+----------------+
+
 .. _mlflowMetric:
 
 Metric
@@ -2649,6 +3704,40 @@ Metric
 
 
 Metric associated with a run, represented as a key-value pair.
+
+
++----------------+------------+-----------------------------------------------------------------------+
+|   Field Name   |    Type    |                              Description                              |
++================+============+=======================================================================+
+| key            | ``STRING`` | Key identifying this metric.                                          |
++----------------+------------+-----------------------------------------------------------------------+
+| value          | ``DOUBLE`` | Value associated with this metric.                                    |
++----------------+------------+-----------------------------------------------------------------------+
+| timestamp      | ``INT64``  | The timestamp at which this metric was recorded.                      |
++----------------+------------+-----------------------------------------------------------------------+
+| step           | ``INT64``  | Step at which to log the metric.                                      |
++----------------+------------+-----------------------------------------------------------------------+
+| dataset_name   | ``STRING`` | The name of the dataset associated with the metric.                   |
+|                |            | E.g. "my.uc.table@2" "nyc-taxi-dataset", "fantastic-elk-3"            |
++----------------+------------+-----------------------------------------------------------------------+
+| dataset_digest | ``STRING`` | Dataset digest of the dataset associated with the metric,             |
+|                |            | e.g. an md5 hash of the dataset that uniquely identifies it           |
+|                |            | within datasets of the same name.                                     |
++----------------+------------+-----------------------------------------------------------------------+
+| model_id       | ``STRING`` | The ID of the LoggedModel or Registered Model Version associated with |
+|                |            | the metric, if applicable.                                            |
++----------------+------------+-----------------------------------------------------------------------+
+| run_id         | ``STRING`` | The ID of the run containing the metric.                              |
++----------------+------------+-----------------------------------------------------------------------+
+
+.. _mlflowMetricWithRunId:
+
+MetricWithRunId
+---------------
+
+
+
+
 
 
 +------------+------------+--------------------------------------------------+
@@ -2662,6 +3751,117 @@ Metric associated with a run, represented as a key-value pair.
 +------------+------------+--------------------------------------------------+
 | step       | ``INT64``  | Step at which to log the metric.                 |
 +------------+------------+--------------------------------------------------+
+| run_id     | ``STRING`` | The ID of the run containing the metric          |
++------------+------------+--------------------------------------------------+
+
+.. _mlflowTraceLocationMlflowExperimentLocation:
+
+MlflowExperimentLocation
+------------------------
+
+
+
+
+
+
++---------------+------------+--------------------------------------------------------------------+
+|  Field Name   |    Type    |                            Description                             |
++===============+============+====================================================================+
+| experiment_id | ``STRING`` | MLflow experiment ID which is the ACL container holding the trace. |
++---------------+------------+--------------------------------------------------------------------+
+
+.. _mlflowModelInput:
+
+ModelInput
+----------
+
+
+
+Represents a LoggedModel or Registered Model Version input to a Run.
+
+
++------------+------------+-------------------------------------+
+| Field Name |    Type    |             Description             |
++============+============+=====================================+
+| model_id   | ``STRING`` | The unique identifier of the model. |
+|            |            | This field is required.             |
+|            |            |                                     |
++------------+------------+-------------------------------------+
+
+.. _mlflowModelMetric:
+
+ModelMetric
+-----------
+
+
+
+Metric associated with a model, represented as a key-value pair.
+Copied from MLflow metric
+
+
++----------------+------------+-----------------------------------------------------------------------+
+|   Field Name   |    Type    |                              Description                              |
++================+============+=======================================================================+
+| key            | ``STRING`` | Key identifying this metric.                                          |
++----------------+------------+-----------------------------------------------------------------------+
+| value          | ``DOUBLE`` | Value associated with this metric.                                    |
++----------------+------------+-----------------------------------------------------------------------+
+| timestamp      | ``INT64``  | The timestamp at which this metric was recorded.                      |
++----------------+------------+-----------------------------------------------------------------------+
+| step           | ``INT64``  | Step at which to log the metric.                                      |
++----------------+------------+-----------------------------------------------------------------------+
+| dataset_name   | ``STRING`` | The name of the dataset associated with the metric.                   |
+|                |            | E.g. "my.uc.table@2" "nyc-taxi-dataset", "fantastic-elk-3"            |
++----------------+------------+-----------------------------------------------------------------------+
+| dataset_digest | ``STRING`` | Dataset digest of the dataset associated with the metric,             |
+|                |            | e.g. an md5 hash of the dataset that uniquely identifies it           |
+|                |            | within datasets of the same name.                                     |
++----------------+------------+-----------------------------------------------------------------------+
+| model_id       | ``STRING`` | The ID of the LoggedModel or Registered Model Version associated with |
+|                |            | the metric                                                            |
++----------------+------------+-----------------------------------------------------------------------+
+| run_id         | ``STRING`` | The ID of the run containing the metric.                              |
++----------------+------------+-----------------------------------------------------------------------+
+
+.. _mlflowModelOutput:
+
+ModelOutput
+-----------
+
+
+
+Represents a LoggedModel output of a Run.
+
+
++------------+------------+---------------------------------------+
+| Field Name |    Type    |              Description              |
++============+============+=======================================+
+| model_id   | ``STRING`` | The unique identifier of the model.   |
+|            |            | This field is required.               |
+|            |            |                                       |
++------------+------------+---------------------------------------+
+| step       | ``INT64``  | Step at which the model was produced. |
+|            |            | This field is required.               |
+|            |            |                                       |
++------------+------------+---------------------------------------+
+
+.. _mlflowModelParam:
+
+ModelParam
+----------
+
+
+
+Param for a model version.
+
+
++------------+------------+-------------------------------------------------------------+
+| Field Name |    Type    |                         Description                         |
++============+============+=============================================================+
+| name       | ``STRING`` | Name of the param.                                          |
++------------+------------+-------------------------------------------------------------+
+| value      | ``STRING`` | Value of the param associated with the name, could be empty |
++------------+------------+-------------------------------------------------------------+
 
 .. _mlflowModelVersion:
 
@@ -2673,39 +3873,71 @@ ModelVersion
 
 
 
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-|       Field Name       |                   Type                   |                                                  Description                                                   |
-+========================+==========================================+================================================================================================================+
-| name                   | ``STRING``                               | Unique name of the model                                                                                       |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| version                | ``STRING``                               | Model's version number.                                                                                        |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| creation_timestamp     | ``INT64``                                | Timestamp recorded when this ``model_version`` was created.                                                    |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| last_updated_timestamp | ``INT64``                                | Timestamp recorded when metadata for this ``model_version`` was last updated.                                  |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| user_id                | ``STRING``                               | User that created this ``model_version``.                                                                      |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| current_stage          | ``STRING``                               | Current stage for this ``model_version``.                                                                      |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| description            | ``STRING``                               | Description of this ``model_version``.                                                                         |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| source                 | ``STRING``                               | URI indicating the location of the source model artifacts, used when creating ``model_version``                |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| run_id                 | ``STRING``                               | MLflow run ID used when creating ``model_version``, if ``source`` was generated by an                          |
-|                        |                                          | experiment run stored in MLflow tracking server.                                                               |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| status                 | :ref:`mlflowmodelversionstatus`          | Current status of ``model_version``                                                                            |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| status_message         | ``STRING``                               | Details on current ``status``, if it is pending or failed.                                                     |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| tags                   | An array of :ref:`mlflowmodelversiontag` | Tags: Additional metadata key-value pairs for this ``model_version``.                                          |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| run_link               | ``STRING``                               | Run Link: Direct link to the run that generated this version. This field is set at model version creation time |
-|                        |                                          | only for model versions whose source run is from a tracking server that is different from the registry server. |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
-| aliases                | An array of ``STRING``                   | Aliases pointing to this ``model_version``.                                                                    |
-+------------------------+------------------------------------------+----------------------------------------------------------------------------------------------------------------+
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+|       Field Name       |                    Type                     |                                                  Description                                                   |
++========================+=============================================+================================================================================================================+
+| name                   | ``STRING``                                  | Unique name of the model                                                                                       |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| version                | ``STRING``                                  | Model's version number.                                                                                        |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| creation_timestamp     | ``INT64``                                   | Timestamp recorded when this ``model_version`` was created.                                                    |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| last_updated_timestamp | ``INT64``                                   | Timestamp recorded when metadata for this ``model_version`` was last updated.                                  |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| user_id                | ``STRING``                                  | User that created this ``model_version``.                                                                      |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| current_stage          | ``STRING``                                  | Current stage for this ``model_version``.                                                                      |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| description            | ``STRING``                                  | Description of this ``model_version``.                                                                         |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| source                 | ``STRING``                                  | URI indicating the location of the source model artifacts, used when creating ``model_version``                |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| run_id                 | ``STRING``                                  | MLflow run ID used when creating ``model_version``, if ``source`` was generated by an                          |
+|                        |                                             | experiment run stored in MLflow tracking server.                                                               |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| status                 | :ref:`mlflowmodelversionstatus`             | Current status of ``model_version``                                                                            |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| status_message         | ``STRING``                                  | Details on current ``status``, if it is pending or failed.                                                     |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| tags                   | An array of :ref:`mlflowmodelversiontag`    | Tags: Additional metadata key-value pairs for this ``model_version``.                                          |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| run_link               | ``STRING``                                  | Run Link: Direct link to the run that generated this version. This field is set at model version creation time |
+|                        |                                             | only for model versions whose source run is from a tracking server that is different from the registry server. |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| aliases                | An array of ``STRING``                      | Aliases pointing to this ``model_version``.                                                                    |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| model_id               | ``STRING``                                  | Optional `model_id` for model version that is used to link the registered model to the source logged model     |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| model_params           | An array of :ref:`mlflowmodelparam`         | Optional parameters for the model.                                                                             |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| model_metrics          | An array of :ref:`mlflowmodelmetric`        | Optional metrics for the model.                                                                                |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+| deployment_job_state   | :ref:`mlflowmodelversiondeploymentjobstate` | Deployment job state for this model version.                                                                   |
++------------------------+---------------------------------------------+----------------------------------------------------------------------------------------------------------------+
+
+.. _mlflowModelVersionDeploymentJobState:
+
+ModelVersionDeploymentJobState
+------------------------------
+
+
+
+
+
+
++-------------------+------------------------------------------------------------------+-------------+
+|    Field Name     |                               Type                               | Description |
++===================+==================================================================+=============+
+| job_id            | ``STRING``                                                       |             |
++-------------------+------------------------------------------------------------------+-------------+
+| run_id            | ``STRING``                                                       |             |
++-------------------+------------------------------------------------------------------+-------------+
+| job_state         | :ref:`mlflowdeploymentjobconnectionstate`                        |             |
++-------------------+------------------------------------------------------------------+-------------+
+| run_state         | :ref:`mlflowmodelversiondeploymentjobstatedeploymentjobrunstate` |             |
++-------------------+------------------------------------------------------------------+-------------+
+| current_task_name | ``STRING``                                                       |             |
++-------------------+------------------------------------------------------------------+-------------+
 
 .. _mlflowModelVersionTag:
 
@@ -2724,6 +3956,35 @@ Tag for a model version.
 +------------+------------+----------------+
 | value      | ``STRING`` | The tag value. |
 +------------+------------+----------------+
+
+.. _mlflowSearchLoggedModelsOrderBy:
+
+OrderBy
+-------
+
+
+
+
+
+
++----------------+------------+---------------------------------------------------------------------------------------------+
+|   Field Name   |    Type    |                                         Description                                         |
++================+============+=============================================================================================+
+| field_name     | ``STRING`` | Name of the field to order by, e.g. "metrics.accuracy".                                     |
+|                |            | This field is required.                                                                     |
+|                |            |                                                                                             |
++----------------+------------+---------------------------------------------------------------------------------------------+
+| ascending      | ``BOOL``   | Whether the order is ascending or not.                                                      |
++----------------+------------+---------------------------------------------------------------------------------------------+
+| dataset_name   | ``STRING`` | If ``field_name`` refers to a metric, this field specifies the name of the dataset          |
+|                |            | associated with the metric. Only metrics associated with the specified dataset name will be |
+|                |            | considered for ordering. This field may only be set if ``field_name`` refers to a metric.   |
++----------------+------------+---------------------------------------------------------------------------------------------+
+| dataset_digest | ``STRING`` | If ``field_name`` refers to a metric, this field specifies the digest of the dataset        |
+|                |            | associated with the metric. Only metrics associated with the specified dataset name         |
+|                |            | and digest will be considered for ordering. This field may only be set if ``dataset_name``  |
+|                |            | is also set.                                                                                |
++----------------+------------+---------------------------------------------------------------------------------------------+
 
 .. _mlflowParam:
 
@@ -2774,6 +4035,10 @@ RegisteredModel
 +------------------------+-----------------------------------------------+----------------------------------------------------------------------------------+
 | aliases                | An array of :ref:`mlflowregisteredmodelalias` | Aliases pointing to model versions associated with this ``registered_model``.    |
 +------------------------+-----------------------------------------------+----------------------------------------------------------------------------------+
+| deployment_job_id      | ``STRING``                                    | Deployment job id for this model.                                                |
++------------------------+-----------------------------------------------+----------------------------------------------------------------------------------+
+| deployment_job_state   | :ref:`mlflowdeploymentjobconnectionstate`     | Deployment job state for this model.                                             |
++------------------------+-----------------------------------------------+----------------------------------------------------------------------------------+
 
 .. _mlflowRegisteredModelAlias:
 
@@ -2811,6 +4076,371 @@ Tag for a registered model
 | value      | ``STRING`` | The tag value. |
 +------------+------------+----------------+
 
+.. _mlflowGetMetricHistoryBulkIntervalResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------------------------------------+--------------------------------------------------------------+
+| Field Name |                   Type                   |                         Description                          |
++============+==========================================+==============================================================+
+| metrics    | An array of :ref:`mlflowmetricwithrunid` | List of metrics representing history of values and metadata. |
++------------+------------------------------------------+--------------------------------------------------------------+
+
+.. _mlflowCreateAssessmentResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------------------------------+-------------------------+
+| Field Name |                Type                |       Description       |
++============+====================================+=========================+
+| assessment | :ref:`mlflowassessmentsassessment` | The created assessment. |
++------------+------------------------------------+-------------------------+
+
+.. _mlflowUpdateAssessmentResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------------------------------+----------------------------------+
+| Field Name |                Type                |           Description            |
++============+====================================+==================================+
+| assessment | :ref:`mlflowassessmentsassessment` | The Assessment after the update. |
++------------+------------------------------------+----------------------------------+
+
+.. _mlflowGetAssessmentRequestResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------------------------------+---------------------------+
+| Field Name |                Type                |        Description        |
++============+====================================+===========================+
+| assessment | :ref:`mlflowassessmentsassessment` | The requested assessment. |
++------------+------------------------------------+---------------------------+
+
+.. _mlflowStartTraceResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------------------+--------------------------+
+| Field Name |          Type          |       Description        |
++============+========================+==========================+
+| trace_info | :ref:`mlflowtraceinfo` | The newly created trace. |
++------------+------------------------+--------------------------+
+
+.. _mlflowEndTraceResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------------------+--------------------+
+| Field Name |          Type          |    Description     |
++============+========================+====================+
+| trace_info | :ref:`mlflowtraceinfo` | The updated trace. |
++------------+------------------------+--------------------+
+
+.. _mlflowGetTraceInfoResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------------------+----------------------------------+
+| Field Name |          Type          |           Description            |
++============+========================+==================================+
+| trace_info | :ref:`mlflowtraceinfo` | Metadata of the requested trace. |
++------------+------------------------+----------------------------------+
+
+.. _mlflowGetTraceInfoV3Response:
+
+Response
+--------
+
+
+
+
+
+
++------------+--------------------+-------------+
+| Field Name |        Type        | Description |
++============+====================+=============+
+| trace      | :ref:`mlflowtrace` |             |
++------------+--------------------+-------------+
+
+.. _mlflowSearchTracesResponse:
+
+Response
+--------
+
+
+
+
+
+
++-----------------+------------------------------------+----------------------------------------------------------+
+|   Field Name    |                Type                |                       Description                        |
++=================+====================================+==========================================================+
+| traces          | An array of :ref:`mlflowtraceinfo` | Information about traces that match the search criteria. |
++-----------------+------------------------------------+----------------------------------------------------------+
+| next_page_token | ``STRING``                         |                                                          |
++-----------------+------------------------------------+----------------------------------------------------------+
+
+.. _mlflowSearchUnifiedTracesResponse:
+
+Response
+--------
+
+
+
+
+
+
++-----------------+------------------------------------+----------------------------------------------------------+
+|   Field Name    |                Type                |                       Description                        |
++=================+====================================+==========================================================+
+| traces          | An array of :ref:`mlflowtraceinfo` | Information about traces that match the search criteria. |
++-----------------+------------------------------------+----------------------------------------------------------+
+| next_page_token | ``STRING``                         |                                                          |
++-----------------+------------------------------------+----------------------------------------------------------+
+
+.. _mlflowGetOnlineTraceDetailsResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+------------+--------------------------------------------------------------+
+| Field Name |    Type    |                         Description                          |
++============+============+==============================================================+
+| trace_data | ``STRING`` | Return trace JSON in string form                             |
+|            |            | Note: we may change this to a TraceData object in the future |
++------------+------------+--------------------------------------------------------------+
+
+.. _mlflowDeleteTracesResponse:
+
+Response
+--------
+
+
+
+
+
+
++----------------+-----------+-------------+
+|   Field Name   |   Type    | Description |
++================+===========+=============+
+| traces_deleted | ``INT32`` |             |
++----------------+-----------+-------------+
+
+.. _mlflowDeleteTracesV3Response:
+
+Response
+--------
+
+
+
+
+
+
++----------------+-----------+-------------+
+|   Field Name   |   Type    | Description |
++================+===========+=============+
+| traces_deleted | ``INT32`` |             |
++----------------+-----------+-------------+
+
+.. _mlflowStartTraceV3Response:
+
+Response
+--------
+
+
+
+
+
+
++------------+--------------------+--------------------------------+
+| Field Name |        Type        |          Description           |
++============+====================+================================+
+| trace      | :ref:`mlflowtrace` | The created trace information. |
++------------+--------------------+--------------------------------+
+
+.. _mlflowSearchDatasetsResponse:
+
+Response
+--------
+
+
+
+
+
+
++-------------------+-----------------------------------------+-----------------------------------------------------------------------------------+
+|    Field Name     |                  Type                   |                                    Description                                    |
++===================+=========================================+===================================================================================+
+| dataset_summaries | An array of :ref:`mlflowdatasetsummary` | Return the summary for most recently created N datasets, as configured in backend |
++-------------------+-----------------------------------------+-----------------------------------------------------------------------------------+
+
+.. _mlflowCreateLoggedModelResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+--------------------------+--------------------------------+
+| Field Name |           Type           |          Description           |
++============+==========================+================================+
+| model      | :ref:`mlflowloggedmodel` | The newly created LoggedModel. |
++------------+--------------------------+--------------------------------+
+
+.. _mlflowFinalizeLoggedModelResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+--------------------------+--------------------------+
+| Field Name |           Type           |       Description        |
++============+==========================+==========================+
+| model      | :ref:`mlflowloggedmodel` | The updated LoggedModel. |
++------------+--------------------------+--------------------------+
+
+.. _mlflowGetLoggedModelResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+--------------------------+----------------------------+
+| Field Name |           Type           |        Description         |
++============+==========================+============================+
+| model      | :ref:`mlflowloggedmodel` | The retrieved LoggedModel. |
++------------+--------------------------+----------------------------+
+
+.. _mlflowSearchLoggedModelsResponse:
+
+Response
+--------
+
+
+
+
+
+
++-----------------+--------------------------------------+--------------------------------------------------------------------+
+|   Field Name    |                 Type                 |                            Description                             |
++=================+======================================+====================================================================+
+| models          | An array of :ref:`mlflowloggedmodel` | Logged Models that match the search criteria.                      |
++-----------------+--------------------------------------+--------------------------------------------------------------------+
+| next_page_token | ``STRING``                           | Token that can be used to retrieve the next page of Logged Models. |
++-----------------+--------------------------------------+--------------------------------------------------------------------+
+
+.. _mlflowSetLoggedModelTagsResponse:
+
+Response
+--------
+
+
+
+
+
+
++------------+--------------------------+--------------------------+
+| Field Name |           Type           |       Description        |
++============+==========================+==========================+
+| model      | :ref:`mlflowloggedmodel` | The updated LoggedModel. |
++------------+--------------------------+--------------------------+
+
+.. _mlflowListLoggedModelArtifactsResponse:
+
+Response
+--------
+
+
+
+
+
+
++-----------------+-----------------------------------+----------------------------------------------------------------------+
+|   Field Name    |               Type                |                             Description                              |
++=================+===================================+======================================================================+
+| root_uri        | ``STRING``                        | Root artifact directory for the logged model.                        |
++-----------------+-----------------------------------+----------------------------------------------------------------------+
+| files           | An array of :ref:`mlflowfileinfo` | File location and metadata for artifacts.                            |
++-----------------+-----------------------------------+----------------------------------------------------------------------+
+| next_page_token | ``STRING``                        | Token that can be used to retrieve the next page of artifact results |
++-----------------+-----------------------------------+----------------------------------------------------------------------+
+
+.. _mlflowSearchTracesV3Response:
+
+Response
+--------
+
+
+
+
+
+
++-----------------+--------------------------------------+----------------------------------------------------------+
+|   Field Name    |                 Type                 |                       Description                        |
++=================+======================================+==========================================================+
+| traces          | An array of :ref:`mlflowtraceinfov3` | Information about traces that match the search criteria. |
++-----------------+--------------------------------------+----------------------------------------------------------+
+| next_page_token | ``STRING``                           |                                                          |
++-----------------+--------------------------------------+----------------------------------------------------------+
+
 .. _mlflowRun:
 
 Run
@@ -2821,15 +4451,17 @@ Run
 A single run.
 
 
-+------------+------------------------+---------------+
-| Field Name |          Type          |  Description  |
-+============+========================+===============+
-| info       | :ref:`mlflowruninfo`   | Run metadata. |
-+------------+------------------------+---------------+
-| data       | :ref:`mlflowrundata`   | Run data.     |
-+------------+------------------------+---------------+
-| inputs     | :ref:`mlflowruninputs` | Run inputs.   |
-+------------+------------------------+---------------+
++------------+-------------------------+---------------+
+| Field Name |          Type           |  Description  |
++============+=========================+===============+
+| info       | :ref:`mlflowruninfo`    | Run metadata. |
++------------+-------------------------+---------------+
+| data       | :ref:`mlflowrundata`    | Run data.     |
++------------+-------------------------+---------------+
+| inputs     | :ref:`mlflowruninputs`  | Run inputs.   |
++------------+-------------------------+---------------+
+| outputs    | :ref:`mlflowrunoutputs` | Run outputs.  |
++------------+-------------------------+---------------+
 
 .. _mlflowRunData:
 
@@ -2898,9 +4530,6 @@ RunInputs
 
 
 
-.. note::
-    Experimental: This API may change or be removed in a future release without warning.
-
 Run inputs.
 
 
@@ -2909,6 +4538,24 @@ Run inputs.
 +================+=======================================+============================+
 | dataset_inputs | An array of :ref:`mlflowdatasetinput` | Dataset inputs to the Run. |
 +----------------+---------------------------------------+----------------------------+
+| model_inputs   | An array of :ref:`mlflowmodelinput`   | Model inputs to the Run.   |
++----------------+---------------------------------------+----------------------------+
+
+.. _mlflowRunOutputs:
+
+RunOutputs
+----------
+
+
+
+Outputs of a Run.
+
+
++---------------+--------------------------------------+---------------------------+
+|  Field Name   |                 Type                 |        Description        |
++===============+======================================+===========================+
+| model_outputs | An array of :ref:`mlflowmodeloutput` | Model outputs of the Run. |
++---------------+--------------------------------------+---------------------------+
 
 .. _mlflowRunTag:
 
@@ -2927,6 +4574,588 @@ Tag for a run.
 +------------+------------+----------------+
 | value      | ``STRING`` | The tag value. |
 +------------+------------+----------------+
+
+.. _mlflowSearchDatasets:
+
+SearchDatasets
+--------------
+
+
+
+
+
+
++----------------+------------------------+----------------------------------------+
+|   Field Name   |          Type          |              Description               |
++================+========================+========================================+
+| experiment_ids | An array of ``STRING`` | List of experiment IDs to search over. |
++----------------+------------------------+----------------------------------------+
+
+.. _mlflowSearchLoggedModels:
+
+SearchLoggedModels
+------------------
+
+
+
+
+
+
++----------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+
+|   Field Name   |                        Type                        |                                          Description                                          |
++================+====================================================+===============================================================================================+
+| experiment_ids | An array of ``STRING``                             | IDs of the Experiments in which to search for Logged Models.                                  |
++----------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| filter         | ``STRING``                                         | A filter expression over Logged Model info and data that allows returning a subset of         |
+|                |                                                    | Logged Models. The syntax is a subset of SQL that supports ANDing together binary operations  |
+|                |                                                    | Example: ``params.alpha < 0.3 AND metrics.accuracy > 0.9``.                                   |
++----------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| datasets       | An array of :ref:`mlflowsearchloggedmodelsdataset` | List of datasets on which to apply the metrics filter clauses.                                |
+|                |                                                    | For example, a filter with `metrics.accuracy > 0.9` and dataset info with name "test_dataset" |
+|                |                                                    | means we will return all logged models with accuracy > 0.9 on the test_dataset.               |
+|                |                                                    | Metric values from ANY dataset matching the criteria are considered.                          |
+|                |                                                    | If no datasets are specified, then metrics across all datasets are considered in the filter.  |
++----------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| max_results    | ``INT32``                                          | Maximum number of Logged Models to return. Max threshold is 50.                               |
++----------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| order_by       | An array of :ref:`mlflowsearchloggedmodelsorderby` | List of columns for ordering the results, with additional fields for sorting criteria.        |
++----------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+
+| page_token     | ``STRING``                                         | Token indicating the page of Logged Models to fetch.                                          |
++----------------+----------------------------------------------------+-----------------------------------------------------------------------------------------------+
+
+.. _mlflowSearchTraces:
+
+SearchTraces
+------------
+
+
+
+
+
+
++----------------+------------------------+---------------------------------------------------------------------------------------+
+|   Field Name   |          Type          |                                      Description                                      |
++================+========================+=======================================================================================+
+| experiment_ids | An array of ``STRING`` | List of experiment IDs to search over.                                                |
++----------------+------------------------+---------------------------------------------------------------------------------------+
+| filter         | ``STRING``             | A filter expression over trace attributes and tags that allows returning a subset of  |
+|                |                        | traces. The syntax is a subset of SQL that supports ANDing together binary operations |
+|                |                        | Example: ``trace.status = 'OK' and trace.timestamp_ms > 1711089570679``.              |
++----------------+------------------------+---------------------------------------------------------------------------------------+
+| max_results    | ``INT32``              | Maximum number of traces desired. Max threshold is 500.                               |
++----------------+------------------------+---------------------------------------------------------------------------------------+
+| order_by       | An array of ``STRING`` | List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.             |
++----------------+------------------------+---------------------------------------------------------------------------------------+
+| page_token     | ``STRING``             | Token indicating the page of traces to fetch.                                         |
++----------------+------------------------+---------------------------------------------------------------------------------------+
+
+.. _mlflowSearchTracesV3:
+
+SearchTracesV3
+--------------
+
+
+
+
+
+
++-------------+----------------------------------------+---------------------------------------------------------------------------------------+
+| Field Name  |                  Type                  |                                      Description                                      |
++=============+========================================+=======================================================================================+
+| locations   | An array of :ref:`mlflowtracelocation` | A list of MLflow experiments to search over.                                          |
++-------------+----------------------------------------+---------------------------------------------------------------------------------------+
+| filter      | ``STRING``                             | A filter expression over trace attributes and tags that allows returning a subset of  |
+|             |                                        | traces. The syntax is a subset of SQL that supports ANDing together binary operations |
+|             |                                        | Example: ``trace.status = 'OK' and trace.timestamp_ms > 1711089570679``.              |
++-------------+----------------------------------------+---------------------------------------------------------------------------------------+
+| max_results | ``INT32``                              | Maximum number of traces desired. Max threshold is 500.                               |
++-------------+----------------------------------------+---------------------------------------------------------------------------------------+
+| order_by    | An array of ``STRING``                 | List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.             |
++-------------+----------------------------------------+---------------------------------------------------------------------------------------+
+| page_token  | ``STRING``                             | Token indicating the page of traces to fetch.                                         |
++-------------+----------------------------------------+---------------------------------------------------------------------------------------+
+
+.. _mlflowSearchUnifiedTraces:
+
+SearchUnifiedTraces
+-------------------
+
+
+
+
+
+
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+|    Field Name    |          Type          |                                                    Description                                                    |
++==================+========================+===================================================================================================================+
+| model_id         | ``STRING``             |                                                                                                                   |
+|                  |                        | This field is required.                                                                                           |
+|                  |                        |                                                                                                                   |
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+| sql_warehouse_id | ``STRING``             |                                                                                                                   |
+|                  |                        | This field is required.                                                                                           |
+|                  |                        |                                                                                                                   |
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+| experiment_ids   | An array of ``STRING`` | TODO: Eventually we want to provide an API that only uses model_id                                                |
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+| filter           | ``STRING``             | A filter expression over trace attributes and tags that allows returning a subset of                              |
+|                  |                        | traces. The syntax is a subset of SQL that supports ANDing together binary operations                             |
+|                  |                        | Example: ``trace.status = 'OK' and trace.timestamp_ms > 1711089570679``.                                          |
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+| max_results      | ``INT32``              | Maximum number of traces desired. Max threshold is 500.                                                           |
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+| order_by         | An array of ``STRING`` | List of columns for ordering the results, e.g. ``["timestamp_ms DESC"]``.                                         |
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+| page_token       | ``STRING``             | Token indicating the page of traces to fetch. This is a unified token that encodes both online and offline traces |
+|                  |                        | tokens.                                                                                                           |
++------------------+------------------------+-------------------------------------------------------------------------------------------------------------------+
+
+.. _mlflowSetLoggedModelTags:
+
+SetLoggedModelTags
+------------------
+
+
+
+
+
+
++------------+-----------------------------------------+----------------------------------------------+
+| Field Name |                  Type                   |                 Description                  |
++============+=========================================+==============================================+
+| model_id   | ``STRING``                              | The ID of the LoggedModel to set the tag on. |
+|            |                                         | This field is required.                      |
+|            |                                         |                                              |
++------------+-----------------------------------------+----------------------------------------------+
+| tags       | An array of :ref:`mlflowloggedmodeltag` | The tag key.                                 |
++------------+-----------------------------------------+----------------------------------------------+
+
+.. _mlflowSetTraceTag:
+
+SetTraceTag
+-----------
+
+
+
+
+
+
++------------+------------+------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                    Description                                     |
++============+============+====================================================================================+
+| request_id | ``STRING`` | ID of the trace on which to set a tag.                                             |
++------------+------------+------------------------------------------------------------------------------------+
+| key        | ``STRING`` | Name of the tag. Maximum size depends on storage backend.                          |
+|            |            | All storage backends are guaranteed to support key values up to 250 bytes in size. |
++------------+------------+------------------------------------------------------------------------------------+
+| value      | ``STRING`` | String value of the tag being logged. Maximum size depends on storage backend.     |
+|            |            | All storage backends are guaranteed to support key values up to 250 bytes in size. |
++------------+------------+------------------------------------------------------------------------------------+
+
+.. _mlflowSetTraceTagV3:
+
+SetTraceTagV3
+-------------
+
+
+
+
+
+
++------------+------------+------------------------------------------------------------------------------------+
+| Field Name |    Type    |                                    Description                                     |
++============+============+====================================================================================+
+| trace_id   | ``STRING`` | ID of the trace on which to set a tag.                                             |
++------------+------------+------------------------------------------------------------------------------------+
+| key        | ``STRING`` | Name of the tag. Maximum size depends on storage backend.                          |
+|            |            | All storage backends are guaranteed to support key values up to 250 bytes in size. |
++------------+------------+------------------------------------------------------------------------------------+
+| value      | ``STRING`` | String value of the tag being logged. Maximum size depends on storage backend.     |
+|            |            | All storage backends are guaranteed to support key values up to 250 bytes in size. |
++------------+------------+------------------------------------------------------------------------------------+
+
+.. _mlflowStartTrace:
+
+StartTrace
+----------
+
+
+
+
+
+
++------------------+-----------------------------------------------+-----------------------------------------------------------+
+|    Field Name    |                     Type                      |                        Description                        |
++==================+===============================================+===========================================================+
+| experiment_id    | ``STRING``                                    | ID of the associated experiment.                          |
++------------------+-----------------------------------------------+-----------------------------------------------------------+
+| timestamp_ms     | ``INT64``                                     | Unix timestamp of when the trace started in milliseconds. |
++------------------+-----------------------------------------------+-----------------------------------------------------------+
+| request_metadata | An array of :ref:`mlflowtracerequestmetadata` | Metadata about the request that initiated the trace.      |
++------------------+-----------------------------------------------+-----------------------------------------------------------+
+| tags             | An array of :ref:`mlflowtracetag`             | Tags for the trace.                                       |
++------------------+-----------------------------------------------+-----------------------------------------------------------+
+
+.. _mlflowStartTraceV3:
+
+StartTraceV3
+------------
+
+
+
+
+
+
++------------+--------------------+----------------------------------------------+
+| Field Name |        Type        |                 Description                  |
++============+====================+==============================================+
+| trace      | :ref:`mlflowtrace` | The information for the trace being created. |
+|            |                    | This field is required.                      |
+|            |                    |                                              |
++------------+--------------------+----------------------------------------------+
+
+.. _mlflowTraceInfoV3TagsEntry:
+
+TagsEntry
+---------
+
+
+
+
+
+
++------------+------------+-------------+
+| Field Name |    Type    | Description |
++============+============+=============+
+| key        | ``STRING`` |             |
++------------+------------+-------------+
+| value      | ``STRING`` |             |
++------------+------------+-------------+
+
+.. _mlflowTrace:
+
+Trace
+-----
+
+
+
+
+
+
++------------+--------------------------+-------------+
+| Field Name |           Type           | Description |
++============+==========================+=============+
+| trace_info | :ref:`mlflowtraceinfov3` |             |
++------------+--------------------------+-------------+
+
+.. _mlflowTraceInfo:
+
+TraceInfo
+---------
+
+
+
+TraceInfo. Represents metadata of a trace.
+
+
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+|    Field Name     |                     Type                      |                           Description                           |
++===================+===============================================+=================================================================+
+| request_id        | ``STRING``                                    | Unique identifier for the trace.                                |
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+| experiment_id     | ``STRING``                                    | The ID of the experiment that contains the trace.               |
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+| timestamp_ms      | ``INT64``                                     | Unix timestamp of when the trace started in milliseconds.       |
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+| execution_time_ms | ``INT64``                                     | Unix timestamp of the duration of the trace in milliseconds.    |
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+| status            | :ref:`mlflowtracestatus`                      | Overall status of the operation being traced (OK, error, etc.). |
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+| request_metadata  | An array of :ref:`mlflowtracerequestmetadata` | Other trace metadata.                                           |
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+| tags              | An array of :ref:`mlflowtracetag`             | Tags for the trace.                                             |
++-------------------+-----------------------------------------------+-----------------------------------------------------------------+
+
+.. _mlflowTraceInfoV3:
+
+TraceInfoV3
+-----------
+
+
+
+
+
+
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+|     Field Name     |                          Type                          |                                                      Description                                                       |
++====================+========================================================+========================================================================================================================+
+| trace_id           | ``STRING``                                             | The primary key associated with the trace                                                                              |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| client_request_id  | ``STRING``                                             | Client supplied request ID associated with the trace. This could be used to identify the trace/request from an         |
+|                    |                                                        | external system that produced the trace.                                                                               |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| trace_location     | :ref:`mlflowtracelocation`                             |                                                                                                                        |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| request            | ``STRING``                                             | [Deprecated, please use `request_preview` instead.]                                                                    |
+|                    |                                                        | Request to the model/agent.                                                                                            |
+|                    |                                                        | Equivalent to the input of the root span but added for ease of access.                                                 |
+|                    |                                                        | Represented as a JSON string.                                                                                          |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| response           | ``STRING``                                             | [Deprecated, please use `request_preview` instead.]                                                                    |
+|                    |                                                        | Response of the model/agent.                                                                                           |
+|                    |                                                        | Equivalent to the output of the root span but added for ease of access.                                                |
+|                    |                                                        | Represented as a JSON string.                                                                                          |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| request_preview    | ``STRING``                                             | A preview of the request to the model/agent represented as a JSON string. This is equivalent to the input of the root  |
+|                    |                                                        | span. This preview value is truncated to 10KB while the full request is stored in the trace data in blob storage.      |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| response_preview   | ``STRING``                                             | A preview of the request to the model/agent represented as a JSON string. This is equivalent to the output of the root |
+|                    |                                                        | span. This preview value is truncated to 10KB while the full response is stored in the trace data in blob storage.     |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| request_time       | :ref:`googleprotobuftimestamp`                         | Start time of the trace                                                                                                |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| execution_duration | :ref:`googleprotobufduration`                          | Execution time of the trace                                                                                            |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| state              | :ref:`mlflowtraceinfov3state`                          |                                                                                                                        |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| trace_metadata     | An array of :ref:`mlflowtraceinfov3tracemetadataentry` | Metadata associated with the trace.                                                                                    |
+|                    |                                                        | Examples include:                                                                                                      |
+|                    |                                                        | - run_id: The ID of the mlflow Run (i.e. evaluation job) that produced the trace. May not be                           |
+|                    |                                                        |           applicable in certain situations such as if the trace was created via interactive vibe checks)               |
+|                    |                                                        | - model_id: The ID of the associated model that produced the trace.                                                    |
+|                    |                                                        | - dataset_id: The ID of the mlflow Dataset (usually used together with dataset_record_id)                              |
+|                    |                                                        | - dataset_record_id: The ID of the mlflow Dataset (usually used together with dataset_record_id)                       |
+|                    |                                                        | - session_id: The ID of the session (e.g. chat conversation) where the request came from                               |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| assessments        | An array of :ref:`mlflowassessmentsassessment`         |                                                                                                                        |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+| tags               | An array of :ref:`mlflowtraceinfov3tagsentry`          | Mutable, user-defined tags for the trace, e.g. "question_topic": "DBSQL"                                               |
++--------------------+--------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
+
+.. _mlflowTraceLocation:
+
+TraceLocation
+-------------
+
+
+
+The location where the traces was stored and produced
+
+
++----------------------------------------------+--------------------------------------------------------------------------------------------------------+----------------------------+
+|                  Field Name                  |                                                  Type                                                  |        Description         |
++==============================================+========================================================================================================+============================+
+| type                                         | :ref:`mlflowtracelocationtracelocationtype`                                                            |                            |
++----------------------------------------------+--------------------------------------------------------------------------------------------------------+----------------------------+
+| ``mlflow_experiment`` OR ``inference_table`` | :ref:`mlflowtracelocationmlflowexperimentlocation` OR :ref:`mlflowtracelocationinferencetablelocation` |                            |
+|                                              |                                                                                                        |                            |
+|                                              |                                                                                                        | If ``mlflow_experiment``,  |
+|                                              |                                                                                                        |                            |
+|                                              |                                                                                                        |                            |
+|                                              |                                                                                                        |                            |
+|                                              |                                                                                                        |                            |
+|                                              |                                                                                                        |                            |
+|                                              |                                                                                                        | If ``inference_table``,    |
++----------------------------------------------+--------------------------------------------------------------------------------------------------------+----------------------------+
+
+.. _mlflowTraceInfoV3TraceMetadataEntry:
+
+TraceMetadataEntry
+------------------
+
+
+
+
+
+
++------------+------------+-------------+
+| Field Name |    Type    | Description |
++============+============+=============+
+| key        | ``STRING`` |             |
++------------+------------+-------------+
+| value      | ``STRING`` |             |
++------------+------------+-------------+
+
+.. _mlflowTraceRequestMetadata:
+
+TraceRequestMetadata
+--------------------
+
+
+
+
+
+
++------------+------------+----------------------------------+
+| Field Name |    Type    |           Description            |
++============+============+==================================+
+| key        | ``STRING`` | Key identifying this metadata.   |
++------------+------------+----------------------------------+
+| value      | ``STRING`` | Value identifying this metadata. |
++------------+------------+----------------------------------+
+
+.. _mlflowTraceTag:
+
+TraceTag
+--------
+
+
+
+
+
+
++------------+------------+---------------------------------------+
+| Field Name |    Type    |              Description              |
++============+============+=======================================+
+| key        | ``STRING`` | Key identifying this trace tag.       |
++------------+------------+---------------------------------------+
+| value      | ``STRING`` | Value associated with this trace tag. |
++------------+------------+---------------------------------------+
+
+.. _mlflowUpdateAssessment:
+
+UpdateAssessment
+----------------
+
+
+
+A request to update an existing assessment.
+
+
++-------------+------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| Field Name  |                Type                |                                                          Description                                                          |
++=============+====================================+===============================================================================================================================+
+| assessment  | :ref:`mlflowassessmentsassessment` | The Assessment containing the fields which should be updated.                                                                 |
+|             |                                    | This field is required.                                                                                                       |
+|             |                                    |                                                                                                                               |
++-------------+------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+| update_mask | :ref:`googleprotobuffieldmask`     | The list of the assessment fields to update. These should correspond to the values (or lack thereof) present in `assessment`. |
+|             |                                    | This field is required.                                                                                                       |
+|             |                                    |                                                                                                                               |
++-------------+------------------------------------+-------------------------------------------------------------------------------------------------------------------------------+
+
+.. _mlflowWebhook:
+
+Webhook
+-------
+
+
+
+Webhook entity
+
+
++------------------------+---------------------------------------+----------------------------------------------+
+|       Field Name       |                 Type                  |                 Description                  |
++========================+=======================================+==============================================+
+| webhook_id             | ``STRING``                            | Unique identifier for the webhook            |
++------------------------+---------------------------------------+----------------------------------------------+
+| name                   | ``STRING``                            | Name of the webhook                          |
++------------------------+---------------------------------------+----------------------------------------------+
+| description            | ``STRING``                            | Optional description for the webhook         |
++------------------------+---------------------------------------+----------------------------------------------+
+| url                    | ``STRING``                            | URL to send webhook events to                |
++------------------------+---------------------------------------+----------------------------------------------+
+| events                 | An array of :ref:`mlflowwebhookevent` | List of events this webhook is subscribed to |
++------------------------+---------------------------------------+----------------------------------------------+
+| status                 | :ref:`mlflowwebhookstatus`            | Current status of the webhook                |
++------------------------+---------------------------------------+----------------------------------------------+
+| creation_timestamp     | ``INT64``                             | Timestamp when webhook was created           |
++------------------------+---------------------------------------+----------------------------------------------+
+| last_updated_timestamp | ``INT64``                             | Timestamp when webhook was last updated      |
++------------------------+---------------------------------------+----------------------------------------------+
+
+.. _mlflowWebhookEvent:
+
+WebhookEvent
+------------
+
+
+
+Webhook event definition
+
+
++------------+----------------------------+-------------------------+
+| Field Name |            Type            |       Description       |
++============+============================+=========================+
+| entity     | :ref:`mlflowwebhookentity` | Entity type (required)  |
+|            |                            | This field is required. |
+|            |                            |                         |
++------------+----------------------------+-------------------------+
+| action     | :ref:`mlflowwebhookaction` | Action type (required)  |
+|            |                            | This field is required. |
+|            |                            |                         |
++------------+----------------------------+-------------------------+
+
+.. _mlflowWebhookTestResult:
+
+WebhookTestResult
+-----------------
+
+
+
+Test webhook result
+
+
++-----------------+------------+----------------------------------------+
+|   Field Name    |    Type    |              Description               |
++=================+============+========================================+
+| success         | ``BOOL``   | Whether the test succeeded             |
++-----------------+------------+----------------------------------------+
+| response_status | ``INT32``  | HTTP response status code if available |
++-----------------+------------+----------------------------------------+
+| response_body   | ``STRING`` | Response body if available             |
++-----------------+------------+----------------------------------------+
+| error_message   | ``STRING`` | Error message if test failed           |
++-----------------+------------+----------------------------------------+
+
+.. _mlflowModelVersionDeploymentJobStateDeploymentJobRunState:
+
+DeploymentJobRunState
+---------------------
+
+
+
+
++--------------------------------------+-------------+
+|                 Name                 | Description |
++======================================+=============+
+| DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED |             |
++--------------------------------------+-------------+
+| NO_VALID_DEPLOYMENT_JOB_FOUND        |             |
++--------------------------------------+-------------+
+| RUNNING                              |             |
++--------------------------------------+-------------+
+| SUCCEEDED                            |             |
++--------------------------------------+-------------+
+| FAILED                               |             |
++--------------------------------------+-------------+
+| PENDING                              |             |
++--------------------------------------+-------------+
+| APPROVAL                             |             |
++--------------------------------------+-------------+
+
+.. _mlflowLoggedModelStatus:
+
+LoggedModelStatus
+-----------------
+
+
+A LoggedModelStatus enum value represents the status of a logged
+model.
+
++---------------------------------+--------------------------------------------------------------------------------+
+|              Name               |                                  Description                                   |
++=================================+================================================================================+
+| LOGGED_MODEL_STATUS_UNSPECIFIED |                                                                                |
++---------------------------------+--------------------------------------------------------------------------------+
+| LOGGED_MODEL_PENDING            | The LoggedModel has been created, but the LoggedModel files are not            |
+|                                 | completely uploaded.                                                           |
++---------------------------------+--------------------------------------------------------------------------------+
+| LOGGED_MODEL_READY              | The LoggedModel is created, and the LoggedModel files are completely uploaded. |
++---------------------------------+--------------------------------------------------------------------------------+
+| LOGGED_MODEL_UPLOAD_FAILED      | The LoggedModel is created, but an error occurred when uploading the           |
+|                                 | LoggedModel files such as model weights / agent code.                          |
++---------------------------------+--------------------------------------------------------------------------------+
 
 .. _mlflowModelVersionStatus:
 
@@ -2968,6 +5197,109 @@ Status of a run.
 | KILLED    | Run killed by user.                      |
 +-----------+------------------------------------------+
 
+.. _mlflowSourceType:
+
+SourceType
+----------
+
+
+Source that generated a run.
+
++----------+------------------------------------------------------------------------+
+|   Name   |                              Description                               |
++==========+========================================================================+
+| NOTEBOOK | Databricks notebook environment.                                       |
++----------+------------------------------------------------------------------------+
+| JOB      | Scheduled or Run Now job.                                              |
++----------+------------------------------------------------------------------------+
+| PROJECT  | As a prepackaged project: either a Docker image or GitHub source, etc. |
++----------+------------------------------------------------------------------------+
+| LOCAL    | Local run: Using CLI, IDE, or local notebook.                          |
++----------+------------------------------------------------------------------------+
+| UNKNOWN  | Unknown source type.                                                   |
++----------+------------------------------------------------------------------------+
+
+.. _mlflowTraceInfoV3State:
+
+State
+-----
+
+
+Execution state of the trace at the time that it was logged.
+
++-------------------+----------------------------------------------------------------------------------------------------------------+
+|       Name        |                                                  Description                                                   |
++===================+================================================================================================================+
+| STATE_UNSPECIFIED |                                                                                                                |
++-------------------+----------------------------------------------------------------------------------------------------------------+
+| OK                | The operation being traced was successful.                                                                     |
++-------------------+----------------------------------------------------------------------------------------------------------------+
+| ERROR             | The operation being traced failed.                                                                             |
++-------------------+----------------------------------------------------------------------------------------------------------------+
+| IN_PROGRESS       | The operation being traced is still in progress. This is useful for incremental/distributed tracing logging in |
+|                   | contrast with when the full trace is logged only upon its completion.                                          |
++-------------------+----------------------------------------------------------------------------------------------------------------+
+
+.. _mlflowDeploymentJobConnectionState:
+
+State
+-----
+
+
+
+
++---------------------------------------------+------------------------------------------------------------------------------------+
+|                    Name                     |                                    Description                                     |
++=============================================+====================================================================================+
+| DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED |                                                                                    |
++---------------------------------------------+------------------------------------------------------------------------------------+
+| NOT_SET_UP                                  | default state                                                                      |
++---------------------------------------------+------------------------------------------------------------------------------------+
+| CONNECTED                                   | connected job: job exists, owner has ACLs, and required job parameters are present |
++---------------------------------------------+------------------------------------------------------------------------------------+
+| NOT_FOUND                                   | job was deleted OR owner had job ACLs removed                                      |
++---------------------------------------------+------------------------------------------------------------------------------------+
+| REQUIRED_PARAMETERS_CHANGED                 | required job parameters were changed                                               |
++---------------------------------------------+------------------------------------------------------------------------------------+
+
+.. _mlflowTraceLocationTraceLocationType:
+
+TraceLocationType
+-----------------
+
+
+
+
++---------------------------------+-------------+
+|              Name               | Description |
++=================================+=============+
+| TRACE_LOCATION_TYPE_UNSPECIFIED |             |
++---------------------------------+-------------+
+| MLFLOW_EXPERIMENT               |             |
++---------------------------------+-------------+
+| INFERENCE_TABLE                 |             |
++---------------------------------+-------------+
+
+.. _mlflowTraceStatus:
+
+TraceStatus
+-----------
+
+
+
+
++--------------------------+--------------------------------------------------+
+|           Name           |                   Description                    |
++==========================+==================================================+
+| TRACE_STATUS_UNSPECIFIED |                                                  |
++--------------------------+--------------------------------------------------+
+| OK                       | The operation being traced was successful.       |
++--------------------------+--------------------------------------------------+
+| ERROR                    | The operation being traced failed.               |
++--------------------------+--------------------------------------------------+
+| IN_PROGRESS              | The operation being traced is still in progress. |
++--------------------------+--------------------------------------------------+
+
 .. _mlflowViewType:
 
 ViewType
@@ -2985,3 +5317,63 @@ View type for ListExperiments query.
 +--------------+------------------------------------------+
 | ALL          | Get all experiments.                     |
 +--------------+------------------------------------------+
+
+.. _mlflowWebhookAction:
+
+WebhookAction
+-------------
+
+
+Webhook action types
+
++--------------------+-------------+
+|        Name        | Description |
++====================+=============+
+| ACTION_UNSPECIFIED |             |
++--------------------+-------------+
+| CREATED            |             |
++--------------------+-------------+
+| UPDATED            |             |
++--------------------+-------------+
+| DELETED            |             |
++--------------------+-------------+
+| SET                |             |
++--------------------+-------------+
+
+.. _mlflowWebhookEntity:
+
+WebhookEntity
+-------------
+
+
+Webhook entity types
+
++---------------------+-------------+
+|        Name         | Description |
++=====================+=============+
+| ENTITY_UNSPECIFIED  |             |
++---------------------+-------------+
+| REGISTERED_MODEL    |             |
++---------------------+-------------+
+| MODEL_VERSION       |             |
++---------------------+-------------+
+| MODEL_VERSION_TAG   |             |
++---------------------+-------------+
+| MODEL_VERSION_ALIAS |             |
++---------------------+-------------+
+
+.. _mlflowWebhookStatus:
+
+WebhookStatus
+-------------
+
+
+Webhook status enumeration
+
++----------+-------------+
+|   Name   | Description |
++==========+=============+
+| ACTIVE   |             |
++----------+-------------+
+| DISABLED |             |
++----------+-------------+


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds automated protobuf documentation generation to the build process:

- **Created `dev/proto_plugin.py`**: A protoc plugin that generates `doc_public.json` from protobuf files containing structured documentation about messages, enums, services, and methods
- **Integrated into `dev/generate_protos.py`**: Added `gen_proto_docs()` function that calls the plugin during the proto generation workflow  
- **Added wrapper script `dev/protoc_gen_doc.py`**: Makes the plugin executable by protoc
- **Updated `.gitignore`**: Excludes the generated `doc_public.json` file from version control

The plugin extracts:
- Proto message definitions with fields, types, and documentation
- Enum definitions with values and visibility
- Service definitions with methods and RPC options
- Source code comments as documentation
- Full path hierarchies for nested elements

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests 
- [x] Manual tests

Manually tested by running `python dev/generate_protos.py` which successfully generates a 1.1MB `doc_public.json` file containing documentation for all 19 protobuf files.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is an internal build process improvement that doesn't affect user-facing functionality.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)