### PR TITLE
Proper support for the @latest alias

### DIFF
--- a/docs/docs/genai/prompt-registry/index.mdx
+++ b/docs/docs/genai/prompt-registry/index.mdx
@@ -313,6 +313,14 @@ To avoid accidental deletion, you can only delete one version at a time via API.
 
 A: No, prompt versions are immutable once created. To update a prompt, create a new version with the desired changes.
 
+#### Q: How to dynamically load the latest version of a prompt?
+
+A: You can load the latest version of a prompt by using the `@latest` alias. This is the reserved alias name and MLflow will automatically find the latest available version of the prompt.
+
+```python
+prompt = mlflow.genai.load_prompt("prompts:/summarization-prompt@latest")
+```
+
 #### Q: Can I use prompt templates with frameworks like LangChain or LlamaIndex?
 
 A: Yes, you can load prompts from MLflow and use them with any framework. For example, the following example demonstrates how to use a prompt registered in MLflow with LangChain. Also refer to [Logging Prompts with LangChain](/genai/prompt-registry/log-with-model#example-1-logging-prompts-with-langchain) for more details.

--- a/docs/docs/genai/prompt-registry/manage-prompt-lifecycles-with-aliases.mdx
+++ b/docs/docs/genai/prompt-registry/manage-prompt-lifecycles-with-aliases.mdx
@@ -81,3 +81,12 @@ To load a prompt using an alias, use the `prompts:/<prompt_name>@<alias>` format
 ```python
 prompt = mlflow.load_prompt("prompts:/summarization-prompt@production")
 ```
+
+### Reserved `@latest` alias
+
+The `@latest` alias is a reserved alias name and MLflow will automatically find the latest available version of the prompt. This is useful when you want to dynamically load the latest version of a prompt without updating the application code.
+
+```python
+prompt = mlflow.load_prompt("prompts:/summarization-prompt@latest")
+```
+

--- a/docs/docs/genai/prompt-registry/manage-prompt-lifecycles-with-aliases.mdx
+++ b/docs/docs/genai/prompt-registry/manage-prompt-lifecycles-with-aliases.mdx
@@ -89,4 +89,3 @@ The `@latest` alias is a reserved alias name and MLflow will automatically find 
 ```python
 prompt = mlflow.load_prompt("prompts:/summarization-prompt@latest")
 ```
-

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -61,7 +61,9 @@ from mlflow.utils.search_utils import SearchModelUtils, SearchModelVersionUtils,
 from mlflow.utils.string_utils import is_string_type
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.validation import (
+    _REGISTERED_MODEL_ALIAS_LATEST,
     _validate_model_alias_name,
+    _validate_model_alias_name_reserved,
     _validate_model_version,
     _validate_model_version_tag,
     _validate_registered_model_tag,
@@ -1015,6 +1017,7 @@ class FileStore(AbstractStore):
             None
         """
         alias_path = self._get_registered_model_alias_path(name, alias)
+        _validate_model_alias_name_reserved(alias)
         self._fetch_file_model_version_if_exists(name, version)
         make_containing_dirs(alias_path)
         write_to(alias_path, self._writeable_value(version))
@@ -1049,6 +1052,10 @@ class FileStore(AbstractStore):
         Returns:
             A single :py:class:`mlflow.entities.model_registry.ModelVersion` object.
         """
+        if alias.lower() == _REGISTERED_MODEL_ALIAS_LATEST:
+            latest_version = next(v for v in self.get_latest_versions(name) if v is not None)
+            return self.get_model_version(name, latest_version.version)
+
         alias_path = self._get_registered_model_alias_path(name, alias)
         if exists(alias_path):
             version = read_file(os.path.dirname(alias_path), os.path.basename(alias_path))

--- a/mlflow/store/model_registry/sqlalchemy_store.py
+++ b/mlflow/store/model_registry/sqlalchemy_store.py
@@ -43,6 +43,7 @@ from mlflow.utils.search_utils import SearchModelUtils, SearchModelVersionUtils,
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import extract_db_type_from_uri
 from mlflow.utils.validation import (
+    _REGISTERED_MODEL_ALIAS_LATEST,
     _validate_model_alias_name,
     _validate_model_name,
     _validate_model_renaming,
@@ -1265,6 +1266,11 @@ class SqlAlchemyStore(AbstractStore):
         """
         _validate_model_name(name)
         _validate_model_alias_name(alias)
+
+        if alias.lower() == _REGISTERED_MODEL_ALIAS_LATEST:
+            latest_version = next(v for v in self.get_latest_versions(name) if v is not None)
+            return self.get_model_version(name, latest_version.version)
+
         with self.ManagedSessionMaker() as session:
             existing_alias = self._get_registered_model_alias(session, name, alias)
             if existing_alias is not None:

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -36,6 +36,9 @@ _REGISTERED_MODEL_ALIAS_REGEX = re.compile(r"^[\w\-]*$")
 # Regex for valid registered model alias to prevent conflict with version aliases.
 _REGISTERED_MODEL_ALIAS_VERSION_REGEX = re.compile(r"^[vV]\d+$")
 
+# The reserver "latest" alias name
+_REGISTERED_MODEL_ALIAS_LATEST = "latest"
+
 _BAD_ALIAS_CHARACTERS_MESSAGE = (
     "Names may only contain alphanumerics, underscores (_), and dashes (-)."
 )
@@ -506,6 +509,9 @@ def _validate_model_alias_name(model_alias_name):
         MAX_REGISTERED_MODEL_ALIAS_LENGTH,
         model_alias_name,
     )
+
+
+def _validate_model_alias_name_reserved(model_alias_name):
     if model_alias_name.lower() == "latest":
         raise MlflowException(
             "'latest' alias name (case insensitive) is reserved.",

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2387,6 +2387,10 @@ def test_load_prompt_with_alias_uri(tracking_uri):
     ):
         client.load_prompt("prompts:/alias_prompt@production")
 
+    # Loading with the 'latest' alias
+    prompt = client.load_prompt("prompts:/alias_prompt@latest")
+    assert prompt.template == "Hello, {{name}}!"
+
 
 def test_create_prompt_chat_format_client_integration():
     """Test client-level integration with chat prompts."""

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -18,6 +18,7 @@ from mlflow.utils.validation import (
     _validate_experiment_name,
     _validate_metric_name,
     _validate_model_alias_name,
+    _validate_model_alias_name_reserved,
     _validate_param_name,
     _validate_run_id,
     _validate_tag_name,
@@ -79,11 +80,6 @@ BAD_ALIAS_NAMES = [
     "a" * 256,
     None,
     "$dgs",
-    "v123",
-    "V1",
-    "latest",
-    "Latest",
-    "LATEST",
 ]
 
 
@@ -195,6 +191,12 @@ def test_validate_model_alias_name_bad(alias_name):
         _validate_model_alias_name(alias_name)
     assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
+
+@pytest.mark.parametrize("alias_name", ["latest", "LATEST", "Latest", "v123", "V1"])
+def test_validate_model_alias_name_reserved(alias_name):
+    with pytest.raises(MlflowException, match="reserved") as e:
+        _validate_model_alias_name_reserved(alias_name)
+    assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
 @pytest.mark.parametrize(
     "run_id",

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -198,6 +198,7 @@ def test_validate_model_alias_name_reserved(alias_name):
         _validate_model_alias_name_reserved(alias_name)
     assert e.value.error_code == ErrorCode.Name(INVALID_PARAMETER_VALUE)
 
+
 @pytest.mark.parametrize(
     "run_id",
     [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17146?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17146/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17146/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17146/merge
```

</p>
</details>

### What changes are proposed in this pull request?

While writing a tutorial, I realized the `@latest` alias is marked as "reserved" and users cannot create it. This itself is not an issue, but the problem is the backend doesn't really support loading prompt/model through `@latest` alias, hence `load_model/prompt` returns NotFound error when the alias is specified. This is very confusing.

This PR add support for the missing read path.

```
prompt = mlflow.genai.load_prompt("prompts:/my-prompt@latest")
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support `@latest` alias for dynamically loading the latest version from the MLflow Model/Prompt Registry.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
