### PR TITLE
Add destination parameter to @mlflow.trace

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -160,7 +160,8 @@ def trace(
             single value to be set as the span output.
         experiment_id: The ID of the experiment to log the trace to. If not provided,
             the experiment ID will be determined by the default resolution order. This
-            parameter should only be used for root span and non-root span will raise an exception.
+            parameter should only be used for root span and setting this for non-root spans
+            will be ignored with a warning.
     """
 
     def decorator(fn):
@@ -464,7 +465,8 @@ def start_span(
         attributes: A dictionary of attributes to set on the span.
         experiment_id: The ID of the experiment to log the trace to. If not provided,
             the experiment ID will be determined by the default resolution order. This
-            parameter should only be used for root span and non-root span will raise an exception.
+            parameter should only be used for root span and setting this for non-root spans
+            will be ignored with a warning.
 
     Returns:
         Yields an :py:class:`mlflow.entities.Span` that represents the created span.

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -306,7 +306,7 @@ def _wrap_generator(
                 span_type=span_type,
                 attributes=attributes,
                 inputs=inputs,
-                experiment_id=trace_destination.experiment_id if trace_destination else None,
+                experiment_id=getattr(trace_destination, "experiment_id", None),
             )
         except Exception as e:
             _logger.debug(f"Failed to start stream span: {e}")

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -88,6 +88,8 @@ def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.
 
     Args:
         name: The name of the span.
+        experiment_id: The ID of the experiment to log the span to. If not specified, the span will
+            be logged to the active experiment or explicitly set trace destination.
 
     Returns:
         The newly created OpenTelemetry span.

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -79,7 +79,7 @@ def _init_trace_user_destination():
 _init_trace_user_destination()
 
 
-def start_span_in_context(name: str) -> trace.Span:
+def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.Span:
     """
     Start a new OpenTelemetry span in the current context.
 
@@ -92,7 +92,17 @@ def start_span_in_context(name: str) -> trace.Span:
     Returns:
         The newly created OpenTelemetry span.
     """
-    return _get_tracer(__name__).start_span(name)
+    attributes = {}
+    if experiment_id:
+        attributes[SpanAttributeKey.EXPERIMENT_ID] = json.dumps(experiment_id)
+    span = _get_tracer(__name__).start_span(name, attributes=attributes)
+
+    if experiment_id and getattr(span, "_parent", None):
+        _logger.warning(
+            "The `experiment_id` parameter can only be used for root spans, but the span "
+            f"`{name}` is not a root span. The specified value `{experiment_id}` will be ignored."
+        )
+    return span
 
 
 def start_detached_span(
@@ -126,7 +136,14 @@ def start_detached_span(
         attributes[SpanAttributeKey.START_TIME_NS] = json.dumps(start_time_ns)
     if experiment_id:
         attributes[SpanAttributeKey.EXPERIMENT_ID] = json.dumps(experiment_id)
-    return tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
+    span = tracer.start_span(name, context=context, attributes=attributes, start_time=start_time_ns)
+
+    if experiment_id and getattr(span, "_parent", None):
+        _logger.warning(
+            "The `experiment_id` parameter can only be used for root spans, but the span "
+            f"`{name}` is not a root span. The specified value `{experiment_id}` will be ignored."
+        )
+    return span
 
 
 @contextmanager

--- a/mlflow/tracing/provider.py
+++ b/mlflow/tracing/provider.py
@@ -104,6 +104,7 @@ def start_span_in_context(name: str, experiment_id: str | None = None) -> trace.
             "The `experiment_id` parameter can only be used for root spans, but the span "
             f"`{name}` is not a root span. The specified value `{experiment_id}` will be ignored."
         )
+        span._span.attributes.pop(SpanAttributeKey.EXPERIMENT_ID, None)
     return span
 
 
@@ -145,6 +146,7 @@ def start_detached_span(
             "The `experiment_id` parameter can only be used for root spans, but the span "
             f"`{name}` is not a root span. The specified value `{experiment_id}` will be ignored."
         )
+        span._span.attributes.pop(SpanAttributeKey.EXPERIMENT_ID, None)
     return span
 
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -607,6 +607,53 @@ def test_trace_skip_resolving_unrelated_tags_to_traces():
     assert "unrelated tags" not in trace.info.tags
 
 
+def test_trace_with_experiment_id():
+    exp_1 = mlflow.create_experiment("exp_1")
+    exp_2 = mlflow.set_experiment("exp_2").experiment_id  # active experiment
+
+    @mlflow.trace(experiment_id=exp_1)
+    def predict_1():
+        with mlflow.start_span(name="child_span"):
+            return
+
+    @mlflow.trace()
+    def predict_2():
+        pass
+
+    predict_1()
+    traces = get_traces(experiment_id=exp_1)
+    assert len(traces) == 1
+    assert traces[0].info.experiment_id == exp_1
+    assert len(traces[0].data.spans) == 2
+    assert get_traces(experiment_id=exp_2) == []
+
+    predict_2()
+    traces = get_traces(experiment_id=exp_2)
+    assert len(traces) == 1
+    assert traces[0].info.experiment_id == exp_2
+
+
+def test_trace_with_experiment_id_issue_warning_when_not_root_span():
+    exp_1 = mlflow.create_experiment("exp_1")
+
+    @mlflow.trace(experiment_id=exp_1)
+    def predict_1():
+        return predict_2()
+
+    @mlflow.trace(experiment_id=exp_1)
+    def predict_2():
+        return
+
+    with mock.patch("mlflow.tracing.provider._logger") as mock_logger:
+        predict_1()
+
+    assert mock_logger.warning.call_count == 1
+    assert mock_logger.warning.call_args[0][0] == (
+        "The `experiment_id` parameter can only be used for root spans, but the span "
+        "`predict_2` is not a root span. The specified value `1` will be ignored."
+    )
+
+
 def test_start_span_context_manager(async_logging_enabled):
     datetime_now = datetime.now()
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -37,6 +37,7 @@ from mlflow.tracing.constant import (
     TraceMetadataKey,
     TraceTagKey,
 )
+from mlflow.tracing.destination import MlflowExperiment
 from mlflow.tracing.export.inference_table import pop_trace
 from mlflow.tracing.fluent import start_span_no_context
 from mlflow.tracing.provider import _get_tracer, set_destination
@@ -613,7 +614,7 @@ def test_trace_with_experiment_id():
     exp_1 = mlflow.create_experiment("exp_1")
     exp_2 = mlflow.set_experiment("exp_2").experiment_id  # active experiment
 
-    @mlflow.trace(experiment_id=exp_1)
+    @mlflow.trace(trace_destination=MlflowExperiment(exp_1))
     def predict_1():
         with mlflow.start_span(name="child_span"):
             return
@@ -640,11 +641,11 @@ def test_trace_with_experiment_id():
 def test_trace_with_experiment_id_issue_warning_when_not_root_span():
     exp_1 = mlflow.create_experiment("exp_1")
 
-    @mlflow.trace(experiment_id=exp_1)
+    @mlflow.trace(trace_destination=MlflowExperiment(exp_1))
     def predict_1():
         return predict_2()
 
-    @mlflow.trace(experiment_id=exp_1)
+    @mlflow.trace(trace_destination=MlflowExperiment(exp_1))
     def predict_2():
         return
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -607,6 +607,8 @@ def test_trace_skip_resolving_unrelated_tags_to_traces():
     assert "unrelated tags" not in trace.info.tags
 
 
+# Tracing SDK doesn't have `create_experiment` support
+@skip_when_testing_trace_sdk
 def test_trace_with_experiment_id():
     exp_1 = mlflow.create_experiment("exp_1")
     exp_2 = mlflow.set_experiment("exp_2").experiment_id  # active experiment
@@ -633,6 +635,8 @@ def test_trace_with_experiment_id():
     assert traces[0].info.experiment_id == exp_2
 
 
+# Tracing SDK doesn't have `create_experiment` support
+@skip_when_testing_trace_sdk
 def test_trace_with_experiment_id_issue_warning_when_not_root_span():
     exp_1 = mlflow.create_experiment("exp_1")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17215?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17215/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17215/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17215/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Add `experiment_id` parameter to the `@mlflow.trace` decorator to allow specifying experiment ID flexibly in a single application.

The main use case is an app that has multiple model endpoints.

```
@app.get("/predict/a")
@mlflow.trace(name="model_A")
async def predict_model_a(...):
   ...


@app.get("/predict/b")
@mlflow.trace(name="model_B")
async def predict)model_b(...):
   ...
```

Currently, there is no way to send trace `model_A` and `model_B` to different MLflow experiments.

The new `experiment_id` can only be specified at root span, because the trace destination is decided when the root span is started. If it is specified for non-root spans, MLflow will issue a warning and ignore it.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
