### PR TITLE
Retire _AUTOLOGGING_SUPPORTED_VERSION_WARNING_SUPPRESS_LIST list

### DIFF
--- a/mlflow/utils/autologging_utils/__init__.py
+++ b/mlflow/utils/autologging_utils/__init__.py
@@ -60,30 +60,6 @@ AUTOLOGGING_CONF_KEY_IS_GLOBALLY_CONFIGURED = "globally_configured"
 # Dict mapping integration name to its config.
 AUTOLOGGING_INTEGRATIONS = {}
 
-# When the library version installed in the user's environment is outside of the supported
-# version range declared in `ml-package-versions.yml`, a warning message is issued to the user.
-# However, some libraries releases versions very frequently, and our configuration (updated on
-# MLflow release) cannot keep up with the pace, resulting in false alarms. Therefore, we
-# suppress warnings for certain libraries that are known to have frequent releases.
-_AUTOLOGGING_SUPPORTED_VERSION_WARNING_SUPPRESS_LIST = [
-    "langchain",
-    "llama_index",
-    "litellm",
-    "openai",
-    "dspy",
-    "autogen",
-    "ag2",
-    "gemini",
-    "anthropic",
-    "crewai",
-    "bedrock",
-    "mistral",
-    "groq",
-    "smolagents",
-    "pydantic_ai",
-    "semantic_kernel",
-]
-
 # Global lock for turning on / off autologging
 # Note "RLock" is required instead of plain lock, for avoid dead-lock
 _autolog_conf_global_lock = threading.RLock()
@@ -378,23 +354,27 @@ def gen_autologging_package_version_requirements_doc(integration_name):
 
 def _check_and_log_warning_for_unsupported_package_versions(integration_name):
     """
-    When autologging is enabled and `disable_for_unsupported_versions=False` for the specified
-    autologging integration, check whether the currently-installed versions of the integration's
-    associated package versions are supported by the specified integration. If the package versions
-    are not supported, log a warning message.
+    If the package version is not supported for autologging, log a warning message.
+
+    Only check the minimum version, not the maximum version. This is because the "maximum" version
+    in the ml-package-versions.yml is only updated per release and it cannot keep up with the pace
+    of the package releases. The cross-version tests in MLflow CI runs tests against the latest
+    available version, not limited to the "maximum" version, so it is safe to assume it supports
+    up to the latest version.
     """
     if (
         integration_name in FLAVOR_TO_MODULE_NAME
-        and integration_name not in _AUTOLOGGING_SUPPORTED_VERSION_WARNING_SUPPRESS_LIST
         and not get_autologging_config(integration_name, "disable", True)
         and not get_autologging_config(integration_name, "disable_for_unsupported_versions", False)
-        and not is_flavor_supported_for_associated_package_versions(integration_name)
+        and not is_flavor_supported_for_associated_package_versions(
+            integration_name, check_max_version=False
+        )
     ):
-        min_var, max_var, pip_release = get_min_max_version_and_pip_release(integration_name)
+        min_var, _, pip_release = get_min_max_version_and_pip_release(integration_name)
         module = importlib.import_module(FLAVOR_TO_MODULE_NAME[integration_name])
         _logger.warning(
             f"MLflow {integration_name} autologging is known to be compatible with "
-            f"{min_var} <= {pip_release} <= {max_var}, but the installed version is "
+            f"{min_var} <= {pip_release}, but the installed version is "
             f"{module.__version__}. If you encounter errors during autologging, try upgrading "
             f"/ downgrading {pip_release} to a compatible version, or try upgrading MLflow.",
         )

--- a/mlflow/utils/autologging_utils/versioning.py
+++ b/mlflow/utils/autologging_utils/versioning.py
@@ -56,7 +56,7 @@ def get_min_max_version_and_pip_release(
     return min_version, max_version, pip_release
 
 
-def is_flavor_supported_for_associated_package_versions(flavor_name):
+def is_flavor_supported_for_associated_package_versions(flavor_name, check_max_version=True):
     """
     Returns:
         True if the specified flavor is supported for the currently-installed versions of its
@@ -92,4 +92,8 @@ def is_flavor_supported_for_associated_package_versions(flavor_name):
             max_version = "3.3.0"
         return _check_spark_version_in_range(actual_version, min_version, max_version)
     else:
-        return _check_version_in_range(actual_version, min_version, max_version)
+        return (
+            _check_version_in_range(actual_version, min_version, max_version)
+            if check_max_version
+            else Version(min_version) <= Version(actual_version)
+        )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17157?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17157/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17157/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17157/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `_AUTOLOGGING_SUPPORTED_VERSION_WARNING_SUPPRESS_LIST` was added to suppress version compatibility warning for GenAI libraries, because the `ml-package-versions.yml` config cannot catch up with the pace of their release.

The list was added because we only wanted to apply it to whilte-listed GenAI libraries. However, it becomes a source of error when adding new flavors. Indeed, we don't have a strong reason to limit this to GenAI libraries, because our cross-version tests runs against latest versions of other libraries anyway. Therefore, this PR remove the list.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
