### PR TITLE
Handle UserMemory import conditionally in crewai

### DIFF
--- a/mlflow/crewai/__init__.py
+++ b/mlflow/crewai/__init__.py
@@ -39,6 +39,8 @@ def autolog(
     # changing drastically. Add patching once it's stabilized
     import crewai
 
+    CREWAI_VERSION = Version(crewai.__version__)
+
     class_method_map = {
         "crewai.Crew": ["kickoff", "kickoff_for_each", "train"],
         "crewai.Agent": ["execute_task"],
@@ -49,17 +51,18 @@ def autolog(
             "_create_long_term_memory"
         ],
     }
-    if Version(crewai.__version__) >= Version("0.83.0"):
+    if CREWAI_VERSION >= Version("0.83.0"):
         # knowledge and memory are not available before 0.83.0
         class_method_map.update(
             {
                 "crewai.memory.ShortTermMemory": ["save", "search"],
                 "crewai.memory.LongTermMemory": ["save", "search"],
-                "crewai.memory.UserMemory": ["save", "search"],
                 "crewai.memory.EntityMemory": ["save", "search"],
                 "crewai.Knowledge": ["query"],
             }
         )
+        if CREWAI_VERSION < Version("0.157.0"):
+            class_method_map.update({"crewai.memory.UserMemory": ["save", "search"]})
     try:
         for class_path, methods in class_method_map.items():
             *module_parts, class_name = class_path.rsplit(".", 1)

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -54,15 +54,21 @@ def _get_span_type(instance) -> str:
 
         # Knowledge and Memory are not available before 0.83.0
         if Version(crewai.__version__) >= Version("0.83.0"):
-            if isinstance(
-                instance,
-                (
-                    crewai.memory.ShortTermMemory,
-                    crewai.memory.LongTermMemory,
-                    crewai.memory.UserMemory,
-                    crewai.memory.EntityMemory,
-                ),
-            ):
+            memory_classes = (
+                crewai.memory.ShortTermMemory,
+                crewai.memory.LongTermMemory,
+                crewai.memory.EntityMemory,
+            )
+            try:
+                # `UserMemory` was removed in 0.157.0:
+                # https://github.com/crewAIInc/crewAI/pull/3225
+                from crewai.memory import UserMemory
+
+                memory_classes = (*memory_classes, UserMemory)
+            except ImportError:
+                pass
+
+            if isinstance(instance, memory_classes):
                 return SpanType.MEMORY
 
             if isinstance(instance, crewai.Knowledge):

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -52,21 +52,18 @@ def _get_span_type(instance) -> str:
         ):
             return SpanType.MEMORY
 
+        CREWAI_VERSION = Version(crewai.__version__)
         # Knowledge and Memory are not available before 0.83.0
-        if Version(crewai.__version__) >= Version("0.83.0"):
+        if CREWAI_VERSION >= Version("0.83.0"):
             memory_classes = (
                 crewai.memory.ShortTermMemory,
                 crewai.memory.LongTermMemory,
                 crewai.memory.EntityMemory,
             )
-            try:
-                # `UserMemory` was removed in 0.157.0:
-                # https://github.com/crewAIInc/crewAI/pull/3225
-                from crewai.memory import UserMemory
-
-                memory_classes = (*memory_classes, UserMemory)
-            except ImportError:
-                pass
+            # UserMemory was removed in 0.157.0:
+            # https://github.com/crewAIInc/crewAI/pull/3225
+            if CREWAI_VERSION >= Version("0.157.0"):
+                memory_classes = (*memory_classes, crewai.memory.UserMemory)
 
             if isinstance(instance, memory_classes):
                 return SpanType.MEMORY

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -62,7 +62,7 @@ def _get_span_type(instance) -> str:
             )
             # UserMemory was removed in 0.157.0:
             # https://github.com/crewAIInc/crewAI/pull/3225
-            if CREWAI_VERSION >= Version("0.157.0"):
+            if CREWAI_VERSION < Version("0.157.0"):
                 memory_classes = (*memory_classes, crewai.memory.UserMemory)
 
             if isinstance(instance, memory_classes):

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -610,8 +610,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     traces = get_traces()
     assert len(traces) == 1
     assert traces[0].info.status == "OK"
-    expected_num_spans = 9 if Version(crewai.__version__) < Version("0.157.0") else 8
-    assert len(traces[0].data.spans) == expected_num_spans
+    assert len(traces[0].data.spans) == 9
     # Crew
     span_0 = traces[0].data.spans[0]
     assert span_0.name == "Crew.kickoff"

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -610,7 +610,8 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     traces = get_traces()
     assert len(traces) == 1
     assert traces[0].info.status == "OK"
-    assert len(traces[0].data.spans) == 9
+    expected_num_spans = 9 if Version(crewai.__version__) < Version("0.157.0") else 8
+    assert len(traces[0].data.spans) == expected_num_spans
     # Crew
     span_0 = traces[0].data.spans[0]
     assert span_0.name == "Crew.kickoff"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17168?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17168/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17168/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17168/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fixes https://github.com/mlflow/dev/actions/runs/16881225796/job/47845642651#step:13:314:

```
2025/08/11 19:10:13 WARNING mlflow.crewai.autolog: An exception happens when resolving the span type. Exception: module 'crewai.memory' has no attribute 'UserMemory'
```

https://github.com/crewAIInc/crewAI/pull/3225 removed the `UserMemory` class.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
