### PR TITLE
Increase assessment error stacktrace size

### DIFF
--- a/mlflow/entities/assessment_error.py
+++ b/mlflow/entities/assessment_error.py
@@ -5,7 +5,7 @@ from mlflow.protos.assessments_pb2 import AssessmentError as ProtoAssessmentErro
 from mlflow.utils.annotations import experimental
 
 _STACK_TRACE_TRUNCATION_PREFIX = "[Stack trace is truncated]\n...\n"
-_STACK_TRACE_TRUNCATION_LENGTH = 1000
+_STACK_TRACE_TRUNCATION_LENGTH = 10000
 
 
 @experimental(version="2.21.0")

--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -13,6 +13,7 @@ from mlflow.entities.assessment import (
     Feedback,
     FeedbackValue,
 )
+from mlflow.entities.assessment_error import _STACK_TRACE_TRUNCATION_LENGTH
 from mlflow.exceptions import MlflowException
 from mlflow.protos.assessments_pb2 import Assessment as ProtoAssessment
 from mlflow.protos.assessments_pb2 import Expectation as ProtoExpectation
@@ -385,9 +386,11 @@ def test_feedback_from_exception(stack_trace_length):
     assert feedback.error_message == "An error occurred."
 
     proto = feedback.to_proto()
-    assert len(proto.feedback.error.stack_trace) == min(stack_trace_length, 1000)
+    assert len(proto.feedback.error.stack_trace) == min(
+        stack_trace_length, _STACK_TRACE_TRUNCATION_LENGTH
+    )
     assert proto.feedback.error.stack_trace.endswith("last line")
-    if stack_trace_length > 1000:
+    if stack_trace_length > _STACK_TRACE_TRUNCATION_LENGTH:
         assert proto.feedback.error.stack_trace.startswith("[Stack trace is truncated]\n...\n")
 
     recovered = Feedback.from_proto(feedback.to_proto())


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17224?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17224/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17224/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17224/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Increase the max number of characters for the stack trace stored in Assessment from 1k to 10k for better observability. The limit was set low because assessment is a part of TraceInfo and we wanted to avoid loading too much data from SearchTrace call on UI. However, now we limit the search return from 10k to 1k, which gives us a room to increase the stacktrace truncation threshold.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
