### PR TITLE
Remove macOS-specific code paths from generate_protos.py

### DIFF
--- a/dev/generate_protos.py
+++ b/dev/generate_protos.py
@@ -146,71 +146,22 @@ def gen_python_protos(protoc_bin: Path, protoc_include_path: Path, out_dir: Path
         apply_python_gencode_replacement(out_dir / _get_python_output_path(proto_file))
 
 
-def build_protoc_from_source(version: Literal["3.19.4", "26.0"]) -> tuple[Path, Path]:
-    """
-    Build and install protoc from source for macOS arm64 version 3.19.4 only.
-    """
-    assert SYSTEM == "Darwin" and MACHINE == "arm64" and version == "3.19.4", (
-        "This function is intended for macOS arm64 only and version 3.19.4."
-    )
-
-    src_dir = CACHE_DIR / f"protobuf-{version}"
-    build_dir = src_dir / "cmake" / "build"
-
-    if not build_dir.exists():
-        build_dir.mkdir(parents=True, exist_ok=True)
-
-        # Download the source code
-        download_file(
-            f"https://github.com/protocolbuffers/protobuf/archive/refs/tags/v{version}.tar.gz",
-            CACHE_DIR / f"protobuf-{version}.tar.gz",
-        )
-
-        # Extract the source code
-        subprocess.check_call(
-            [
-                "tar",
-                "-xzf",
-                CACHE_DIR / f"protobuf-{version}.tar.gz",
-                "-C",
-                CACHE_DIR,
-            ]
-        )
-
-        # Build protoc from source
-        subprocess.check_call(["./autogen.sh"], cwd=src_dir)
-        subprocess.check_call(["./configure"], cwd=src_dir)
-        subprocess.check_call(["make", "-j4"], cwd=src_dir)
-
-    protoc_bin = src_dir / "src" / "protoc"
-    protoc_include_path = src_dir / "src"
-    return protoc_bin, protoc_include_path
-
-
 def download_file(url: str, output_path: Path) -> None:
     urllib.request.urlretrieve(url, output_path)
 
 
 def download_and_extract_protoc(version: Literal["3.19.4", "26.0"]) -> tuple[Path, Path]:
     """
-    Download and extract specific version protoc tool, return extracted protoc executable file path
-    and include path.
+    Download and extract specific version protoc tool for Linux systems,
+    return extracted protoc executable file path and include path.
     """
-    assert SYSTEM in ["Darwin", "Linux"], "The script only supports MacOS or Linux system."
-    assert MACHINE in ["x86_64", "aarch64", "arm64"], (
-        "The script only supports x86_64, arm64 or aarch64 CPU."
+    assert SYSTEM == "Linux", "This script only supports Linux systems."
+    assert MACHINE in ["x86_64", "aarch64"], (
+        "This script only supports x86_64 or aarch64 CPU architectures."
     )
 
-    if SYSTEM == "Darwin" and MACHINE == "arm64" and version == "3.19.4":
-        return build_protoc_from_source(version)
-
-    os_type = "osx" if SYSTEM == "Darwin" else "linux"
     cpu_type = "x86_64" if MACHINE == "x86_64" else "aarch_64"
-
-    if SYSTEM == "Darwin" and MACHINE == "arm64":
-        protoc_zip_filename = f"protoc-{version}-osx-universal_binary.zip"
-    else:
-        protoc_zip_filename = f"protoc-{version}-{os_type}-{cpu_type}.zip"
+    protoc_zip_filename = f"protoc-{version}-linux-{cpu_type}.zip"
 
     downloaded_protoc_bin = CACHE_DIR / f"protoc-{version}" / "bin" / "protoc"
     downloaded_protoc_include_path = CACHE_DIR / f"protoc-{version}" / "include"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17218?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17218/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17218/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17218/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR removes macOS-specific code paths from the `dev/generate_protos.py` script since it is no longer run in macOS systems.

Changes made:
- Removed the `build_protoc_from_source()` function which was only used for building protoc from source on macOS arm64 with version 3.19.4
- Simplified the `download_and_extract_protoc()` function to only support Linux (x86_64 and aarch64 architectures)
- Removed all Darwin/macOS-specific checks and special handling for macOS universal binary
- Updated assertions to reflect Linux-only support

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The script syntax has been verified and all linting checks pass.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is an internal development script change that doesn't affect users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)