### PR TITLE
Support 1-year support window for GenAI packages

### DIFF
--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -85,6 +85,7 @@ class PackageInfo(BaseModel):
     pip_release: str
     install_dev: str | None = None
     module_name: str | None = None
+    genai: bool = False
 
 
 class TestConfig(BaseModel):

--- a/dev/update_ml_package_versions.py
+++ b/dev/update_ml_package_versions.py
@@ -225,11 +225,12 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_min_supported_version(versions_infos: list[VersionInfo]) -> str | None:
+def get_min_supported_version(versions_infos: list[VersionInfo], genai: bool = False) -> str | None:
     """
     Get the minimum version that is released within the past two years
     """
-    min_support_date = datetime.now() - timedelta(days=2 * 365)
+    years = 1 if genai else 2
+    min_support_date = datetime.now() - timedelta(days=years * 365)
     min_support_date = min_support_date.replace(tzinfo=None)
 
     # Extract versions that were released in the past two years
@@ -254,8 +255,11 @@ def update(skip_yml=False):
             if flavor_key in ["litellm"]:
                 continue
             package_name = config["package_info"]["pip_release"]
+            genai = config["package_info"].get("genai", False)
             versions_and_upload_times = get_package_version_infos(package_name)
-            min_supported_version = get_min_supported_version(versions_and_upload_times)
+            min_supported_version = get_min_supported_version(
+                versions_and_upload_times, genai=genai
+            )
 
             for category in ["autologging", "models"]:
                 print("Processing", flavor_key, category)

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -95,7 +95,7 @@ genai = [
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
-langchain = ["langchain>=0.1.0,<=0.3.27"]
+langchain = ["langchain>=0.2.14,<=0.3.27"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -530,6 +530,7 @@ transformers:
 
 openai:
   package_info:
+    genai: true
     pip_release: "openai"
     install_dev: |
       pip install git+https://github.com/openai/openai-python
@@ -572,6 +573,7 @@ openai:
 
 dspy:
   package_info:
+    genai: true
     pip_release: "dspy"
     install_dev: |
       pip install git+https://github.com/stanfordnlp/dspy.git
@@ -593,6 +595,7 @@ dspy:
 
 langchain:
   package_info:
+    genai: true
     pip_release: "langchain"
     install_dev: |
       pip install git+https://github.com/langchain-ai/langchain#subdirectory=libs/langchain
@@ -694,6 +697,7 @@ langchain:
 
 langgraph:
   package_info:
+    genai: true
     pip_release: "langgraph"
     install_dev: |
       pip install git+https://github.com/langchain-ai/langgraph#subdirectory=libs/langgraph
@@ -737,6 +741,7 @@ langgraph:
 
 llama_index:
   package_info:
+    genai: true
     pip_release: "llama-index"
     module_name: "llama_index.core"
     install_dev: |
@@ -795,6 +800,7 @@ ag2:
 
 autogen:
   package_info:
+    genai: true
     pip_release: "autogen-agentchat"
     module_name: "autogen_agentchat"
   autologging:
@@ -812,6 +818,7 @@ autogen:
 
 gemini:
   package_info:
+    genai: true
     pip_release: "google-genai"
     module_name: "google.genai"
     install_dev: |
@@ -828,6 +835,7 @@ gemini:
 
 anthropic:
   package_info:
+    genai: true
     pip_release: "anthropic"
     install_dev: |
       pip install git+https://github.com/anthropics/anthropic-sdk-python
@@ -844,6 +852,7 @@ anthropic:
 
 crewai:
   package_info:
+    genai: true
     pip_release: "crewai"
     module_name: "crewai"
     install_dev: |
@@ -858,6 +867,7 @@ crewai:
 
 agno:
   package_info:
+    genai: true
     pip_release: "agno"
     module_name: "agno"
     install_dev: |
@@ -874,6 +884,7 @@ agno:
 
 pydantic_ai:
   package_info:
+    genai: true
     pip_release: "pydantic-ai"
     module_name: "pydantic_ai"
 
@@ -901,6 +912,7 @@ pydantic_ai:
 
 smolagents:
   package_info:
+    genai: true
     pip_release: "smolagents"
     module_name: "smolagents"
     install_dev: |
@@ -918,6 +930,7 @@ smolagents:
 
 mistral:
   package_info:
+    genai: true
     pip_release: "mistralai"
     module_name: "mistralai"
     install_dev: |
@@ -1015,6 +1028,7 @@ litellm:
 
 groq:
   package_info:
+    genai: true
     pip_release: "groq"
     install_dev: |
       pip install git+https://github.com/groq/groq-python
@@ -1027,6 +1041,7 @@ groq:
 
 bedrock:
   package_info:
+    genai: true
     pip_release: "boto3"
     module_name: "boto3"
   autologging:

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -218,6 +218,7 @@ onnx:
 
 semantic_kernel:
   package_info:
+    genai: true
     pip_release: "semantic-kernel"
     install_dev: |
       pip install git+https://github.com/microsoft/semantic-kernel.git@main#subdirectory=python

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -783,9 +783,9 @@ llama_index:
 
 ag2:
   package_info:
+    genai: true
     pip_release: "ag2"
     module_name: "autogen"
-    genai: true
   autologging:
     minimum: "0.7.0"
     maximum: "0.9.7"

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -625,9 +625,6 @@ langchain:
           # Required for testing Databricks dependency extraction
           "databricks-vectorsearch",
         ]
-      # langchain-openai 0.1.22 is imcomptible with earlier langchain-core due to
-      # https://github.com/langchain-ai/langchain/commit/b83f1eb0d56dbf99605a1fce93953ee09d77aabf
-      "< 0.2": ["langchain-openai<=0.1.22"]
       ">= 0.2": [
           "langchain-huggingface",
           # Required for testing uc tools

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -785,6 +785,7 @@ ag2:
   package_info:
     pip_release: "ag2"
     module_name: "autogen"
+    genai: true
   autologging:
     minimum: "0.7.0"
     maximum: "0.9.7"
@@ -1008,6 +1009,7 @@ promptflow:
 
 litellm:
   package_info:
+    genai: true
     pip_release: "litellm"
     install_dev: |
       pip install git+https://github.com/BerriAI/litellm.git

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -535,7 +535,7 @@ openai:
     install_dev: |
       pip install git+https://github.com/openai/openai-python
   models:
-    minimum: "1.0.1"
+    minimum: "1.40.7"
     maximum: "1.99.6"
     requirements:
       ">= 0.0.0": [
@@ -554,7 +554,7 @@ openai:
     # many test tasks for openai. Reducing the number of testing only for every 10 version.
     test_every_n_versions: 10
   autologging:
-    minimum: "1.17.0"
+    minimum: "1.40.7"
     maximum: "1.99.6"
     requirements:
       ">= 0.0.0": [
@@ -601,7 +601,7 @@ langchain:
       pip install git+https://github.com/langchain-ai/langchain#subdirectory=libs/langchain
   models:
     # Where the large package update was made (langchain-core, community, ...)
-    minimum: "0.0.354"
+    minimum: "0.2.14"
     maximum: "0.3.27"
     requirements:
       ">= 0.0.0": [
@@ -653,7 +653,7 @@ langchain:
         pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
       fi
   autologging:
-    minimum: "0.1.0"
+    minimum: "0.2.14"
     maximum: "0.3.27"
     requirements:
       ">= 0.0.0": [
@@ -705,7 +705,7 @@ langgraph:
       pip install --force-reinstall --no-deps git+https://github.com/langchain-ai/langgraph#subdirectory=libs/prebuilt
 
   models:
-    minimum: "0.2.0"
+    minimum: "0.2.4"
     maximum: "0.6.4"
     requirements:
       ">= 0.0.0": [
@@ -722,7 +722,7 @@ langgraph:
       pytest tests/langgraph --ignore tests/langgraph/test_langgraph_autolog.py
 
   autologging:
-    minimum: "0.2.0"
+    minimum: "0.2.4"
     maximum: "0.6.4"
     requirements:
       ">= 0.0.0": [
@@ -748,7 +748,7 @@ llama_index:
       pip install git+https://github.com/run-llama/llama_index.git
   models:
     # New event/span framework is fully implemented in 0.10.44
-    minimum: "0.10.44"
+    minimum: "0.10.67.post1"
     maximum: "0.13.1"
     requirements:
       ">= 0.0.0": [
@@ -766,7 +766,7 @@ llama_index:
         ]
     run: pytest tests/llama_index --ignore tests/llama_index/test_llama_index_autolog.py --ignore tests/llama_index/test_llama_index_tracer.py
   autologging:
-    minimum: "0.10.44"
+    minimum: "0.10.67.post1"
     maximum: "0.13.1"
     requirements:
       ">= 0.0.0": [
@@ -841,7 +841,7 @@ anthropic:
     install_dev: |
       pip install git+https://github.com/anthropics/anthropic-sdk-python
   autologging:
-    minimum: "0.30.0"
+    minimum: "0.34.0"
     maximum: "0.62.0"
     requirements:
       "< 0.40.0": ["httpx<0.28.0"]
@@ -942,7 +942,7 @@ mistral:
       pip install .
       rm -rf $TMP_DIR
   autologging:
-    minimum: "1.0.0"
+    minimum: "1.0.2"
     maximum: "1.9.3"
     requirements:
     run: pytest tests/mistral
@@ -1048,7 +1048,7 @@ bedrock:
     module_name: "boto3"
   autologging:
     # BedrockRuntime client is added in boto3 1.33
-    minimum: "1.33.0"
+    minimum: "1.34.161"
     maximum: "1.40.6"
     run: pytest tests/bedrock
     test_tracing_sdk: true

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -230,11 +230,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "openai"
         },
         "models": {
-            "minimum": "1.0.1",
+            "minimum": "1.40.7",
             "maximum": "1.99.6"
         },
         "autologging": {
-            "minimum": "1.17.0",
+            "minimum": "1.40.7",
             "maximum": "1.99.6"
         }
     },
@@ -256,11 +256,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langchain"
         },
         "models": {
-            "minimum": "0.0.354",
+            "minimum": "0.2.14",
             "maximum": "0.3.27"
         },
         "autologging": {
-            "minimum": "0.1.0",
+            "minimum": "0.2.14",
             "maximum": "0.3.27"
         }
     },
@@ -269,11 +269,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langgraph"
         },
         "models": {
-            "minimum": "0.2.0",
+            "minimum": "0.2.4",
             "maximum": "0.6.4"
         },
         "autologging": {
-            "minimum": "0.2.0",
+            "minimum": "0.2.4",
             "maximum": "0.6.4"
         }
     },
@@ -283,11 +283,11 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "llama_index.core"
         },
         "models": {
-            "minimum": "0.10.44",
+            "minimum": "0.10.67.post1",
             "maximum": "0.13.1"
         },
         "autologging": {
-            "minimum": "0.10.44",
+            "minimum": "0.10.67.post1",
             "maximum": "0.13.1"
         }
     },
@@ -326,7 +326,7 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "anthropic"
         },
         "autologging": {
-            "minimum": "0.30.0",
+            "minimum": "0.34.0",
             "maximum": "0.62.0"
         }
     },
@@ -376,7 +376,7 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "mistralai"
         },
         "autologging": {
-            "minimum": "1.0.0",
+            "minimum": "1.0.2",
             "maximum": "1.9.3"
         }
     },
@@ -431,7 +431,7 @@ _ML_PACKAGE_VERSIONS = {
             "module_name": "boto3"
         },
         "autologging": {
-            "minimum": "1.33.0",
+            "minimum": "1.34.161",
             "maximum": "1.40.6"
         }
     }

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -96,7 +96,7 @@ genai = [
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
-langchain = ["langchain>=0.1.0,<=0.3.27"]
+langchain = ["langchain>=0.2.14,<=0.3.27"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,7 +111,7 @@ genai = [
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
-langchain = ["langchain>=0.1.0,<=0.3.27"]
+langchain = ["langchain>=0.2.14,<=0.3.27"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/tests/autologging/test_autologging_utils.py
+++ b/tests/autologging/test_autologging_utils.py
@@ -723,7 +723,7 @@ def test_violates_pep_440():
         ("pytorch", "1.5.99", False),
         ("pyspark.ml", "3.5.1", True),
         ("pyspark.ml", "3.0.0", False),
-        ("llama_index", "0.10.56", True),
+        ("llama_index", "0.13.1", True),
         ("llama_index", "0.1.2", False),
     ],
 )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17223?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17223/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17223/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17223/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR introduces a 1-year support window for GenAI packages instead of the default 2-year window. GenAI packages evolve rapidly, making a 2-year support window impractical for maintaining compatibility.

The changes include:
- Added a `genai` boolean flag to the `PackageInfo` model in `dev/set_matrix.py`
- Modified `get_min_supported_version()` in `dev/update_ml_package_versions.py` to accept a `genai` parameter that reduces the support window to 1 year when set to `True`
- Added `genai: true` flag to all GenAI-related packages in `mlflow/ml-package-versions.yml`

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is an internal development tool change that doesn't affect end users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)