### PR TITLE
Make set_destination to use ContextVar rather than ThreadLocalVariable

### DIFF
--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -174,7 +174,8 @@ The `trace_destination` parameter was introduced to the <APILink fn="mlflow.trac
 import mlflow
 from mlflow.tracing.destination import MlflowExperiment
 
-@mlflow.trace(span_type="AGENT", trace_destination=MlflowExperiment(experiment_id="1234"))
+
+@mlflow.trace(trace_destination=MlflowExperiment(experiment_id="1234"))
 def math_agent(request: Request):
     # Your model logic here
     ...
@@ -189,6 +190,7 @@ The <APILink fn="mlflow.tracing.set_destination" /> API is a purpose-built API f
 ```python
 import mlflow
 
+
 @app.get("/math-agent")
 def math_agent(request: Request):
     # The API is super low-overhead, so you can call it inside the request handler.
@@ -197,6 +199,7 @@ def math_agent(request: Request):
     # Your model logic here
     with mlflow.start_span(name="math-agent") as span:
         ...
+
 
 @app.get("/chat-agent")
 def chat_agent(request: Request):

--- a/docs/docs/genai/tracing/faq.mdx
+++ b/docs/docs/genai/tracing/faq.mdx
@@ -158,6 +158,55 @@ mlflow.tracing.configure(span_processors=[filter_retrieval_output])
 
 Refer to the [Redacting Sensitive Data Safe](/genai/tracing/observe-with-traces/masking) guide for more details about the hook API and examples.
 
+### Q. Can I log traces to different experiments from a single application?
+
+Yes, you can log traces to different experiments from a single application. By default, MLflow logs traces to the current active experiment set via either the `mlflow.set_experiment` API or the `MLFLOW_EXPERIMENT_ID` environment variable.
+
+However, you may sometimes want to dynamically route traces to different experiments from a single application. For example, your application server may expose two endpoints, each serves a different model. Switching active experiment does not work because active experiment is globally defined and not isolated per thread or async context.
+
+Therefore, MLflow provides two different ways to switch target experiments to log traces:
+
+#### Optional 1. Set the `trace_destination` parameter when starting a manual trace
+
+The `trace_destination` parameter was introduced to the <APILink fn="mlflow.trace">@mlflow.trace</APILink> decorator and the <APILink fn="mlflow.start_span">mlflow.start_span</APILink> API in MLflow 3.3 to allow you to specify the target experiment for each trace explicitly.
+
+```python
+import mlflow
+from mlflow.tracing.destination import MlflowExperiment
+
+@mlflow.trace(span_type="AGENT", trace_destination=MlflowExperiment(experiment_id="1234"))
+def math_agent(request: Request):
+    # Your model logic here
+    ...
+```
+
+Note that the `trace_destination` parameter is only effective when it is set to the root span of the trace. If it is set to a child span, MLflow will ignore it and print a warning.
+
+#### Option 2. Use `mlflow.tracing.set_destination` with `context_local=True`
+
+The <APILink fn="mlflow.tracing.set_destination" /> API is a purpose-built API for setting the destination of traces, while bypassing the overhead of `mlflow.set_experiment`. The `context_local` parameter allows you to set the destination per async task or thread, providing isolation in concurrent applications. This option is useful when you use automatic tracing and not using the manual tracing APIs.
+
+```python
+import mlflow
+
+@app.get("/math-agent")
+def math_agent(request: Request):
+    # The API is super low-overhead, so you can call it inside the request handler.
+    mlflow.tracing.set_destination(MlflowExperiment(experiment_id="1234"))
+
+    # Your model logic here
+    with mlflow.start_span(name="math-agent") as span:
+        ...
+
+@app.get("/chat-agent")
+def chat_agent(request: Request):
+    mlflow.tracing.set_destination(MlflowExperiment(experiment_id="5678"))
+
+    # Your model logic here
+    with mlflow.start_span(name="chat-agent") as span:
+        ...
+```
+
 ## Troubleshooting
 
 ### Q: I cannot open my trace in the MLflow UI. What should I do?

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -927,9 +927,3 @@ MLFLOW_DISABLE_TELEMETRY = _BooleanEnvironmentVariable("MLFLOW_DISABLE_TELEMETRY
 #: Internal flag to enable telemetry in mlflow tests.
 #: (default: ``False``)
 _MLFLOW_TESTING_TELEMETRY = _BooleanEnvironmentVariable("_MLFLOW_TESTING_TELEMETRY", False)
-
-#: Whether to allow setting thread local tracing destination.
-#: (default: ``False``)
-MLFLOW_ENABLE_THREAD_LOCAL_TRACING_DESTINATION = _BooleanEnvironmentVariable(
-    "MLFLOW_ENABLE_THREAD_LOCAL_TRACING_DESTINATION", False
-)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -2152,6 +2152,7 @@ def test_search_traces_with_run_id_validates_store_filter_string(is_databricks):
         assert actual_filter_string == expected_filter_string
 
 
+@skip_when_testing_trace_sdk
 def test_set_destination_in_threads(async_logging_enabled):
     # This test makes sure `set_destination` obeys thread-local behavior.
     class TestModel:
@@ -2223,6 +2224,7 @@ def test_set_destination_in_threads(async_logging_enabled):
 
 
 @pytest.mark.asyncio
+@skip_when_testing_trace_sdk
 async def test_set_destination_in_async_contexts(async_logging_enabled):
     class TestModel:
         async def predict(self, x):

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -22,10 +22,7 @@ from mlflow.entities import (
 )
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
-from mlflow.environment_variables import (
-    MLFLOW_ENABLE_THREAD_LOCAL_TRACING_DESTINATION,
-    MLFLOW_TRACKING_USERNAME,
-)
+from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.exceptions import MlflowException
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
@@ -2155,24 +2152,15 @@ def test_search_traces_with_run_id_validates_store_filter_string(is_databricks):
         assert actual_filter_string == expected_filter_string
 
 
-def test_set_destination_in_threads(async_logging_enabled, tmp_path, monkeypatch):
-    from mlflow.tracing.destination import MlflowExperiment
-    from mlflow.tracing.provider import _init_trace_user_destination
-
-    monkeypatch.setenv(MLFLOW_ENABLE_THREAD_LOCAL_TRACING_DESTINATION.name, "true")
-
-    _init_trace_user_destination()
-
+def test_set_destination_in_threads(async_logging_enabled):
     # This test makes sure `set_destination` obeys thread-local behavior.
     class TestModel:
         def predict(self, x):
             with mlflow.start_span(name="root_span") as root_span:
-                root_span.set_inputs({"x": x})
 
                 def child_span_thread(z):
                     child_span = start_span_no_context(
                         name="child_span_1",
-                        span_type=SpanType.LLM,
                         parent_span=root_span,
                     )
                     child_span.set_inputs(z)
@@ -2186,46 +2174,92 @@ def test_set_destination_in_threads(async_logging_enabled, tmp_path, monkeypatch
 
     model = TestModel()
 
-    def func(experiment_id, x):
-        set_destination(MlflowExperiment(experiment_id))
+    def func(experiment_id: str | None, x: int):
+        if experiment_id is not None:
+            set_destination(MlflowExperiment(experiment_id), context_local=True)
+
         time.sleep(0.5)
         model.predict(x)
 
-    experiment_id1 = mlflow.set_experiment(uuid.uuid4().hex).experiment_id
-    thread1 = threading.Thread(target=func, args=(experiment_id1, 3))
+    # Main thread: global config
+    experiment_id1 = mlflow.create_experiment(uuid.uuid4().hex)
+    set_destination(MlflowExperiment(experiment_id1))
+    func(None, 3)
 
-    experiment_id2 = mlflow.set_experiment(uuid.uuid4().hex).experiment_id
-    thread2 = threading.Thread(target=func, args=(experiment_id2, 40))
+    # Thread 1: context-local config
+    experiment_id2 = mlflow.create_experiment(uuid.uuid4().hex)
+    thread1 = threading.Thread(target=func, args=(experiment_id2, 3))
+
+    # Thread 2: context-local config
+    experiment_id3 = mlflow.create_experiment(uuid.uuid4().hex)
+    thread2 = threading.Thread(target=func, args=(experiment_id3, 40))
+
+    # Thread 3: no config -> fallback to global config
+    thread3 = threading.Thread(target=func, args=(None, 40))
 
     thread1.start()
     thread2.start()
+    thread3.start()
 
     thread1.join()
     thread2.join()
+    thread3.join()
 
     if async_logging_enabled:
         mlflow.flush_trace_async_logging(terminate=True)
 
     traces = get_traces(experiment_id1)
-    assert len(traces) == 1
-    trace = traces[0]
-    assert trace.info.trace_id is not None
-    assert trace.info.experiment_id == experiment_id1
-    assert trace.info.execution_time_ms >= 0.5 * 1e3
-    assert trace.info.state == TraceState.OK
-    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 3}'
-    assert len(trace.data.spans) == 2
-    assert trace.data.spans[0].inputs == {"x": 3}
-    assert trace.data.spans[1].inputs == 4
+    assert len(traces) == 2  # main thread + thread 3
+    assert traces[0].info.experiment_id == experiment_id1
+    assert len(traces[0].data.spans) == 2
+    assert traces[1].info.experiment_id == experiment_id1
+    assert len(traces[1].data.spans) == 2
 
-    traces = get_traces(experiment_id2)
-    assert len(traces) == 1
-    trace = traces[0]
-    assert trace.info.trace_id is not None
-    assert trace.info.experiment_id == experiment_id2
-    assert trace.info.execution_time_ms >= 0.5 * 1e3
-    assert trace.info.state == TraceState.OK
-    assert trace.info.request_metadata[TraceMetadataKey.INPUTS] == '{"x": 40}'
-    assert len(trace.data.spans) == 2
-    assert trace.data.spans[0].inputs == {"x": 40}
-    assert trace.data.spans[1].inputs == 41
+    for exp_id in [experiment_id2, experiment_id3]:
+        traces = get_traces(exp_id)
+        assert len(traces) == 1
+        assert traces[0].info.experiment_id == exp_id
+        assert len(traces[0].data.spans) == 2
+
+
+@pytest.mark.asyncio
+async def test_set_destination_in_async_contexts(async_logging_enabled):
+    class TestModel:
+        async def predict(self, x):
+            with mlflow.start_span(name="root_span") as root_span:
+
+                async def child_span_task(z):
+                    child_span = start_span_no_context(
+                        name="child_span_1",
+                        parent_span=root_span,
+                    )
+                    child_span.set_inputs(z)
+                    await asyncio.sleep(0.5)
+                    child_span.end()
+
+                await child_span_task(x + 1)
+            return x
+
+    model = TestModel()
+
+    async def async_func(experiment_id: str, x: int):
+        set_destination(MlflowExperiment(experiment_id), context_local=True)
+        await asyncio.sleep(0.5)
+        await model.predict(x)
+
+    experiment_id1 = mlflow.create_experiment(uuid.uuid4().hex)
+    task1 = asyncio.create_task(async_func(experiment_id1, 3))
+
+    experiment_id2 = mlflow.create_experiment(uuid.uuid4().hex)
+    task2 = asyncio.create_task(async_func(experiment_id2, 40))
+
+    await asyncio.gather(task1, task2)
+
+    if async_logging_enabled:
+        mlflow.flush_trace_async_logging(terminate=True)
+
+    for exp_id in [experiment_id1, experiment_id2]:
+        traces = get_traces(exp_id)
+        assert len(traces) == 1
+        assert traces[0].info.experiment_id == exp_id
+        assert len(traces[0].data.spans) == 2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17219?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17219/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17219/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17219/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.tracing.set_destination` API support thread local configuration today. This mode is enabled when users set `MLFLOW_ENABLE_THREAD_LOCAL_TRACING_DESTINATION` env var to `True`.

The thread isolcation is achieved by `ThreadLocalVariable`, but it doesn't work for async concurrency. Python runs an event loop in a single thread, so all async tasks will share the same destination, even when user enables thread local mode. This is problematic because popular web server like FastAPI uses async event loop, rather than threads by default.

To resolve the issue, this PR replaces `ThreadLocalVariable` with `ContextVar`, which provides both thread and async context isolation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support async context isolation for `mlflow.tracing.set_destination` API.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
