### PR TITLE
Add error handling for s3 client errors

### DIFF
--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -1151,7 +1151,6 @@ def list_artifacts_impl(request_message):
     return response_message
 
 
-@catch_mlflow_exception
 def _list_artifacts_for_proxied_run_artifact_root(proxied_artifact_root, relative_path=None):
     """
     Lists artifacts from the specified ``relative_path`` within the specified proxied Run artifact

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -18,6 +18,12 @@ from mlflow.environment_variables import (
     MLFLOW_S3_UPLOAD_EXTRA_ARGS,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.protos.databricks_pb2 import (
+    INTERNAL_ERROR,
+    PERMISSION_DENIED,
+    RESOURCE_DOES_NOT_EXIST,
+    UNAUTHENTICATED,
+)
 from mlflow.store.artifact.artifact_repo import (
     ArtifactRepository,
     MultipartUploadMixin,
@@ -25,6 +31,14 @@ from mlflow.store.artifact.artifact_repo import (
 from mlflow.utils.file_utils import relative_path_to_artifact_path
 
 _MAX_CACHE_SECONDS = 300
+
+BOTO_TO_MLFLOW_ERROR = {
+    "AccessDenied": PERMISSION_DENIED,
+    "NoSuchBucket": RESOURCE_DOES_NOT_EXIST,
+    "NoSuchKey": RESOURCE_DOES_NOT_EXIST,
+    "InvalidAccessKeyId": UNAUTHENTICATED,
+    "SignatureDoesNotMatch": UNAUTHENTICATED,
+}
 
 
 def _get_utcnow_timestamp():
@@ -309,37 +323,49 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             - is_dir: True if the artifact represents a directory (S3 prefix)
             - file_size: Size in bytes for files, None for directories
         """
-        (bucket, artifact_path) = self.parse_s3_compliant_uri(self.artifact_uri)
-        dest_path = artifact_path
-        if path:
-            dest_path = posixpath.join(dest_path, path)
-        dest_path = dest_path.rstrip("/") if dest_path else ""
-        infos = []
-        prefix = dest_path + "/" if dest_path else ""
-        s3_client = self._get_s3_client()
-        paginator = s3_client.get_paginator("list_objects_v2")
-        results = paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/")
-        for result in results:
-            # Subdirectories will be listed as "common prefixes" due to the way we made the request
-            for obj in result.get("CommonPrefixes", []):
-                subdir_path = obj.get("Prefix")
-                self._verify_listed_object_contains_artifact_path_prefix(
-                    listed_object_path=subdir_path, artifact_path=artifact_path
-                )
-                subdir_rel_path = posixpath.relpath(path=subdir_path, start=artifact_path)
-                if subdir_rel_path.endswith("/"):
-                    subdir_rel_path = subdir_rel_path[:-1]
-                infos.append(FileInfo(subdir_rel_path, True, None))
-            # Objects listed directly will be files
-            for obj in result.get("Contents", []):
-                file_path = obj.get("Key")
-                self._verify_listed_object_contains_artifact_path_prefix(
-                    listed_object_path=file_path, artifact_path=artifact_path
-                )
-                file_rel_path = posixpath.relpath(path=file_path, start=artifact_path)
-                file_size = int(obj.get("Size"))
-                infos.append(FileInfo(file_rel_path, False, file_size))
-        return sorted(infos, key=lambda f: f.path)
+        from botocore.exceptions import ClientError
+
+        try:
+            (bucket, artifact_path) = self.parse_s3_compliant_uri(self.artifact_uri)
+            dest_path = artifact_path
+            if path:
+                dest_path = posixpath.join(dest_path, path)
+            dest_path = dest_path.rstrip("/") if dest_path else ""
+            infos = []
+            prefix = dest_path + "/" if dest_path else ""
+            s3_client = self._get_s3_client()
+            paginator = s3_client.get_paginator("list_objects_v2")
+            results = paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/")
+            for result in results:
+                # Subdirectories will be listed as "common prefixes"
+                # due to the way we made the request
+                for obj in result.get("CommonPrefixes", []):
+                    subdir_path = obj.get("Prefix")
+                    self._verify_listed_object_contains_artifact_path_prefix(
+                        listed_object_path=subdir_path, artifact_path=artifact_path
+                    )
+                    subdir_rel_path = posixpath.relpath(path=subdir_path, start=artifact_path)
+                    if subdir_rel_path.endswith("/"):
+                        subdir_rel_path = subdir_rel_path[:-1]
+                    infos.append(FileInfo(subdir_rel_path, True, None))
+                # Objects listed directly will be files
+                for obj in result.get("Contents", []):
+                    file_path = obj.get("Key")
+                    self._verify_listed_object_contains_artifact_path_prefix(
+                        listed_object_path=file_path, artifact_path=artifact_path
+                    )
+                    file_rel_path = posixpath.relpath(path=file_path, start=artifact_path)
+                    file_size = int(obj.get("Size"))
+                    infos.append(FileInfo(file_rel_path, False, file_size))
+            return sorted(infos, key=lambda f: f.path)
+        except ClientError as error:
+            error_code = error.response["Error"]["Code"]
+            mlflow_error_code = BOTO_TO_MLFLOW_ERROR.get(error_code, INTERNAL_ERROR)
+            error_message = error.response["Error"]["Message"]
+            raise MlflowException(
+                f"Failed to list artifacts in {self.artifact_uri}: {error_message}",
+                error_code=mlflow_error_code,
+            )
 
     @staticmethod
     def _verify_listed_object_contains_artifact_path_prefix(listed_object_path, artifact_path):

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -339,31 +339,6 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 error_code=mlflow_error_code,
             )
 
-    def _parse_s3_path_prefix(self, path=None):
-        """
-        Parse and resolve S3 path components for artifact operations.
-
-        This helper method takes the optional path parameter and resolves it
-        against the repository's artifact URI to produce the S3 bucket,
-        artifact path, and properly formatted S3 prefix.
-
-        Args:
-            path: Optional relative path within the S3 bucket
-
-        Returns:
-            A tuple containing (bucket, artifact_path, prefix) where:
-            - bucket: S3 bucket name
-            - artifact_path: Base artifact path within the bucket
-            - prefix: S3 prefix for listing operations (with trailing slash)
-        """
-        (bucket, artifact_path) = self.parse_s3_compliant_uri(self.artifact_uri)
-        dest_path = artifact_path
-        if path:
-            dest_path = posixpath.join(dest_path, path)
-        dest_path = dest_path.rstrip("/") if dest_path else ""
-        prefix = dest_path + "/" if dest_path else ""
-        return bucket, artifact_path, prefix
-
     def list_artifacts(self, path=None):
         """
         List all artifacts directly under the specified S3 path.
@@ -384,8 +359,13 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             - is_dir: True if the artifact represents a directory (S3 prefix)
             - file_size: Size in bytes for files, None for directories
         """
-        bucket, artifact_path, prefix = self._parse_s3_path_prefix(path)
+        (bucket, artifact_path) = self.parse_s3_compliant_uri(self.artifact_uri)
+        dest_path = artifact_path
+        if path:
+            dest_path = posixpath.join(dest_path, path)
+        dest_path = dest_path.rstrip("/") if dest_path else ""
         infos = []
+        prefix = dest_path + "/" if dest_path else ""
         for result in self._iterate_s3_paginated_results(bucket, prefix):
             # Subdirectories will be listed as "common prefixes"
             # due to the way we made the request

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -11,7 +11,7 @@ import pytest
 import requests
 
 from mlflow.entities.multipart_upload import MultipartUploadPart
-from mlflow.exceptions import MlflowTraceDataCorrupted
+from mlflow.exceptions import MlflowException, MlflowTraceDataCorrupted
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
 from mlflow.store.artifact.optimized_s3_artifact_repo import OptimizedS3ArtifactRepository
 from mlflow.store.artifact.s3_artifact_repo import (
@@ -388,6 +388,36 @@ def test_list_and_delete_artifacts_path(s3_artifact_repo, tmp_path, artifact_pat
     s3_artifact_repo.delete_artifacts(artifact_path=artifact_path)
     assert s3_artifact_repo.list_artifacts(artifact_path) == []
     assert s3_artifact_repo.list_artifacts() == []
+
+
+@pytest.mark.parametrize(
+    ("boto_error_code", "expected_mlflow_error"),
+    [
+        ("AccessDenied", "PERMISSION_DENIED"),
+        ("NoSuchBucket", "RESOURCE_DOES_NOT_EXIST"),
+        ("NoSuchKey", "RESOURCE_DOES_NOT_EXIST"),
+        ("InvalidAccessKeyId", "UNAUTHENTICATED"),
+        ("SignatureDoesNotMatch", "UNAUTHENTICATED"),
+    ],
+)
+def test_list_artifacts_error_handling(s3_artifact_root, boto_error_code, expected_mlflow_error):
+    artifact_path = "some/path/"
+    s3_repo = S3ArtifactRepository(posixpath.join(s3_artifact_root, artifact_path))
+
+    with mock.patch.object(s3_repo, "_get_s3_client") as mock_client:
+        mock_paginator = mock.Mock()
+        boto_error_message = "Error message from the client"
+        mock_paginator.paginate.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": boto_error_code, "Message": boto_error_message}}, "ListObjectsV2"
+        )
+        mock_client.return_value.get_paginator.return_value = mock_paginator
+
+        with pytest.raises(
+            MlflowException, match=f"Failed to list artifacts in {s3_repo.artifact_uri}:"
+        ) as exc_info:
+            s3_repo.list_artifacts(artifact_path)
+        assert exc_info.value.error_code == expected_mlflow_error
+        assert boto_error_message in exc_info.value.message
 
 
 def test_delete_artifacts_pagination(s3_artifact_repo, tmp_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ctaymor/mlflow/pull/17121?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17121/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17121/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17121/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #17040

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

*Manual testing:*
Run the local server, using a real s3 bucket, and fake access keys.
```bash
export AWS_ACCESS_KEY_ID=fake_key_id
export AWS_SECRET_ACCESS_KEY=fake_secret_key
export AWS_DEFAULT_REGION=us-east-1

mlflow server \
  --backend-store-uri file:///Users/<USERNAME>/workspace/mlflow/mlruns \
  --artifacts-destination s3://test-s3-mlflow-ct-08-05/artifacts \
  --host 127.0.0.1 \
  --port 5000
```
In a separate window, run the test-bug.sh code:
```bash
#!/usr/bin/env bash

set -eux

python -c "
import mlflow
import os

current_dir = os.getcwd()
mlflow.set_tracking_uri('http://127.0.0.1:5000')  # Point to the server

with mlflow.start_run() as run:
    mlflow.log_param('test', 'value')
    print(f'Created run with ID: {run.info.run_id}')

    with open('run_id_s3.txt', 'w') as f:
        f.write(run.info.run_id)
"

# Test with the new run ID
RUN_ID=$(cat run_id_s3.txt)
curl -X GET "http://127.0.0.1:5000/api/2.0/mlflow/artifacts/list?run_id=$RUN_ID" -H "accept: application/json" -v
```
Before the change, you should get a 500. After the change, you will get a 401 Unauthorized.


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes a bug where list_artifacts was throwing a 500 error, when Mlflow receives a 4xx error from S3. The list_artifacts endpoint backed by S3 will now appropriately surface the 4xx error from S3.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
