### PR TITLE
Enable diagnostic settings for agents in semantic kernel autolog

### DIFF
--- a/mlflow/semantic_kernel/autolog.py
+++ b/mlflow/semantic_kernel/autolog.py
@@ -37,11 +37,10 @@ def _enable_experimental_genai_tracing():
         MODEL_DIAGNOSTICS_SETTINGS,
     )
 
-    MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
-    MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
-
     AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
     AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
+    MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
+    MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
 
     _logger.info("Semantic Kernel Otel diagnostics is turned on for enabling tracing.")
 

--- a/mlflow/semantic_kernel/autolog.py
+++ b/mlflow/semantic_kernel/autolog.py
@@ -30,17 +30,24 @@ def _enable_experimental_genai_tracing():
     # We directly update the singleton setting object instead of using env vars,
     # because the object might be already initialized by the time we call this function.
     # https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/telemetry-with-console
-    from semantic_kernel.utils.telemetry.agent_diagnostics.decorators import (
-        MODEL_DIAGNOSTICS_SETTINGS as AGENT_DIAGNOSTICS_SETTINGS,
-    )
+
     from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
         MODEL_DIAGNOSTICS_SETTINGS,
     )
 
-    AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
-    AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
     MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
     MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
+
+    try:
+        # This only exists in Semantic Kernel 1.35.1 or later.
+        from semantic_kernel.utils.telemetry.agent_diagnostics.decorators import (
+            MODEL_DIAGNOSTICS_SETTINGS as AGENT_DIAGNOSTICS_SETTINGS,
+        )
+
+        AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
+        AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
+    except ImportError:
+        pass
 
     _logger.info("Semantic Kernel Otel diagnostics is turned on for enabling tracing.")
 

--- a/mlflow/semantic_kernel/autolog.py
+++ b/mlflow/semantic_kernel/autolog.py
@@ -30,7 +30,6 @@ def _enable_experimental_genai_tracing():
     # We directly update the singleton setting object instead of using env vars,
     # because the object might be already initialized by the time we call this function.
     # https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/telemetry-with-console
-
     from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
         MODEL_DIAGNOSTICS_SETTINGS,
     )

--- a/mlflow/semantic_kernel/autolog.py
+++ b/mlflow/semantic_kernel/autolog.py
@@ -30,12 +30,18 @@ def _enable_experimental_genai_tracing():
     # We directly update the singleton setting object instead of using env vars,
     # because the object might be already initialized by the time we call this function.
     # https://learn.microsoft.com/en-us/semantic-kernel/concepts/enterprise-readiness/observability/telemetry-with-console
+    from semantic_kernel.utils.telemetry.agent_diagnostics.decorators import (
+        MODEL_DIAGNOSTICS_SETTINGS as AGENT_DIAGNOSTICS_SETTINGS,
+    )
     from semantic_kernel.utils.telemetry.model_diagnostics.decorators import (
         MODEL_DIAGNOSTICS_SETTINGS,
     )
 
     MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
     MODEL_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
+
+    AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics = True
+    AGENT_DIAGNOSTICS_SETTINGS.enable_otel_diagnostics_sensitive = True
 
     _logger.info("Semantic Kernel Otel diagnostics is turned on for enabling tracing.")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17182?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17182/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17182/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17182/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Fix #17175.

https://github.com/microsoft/semantic-kernel/commit/b7bb2832aaa7729d5fd124c33bc40c0a2b8e7fab added an isolated config for agents (`semantic_kernel.utils.telemetry.agent_diagnostics.decorators.MODEL_DIAGNOSTICS_SETTINGS`). For autolog to work properly, `enable_otel_diagnostics` and `enable_otel_diagnostics_sensitive` of this config needs to enabled.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
