### PR TITLE
Update `dev/update_changelog.py` to create a major new features section

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -62,7 +62,6 @@ Note that GitHub prefixes anchor names in markdown with "user-content-".
 - [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
 - [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
 - [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
-- [ ] `rn/highlight` - A major new feature or improvement worth highlighting in the release notes
 - [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
 - [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -62,6 +62,7 @@ Note that GitHub prefixes anchor names in markdown with "user-content-".
 - [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
 - [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
 - [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
+- [ ] `rn/highlight` - A major new feature or improvement worth highlighting in the release notes
 - [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
 - [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes
 

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -232,6 +232,7 @@ def main(prev_version, release_version, remote):
     )
 
     unknown_labels = set(label_to_prs.keys()) - {
+        "rn/highlight",
         "rn/feature",
         "rn/breaking-change",
         "rn/bug-fix",
@@ -241,6 +242,7 @@ def main(prev_version, release_version, remote):
     assert len(unknown_labels) == 0, f"Unknown labels: {unknown_labels}"
 
     breaking_changes = Section("Breaking changes:", label_to_prs.get("rn/breaking-change", []))
+    highlights = Section("Major new features", label_to_prs.get("rn/highlight", []))
     features = Section("Features:", label_to_prs.get("rn/feature", []))
     bug_fixes = Section("Bug fixes:", label_to_prs.get("rn/bug-fix", []))
     doc_updates = Section("Documentation updates:", label_to_prs.get("rn/documentation", []))
@@ -257,6 +259,7 @@ def main(prev_version, release_version, remote):
                 get_header_for_version(release_version),
                 f"MLflow {release_version} includes several major features and improvements",
                 breaking_changes,
+                highlights,
                 features,
                 bug_fixes,
                 doc_updates,

--- a/dev/update_changelog.py
+++ b/dev/update_changelog.py
@@ -242,7 +242,7 @@ def main(prev_version, release_version, remote):
     assert len(unknown_labels) == 0, f"Unknown labels: {unknown_labels}"
 
     breaking_changes = Section("Breaking changes:", label_to_prs.get("rn/breaking-change", []))
-    highlights = Section("Major new features", label_to_prs.get("rn/highlight", []))
+    highlights = Section("Major new features:", label_to_prs.get("rn/highlight", []))
     features = Section("Features:", label_to_prs.get("rn/feature", []))
     bug_fixes = Section("Bug fixes:", label_to_prs.get("rn/bug-fix", []))
     doc_updates = Section("Documentation updates:", label_to_prs.get("rn/documentation", []))


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17216?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17216/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17216/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17216/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Update `dev/update_changelog.py` to create a major new features section.

https://github.com/mlflow/mlflow/pulls?q=is%3Aopen+is%3Apr+label%3Arn%2Fhighlight

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
