### PR TITLE
Revert "Deprecate set_destination API (#17067)"

### DIFF
--- a/mlflow/tracing/destination.py
+++ b/mlflow/tracing/destination.py
@@ -1,15 +1,13 @@
 from dataclasses import dataclass
 
 from mlflow.exceptions import MlflowException
-from mlflow.utils.annotations import deprecated
+from mlflow.utils.annotations import experimental
 
 
-@deprecated(alternative="mlflow.set_tracking_uri`` and ``mlflow.set_experiment", since="3.3.0")
+@experimental(version="2.21.0")
 @dataclass
 class TraceDestination:
-    """
-    A configuration object for specifying the destination of trace data.
-    """
+    """A configuration object for specifying the destination of trace data."""
 
     @property
     def type(self) -> str:
@@ -17,7 +15,7 @@ class TraceDestination:
         raise NotImplementedError
 
 
-@deprecated(alternative="mlflow.set_tracking_uri`` and ``mlflow.set_experiment", since="3.3.0")
+@experimental(version="2.21.0")
 @dataclass
 class MlflowExperiment(TraceDestination):
     """
@@ -38,7 +36,7 @@ class MlflowExperiment(TraceDestination):
         return "experiment"
 
 
-@deprecated(alternative="mlflow.set_tracking_uri`` and ``mlflow.set_experiment", since="3.3.0")
+@experimental(version="2.22.0")
 @dataclass
 class Databricks(TraceDestination):
     """

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -32,7 +32,7 @@ from mlflow.tracing.destination import Databricks, MlflowExperiment, TraceDestin
 from mlflow.tracing.utils.exception import raise_as_trace_exception
 from mlflow.tracing.utils.once import Once
 from mlflow.tracing.utils.otlp import get_otlp_exporter, should_use_otlp_exporter
-from mlflow.utils.annotations import deprecated
+from mlflow.utils.annotations import experimental
 from mlflow.utils.databricks_utils import (
     is_in_databricks_model_serving_environment,
     is_mlflow_tracing_enabled_in_model_serving,
@@ -182,7 +182,7 @@ def detach_span_from_context(token: contextvars.Token):
     context_api.detach(token)
 
 
-@deprecated(alternative="mlflow.set_tracking_uri`` and ``mlflow.set_experiment``", since="3.3.0")
+@experimental(version="2.21.0")
 def set_destination(destination: TraceDestination):
     """
     Set a custom span destination to which MLflow will export the traces.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17193?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17193/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17193/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17193/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This reverts commit 8c49579b4db619e4cfd6f22269dc8b8b14185562. We (might) use this API for the new trace server export.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
