### PR TITLE
Support resume run for Optuna 

### DIFF
--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -277,6 +277,39 @@ class MlflowStorage(BaseStorage):
         else:
             raise Exception(f"Study {study_name} not found")
 
+    def study_exists(self, study_name: str) -> bool:
+        """Check if a study with the given name exists.
+        
+        Args:
+            study_name: The name of the study to check
+            
+        Returns:
+            True if the study exists, False otherwise
+        """
+        # Flush all batches to ensure we have the latest data
+        self.flush_all_batches()
+        
+        runs = self._search_run_by_name(study_name)
+        return len(runs) > 0
+
+    def get_study_id_from_name_if_exists(self, study_name: str):
+        """Get study ID from name if it exists, otherwise return None.
+        
+        Args:
+            study_name: The name of the study to look for
+            
+        Returns:
+            Study ID if found, None otherwise
+        """
+        # Flush all batches to ensure we have the latest data
+        self.flush_all_batches()
+
+        runs = self._search_run_by_name(study_name)
+        if len(runs):
+            return runs[0].info.run_id
+        else:
+            return None
+
     def get_study_name_from_id(self, study_id) -> str:
         # Flush the batch for this study to ensure we have the latest data
         self._flush_batch(study_id)

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -230,7 +230,9 @@ class MlflowStorage(BaseStorage):
     def _search_run_by_name(self, run_name: str):
         filter_string = f"tags.mlflow.runName = '{run_name}'"
         return self._mlflow_client.search_runs(
-            experiment_ids=[self._experiment_id], filter_string=filter_string
+            experiment_ids=[self._experiment_id], 
+            filter_string=filter_string,
+            order_by=["attributes.start_time DESC"]
         )
 
     def create_new_study(

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -279,7 +279,7 @@ class MlflowStorage(BaseStorage):
         else:
             raise Exception(f"Study {study_name} not found")
 
-    def get_study_id_by_name_if_exists(self, study_name: str):
+    def get_study_id_by_name_if_exists(self, study_name: str) -> str | None:
         """Get study ID from name if it exists, otherwise return None.
 
         Args:
@@ -291,8 +291,7 @@ class MlflowStorage(BaseStorage):
         # Flush all batches to ensure we have the latest data
         self.flush_all_batches()
 
-        runs = self._search_runs_by_name(study_name)
-        if len(runs):
+        if runs := self._search_runs_by_name(study_name):
             return runs[0].info.run_id
         else:
             return None

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -279,21 +279,6 @@ class MlflowStorage(BaseStorage):
         else:
             raise Exception(f"Study {study_name} not found")
 
-    def study_exists(self, study_name: str) -> bool:
-        """Check if a study with the given name exists.
-
-        Args:
-            study_name: The name of the study to check
-
-        Returns:
-            True if the study exists, False otherwise
-        """
-        # Flush all batches to ensure we have the latest data
-        self.flush_all_batches()
-
-        runs = self._search_runs_by_name(study_name)
-        return len(runs) > 0
-
     def get_study_id_by_name_if_exists(self, study_name: str):
         """Get study ID from name if it exists, otherwise return None.
 

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -227,10 +227,10 @@ class MlflowStorage(BaseStorage):
         for run_id in run_ids:
             self._flush_batch(run_id)
 
-    def _search_run_by_name(self, run_name: str):
+    def _search_runs_by_name(self, run_name: str):
         filter_string = f"tags.mlflow.runName = '{run_name}'"
         return self._mlflow_client.search_runs(
-            experiment_ids=[self._experiment_id], 
+            experiment_ids=[self._experiment_id],
             filter_string=filter_string,
             order_by=["attributes.start_time DESC"]
         )
@@ -273,7 +273,7 @@ class MlflowStorage(BaseStorage):
         # Flush all batches to ensure we have the latest data
         self.flush_all_batches()
 
-        runs = self._search_run_by_name(study_name)
+        runs = self._search_runs_by_name(study_name)
         if len(runs):
             return runs[0].info.run_id
         else:
@@ -291,10 +291,10 @@ class MlflowStorage(BaseStorage):
         # Flush all batches to ensure we have the latest data
         self.flush_all_batches()
 
-        runs = self._search_run_by_name(study_name)
+        runs = self._search_runs_by_name(study_name)
         return len(runs) > 0
 
-    def get_study_id_from_name_if_exists(self, study_name: str):
+    def get_study_id_by_name_if_exists(self, study_name: str):
         """Get study ID from name if it exists, otherwise return None.
 
         Args:
@@ -306,7 +306,7 @@ class MlflowStorage(BaseStorage):
         # Flush all batches to ensure we have the latest data
         self.flush_all_batches()
 
-        runs = self._search_run_by_name(study_name)
+        runs = self._search_runs_by_name(study_name)
         if len(runs):
             return runs[0].info.run_id
         else:

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -232,7 +232,7 @@ class MlflowStorage(BaseStorage):
         return self._mlflow_client.search_runs(
             experiment_ids=[self._experiment_id],
             filter_string=filter_string,
-            order_by=["attributes.start_time DESC"]
+            order_by=["attributes.start_time DESC"],
         )
 
     def create_new_study(

--- a/mlflow/optuna/storage.py
+++ b/mlflow/optuna/storage.py
@@ -279,25 +279,25 @@ class MlflowStorage(BaseStorage):
 
     def study_exists(self, study_name: str) -> bool:
         """Check if a study with the given name exists.
-        
+
         Args:
             study_name: The name of the study to check
-            
+
         Returns:
             True if the study exists, False otherwise
         """
         # Flush all batches to ensure we have the latest data
         self.flush_all_batches()
-        
+
         runs = self._search_run_by_name(study_name)
         return len(runs) > 0
 
     def get_study_id_from_name_if_exists(self, study_name: str):
         """Get study ID from name if it exists, otherwise return None.
-        
+
         Args:
             study_name: The name of the study to look for
-            
+
         Returns:
             Study ID if found, None otherwise
         """

--- a/mlflow/pyspark/optuna/study.py
+++ b/mlflow/pyspark/optuna/study.py
@@ -256,8 +256,10 @@ class MlflowSparkStudy(Study):
     ) -> None:
         # Add logging for resume information
         if self._is_resumed and self._study.trials:
-            _logger.info(f"Continuing optimization with {len(self._study.trials)} existing trials")
-            _logger.info(f"Current best value: {self._study.best_value}")
+            _logger.info(f"""
+            Continuing optimization with {len(self._study.trials)} existing trials.
+            Current best value: {self._study.best_value}
+            """)
         elif self._is_resumed:
             _logger.info("Resuming study with no previous trials")
         else:

--- a/mlflow/pyspark/optuna/study.py
+++ b/mlflow/pyspark/optuna/study.py
@@ -214,7 +214,7 @@ class MlflowSparkStudy(Study):
         """
         return len([t for t in self._study.trials if t.state == TrialState.COMPLETE])
 
-    def get_resume_info(self) -> dict:
+    def get_resume_info(self) -> dict[str, any]:
         """Get information about the resumed study.
 
         Returns:

--- a/mlflow/pyspark/optuna/study.py
+++ b/mlflow/pyspark/optuna/study.py
@@ -4,6 +4,7 @@ import tempfile
 import traceback
 from collections.abc import Callable, Iterable
 from pathlib import Path
+from typing import Any
 
 import optuna
 import pandas as pd
@@ -214,7 +215,7 @@ class MlflowSparkStudy(Study):
         """
         return len([t for t in self._study.trials if t.state == TrialState.COMPLETE])
 
-    def get_resume_info(self) -> dict[str, any]:
+    def get_resume_info(self) -> dict[str, Any]:
         """Get information about the resumed study.
 
         Returns:

--- a/mlflow/pyspark/optuna/study.py
+++ b/mlflow/pyspark/optuna/study.py
@@ -29,8 +29,8 @@ class ResumeInfo:
     study_name: str | None = None
     existing_trials: int | None = None
     completed_trials: int | None = None
-    best_value: Any | None = None
-    best_params: Any | None = None
+    best_value: float | None = None
+    best_params: dict[str, Any] | None = None
 
 
 def is_spark_connect_mode() -> bool:
@@ -187,7 +187,7 @@ class MlflowSparkStudy(Study):
             )
 
         # Check if study exists and auto-resume if it does
-        if self._storage.study_exists(self.study_name):
+        if self._storage.get_study_id_by_name_if_exists(self.study_name):
             # Load existing study
             self._study = optuna.load_study(
                 study_name=self.study_name, sampler=self.sampler, storage=self._storage
@@ -226,7 +226,7 @@ class MlflowSparkStudy(Study):
         """
         return len([t for t in self._study.trials if t.state == TrialState.COMPLETE])
 
-    def get_resume_info(self) -> ResumeInfo:
+    def get_resume_info(self) -> ResumeInfo | None:
         """Get information about the resumed study.
 
         Returns:

--- a/mlflow/pyspark/optuna/study.py
+++ b/mlflow/pyspark/optuna/study.py
@@ -141,7 +141,7 @@ class MlflowSparkStudy(Study):
         storage = MlflowStorage(experiment_id=experiment_id)
         mlflow_study = MlflowSparkStudy(study_name, storage)
         mlflow_study.optimize(objective, n_trials=4)
-        
+
         # Later, create another instance with same name to resume
         resumed_study = MlflowSparkStudy(study_name, storage)
         print(f"Resumed with {len(resumed_study.trials)} existing trials")
@@ -182,7 +182,9 @@ class MlflowSparkStudy(Study):
             )
             self._study_id = self._storage.get_study_id_from_name(self.study_name)
             self._is_resumed = True
-            _logger.info(f"Resuming existing study '{self.study_name}' with {len(self._study.trials)} trials")
+            _logger.info(
+                f"Resuming existing study '{self.study_name}' with {len(self._study.trials)} trials"
+            )
         else:
             # Create new study
             self._study = optuna.create_study(
@@ -191,22 +193,22 @@ class MlflowSparkStudy(Study):
             self._study_id = self._storage.get_study_id_from_name(self.study_name)
             self._is_resumed = False
             _logger.info(f"Created new study '{self.study_name}'")
-            
+
         self._directions = self._storage.get_study_directions(self._study_id)
 
     @property
     def is_resumed_study(self) -> bool:
         """Check if this study was resumed from existing data.
-        
+
         Returns:
             True if the study was resumed from existing data, False if it's a new study
         """
         return self._is_resumed
 
-    @property  
+    @property
     def completed_trials_count(self) -> int:
         """Number of completed trials in the study.
-        
+
         Returns:
             Count of trials that have completed successfully
         """
@@ -214,13 +216,13 @@ class MlflowSparkStudy(Study):
 
     def get_resume_info(self) -> dict:
         """Get information about the resumed study.
-        
+
         Returns:
             Dictionary containing resume information including trial counts and best results
         """
         if not self._is_resumed:
             return {"is_resumed": False}
-        
+
         return {
             "is_resumed": True,
             "study_name": self.study_name,
@@ -247,7 +249,7 @@ class MlflowSparkStudy(Study):
             _logger.info("Resuming study with no previous trials")
         else:
             _logger.info("Starting optimization for new study")
-            
+
         experiment_id = self._storage._experiment_id
         study_name = self.study_name
         mlflow_tracking_env = self._mlflow_tracking_env

--- a/mlflow/pyspark/optuna/study.py
+++ b/mlflow/pyspark/optuna/study.py
@@ -29,8 +29,8 @@ class ResumeInfo:
     study_name: str | None = None
     existing_trials: int | None = None
     completed_trials: int | None = None
-    best_value: Any = None
-    best_params: Any = None
+    best_value: Any | None = None
+    best_params: Any | None = None
 
 
 def is_spark_connect_mode() -> bool:

--- a/tests/optuna/test_storage.py
+++ b/tests/optuna/test_storage.py
@@ -689,7 +689,7 @@ def test_study_exists_method(setup_storage):
     assert not storage.study_exists("non-existent-study")
 
     # Create a study
-    study_id = storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
+    storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
 
     # Test existing study
     assert storage.study_exists("test-study")

--- a/tests/optuna/test_storage.py
+++ b/tests/optuna/test_storage.py
@@ -682,7 +682,6 @@ def test_get_n_trials(setup_storage):
 
 
 def test_study_exists_method(setup_storage):
-    """Test study_exists method."""
     storage = setup_storage
 
     # Test non-existent study
@@ -696,7 +695,6 @@ def test_study_exists_method(setup_storage):
 
 
 def test_get_study_id_by_name_if_exists(setup_storage):
-    """Test get_study_id_by_name_if_exists method."""
     storage = setup_storage
 
     # Test non-existent study

--- a/tests/optuna/test_storage.py
+++ b/tests/optuna/test_storage.py
@@ -686,13 +686,13 @@ def test_study_exists_method(setup_storage):
     storage = setup_storage
 
     # Test non-existent study
-    assert not storage.study_exists("non-existent-study")
+    assert not storage.get_study_id_by_name_if_exists("non-existent-study")
 
     # Create a study
     storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
 
     # Test existing study
-    assert storage.study_exists("test-study")
+    assert storage.get_study_id_by_name_if_exists("test-study")
 
 
 def test_get_study_id_by_name_if_exists(setup_storage):

--- a/tests/optuna/test_storage.py
+++ b/tests/optuna/test_storage.py
@@ -684,13 +684,13 @@ def test_get_n_trials(setup_storage):
 def test_study_exists_method(setup_storage):
     """Test study_exists method."""
     storage = setup_storage
-    
+
     # Test non-existent study
     assert not storage.study_exists("non-existent-study")
-    
+
     # Create a study
     study_id = storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
-    
+
     # Test existing study
     assert storage.study_exists("test-study")
 
@@ -698,13 +698,13 @@ def test_study_exists_method(setup_storage):
 def test_get_study_id_from_name_if_exists(setup_storage):
     """Test get_study_id_from_name_if_exists method."""
     storage = setup_storage
-    
+
     # Test non-existent study
     assert storage.get_study_id_from_name_if_exists("non-existent") is None
-    
+
     # Create a study
     study_id = storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
-    
+
     # Test existing study
     result = storage.get_study_id_from_name_if_exists("test-study")
     assert result == study_id

--- a/tests/optuna/test_storage.py
+++ b/tests/optuna/test_storage.py
@@ -695,16 +695,16 @@ def test_study_exists_method(setup_storage):
     assert storage.study_exists("test-study")
 
 
-def test_get_study_id_from_name_if_exists(setup_storage):
-    """Test get_study_id_from_name_if_exists method."""
+def test_get_study_id_by_name_if_exists(setup_storage):
+    """Test get_study_id_by_name_if_exists method."""
     storage = setup_storage
 
     # Test non-existent study
-    assert storage.get_study_id_from_name_if_exists("non-existent") is None
+    assert storage.get_study_id_by_name_if_exists("non-existent") is None
 
     # Create a study
     study_id = storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
 
     # Test existing study
-    result = storage.get_study_id_from_name_if_exists("test-study")
+    result = storage.get_study_id_by_name_if_exists("test-study")
     assert result == study_id

--- a/tests/optuna/test_storage.py
+++ b/tests/optuna/test_storage.py
@@ -679,3 +679,32 @@ def test_get_n_trials(setup_storage):
     study_id_to_frozen_studies, _ = _setup_studies(storage, n_study=2, n_trial=7, seed=50)
     for study_id in study_id_to_frozen_studies:
         assert storage.get_n_trials(study_id) == 7
+
+
+def test_study_exists_method(setup_storage):
+    """Test study_exists method."""
+    storage = setup_storage
+    
+    # Test non-existent study
+    assert not storage.study_exists("non-existent-study")
+    
+    # Create a study
+    study_id = storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
+    
+    # Test existing study
+    assert storage.study_exists("test-study")
+
+
+def test_get_study_id_from_name_if_exists(setup_storage):
+    """Test get_study_id_from_name_if_exists method."""
+    storage = setup_storage
+    
+    # Test non-existent study
+    assert storage.get_study_id_from_name_if_exists("non-existent") is None
+    
+    # Create a study
+    study_id = storage.create_new_study([StudyDirection.MINIMIZE], "test-study")
+    
+    # Test existing study
+    result = storage.get_study_id_from_name_if_exists("test-study")
+    assert result == study_id

--- a/tests/pyspark/optuna/test_study.py
+++ b/tests/pyspark/optuna/test_study.py
@@ -92,7 +92,6 @@ def test_study_with_failed_objective(setup_storage):
 
 
 def test_auto_resume_existing_study(setup_storage):
-    """Test that MlflowSparkStudy automatically resumes existing studies."""
     storage = setup_storage
     study_name = "resume-test-study"
     sampler = TPESampler(seed=42)
@@ -118,9 +117,11 @@ def test_auto_resume_existing_study(setup_storage):
     study2.optimize(objective, n_trials=2, n_jobs=1)
     assert len(study2.trials) == first_trial_count + 2
 
+    # Assert that the resumed study generates a better (lower) objective value than the first study
+    assert study2.best_value <= first_best_value
+
 
 def test_new_study_is_not_resumed(setup_storage):
-    """Test that new studies are correctly identified as not resumed."""
     storage = setup_storage
     study_name = "new-study"
 
@@ -133,7 +134,6 @@ def test_new_study_is_not_resumed(setup_storage):
 
 
 def test_resume_info_method(setup_storage):
-    """Test get_resume_info method."""
     storage = setup_storage
     study_name = "info-test-study"
     sampler = TPESampler(seed=123)
@@ -163,7 +163,6 @@ def test_resume_info_method(setup_storage):
 
 
 def test_completed_trials_count_property(setup_storage):
-    """Test completed_trials_count property."""
     storage = setup_storage
     study_name = "count-test-study"
 
@@ -182,7 +181,6 @@ def test_completed_trials_count_property(setup_storage):
 
 
 def test_resume_preserves_best_results(setup_storage):
-    """Test that resuming preserves best results from previous optimization."""
     storage = setup_storage
     study_name = "best-results-study"
     sampler = TPESampler(seed=456)

--- a/tests/pyspark/optuna/test_study.py
+++ b/tests/pyspark/optuna/test_study.py
@@ -89,3 +89,122 @@ def test_study_with_failed_objective(setup_storage):
         match="Optimization run for Optuna MlflowSparkStudy failed",
     ):
         mlflow_study.optimize(fail_objective, n_trials=4)
+
+
+def test_auto_resume_existing_study(setup_storage):
+    """Test that MlflowSparkStudy automatically resumes existing studies."""
+    storage = setup_storage
+    study_name = "resume-test-study"
+    sampler = TPESampler(seed=42)
+    
+    # Create first study and run some trials
+    study1 = MlflowSparkStudy(study_name, storage, sampler=sampler)
+    assert not study1.is_resumed_study
+    
+    def objective(trial):
+        return trial.suggest_float("x", 0, 10) ** 2
+    
+    study1.optimize(objective, n_trials=3, n_jobs=1)
+    first_trial_count = len(study1.trials)
+    first_best_value = study1.best_value
+    
+    # Create second study with same name - should resume
+    study2 = MlflowSparkStudy(study_name, storage, sampler=sampler)
+    assert study2.is_resumed_study
+    assert len(study2.trials) == first_trial_count
+    assert study2.best_value == first_best_value
+    
+    # Continue optimization
+    study2.optimize(objective, n_trials=2, n_jobs=1)
+    assert len(study2.trials) == first_trial_count + 2
+
+
+def test_new_study_is_not_resumed(setup_storage):
+    """Test that new studies are correctly identified as not resumed."""
+    storage = setup_storage
+    study_name = "new-study"
+    
+    study = MlflowSparkStudy(study_name, storage)
+    assert not study.is_resumed_study
+    assert study.completed_trials_count == 0
+    
+    info = study.get_resume_info()
+    assert not info["is_resumed"]
+
+
+def test_resume_info_method(setup_storage):
+    """Test get_resume_info method."""
+    storage = setup_storage
+    study_name = "info-test-study"
+    sampler = TPESampler(seed=123)
+    
+    # New study
+    study1 = MlflowSparkStudy(study_name, storage, sampler=sampler)
+    info = study1.get_resume_info()
+    assert not info["is_resumed"]
+    
+    # Run some trials
+    def objective(trial):
+        return trial.suggest_float("x", 0, 1) ** 2
+        
+    study1.optimize(objective, n_trials=2, n_jobs=1)
+    
+    # Resume study
+    study2 = MlflowSparkStudy(study_name, storage, sampler=sampler)
+    info = study2.get_resume_info()
+    assert info["is_resumed"]
+    assert info["study_name"] == study_name
+    assert info["existing_trials"] == 2
+    assert info["completed_trials"] == 2
+    assert "best_value" in info
+    assert "best_params" in info
+    assert info["best_value"] is not None
+    assert info["best_params"] is not None
+
+
+def test_completed_trials_count_property(setup_storage):
+    """Test completed_trials_count property."""
+    storage = setup_storage
+    study_name = "count-test-study"
+    
+    study = MlflowSparkStudy(study_name, storage)
+    assert study.completed_trials_count == 0
+    
+    def objective(trial):
+        return trial.suggest_float("x", 0, 1)
+    
+    study.optimize(objective, n_trials=3, n_jobs=1)
+    assert study.completed_trials_count == 3
+    
+    # Resume and check count is preserved
+    resumed_study = MlflowSparkStudy(study_name, storage)
+    assert resumed_study.completed_trials_count == 3
+
+
+def test_resume_preserves_best_results(setup_storage):
+    """Test that resuming preserves best results from previous optimization."""
+    storage = setup_storage
+    study_name = "best-results-study"
+    sampler = TPESampler(seed=456)
+    
+    def objective(trial):
+        x = trial.suggest_float("x", -10, 10)
+        return (x - 2) ** 2
+    
+    # First optimization
+    study1 = MlflowSparkStudy(study_name, storage, sampler=sampler)
+    study1.optimize(objective, n_trials=5, n_jobs=1)
+    
+    original_best_value = study1.best_value
+    original_best_params = study1.best_params.copy()
+    
+    # Resume and verify best results are preserved
+    study2 = MlflowSparkStudy(study_name, storage, sampler=sampler)
+    assert study2.best_value == original_best_value
+    assert study2.best_params == original_best_params
+    
+    # Continue optimization and verify it can improve
+    study2.optimize(objective, n_trials=5, n_jobs=1)
+    
+    # Best value should be the same or better (lower for minimization)
+    assert study2.best_value <= original_best_value

--- a/tests/pyspark/optuna/test_study.py
+++ b/tests/pyspark/optuna/test_study.py
@@ -130,7 +130,7 @@ def test_new_study_is_not_resumed(setup_storage):
     assert study.completed_trials_count == 0
 
     info = study.get_resume_info()
-    assert not info["is_resumed"]
+    assert not info.is_resumed
 
 
 def test_resume_info_method(setup_storage):
@@ -141,7 +141,7 @@ def test_resume_info_method(setup_storage):
     # New study
     study1 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     info = study1.get_resume_info()
-    assert not info["is_resumed"]
+    assert not info.is_resumed
 
     # Run some trials
     def objective(trial):
@@ -152,14 +152,14 @@ def test_resume_info_method(setup_storage):
     # Resume study
     study2 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     info = study2.get_resume_info()
-    assert info["is_resumed"]
-    assert info["study_name"] == study_name
-    assert info["existing_trials"] == 2
-    assert info["completed_trials"] == 2
-    assert "best_value" in info
-    assert "best_params" in info
-    assert info["best_value"] is not None
-    assert info["best_params"] is not None
+    assert info.is_resumed
+    assert info.study_name == study_name
+    assert info.existing_trials == 2
+    assert info.completed_trials == 2
+    assert hasattr(info, "best_value")
+    assert hasattr(info, "best_params")
+    assert info.best_value is not None
+    assert info.best_params is not None
 
 
 def test_completed_trials_count_property(setup_storage):

--- a/tests/pyspark/optuna/test_study.py
+++ b/tests/pyspark/optuna/test_study.py
@@ -96,24 +96,24 @@ def test_auto_resume_existing_study(setup_storage):
     storage = setup_storage
     study_name = "resume-test-study"
     sampler = TPESampler(seed=42)
-    
+
     # Create first study and run some trials
     study1 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     assert not study1.is_resumed_study
-    
+
     def objective(trial):
         return trial.suggest_float("x", 0, 10) ** 2
-    
+
     study1.optimize(objective, n_trials=3, n_jobs=1)
     first_trial_count = len(study1.trials)
     first_best_value = study1.best_value
-    
+
     # Create second study with same name - should resume
     study2 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     assert study2.is_resumed_study
     assert len(study2.trials) == first_trial_count
     assert study2.best_value == first_best_value
-    
+
     # Continue optimization
     study2.optimize(objective, n_trials=2, n_jobs=1)
     assert len(study2.trials) == first_trial_count + 2
@@ -123,11 +123,11 @@ def test_new_study_is_not_resumed(setup_storage):
     """Test that new studies are correctly identified as not resumed."""
     storage = setup_storage
     study_name = "new-study"
-    
+
     study = MlflowSparkStudy(study_name, storage)
     assert not study.is_resumed_study
     assert study.completed_trials_count == 0
-    
+
     info = study.get_resume_info()
     assert not info["is_resumed"]
 
@@ -137,18 +137,18 @@ def test_resume_info_method(setup_storage):
     storage = setup_storage
     study_name = "info-test-study"
     sampler = TPESampler(seed=123)
-    
+
     # New study
     study1 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     info = study1.get_resume_info()
     assert not info["is_resumed"]
-    
+
     # Run some trials
     def objective(trial):
         return trial.suggest_float("x", 0, 1) ** 2
-        
+
     study1.optimize(objective, n_trials=2, n_jobs=1)
-    
+
     # Resume study
     study2 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     info = study2.get_resume_info()
@@ -166,16 +166,16 @@ def test_completed_trials_count_property(setup_storage):
     """Test completed_trials_count property."""
     storage = setup_storage
     study_name = "count-test-study"
-    
+
     study = MlflowSparkStudy(study_name, storage)
     assert study.completed_trials_count == 0
-    
+
     def objective(trial):
         return trial.suggest_float("x", 0, 1)
-    
+
     study.optimize(objective, n_trials=3, n_jobs=1)
     assert study.completed_trials_count == 3
-    
+
     # Resume and check count is preserved
     resumed_study = MlflowSparkStudy(study_name, storage)
     assert resumed_study.completed_trials_count == 3
@@ -186,25 +186,25 @@ def test_resume_preserves_best_results(setup_storage):
     storage = setup_storage
     study_name = "best-results-study"
     sampler = TPESampler(seed=456)
-    
+
     def objective(trial):
         x = trial.suggest_float("x", -10, 10)
         return (x - 2) ** 2
-    
+
     # First optimization
     study1 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     study1.optimize(objective, n_trials=5, n_jobs=1)
-    
+
     original_best_value = study1.best_value
     original_best_params = study1.best_params.copy()
-    
+
     # Resume and verify best results are preserved
     study2 = MlflowSparkStudy(study_name, storage, sampler=sampler)
     assert study2.best_value == original_best_value
     assert study2.best_params == original_best_params
-    
+
     # Continue optimization and verify it can improve
     study2.optimize(objective, n_trials=5, n_jobs=1)
-    
+
     # Best value should be the same or better (lower for minimization)
     assert study2.best_value <= original_best_value


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/lu-wang-dl/mlflow/pull/17191?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17191/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17191/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17191/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add support to resume an optuna run.
- Checking whether the study_name exists in current storage. If exists, resume the run instead of creating a new run.
- Add function in MlflowStorage to check whether a study_name exists.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
