### PR TITLE
Fix Databricks SDK error code to HTTP status mapping

### DIFF
--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -422,7 +422,9 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
             return call_func()
         except DatabricksError as e:
             # Get HTTP status code from the error
-            status_code = next((k for k, v in STATUS_CODE_MAPPING.items() if isinstance(e, v)), 500)
+            status_code = next(
+                (code for code, cls in STATUS_CODE_MAPPING.items() if isinstance(e, cls)), 500
+            )
             # Check if this is a retryable error
             if status_code not in retry_codes:
                 raise

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -412,7 +412,7 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
     Raises:
         DatabricksError: If all retries are exhausted or non-retryable error occurs
     """
-    from databricks.sdk.errors import DatabricksError
+    from databricks.sdk.errors import STATUS_CODE_MAPPING, DatabricksError
 
     start_time = time.time()
     attempt = 0
@@ -421,10 +421,8 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
         try:
             return call_func()
         except DatabricksError as e:
-            print(e, "type:", type(e), "✅")  # noqa: T201
             # Get HTTP status code from the error
-            status_code = ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)
-
+            status_code = next((k for k, v in STATUS_CODE_MAPPING.items() if isinstance(e, v)), 500)
             # Check if this is a retryable error
             if status_code not in retry_codes:
                 raise

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -421,7 +421,7 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
         try:
             return call_func()
         except DatabricksError as e:
-            print(e, "✅")  # noqa: T201
+            print(e, "type:", type(e), "✅")  # noqa: T201
             # Get HTTP status code from the error
             status_code = ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -421,6 +421,7 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
         try:
             return call_func()
         except DatabricksError as e:
+            print(e)  # noqa: T201
             # Get HTTP status code from the error
             status_code = ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -421,7 +421,7 @@ def _retry_databricks_sdk_call_with_exponential_backoff(
         try:
             return call_func()
         except DatabricksError as e:
-            print(e)  # noqa: T201
+            print(e, "✅")  # noqa: T201
             # Get HTTP status code from the error
             status_code = ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)
 

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -772,10 +772,10 @@ def test_databricks_sdk_retry_non_retryable_error():
     def mock_do_non_retryable_error(*args, **kwargs):
         nonlocal call_count
         call_count += 1
-        from databricks.sdk.errors import DatabricksError
+        from databricks.sdk.errors import InvalidParameterValue
 
         # Use an error code that maps to 400 (non-retryable)
-        raise DatabricksError(error_code="INVALID_PARAMETER_VALUE", message="Bad request")
+        raise InvalidParameterValue(error_code="INVALID_PARAMETER_VALUE", message="Bad request")
 
     with mock.patch("mlflow.utils.rest_utils.get_workspace_client") as mock_get_workspace_client:
         mock_workspace_client = mock.MagicMock()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17095?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17095/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17095/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17095/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR fixes the error code to HTTP status mapping in `_retry_databricks_sdk_call_with_exponential_backoff`. Instead of using `ERROR_CODE_TO_HTTP_STATUS.get(e.error_code, 500)` which relies on the `error_code` attribute that may not be available, it now uses the Databricks SDK's `STATUS_CODE_MAPPING` to determine the HTTP status code by checking the exception type with `isinstance()`.

The change improves error handling by:
- Using the canonical status code mapping from the Databricks SDK itself
- Checking exception type rather than relying on error code attributes
- Providing more reliable HTTP status code detection for retry logic

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix Databricks SDK error code handling in retry logic to use proper status code mapping

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)