### PR TITLE
Add `status` field to scorers

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -444,6 +444,7 @@ class Scorer(BaseModel):
             A new Scorer instance with server registration information.
 
         Example:
+
             .. code-block:: python
 
                 import mlflow
@@ -514,6 +515,7 @@ class Scorer(BaseModel):
             A new Scorer instance with updated sampling configuration.
 
         Example:
+
             .. code-block:: python
 
                 import mlflow
@@ -588,6 +590,7 @@ class Scorer(BaseModel):
             A new Scorer instance with updated configuration.
 
         Example:
+
             .. code-block:: python
 
                 import mlflow
@@ -650,6 +653,7 @@ class Scorer(BaseModel):
             A new Scorer instance with sample rate set to 0.
 
         Example:
+
             .. code-block:: python
 
                 import mlflow

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -119,9 +119,7 @@ class Scorer(BaseModel):
         if self._sampling_config is None:
             return ScorerStatus.UNREGISTERED
 
-        if self.sample_rate is not None and self.sample_rate > 0:
-            return ScorerStatus.STARTED
-        return ScorerStatus.STOPPED
+        return ScorerStatus.STARTED if self.sample_rate > 0 else ScorerStatus.STOPPED
 
     def __repr__(self) -> str:
         # Get the standard representation from the parent class

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -39,6 +39,7 @@ class ScorerStatus(Enum):
     Scorer status is determined by the sample rate due to the backend not having
     a notion of whether a scorer is started or stopped.
     """
+
     UNREGISTERED = "UNREGISTERED"  # sampling config not set
     STARTED = "STARTED"  # sample_rate > 0
     STOPPED = "STOPPED"  # sample_rate == 0

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -507,8 +507,7 @@ class Scorer(BaseModel):
             experiment_id: The ID of the MLflow experiment containing the scorer.
                 If None, uses the currently active experiment.
             sampling_config: Configuration object containing:
-                - sample_rate: Fraction of traces to evaluate (0.0 to 1.0).
-                    Must be greater than 0. Required.
+                - sample_rate: Fraction of traces to evaluate (0.0 to 1.0). Required.
                 - filter_string: Optional MLflow search_traces compatible filter string.
 
         Returns:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -34,6 +34,11 @@ _ALLOWED_SCORERS_FOR_REGISTRATION = [ScorerKind.BUILTIN, ScorerKind.DECORATOR]
 
 
 class ScorerStatus(Enum):
+    """Status of a scorer.
+
+    Scorer status is determined by the sample rate due to the backend not having
+    a notion of whether a scorer is started or stopped.
+    """
     UNREGISTERED = "UNREGISTERED"  # sampling config not set
     STARTED = "STARTED"  # sample_rate > 0
     STOPPED = "STOPPED"  # sample_rate == 0

--- a/tests/genai/scorers/test_registered_scorers_scheduling.py
+++ b/tests/genai/scorers/test_registered_scorers_scheduling.py
@@ -96,6 +96,19 @@ def test_scorer_start(mock_update, _):
     assert call_args["filter_string"] == "trace.status = 'OK'"
 
 
+def test_scorer_start_with_zero_sample_rate_raises_error():
+    """Test that starting a scorer with sample_rate=0 raises an error."""
+    my_scorer = length_check
+
+    # Attempting to start with sample_rate=0 should raise an exception
+    with pytest.raises(MlflowException, match="sample rate must be greater than 0"):
+        my_scorer.start(sampling_config=ScorerSamplingConfig(sample_rate=0))
+
+    # Also test with negative sample rate
+    with pytest.raises(MlflowException, match="sample rate must be greater than 0"):
+        my_scorer.start(sampling_config=ScorerSamplingConfig(sample_rate=-0.1))
+
+
 @patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
 def test_scorer_start_not_registered(_):
     """Test starting a scorer that isn't registered."""


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbrx-euirim/mlflow/pull/17222?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17222/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17222/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17222/merge
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

This PR adds a `status` field to `Scorer` that summarizes the local state of the scorer with respect to registration.

This PR also updates `start` to prevent scorers from being started with a sample rate == 0. This change is meant to correlate well with the enum returned by the `status` method.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add `status` field to scorers. The field describes the local state of the scorer.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
