### PR TITLE
Remove TensorFlow-based transformers tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -488,7 +488,7 @@ transformers:
       # Run all Transformers tests except autologging
       pytest tests/transformers --ignore tests/transformers/test_transformers_autolog.py
       pip uninstall -y accelerate
-      pytest tests/transformers/test_transformers_model_export.py -k "test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies or test_transformers_pt_model_save_dependencies_without_accelerate"
+      pytest tests/transformers/test_transformers_model_export.py -k "test_transformers_pt_model_save_dependencies_without_accelerate"
   autologging:
     minimum: "4.38.2"
     maximum: "4.54.1"

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -148,7 +148,6 @@ def start_container(port: int):
         "statsmodels",
         "tensorflow",
         "transformers_pt",  # Test with Pytorch-based model
-        "transformers_tf",  # Test with TensorFlow-based model
     ],
 )
 def test_build_image_and_serve(flavor, request):

--- a/tests/pyfunc/docker/test_docker_flavors.py
+++ b/tests/pyfunc/docker/test_docker_flavors.py
@@ -60,10 +60,7 @@ if _MLFLOW_RUN_SLOW_TESTS.get():
     )
     from tests.statsmodels.model_fixtures import ols_model
     from tests.tensorflow.test_tensorflow2_core_model_export import tf2_toy_model  # noqa: F401
-    from tests.transformers.helper import (
-        load_small_qa_tf_pipeline,
-        load_text_classification_pipeline,
-    )
+    from tests.transformers.helper import load_text_classification_pipeline
 
 
 pytestmark = pytest.mark.skipif(
@@ -423,17 +420,5 @@ def transformers_pt_model(model_path):
         transformers_model=pipeline,
         path=model_path,
         input_example="hi",
-    )
-    return model_path
-
-
-@pytest.fixture
-def transformers_tf_model(model_path):
-    pipeline = load_small_qa_tf_pipeline()
-    save_model_with_latest_mlflow_version(
-        flavor="transformers",
-        transformers_model=pipeline,
-        path=model_path,
-        input_example={"question": "What is MLflow", "context": "It's an open source platform"},
     )
     return model_path

--- a/tests/transformers/conftest.py
+++ b/tests/transformers/conftest.py
@@ -15,7 +15,6 @@ from tests.transformers.helper import (
     load_small_conversational_model,
     load_small_multi_modal_pipeline,
     load_small_qa_pipeline,
-    load_small_qa_tf_pipeline,
     load_small_vision_model,
     load_summarizer_pipeline,
     load_table_question_answering_pipeline,
@@ -31,11 +30,6 @@ from tests.transformers.helper import (
 @pytest.fixture
 def small_qa_pipeline():
     return load_small_qa_pipeline()
-
-
-@pytest.fixture
-def small_qa_tf_pipeline():
-    return load_small_qa_tf_pipeline()
 
 
 @pytest.fixture

--- a/tests/transformers/helper.py
+++ b/tests/transformers/helper.py
@@ -39,16 +39,6 @@ def load_small_qa_pipeline():
 
 @prefetch
 @flaky()
-def load_small_qa_tf_pipeline():
-    # Same architecture as above but loaded as a Tensorflow based model
-    architecture = "csarron/mobilebert-uncased-squad-v2"
-    tokenizer = transformers.AutoTokenizer.from_pretrained(architecture)
-    model = transformers.TFAutoModelForQuestionAnswering.from_pretrained(architecture)
-    return transformers.pipeline(task="question-answering", model=model, tokenizer=tokenizer)
-
-
-@prefetch
-@flaky()
 def load_small_vision_model():
     architecture = "google/mobilenet_v2_1.0_224"
     feature_extractor = transformers.AutoFeatureExtractor.from_pretrained(

--- a/tests/transformers/test_flavor_configs.py
+++ b/tests/transformers/test_flavor_configs.py
@@ -34,21 +34,6 @@ def multi_modal_pipeline(component_multi_modal):
     return pipeline, task, processor, components
 
 
-def test_flavor_config_tf(small_qa_tf_pipeline):
-    expected = {
-        "task": "question-answering",
-        "instance_type": "QuestionAnsweringPipeline",
-        "pipeline_model_type": "TFMobileBertForQuestionAnswering",
-        "source_model_name": "csarron/mobilebert-uncased-squad-v2",
-        "model_binary": "model",
-        "framework": "tf",
-        "components": ["tokenizer"],
-        "tokenizer_type": "MobileBertTokenizerFast",
-    }
-    conf = build_flavor_config(small_qa_tf_pipeline)
-    assert conf == expected
-
-
 def test_flavor_config_pt_save_pretrained_false(small_qa_pipeline):
     expected = {
         "task": "question-answering",

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -126,7 +126,6 @@ def image_for_test():
     ("pipeline", "expected_requirements"),
     [
         ("small_qa_pipeline", {"transformers", "torch", "torchvision"}),
-        ("small_qa_tf_pipeline", {"transformers", "tensorflow"}),
         pytest.param(
             "peft_pipeline",
             {"peft", "transformers", "torch", "torchvision"},
@@ -734,22 +733,6 @@ def test_transformers_log_with_duplicate_extra_pip_requirements(small_multi_moda
             )
 
 
-@pytest.mark.skipif(
-    importlib.util.find_spec("accelerate") is not None, reason="fails when accelerate is installed"
-)
-def test_transformers_tf_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
-    small_qa_tf_pipeline, model_path
-):
-    mlflow.transformers.save_model(small_qa_tf_pipeline, model_path)
-    _assert_pip_requirements(
-        model_path, mlflow.transformers.get_default_pip_requirements(small_qa_tf_pipeline.model)
-    )
-    pip_requirements = _get_deps_from_requirement_file(model_path)
-    assert "tensorflow" in pip_requirements
-    assert "torch" not in pip_requirements
-    assert "accelerate" not in pip_requirements
-
-
 def test_transformers_pt_model_save_without_conda_env_uses_default_env_with_expected_dependencies(
     small_qa_pipeline, model_path
 ):
@@ -777,26 +760,6 @@ def test_transformers_pt_model_save_dependencies_without_accelerate(
     assert "tensorflow" not in pip_requirements
     assert "accelerate" not in pip_requirements
     assert "torch" in pip_requirements
-
-
-@pytest.mark.skipif(
-    importlib.util.find_spec("accelerate") is not None, reason="fails when accelerate is installed"
-)
-def test_transformers_tf_model_log_without_conda_env_uses_default_env_with_expected_dependencies(
-    small_qa_tf_pipeline,
-):
-    artifact_path = "model"
-    with mlflow.start_run():
-        model_info = mlflow.transformers.log_model(small_qa_tf_pipeline, name=artifact_path)
-    _assert_pip_requirements(
-        model_info.model_uri,
-        mlflow.transformers.get_default_pip_requirements(small_qa_tf_pipeline.model),
-    )
-    pip_requirements = _get_deps_from_requirement_file(model_info.model_uri)
-    assert "tensorflow" in pip_requirements
-    assert "torch" not in pip_requirements
-    # Accelerate installs Pytorch along with it, so it should not be present in the requirements
-    assert "accelerate" not in pip_requirements
 
 
 def test_transformers_pt_model_log_without_conda_env_uses_default_env_with_expected_dependencies(
@@ -3577,10 +3540,10 @@ def test_save_and_load_pipeline_without_save_pretrained_false(
 
 # Patch tempdir just to verify the invocation
 @mock.patch("mlflow.transformers.TempDir", side_effect=mlflow.utils.file_utils.TempDir)
-def test_persist_pretrained_model(mock_tmpdir, small_qa_tf_pipeline):
+def test_persist_pretrained_model(mock_tmpdir, small_qa_pipeline):
     with mlflow.start_run():
         model_info = mlflow.transformers.log_model(
-            small_qa_tf_pipeline,
+            small_qa_pipeline,
             name="model",
             save_pretrained=False,
             pip_requirements=["mlflow"],  # For speed up logging

--- a/tests/transformers/test_transformers_model_export.py
+++ b/tests/transformers/test_transformers_model_export.py
@@ -3566,7 +3566,8 @@ def test_persist_pretrained_model(mock_tmpdir, small_qa_pipeline):
     assert "model_binary" in updated_config
     assert "source_model_revision" not in updated_config
     assert model_path.exists()
-    assert (model_path / "tf_model.h5").exists()
+    model_path_files = list(model_path.iterdir())
+    assert len(model_path_files) > 0
     assert tokenizer_path.exists()
     assert (tokenizer_path / "tokenizer.json").exists()
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17170?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17170/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17170/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17170/merge
```

</p>
</details>

### Related Issues/PRs

Related to https://github.com/huggingface/transformers/issues/40028

### What changes are proposed in this pull request?

TF models in transformers are deprecated and no longer actively maintained. This PR removes them to reduce maintenance burden.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The remaining transformers tests continue to work with both older and newer versions of the transformers library.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This change only affects test code and does not impact user-facing functionality.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)