### PR TITLE
Install `ddgs` if `smolagents` >= 1.21.0

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -55,8 +55,13 @@ T = TypeVar("T")
 
 
 class Version(OriginalVersion):
-    def __init__(self, version):
+    def __init__(self, version: str, release_date: datetime | None = None):
         self._is_dev = version == DEV_VERSION
+        # For dev versions, use current time if no release date provided
+        if self._is_dev and release_date is None:
+            self._release_date = datetime.now(timezone.utc)
+        else:
+            self._release_date = release_date
         super().__init__(DEV_NUMERIC if self._is_dev else version)
 
     def __str__(self):
@@ -64,7 +69,18 @@ class Version(OriginalVersion):
 
     @classmethod
     def create_dev(cls):
-        return cls(DEV_VERSION)
+        return cls(DEV_VERSION, datetime.now(timezone.utc))
+
+    @property
+    def days_since_release(self) -> int | None:
+        """
+        Compute the number of days since this version was released.
+        Returns None if release date is not available.
+        """
+        if self._release_date is None:
+            return None
+        delta = datetime.now(timezone.utc) - self._release_date
+        return delta.days
 
 
 class PackageInfo(BaseModel, extra="forbid"):
@@ -168,18 +184,23 @@ def uploaded_recently(dist: dict[str, Any]) -> bool:
 def get_released_versions(package_name: str) -> list[Version]:
     data = pypi_json(package_name)
     versions: list[Version] = []
-    for version, distributions in data["releases"].items():
+    for version_str, distributions in data["releases"].items():
         if len(distributions) == 0 or any(d.get("yanked", False) for d in distributions):
             continue
 
-        # Ignore versions that were uploaded recently to avoid testing unstable
-        # versions. Newly released versions often contain undiscovered bugs
-        # (example: https://github.com/huggingface/transformers/issues/34370).
-        if any(map(uploaded_recently, distributions)):
+        # Extract the earliest upload time as the release date
+        upload_times = []
+        for dist in distributions:
+            if ut := dist.get("upload_time_iso_8601"):
+                upload_times.append(datetime.fromisoformat(ut.replace("Z", "+00:00")))
+
+        # Skip if no upload time is available
+        if not upload_times:
             continue
 
+        release_date = min(upload_times)
         try:
-            version = Version(version)
+            version = Version(version_str, release_date)
         except InvalidVersion:
             # Ignore invalid versions such as https://pypi.org/project/pytz/2004d
             continue
@@ -234,10 +255,15 @@ def filter_versions(
                 return False
         return True
 
-    def _is_older_than_or_equal_to_max_major_version(v):
-        return v.major <= max_ver.major
+    def _check_max(v: Version) -> bool:
+        return v <= max_ver or (
+            # Exclude versions uploaded very recently to avoid testing unstable or potentially
+            # buggy releases. Newly released versions may have unresolved issues
+            # (see: https://github.com/huggingface/transformers/issues/34370).
+            v.major <= max_ver.major and v.days_since_release and v.days_since_release >= 1
+        )
 
-    def _is_newer_than_or_equal_to_min_version(v):
+    def _check_min(v: Version) -> bool:
         return v >= min_ver
 
     return list(
@@ -245,8 +271,8 @@ def filter_versions(
             lambda vers, f: filter(f, vers),
             [
                 _is_supported,
-                _is_older_than_or_equal_to_max_major_version,
-                _is_newer_than_or_equal_to_min_version,
+                _check_max,
+                _check_min,
             ],
             versions,
         )
@@ -587,7 +613,7 @@ def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[Matrix
                     name,
                     category,
                     package_info,
-                    versions + ([Version.create_dev()] if package_info.install_dev else []),
+                    versions,
                 )
 
             for ver in versions:

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -582,7 +582,13 @@ def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[Matrix
                 versions.append(cfg.minimum)
 
             if not is_ref and cfg.requirements:
-                validate_requirements(cfg.requirements, name, category, package_info, versions)
+                validate_requirements(
+                    cfg.requirements,
+                    name,
+                    category,
+                    package_info,
+                    versions + ([Version.create_dev()] if package_info.install_dev else []),
+                )
 
             for ver in versions:
                 requirements = [f"{package_info.pip_release}=={ver}"]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -885,6 +885,7 @@ smolagents:
     maximum: "1.20.0"
     requirements:
       "< 1.21.0": ["duckduckgo-search"]
+      # `duckduckgo_search` has been renamed to `ddgs`:
       # https://github.com/huggingface/smolagents/pull/1593
       ">= 1.21.0": ["ddgs"]
     run: pytest tests/smolagents

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -884,7 +884,9 @@ smolagents:
     minimum: "1.14.0"
     maximum: "1.20.0"
     requirements:
-      ">= 0.0.0": ["duckduckgo-search"]
+      "< 1.21.0": ["duckduckgo-search"]
+      # https://github.com/huggingface/smolagents/pull/1593
+      ">= 1.21.0": ["ddgs"]
     run: pytest tests/smolagents
     test_tracing_sdk: true
 

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -882,7 +882,7 @@ smolagents:
       pip install "git+https://github.com/huggingface/smolagents"
   autologging:
     minimum: "1.14.0"
-    maximum: "1.20.0"
+    maximum: "1.21.0"
     requirements:
       "< 1.21.0": ["duckduckgo-search"]
       # `duckduckgo_search` has been renamed to `ddgs`:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -882,7 +882,7 @@ smolagents:
       pip install "git+https://github.com/huggingface/smolagents"
   autologging:
     minimum: "1.14.0"
-    maximum: "1.21.0"
+    maximum: "1.20.0"
     requirements:
       "< 1.21.0": ["duckduckgo-search"]
       # `duckduckgo_search` has been renamed to `ddgs`:

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -357,7 +357,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "1.14.0",
-            "maximum": "1.21.0"
+            "maximum": "1.20.0"
         }
     },
     "mistral": {

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -357,7 +357,7 @@ _ML_PACKAGE_VERSIONS = {
         },
         "autologging": {
             "minimum": "1.14.0",
-            "maximum": "1.20.0"
+            "maximum": "1.21.0"
         }
     },
     "mistral": {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17119?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17119/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17119/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17119/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix https://github.com/mlflow/dev/actions/runs/16805673310/job/47624347087#step:13:146:

<!-- Please fill in changes proposed in this PR. -->

```
        try:
            from ddgs import DDGS
        except ImportError as e:
>           raise ImportError(
                "You must install package `ddgs` to run this tool: for instance run `pip install ddgs`."
            ) from e
E           ImportError: You must install package `ddgs` to run this tool: for instance run `pip install ddgs`.

__class__  = <class 'smolagents.default_tools.DuckDuckGoSearchTool'>
kwargs     = {}
max_results = 10
rate_limit = 1.0
self       = <smolagents.default_tools.DuckDuckGoSearchTool object at 0x7f16de01b520>
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
