### PR TITLE
Skip optimized prompt registration when autolog=False

### DIFF
--- a/mlflow/genai/optimize/base.py
+++ b/mlflow/genai/optimize/base.py
@@ -148,10 +148,8 @@ def optimize_prompt(
         )
 
         if optimizer_config.skip_registration:
-            # Skip registration and return the raw optimized template
             result_prompt = optimizer_output.optimized_prompt
         else:
-            # Register the optimized prompt as a new version
             optimized_prompt = register_prompt(
                 name=prompt.name,
                 template=optimizer_output.optimized_prompt,

--- a/mlflow/genai/optimize/base.py
+++ b/mlflow/genai/optimize/base.py
@@ -52,8 +52,9 @@ def optimize_prompt(
     """
     Optimize a LLM prompt using the given dataset and evaluation metrics.
     By default, the optimized prompt template is automatically registered as a new version of the
-    original prompt. This can be disabled using the skip_registration parameter in optimizer_config.
-    Currently, this API only supports DSPy's MIPROv2 optimizer.
+    original prompt and optimization metrics are logged.
+    Currently, this API provides built-in support for DSPy's MIPROv2 optimizer and
+    you can also implement custom optimization algorithms by extending BasePromptOptimizer class.
 
     Args:
         target_llm_params: Parameters for the the LLM that prompt is optimized for.
@@ -83,8 +84,7 @@ def optimize_prompt(
             returns a float value (greater is better).
         eval_data: Evaluation dataset with the same format as train_data. If not provided,
             train_data will be automatically split into training and evaluation sets.
-        optimizer_config: Configuration parameters for the optimizer. Use skip_registration=True
-            to disable automatic prompt registration and get the raw optimized template instead.
+        optimizer_config: Configuration parameters for the optimizer.
 
     Returns:
         PromptOptimizationResult: The optimization result including the optimized prompt.
@@ -147,7 +147,7 @@ def optimize_prompt(
             eval_data=eval_data,
         )
 
-        if optimizer_config.skip_registration:
+        if not optimizer_config.autolog:
             result_prompt = optimizer_output.optimized_prompt
         else:
             optimized_prompt = register_prompt(
@@ -158,8 +158,7 @@ def optimize_prompt(
                 },
             )
             result_prompt = optimized_prompt
-            if optimizer_config.autolog:
-                _log_optimization_result(optimizer_output.final_eval_score, optimized_prompt)
+            _log_optimization_result(optimizer_output.final_eval_score, optimized_prompt)
 
     return PromptOptimizationResult(
         prompt=result_prompt,

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -20,9 +20,9 @@ class PromptOptimizationResult:
     Result of the :py:func:`mlflow.genai.optimize_prompt()` API.
 
     Args:
-        prompt: The optimized prompt. When skip_registration=False (default), this is a
+        prompt: The optimized prompt. When autolog=True (default), this is a
             PromptVersion entity containing the registered optimized template.
-            When skip_registration=True, this is the raw optimized template (str or dict).
+            When autolog=False, this is the raw optimized template (str or dict).
         initial_prompt: A prompt version entity containing the initial template.
         optimizer_name: The name of the optimizer.
         final_eval_score: The final evaluation score of the optimized prompt.
@@ -78,16 +78,15 @@ class OptimizerConfig:
             When a BasePromptOptimizer is provided, it will be used as the optimizer.
             Default: "DSPy/MIPROv2"
         verbose: Whether to show optimizer logs during optimization. Default: False
-        autolog: Whether to log the optimization parameters, datasets and metrics.
-            If set to True, a MLflow run is automatically created to store them.
-            Default: False
+        autolog: Whether to enable automatic logging and prompt registration.
+            If set to True, a MLflow run is automatically created to store optimization
+            parameters, datasets and metrics, and the optimized prompt is registered.
+            If set to False, the raw optimized template is returned without registration.
+            Default: True
         convert_to_single_text: Whether to convert the optimized prompt to a single prompt.
             Default: True
         extract_instructions: Whether to extract instructions from the initial prompt.
             Default: True
-        skip_registration: Whether to skip registering the optimized prompt as a new version.
-            If True, the optimized prompt will be returned in the result without registration.
-            Default: False
     """
 
     num_instruction_candidates: int = 6
@@ -96,10 +95,9 @@ class OptimizerConfig:
     optimizer_llm: LLMParams | None = None
     algorithm: str | type["BasePromptOptimizer"] = "DSPy/MIPROv2"
     verbose: bool = False
-    autolog: bool = False
+    autolog: bool = True
     convert_to_single_text: bool = True
     extract_instructions: bool = True
-    skip_registration: bool = False
 
 
 @experimental(version="3.3.0")

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -20,14 +20,16 @@ class PromptOptimizationResult:
     Result of the :py:func:`mlflow.genai.optimize_prompt()` API.
 
     Args:
-        prompt: A prompt version entity containing the optimized template.
+        prompt: The optimized prompt. When skip_registration=False (default), this is a
+            PromptVersion entity containing the registered optimized template.
+            When skip_registration=True, this is the raw optimized template (str or dict).
         initial_prompt: A prompt version entity containing the initial template.
         optimizer_name: The name of the optimizer.
         final_eval_score: The final evaluation score of the optimized prompt.
         initial_eval_score: The initial evaluation score of the optimized prompt.
     """
 
-    prompt: PromptVersion
+    prompt: str | dict[str, Any] | PromptVersion
     initial_prompt: PromptVersion
     optimizer_name: str
     final_eval_score: float | None
@@ -83,6 +85,9 @@ class OptimizerConfig:
             Default: True
         extract_instructions: Whether to extract instructions from the initial prompt.
             Default: True
+        skip_registration: Whether to skip registering the optimized prompt as a new version.
+            If True, the optimized prompt will be returned in the result without registration.
+            Default: False
     """
 
     num_instruction_candidates: int = 6
@@ -94,6 +99,7 @@ class OptimizerConfig:
     autolog: bool = False
     convert_to_single_text: bool = True
     extract_instructions: bool = True
+    skip_registration: bool = False
 
 
 @experimental(version="3.3.0")


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR changes the behavior of optimize_prompt and skip prompt registration when `autolog=False`. This is useful when developers just want to get the optimized result. We also change the default to autolog=True.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
