### PR TITLE
Remove `xethub` extra

### DIFF
--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -315,7 +315,6 @@ def build(package_type: PackageType) -> None:
                 "genai": gateways_requirements,
                 "sqlserver": ["mlflow-dbstore"],
                 "aliyun-oss": ["aliyunstoreplugin"],
-                "xethub": ["mlflow-xethub"],
                 "jfrog": ["mlflow-jfrog-plugin"],
                 "langchain": langchain_requirements,
                 "auth": ["Flask-WTF<2"],

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -94,7 +94,6 @@ genai = [
 ]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
-xethub = ["mlflow-xethub"]
 jfrog = ["mlflow-jfrog-plugin"]
 langchain = ["langchain>=0.1.0,<=0.3.27"]
 auth = ["Flask-WTF<2"]

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -94,7 +94,6 @@ genai = [
 ]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
-xethub = ["mlflow-xethub"]
 jfrog = ["mlflow-jfrog-plugin"]
 langchain = ["langchain>=0.1.0,<=0.3.27"]
 auth = ["Flask-WTF<2"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,7 +109,6 @@ genai = [
 ]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
-xethub = ["mlflow-xethub"]
 jfrog = ["mlflow-jfrog-plugin"]
 langchain = ["langchain>=0.1.0,<=0.3.27"]
 auth = ["Flask-WTF<2"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17123?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17123/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17123/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17123/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

The `xethub` extra causes the following error when running `uv run`:

```
% uv run
  × No solution found when resolving dependencies for split (python_full_version >= '3.13'):
  ╰─▶ Because pyxet was not found in the package registry and mlflow-xethub==0.0.0 depends on pyxet>=0.1.0, we can conclude
      that mlflow-xethub==0.0.0 cannot be used.
      And because only mlflow-xethub==0.0.0 is available, we can conclude that all versions of mlflow-xethub cannot be used.
      And because mlflow[xethub] depends on mlflow-xethub and your project requires mlflow[xethub], we can conclude that
      your project's requirements are unsatisfiable.
```

Since https://github.com/xetdata/pyxet is already deprecated and the number of daily downloads is nearly zero, we can drop this extra.

https://clickpy.clickhouse.com/dashboard/mlflow-xethub

<img width="974" height="653" alt="image" src="https://github.com/user-attachments/assets/a19b9745-a6b5-40e1-88f8-9422121f05dc" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
