### PR TITLE
Fix DSPy test compatibility with dspy>=3.0.0

### DIFF
--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -483,14 +483,22 @@ def test_predict_stream_success(dummy_model):
         output = loaded_model.predict_stream({"question": "What is 2 + 2?"})
         for o in output:
             results.append(o)
-    assert results == [
-        {"predict_name": "prog.predict", "signature_field_name": "answer", "chunk": "2"},
-        {
-            "predict_name": "prog.predict",
-            "signature_field_name": _REASONING_KEYWORD,
-            "chunk": "reason",
-        },
-    ]
+
+    assert len(results) == 2
+    extra_kwargs = {"is_last_chunk": False} if _DSPY_VERSION.major >= 3 else {}
+    assert results[0] == {
+        "predict_name": "prog.predict",
+        "signature_field_name": "answer",
+        "chunk": "2",
+        **extra_kwargs,
+    }
+    extra_kwargs = {"is_last_chunk": True} if _DSPY_VERSION.major >= 3 else {}
+    assert results[1] == {
+        "predict_name": "prog.predict",
+        "signature_field_name": _REASONING_KEYWORD,
+        "chunk": "reason",
+        **extra_kwargs,
+    }
 
 
 def test_predict_output(dummy_model):

--- a/tests/dspy/test_save.py
+++ b/tests/dspy/test_save.py
@@ -462,15 +462,21 @@ def test_predict_stream_success(dummy_model):
     results = []
 
     def dummy_streamify(*args, **kwargs):
+        # In dspy>=3, `StreamResponse` requires `is_last_chunk` argument.
+        # https://github.com/stanfordnlp/dspy/pull/8587
+        extra_kwargs = {"is_last_chunk": False} if _DSPY_VERSION.major >= 3 else {}
         yield dspy.streaming.StreamResponse(
             predict_name="prog.predict",
             signature_field_name="answer",
             chunk="2",
+            **extra_kwargs,
         )
+        extra_kwargs = {"is_last_chunk": True} if _DSPY_VERSION.major >= 3 else {}
         yield dspy.streaming.StreamResponse(
             predict_name="prog.predict",
             signature_field_name=_REASONING_KEYWORD,
             chunk="reason",
+            **extra_kwargs,
         )
 
     with mock.patch("dspy.streamify", return_value=dummy_streamify):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17101?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17101/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17101/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17101/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Resolve --> #[Issue number if applicable]

### What changes are proposed in this pull request?

This PR fixes a test compatibility issue with dspy>=3.0.0. In the newer version of dspy, the `StreamResponse` class requires an `is_last_chunk` argument. This change adds version-based compatibility to conditionally include this argument.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The existing `test_predict_stream_success` test now works with both older and newer versions of dspy.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)