### PR TITLE
Fix OpenAI Agents tracing

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -392,10 +392,6 @@ const config: Config = {
             from: ['/tracing/integrations/openai-agent'],
           },
           {
-            to: '/genai/tracing/integrations/listing/swarm',
-            from: ['/tracing/integrations/swarm'],
-          },
-          {
             to: '/genai/tracing/integrations/listing/txtai',
             from: ['/tracing/integrations/txtai'],
           },

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -564,7 +564,8 @@ openai:
           "uvicorn",
         ]
       "< 1.55.3": ["httpx<0.28.0"]
-      ">= 1.66.2": ["openai-agents"]
+      # minimum version supported by openai-agents>=0.2.0
+      ">= 1.93.1": ["openai-agents"]
     run: |
       pytest tests/openai/*_autolog.py
     test_every_n_versions: 10

--- a/mlflow/openai/_agent_tracer.py
+++ b/mlflow/openai/_agent_tracer.py
@@ -6,22 +6,28 @@ from typing import Any
 
 import agents.tracing as oai
 from agents import add_trace_processor
-from agents._run_impl import TraceCtxManager
 from agents.tracing.setup import GLOBAL_TRACE_PROVIDER
 
 from mlflow.entities.span import LiveSpan, SpanType
 from mlflow.entities.span_event import SpanEvent
 from mlflow.entities.span_status import SpanStatus, SpanStatusCode
-from mlflow.openai import FLAVOR_NAME
 from mlflow.tracing.constant import SpanAttributeKey
-from mlflow.tracing.fluent import start_span_no_context
+from mlflow.tracing.fluent import (
+    get_current_active_span,
+    start_span,
+    start_span_no_context,
+)
+from mlflow.tracing.provider import detach_span_from_context, set_span_in_context
+from mlflow.tracing.utils import construct_full_inputs
 from mlflow.types.chat import (
     ChatTool,
     FunctionToolDefinition,
 )
-from mlflow.utils.autologging_utils.safety import safe_patch
 
 _logger = logging.getLogger(__name__)
+
+
+_AGENT_RUN_SPAN_NAME = "AgentRunner.run"
 
 
 class OpenAISpanType:
@@ -73,31 +79,16 @@ class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):
     ) -> None:
         super().__init__(**kwargs)
         self._span_id_to_mlflow_span: dict[str, LiveSpan] = {}
-        self._project_name = project_name
-
-        # Patch TraceCtxManager to handle exceptions from the agent properly
-        # The original implementation does not propagate exception to the root span,
-        # resulting in the trace to have status OK even if there is an exception.
-        def _patched_exit(original, instance, exc_type, exc_val, exc_tb):
-            try:
-                if exc_val and instance.trace:
-                    span = self._span_id_to_mlflow_span.get(instance.trace.trace_id)
-                    span.add_event(SpanEvent.from_exception(exc_val))
-                    span.set_status(SpanStatusCode.ERROR)
-            except Exception:
-                _logger.debug("Failed to handle exception in MLflow trace", exc_info=True)
-
-            return original(instance, exc_type, exc_val, exc_tb)
-
-        safe_patch(
-            FLAVOR_NAME,
-            TraceCtxManager,
-            "__exit__",
-            _patched_exit,
-        )
 
     def on_trace_start(self, trace: oai.Trace) -> None:
-        try:
+        if (active_span := get_current_active_span()) and active_span.name == _AGENT_RUN_SPAN_NAME:
+            # The root span is already started by the _patched_agent_run
+            mlflow_span = active_span
+            token = None
+        else:
+            # Users create a trace using `agents.trace` in OpenAI Agent SDK
+            # Ref: ...
+            # We need to create a corresponding MLflow span to track the trace
             mlflow_span = start_span_no_context(
                 name=trace.name,
                 span_type=SpanType.AGENT,
@@ -105,47 +96,33 @@ class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):
                 inputs="",
                 attributes=trace.metadata,
             )
-            # NB: Trace ID has different prefix as span ID so will not conflict
-            self._span_id_to_mlflow_span[trace.trace_id] = mlflow_span
+            token = set_span_in_context(mlflow_span)
 
-            if trace.group_id:
-                # Group ID is used for grouping multiple agent executions together
-                mlflow_span.set_tag("group_id", trace.group_id)
+        # NB: Trace ID has different prefix as span ID so will not conflict
+        self._span_id_to_mlflow_span[trace.trace_id] = (mlflow_span, token)
 
-            original_exit = trace.__exit__
-
-            # Patch __exit__ method to handle exception properly
-            def _patched_exit(self, exc_type, exc_val, exc_tb):
-                if exc_val:
-                    mlflow_span.add_event(SpanEvent.from_exception(exc_val))
-                    mlflow_span.set_status(SpanStatusCode.ERROR)
-
-                original_exit(exc_type, exc_val, exc_tb)
-
-            safe_patch(
-                FLAVOR_NAME,
-                trace.__class__,
-                "__exit__",
-                _patched_exit,
-            )
-
-        except Exception:
-            _logger.debug("Failed to start MLflow trace", exc_info=True)
+        if trace.group_id:
+            # Group ID is used for grouping multiple agent executions together
+            mlflow_span.set_tag("group_id", trace.group_id)
 
     def on_trace_end(self, trace: oai.Trace) -> None:
         try:
-            mlflow_span = self._span_id_to_mlflow_span.pop(trace.trace_id, None)
-            mlflow_span.end(status=mlflow_span.status, outputs="")
+            mlflow_span, token = self._span_id_to_mlflow_span.pop(trace.trace_id, (None, None))
+            if token:
+                detach_span_from_context(token)
+                mlflow_span.end(status=mlflow_span.status, outputs="")
         except Exception:
             _logger.debug("Failed to end MLflow trace", exc_info=True)
 
     def on_span_start(self, span: oai.Span[Any]) -> None:
         try:
-            parent_mlflow_span = self._span_id_to_mlflow_span.get(span.parent_id)
+            parent_mlflow_span, _ = self._span_id_to_mlflow_span.get(span.parent_id, (None, None))
 
             # Parent might be a trace
             if not parent_mlflow_span:
-                parent_mlflow_span = self._span_id_to_mlflow_span.get(span.trace_id)
+                parent_mlflow_span, _ = self._span_id_to_mlflow_span.get(
+                    span.trace_id, (None, None)
+                )
 
             inputs, _, attributes = _parse_span_data(span.span_data)
             span_type = _SPAN_TYPE_MAP.get(span.span_data.type, SpanType.CHAIN)
@@ -157,18 +134,20 @@ class MlflowOpenAgentTracingProcessor(oai.TracingProcessor):
                 inputs=inputs,
                 attributes=attributes,
             )
+            token = set_span_in_context(mlflow_span)
 
             if span_type == SpanType.CHAT_MODEL:
                 mlflow_span.set_attribute(SpanAttributeKey.MESSAGE_FORMAT, "openai-agent")
 
-            self._span_id_to_mlflow_span[span.span_id] = mlflow_span
+            self._span_id_to_mlflow_span[span.span_id] = (mlflow_span, token)
         except Exception:
             _logger.debug("Failed to start MLflow span", exc_info=True)
 
     def on_span_end(self, span: oai.Span[Any]) -> None:
         try:
             # parsed_span_data = parse_spandata(span.span_data)
-            mlflow_span = self._span_id_to_mlflow_span.pop(span.span_id, None)
+            mlflow_span, token = self._span_id_to_mlflow_span.pop(span.span_id, (None, None))
+            detach_span_from_context(token)
 
             inputs, outputs, attributes = _parse_span_data(span.span_data)
 
@@ -292,3 +271,19 @@ def _parse_response_span_data(span_data: oai.ResponseSpanData) -> tuple[Any, Any
         attributes[SpanAttributeKey.CHAT_TOOLS] = chat_tools
 
     return inputs, outputs, attributes
+
+
+async def _patched_agent_run(original, self, *args, **kwargs):
+    inputs = construct_full_inputs(original, self, *args, **kwargs)
+    attributes = {k: v for k, v in inputs.items() if k not in ("starting_agent", "input")}
+
+    with start_span(
+        name=_AGENT_RUN_SPAN_NAME,
+        span_type=SpanType.AGENT,
+        attributes=attributes,
+    ) as span:
+        span.set_inputs(inputs.get("input"))
+        result = await original(self, *args, **kwargs)
+        span.set_outputs(result.final_output)
+
+    return result

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -75,6 +75,14 @@ def autolog(
     # Tracing OpenAI Agent SDK. This has to be done outside the function annotated with
     # `@autologging_integration` because the function is not executed when `disable=True`.
     try:
+        from agents.run import AgentRunner
+        from mlflow.openai._agent_tracer import _patched_agent_run
+
+        # NB: The OpenAI's built-in tracer does not capture inputs/outputs of the
+        # root span, which is not inconvenient. Therefore, we add a patch for the
+        # runner.run() method instead.
+        safe_patch(FLAVOR_NAME, AgentRunner, "run", _patched_agent_run)
+
         from mlflow.openai._agent_tracer import (
             add_mlflow_trace_processor,
             remove_mlflow_trace_processor,

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -76,6 +76,7 @@ def autolog(
     # `@autologging_integration` because the function is not executed when `disable=True`.
     try:
         from agents.run import AgentRunner
+
         from mlflow.openai._agent_tracer import _patched_agent_run
 
         # NB: The OpenAI's built-in tracer does not capture inputs/outputs of the


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17227?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17227/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17227/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17227/merge
```

</p>
</details>

### What changes are proposed in this pull request?

OpenAI Agents SDK tracing is based on their built-in callback mechanism. However, it doesn't pass the end request and response for the agent, hence we cannot capture inputs and outputs for the root span. This makes it hard to integrate it with downstream tasks like eval.

This PR updates the tracing logic to patch the entrypoint `agent.run` directly to capture end request and response.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix OpenAI Agents SDK auto-tracing to capture end request and response properly.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
