### PR TITLE
Add protobuf stub file generation to generate_protos.py

### DIFF
--- a/dev/generate_protos.py
+++ b/dev/generate_protos.py
@@ -36,6 +36,24 @@ def gen_protos(
     )
 
 
+def gen_stub_files(
+    proto_dir: Path,
+    proto_files: list[Path],
+    protoc_bin: Path,
+    protoc_include_path: Path,
+    out_dir: Path,
+) -> None:
+    subprocess.check_call(
+        [
+            protoc_bin,
+            f"-I={protoc_include_path}",
+            f"-I={proto_dir}",
+            f"--pyi_out={out_dir}",
+            *[proto_dir / pf for pf in proto_files],
+        ]
+    )
+
+
 def apply_python_gencode_replacement(file_path: Path) -> None:
     content = file_path.read_text()
 
@@ -233,6 +251,14 @@ def main() -> None:
         protoc3194,
         protoc3194_include,
         Path("mlflow/java/client/src/main/java"),
+    )
+
+    gen_stub_files(
+        MLFLOW_PROTOS_DIR,
+        python_proto_files,
+        protoc5260,
+        protoc5260_include,
+        Path("mlflow/protos/"),
     )
 
 

--- a/mlflow/protos/assessments_pb2.pyi
+++ b/mlflow/protos/assessments_pb2.pyi
@@ -1,0 +1,100 @@
+import databricks_pb2 as _databricks_pb2
+from google.protobuf import struct_pb2 as _struct_pb2
+from google.protobuf import timestamp_pb2 as _timestamp_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class AssessmentSource(_message.Message):
+    __slots__ = ("source_type", "source_id")
+    class SourceType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        SOURCE_TYPE_UNSPECIFIED: _ClassVar[AssessmentSource.SourceType]
+        HUMAN: _ClassVar[AssessmentSource.SourceType]
+        LLM_JUDGE: _ClassVar[AssessmentSource.SourceType]
+        CODE: _ClassVar[AssessmentSource.SourceType]
+    SOURCE_TYPE_UNSPECIFIED: AssessmentSource.SourceType
+    HUMAN: AssessmentSource.SourceType
+    LLM_JUDGE: AssessmentSource.SourceType
+    CODE: AssessmentSource.SourceType
+    SOURCE_TYPE_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_ID_FIELD_NUMBER: _ClassVar[int]
+    source_type: AssessmentSource.SourceType
+    source_id: str
+    def __init__(self, source_type: _Optional[_Union[AssessmentSource.SourceType, str]] = ..., source_id: _Optional[str] = ...) -> None: ...
+
+class AssessmentError(_message.Message):
+    __slots__ = ("error_code", "error_message", "stack_trace")
+    ERROR_CODE_FIELD_NUMBER: _ClassVar[int]
+    ERROR_MESSAGE_FIELD_NUMBER: _ClassVar[int]
+    STACK_TRACE_FIELD_NUMBER: _ClassVar[int]
+    error_code: str
+    error_message: str
+    stack_trace: str
+    def __init__(self, error_code: _Optional[str] = ..., error_message: _Optional[str] = ..., stack_trace: _Optional[str] = ...) -> None: ...
+
+class Expectation(_message.Message):
+    __slots__ = ("value", "serialized_value")
+    class SerializedValue(_message.Message):
+        __slots__ = ("serialization_format", "value")
+        SERIALIZATION_FORMAT_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        serialization_format: str
+        value: str
+        def __init__(self, serialization_format: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    SERIALIZED_VALUE_FIELD_NUMBER: _ClassVar[int]
+    value: _struct_pb2.Value
+    serialized_value: Expectation.SerializedValue
+    def __init__(self, value: _Optional[_Union[_struct_pb2.Value, _Mapping]] = ..., serialized_value: _Optional[_Union[Expectation.SerializedValue, _Mapping]] = ...) -> None: ...
+
+class Feedback(_message.Message):
+    __slots__ = ("value", "error")
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
+    value: _struct_pb2.Value
+    error: AssessmentError
+    def __init__(self, value: _Optional[_Union[_struct_pb2.Value, _Mapping]] = ..., error: _Optional[_Union[AssessmentError, _Mapping]] = ...) -> None: ...
+
+class Assessment(_message.Message):
+    __slots__ = ("assessment_id", "assessment_name", "trace_id", "span_id", "source", "create_time", "last_update_time", "feedback", "expectation", "rationale", "error", "metadata", "overrides", "valid")
+    class MetadataEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: str
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    ASSESSMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    ASSESSMENT_NAME_FIELD_NUMBER: _ClassVar[int]
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    SPAN_ID_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    CREATE_TIME_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATE_TIME_FIELD_NUMBER: _ClassVar[int]
+    FEEDBACK_FIELD_NUMBER: _ClassVar[int]
+    EXPECTATION_FIELD_NUMBER: _ClassVar[int]
+    RATIONALE_FIELD_NUMBER: _ClassVar[int]
+    ERROR_FIELD_NUMBER: _ClassVar[int]
+    METADATA_FIELD_NUMBER: _ClassVar[int]
+    OVERRIDES_FIELD_NUMBER: _ClassVar[int]
+    VALID_FIELD_NUMBER: _ClassVar[int]
+    assessment_id: str
+    assessment_name: str
+    trace_id: str
+    span_id: str
+    source: AssessmentSource
+    create_time: _timestamp_pb2.Timestamp
+    last_update_time: _timestamp_pb2.Timestamp
+    feedback: Feedback
+    expectation: Expectation
+    rationale: str
+    error: AssessmentError
+    metadata: _containers.ScalarMap[str, str]
+    overrides: str
+    valid: bool
+    def __init__(self, assessment_id: _Optional[str] = ..., assessment_name: _Optional[str] = ..., trace_id: _Optional[str] = ..., span_id: _Optional[str] = ..., source: _Optional[_Union[AssessmentSource, _Mapping]] = ..., create_time: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., last_update_time: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., feedback: _Optional[_Union[Feedback, _Mapping]] = ..., expectation: _Optional[_Union[Expectation, _Mapping]] = ..., rationale: _Optional[str] = ..., error: _Optional[_Union[AssessmentError, _Mapping]] = ..., metadata: _Optional[_Mapping[str, str]] = ..., overrides: _Optional[str] = ..., valid: bool = ...) -> None: ...

--- a/mlflow/protos/databricks_artifacts_pb2.pyi
+++ b/mlflow/protos/databricks_artifacts_pb2.pyi
@@ -1,0 +1,203 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import databricks_pb2 as _databricks_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class ArtifactCredentialType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    AZURE_SAS_URI: _ClassVar[ArtifactCredentialType]
+    AWS_PRESIGNED_URL: _ClassVar[ArtifactCredentialType]
+    GCP_SIGNED_URL: _ClassVar[ArtifactCredentialType]
+    AZURE_ADLS_GEN2_SAS_URI: _ClassVar[ArtifactCredentialType]
+AZURE_SAS_URI: ArtifactCredentialType
+AWS_PRESIGNED_URL: ArtifactCredentialType
+GCP_SIGNED_URL: ArtifactCredentialType
+AZURE_ADLS_GEN2_SAS_URI: ArtifactCredentialType
+
+class ArtifactCredentialInfo(_message.Message):
+    __slots__ = ("run_id", "path", "signed_uri", "headers", "type")
+    class HttpHeader(_message.Message):
+        __slots__ = ("name", "value")
+        NAME_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        name: str
+        value: str
+        def __init__(self, name: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    SIGNED_URI_FIELD_NUMBER: _ClassVar[int]
+    HEADERS_FIELD_NUMBER: _ClassVar[int]
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    path: str
+    signed_uri: str
+    headers: _containers.RepeatedCompositeFieldContainer[ArtifactCredentialInfo.HttpHeader]
+    type: ArtifactCredentialType
+    def __init__(self, run_id: _Optional[str] = ..., path: _Optional[str] = ..., signed_uri: _Optional[str] = ..., headers: _Optional[_Iterable[_Union[ArtifactCredentialInfo.HttpHeader, _Mapping]]] = ..., type: _Optional[_Union[ArtifactCredentialType, str]] = ...) -> None: ...
+
+class LoggedModelArtifactCredential(_message.Message):
+    __slots__ = ("model_id", "credential_info")
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    CREDENTIAL_INFO_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    credential_info: ArtifactCredentialInfo
+    def __init__(self, model_id: _Optional[str] = ..., credential_info: _Optional[_Union[ArtifactCredentialInfo, _Mapping]] = ...) -> None: ...
+
+class GetCredentialsForRead(_message.Message):
+    __slots__ = ("run_id", "path", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("credential_infos", "next_page_token")
+        CREDENTIAL_INFOS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        credential_infos: _containers.RepeatedCompositeFieldContainer[ArtifactCredentialInfo]
+        next_page_token: str
+        def __init__(self, credential_infos: _Optional[_Iterable[_Union[ArtifactCredentialInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    path: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, run_id: _Optional[str] = ..., path: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class GetCredentialsForWrite(_message.Message):
+    __slots__ = ("run_id", "path", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("credential_infos", "next_page_token")
+        CREDENTIAL_INFOS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        credential_infos: _containers.RepeatedCompositeFieldContainer[ArtifactCredentialInfo]
+        next_page_token: str
+        def __init__(self, credential_infos: _Optional[_Iterable[_Union[ArtifactCredentialInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    path: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, run_id: _Optional[str] = ..., path: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class CreateMultipartUpload(_message.Message):
+    __slots__ = ("run_id", "path", "num_parts")
+    class Response(_message.Message):
+        __slots__ = ("upload_id", "upload_credential_infos", "abort_credential_info")
+        UPLOAD_ID_FIELD_NUMBER: _ClassVar[int]
+        UPLOAD_CREDENTIAL_INFOS_FIELD_NUMBER: _ClassVar[int]
+        ABORT_CREDENTIAL_INFO_FIELD_NUMBER: _ClassVar[int]
+        upload_id: str
+        upload_credential_infos: _containers.RepeatedCompositeFieldContainer[ArtifactCredentialInfo]
+        abort_credential_info: ArtifactCredentialInfo
+        def __init__(self, upload_id: _Optional[str] = ..., upload_credential_infos: _Optional[_Iterable[_Union[ArtifactCredentialInfo, _Mapping]]] = ..., abort_credential_info: _Optional[_Union[ArtifactCredentialInfo, _Mapping]] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    NUM_PARTS_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    path: str
+    num_parts: int
+    def __init__(self, run_id: _Optional[str] = ..., path: _Optional[str] = ..., num_parts: _Optional[int] = ...) -> None: ...
+
+class PartEtag(_message.Message):
+    __slots__ = ("part_number", "etag")
+    PART_NUMBER_FIELD_NUMBER: _ClassVar[int]
+    ETAG_FIELD_NUMBER: _ClassVar[int]
+    part_number: int
+    etag: str
+    def __init__(self, part_number: _Optional[int] = ..., etag: _Optional[str] = ...) -> None: ...
+
+class CompleteMultipartUpload(_message.Message):
+    __slots__ = ("run_id", "path", "upload_id", "part_etags")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    UPLOAD_ID_FIELD_NUMBER: _ClassVar[int]
+    PART_ETAGS_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    path: str
+    upload_id: str
+    part_etags: _containers.RepeatedCompositeFieldContainer[PartEtag]
+    def __init__(self, run_id: _Optional[str] = ..., path: _Optional[str] = ..., upload_id: _Optional[str] = ..., part_etags: _Optional[_Iterable[_Union[PartEtag, _Mapping]]] = ...) -> None: ...
+
+class GetPresignedUploadPartUrl(_message.Message):
+    __slots__ = ("run_id", "path", "upload_id", "part_number")
+    class Response(_message.Message):
+        __slots__ = ("upload_credential_info",)
+        UPLOAD_CREDENTIAL_INFO_FIELD_NUMBER: _ClassVar[int]
+        upload_credential_info: ArtifactCredentialInfo
+        def __init__(self, upload_credential_info: _Optional[_Union[ArtifactCredentialInfo, _Mapping]] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    UPLOAD_ID_FIELD_NUMBER: _ClassVar[int]
+    PART_NUMBER_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    path: str
+    upload_id: str
+    part_number: int
+    def __init__(self, run_id: _Optional[str] = ..., path: _Optional[str] = ..., upload_id: _Optional[str] = ..., part_number: _Optional[int] = ...) -> None: ...
+
+class GetCredentialsForTraceDataDownload(_message.Message):
+    __slots__ = ("request_id",)
+    class Response(_message.Message):
+        __slots__ = ("credential_info",)
+        CREDENTIAL_INFO_FIELD_NUMBER: _ClassVar[int]
+        credential_info: ArtifactCredentialInfo
+        def __init__(self, credential_info: _Optional[_Union[ArtifactCredentialInfo, _Mapping]] = ...) -> None: ...
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    request_id: str
+    def __init__(self, request_id: _Optional[str] = ...) -> None: ...
+
+class GetCredentialsForTraceDataUpload(_message.Message):
+    __slots__ = ("request_id",)
+    class Response(_message.Message):
+        __slots__ = ("credential_info",)
+        CREDENTIAL_INFO_FIELD_NUMBER: _ClassVar[int]
+        credential_info: ArtifactCredentialInfo
+        def __init__(self, credential_info: _Optional[_Union[ArtifactCredentialInfo, _Mapping]] = ...) -> None: ...
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    request_id: str
+    def __init__(self, request_id: _Optional[str] = ...) -> None: ...
+
+class GetCredentialsForLoggedModelUpload(_message.Message):
+    __slots__ = ("model_id", "paths", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("credentials", "next_page_token")
+        CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        credentials: _containers.RepeatedCompositeFieldContainer[LoggedModelArtifactCredential]
+        next_page_token: str
+        def __init__(self, credentials: _Optional[_Iterable[_Union[LoggedModelArtifactCredential, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    PATHS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    paths: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, model_id: _Optional[str] = ..., paths: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class GetCredentialsForLoggedModelDownload(_message.Message):
+    __slots__ = ("model_id", "paths", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("credentials", "next_page_token")
+        CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        credentials: _containers.RepeatedCompositeFieldContainer[LoggedModelArtifactCredential]
+        next_page_token: str
+        def __init__(self, credentials: _Optional[_Iterable[_Union[LoggedModelArtifactCredential, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    PATHS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    paths: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, model_id: _Optional[str] = ..., paths: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class DatabricksMlflowArtifactsService(_service.service): ...
+
+class DatabricksMlflowArtifactsService_Stub(DatabricksMlflowArtifactsService): ...

--- a/mlflow/protos/databricks_filesystem_service_pb2.pyi
+++ b/mlflow/protos/databricks_filesystem_service_pb2.pyi
@@ -1,0 +1,71 @@
+import databricks_pb2 as _databricks_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class HttpHeader(_message.Message):
+    __slots__ = ("name", "value")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class CreateDownloadUrlRequest(_message.Message):
+    __slots__ = ("path",)
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    def __init__(self, path: _Optional[str] = ...) -> None: ...
+
+class CreateDownloadUrlResponse(_message.Message):
+    __slots__ = ("url", "headers")
+    URL_FIELD_NUMBER: _ClassVar[int]
+    HEADERS_FIELD_NUMBER: _ClassVar[int]
+    url: str
+    headers: _containers.RepeatedCompositeFieldContainer[HttpHeader]
+    def __init__(self, url: _Optional[str] = ..., headers: _Optional[_Iterable[_Union[HttpHeader, _Mapping]]] = ...) -> None: ...
+
+class CreateUploadUrlRequest(_message.Message):
+    __slots__ = ("path",)
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    def __init__(self, path: _Optional[str] = ...) -> None: ...
+
+class CreateUploadUrlResponse(_message.Message):
+    __slots__ = ("url", "headers")
+    URL_FIELD_NUMBER: _ClassVar[int]
+    HEADERS_FIELD_NUMBER: _ClassVar[int]
+    url: str
+    headers: _containers.RepeatedCompositeFieldContainer[HttpHeader]
+    def __init__(self, url: _Optional[str] = ..., headers: _Optional[_Iterable[_Union[HttpHeader, _Mapping]]] = ...) -> None: ...
+
+class DirectoryEntry(_message.Message):
+    __slots__ = ("path", "is_directory", "file_size", "last_modified", "name")
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    IS_DIRECTORY_FIELD_NUMBER: _ClassVar[int]
+    FILE_SIZE_FIELD_NUMBER: _ClassVar[int]
+    LAST_MODIFIED_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    is_directory: bool
+    file_size: int
+    last_modified: int
+    name: str
+    def __init__(self, path: _Optional[str] = ..., is_directory: bool = ..., file_size: _Optional[int] = ..., last_modified: _Optional[int] = ..., name: _Optional[str] = ...) -> None: ...
+
+class ListDirectoryResponse(_message.Message):
+    __slots__ = ("contents", "next_page_token")
+    CONTENTS_FIELD_NUMBER: _ClassVar[int]
+    NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    contents: _containers.RepeatedCompositeFieldContainer[DirectoryEntry]
+    next_page_token: str
+    def __init__(self, contents: _Optional[_Iterable[_Union[DirectoryEntry, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+
+class FilesystemService(_service.service): ...
+
+class FilesystemService_Stub(FilesystemService): ...

--- a/mlflow/protos/databricks_managed_catalog_messages_pb2.pyi
+++ b/mlflow/protos/databricks_managed_catalog_messages_pb2.pyi
@@ -1,0 +1,40 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Optional as _Optional
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class TableInfo(_message.Message):
+    __slots__ = ("full_name", "table_id")
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    TABLE_ID_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    table_id: str
+    def __init__(self, full_name: _Optional[str] = ..., table_id: _Optional[str] = ...) -> None: ...
+
+class GetTable(_message.Message):
+    __slots__ = ("full_name_arg", "omit_columns", "omit_properties", "omit_constraints", "omit_dependencies", "omit_username", "omit_storage_credential_name")
+    FULL_NAME_ARG_FIELD_NUMBER: _ClassVar[int]
+    OMIT_COLUMNS_FIELD_NUMBER: _ClassVar[int]
+    OMIT_PROPERTIES_FIELD_NUMBER: _ClassVar[int]
+    OMIT_CONSTRAINTS_FIELD_NUMBER: _ClassVar[int]
+    OMIT_DEPENDENCIES_FIELD_NUMBER: _ClassVar[int]
+    OMIT_USERNAME_FIELD_NUMBER: _ClassVar[int]
+    OMIT_STORAGE_CREDENTIAL_NAME_FIELD_NUMBER: _ClassVar[int]
+    full_name_arg: str
+    omit_columns: bool
+    omit_properties: bool
+    omit_constraints: bool
+    omit_dependencies: bool
+    omit_username: bool
+    omit_storage_credential_name: bool
+    def __init__(self, full_name_arg: _Optional[str] = ..., omit_columns: bool = ..., omit_properties: bool = ..., omit_constraints: bool = ..., omit_dependencies: bool = ..., omit_username: bool = ..., omit_storage_credential_name: bool = ...) -> None: ...
+
+class GetTableResponse(_message.Message):
+    __slots__ = ("full_name", "table_id")
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    TABLE_ID_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    table_id: str
+    def __init__(self, full_name: _Optional[str] = ..., table_id: _Optional[str] = ...) -> None: ...

--- a/mlflow/protos/databricks_managed_catalog_service_pb2.pyi
+++ b/mlflow/protos/databricks_managed_catalog_service_pb2.pyi
@@ -1,0 +1,12 @@
+import databricks_pb2 as _databricks_pb2
+import databricks_managed_catalog_messages_pb2 as _databricks_managed_catalog_messages_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class DatabricksUnityCatalogService(_service.service): ...
+
+class DatabricksUnityCatalogService_Stub(DatabricksUnityCatalogService): ...

--- a/mlflow/protos/databricks_pb2.pyi
+++ b/mlflow/protos/databricks_pb2.pyi
@@ -1,0 +1,263 @@
+from google.protobuf import descriptor_pb2 as _descriptor_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class Visibility(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    PUBLIC: _ClassVar[Visibility]
+    INTERNAL: _ClassVar[Visibility]
+    PUBLIC_UNDOCUMENTED: _ClassVar[Visibility]
+
+class ErrorCode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    INTERNAL_ERROR: _ClassVar[ErrorCode]
+    TEMPORARILY_UNAVAILABLE: _ClassVar[ErrorCode]
+    IO_ERROR: _ClassVar[ErrorCode]
+    BAD_REQUEST: _ClassVar[ErrorCode]
+    SERVICE_UNDER_MAINTENANCE: _ClassVar[ErrorCode]
+    WORKSPACE_TEMPORARILY_UNAVAILABLE: _ClassVar[ErrorCode]
+    DEADLINE_EXCEEDED: _ClassVar[ErrorCode]
+    CANCELLED: _ClassVar[ErrorCode]
+    RESOURCE_EXHAUSTED: _ClassVar[ErrorCode]
+    ABORTED: _ClassVar[ErrorCode]
+    NOT_FOUND: _ClassVar[ErrorCode]
+    ALREADY_EXISTS: _ClassVar[ErrorCode]
+    UNAUTHENTICATED: _ClassVar[ErrorCode]
+    INVALID_PARAMETER_VALUE: _ClassVar[ErrorCode]
+    ENDPOINT_NOT_FOUND: _ClassVar[ErrorCode]
+    MALFORMED_REQUEST: _ClassVar[ErrorCode]
+    INVALID_STATE: _ClassVar[ErrorCode]
+    PERMISSION_DENIED: _ClassVar[ErrorCode]
+    FEATURE_DISABLED: _ClassVar[ErrorCode]
+    CUSTOMER_UNAUTHORIZED: _ClassVar[ErrorCode]
+    REQUEST_LIMIT_EXCEEDED: _ClassVar[ErrorCode]
+    RESOURCE_CONFLICT: _ClassVar[ErrorCode]
+    UNPARSEABLE_HTTP_ERROR: _ClassVar[ErrorCode]
+    NOT_IMPLEMENTED: _ClassVar[ErrorCode]
+    DATA_LOSS: _ClassVar[ErrorCode]
+    INVALID_STATE_TRANSITION: _ClassVar[ErrorCode]
+    COULD_NOT_ACQUIRE_LOCK: _ClassVar[ErrorCode]
+    RESOURCE_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    RESOURCE_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    QUOTA_EXCEEDED: _ClassVar[ErrorCode]
+    MAX_BLOCK_SIZE_EXCEEDED: _ClassVar[ErrorCode]
+    MAX_READ_SIZE_EXCEEDED: _ClassVar[ErrorCode]
+    PARTIAL_DELETE: _ClassVar[ErrorCode]
+    MAX_LIST_SIZE_EXCEEDED: _ClassVar[ErrorCode]
+    DRY_RUN_FAILED: _ClassVar[ErrorCode]
+    RESOURCE_LIMIT_EXCEEDED: _ClassVar[ErrorCode]
+    DIRECTORY_NOT_EMPTY: _ClassVar[ErrorCode]
+    DIRECTORY_PROTECTED: _ClassVar[ErrorCode]
+    MAX_NOTEBOOK_SIZE_EXCEEDED: _ClassVar[ErrorCode]
+    MAX_CHILD_NODE_SIZE_EXCEEDED: _ClassVar[ErrorCode]
+    SEARCH_QUERY_TOO_LONG: _ClassVar[ErrorCode]
+    SEARCH_QUERY_TOO_SHORT: _ClassVar[ErrorCode]
+    MANAGED_RESOURCE_GROUP_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    PERMISSION_NOT_PROPAGATED: _ClassVar[ErrorCode]
+    DEPLOYMENT_TIMEOUT: _ClassVar[ErrorCode]
+    GIT_CONFLICT: _ClassVar[ErrorCode]
+    GIT_UNKNOWN_REF: _ClassVar[ErrorCode]
+    GIT_SENSITIVE_TOKEN_DETECTED: _ClassVar[ErrorCode]
+    GIT_URL_NOT_ON_ALLOW_LIST: _ClassVar[ErrorCode]
+    GIT_REMOTE_ERROR: _ClassVar[ErrorCode]
+    PROJECTS_OPERATION_TIMEOUT: _ClassVar[ErrorCode]
+    IPYNB_FILE_IN_REPO: _ClassVar[ErrorCode]
+    INSECURE_PARTNER_RESPONSE: _ClassVar[ErrorCode]
+    MALFORMED_PARTNER_RESPONSE: _ClassVar[ErrorCode]
+    METASTORE_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    DAC_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    CATALOG_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    SCHEMA_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    TABLE_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    SHARE_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    RECIPIENT_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    STORAGE_CREDENTIAL_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    EXTERNAL_LOCATION_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    PRINCIPAL_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    PROVIDER_DOES_NOT_EXIST: _ClassVar[ErrorCode]
+    METASTORE_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    DAC_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    CATALOG_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    SCHEMA_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    TABLE_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    SHARE_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    RECIPIENT_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    STORAGE_CREDENTIAL_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    EXTERNAL_LOCATION_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    PROVIDER_ALREADY_EXISTS: _ClassVar[ErrorCode]
+    CATALOG_NOT_EMPTY: _ClassVar[ErrorCode]
+    SCHEMA_NOT_EMPTY: _ClassVar[ErrorCode]
+    METASTORE_NOT_EMPTY: _ClassVar[ErrorCode]
+    PROVIDER_SHARE_NOT_ACCESSIBLE: _ClassVar[ErrorCode]
+PUBLIC: Visibility
+INTERNAL: Visibility
+PUBLIC_UNDOCUMENTED: Visibility
+INTERNAL_ERROR: ErrorCode
+TEMPORARILY_UNAVAILABLE: ErrorCode
+IO_ERROR: ErrorCode
+BAD_REQUEST: ErrorCode
+SERVICE_UNDER_MAINTENANCE: ErrorCode
+WORKSPACE_TEMPORARILY_UNAVAILABLE: ErrorCode
+DEADLINE_EXCEEDED: ErrorCode
+CANCELLED: ErrorCode
+RESOURCE_EXHAUSTED: ErrorCode
+ABORTED: ErrorCode
+NOT_FOUND: ErrorCode
+ALREADY_EXISTS: ErrorCode
+UNAUTHENTICATED: ErrorCode
+INVALID_PARAMETER_VALUE: ErrorCode
+ENDPOINT_NOT_FOUND: ErrorCode
+MALFORMED_REQUEST: ErrorCode
+INVALID_STATE: ErrorCode
+PERMISSION_DENIED: ErrorCode
+FEATURE_DISABLED: ErrorCode
+CUSTOMER_UNAUTHORIZED: ErrorCode
+REQUEST_LIMIT_EXCEEDED: ErrorCode
+RESOURCE_CONFLICT: ErrorCode
+UNPARSEABLE_HTTP_ERROR: ErrorCode
+NOT_IMPLEMENTED: ErrorCode
+DATA_LOSS: ErrorCode
+INVALID_STATE_TRANSITION: ErrorCode
+COULD_NOT_ACQUIRE_LOCK: ErrorCode
+RESOURCE_ALREADY_EXISTS: ErrorCode
+RESOURCE_DOES_NOT_EXIST: ErrorCode
+QUOTA_EXCEEDED: ErrorCode
+MAX_BLOCK_SIZE_EXCEEDED: ErrorCode
+MAX_READ_SIZE_EXCEEDED: ErrorCode
+PARTIAL_DELETE: ErrorCode
+MAX_LIST_SIZE_EXCEEDED: ErrorCode
+DRY_RUN_FAILED: ErrorCode
+RESOURCE_LIMIT_EXCEEDED: ErrorCode
+DIRECTORY_NOT_EMPTY: ErrorCode
+DIRECTORY_PROTECTED: ErrorCode
+MAX_NOTEBOOK_SIZE_EXCEEDED: ErrorCode
+MAX_CHILD_NODE_SIZE_EXCEEDED: ErrorCode
+SEARCH_QUERY_TOO_LONG: ErrorCode
+SEARCH_QUERY_TOO_SHORT: ErrorCode
+MANAGED_RESOURCE_GROUP_DOES_NOT_EXIST: ErrorCode
+PERMISSION_NOT_PROPAGATED: ErrorCode
+DEPLOYMENT_TIMEOUT: ErrorCode
+GIT_CONFLICT: ErrorCode
+GIT_UNKNOWN_REF: ErrorCode
+GIT_SENSITIVE_TOKEN_DETECTED: ErrorCode
+GIT_URL_NOT_ON_ALLOW_LIST: ErrorCode
+GIT_REMOTE_ERROR: ErrorCode
+PROJECTS_OPERATION_TIMEOUT: ErrorCode
+IPYNB_FILE_IN_REPO: ErrorCode
+INSECURE_PARTNER_RESPONSE: ErrorCode
+MALFORMED_PARTNER_RESPONSE: ErrorCode
+METASTORE_DOES_NOT_EXIST: ErrorCode
+DAC_DOES_NOT_EXIST: ErrorCode
+CATALOG_DOES_NOT_EXIST: ErrorCode
+SCHEMA_DOES_NOT_EXIST: ErrorCode
+TABLE_DOES_NOT_EXIST: ErrorCode
+SHARE_DOES_NOT_EXIST: ErrorCode
+RECIPIENT_DOES_NOT_EXIST: ErrorCode
+STORAGE_CREDENTIAL_DOES_NOT_EXIST: ErrorCode
+EXTERNAL_LOCATION_DOES_NOT_EXIST: ErrorCode
+PRINCIPAL_DOES_NOT_EXIST: ErrorCode
+PROVIDER_DOES_NOT_EXIST: ErrorCode
+METASTORE_ALREADY_EXISTS: ErrorCode
+DAC_ALREADY_EXISTS: ErrorCode
+CATALOG_ALREADY_EXISTS: ErrorCode
+SCHEMA_ALREADY_EXISTS: ErrorCode
+TABLE_ALREADY_EXISTS: ErrorCode
+SHARE_ALREADY_EXISTS: ErrorCode
+RECIPIENT_ALREADY_EXISTS: ErrorCode
+STORAGE_CREDENTIAL_ALREADY_EXISTS: ErrorCode
+EXTERNAL_LOCATION_ALREADY_EXISTS: ErrorCode
+PROVIDER_ALREADY_EXISTS: ErrorCode
+CATALOG_NOT_EMPTY: ErrorCode
+SCHEMA_NOT_EMPTY: ErrorCode
+METASTORE_NOT_EMPTY: ErrorCode
+PROVIDER_SHARE_NOT_ACCESSIBLE: ErrorCode
+VISIBILITY_FIELD_NUMBER: _ClassVar[int]
+visibility: _descriptor.FieldDescriptor
+VALIDATE_REQUIRED_FIELD_NUMBER: _ClassVar[int]
+validate_required: _descriptor.FieldDescriptor
+JSON_INLINE_FIELD_NUMBER: _ClassVar[int]
+json_inline: _descriptor.FieldDescriptor
+JSON_MAP_FIELD_NUMBER: _ClassVar[int]
+json_map: _descriptor.FieldDescriptor
+FIELD_DOC_FIELD_NUMBER: _ClassVar[int]
+field_doc: _descriptor.FieldDescriptor
+RPC_FIELD_NUMBER: _ClassVar[int]
+rpc: _descriptor.FieldDescriptor
+METHOD_DOC_FIELD_NUMBER: _ClassVar[int]
+method_doc: _descriptor.FieldDescriptor
+GRAPHQL_FIELD_NUMBER: _ClassVar[int]
+graphql: _descriptor.FieldDescriptor
+MESSAGE_DOC_FIELD_NUMBER: _ClassVar[int]
+message_doc: _descriptor.FieldDescriptor
+SERVICE_DOC_FIELD_NUMBER: _ClassVar[int]
+service_doc: _descriptor.FieldDescriptor
+ENUM_DOC_FIELD_NUMBER: _ClassVar[int]
+enum_doc: _descriptor.FieldDescriptor
+ENUM_VALUE_VISIBILITY_FIELD_NUMBER: _ClassVar[int]
+enum_value_visibility: _descriptor.FieldDescriptor
+ENUM_VALUE_DOC_FIELD_NUMBER: _ClassVar[int]
+enum_value_doc: _descriptor.FieldDescriptor
+
+class DatabricksRpcOptions(_message.Message):
+    __slots__ = ("endpoints", "visibility", "error_codes", "rate_limit", "rpc_doc_title")
+    ENDPOINTS_FIELD_NUMBER: _ClassVar[int]
+    VISIBILITY_FIELD_NUMBER: _ClassVar[int]
+    ERROR_CODES_FIELD_NUMBER: _ClassVar[int]
+    RATE_LIMIT_FIELD_NUMBER: _ClassVar[int]
+    RPC_DOC_TITLE_FIELD_NUMBER: _ClassVar[int]
+    endpoints: _containers.RepeatedCompositeFieldContainer[HttpEndpoint]
+    visibility: Visibility
+    error_codes: _containers.RepeatedScalarFieldContainer[ErrorCode]
+    rate_limit: RateLimit
+    rpc_doc_title: str
+    def __init__(self, endpoints: _Optional[_Iterable[_Union[HttpEndpoint, _Mapping]]] = ..., visibility: _Optional[_Union[Visibility, str]] = ..., error_codes: _Optional[_Iterable[_Union[ErrorCode, str]]] = ..., rate_limit: _Optional[_Union[RateLimit, _Mapping]] = ..., rpc_doc_title: _Optional[str] = ...) -> None: ...
+
+class DatabricksGraphqlOptions(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class HttpEndpoint(_message.Message):
+    __slots__ = ("method", "path", "since")
+    METHOD_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    SINCE_FIELD_NUMBER: _ClassVar[int]
+    method: str
+    path: str
+    since: ApiVersion
+    def __init__(self, method: _Optional[str] = ..., path: _Optional[str] = ..., since: _Optional[_Union[ApiVersion, _Mapping]] = ...) -> None: ...
+
+class ApiVersion(_message.Message):
+    __slots__ = ("major", "minor")
+    MAJOR_FIELD_NUMBER: _ClassVar[int]
+    MINOR_FIELD_NUMBER: _ClassVar[int]
+    major: int
+    minor: int
+    def __init__(self, major: _Optional[int] = ..., minor: _Optional[int] = ...) -> None: ...
+
+class RateLimit(_message.Message):
+    __slots__ = ("max_burst", "max_sustained_per_second")
+    MAX_BURST_FIELD_NUMBER: _ClassVar[int]
+    MAX_SUSTAINED_PER_SECOND_FIELD_NUMBER: _ClassVar[int]
+    max_burst: int
+    max_sustained_per_second: int
+    def __init__(self, max_burst: _Optional[int] = ..., max_sustained_per_second: _Optional[int] = ...) -> None: ...
+
+class DocumentationMetadata(_message.Message):
+    __slots__ = ("docstring", "lead_doc", "visibility", "original_proto_path", "position")
+    DOCSTRING_FIELD_NUMBER: _ClassVar[int]
+    LEAD_DOC_FIELD_NUMBER: _ClassVar[int]
+    VISIBILITY_FIELD_NUMBER: _ClassVar[int]
+    ORIGINAL_PROTO_PATH_FIELD_NUMBER: _ClassVar[int]
+    POSITION_FIELD_NUMBER: _ClassVar[int]
+    docstring: str
+    lead_doc: str
+    visibility: Visibility
+    original_proto_path: _containers.RepeatedScalarFieldContainer[str]
+    position: int
+    def __init__(self, docstring: _Optional[str] = ..., lead_doc: _Optional[str] = ..., visibility: _Optional[_Union[Visibility, str]] = ..., original_proto_path: _Optional[_Iterable[str]] = ..., position: _Optional[int] = ...) -> None: ...

--- a/mlflow/protos/databricks_trace_server_pb2.pyi
+++ b/mlflow/protos/databricks_trace_server_pb2.pyi
@@ -1,0 +1,234 @@
+import databricks_pb2 as _databricks_pb2
+import assessments_pb2 as _assessments_pb2
+from google.protobuf import duration_pb2 as _duration_pb2
+from google.protobuf import struct_pb2 as _struct_pb2
+from google.protobuf import timestamp_pb2 as _timestamp_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class CreateTrace(_message.Message):
+    __slots__ = ("info", "data")
+    INFO_FIELD_NUMBER: _ClassVar[int]
+    DATA_FIELD_NUMBER: _ClassVar[int]
+    info: TraceInfo
+    data: TraceData
+    def __init__(self, info: _Optional[_Union[TraceInfo, _Mapping]] = ..., data: _Optional[_Union[TraceData, _Mapping]] = ...) -> None: ...
+
+class Trace(_message.Message):
+    __slots__ = ("info", "data")
+    INFO_FIELD_NUMBER: _ClassVar[int]
+    DATA_FIELD_NUMBER: _ClassVar[int]
+    info: TraceInfo
+    data: TraceData
+    def __init__(self, info: _Optional[_Union[TraceInfo, _Mapping]] = ..., data: _Optional[_Union[TraceData, _Mapping]] = ...) -> None: ...
+
+class TraceInfo(_message.Message):
+    __slots__ = ("trace_id", "client_request_id", "trace_location", "request", "response", "request_preview", "response_preview", "request_time", "execution_duration", "state", "trace_metadata", "assessments", "tags")
+    class State(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        STATE_UNSPECIFIED: _ClassVar[TraceInfo.State]
+        OK: _ClassVar[TraceInfo.State]
+        ERROR: _ClassVar[TraceInfo.State]
+        IN_PROGRESS: _ClassVar[TraceInfo.State]
+    STATE_UNSPECIFIED: TraceInfo.State
+    OK: TraceInfo.State
+    ERROR: TraceInfo.State
+    IN_PROGRESS: TraceInfo.State
+    class TraceMetadataEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: str
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    class TagsEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: str
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    CLIENT_REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    TRACE_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_FIELD_NUMBER: _ClassVar[int]
+    RESPONSE_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_PREVIEW_FIELD_NUMBER: _ClassVar[int]
+    RESPONSE_PREVIEW_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_TIME_FIELD_NUMBER: _ClassVar[int]
+    EXECUTION_DURATION_FIELD_NUMBER: _ClassVar[int]
+    STATE_FIELD_NUMBER: _ClassVar[int]
+    TRACE_METADATA_FIELD_NUMBER: _ClassVar[int]
+    ASSESSMENTS_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    client_request_id: str
+    trace_location: TraceLocation
+    request: str
+    response: str
+    request_preview: str
+    response_preview: str
+    request_time: _timestamp_pb2.Timestamp
+    execution_duration: _duration_pb2.Duration
+    state: TraceInfo.State
+    trace_metadata: _containers.ScalarMap[str, str]
+    assessments: _containers.RepeatedCompositeFieldContainer[_assessments_pb2.Assessment]
+    tags: _containers.ScalarMap[str, str]
+    def __init__(self, trace_id: _Optional[str] = ..., client_request_id: _Optional[str] = ..., trace_location: _Optional[_Union[TraceLocation, _Mapping]] = ..., request: _Optional[str] = ..., response: _Optional[str] = ..., request_preview: _Optional[str] = ..., response_preview: _Optional[str] = ..., request_time: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., execution_duration: _Optional[_Union[_duration_pb2.Duration, _Mapping]] = ..., state: _Optional[_Union[TraceInfo.State, str]] = ..., trace_metadata: _Optional[_Mapping[str, str]] = ..., assessments: _Optional[_Iterable[_Union[_assessments_pb2.Assessment, _Mapping]]] = ..., tags: _Optional[_Mapping[str, str]] = ...) -> None: ...
+
+class TraceLocation(_message.Message):
+    __slots__ = ("type", "mlflow_experiment", "inference_table")
+    class TraceLocationType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        TRACE_LOCATION_TYPE_UNSPECIFIED: _ClassVar[TraceLocation.TraceLocationType]
+        MLFLOW_EXPERIMENT: _ClassVar[TraceLocation.TraceLocationType]
+        INFERENCE_TABLE: _ClassVar[TraceLocation.TraceLocationType]
+    TRACE_LOCATION_TYPE_UNSPECIFIED: TraceLocation.TraceLocationType
+    MLFLOW_EXPERIMENT: TraceLocation.TraceLocationType
+    INFERENCE_TABLE: TraceLocation.TraceLocationType
+    class MlflowExperimentLocation(_message.Message):
+        __slots__ = ("experiment_id",)
+        EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+        experiment_id: str
+        def __init__(self, experiment_id: _Optional[str] = ...) -> None: ...
+    class InferenceTableLocation(_message.Message):
+        __slots__ = ("full_table_name",)
+        FULL_TABLE_NAME_FIELD_NUMBER: _ClassVar[int]
+        full_table_name: str
+        def __init__(self, full_table_name: _Optional[str] = ...) -> None: ...
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    MLFLOW_EXPERIMENT_FIELD_NUMBER: _ClassVar[int]
+    INFERENCE_TABLE_FIELD_NUMBER: _ClassVar[int]
+    type: TraceLocation.TraceLocationType
+    mlflow_experiment: TraceLocation.MlflowExperimentLocation
+    inference_table: TraceLocation.InferenceTableLocation
+    def __init__(self, type: _Optional[_Union[TraceLocation.TraceLocationType, str]] = ..., mlflow_experiment: _Optional[_Union[TraceLocation.MlflowExperimentLocation, _Mapping]] = ..., inference_table: _Optional[_Union[TraceLocation.InferenceTableLocation, _Mapping]] = ...) -> None: ...
+
+class TraceData(_message.Message):
+    __slots__ = ("spans",)
+    SPANS_FIELD_NUMBER: _ClassVar[int]
+    spans: _containers.RepeatedCompositeFieldContainer[Span]
+    def __init__(self, spans: _Optional[_Iterable[_Union[Span, _Mapping]]] = ...) -> None: ...
+
+class Span(_message.Message):
+    __slots__ = ("trace_id", "span_id", "trace_state", "parent_span_id", "flags", "name", "kind", "start_time_unix_nano", "end_time_unix_nano", "attributes", "dropped_attributes_count", "events", "dropped_events_count", "links", "dropped_links_count", "status")
+    class SpanKind(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        SPAN_KIND_UNSPECIFIED: _ClassVar[Span.SpanKind]
+        SPAN_KIND_INTERNAL: _ClassVar[Span.SpanKind]
+        SPAN_KIND_SERVER: _ClassVar[Span.SpanKind]
+        SPAN_KIND_CLIENT: _ClassVar[Span.SpanKind]
+        SPAN_KIND_PRODUCER: _ClassVar[Span.SpanKind]
+        SPAN_KIND_CONSUMER: _ClassVar[Span.SpanKind]
+    SPAN_KIND_UNSPECIFIED: Span.SpanKind
+    SPAN_KIND_INTERNAL: Span.SpanKind
+    SPAN_KIND_SERVER: Span.SpanKind
+    SPAN_KIND_CLIENT: Span.SpanKind
+    SPAN_KIND_PRODUCER: Span.SpanKind
+    SPAN_KIND_CONSUMER: Span.SpanKind
+    class AttributesEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: _struct_pb2.Value
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[_Union[_struct_pb2.Value, _Mapping]] = ...) -> None: ...
+    class Event(_message.Message):
+        __slots__ = ("time_unix_nano", "name", "attributes", "dropped_attributes_count")
+        class AttributesEntry(_message.Message):
+            __slots__ = ("key", "value")
+            KEY_FIELD_NUMBER: _ClassVar[int]
+            VALUE_FIELD_NUMBER: _ClassVar[int]
+            key: str
+            value: _struct_pb2.Value
+            def __init__(self, key: _Optional[str] = ..., value: _Optional[_Union[_struct_pb2.Value, _Mapping]] = ...) -> None: ...
+        TIME_UNIX_NANO_FIELD_NUMBER: _ClassVar[int]
+        NAME_FIELD_NUMBER: _ClassVar[int]
+        ATTRIBUTES_FIELD_NUMBER: _ClassVar[int]
+        DROPPED_ATTRIBUTES_COUNT_FIELD_NUMBER: _ClassVar[int]
+        time_unix_nano: int
+        name: str
+        attributes: _containers.MessageMap[str, _struct_pb2.Value]
+        dropped_attributes_count: int
+        def __init__(self, time_unix_nano: _Optional[int] = ..., name: _Optional[str] = ..., attributes: _Optional[_Mapping[str, _struct_pb2.Value]] = ..., dropped_attributes_count: _Optional[int] = ...) -> None: ...
+    class Link(_message.Message):
+        __slots__ = ("trace_id", "span_id", "trace_state", "attributes", "dropped_attributes_count", "flags")
+        class AttributesEntry(_message.Message):
+            __slots__ = ("key", "value")
+            KEY_FIELD_NUMBER: _ClassVar[int]
+            VALUE_FIELD_NUMBER: _ClassVar[int]
+            key: str
+            value: _struct_pb2.Value
+            def __init__(self, key: _Optional[str] = ..., value: _Optional[_Union[_struct_pb2.Value, _Mapping]] = ...) -> None: ...
+        TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+        SPAN_ID_FIELD_NUMBER: _ClassVar[int]
+        TRACE_STATE_FIELD_NUMBER: _ClassVar[int]
+        ATTRIBUTES_FIELD_NUMBER: _ClassVar[int]
+        DROPPED_ATTRIBUTES_COUNT_FIELD_NUMBER: _ClassVar[int]
+        FLAGS_FIELD_NUMBER: _ClassVar[int]
+        trace_id: bytes
+        span_id: bytes
+        trace_state: str
+        attributes: _containers.MessageMap[str, _struct_pb2.Value]
+        dropped_attributes_count: int
+        flags: int
+        def __init__(self, trace_id: _Optional[bytes] = ..., span_id: _Optional[bytes] = ..., trace_state: _Optional[str] = ..., attributes: _Optional[_Mapping[str, _struct_pb2.Value]] = ..., dropped_attributes_count: _Optional[int] = ..., flags: _Optional[int] = ...) -> None: ...
+    class Status(_message.Message):
+        __slots__ = ("message", "code")
+        class StatusCode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+            __slots__ = ()
+            STATUS_CODE_UNSET: _ClassVar[Span.Status.StatusCode]
+            STATUS_CODE_OK: _ClassVar[Span.Status.StatusCode]
+            STATUS_CODE_ERROR: _ClassVar[Span.Status.StatusCode]
+        STATUS_CODE_UNSET: Span.Status.StatusCode
+        STATUS_CODE_OK: Span.Status.StatusCode
+        STATUS_CODE_ERROR: Span.Status.StatusCode
+        MESSAGE_FIELD_NUMBER: _ClassVar[int]
+        CODE_FIELD_NUMBER: _ClassVar[int]
+        message: str
+        code: Span.Status.StatusCode
+        def __init__(self, message: _Optional[str] = ..., code: _Optional[_Union[Span.Status.StatusCode, str]] = ...) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    SPAN_ID_FIELD_NUMBER: _ClassVar[int]
+    TRACE_STATE_FIELD_NUMBER: _ClassVar[int]
+    PARENT_SPAN_ID_FIELD_NUMBER: _ClassVar[int]
+    FLAGS_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    KIND_FIELD_NUMBER: _ClassVar[int]
+    START_TIME_UNIX_NANO_FIELD_NUMBER: _ClassVar[int]
+    END_TIME_UNIX_NANO_FIELD_NUMBER: _ClassVar[int]
+    ATTRIBUTES_FIELD_NUMBER: _ClassVar[int]
+    DROPPED_ATTRIBUTES_COUNT_FIELD_NUMBER: _ClassVar[int]
+    EVENTS_FIELD_NUMBER: _ClassVar[int]
+    DROPPED_EVENTS_COUNT_FIELD_NUMBER: _ClassVar[int]
+    LINKS_FIELD_NUMBER: _ClassVar[int]
+    DROPPED_LINKS_COUNT_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    trace_id: bytes
+    span_id: bytes
+    trace_state: str
+    parent_span_id: bytes
+    flags: int
+    name: str
+    kind: Span.SpanKind
+    start_time_unix_nano: int
+    end_time_unix_nano: int
+    attributes: _containers.MessageMap[str, _struct_pb2.Value]
+    dropped_attributes_count: int
+    events: _containers.RepeatedCompositeFieldContainer[Span.Event]
+    dropped_events_count: int
+    links: _containers.RepeatedCompositeFieldContainer[Span.Link]
+    dropped_links_count: int
+    status: Span.Status
+    def __init__(self, trace_id: _Optional[bytes] = ..., span_id: _Optional[bytes] = ..., trace_state: _Optional[str] = ..., parent_span_id: _Optional[bytes] = ..., flags: _Optional[int] = ..., name: _Optional[str] = ..., kind: _Optional[_Union[Span.SpanKind, str]] = ..., start_time_unix_nano: _Optional[int] = ..., end_time_unix_nano: _Optional[int] = ..., attributes: _Optional[_Mapping[str, _struct_pb2.Value]] = ..., dropped_attributes_count: _Optional[int] = ..., events: _Optional[_Iterable[_Union[Span.Event, _Mapping]]] = ..., dropped_events_count: _Optional[int] = ..., links: _Optional[_Iterable[_Union[Span.Link, _Mapping]]] = ..., dropped_links_count: _Optional[int] = ..., status: _Optional[_Union[Span.Status, _Mapping]] = ...) -> None: ...
+
+class DatabricksTracingServerService(_service.service): ...
+
+class DatabricksTracingServerService_Stub(DatabricksTracingServerService): ...

--- a/mlflow/protos/databricks_uc_registry_messages_pb2.pyi
+++ b/mlflow/protos/databricks_uc_registry_messages_pb2.pyi
@@ -1,0 +1,728 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import databricks_pb2 as _databricks_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class ModelVersionStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    UNSPECIFIED: _ClassVar[ModelVersionStatus]
+    PENDING_REGISTRATION: _ClassVar[ModelVersionStatus]
+    FAILED_REGISTRATION: _ClassVar[ModelVersionStatus]
+    READY: _ClassVar[ModelVersionStatus]
+
+class ModelVersionOperation(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    MODEL_VERSION_OPERATION_UNSPECIFIED: _ClassVar[ModelVersionOperation]
+    MODEL_VERSION_OPERATION_READ: _ClassVar[ModelVersionOperation]
+    MODEL_VERSION_OPERATION_READ_WRITE: _ClassVar[ModelVersionOperation]
+
+class StorageMode(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    STORAGE_MODE_UNSPECIFIED: _ClassVar[StorageMode]
+    CUSTOMER_HOSTED: _ClassVar[StorageMode]
+    DEFAULT_STORAGE: _ClassVar[StorageMode]
+
+class SseEncryptionAlgorithm(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    SSE_ENCRYPTION_ALGORITHM_UNSPECIFIED: _ClassVar[SseEncryptionAlgorithm]
+    AWS_SSE_S3: _ClassVar[SseEncryptionAlgorithm]
+    AWS_SSE_KMS: _ClassVar[SseEncryptionAlgorithm]
+
+class DependencyType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    DEPENDENCY_TYPE_UNSPECIFIED: _ClassVar[DependencyType]
+    DATABRICKS_VECTOR_INDEX: _ClassVar[DependencyType]
+    DATABRICKS_MODEL_ENDPOINT: _ClassVar[DependencyType]
+    DATABRICKS_UC_FUNCTION: _ClassVar[DependencyType]
+    DATABRICKS_UC_CONNECTION: _ClassVar[DependencyType]
+    DATABRICKS_TABLE: _ClassVar[DependencyType]
+
+class TableType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    TABLE: _ClassVar[TableType]
+    PERSISTED_VIEW: _ClassVar[TableType]
+    TEMP_VIEW: _ClassVar[TableType]
+    MATERIALIZED_VIEW: _ClassVar[TableType]
+    STREAMING_LIVE_TABLE: _ClassVar[TableType]
+    PATH: _ClassVar[TableType]
+
+class ModelVersionLineageDirection(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    UPSTREAM: _ClassVar[ModelVersionLineageDirection]
+    DOWNSTREAM: _ClassVar[ModelVersionLineageDirection]
+UNSPECIFIED: ModelVersionStatus
+PENDING_REGISTRATION: ModelVersionStatus
+FAILED_REGISTRATION: ModelVersionStatus
+READY: ModelVersionStatus
+MODEL_VERSION_OPERATION_UNSPECIFIED: ModelVersionOperation
+MODEL_VERSION_OPERATION_READ: ModelVersionOperation
+MODEL_VERSION_OPERATION_READ_WRITE: ModelVersionOperation
+STORAGE_MODE_UNSPECIFIED: StorageMode
+CUSTOMER_HOSTED: StorageMode
+DEFAULT_STORAGE: StorageMode
+SSE_ENCRYPTION_ALGORITHM_UNSPECIFIED: SseEncryptionAlgorithm
+AWS_SSE_S3: SseEncryptionAlgorithm
+AWS_SSE_KMS: SseEncryptionAlgorithm
+DEPENDENCY_TYPE_UNSPECIFIED: DependencyType
+DATABRICKS_VECTOR_INDEX: DependencyType
+DATABRICKS_MODEL_ENDPOINT: DependencyType
+DATABRICKS_UC_FUNCTION: DependencyType
+DATABRICKS_UC_CONNECTION: DependencyType
+DATABRICKS_TABLE: DependencyType
+TABLE: TableType
+PERSISTED_VIEW: TableType
+TEMP_VIEW: TableType
+MATERIALIZED_VIEW: TableType
+STREAMING_LIVE_TABLE: TableType
+PATH: TableType
+UPSTREAM: ModelVersionLineageDirection
+DOWNSTREAM: ModelVersionLineageDirection
+
+class RegisteredModel(_message.Message):
+    __slots__ = ("name", "creation_timestamp", "last_updated_timestamp", "user_id", "description", "aliases", "tags", "deployment_job_id", "deployment_job_state")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    USER_ID_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    ALIASES_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_STATE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    creation_timestamp: int
+    last_updated_timestamp: int
+    user_id: str
+    description: str
+    aliases: _containers.RepeatedCompositeFieldContainer[RegisteredModelAlias]
+    tags: _containers.RepeatedCompositeFieldContainer[RegisteredModelTag]
+    deployment_job_id: str
+    deployment_job_state: DeploymentJobConnection.State
+    def __init__(self, name: _Optional[str] = ..., creation_timestamp: _Optional[int] = ..., last_updated_timestamp: _Optional[int] = ..., user_id: _Optional[str] = ..., description: _Optional[str] = ..., aliases: _Optional[_Iterable[_Union[RegisteredModelAlias, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[RegisteredModelTag, _Mapping]]] = ..., deployment_job_id: _Optional[str] = ..., deployment_job_state: _Optional[_Union[DeploymentJobConnection.State, str]] = ...) -> None: ...
+
+class RegisteredModelAlias(_message.Message):
+    __slots__ = ("alias", "version")
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    alias: str
+    version: str
+    def __init__(self, alias: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class RegisteredModelTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class ModelParam(_message.Message):
+    __slots__ = ("name", "value")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class ModelMetric(_message.Message):
+    __slots__ = ("key", "value", "timestamp", "step", "dataset_name", "dataset_digest", "model_id", "run_id")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    STEP_FIELD_NUMBER: _ClassVar[int]
+    DATASET_NAME_FIELD_NUMBER: _ClassVar[int]
+    DATASET_DIGEST_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: float
+    timestamp: int
+    step: int
+    dataset_name: str
+    dataset_digest: str
+    model_id: str
+    run_id: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[float] = ..., timestamp: _Optional[int] = ..., step: _Optional[int] = ..., dataset_name: _Optional[str] = ..., dataset_digest: _Optional[str] = ..., model_id: _Optional[str] = ..., run_id: _Optional[str] = ...) -> None: ...
+
+class ModelVersionTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class ModelVersion(_message.Message):
+    __slots__ = ("name", "version", "creation_timestamp", "last_updated_timestamp", "user_id", "description", "source", "run_id", "run_experiment_id", "run_tracking_server_id", "status", "status_message", "storage_location", "aliases", "tags", "model_id", "model_params", "model_metrics", "deployment_job_state")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    USER_ID_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_TRACKING_SERVER_ID_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    STATUS_MESSAGE_FIELD_NUMBER: _ClassVar[int]
+    STORAGE_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    ALIASES_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    MODEL_PARAMS_FIELD_NUMBER: _ClassVar[int]
+    MODEL_METRICS_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_STATE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    creation_timestamp: int
+    last_updated_timestamp: int
+    user_id: str
+    description: str
+    source: str
+    run_id: str
+    run_experiment_id: str
+    run_tracking_server_id: str
+    status: ModelVersionStatus
+    status_message: str
+    storage_location: str
+    aliases: _containers.RepeatedCompositeFieldContainer[RegisteredModelAlias]
+    tags: _containers.RepeatedCompositeFieldContainer[ModelVersionTag]
+    model_id: str
+    model_params: _containers.RepeatedCompositeFieldContainer[ModelParam]
+    model_metrics: _containers.RepeatedCompositeFieldContainer[ModelMetric]
+    deployment_job_state: ModelVersionDeploymentJobState
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., creation_timestamp: _Optional[int] = ..., last_updated_timestamp: _Optional[int] = ..., user_id: _Optional[str] = ..., description: _Optional[str] = ..., source: _Optional[str] = ..., run_id: _Optional[str] = ..., run_experiment_id: _Optional[str] = ..., run_tracking_server_id: _Optional[str] = ..., status: _Optional[_Union[ModelVersionStatus, str]] = ..., status_message: _Optional[str] = ..., storage_location: _Optional[str] = ..., aliases: _Optional[_Iterable[_Union[RegisteredModelAlias, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[ModelVersionTag, _Mapping]]] = ..., model_id: _Optional[str] = ..., model_params: _Optional[_Iterable[_Union[ModelParam, _Mapping]]] = ..., model_metrics: _Optional[_Iterable[_Union[ModelMetric, _Mapping]]] = ..., deployment_job_state: _Optional[_Union[ModelVersionDeploymentJobState, _Mapping]] = ...) -> None: ...
+
+class DeploymentJobConnection(_message.Message):
+    __slots__ = ()
+    class State(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED: _ClassVar[DeploymentJobConnection.State]
+        NOT_SET_UP: _ClassVar[DeploymentJobConnection.State]
+        CONNECTED: _ClassVar[DeploymentJobConnection.State]
+        NOT_FOUND: _ClassVar[DeploymentJobConnection.State]
+        REQUIRED_PARAMETERS_CHANGED: _ClassVar[DeploymentJobConnection.State]
+    DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED: DeploymentJobConnection.State
+    NOT_SET_UP: DeploymentJobConnection.State
+    CONNECTED: DeploymentJobConnection.State
+    NOT_FOUND: DeploymentJobConnection.State
+    REQUIRED_PARAMETERS_CHANGED: DeploymentJobConnection.State
+    def __init__(self) -> None: ...
+
+class ModelVersionDeploymentJobState(_message.Message):
+    __slots__ = ("job_id", "run_id", "job_state", "run_state", "current_task_name")
+    class DeploymentJobRunState(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        NO_VALID_DEPLOYMENT_JOB_FOUND: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        RUNNING: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        SUCCEEDED: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        FAILED: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        PENDING: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        APPROVAL: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+    DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED: ModelVersionDeploymentJobState.DeploymentJobRunState
+    NO_VALID_DEPLOYMENT_JOB_FOUND: ModelVersionDeploymentJobState.DeploymentJobRunState
+    RUNNING: ModelVersionDeploymentJobState.DeploymentJobRunState
+    SUCCEEDED: ModelVersionDeploymentJobState.DeploymentJobRunState
+    FAILED: ModelVersionDeploymentJobState.DeploymentJobRunState
+    PENDING: ModelVersionDeploymentJobState.DeploymentJobRunState
+    APPROVAL: ModelVersionDeploymentJobState.DeploymentJobRunState
+    JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    JOB_STATE_FIELD_NUMBER: _ClassVar[int]
+    RUN_STATE_FIELD_NUMBER: _ClassVar[int]
+    CURRENT_TASK_NAME_FIELD_NUMBER: _ClassVar[int]
+    job_id: str
+    run_id: str
+    job_state: DeploymentJobConnection.State
+    run_state: ModelVersionDeploymentJobState.DeploymentJobRunState
+    current_task_name: str
+    def __init__(self, job_id: _Optional[str] = ..., run_id: _Optional[str] = ..., job_state: _Optional[_Union[DeploymentJobConnection.State, str]] = ..., run_state: _Optional[_Union[ModelVersionDeploymentJobState.DeploymentJobRunState, str]] = ..., current_task_name: _Optional[str] = ...) -> None: ...
+
+class TemporaryCredentials(_message.Message):
+    __slots__ = ("aws_temp_credentials", "azure_user_delegation_sas", "gcp_oauth_token", "r2_temp_credentials", "expiration_time", "storage_mode", "encryption_details")
+    AWS_TEMP_CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+    AZURE_USER_DELEGATION_SAS_FIELD_NUMBER: _ClassVar[int]
+    GCP_OAUTH_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    R2_TEMP_CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+    EXPIRATION_TIME_FIELD_NUMBER: _ClassVar[int]
+    STORAGE_MODE_FIELD_NUMBER: _ClassVar[int]
+    ENCRYPTION_DETAILS_FIELD_NUMBER: _ClassVar[int]
+    aws_temp_credentials: AwsCredentials
+    azure_user_delegation_sas: AzureUserDelegationSAS
+    gcp_oauth_token: GcpOauthToken
+    r2_temp_credentials: R2Credentials
+    expiration_time: int
+    storage_mode: StorageMode
+    encryption_details: EncryptionDetails
+    def __init__(self, aws_temp_credentials: _Optional[_Union[AwsCredentials, _Mapping]] = ..., azure_user_delegation_sas: _Optional[_Union[AzureUserDelegationSAS, _Mapping]] = ..., gcp_oauth_token: _Optional[_Union[GcpOauthToken, _Mapping]] = ..., r2_temp_credentials: _Optional[_Union[R2Credentials, _Mapping]] = ..., expiration_time: _Optional[int] = ..., storage_mode: _Optional[_Union[StorageMode, str]] = ..., encryption_details: _Optional[_Union[EncryptionDetails, _Mapping]] = ...) -> None: ...
+
+class AwsCredentials(_message.Message):
+    __slots__ = ("access_key_id", "secret_access_key", "session_token")
+    ACCESS_KEY_ID_FIELD_NUMBER: _ClassVar[int]
+    SECRET_ACCESS_KEY_FIELD_NUMBER: _ClassVar[int]
+    SESSION_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+    def __init__(self, access_key_id: _Optional[str] = ..., secret_access_key: _Optional[str] = ..., session_token: _Optional[str] = ...) -> None: ...
+
+class AzureUserDelegationSAS(_message.Message):
+    __slots__ = ("sas_token",)
+    SAS_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    sas_token: str
+    def __init__(self, sas_token: _Optional[str] = ...) -> None: ...
+
+class GcpOauthToken(_message.Message):
+    __slots__ = ("oauth_token",)
+    OAUTH_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    oauth_token: str
+    def __init__(self, oauth_token: _Optional[str] = ...) -> None: ...
+
+class R2Credentials(_message.Message):
+    __slots__ = ("access_key_id", "secret_access_key", "session_token")
+    ACCESS_KEY_ID_FIELD_NUMBER: _ClassVar[int]
+    SECRET_ACCESS_KEY_FIELD_NUMBER: _ClassVar[int]
+    SESSION_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+    def __init__(self, access_key_id: _Optional[str] = ..., secret_access_key: _Optional[str] = ..., session_token: _Optional[str] = ...) -> None: ...
+
+class EncryptionDetails(_message.Message):
+    __slots__ = ("sse_encryption_details",)
+    SSE_ENCRYPTION_DETAILS_FIELD_NUMBER: _ClassVar[int]
+    sse_encryption_details: SseEncryptionDetails
+    def __init__(self, sse_encryption_details: _Optional[_Union[SseEncryptionDetails, _Mapping]] = ...) -> None: ...
+
+class SseEncryptionDetails(_message.Message):
+    __slots__ = ("algorithm", "aws_kms_key_arn")
+    ALGORITHM_FIELD_NUMBER: _ClassVar[int]
+    AWS_KMS_KEY_ARN_FIELD_NUMBER: _ClassVar[int]
+    algorithm: SseEncryptionAlgorithm
+    aws_kms_key_arn: str
+    def __init__(self, algorithm: _Optional[_Union[SseEncryptionAlgorithm, str]] = ..., aws_kms_key_arn: _Optional[str] = ...) -> None: ...
+
+class CreateRegisteredModelRequest(_message.Message):
+    __slots__ = ("name", "tags", "description", "deployment_job_id")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    tags: _containers.RepeatedCompositeFieldContainer[RegisteredModelTag]
+    description: str
+    deployment_job_id: str
+    def __init__(self, name: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[RegisteredModelTag, _Mapping]]] = ..., description: _Optional[str] = ..., deployment_job_id: _Optional[str] = ...) -> None: ...
+
+class CreateRegisteredModelResponse(_message.Message):
+    __slots__ = ("registered_model",)
+    REGISTERED_MODEL_FIELD_NUMBER: _ClassVar[int]
+    registered_model: RegisteredModel
+    def __init__(self, registered_model: _Optional[_Union[RegisteredModel, _Mapping]] = ...) -> None: ...
+
+class UpdateRegisteredModelRequest(_message.Message):
+    __slots__ = ("name", "new_name", "description", "deployment_job_id")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    NEW_NAME_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    new_name: str
+    description: str
+    deployment_job_id: str
+    def __init__(self, name: _Optional[str] = ..., new_name: _Optional[str] = ..., description: _Optional[str] = ..., deployment_job_id: _Optional[str] = ...) -> None: ...
+
+class UpdateRegisteredModelResponse(_message.Message):
+    __slots__ = ("registered_model",)
+    REGISTERED_MODEL_FIELD_NUMBER: _ClassVar[int]
+    registered_model: RegisteredModel
+    def __init__(self, registered_model: _Optional[_Union[RegisteredModel, _Mapping]] = ...) -> None: ...
+
+class DeleteRegisteredModelRequest(_message.Message):
+    __slots__ = ("name",)
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    def __init__(self, name: _Optional[str] = ...) -> None: ...
+
+class DeleteRegisteredModelResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class GetRegisteredModelRequest(_message.Message):
+    __slots__ = ("name",)
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    def __init__(self, name: _Optional[str] = ...) -> None: ...
+
+class GetRegisteredModelResponse(_message.Message):
+    __slots__ = ("registered_model",)
+    REGISTERED_MODEL_FIELD_NUMBER: _ClassVar[int]
+    registered_model: RegisteredModel
+    def __init__(self, registered_model: _Optional[_Union[RegisteredModel, _Mapping]] = ...) -> None: ...
+
+class SearchRegisteredModelsRequest(_message.Message):
+    __slots__ = ("max_results", "page_token")
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    max_results: int
+    page_token: str
+    def __init__(self, max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class SearchRegisteredModelsResponse(_message.Message):
+    __slots__ = ("registered_models", "next_page_token")
+    REGISTERED_MODELS_FIELD_NUMBER: _ClassVar[int]
+    NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    registered_models: _containers.RepeatedCompositeFieldContainer[RegisteredModel]
+    next_page_token: str
+    def __init__(self, registered_models: _Optional[_Iterable[_Union[RegisteredModel, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+
+class Dependency(_message.Message):
+    __slots__ = ("type", "name")
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    type: DependencyType
+    name: str
+    def __init__(self, type: _Optional[_Union[DependencyType, str]] = ..., name: _Optional[str] = ...) -> None: ...
+
+class CreateModelVersionRequest(_message.Message):
+    __slots__ = ("name", "source", "run_id", "description", "run_tracking_server_id", "feature_deps", "tags", "model_version_dependencies", "model_id")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    RUN_TRACKING_SERVER_ID_FIELD_NUMBER: _ClassVar[int]
+    FEATURE_DEPS_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    MODEL_VERSION_DEPENDENCIES_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    source: str
+    run_id: str
+    description: str
+    run_tracking_server_id: str
+    feature_deps: str
+    tags: _containers.RepeatedCompositeFieldContainer[ModelVersionTag]
+    model_version_dependencies: _containers.RepeatedCompositeFieldContainer[Dependency]
+    model_id: str
+    def __init__(self, name: _Optional[str] = ..., source: _Optional[str] = ..., run_id: _Optional[str] = ..., description: _Optional[str] = ..., run_tracking_server_id: _Optional[str] = ..., feature_deps: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[ModelVersionTag, _Mapping]]] = ..., model_version_dependencies: _Optional[_Iterable[_Union[Dependency, _Mapping]]] = ..., model_id: _Optional[str] = ...) -> None: ...
+
+class CreateModelVersionResponse(_message.Message):
+    __slots__ = ("model_version",)
+    MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+    model_version: ModelVersion
+    def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+
+class UpdateModelVersionRequest(_message.Message):
+    __slots__ = ("name", "version", "description")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    description: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., description: _Optional[str] = ...) -> None: ...
+
+class UpdateModelVersionResponse(_message.Message):
+    __slots__ = ("model_version",)
+    MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+    model_version: ModelVersion
+    def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+
+class DeleteModelVersionRequest(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class DeleteModelVersionResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class GetModelVersionRequest(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class GetModelVersionResponse(_message.Message):
+    __slots__ = ("model_version",)
+    MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+    model_version: ModelVersion
+    def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+
+class SearchModelVersionsRequest(_message.Message):
+    __slots__ = ("filter", "max_results", "page_token")
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    filter: str
+    max_results: int
+    page_token: str
+    def __init__(self, filter: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class SearchModelVersionsResponse(_message.Message):
+    __slots__ = ("model_versions", "next_page_token")
+    MODEL_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+    NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    model_versions: _containers.RepeatedCompositeFieldContainer[ModelVersion]
+    next_page_token: str
+    def __init__(self, model_versions: _Optional[_Iterable[_Union[ModelVersion, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+
+class GenerateTemporaryModelVersionCredentialsRequest(_message.Message):
+    __slots__ = ("name", "version", "operation")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    OPERATION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    operation: ModelVersionOperation
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., operation: _Optional[_Union[ModelVersionOperation, str]] = ...) -> None: ...
+
+class GenerateTemporaryModelVersionCredentialsResponse(_message.Message):
+    __slots__ = ("credentials",)
+    CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+    credentials: TemporaryCredentials
+    def __init__(self, credentials: _Optional[_Union[TemporaryCredentials, _Mapping]] = ...) -> None: ...
+
+class GetModelVersionDownloadUriRequest(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class GetModelVersionDownloadUriResponse(_message.Message):
+    __slots__ = ("artifact_uri",)
+    ARTIFACT_URI_FIELD_NUMBER: _ClassVar[int]
+    artifact_uri: str
+    def __init__(self, artifact_uri: _Optional[str] = ...) -> None: ...
+
+class FinalizeModelVersionRequest(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class FinalizeModelVersionResponse(_message.Message):
+    __slots__ = ("model_version",)
+    MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+    model_version: ModelVersion
+    def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+
+class SetRegisteredModelAliasRequest(_message.Message):
+    __slots__ = ("name", "alias", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class SetRegisteredModelAliasResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class DeleteRegisteredModelAliasRequest(_message.Message):
+    __slots__ = ("name", "alias")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ...) -> None: ...
+
+class DeleteRegisteredModelAliasResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class SetRegisteredModelTagRequest(_message.Message):
+    __slots__ = ("name", "key", "value")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    key: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class SetRegisteredModelTagResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class DeleteRegisteredModelTagRequest(_message.Message):
+    __slots__ = ("name", "key")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    key: str
+    def __init__(self, name: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class DeleteRegisteredModelTagResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class SetModelVersionTagRequest(_message.Message):
+    __slots__ = ("name", "version", "key", "value")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    key: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class SetModelVersionTagResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class DeleteModelVersionTagRequest(_message.Message):
+    __slots__ = ("name", "version", "key")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    key: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class DeleteModelVersionTagResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class GetModelVersionByAliasRequest(_message.Message):
+    __slots__ = ("name", "alias")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ...) -> None: ...
+
+class GetModelVersionByAliasResponse(_message.Message):
+    __slots__ = ("model_version",)
+    MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+    model_version: ModelVersion
+    def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+
+class Entity(_message.Message):
+    __slots__ = ("job", "notebook", "pipeline")
+    JOB_FIELD_NUMBER: _ClassVar[int]
+    NOTEBOOK_FIELD_NUMBER: _ClassVar[int]
+    PIPELINE_FIELD_NUMBER: _ClassVar[int]
+    job: Job
+    notebook: Notebook
+    pipeline: Pipeline
+    def __init__(self, job: _Optional[_Union[Job, _Mapping]] = ..., notebook: _Optional[_Union[Notebook, _Mapping]] = ..., pipeline: _Optional[_Union[Pipeline, _Mapping]] = ...) -> None: ...
+
+class Pipeline(_message.Message):
+    __slots__ = ("pipeline_id", "pipeline_update_id")
+    PIPELINE_ID_FIELD_NUMBER: _ClassVar[int]
+    PIPELINE_UPDATE_ID_FIELD_NUMBER: _ClassVar[int]
+    pipeline_id: str
+    pipeline_update_id: str
+    def __init__(self, pipeline_id: _Optional[str] = ..., pipeline_update_id: _Optional[str] = ...) -> None: ...
+
+class Job(_message.Message):
+    __slots__ = ("id", "task_key", "job_run_id", "task_run_id")
+    ID_FIELD_NUMBER: _ClassVar[int]
+    TASK_KEY_FIELD_NUMBER: _ClassVar[int]
+    JOB_RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    TASK_RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    id: str
+    task_key: str
+    job_run_id: str
+    task_run_id: str
+    def __init__(self, id: _Optional[str] = ..., task_key: _Optional[str] = ..., job_run_id: _Optional[str] = ..., task_run_id: _Optional[str] = ...) -> None: ...
+
+class Notebook(_message.Message):
+    __slots__ = ("id", "command_id", "notebook_run_id")
+    ID_FIELD_NUMBER: _ClassVar[int]
+    COMMAND_ID_FIELD_NUMBER: _ClassVar[int]
+    NOTEBOOK_RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    id: str
+    command_id: str
+    notebook_run_id: str
+    def __init__(self, id: _Optional[str] = ..., command_id: _Optional[str] = ..., notebook_run_id: _Optional[str] = ...) -> None: ...
+
+class Table(_message.Message):
+    __slots__ = ("name", "table_type", "location", "table_id")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    TABLE_TYPE_FIELD_NUMBER: _ClassVar[int]
+    LOCATION_FIELD_NUMBER: _ClassVar[int]
+    TABLE_ID_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    table_type: TableType
+    location: str
+    table_id: str
+    def __init__(self, name: _Optional[str] = ..., table_type: _Optional[_Union[TableType, str]] = ..., location: _Optional[str] = ..., table_id: _Optional[str] = ...) -> None: ...
+
+class Securable(_message.Message):
+    __slots__ = ("table",)
+    TABLE_FIELD_NUMBER: _ClassVar[int]
+    table: Table
+    def __init__(self, table: _Optional[_Union[Table, _Mapping]] = ...) -> None: ...
+
+class Lineage(_message.Message):
+    __slots__ = ("target_securable", "source_securables")
+    TARGET_SECURABLE_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_SECURABLES_FIELD_NUMBER: _ClassVar[int]
+    target_securable: Securable
+    source_securables: _containers.RepeatedCompositeFieldContainer[Securable]
+    def __init__(self, target_securable: _Optional[_Union[Securable, _Mapping]] = ..., source_securables: _Optional[_Iterable[_Union[Securable, _Mapping]]] = ...) -> None: ...
+
+class LineageHeaderInfo(_message.Message):
+    __slots__ = ("entities", "lineages")
+    ENTITIES_FIELD_NUMBER: _ClassVar[int]
+    LINEAGES_FIELD_NUMBER: _ClassVar[int]
+    entities: _containers.RepeatedCompositeFieldContainer[Entity]
+    lineages: _containers.RepeatedCompositeFieldContainer[Lineage]
+    def __init__(self, entities: _Optional[_Iterable[_Union[Entity, _Mapping]]] = ..., lineages: _Optional[_Iterable[_Union[Lineage, _Mapping]]] = ...) -> None: ...
+
+class ModelVersionLineageInfo(_message.Message):
+    __slots__ = ("entities", "direction")
+    ENTITIES_FIELD_NUMBER: _ClassVar[int]
+    DIRECTION_FIELD_NUMBER: _ClassVar[int]
+    entities: _containers.RepeatedCompositeFieldContainer[Entity]
+    direction: ModelVersionLineageDirection
+    def __init__(self, entities: _Optional[_Iterable[_Union[Entity, _Mapping]]] = ..., direction: _Optional[_Union[ModelVersionLineageDirection, str]] = ...) -> None: ...
+
+class EmitModelVersionLineageRequest(_message.Message):
+    __slots__ = ("name", "version", "model_version_lineage_info", "securable")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    MODEL_VERSION_LINEAGE_INFO_FIELD_NUMBER: _ClassVar[int]
+    SECURABLE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    model_version_lineage_info: ModelVersionLineageInfo
+    securable: Securable
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., model_version_lineage_info: _Optional[_Union[ModelVersionLineageInfo, _Mapping]] = ..., securable: _Optional[_Union[Securable, _Mapping]] = ...) -> None: ...
+
+class EmitModelVersionLineageResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class IsDatabricksSdkModelsArtifactRepositoryEnabledRequest(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class IsDatabricksSdkModelsArtifactRepositoryEnabledResponse(_message.Message):
+    __slots__ = ("is_databricks_sdk_models_artifact_repository_enabled",)
+    IS_DATABRICKS_SDK_MODELS_ARTIFACT_REPOSITORY_ENABLED_FIELD_NUMBER: _ClassVar[int]
+    is_databricks_sdk_models_artifact_repository_enabled: bool
+    def __init__(self, is_databricks_sdk_models_artifact_repository_enabled: bool = ...) -> None: ...

--- a/mlflow/protos/databricks_uc_registry_service_pb2.pyi
+++ b/mlflow/protos/databricks_uc_registry_service_pb2.pyi
@@ -1,0 +1,12 @@
+import databricks_pb2 as _databricks_pb2
+import databricks_uc_registry_messages_pb2 as _databricks_uc_registry_messages_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class UcModelRegistryService(_service.service): ...
+
+class UcModelRegistryService_Stub(UcModelRegistryService): ...

--- a/mlflow/protos/facet_feature_statistics_pb2.pyi
+++ b/mlflow/protos/facet_feature_statistics_pb2.pyi
@@ -1,0 +1,250 @@
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class DatasetFeatureStatisticsList(_message.Message):
+    __slots__ = ("datasets",)
+    DATASETS_FIELD_NUMBER: _ClassVar[int]
+    datasets: _containers.RepeatedCompositeFieldContainer[DatasetFeatureStatistics]
+    def __init__(self, datasets: _Optional[_Iterable[_Union[DatasetFeatureStatistics, _Mapping]]] = ...) -> None: ...
+
+class Path(_message.Message):
+    __slots__ = ("step",)
+    STEP_FIELD_NUMBER: _ClassVar[int]
+    step: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, step: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class DatasetFeatureStatistics(_message.Message):
+    __slots__ = ("name", "num_examples", "weighted_num_examples", "features")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    NUM_EXAMPLES_FIELD_NUMBER: _ClassVar[int]
+    WEIGHTED_NUM_EXAMPLES_FIELD_NUMBER: _ClassVar[int]
+    FEATURES_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    num_examples: int
+    weighted_num_examples: float
+    features: _containers.RepeatedCompositeFieldContainer[FeatureNameStatistics]
+    def __init__(self, name: _Optional[str] = ..., num_examples: _Optional[int] = ..., weighted_num_examples: _Optional[float] = ..., features: _Optional[_Iterable[_Union[FeatureNameStatistics, _Mapping]]] = ...) -> None: ...
+
+class FeatureNameStatistics(_message.Message):
+    __slots__ = ("name", "path", "type", "num_stats", "string_stats", "bytes_stats", "struct_stats", "custom_stats")
+    class Type(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        INT: _ClassVar[FeatureNameStatistics.Type]
+        FLOAT: _ClassVar[FeatureNameStatistics.Type]
+        STRING: _ClassVar[FeatureNameStatistics.Type]
+        BYTES: _ClassVar[FeatureNameStatistics.Type]
+        STRUCT: _ClassVar[FeatureNameStatistics.Type]
+    INT: FeatureNameStatistics.Type
+    FLOAT: FeatureNameStatistics.Type
+    STRING: FeatureNameStatistics.Type
+    BYTES: FeatureNameStatistics.Type
+    STRUCT: FeatureNameStatistics.Type
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    NUM_STATS_FIELD_NUMBER: _ClassVar[int]
+    STRING_STATS_FIELD_NUMBER: _ClassVar[int]
+    BYTES_STATS_FIELD_NUMBER: _ClassVar[int]
+    STRUCT_STATS_FIELD_NUMBER: _ClassVar[int]
+    CUSTOM_STATS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    path: Path
+    type: FeatureNameStatistics.Type
+    num_stats: NumericStatistics
+    string_stats: StringStatistics
+    bytes_stats: BytesStatistics
+    struct_stats: StructStatistics
+    custom_stats: _containers.RepeatedCompositeFieldContainer[CustomStatistic]
+    def __init__(self, name: _Optional[str] = ..., path: _Optional[_Union[Path, _Mapping]] = ..., type: _Optional[_Union[FeatureNameStatistics.Type, str]] = ..., num_stats: _Optional[_Union[NumericStatistics, _Mapping]] = ..., string_stats: _Optional[_Union[StringStatistics, _Mapping]] = ..., bytes_stats: _Optional[_Union[BytesStatistics, _Mapping]] = ..., struct_stats: _Optional[_Union[StructStatistics, _Mapping]] = ..., custom_stats: _Optional[_Iterable[_Union[CustomStatistic, _Mapping]]] = ...) -> None: ...
+
+class WeightedCommonStatistics(_message.Message):
+    __slots__ = ("num_non_missing", "num_missing", "avg_num_values", "tot_num_values")
+    NUM_NON_MISSING_FIELD_NUMBER: _ClassVar[int]
+    NUM_MISSING_FIELD_NUMBER: _ClassVar[int]
+    AVG_NUM_VALUES_FIELD_NUMBER: _ClassVar[int]
+    TOT_NUM_VALUES_FIELD_NUMBER: _ClassVar[int]
+    num_non_missing: float
+    num_missing: float
+    avg_num_values: float
+    tot_num_values: float
+    def __init__(self, num_non_missing: _Optional[float] = ..., num_missing: _Optional[float] = ..., avg_num_values: _Optional[float] = ..., tot_num_values: _Optional[float] = ...) -> None: ...
+
+class CustomStatistic(_message.Message):
+    __slots__ = ("name", "num", "str", "histogram", "rank_histogram")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    NUM_FIELD_NUMBER: _ClassVar[int]
+    STR_FIELD_NUMBER: _ClassVar[int]
+    HISTOGRAM_FIELD_NUMBER: _ClassVar[int]
+    RANK_HISTOGRAM_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    num: float
+    str: str
+    histogram: Histogram
+    rank_histogram: RankHistogram
+    def __init__(self, name: _Optional[str] = ..., num: _Optional[float] = ..., str: _Optional[str] = ..., histogram: _Optional[_Union[Histogram, _Mapping]] = ..., rank_histogram: _Optional[_Union[RankHistogram, _Mapping]] = ...) -> None: ...
+
+class NumericStatistics(_message.Message):
+    __slots__ = ("common_stats", "mean", "std_dev", "num_zeros", "min", "median", "max", "histograms", "weighted_numeric_stats")
+    COMMON_STATS_FIELD_NUMBER: _ClassVar[int]
+    MEAN_FIELD_NUMBER: _ClassVar[int]
+    STD_DEV_FIELD_NUMBER: _ClassVar[int]
+    NUM_ZEROS_FIELD_NUMBER: _ClassVar[int]
+    MIN_FIELD_NUMBER: _ClassVar[int]
+    MEDIAN_FIELD_NUMBER: _ClassVar[int]
+    MAX_FIELD_NUMBER: _ClassVar[int]
+    HISTOGRAMS_FIELD_NUMBER: _ClassVar[int]
+    WEIGHTED_NUMERIC_STATS_FIELD_NUMBER: _ClassVar[int]
+    common_stats: CommonStatistics
+    mean: float
+    std_dev: float
+    num_zeros: int
+    min: float
+    median: float
+    max: float
+    histograms: _containers.RepeatedCompositeFieldContainer[Histogram]
+    weighted_numeric_stats: WeightedNumericStatistics
+    def __init__(self, common_stats: _Optional[_Union[CommonStatistics, _Mapping]] = ..., mean: _Optional[float] = ..., std_dev: _Optional[float] = ..., num_zeros: _Optional[int] = ..., min: _Optional[float] = ..., median: _Optional[float] = ..., max: _Optional[float] = ..., histograms: _Optional[_Iterable[_Union[Histogram, _Mapping]]] = ..., weighted_numeric_stats: _Optional[_Union[WeightedNumericStatistics, _Mapping]] = ...) -> None: ...
+
+class StringStatistics(_message.Message):
+    __slots__ = ("common_stats", "unique", "top_values", "avg_length", "rank_histogram", "weighted_string_stats")
+    class FreqAndValue(_message.Message):
+        __slots__ = ("deprecated_freq", "value", "frequency")
+        DEPRECATED_FREQ_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        FREQUENCY_FIELD_NUMBER: _ClassVar[int]
+        deprecated_freq: int
+        value: str
+        frequency: float
+        def __init__(self, deprecated_freq: _Optional[int] = ..., value: _Optional[str] = ..., frequency: _Optional[float] = ...) -> None: ...
+    COMMON_STATS_FIELD_NUMBER: _ClassVar[int]
+    UNIQUE_FIELD_NUMBER: _ClassVar[int]
+    TOP_VALUES_FIELD_NUMBER: _ClassVar[int]
+    AVG_LENGTH_FIELD_NUMBER: _ClassVar[int]
+    RANK_HISTOGRAM_FIELD_NUMBER: _ClassVar[int]
+    WEIGHTED_STRING_STATS_FIELD_NUMBER: _ClassVar[int]
+    common_stats: CommonStatistics
+    unique: int
+    top_values: _containers.RepeatedCompositeFieldContainer[StringStatistics.FreqAndValue]
+    avg_length: float
+    rank_histogram: RankHistogram
+    weighted_string_stats: WeightedStringStatistics
+    def __init__(self, common_stats: _Optional[_Union[CommonStatistics, _Mapping]] = ..., unique: _Optional[int] = ..., top_values: _Optional[_Iterable[_Union[StringStatistics.FreqAndValue, _Mapping]]] = ..., avg_length: _Optional[float] = ..., rank_histogram: _Optional[_Union[RankHistogram, _Mapping]] = ..., weighted_string_stats: _Optional[_Union[WeightedStringStatistics, _Mapping]] = ...) -> None: ...
+
+class WeightedNumericStatistics(_message.Message):
+    __slots__ = ("mean", "std_dev", "median", "histograms")
+    MEAN_FIELD_NUMBER: _ClassVar[int]
+    STD_DEV_FIELD_NUMBER: _ClassVar[int]
+    MEDIAN_FIELD_NUMBER: _ClassVar[int]
+    HISTOGRAMS_FIELD_NUMBER: _ClassVar[int]
+    mean: float
+    std_dev: float
+    median: float
+    histograms: _containers.RepeatedCompositeFieldContainer[Histogram]
+    def __init__(self, mean: _Optional[float] = ..., std_dev: _Optional[float] = ..., median: _Optional[float] = ..., histograms: _Optional[_Iterable[_Union[Histogram, _Mapping]]] = ...) -> None: ...
+
+class WeightedStringStatistics(_message.Message):
+    __slots__ = ("top_values", "rank_histogram")
+    TOP_VALUES_FIELD_NUMBER: _ClassVar[int]
+    RANK_HISTOGRAM_FIELD_NUMBER: _ClassVar[int]
+    top_values: _containers.RepeatedCompositeFieldContainer[StringStatistics.FreqAndValue]
+    rank_histogram: RankHistogram
+    def __init__(self, top_values: _Optional[_Iterable[_Union[StringStatistics.FreqAndValue, _Mapping]]] = ..., rank_histogram: _Optional[_Union[RankHistogram, _Mapping]] = ...) -> None: ...
+
+class BytesStatistics(_message.Message):
+    __slots__ = ("common_stats", "unique", "avg_num_bytes", "min_num_bytes", "max_num_bytes")
+    COMMON_STATS_FIELD_NUMBER: _ClassVar[int]
+    UNIQUE_FIELD_NUMBER: _ClassVar[int]
+    AVG_NUM_BYTES_FIELD_NUMBER: _ClassVar[int]
+    MIN_NUM_BYTES_FIELD_NUMBER: _ClassVar[int]
+    MAX_NUM_BYTES_FIELD_NUMBER: _ClassVar[int]
+    common_stats: CommonStatistics
+    unique: int
+    avg_num_bytes: float
+    min_num_bytes: float
+    max_num_bytes: float
+    def __init__(self, common_stats: _Optional[_Union[CommonStatistics, _Mapping]] = ..., unique: _Optional[int] = ..., avg_num_bytes: _Optional[float] = ..., min_num_bytes: _Optional[float] = ..., max_num_bytes: _Optional[float] = ...) -> None: ...
+
+class StructStatistics(_message.Message):
+    __slots__ = ("common_stats",)
+    COMMON_STATS_FIELD_NUMBER: _ClassVar[int]
+    common_stats: CommonStatistics
+    def __init__(self, common_stats: _Optional[_Union[CommonStatistics, _Mapping]] = ...) -> None: ...
+
+class CommonStatistics(_message.Message):
+    __slots__ = ("num_non_missing", "num_missing", "min_num_values", "max_num_values", "avg_num_values", "tot_num_values", "num_values_histogram", "weighted_common_stats", "feature_list_length_histogram")
+    NUM_NON_MISSING_FIELD_NUMBER: _ClassVar[int]
+    NUM_MISSING_FIELD_NUMBER: _ClassVar[int]
+    MIN_NUM_VALUES_FIELD_NUMBER: _ClassVar[int]
+    MAX_NUM_VALUES_FIELD_NUMBER: _ClassVar[int]
+    AVG_NUM_VALUES_FIELD_NUMBER: _ClassVar[int]
+    TOT_NUM_VALUES_FIELD_NUMBER: _ClassVar[int]
+    NUM_VALUES_HISTOGRAM_FIELD_NUMBER: _ClassVar[int]
+    WEIGHTED_COMMON_STATS_FIELD_NUMBER: _ClassVar[int]
+    FEATURE_LIST_LENGTH_HISTOGRAM_FIELD_NUMBER: _ClassVar[int]
+    num_non_missing: int
+    num_missing: int
+    min_num_values: int
+    max_num_values: int
+    avg_num_values: float
+    tot_num_values: int
+    num_values_histogram: Histogram
+    weighted_common_stats: WeightedCommonStatistics
+    feature_list_length_histogram: Histogram
+    def __init__(self, num_non_missing: _Optional[int] = ..., num_missing: _Optional[int] = ..., min_num_values: _Optional[int] = ..., max_num_values: _Optional[int] = ..., avg_num_values: _Optional[float] = ..., tot_num_values: _Optional[int] = ..., num_values_histogram: _Optional[_Union[Histogram, _Mapping]] = ..., weighted_common_stats: _Optional[_Union[WeightedCommonStatistics, _Mapping]] = ..., feature_list_length_histogram: _Optional[_Union[Histogram, _Mapping]] = ...) -> None: ...
+
+class Histogram(_message.Message):
+    __slots__ = ("num_nan", "num_undefined", "buckets", "type", "name")
+    class HistogramType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        STANDARD: _ClassVar[Histogram.HistogramType]
+        QUANTILES: _ClassVar[Histogram.HistogramType]
+    STANDARD: Histogram.HistogramType
+    QUANTILES: Histogram.HistogramType
+    class Bucket(_message.Message):
+        __slots__ = ("low_value", "high_value", "deprecated_count", "sample_count")
+        LOW_VALUE_FIELD_NUMBER: _ClassVar[int]
+        HIGH_VALUE_FIELD_NUMBER: _ClassVar[int]
+        DEPRECATED_COUNT_FIELD_NUMBER: _ClassVar[int]
+        SAMPLE_COUNT_FIELD_NUMBER: _ClassVar[int]
+        low_value: float
+        high_value: float
+        deprecated_count: int
+        sample_count: float
+        def __init__(self, low_value: _Optional[float] = ..., high_value: _Optional[float] = ..., deprecated_count: _Optional[int] = ..., sample_count: _Optional[float] = ...) -> None: ...
+    NUM_NAN_FIELD_NUMBER: _ClassVar[int]
+    NUM_UNDEFINED_FIELD_NUMBER: _ClassVar[int]
+    BUCKETS_FIELD_NUMBER: _ClassVar[int]
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    num_nan: int
+    num_undefined: int
+    buckets: _containers.RepeatedCompositeFieldContainer[Histogram.Bucket]
+    type: Histogram.HistogramType
+    name: str
+    def __init__(self, num_nan: _Optional[int] = ..., num_undefined: _Optional[int] = ..., buckets: _Optional[_Iterable[_Union[Histogram.Bucket, _Mapping]]] = ..., type: _Optional[_Union[Histogram.HistogramType, str]] = ..., name: _Optional[str] = ...) -> None: ...
+
+class RankHistogram(_message.Message):
+    __slots__ = ("buckets", "name")
+    class Bucket(_message.Message):
+        __slots__ = ("low_rank", "high_rank", "deprecated_count", "label", "sample_count")
+        LOW_RANK_FIELD_NUMBER: _ClassVar[int]
+        HIGH_RANK_FIELD_NUMBER: _ClassVar[int]
+        DEPRECATED_COUNT_FIELD_NUMBER: _ClassVar[int]
+        LABEL_FIELD_NUMBER: _ClassVar[int]
+        SAMPLE_COUNT_FIELD_NUMBER: _ClassVar[int]
+        low_rank: int
+        high_rank: int
+        deprecated_count: int
+        label: str
+        sample_count: float
+        def __init__(self, low_rank: _Optional[int] = ..., high_rank: _Optional[int] = ..., deprecated_count: _Optional[int] = ..., label: _Optional[str] = ..., sample_count: _Optional[float] = ...) -> None: ...
+    BUCKETS_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    buckets: _containers.RepeatedCompositeFieldContainer[RankHistogram.Bucket]
+    name: str
+    def __init__(self, buckets: _Optional[_Iterable[_Union[RankHistogram.Bucket, _Mapping]]] = ..., name: _Optional[str] = ...) -> None: ...

--- a/mlflow/protos/internal_pb2.pyi
+++ b/mlflow/protos/internal_pb2.pyi
@@ -1,0 +1,22 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from typing import ClassVar as _ClassVar
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class InputVertexType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    RUN: _ClassVar[InputVertexType]
+    DATASET: _ClassVar[InputVertexType]
+    MODEL: _ClassVar[InputVertexType]
+
+class OutputVertexType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    RUN_OUTPUT: _ClassVar[OutputVertexType]
+    MODEL_OUTPUT: _ClassVar[OutputVertexType]
+RUN: InputVertexType
+DATASET: InputVertexType
+MODEL: InputVertexType
+RUN_OUTPUT: OutputVertexType
+MODEL_OUTPUT: OutputVertexType

--- a/mlflow/protos/mlflow_artifacts_pb2.pyi
+++ b/mlflow/protos/mlflow_artifacts_pb2.pyi
@@ -1,0 +1,121 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import databricks_pb2 as _databricks_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class DownloadArtifact(_message.Message):
+    __slots__ = ()
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    def __init__(self) -> None: ...
+
+class UploadArtifact(_message.Message):
+    __slots__ = ()
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    def __init__(self) -> None: ...
+
+class ListArtifacts(_message.Message):
+    __slots__ = ("path",)
+    class Response(_message.Message):
+        __slots__ = ("files",)
+        FILES_FIELD_NUMBER: _ClassVar[int]
+        files: _containers.RepeatedCompositeFieldContainer[FileInfo]
+        def __init__(self, files: _Optional[_Iterable[_Union[FileInfo, _Mapping]]] = ...) -> None: ...
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    def __init__(self, path: _Optional[str] = ...) -> None: ...
+
+class DeleteArtifact(_message.Message):
+    __slots__ = ()
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    def __init__(self) -> None: ...
+
+class FileInfo(_message.Message):
+    __slots__ = ("path", "is_dir", "file_size")
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    IS_DIR_FIELD_NUMBER: _ClassVar[int]
+    FILE_SIZE_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    is_dir: bool
+    file_size: int
+    def __init__(self, path: _Optional[str] = ..., is_dir: bool = ..., file_size: _Optional[int] = ...) -> None: ...
+
+class CreateMultipartUpload(_message.Message):
+    __slots__ = ("path", "num_parts")
+    class Response(_message.Message):
+        __slots__ = ("upload_id", "credentials")
+        UPLOAD_ID_FIELD_NUMBER: _ClassVar[int]
+        CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+        upload_id: str
+        credentials: _containers.RepeatedCompositeFieldContainer[MultipartUploadCredential]
+        def __init__(self, upload_id: _Optional[str] = ..., credentials: _Optional[_Iterable[_Union[MultipartUploadCredential, _Mapping]]] = ...) -> None: ...
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    NUM_PARTS_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    num_parts: int
+    def __init__(self, path: _Optional[str] = ..., num_parts: _Optional[int] = ...) -> None: ...
+
+class CompleteMultipartUpload(_message.Message):
+    __slots__ = ("path", "upload_id", "parts")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    UPLOAD_ID_FIELD_NUMBER: _ClassVar[int]
+    PARTS_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    upload_id: str
+    parts: _containers.RepeatedCompositeFieldContainer[MultipartUploadPart]
+    def __init__(self, path: _Optional[str] = ..., upload_id: _Optional[str] = ..., parts: _Optional[_Iterable[_Union[MultipartUploadPart, _Mapping]]] = ...) -> None: ...
+
+class AbortMultipartUpload(_message.Message):
+    __slots__ = ("path", "upload_id")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    UPLOAD_ID_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    upload_id: str
+    def __init__(self, path: _Optional[str] = ..., upload_id: _Optional[str] = ...) -> None: ...
+
+class MultipartUploadCredential(_message.Message):
+    __slots__ = ("url", "part_number", "headers")
+    class HeadersEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: str
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    URL_FIELD_NUMBER: _ClassVar[int]
+    PART_NUMBER_FIELD_NUMBER: _ClassVar[int]
+    HEADERS_FIELD_NUMBER: _ClassVar[int]
+    url: str
+    part_number: int
+    headers: _containers.ScalarMap[str, str]
+    def __init__(self, url: _Optional[str] = ..., part_number: _Optional[int] = ..., headers: _Optional[_Mapping[str, str]] = ...) -> None: ...
+
+class MultipartUploadPart(_message.Message):
+    __slots__ = ("part_number", "etag", "url")
+    PART_NUMBER_FIELD_NUMBER: _ClassVar[int]
+    ETAG_FIELD_NUMBER: _ClassVar[int]
+    URL_FIELD_NUMBER: _ClassVar[int]
+    part_number: int
+    etag: str
+    url: str
+    def __init__(self, part_number: _Optional[int] = ..., etag: _Optional[str] = ..., url: _Optional[str] = ...) -> None: ...
+
+class MlflowArtifactsService(_service.service): ...
+
+class MlflowArtifactsService_Stub(MlflowArtifactsService): ...

--- a/mlflow/protos/model_registry_pb2.pyi
+++ b/mlflow/protos/model_registry_pb2.pyi
@@ -1,0 +1,482 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import databricks_pb2 as _databricks_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class ModelVersionStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    PENDING_REGISTRATION: _ClassVar[ModelVersionStatus]
+    FAILED_REGISTRATION: _ClassVar[ModelVersionStatus]
+    READY: _ClassVar[ModelVersionStatus]
+PENDING_REGISTRATION: ModelVersionStatus
+FAILED_REGISTRATION: ModelVersionStatus
+READY: ModelVersionStatus
+
+class RegisteredModel(_message.Message):
+    __slots__ = ("name", "creation_timestamp", "last_updated_timestamp", "user_id", "description", "latest_versions", "tags", "aliases", "deployment_job_id", "deployment_job_state")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    USER_ID_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    LATEST_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    ALIASES_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_STATE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    creation_timestamp: int
+    last_updated_timestamp: int
+    user_id: str
+    description: str
+    latest_versions: _containers.RepeatedCompositeFieldContainer[ModelVersion]
+    tags: _containers.RepeatedCompositeFieldContainer[RegisteredModelTag]
+    aliases: _containers.RepeatedCompositeFieldContainer[RegisteredModelAlias]
+    deployment_job_id: str
+    deployment_job_state: DeploymentJobConnection.State
+    def __init__(self, name: _Optional[str] = ..., creation_timestamp: _Optional[int] = ..., last_updated_timestamp: _Optional[int] = ..., user_id: _Optional[str] = ..., description: _Optional[str] = ..., latest_versions: _Optional[_Iterable[_Union[ModelVersion, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[RegisteredModelTag, _Mapping]]] = ..., aliases: _Optional[_Iterable[_Union[RegisteredModelAlias, _Mapping]]] = ..., deployment_job_id: _Optional[str] = ..., deployment_job_state: _Optional[_Union[DeploymentJobConnection.State, str]] = ...) -> None: ...
+
+class ModelVersion(_message.Message):
+    __slots__ = ("name", "version", "creation_timestamp", "last_updated_timestamp", "user_id", "current_stage", "description", "source", "run_id", "status", "status_message", "tags", "run_link", "aliases", "model_id", "model_params", "model_metrics", "deployment_job_state")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    USER_ID_FIELD_NUMBER: _ClassVar[int]
+    CURRENT_STAGE_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    STATUS_MESSAGE_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    RUN_LINK_FIELD_NUMBER: _ClassVar[int]
+    ALIASES_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    MODEL_PARAMS_FIELD_NUMBER: _ClassVar[int]
+    MODEL_METRICS_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_STATE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    creation_timestamp: int
+    last_updated_timestamp: int
+    user_id: str
+    current_stage: str
+    description: str
+    source: str
+    run_id: str
+    status: ModelVersionStatus
+    status_message: str
+    tags: _containers.RepeatedCompositeFieldContainer[ModelVersionTag]
+    run_link: str
+    aliases: _containers.RepeatedScalarFieldContainer[str]
+    model_id: str
+    model_params: _containers.RepeatedCompositeFieldContainer[ModelParam]
+    model_metrics: _containers.RepeatedCompositeFieldContainer[ModelMetric]
+    deployment_job_state: ModelVersionDeploymentJobState
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., creation_timestamp: _Optional[int] = ..., last_updated_timestamp: _Optional[int] = ..., user_id: _Optional[str] = ..., current_stage: _Optional[str] = ..., description: _Optional[str] = ..., source: _Optional[str] = ..., run_id: _Optional[str] = ..., status: _Optional[_Union[ModelVersionStatus, str]] = ..., status_message: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[ModelVersionTag, _Mapping]]] = ..., run_link: _Optional[str] = ..., aliases: _Optional[_Iterable[str]] = ..., model_id: _Optional[str] = ..., model_params: _Optional[_Iterable[_Union[ModelParam, _Mapping]]] = ..., model_metrics: _Optional[_Iterable[_Union[ModelMetric, _Mapping]]] = ..., deployment_job_state: _Optional[_Union[ModelVersionDeploymentJobState, _Mapping]] = ...) -> None: ...
+
+class DeploymentJobConnection(_message.Message):
+    __slots__ = ()
+    class State(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED: _ClassVar[DeploymentJobConnection.State]
+        NOT_SET_UP: _ClassVar[DeploymentJobConnection.State]
+        CONNECTED: _ClassVar[DeploymentJobConnection.State]
+        NOT_FOUND: _ClassVar[DeploymentJobConnection.State]
+        REQUIRED_PARAMETERS_CHANGED: _ClassVar[DeploymentJobConnection.State]
+    DEPLOYMENT_JOB_CONNECTION_STATE_UNSPECIFIED: DeploymentJobConnection.State
+    NOT_SET_UP: DeploymentJobConnection.State
+    CONNECTED: DeploymentJobConnection.State
+    NOT_FOUND: DeploymentJobConnection.State
+    REQUIRED_PARAMETERS_CHANGED: DeploymentJobConnection.State
+    def __init__(self) -> None: ...
+
+class ModelVersionDeploymentJobState(_message.Message):
+    __slots__ = ("job_id", "run_id", "job_state", "run_state", "current_task_name")
+    class DeploymentJobRunState(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        NO_VALID_DEPLOYMENT_JOB_FOUND: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        RUNNING: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        SUCCEEDED: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        FAILED: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        PENDING: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+        APPROVAL: _ClassVar[ModelVersionDeploymentJobState.DeploymentJobRunState]
+    DEPLOYMENT_JOB_RUN_STATE_UNSPECIFIED: ModelVersionDeploymentJobState.DeploymentJobRunState
+    NO_VALID_DEPLOYMENT_JOB_FOUND: ModelVersionDeploymentJobState.DeploymentJobRunState
+    RUNNING: ModelVersionDeploymentJobState.DeploymentJobRunState
+    SUCCEEDED: ModelVersionDeploymentJobState.DeploymentJobRunState
+    FAILED: ModelVersionDeploymentJobState.DeploymentJobRunState
+    PENDING: ModelVersionDeploymentJobState.DeploymentJobRunState
+    APPROVAL: ModelVersionDeploymentJobState.DeploymentJobRunState
+    JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    JOB_STATE_FIELD_NUMBER: _ClassVar[int]
+    RUN_STATE_FIELD_NUMBER: _ClassVar[int]
+    CURRENT_TASK_NAME_FIELD_NUMBER: _ClassVar[int]
+    job_id: str
+    run_id: str
+    job_state: DeploymentJobConnection.State
+    run_state: ModelVersionDeploymentJobState.DeploymentJobRunState
+    current_task_name: str
+    def __init__(self, job_id: _Optional[str] = ..., run_id: _Optional[str] = ..., job_state: _Optional[_Union[DeploymentJobConnection.State, str]] = ..., run_state: _Optional[_Union[ModelVersionDeploymentJobState.DeploymentJobRunState, str]] = ..., current_task_name: _Optional[str] = ...) -> None: ...
+
+class CreateRegisteredModel(_message.Message):
+    __slots__ = ("name", "tags", "description", "deployment_job_id")
+    class Response(_message.Message):
+        __slots__ = ("registered_model",)
+        REGISTERED_MODEL_FIELD_NUMBER: _ClassVar[int]
+        registered_model: RegisteredModel
+        def __init__(self, registered_model: _Optional[_Union[RegisteredModel, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    tags: _containers.RepeatedCompositeFieldContainer[RegisteredModelTag]
+    description: str
+    deployment_job_id: str
+    def __init__(self, name: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[RegisteredModelTag, _Mapping]]] = ..., description: _Optional[str] = ..., deployment_job_id: _Optional[str] = ...) -> None: ...
+
+class RenameRegisteredModel(_message.Message):
+    __slots__ = ("name", "new_name")
+    class Response(_message.Message):
+        __slots__ = ("registered_model",)
+        REGISTERED_MODEL_FIELD_NUMBER: _ClassVar[int]
+        registered_model: RegisteredModel
+        def __init__(self, registered_model: _Optional[_Union[RegisteredModel, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    NEW_NAME_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    new_name: str
+    def __init__(self, name: _Optional[str] = ..., new_name: _Optional[str] = ...) -> None: ...
+
+class UpdateRegisteredModel(_message.Message):
+    __slots__ = ("name", "description", "deployment_job_id")
+    class Response(_message.Message):
+        __slots__ = ("registered_model",)
+        REGISTERED_MODEL_FIELD_NUMBER: _ClassVar[int]
+        registered_model: RegisteredModel
+        def __init__(self, registered_model: _Optional[_Union[RegisteredModel, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    DEPLOYMENT_JOB_ID_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    description: str
+    deployment_job_id: str
+    def __init__(self, name: _Optional[str] = ..., description: _Optional[str] = ..., deployment_job_id: _Optional[str] = ...) -> None: ...
+
+class DeleteRegisteredModel(_message.Message):
+    __slots__ = ("name",)
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    def __init__(self, name: _Optional[str] = ...) -> None: ...
+
+class GetRegisteredModel(_message.Message):
+    __slots__ = ("name",)
+    class Response(_message.Message):
+        __slots__ = ("registered_model",)
+        REGISTERED_MODEL_FIELD_NUMBER: _ClassVar[int]
+        registered_model: RegisteredModel
+        def __init__(self, registered_model: _Optional[_Union[RegisteredModel, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    def __init__(self, name: _Optional[str] = ...) -> None: ...
+
+class SearchRegisteredModels(_message.Message):
+    __slots__ = ("filter", "max_results", "order_by", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("registered_models", "next_page_token")
+        REGISTERED_MODELS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        registered_models: _containers.RepeatedCompositeFieldContainer[RegisteredModel]
+        next_page_token: str
+        def __init__(self, registered_models: _Optional[_Iterable[_Union[RegisteredModel, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    filter: str
+    max_results: int
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, filter: _Optional[str] = ..., max_results: _Optional[int] = ..., order_by: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class GetLatestVersions(_message.Message):
+    __slots__ = ("name", "stages")
+    class Response(_message.Message):
+        __slots__ = ("model_versions",)
+        MODEL_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+        model_versions: _containers.RepeatedCompositeFieldContainer[ModelVersion]
+        def __init__(self, model_versions: _Optional[_Iterable[_Union[ModelVersion, _Mapping]]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    STAGES_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    stages: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, name: _Optional[str] = ..., stages: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class CreateModelVersion(_message.Message):
+    __slots__ = ("name", "source", "run_id", "tags", "run_link", "description", "model_id")
+    class Response(_message.Message):
+        __slots__ = ("model_version",)
+        MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+        model_version: ModelVersion
+        def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    RUN_LINK_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    source: str
+    run_id: str
+    tags: _containers.RepeatedCompositeFieldContainer[ModelVersionTag]
+    run_link: str
+    description: str
+    model_id: str
+    def __init__(self, name: _Optional[str] = ..., source: _Optional[str] = ..., run_id: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[ModelVersionTag, _Mapping]]] = ..., run_link: _Optional[str] = ..., description: _Optional[str] = ..., model_id: _Optional[str] = ...) -> None: ...
+
+class UpdateModelVersion(_message.Message):
+    __slots__ = ("name", "version", "description")
+    class Response(_message.Message):
+        __slots__ = ("model_version",)
+        MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+        model_version: ModelVersion
+        def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    description: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., description: _Optional[str] = ...) -> None: ...
+
+class TransitionModelVersionStage(_message.Message):
+    __slots__ = ("name", "version", "stage", "archive_existing_versions")
+    class Response(_message.Message):
+        __slots__ = ("model_version",)
+        MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+        model_version: ModelVersion
+        def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    STAGE_FIELD_NUMBER: _ClassVar[int]
+    ARCHIVE_EXISTING_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    stage: str
+    archive_existing_versions: bool
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., stage: _Optional[str] = ..., archive_existing_versions: bool = ...) -> None: ...
+
+class DeleteModelVersion(_message.Message):
+    __slots__ = ("name", "version")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class GetModelVersion(_message.Message):
+    __slots__ = ("name", "version")
+    class Response(_message.Message):
+        __slots__ = ("model_version",)
+        MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+        model_version: ModelVersion
+        def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class SearchModelVersions(_message.Message):
+    __slots__ = ("filter", "max_results", "order_by", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("model_versions", "next_page_token")
+        MODEL_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        model_versions: _containers.RepeatedCompositeFieldContainer[ModelVersion]
+        next_page_token: str
+        def __init__(self, model_versions: _Optional[_Iterable[_Union[ModelVersion, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    filter: str
+    max_results: int
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, filter: _Optional[str] = ..., max_results: _Optional[int] = ..., order_by: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class GetModelVersionDownloadUri(_message.Message):
+    __slots__ = ("name", "version")
+    class Response(_message.Message):
+        __slots__ = ("artifact_uri",)
+        ARTIFACT_URI_FIELD_NUMBER: _ClassVar[int]
+        artifact_uri: str
+        def __init__(self, artifact_uri: _Optional[str] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class ModelVersionTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class ModelParam(_message.Message):
+    __slots__ = ("name", "value")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class ModelMetric(_message.Message):
+    __slots__ = ("key", "value", "timestamp", "step", "dataset_name", "dataset_digest", "model_id", "run_id")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    STEP_FIELD_NUMBER: _ClassVar[int]
+    DATASET_NAME_FIELD_NUMBER: _ClassVar[int]
+    DATASET_DIGEST_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: float
+    timestamp: int
+    step: int
+    dataset_name: str
+    dataset_digest: str
+    model_id: str
+    run_id: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[float] = ..., timestamp: _Optional[int] = ..., step: _Optional[int] = ..., dataset_name: _Optional[str] = ..., dataset_digest: _Optional[str] = ..., model_id: _Optional[str] = ..., run_id: _Optional[str] = ...) -> None: ...
+
+class RegisteredModelTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class SetRegisteredModelTag(_message.Message):
+    __slots__ = ("name", "key", "value")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    key: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class SetModelVersionTag(_message.Message):
+    __slots__ = ("name", "version", "key", "value")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    key: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class DeleteRegisteredModelTag(_message.Message):
+    __slots__ = ("name", "key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    key: str
+    def __init__(self, name: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class DeleteModelVersionTag(_message.Message):
+    __slots__ = ("name", "version", "key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    key: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class RegisteredModelAlias(_message.Message):
+    __slots__ = ("alias", "version")
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    alias: str
+    version: str
+    def __init__(self, alias: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class SetRegisteredModelAlias(_message.Message):
+    __slots__ = ("name", "alias", "version")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class DeleteRegisteredModelAlias(_message.Message):
+    __slots__ = ("name", "alias")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ...) -> None: ...
+
+class GetModelVersionByAlias(_message.Message):
+    __slots__ = ("name", "alias")
+    class Response(_message.Message):
+        __slots__ = ("model_version",)
+        MODEL_VERSION_FIELD_NUMBER: _ClassVar[int]
+        model_version: ModelVersion
+        def __init__(self, model_version: _Optional[_Union[ModelVersion, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ...) -> None: ...
+
+class ModelRegistryService(_service.service): ...
+
+class ModelRegistryService_Stub(ModelRegistryService): ...

--- a/mlflow/protos/scalapb/scalapb_pb2.pyi
+++ b/mlflow/protos/scalapb/scalapb_pb2.pyi
@@ -1,0 +1,34 @@
+from google.protobuf import descriptor_pb2 as _descriptor_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Optional as _Optional
+
+DESCRIPTOR: _descriptor.FileDescriptor
+OPTIONS_FIELD_NUMBER: _ClassVar[int]
+options: _descriptor.FieldDescriptor
+MESSAGE_FIELD_NUMBER: _ClassVar[int]
+message: _descriptor.FieldDescriptor
+FIELD_FIELD_NUMBER: _ClassVar[int]
+field: _descriptor.FieldDescriptor
+
+class ScalaPbOptions(_message.Message):
+    __slots__ = ("package_name", "flat_package")
+    PACKAGE_NAME_FIELD_NUMBER: _ClassVar[int]
+    FLAT_PACKAGE_FIELD_NUMBER: _ClassVar[int]
+    IMPORT_FIELD_NUMBER: _ClassVar[int]
+    package_name: str
+    flat_package: bool
+    def __init__(self, package_name: _Optional[str] = ..., flat_package: bool = ..., **kwargs) -> None: ...
+
+class MessageOptions(_message.Message):
+    __slots__ = ("extends",)
+    EXTENDS_FIELD_NUMBER: _ClassVar[int]
+    extends: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, extends: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class FieldOptions(_message.Message):
+    __slots__ = ("type",)
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    type: str
+    def __init__(self, type: _Optional[str] = ...) -> None: ...

--- a/mlflow/protos/service_pb2.pyi
+++ b/mlflow/protos/service_pb2.pyi
@@ -1,0 +1,1305 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import databricks_pb2 as _databricks_pb2
+from google.protobuf import duration_pb2 as _duration_pb2
+from google.protobuf import field_mask_pb2 as _field_mask_pb2
+from google.protobuf import timestamp_pb2 as _timestamp_pb2
+import assessments_pb2 as _assessments_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class ViewType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    ACTIVE_ONLY: _ClassVar[ViewType]
+    DELETED_ONLY: _ClassVar[ViewType]
+    ALL: _ClassVar[ViewType]
+
+class SourceType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    NOTEBOOK: _ClassVar[SourceType]
+    JOB: _ClassVar[SourceType]
+    PROJECT: _ClassVar[SourceType]
+    LOCAL: _ClassVar[SourceType]
+    UNKNOWN: _ClassVar[SourceType]
+
+class RunStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    RUNNING: _ClassVar[RunStatus]
+    SCHEDULED: _ClassVar[RunStatus]
+    FINISHED: _ClassVar[RunStatus]
+    FAILED: _ClassVar[RunStatus]
+    KILLED: _ClassVar[RunStatus]
+
+class TraceStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    TRACE_STATUS_UNSPECIFIED: _ClassVar[TraceStatus]
+    OK: _ClassVar[TraceStatus]
+    ERROR: _ClassVar[TraceStatus]
+    IN_PROGRESS: _ClassVar[TraceStatus]
+
+class LoggedModelStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    LOGGED_MODEL_STATUS_UNSPECIFIED: _ClassVar[LoggedModelStatus]
+    LOGGED_MODEL_PENDING: _ClassVar[LoggedModelStatus]
+    LOGGED_MODEL_READY: _ClassVar[LoggedModelStatus]
+    LOGGED_MODEL_UPLOAD_FAILED: _ClassVar[LoggedModelStatus]
+ACTIVE_ONLY: ViewType
+DELETED_ONLY: ViewType
+ALL: ViewType
+NOTEBOOK: SourceType
+JOB: SourceType
+PROJECT: SourceType
+LOCAL: SourceType
+UNKNOWN: SourceType
+RUNNING: RunStatus
+SCHEDULED: RunStatus
+FINISHED: RunStatus
+FAILED: RunStatus
+KILLED: RunStatus
+TRACE_STATUS_UNSPECIFIED: TraceStatus
+OK: TraceStatus
+ERROR: TraceStatus
+IN_PROGRESS: TraceStatus
+LOGGED_MODEL_STATUS_UNSPECIFIED: LoggedModelStatus
+LOGGED_MODEL_PENDING: LoggedModelStatus
+LOGGED_MODEL_READY: LoggedModelStatus
+LOGGED_MODEL_UPLOAD_FAILED: LoggedModelStatus
+
+class Metric(_message.Message):
+    __slots__ = ("key", "value", "timestamp", "step", "dataset_name", "dataset_digest", "model_id", "run_id")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    STEP_FIELD_NUMBER: _ClassVar[int]
+    DATASET_NAME_FIELD_NUMBER: _ClassVar[int]
+    DATASET_DIGEST_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: float
+    timestamp: int
+    step: int
+    dataset_name: str
+    dataset_digest: str
+    model_id: str
+    run_id: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[float] = ..., timestamp: _Optional[int] = ..., step: _Optional[int] = ..., dataset_name: _Optional[str] = ..., dataset_digest: _Optional[str] = ..., model_id: _Optional[str] = ..., run_id: _Optional[str] = ...) -> None: ...
+
+class Param(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class Run(_message.Message):
+    __slots__ = ("info", "data", "inputs", "outputs")
+    INFO_FIELD_NUMBER: _ClassVar[int]
+    DATA_FIELD_NUMBER: _ClassVar[int]
+    INPUTS_FIELD_NUMBER: _ClassVar[int]
+    OUTPUTS_FIELD_NUMBER: _ClassVar[int]
+    info: RunInfo
+    data: RunData
+    inputs: RunInputs
+    outputs: RunOutputs
+    def __init__(self, info: _Optional[_Union[RunInfo, _Mapping]] = ..., data: _Optional[_Union[RunData, _Mapping]] = ..., inputs: _Optional[_Union[RunInputs, _Mapping]] = ..., outputs: _Optional[_Union[RunOutputs, _Mapping]] = ...) -> None: ...
+
+class RunData(_message.Message):
+    __slots__ = ("metrics", "params", "tags")
+    METRICS_FIELD_NUMBER: _ClassVar[int]
+    PARAMS_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    metrics: _containers.RepeatedCompositeFieldContainer[Metric]
+    params: _containers.RepeatedCompositeFieldContainer[Param]
+    tags: _containers.RepeatedCompositeFieldContainer[RunTag]
+    def __init__(self, metrics: _Optional[_Iterable[_Union[Metric, _Mapping]]] = ..., params: _Optional[_Iterable[_Union[Param, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[RunTag, _Mapping]]] = ...) -> None: ...
+
+class RunInputs(_message.Message):
+    __slots__ = ("dataset_inputs", "model_inputs")
+    DATASET_INPUTS_FIELD_NUMBER: _ClassVar[int]
+    MODEL_INPUTS_FIELD_NUMBER: _ClassVar[int]
+    dataset_inputs: _containers.RepeatedCompositeFieldContainer[DatasetInput]
+    model_inputs: _containers.RepeatedCompositeFieldContainer[ModelInput]
+    def __init__(self, dataset_inputs: _Optional[_Iterable[_Union[DatasetInput, _Mapping]]] = ..., model_inputs: _Optional[_Iterable[_Union[ModelInput, _Mapping]]] = ...) -> None: ...
+
+class RunOutputs(_message.Message):
+    __slots__ = ("model_outputs",)
+    MODEL_OUTPUTS_FIELD_NUMBER: _ClassVar[int]
+    model_outputs: _containers.RepeatedCompositeFieldContainer[ModelOutput]
+    def __init__(self, model_outputs: _Optional[_Iterable[_Union[ModelOutput, _Mapping]]] = ...) -> None: ...
+
+class RunTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class ExperimentTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class RunInfo(_message.Message):
+    __slots__ = ("run_id", "run_uuid", "run_name", "experiment_id", "user_id", "status", "start_time", "end_time", "artifact_uri", "lifecycle_stage")
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    RUN_NAME_FIELD_NUMBER: _ClassVar[int]
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    USER_ID_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    START_TIME_FIELD_NUMBER: _ClassVar[int]
+    END_TIME_FIELD_NUMBER: _ClassVar[int]
+    ARTIFACT_URI_FIELD_NUMBER: _ClassVar[int]
+    LIFECYCLE_STAGE_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    run_name: str
+    experiment_id: str
+    user_id: str
+    status: RunStatus
+    start_time: int
+    end_time: int
+    artifact_uri: str
+    lifecycle_stage: str
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ..., run_name: _Optional[str] = ..., experiment_id: _Optional[str] = ..., user_id: _Optional[str] = ..., status: _Optional[_Union[RunStatus, str]] = ..., start_time: _Optional[int] = ..., end_time: _Optional[int] = ..., artifact_uri: _Optional[str] = ..., lifecycle_stage: _Optional[str] = ...) -> None: ...
+
+class Experiment(_message.Message):
+    __slots__ = ("experiment_id", "name", "artifact_location", "lifecycle_stage", "last_update_time", "creation_time", "tags")
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ARTIFACT_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    LIFECYCLE_STAGE_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATE_TIME_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIME_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    name: str
+    artifact_location: str
+    lifecycle_stage: str
+    last_update_time: int
+    creation_time: int
+    tags: _containers.RepeatedCompositeFieldContainer[ExperimentTag]
+    def __init__(self, experiment_id: _Optional[str] = ..., name: _Optional[str] = ..., artifact_location: _Optional[str] = ..., lifecycle_stage: _Optional[str] = ..., last_update_time: _Optional[int] = ..., creation_time: _Optional[int] = ..., tags: _Optional[_Iterable[_Union[ExperimentTag, _Mapping]]] = ...) -> None: ...
+
+class DatasetInput(_message.Message):
+    __slots__ = ("tags", "dataset")
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    DATASET_FIELD_NUMBER: _ClassVar[int]
+    tags: _containers.RepeatedCompositeFieldContainer[InputTag]
+    dataset: Dataset
+    def __init__(self, tags: _Optional[_Iterable[_Union[InputTag, _Mapping]]] = ..., dataset: _Optional[_Union[Dataset, _Mapping]] = ...) -> None: ...
+
+class ModelInput(_message.Message):
+    __slots__ = ("model_id",)
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    def __init__(self, model_id: _Optional[str] = ...) -> None: ...
+
+class InputTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class Dataset(_message.Message):
+    __slots__ = ("name", "digest", "source_type", "source", "schema", "profile")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    DIGEST_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_TYPE_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    PROFILE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    digest: str
+    source_type: str
+    source: str
+    schema: str
+    profile: str
+    def __init__(self, name: _Optional[str] = ..., digest: _Optional[str] = ..., source_type: _Optional[str] = ..., source: _Optional[str] = ..., schema: _Optional[str] = ..., profile: _Optional[str] = ...) -> None: ...
+
+class ModelOutput(_message.Message):
+    __slots__ = ("model_id", "step")
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    STEP_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    step: int
+    def __init__(self, model_id: _Optional[str] = ..., step: _Optional[int] = ...) -> None: ...
+
+class CreateExperiment(_message.Message):
+    __slots__ = ("name", "artifact_location", "tags")
+    class Response(_message.Message):
+        __slots__ = ("experiment_id",)
+        EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+        experiment_id: str
+        def __init__(self, experiment_id: _Optional[str] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ARTIFACT_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    artifact_location: str
+    tags: _containers.RepeatedCompositeFieldContainer[ExperimentTag]
+    def __init__(self, name: _Optional[str] = ..., artifact_location: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[ExperimentTag, _Mapping]]] = ...) -> None: ...
+
+class SearchExperiments(_message.Message):
+    __slots__ = ("max_results", "page_token", "filter", "order_by", "view_type")
+    class Response(_message.Message):
+        __slots__ = ("experiments", "next_page_token")
+        EXPERIMENTS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        experiments: _containers.RepeatedCompositeFieldContainer[Experiment]
+        next_page_token: str
+        def __init__(self, experiments: _Optional[_Iterable[_Union[Experiment, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    VIEW_TYPE_FIELD_NUMBER: _ClassVar[int]
+    max_results: int
+    page_token: str
+    filter: str
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    view_type: ViewType
+    def __init__(self, max_results: _Optional[int] = ..., page_token: _Optional[str] = ..., filter: _Optional[str] = ..., order_by: _Optional[_Iterable[str]] = ..., view_type: _Optional[_Union[ViewType, str]] = ...) -> None: ...
+
+class GetExperiment(_message.Message):
+    __slots__ = ("experiment_id",)
+    class Response(_message.Message):
+        __slots__ = ("experiment",)
+        EXPERIMENT_FIELD_NUMBER: _ClassVar[int]
+        experiment: Experiment
+        def __init__(self, experiment: _Optional[_Union[Experiment, _Mapping]] = ...) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    def __init__(self, experiment_id: _Optional[str] = ...) -> None: ...
+
+class DeleteExperiment(_message.Message):
+    __slots__ = ("experiment_id",)
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    def __init__(self, experiment_id: _Optional[str] = ...) -> None: ...
+
+class RestoreExperiment(_message.Message):
+    __slots__ = ("experiment_id",)
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    def __init__(self, experiment_id: _Optional[str] = ...) -> None: ...
+
+class UpdateExperiment(_message.Message):
+    __slots__ = ("experiment_id", "new_name")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    NEW_NAME_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    new_name: str
+    def __init__(self, experiment_id: _Optional[str] = ..., new_name: _Optional[str] = ...) -> None: ...
+
+class CreateRun(_message.Message):
+    __slots__ = ("experiment_id", "user_id", "run_name", "start_time", "tags")
+    class Response(_message.Message):
+        __slots__ = ("run",)
+        RUN_FIELD_NUMBER: _ClassVar[int]
+        run: Run
+        def __init__(self, run: _Optional[_Union[Run, _Mapping]] = ...) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    USER_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_NAME_FIELD_NUMBER: _ClassVar[int]
+    START_TIME_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    user_id: str
+    run_name: str
+    start_time: int
+    tags: _containers.RepeatedCompositeFieldContainer[RunTag]
+    def __init__(self, experiment_id: _Optional[str] = ..., user_id: _Optional[str] = ..., run_name: _Optional[str] = ..., start_time: _Optional[int] = ..., tags: _Optional[_Iterable[_Union[RunTag, _Mapping]]] = ...) -> None: ...
+
+class UpdateRun(_message.Message):
+    __slots__ = ("run_id", "run_uuid", "status", "end_time", "run_name")
+    class Response(_message.Message):
+        __slots__ = ("run_info",)
+        RUN_INFO_FIELD_NUMBER: _ClassVar[int]
+        run_info: RunInfo
+        def __init__(self, run_info: _Optional[_Union[RunInfo, _Mapping]] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    END_TIME_FIELD_NUMBER: _ClassVar[int]
+    RUN_NAME_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    status: RunStatus
+    end_time: int
+    run_name: str
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ..., status: _Optional[_Union[RunStatus, str]] = ..., end_time: _Optional[int] = ..., run_name: _Optional[str] = ...) -> None: ...
+
+class DeleteRun(_message.Message):
+    __slots__ = ("run_id",)
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    def __init__(self, run_id: _Optional[str] = ...) -> None: ...
+
+class RestoreRun(_message.Message):
+    __slots__ = ("run_id",)
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    def __init__(self, run_id: _Optional[str] = ...) -> None: ...
+
+class LogMetric(_message.Message):
+    __slots__ = ("run_id", "run_uuid", "key", "value", "timestamp", "step", "model_id", "dataset_name", "dataset_digest")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    STEP_FIELD_NUMBER: _ClassVar[int]
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    DATASET_NAME_FIELD_NUMBER: _ClassVar[int]
+    DATASET_DIGEST_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    key: str
+    value: float
+    timestamp: int
+    step: int
+    model_id: str
+    dataset_name: str
+    dataset_digest: str
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[float] = ..., timestamp: _Optional[int] = ..., step: _Optional[int] = ..., model_id: _Optional[str] = ..., dataset_name: _Optional[str] = ..., dataset_digest: _Optional[str] = ...) -> None: ...
+
+class LogParam(_message.Message):
+    __slots__ = ("run_id", "run_uuid", "key", "value")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    key: str
+    value: str
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class SetExperimentTag(_message.Message):
+    __slots__ = ("experiment_id", "key", "value")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    key: str
+    value: str
+    def __init__(self, experiment_id: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class DeleteExperimentTag(_message.Message):
+    __slots__ = ("experiment_id", "key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    key: str
+    def __init__(self, experiment_id: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class SetTag(_message.Message):
+    __slots__ = ("run_id", "run_uuid", "key", "value")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    key: str
+    value: str
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class DeleteTag(_message.Message):
+    __slots__ = ("run_id", "key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    key: str
+    def __init__(self, run_id: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class GetRun(_message.Message):
+    __slots__ = ("run_id", "run_uuid")
+    class Response(_message.Message):
+        __slots__ = ("run",)
+        RUN_FIELD_NUMBER: _ClassVar[int]
+        run: Run
+        def __init__(self, run: _Optional[_Union[Run, _Mapping]] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ...) -> None: ...
+
+class SearchRuns(_message.Message):
+    __slots__ = ("experiment_ids", "filter", "run_view_type", "max_results", "order_by", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("runs", "next_page_token")
+        RUNS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        runs: _containers.RepeatedCompositeFieldContainer[Run]
+        next_page_token: str
+        def __init__(self, runs: _Optional[_Iterable[_Union[Run, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    EXPERIMENT_IDS_FIELD_NUMBER: _ClassVar[int]
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    RUN_VIEW_TYPE_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    experiment_ids: _containers.RepeatedScalarFieldContainer[str]
+    filter: str
+    run_view_type: ViewType
+    max_results: int
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, experiment_ids: _Optional[_Iterable[str]] = ..., filter: _Optional[str] = ..., run_view_type: _Optional[_Union[ViewType, str]] = ..., max_results: _Optional[int] = ..., order_by: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class ListArtifacts(_message.Message):
+    __slots__ = ("run_id", "run_uuid", "path", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("root_uri", "files", "next_page_token")
+        ROOT_URI_FIELD_NUMBER: _ClassVar[int]
+        FILES_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        root_uri: str
+        files: _containers.RepeatedCompositeFieldContainer[FileInfo]
+        next_page_token: str
+        def __init__(self, root_uri: _Optional[str] = ..., files: _Optional[_Iterable[_Union[FileInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    path: str
+    page_token: str
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ..., path: _Optional[str] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class FileInfo(_message.Message):
+    __slots__ = ("path", "is_dir", "file_size")
+    PATH_FIELD_NUMBER: _ClassVar[int]
+    IS_DIR_FIELD_NUMBER: _ClassVar[int]
+    FILE_SIZE_FIELD_NUMBER: _ClassVar[int]
+    path: str
+    is_dir: bool
+    file_size: int
+    def __init__(self, path: _Optional[str] = ..., is_dir: bool = ..., file_size: _Optional[int] = ...) -> None: ...
+
+class GetMetricHistory(_message.Message):
+    __slots__ = ("run_id", "run_uuid", "metric_key", "page_token", "max_results")
+    class Response(_message.Message):
+        __slots__ = ("metrics", "next_page_token")
+        METRICS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        metrics: _containers.RepeatedCompositeFieldContainer[Metric]
+        next_page_token: str
+        def __init__(self, metrics: _Optional[_Iterable[_Union[Metric, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    RUN_UUID_FIELD_NUMBER: _ClassVar[int]
+    METRIC_KEY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    run_uuid: str
+    metric_key: str
+    page_token: str
+    max_results: int
+    def __init__(self, run_id: _Optional[str] = ..., run_uuid: _Optional[str] = ..., metric_key: _Optional[str] = ..., page_token: _Optional[str] = ..., max_results: _Optional[int] = ...) -> None: ...
+
+class MetricWithRunId(_message.Message):
+    __slots__ = ("key", "value", "timestamp", "step", "run_id")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    STEP_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: float
+    timestamp: int
+    step: int
+    run_id: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[float] = ..., timestamp: _Optional[int] = ..., step: _Optional[int] = ..., run_id: _Optional[str] = ...) -> None: ...
+
+class GetMetricHistoryBulkInterval(_message.Message):
+    __slots__ = ("run_ids", "metric_key", "start_step", "end_step", "max_results")
+    class Response(_message.Message):
+        __slots__ = ("metrics",)
+        METRICS_FIELD_NUMBER: _ClassVar[int]
+        metrics: _containers.RepeatedCompositeFieldContainer[MetricWithRunId]
+        def __init__(self, metrics: _Optional[_Iterable[_Union[MetricWithRunId, _Mapping]]] = ...) -> None: ...
+    RUN_IDS_FIELD_NUMBER: _ClassVar[int]
+    METRIC_KEY_FIELD_NUMBER: _ClassVar[int]
+    START_STEP_FIELD_NUMBER: _ClassVar[int]
+    END_STEP_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    run_ids: _containers.RepeatedScalarFieldContainer[str]
+    metric_key: str
+    start_step: int
+    end_step: int
+    max_results: int
+    def __init__(self, run_ids: _Optional[_Iterable[str]] = ..., metric_key: _Optional[str] = ..., start_step: _Optional[int] = ..., end_step: _Optional[int] = ..., max_results: _Optional[int] = ...) -> None: ...
+
+class LogBatch(_message.Message):
+    __slots__ = ("run_id", "metrics", "params", "tags")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    METRICS_FIELD_NUMBER: _ClassVar[int]
+    PARAMS_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    metrics: _containers.RepeatedCompositeFieldContainer[Metric]
+    params: _containers.RepeatedCompositeFieldContainer[Param]
+    tags: _containers.RepeatedCompositeFieldContainer[RunTag]
+    def __init__(self, run_id: _Optional[str] = ..., metrics: _Optional[_Iterable[_Union[Metric, _Mapping]]] = ..., params: _Optional[_Iterable[_Union[Param, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[RunTag, _Mapping]]] = ...) -> None: ...
+
+class LogModel(_message.Message):
+    __slots__ = ("run_id", "model_json")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    MODEL_JSON_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    model_json: str
+    def __init__(self, run_id: _Optional[str] = ..., model_json: _Optional[str] = ...) -> None: ...
+
+class LogInputs(_message.Message):
+    __slots__ = ("run_id", "datasets", "models")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    DATASETS_FIELD_NUMBER: _ClassVar[int]
+    MODELS_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    datasets: _containers.RepeatedCompositeFieldContainer[DatasetInput]
+    models: _containers.RepeatedCompositeFieldContainer[ModelInput]
+    def __init__(self, run_id: _Optional[str] = ..., datasets: _Optional[_Iterable[_Union[DatasetInput, _Mapping]]] = ..., models: _Optional[_Iterable[_Union[ModelInput, _Mapping]]] = ...) -> None: ...
+
+class LogOutputs(_message.Message):
+    __slots__ = ("run_id", "models")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    MODELS_FIELD_NUMBER: _ClassVar[int]
+    run_id: str
+    models: _containers.RepeatedCompositeFieldContainer[ModelOutput]
+    def __init__(self, run_id: _Optional[str] = ..., models: _Optional[_Iterable[_Union[ModelOutput, _Mapping]]] = ...) -> None: ...
+
+class GetExperimentByName(_message.Message):
+    __slots__ = ("experiment_name",)
+    class Response(_message.Message):
+        __slots__ = ("experiment",)
+        EXPERIMENT_FIELD_NUMBER: _ClassVar[int]
+        experiment: Experiment
+        def __init__(self, experiment: _Optional[_Union[Experiment, _Mapping]] = ...) -> None: ...
+    EXPERIMENT_NAME_FIELD_NUMBER: _ClassVar[int]
+    experiment_name: str
+    def __init__(self, experiment_name: _Optional[str] = ...) -> None: ...
+
+class CreateAssessment(_message.Message):
+    __slots__ = ("assessment",)
+    class Response(_message.Message):
+        __slots__ = ("assessment",)
+        ASSESSMENT_FIELD_NUMBER: _ClassVar[int]
+        assessment: _assessments_pb2.Assessment
+        def __init__(self, assessment: _Optional[_Union[_assessments_pb2.Assessment, _Mapping]] = ...) -> None: ...
+    ASSESSMENT_FIELD_NUMBER: _ClassVar[int]
+    assessment: _assessments_pb2.Assessment
+    def __init__(self, assessment: _Optional[_Union[_assessments_pb2.Assessment, _Mapping]] = ...) -> None: ...
+
+class UpdateAssessment(_message.Message):
+    __slots__ = ("assessment", "update_mask")
+    class Response(_message.Message):
+        __slots__ = ("assessment",)
+        ASSESSMENT_FIELD_NUMBER: _ClassVar[int]
+        assessment: _assessments_pb2.Assessment
+        def __init__(self, assessment: _Optional[_Union[_assessments_pb2.Assessment, _Mapping]] = ...) -> None: ...
+    ASSESSMENT_FIELD_NUMBER: _ClassVar[int]
+    UPDATE_MASK_FIELD_NUMBER: _ClassVar[int]
+    assessment: _assessments_pb2.Assessment
+    update_mask: _field_mask_pb2.FieldMask
+    def __init__(self, assessment: _Optional[_Union[_assessments_pb2.Assessment, _Mapping]] = ..., update_mask: _Optional[_Union[_field_mask_pb2.FieldMask, _Mapping]] = ...) -> None: ...
+
+class DeleteAssessment(_message.Message):
+    __slots__ = ("trace_id", "assessment_id")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    ASSESSMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    assessment_id: str
+    def __init__(self, trace_id: _Optional[str] = ..., assessment_id: _Optional[str] = ...) -> None: ...
+
+class GetAssessmentRequest(_message.Message):
+    __slots__ = ("trace_id", "assessment_id")
+    class Response(_message.Message):
+        __slots__ = ("assessment",)
+        ASSESSMENT_FIELD_NUMBER: _ClassVar[int]
+        assessment: _assessments_pb2.Assessment
+        def __init__(self, assessment: _Optional[_Union[_assessments_pb2.Assessment, _Mapping]] = ...) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    ASSESSMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    assessment_id: str
+    def __init__(self, trace_id: _Optional[str] = ..., assessment_id: _Optional[str] = ...) -> None: ...
+
+class TraceInfo(_message.Message):
+    __slots__ = ("request_id", "experiment_id", "timestamp_ms", "execution_time_ms", "status", "request_metadata", "tags")
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_MS_FIELD_NUMBER: _ClassVar[int]
+    EXECUTION_TIME_MS_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_METADATA_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    request_id: str
+    experiment_id: str
+    timestamp_ms: int
+    execution_time_ms: int
+    status: TraceStatus
+    request_metadata: _containers.RepeatedCompositeFieldContainer[TraceRequestMetadata]
+    tags: _containers.RepeatedCompositeFieldContainer[TraceTag]
+    def __init__(self, request_id: _Optional[str] = ..., experiment_id: _Optional[str] = ..., timestamp_ms: _Optional[int] = ..., execution_time_ms: _Optional[int] = ..., status: _Optional[_Union[TraceStatus, str]] = ..., request_metadata: _Optional[_Iterable[_Union[TraceRequestMetadata, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[TraceTag, _Mapping]]] = ...) -> None: ...
+
+class TraceRequestMetadata(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class TraceTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class StartTrace(_message.Message):
+    __slots__ = ("experiment_id", "timestamp_ms", "request_metadata", "tags")
+    class Response(_message.Message):
+        __slots__ = ("trace_info",)
+        TRACE_INFO_FIELD_NUMBER: _ClassVar[int]
+        trace_info: TraceInfo
+        def __init__(self, trace_info: _Optional[_Union[TraceInfo, _Mapping]] = ...) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_MS_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_METADATA_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    timestamp_ms: int
+    request_metadata: _containers.RepeatedCompositeFieldContainer[TraceRequestMetadata]
+    tags: _containers.RepeatedCompositeFieldContainer[TraceTag]
+    def __init__(self, experiment_id: _Optional[str] = ..., timestamp_ms: _Optional[int] = ..., request_metadata: _Optional[_Iterable[_Union[TraceRequestMetadata, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[TraceTag, _Mapping]]] = ...) -> None: ...
+
+class EndTrace(_message.Message):
+    __slots__ = ("request_id", "timestamp_ms", "status", "request_metadata", "tags")
+    class Response(_message.Message):
+        __slots__ = ("trace_info",)
+        TRACE_INFO_FIELD_NUMBER: _ClassVar[int]
+        trace_info: TraceInfo
+        def __init__(self, trace_info: _Optional[_Union[TraceInfo, _Mapping]] = ...) -> None: ...
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    TIMESTAMP_MS_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_METADATA_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    request_id: str
+    timestamp_ms: int
+    status: TraceStatus
+    request_metadata: _containers.RepeatedCompositeFieldContainer[TraceRequestMetadata]
+    tags: _containers.RepeatedCompositeFieldContainer[TraceTag]
+    def __init__(self, request_id: _Optional[str] = ..., timestamp_ms: _Optional[int] = ..., status: _Optional[_Union[TraceStatus, str]] = ..., request_metadata: _Optional[_Iterable[_Union[TraceRequestMetadata, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[TraceTag, _Mapping]]] = ...) -> None: ...
+
+class GetTraceInfo(_message.Message):
+    __slots__ = ("request_id",)
+    class Response(_message.Message):
+        __slots__ = ("trace_info",)
+        TRACE_INFO_FIELD_NUMBER: _ClassVar[int]
+        trace_info: TraceInfo
+        def __init__(self, trace_info: _Optional[_Union[TraceInfo, _Mapping]] = ...) -> None: ...
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    request_id: str
+    def __init__(self, request_id: _Optional[str] = ...) -> None: ...
+
+class GetTraceInfoV3(_message.Message):
+    __slots__ = ("trace_id",)
+    class Response(_message.Message):
+        __slots__ = ("trace",)
+        TRACE_FIELD_NUMBER: _ClassVar[int]
+        trace: Trace
+        def __init__(self, trace: _Optional[_Union[Trace, _Mapping]] = ...) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    def __init__(self, trace_id: _Optional[str] = ...) -> None: ...
+
+class SearchTraces(_message.Message):
+    __slots__ = ("experiment_ids", "filter", "max_results", "order_by", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("traces", "next_page_token")
+        TRACES_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        traces: _containers.RepeatedCompositeFieldContainer[TraceInfo]
+        next_page_token: str
+        def __init__(self, traces: _Optional[_Iterable[_Union[TraceInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    EXPERIMENT_IDS_FIELD_NUMBER: _ClassVar[int]
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    experiment_ids: _containers.RepeatedScalarFieldContainer[str]
+    filter: str
+    max_results: int
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, experiment_ids: _Optional[_Iterable[str]] = ..., filter: _Optional[str] = ..., max_results: _Optional[int] = ..., order_by: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class SearchUnifiedTraces(_message.Message):
+    __slots__ = ("model_id", "sql_warehouse_id", "experiment_ids", "filter", "max_results", "order_by", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("traces", "next_page_token")
+        TRACES_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        traces: _containers.RepeatedCompositeFieldContainer[TraceInfo]
+        next_page_token: str
+        def __init__(self, traces: _Optional[_Iterable[_Union[TraceInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    SQL_WAREHOUSE_ID_FIELD_NUMBER: _ClassVar[int]
+    EXPERIMENT_IDS_FIELD_NUMBER: _ClassVar[int]
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    sql_warehouse_id: str
+    experiment_ids: _containers.RepeatedScalarFieldContainer[str]
+    filter: str
+    max_results: int
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, model_id: _Optional[str] = ..., sql_warehouse_id: _Optional[str] = ..., experiment_ids: _Optional[_Iterable[str]] = ..., filter: _Optional[str] = ..., max_results: _Optional[int] = ..., order_by: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class GetOnlineTraceDetails(_message.Message):
+    __slots__ = ("trace_id", "sql_warehouse_id", "source_inference_table", "source_databricks_request_id")
+    class Response(_message.Message):
+        __slots__ = ("trace_data",)
+        TRACE_DATA_FIELD_NUMBER: _ClassVar[int]
+        trace_data: str
+        def __init__(self, trace_data: _Optional[str] = ...) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    SQL_WAREHOUSE_ID_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_INFERENCE_TABLE_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_DATABRICKS_REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    sql_warehouse_id: str
+    source_inference_table: str
+    source_databricks_request_id: str
+    def __init__(self, trace_id: _Optional[str] = ..., sql_warehouse_id: _Optional[str] = ..., source_inference_table: _Optional[str] = ..., source_databricks_request_id: _Optional[str] = ...) -> None: ...
+
+class DeleteTraces(_message.Message):
+    __slots__ = ("experiment_id", "max_timestamp_millis", "max_traces", "request_ids")
+    class Response(_message.Message):
+        __slots__ = ("traces_deleted",)
+        TRACES_DELETED_FIELD_NUMBER: _ClassVar[int]
+        traces_deleted: int
+        def __init__(self, traces_deleted: _Optional[int] = ...) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    MAX_TIMESTAMP_MILLIS_FIELD_NUMBER: _ClassVar[int]
+    MAX_TRACES_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_IDS_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    max_timestamp_millis: int
+    max_traces: int
+    request_ids: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, experiment_id: _Optional[str] = ..., max_timestamp_millis: _Optional[int] = ..., max_traces: _Optional[int] = ..., request_ids: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class DeleteTracesV3(_message.Message):
+    __slots__ = ("experiment_id", "max_timestamp_millis", "max_traces", "request_ids")
+    class Response(_message.Message):
+        __slots__ = ("traces_deleted",)
+        TRACES_DELETED_FIELD_NUMBER: _ClassVar[int]
+        traces_deleted: int
+        def __init__(self, traces_deleted: _Optional[int] = ...) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    MAX_TIMESTAMP_MILLIS_FIELD_NUMBER: _ClassVar[int]
+    MAX_TRACES_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_IDS_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    max_timestamp_millis: int
+    max_traces: int
+    request_ids: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, experiment_id: _Optional[str] = ..., max_timestamp_millis: _Optional[int] = ..., max_traces: _Optional[int] = ..., request_ids: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class SetTraceTag(_message.Message):
+    __slots__ = ("request_id", "key", "value")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    request_id: str
+    key: str
+    value: str
+    def __init__(self, request_id: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class SetTraceTagV3(_message.Message):
+    __slots__ = ("trace_id", "key", "value")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    key: str
+    value: str
+    def __init__(self, trace_id: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class DeleteTraceTag(_message.Message):
+    __slots__ = ("trace_id", "key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    key: str
+    def __init__(self, trace_id: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class DeleteTraceTagV3(_message.Message):
+    __slots__ = ("request_id", "key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    request_id: str
+    key: str
+    def __init__(self, request_id: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class Trace(_message.Message):
+    __slots__ = ("trace_info",)
+    TRACE_INFO_FIELD_NUMBER: _ClassVar[int]
+    trace_info: TraceInfoV3
+    def __init__(self, trace_info: _Optional[_Union[TraceInfoV3, _Mapping]] = ...) -> None: ...
+
+class TraceLocation(_message.Message):
+    __slots__ = ("type", "mlflow_experiment", "inference_table")
+    class TraceLocationType(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        TRACE_LOCATION_TYPE_UNSPECIFIED: _ClassVar[TraceLocation.TraceLocationType]
+        MLFLOW_EXPERIMENT: _ClassVar[TraceLocation.TraceLocationType]
+        INFERENCE_TABLE: _ClassVar[TraceLocation.TraceLocationType]
+    TRACE_LOCATION_TYPE_UNSPECIFIED: TraceLocation.TraceLocationType
+    MLFLOW_EXPERIMENT: TraceLocation.TraceLocationType
+    INFERENCE_TABLE: TraceLocation.TraceLocationType
+    class MlflowExperimentLocation(_message.Message):
+        __slots__ = ("experiment_id",)
+        EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+        experiment_id: str
+        def __init__(self, experiment_id: _Optional[str] = ...) -> None: ...
+    class InferenceTableLocation(_message.Message):
+        __slots__ = ("full_table_name",)
+        FULL_TABLE_NAME_FIELD_NUMBER: _ClassVar[int]
+        full_table_name: str
+        def __init__(self, full_table_name: _Optional[str] = ...) -> None: ...
+    TYPE_FIELD_NUMBER: _ClassVar[int]
+    MLFLOW_EXPERIMENT_FIELD_NUMBER: _ClassVar[int]
+    INFERENCE_TABLE_FIELD_NUMBER: _ClassVar[int]
+    type: TraceLocation.TraceLocationType
+    mlflow_experiment: TraceLocation.MlflowExperimentLocation
+    inference_table: TraceLocation.InferenceTableLocation
+    def __init__(self, type: _Optional[_Union[TraceLocation.TraceLocationType, str]] = ..., mlflow_experiment: _Optional[_Union[TraceLocation.MlflowExperimentLocation, _Mapping]] = ..., inference_table: _Optional[_Union[TraceLocation.InferenceTableLocation, _Mapping]] = ...) -> None: ...
+
+class TraceInfoV3(_message.Message):
+    __slots__ = ("trace_id", "client_request_id", "trace_location", "request", "response", "request_preview", "response_preview", "request_time", "execution_duration", "state", "trace_metadata", "assessments", "tags")
+    class State(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+        __slots__ = ()
+        STATE_UNSPECIFIED: _ClassVar[TraceInfoV3.State]
+        OK: _ClassVar[TraceInfoV3.State]
+        ERROR: _ClassVar[TraceInfoV3.State]
+        IN_PROGRESS: _ClassVar[TraceInfoV3.State]
+    STATE_UNSPECIFIED: TraceInfoV3.State
+    OK: TraceInfoV3.State
+    ERROR: TraceInfoV3.State
+    IN_PROGRESS: TraceInfoV3.State
+    class TraceMetadataEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: str
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    class TagsEntry(_message.Message):
+        __slots__ = ("key", "value")
+        KEY_FIELD_NUMBER: _ClassVar[int]
+        VALUE_FIELD_NUMBER: _ClassVar[int]
+        key: str
+        value: str
+        def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    CLIENT_REQUEST_ID_FIELD_NUMBER: _ClassVar[int]
+    TRACE_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_FIELD_NUMBER: _ClassVar[int]
+    RESPONSE_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_PREVIEW_FIELD_NUMBER: _ClassVar[int]
+    RESPONSE_PREVIEW_FIELD_NUMBER: _ClassVar[int]
+    REQUEST_TIME_FIELD_NUMBER: _ClassVar[int]
+    EXECUTION_DURATION_FIELD_NUMBER: _ClassVar[int]
+    STATE_FIELD_NUMBER: _ClassVar[int]
+    TRACE_METADATA_FIELD_NUMBER: _ClassVar[int]
+    ASSESSMENTS_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    client_request_id: str
+    trace_location: TraceLocation
+    request: str
+    response: str
+    request_preview: str
+    response_preview: str
+    request_time: _timestamp_pb2.Timestamp
+    execution_duration: _duration_pb2.Duration
+    state: TraceInfoV3.State
+    trace_metadata: _containers.ScalarMap[str, str]
+    assessments: _containers.RepeatedCompositeFieldContainer[_assessments_pb2.Assessment]
+    tags: _containers.ScalarMap[str, str]
+    def __init__(self, trace_id: _Optional[str] = ..., client_request_id: _Optional[str] = ..., trace_location: _Optional[_Union[TraceLocation, _Mapping]] = ..., request: _Optional[str] = ..., response: _Optional[str] = ..., request_preview: _Optional[str] = ..., response_preview: _Optional[str] = ..., request_time: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., execution_duration: _Optional[_Union[_duration_pb2.Duration, _Mapping]] = ..., state: _Optional[_Union[TraceInfoV3.State, str]] = ..., trace_metadata: _Optional[_Mapping[str, str]] = ..., assessments: _Optional[_Iterable[_Union[_assessments_pb2.Assessment, _Mapping]]] = ..., tags: _Optional[_Mapping[str, str]] = ...) -> None: ...
+
+class StartTraceV3(_message.Message):
+    __slots__ = ("trace",)
+    class Response(_message.Message):
+        __slots__ = ("trace",)
+        TRACE_FIELD_NUMBER: _ClassVar[int]
+        trace: Trace
+        def __init__(self, trace: _Optional[_Union[Trace, _Mapping]] = ...) -> None: ...
+    TRACE_FIELD_NUMBER: _ClassVar[int]
+    trace: Trace
+    def __init__(self, trace: _Optional[_Union[Trace, _Mapping]] = ...) -> None: ...
+
+class LinkTracesToRun(_message.Message):
+    __slots__ = ("trace_ids", "run_id")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    TRACE_IDS_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    trace_ids: _containers.RepeatedScalarFieldContainer[str]
+    run_id: str
+    def __init__(self, trace_ids: _Optional[_Iterable[str]] = ..., run_id: _Optional[str] = ...) -> None: ...
+
+class DatasetSummary(_message.Message):
+    __slots__ = ("experiment_id", "name", "digest", "context")
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    DIGEST_FIELD_NUMBER: _ClassVar[int]
+    CONTEXT_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    name: str
+    digest: str
+    context: str
+    def __init__(self, experiment_id: _Optional[str] = ..., name: _Optional[str] = ..., digest: _Optional[str] = ..., context: _Optional[str] = ...) -> None: ...
+
+class SearchDatasets(_message.Message):
+    __slots__ = ("experiment_ids",)
+    class Response(_message.Message):
+        __slots__ = ("dataset_summaries",)
+        DATASET_SUMMARIES_FIELD_NUMBER: _ClassVar[int]
+        dataset_summaries: _containers.RepeatedCompositeFieldContainer[DatasetSummary]
+        def __init__(self, dataset_summaries: _Optional[_Iterable[_Union[DatasetSummary, _Mapping]]] = ...) -> None: ...
+    EXPERIMENT_IDS_FIELD_NUMBER: _ClassVar[int]
+    experiment_ids: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, experiment_ids: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class CreateLoggedModel(_message.Message):
+    __slots__ = ("experiment_id", "name", "model_type", "source_run_id", "params", "tags")
+    class Response(_message.Message):
+        __slots__ = ("model",)
+        MODEL_FIELD_NUMBER: _ClassVar[int]
+        model: LoggedModel
+        def __init__(self, model: _Optional[_Union[LoggedModel, _Mapping]] = ...) -> None: ...
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    MODEL_TYPE_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    PARAMS_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    experiment_id: str
+    name: str
+    model_type: str
+    source_run_id: str
+    params: _containers.RepeatedCompositeFieldContainer[LoggedModelParameter]
+    tags: _containers.RepeatedCompositeFieldContainer[LoggedModelTag]
+    def __init__(self, experiment_id: _Optional[str] = ..., name: _Optional[str] = ..., model_type: _Optional[str] = ..., source_run_id: _Optional[str] = ..., params: _Optional[_Iterable[_Union[LoggedModelParameter, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[LoggedModelTag, _Mapping]]] = ...) -> None: ...
+
+class FinalizeLoggedModel(_message.Message):
+    __slots__ = ("model_id", "status")
+    class Response(_message.Message):
+        __slots__ = ("model",)
+        MODEL_FIELD_NUMBER: _ClassVar[int]
+        model: LoggedModel
+        def __init__(self, model: _Optional[_Union[LoggedModel, _Mapping]] = ...) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    status: LoggedModelStatus
+    def __init__(self, model_id: _Optional[str] = ..., status: _Optional[_Union[LoggedModelStatus, str]] = ...) -> None: ...
+
+class GetLoggedModel(_message.Message):
+    __slots__ = ("model_id",)
+    class Response(_message.Message):
+        __slots__ = ("model",)
+        MODEL_FIELD_NUMBER: _ClassVar[int]
+        model: LoggedModel
+        def __init__(self, model: _Optional[_Union[LoggedModel, _Mapping]] = ...) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    def __init__(self, model_id: _Optional[str] = ...) -> None: ...
+
+class DeleteLoggedModel(_message.Message):
+    __slots__ = ("model_id",)
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    def __init__(self, model_id: _Optional[str] = ...) -> None: ...
+
+class SearchLoggedModels(_message.Message):
+    __slots__ = ("experiment_ids", "filter", "datasets", "max_results", "order_by", "page_token")
+    class Dataset(_message.Message):
+        __slots__ = ("dataset_name", "dataset_digest")
+        DATASET_NAME_FIELD_NUMBER: _ClassVar[int]
+        DATASET_DIGEST_FIELD_NUMBER: _ClassVar[int]
+        dataset_name: str
+        dataset_digest: str
+        def __init__(self, dataset_name: _Optional[str] = ..., dataset_digest: _Optional[str] = ...) -> None: ...
+    class OrderBy(_message.Message):
+        __slots__ = ("field_name", "ascending", "dataset_name", "dataset_digest")
+        FIELD_NAME_FIELD_NUMBER: _ClassVar[int]
+        ASCENDING_FIELD_NUMBER: _ClassVar[int]
+        DATASET_NAME_FIELD_NUMBER: _ClassVar[int]
+        DATASET_DIGEST_FIELD_NUMBER: _ClassVar[int]
+        field_name: str
+        ascending: bool
+        dataset_name: str
+        dataset_digest: str
+        def __init__(self, field_name: _Optional[str] = ..., ascending: bool = ..., dataset_name: _Optional[str] = ..., dataset_digest: _Optional[str] = ...) -> None: ...
+    class Response(_message.Message):
+        __slots__ = ("models", "next_page_token")
+        MODELS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        models: _containers.RepeatedCompositeFieldContainer[LoggedModel]
+        next_page_token: str
+        def __init__(self, models: _Optional[_Iterable[_Union[LoggedModel, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    EXPERIMENT_IDS_FIELD_NUMBER: _ClassVar[int]
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    DATASETS_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    experiment_ids: _containers.RepeatedScalarFieldContainer[str]
+    filter: str
+    datasets: _containers.RepeatedCompositeFieldContainer[SearchLoggedModels.Dataset]
+    max_results: int
+    order_by: _containers.RepeatedCompositeFieldContainer[SearchLoggedModels.OrderBy]
+    page_token: str
+    def __init__(self, experiment_ids: _Optional[_Iterable[str]] = ..., filter: _Optional[str] = ..., datasets: _Optional[_Iterable[_Union[SearchLoggedModels.Dataset, _Mapping]]] = ..., max_results: _Optional[int] = ..., order_by: _Optional[_Iterable[_Union[SearchLoggedModels.OrderBy, _Mapping]]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class SetLoggedModelTags(_message.Message):
+    __slots__ = ("model_id", "tags")
+    class Response(_message.Message):
+        __slots__ = ("model",)
+        MODEL_FIELD_NUMBER: _ClassVar[int]
+        model: LoggedModel
+        def __init__(self, model: _Optional[_Union[LoggedModel, _Mapping]] = ...) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    tags: _containers.RepeatedCompositeFieldContainer[LoggedModelTag]
+    def __init__(self, model_id: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[LoggedModelTag, _Mapping]]] = ...) -> None: ...
+
+class DeleteLoggedModelTag(_message.Message):
+    __slots__ = ("model_id", "tag_key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    TAG_KEY_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    tag_key: str
+    def __init__(self, model_id: _Optional[str] = ..., tag_key: _Optional[str] = ...) -> None: ...
+
+class ListLoggedModelArtifacts(_message.Message):
+    __slots__ = ("model_id", "artifact_directory_path", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("root_uri", "files", "next_page_token")
+        ROOT_URI_FIELD_NUMBER: _ClassVar[int]
+        FILES_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        root_uri: str
+        files: _containers.RepeatedCompositeFieldContainer[FileInfo]
+        next_page_token: str
+        def __init__(self, root_uri: _Optional[str] = ..., files: _Optional[_Iterable[_Union[FileInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    ARTIFACT_DIRECTORY_PATH_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    artifact_directory_path: str
+    page_token: str
+    def __init__(self, model_id: _Optional[str] = ..., artifact_directory_path: _Optional[str] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class LogLoggedModelParamsRequest(_message.Message):
+    __slots__ = ("model_id", "params")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    PARAMS_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    params: _containers.RepeatedCompositeFieldContainer[LoggedModelParameter]
+    def __init__(self, model_id: _Optional[str] = ..., params: _Optional[_Iterable[_Union[LoggedModelParameter, _Mapping]]] = ...) -> None: ...
+
+class LoggedModel(_message.Message):
+    __slots__ = ("info", "data")
+    INFO_FIELD_NUMBER: _ClassVar[int]
+    DATA_FIELD_NUMBER: _ClassVar[int]
+    info: LoggedModelInfo
+    data: LoggedModelData
+    def __init__(self, info: _Optional[_Union[LoggedModelInfo, _Mapping]] = ..., data: _Optional[_Union[LoggedModelData, _Mapping]] = ...) -> None: ...
+
+class LoggedModelInfo(_message.Message):
+    __slots__ = ("model_id", "experiment_id", "name", "creation_timestamp_ms", "last_updated_timestamp_ms", "artifact_uri", "status", "creator_id", "model_type", "source_run_id", "status_message", "tags", "registrations")
+    MODEL_ID_FIELD_NUMBER: _ClassVar[int]
+    EXPERIMENT_ID_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_MS_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_MS_FIELD_NUMBER: _ClassVar[int]
+    ARTIFACT_URI_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    CREATOR_ID_FIELD_NUMBER: _ClassVar[int]
+    MODEL_TYPE_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    STATUS_MESSAGE_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    REGISTRATIONS_FIELD_NUMBER: _ClassVar[int]
+    model_id: str
+    experiment_id: str
+    name: str
+    creation_timestamp_ms: int
+    last_updated_timestamp_ms: int
+    artifact_uri: str
+    status: LoggedModelStatus
+    creator_id: int
+    model_type: str
+    source_run_id: str
+    status_message: str
+    tags: _containers.RepeatedCompositeFieldContainer[LoggedModelTag]
+    registrations: _containers.RepeatedCompositeFieldContainer[LoggedModelRegistrationInfo]
+    def __init__(self, model_id: _Optional[str] = ..., experiment_id: _Optional[str] = ..., name: _Optional[str] = ..., creation_timestamp_ms: _Optional[int] = ..., last_updated_timestamp_ms: _Optional[int] = ..., artifact_uri: _Optional[str] = ..., status: _Optional[_Union[LoggedModelStatus, str]] = ..., creator_id: _Optional[int] = ..., model_type: _Optional[str] = ..., source_run_id: _Optional[str] = ..., status_message: _Optional[str] = ..., tags: _Optional[_Iterable[_Union[LoggedModelTag, _Mapping]]] = ..., registrations: _Optional[_Iterable[_Union[LoggedModelRegistrationInfo, _Mapping]]] = ...) -> None: ...
+
+class LoggedModelTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class LoggedModelRegistrationInfo(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class LoggedModelData(_message.Message):
+    __slots__ = ("params", "metrics")
+    PARAMS_FIELD_NUMBER: _ClassVar[int]
+    METRICS_FIELD_NUMBER: _ClassVar[int]
+    params: _containers.RepeatedCompositeFieldContainer[LoggedModelParameter]
+    metrics: _containers.RepeatedCompositeFieldContainer[Metric]
+    def __init__(self, params: _Optional[_Iterable[_Union[LoggedModelParameter, _Mapping]]] = ..., metrics: _Optional[_Iterable[_Union[Metric, _Mapping]]] = ...) -> None: ...
+
+class LoggedModelParameter(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class SearchTracesV3(_message.Message):
+    __slots__ = ("locations", "filter", "max_results", "order_by", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("traces", "next_page_token")
+        TRACES_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        traces: _containers.RepeatedCompositeFieldContainer[TraceInfoV3]
+        next_page_token: str
+        def __init__(self, traces: _Optional[_Iterable[_Union[TraceInfoV3, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    LOCATIONS_FIELD_NUMBER: _ClassVar[int]
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    ORDER_BY_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    locations: _containers.RepeatedCompositeFieldContainer[TraceLocation]
+    filter: str
+    max_results: int
+    order_by: _containers.RepeatedScalarFieldContainer[str]
+    page_token: str
+    def __init__(self, locations: _Optional[_Iterable[_Union[TraceLocation, _Mapping]]] = ..., filter: _Optional[str] = ..., max_results: _Optional[int] = ..., order_by: _Optional[_Iterable[str]] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class MlflowService(_service.service): ...
+
+class MlflowService_Stub(MlflowService): ...

--- a/mlflow/protos/unity_catalog_oss_messages_pb2.pyi
+++ b/mlflow/protos/unity_catalog_oss_messages_pb2.pyi
@@ -1,0 +1,307 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import databricks_pb2 as _databricks_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class ModelVersionStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    MODEL_VERSION_STATUS_UNKNOWN: _ClassVar[ModelVersionStatus]
+    PENDING_REGISTRATION: _ClassVar[ModelVersionStatus]
+    FAILED_REGISTRATION: _ClassVar[ModelVersionStatus]
+    READY: _ClassVar[ModelVersionStatus]
+
+class ModelVersionOperation(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    UNKNOWN_MODEL_VERSION_OPERATION: _ClassVar[ModelVersionOperation]
+    READ_MODEL_VERSION: _ClassVar[ModelVersionOperation]
+    READ_WRITE_MODEL_VERSION: _ClassVar[ModelVersionOperation]
+MODEL_VERSION_STATUS_UNKNOWN: ModelVersionStatus
+PENDING_REGISTRATION: ModelVersionStatus
+FAILED_REGISTRATION: ModelVersionStatus
+READY: ModelVersionStatus
+UNKNOWN_MODEL_VERSION_OPERATION: ModelVersionOperation
+READ_MODEL_VERSION: ModelVersionOperation
+READ_WRITE_MODEL_VERSION: ModelVersionOperation
+
+class RegisteredModelInfo(_message.Message):
+    __slots__ = ("name", "catalog_name", "schema_name", "comment", "storage_location", "full_name", "created_at", "created_by", "updated_at", "updated_by", "id", "browse_only")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    COMMENT_FIELD_NUMBER: _ClassVar[int]
+    STORAGE_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    CREATED_AT_FIELD_NUMBER: _ClassVar[int]
+    CREATED_BY_FIELD_NUMBER: _ClassVar[int]
+    UPDATED_AT_FIELD_NUMBER: _ClassVar[int]
+    UPDATED_BY_FIELD_NUMBER: _ClassVar[int]
+    ID_FIELD_NUMBER: _ClassVar[int]
+    BROWSE_ONLY_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    catalog_name: str
+    schema_name: str
+    comment: str
+    storage_location: str
+    full_name: str
+    created_at: int
+    created_by: str
+    updated_at: int
+    updated_by: str
+    id: str
+    browse_only: bool
+    def __init__(self, name: _Optional[str] = ..., catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., comment: _Optional[str] = ..., storage_location: _Optional[str] = ..., full_name: _Optional[str] = ..., created_at: _Optional[int] = ..., created_by: _Optional[str] = ..., updated_at: _Optional[int] = ..., updated_by: _Optional[str] = ..., id: _Optional[str] = ..., browse_only: bool = ...) -> None: ...
+
+class CreateRegisteredModel(_message.Message):
+    __slots__ = ("name", "catalog_name", "schema_name", "comment", "storage_location")
+    class Response(_message.Message):
+        __slots__ = ("registered_model_info",)
+        REGISTERED_MODEL_INFO_FIELD_NUMBER: _ClassVar[int]
+        registered_model_info: RegisteredModelInfo
+        def __init__(self, registered_model_info: _Optional[_Union[RegisteredModelInfo, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    COMMENT_FIELD_NUMBER: _ClassVar[int]
+    STORAGE_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    catalog_name: str
+    schema_name: str
+    comment: str
+    storage_location: str
+    def __init__(self, name: _Optional[str] = ..., catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., comment: _Optional[str] = ..., storage_location: _Optional[str] = ...) -> None: ...
+
+class DeleteRegisteredModel(_message.Message):
+    __slots__ = ("full_name", "force")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    FORCE_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    force: bool
+    def __init__(self, full_name: _Optional[str] = ..., force: bool = ...) -> None: ...
+
+class GetRegisteredModel(_message.Message):
+    __slots__ = ("full_name",)
+    class Response(_message.Message):
+        __slots__ = ("registered_model_info",)
+        REGISTERED_MODEL_INFO_FIELD_NUMBER: _ClassVar[int]
+        registered_model_info: RegisteredModelInfo
+        def __init__(self, registered_model_info: _Optional[_Union[RegisteredModelInfo, _Mapping]] = ...) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    def __init__(self, full_name: _Optional[str] = ...) -> None: ...
+
+class UpdateRegisteredModel(_message.Message):
+    __slots__ = ("full_name", "new_name", "comment")
+    class Response(_message.Message):
+        __slots__ = ("registered_model_info",)
+        REGISTERED_MODEL_INFO_FIELD_NUMBER: _ClassVar[int]
+        registered_model_info: RegisteredModelInfo
+        def __init__(self, registered_model_info: _Optional[_Union[RegisteredModelInfo, _Mapping]] = ...) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    NEW_NAME_FIELD_NUMBER: _ClassVar[int]
+    COMMENT_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    new_name: str
+    comment: str
+    def __init__(self, full_name: _Optional[str] = ..., new_name: _Optional[str] = ..., comment: _Optional[str] = ...) -> None: ...
+
+class ListRegisteredModels(_message.Message):
+    __slots__ = ("catalog_name", "schema_name", "max_results", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("registered_models", "next_page_token")
+        REGISTERED_MODELS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        registered_models: _containers.RepeatedCompositeFieldContainer[RegisteredModelInfo]
+        next_page_token: str
+        def __init__(self, registered_models: _Optional[_Iterable[_Union[RegisteredModelInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    catalog_name: str
+    schema_name: str
+    max_results: int
+    page_token: str
+    def __init__(self, catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class ModelVersionInfo(_message.Message):
+    __slots__ = ("model_name", "catalog_name", "schema_name", "source", "comment", "run_id", "status", "version", "storage_location", "created_at", "created_by", "updated_at", "updated_by", "id")
+    MODEL_NAME_FIELD_NUMBER: _ClassVar[int]
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    COMMENT_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    STORAGE_LOCATION_FIELD_NUMBER: _ClassVar[int]
+    CREATED_AT_FIELD_NUMBER: _ClassVar[int]
+    CREATED_BY_FIELD_NUMBER: _ClassVar[int]
+    UPDATED_AT_FIELD_NUMBER: _ClassVar[int]
+    UPDATED_BY_FIELD_NUMBER: _ClassVar[int]
+    ID_FIELD_NUMBER: _ClassVar[int]
+    model_name: str
+    catalog_name: str
+    schema_name: str
+    source: str
+    comment: str
+    run_id: str
+    status: ModelVersionStatus
+    version: int
+    storage_location: str
+    created_at: int
+    created_by: str
+    updated_at: int
+    updated_by: str
+    id: str
+    def __init__(self, model_name: _Optional[str] = ..., catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., source: _Optional[str] = ..., comment: _Optional[str] = ..., run_id: _Optional[str] = ..., status: _Optional[_Union[ModelVersionStatus, str]] = ..., version: _Optional[int] = ..., storage_location: _Optional[str] = ..., created_at: _Optional[int] = ..., created_by: _Optional[str] = ..., updated_at: _Optional[int] = ..., updated_by: _Optional[str] = ..., id: _Optional[str] = ...) -> None: ...
+
+class CreateModelVersion(_message.Message):
+    __slots__ = ("model_name", "catalog_name", "schema_name", "source", "run_id", "comment")
+    class Response(_message.Message):
+        __slots__ = ("model_version_info",)
+        MODEL_VERSION_INFO_FIELD_NUMBER: _ClassVar[int]
+        model_version_info: ModelVersionInfo
+        def __init__(self, model_version_info: _Optional[_Union[ModelVersionInfo, _Mapping]] = ...) -> None: ...
+    MODEL_NAME_FIELD_NUMBER: _ClassVar[int]
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    SOURCE_FIELD_NUMBER: _ClassVar[int]
+    RUN_ID_FIELD_NUMBER: _ClassVar[int]
+    COMMENT_FIELD_NUMBER: _ClassVar[int]
+    model_name: str
+    catalog_name: str
+    schema_name: str
+    source: str
+    run_id: str
+    comment: str
+    def __init__(self, model_name: _Optional[str] = ..., catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., source: _Optional[str] = ..., run_id: _Optional[str] = ..., comment: _Optional[str] = ...) -> None: ...
+
+class DeleteModelVersion(_message.Message):
+    __slots__ = ("full_name", "version")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    version: int
+    def __init__(self, full_name: _Optional[str] = ..., version: _Optional[int] = ...) -> None: ...
+
+class FinalizeModelVersion(_message.Message):
+    __slots__ = ("full_name", "version")
+    class Response(_message.Message):
+        __slots__ = ("model_version_info",)
+        MODEL_VERSION_INFO_FIELD_NUMBER: _ClassVar[int]
+        model_version_info: ModelVersionInfo
+        def __init__(self, model_version_info: _Optional[_Union[ModelVersionInfo, _Mapping]] = ...) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    version: int
+    def __init__(self, full_name: _Optional[str] = ..., version: _Optional[int] = ...) -> None: ...
+
+class GetModelVersion(_message.Message):
+    __slots__ = ("full_name", "version")
+    class Response(_message.Message):
+        __slots__ = ("model_version_info",)
+        MODEL_VERSION_INFO_FIELD_NUMBER: _ClassVar[int]
+        model_version_info: ModelVersionInfo
+        def __init__(self, model_version_info: _Optional[_Union[ModelVersionInfo, _Mapping]] = ...) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    version: int
+    def __init__(self, full_name: _Optional[str] = ..., version: _Optional[int] = ...) -> None: ...
+
+class UpdateModelVersion(_message.Message):
+    __slots__ = ("full_name", "version", "comment")
+    class Response(_message.Message):
+        __slots__ = ("model_version_info",)
+        MODEL_VERSION_INFO_FIELD_NUMBER: _ClassVar[int]
+        model_version_info: ModelVersionInfo
+        def __init__(self, model_version_info: _Optional[_Union[ModelVersionInfo, _Mapping]] = ...) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    COMMENT_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    version: int
+    comment: str
+    def __init__(self, full_name: _Optional[str] = ..., version: _Optional[int] = ..., comment: _Optional[str] = ...) -> None: ...
+
+class ListModelVersions(_message.Message):
+    __slots__ = ("full_name", "max_results", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("model_versions", "next_page_token")
+        MODEL_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        model_versions: _containers.RepeatedCompositeFieldContainer[ModelVersionInfo]
+        next_page_token: str
+        def __init__(self, model_versions: _Optional[_Iterable[_Union[ModelVersionInfo, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    FULL_NAME_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    full_name: str
+    max_results: int
+    page_token: str
+    def __init__(self, full_name: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class TemporaryCredentials(_message.Message):
+    __slots__ = ("aws_temp_credentials", "azure_user_delegation_sas", "gcp_oauth_token", "expiration_time")
+    AWS_TEMP_CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+    AZURE_USER_DELEGATION_SAS_FIELD_NUMBER: _ClassVar[int]
+    GCP_OAUTH_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    EXPIRATION_TIME_FIELD_NUMBER: _ClassVar[int]
+    aws_temp_credentials: AwsCredentials
+    azure_user_delegation_sas: AzureUserDelegationSAS
+    gcp_oauth_token: GcpOauthToken
+    expiration_time: int
+    def __init__(self, aws_temp_credentials: _Optional[_Union[AwsCredentials, _Mapping]] = ..., azure_user_delegation_sas: _Optional[_Union[AzureUserDelegationSAS, _Mapping]] = ..., gcp_oauth_token: _Optional[_Union[GcpOauthToken, _Mapping]] = ..., expiration_time: _Optional[int] = ...) -> None: ...
+
+class AwsCredentials(_message.Message):
+    __slots__ = ("access_key_id", "secret_access_key", "session_token")
+    ACCESS_KEY_ID_FIELD_NUMBER: _ClassVar[int]
+    SECRET_ACCESS_KEY_FIELD_NUMBER: _ClassVar[int]
+    SESSION_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    access_key_id: str
+    secret_access_key: str
+    session_token: str
+    def __init__(self, access_key_id: _Optional[str] = ..., secret_access_key: _Optional[str] = ..., session_token: _Optional[str] = ...) -> None: ...
+
+class AzureUserDelegationSAS(_message.Message):
+    __slots__ = ("sas_token",)
+    SAS_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    sas_token: str
+    def __init__(self, sas_token: _Optional[str] = ...) -> None: ...
+
+class GcpOauthToken(_message.Message):
+    __slots__ = ("oauth_token",)
+    OAUTH_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    oauth_token: str
+    def __init__(self, oauth_token: _Optional[str] = ...) -> None: ...
+
+class GenerateTemporaryModelVersionCredential(_message.Message):
+    __slots__ = ("catalog_name", "schema_name", "model_name", "version", "operation")
+    class Response(_message.Message):
+        __slots__ = ("credentials",)
+        CREDENTIALS_FIELD_NUMBER: _ClassVar[int]
+        credentials: TemporaryCredentials
+        def __init__(self, credentials: _Optional[_Union[TemporaryCredentials, _Mapping]] = ...) -> None: ...
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    MODEL_NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    OPERATION_FIELD_NUMBER: _ClassVar[int]
+    catalog_name: str
+    schema_name: str
+    model_name: str
+    version: int
+    operation: ModelVersionOperation
+    def __init__(self, catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ..., model_name: _Optional[str] = ..., version: _Optional[int] = ..., operation: _Optional[_Union[ModelVersionOperation, str]] = ...) -> None: ...

--- a/mlflow/protos/unity_catalog_oss_service_pb2.pyi
+++ b/mlflow/protos/unity_catalog_oss_service_pb2.pyi
@@ -1,0 +1,12 @@
+import databricks_pb2 as _databricks_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import unity_catalog_oss_messages_pb2 as _unity_catalog_oss_messages_pb2
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class UnityCatalogService(_service.service): ...
+
+class UnityCatalogService_Stub(UnityCatalogService): ...

--- a/mlflow/protos/unity_catalog_prompt_messages_pb2.pyi
+++ b/mlflow/protos/unity_catalog_prompt_messages_pb2.pyi
@@ -1,0 +1,281 @@
+from google.protobuf import struct_pb2 as _struct_pb2
+from google.protobuf import timestamp_pb2 as _timestamp_pb2
+from google.protobuf import empty_pb2 as _empty_pb2
+import databricks_pb2 as _databricks_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class Prompt(_message.Message):
+    __slots__ = ("name", "creation_timestamp", "last_updated_timestamp", "description", "aliases", "tags")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    ALIASES_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    creation_timestamp: _timestamp_pb2.Timestamp
+    last_updated_timestamp: _timestamp_pb2.Timestamp
+    description: str
+    aliases: _containers.RepeatedCompositeFieldContainer[PromptAlias]
+    tags: _containers.RepeatedCompositeFieldContainer[PromptTag]
+    def __init__(self, name: _Optional[str] = ..., creation_timestamp: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., last_updated_timestamp: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., description: _Optional[str] = ..., aliases: _Optional[_Iterable[_Union[PromptAlias, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[PromptTag, _Mapping]]] = ...) -> None: ...
+
+class PromptVersion(_message.Message):
+    __slots__ = ("name", "version", "creation_timestamp", "last_updated_timestamp", "description", "template", "aliases", "tags")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    TEMPLATE_FIELD_NUMBER: _ClassVar[int]
+    ALIASES_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    creation_timestamp: _timestamp_pb2.Timestamp
+    last_updated_timestamp: _timestamp_pb2.Timestamp
+    description: str
+    template: str
+    aliases: _containers.RepeatedCompositeFieldContainer[PromptAlias]
+    tags: _containers.RepeatedCompositeFieldContainer[PromptVersionTag]
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., creation_timestamp: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., last_updated_timestamp: _Optional[_Union[_timestamp_pb2.Timestamp, _Mapping]] = ..., description: _Optional[str] = ..., template: _Optional[str] = ..., aliases: _Optional[_Iterable[_Union[PromptAlias, _Mapping]]] = ..., tags: _Optional[_Iterable[_Union[PromptVersionTag, _Mapping]]] = ...) -> None: ...
+
+class PromptTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class PromptVersionTag(_message.Message):
+    __slots__ = ("key", "value")
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    key: str
+    value: str
+    def __init__(self, key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class PromptAlias(_message.Message):
+    __slots__ = ("alias", "version")
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    alias: str
+    version: str
+    def __init__(self, alias: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class UnityCatalogSchema(_message.Message):
+    __slots__ = ("catalog_name", "schema_name")
+    CATALOG_NAME_FIELD_NUMBER: _ClassVar[int]
+    SCHEMA_NAME_FIELD_NUMBER: _ClassVar[int]
+    catalog_name: str
+    schema_name: str
+    def __init__(self, catalog_name: _Optional[str] = ..., schema_name: _Optional[str] = ...) -> None: ...
+
+class CreatePromptRequest(_message.Message):
+    __slots__ = ("name", "prompt")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    PROMPT_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    prompt: Prompt
+    def __init__(self, name: _Optional[str] = ..., prompt: _Optional[_Union[Prompt, _Mapping]] = ...) -> None: ...
+
+class UpdatePromptRequest(_message.Message):
+    __slots__ = ("name", "prompt")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    PROMPT_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    prompt: Prompt
+    def __init__(self, name: _Optional[str] = ..., prompt: _Optional[_Union[Prompt, _Mapping]] = ...) -> None: ...
+
+class DeletePromptRequest(_message.Message):
+    __slots__ = ("name",)
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    def __init__(self, name: _Optional[str] = ...) -> None: ...
+
+class DeletePromptResponse(_message.Message):
+    __slots__ = ()
+    def __init__(self) -> None: ...
+
+class GetPromptRequest(_message.Message):
+    __slots__ = ("name",)
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    def __init__(self, name: _Optional[str] = ...) -> None: ...
+
+class SearchPromptsRequest(_message.Message):
+    __slots__ = ("filter", "catalog_schema", "max_results", "page_token")
+    FILTER_FIELD_NUMBER: _ClassVar[int]
+    CATALOG_SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    filter: str
+    catalog_schema: UnityCatalogSchema
+    max_results: int
+    page_token: str
+    def __init__(self, filter: _Optional[str] = ..., catalog_schema: _Optional[_Union[UnityCatalogSchema, _Mapping]] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class SearchPromptsResponse(_message.Message):
+    __slots__ = ("prompts", "next_page_token")
+    PROMPTS_FIELD_NUMBER: _ClassVar[int]
+    NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    prompts: _containers.RepeatedCompositeFieldContainer[Prompt]
+    next_page_token: str
+    def __init__(self, prompts: _Optional[_Iterable[_Union[Prompt, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+
+class CreatePromptVersionRequest(_message.Message):
+    __slots__ = ("name", "prompt_version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    PROMPT_VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    prompt_version: PromptVersion
+    def __init__(self, name: _Optional[str] = ..., prompt_version: _Optional[_Union[PromptVersion, _Mapping]] = ...) -> None: ...
+
+class UpdatePromptVersionRequest(_message.Message):
+    __slots__ = ("name", "version", "prompt_version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    PROMPT_VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    prompt_version: PromptVersion
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., prompt_version: _Optional[_Union[PromptVersion, _Mapping]] = ...) -> None: ...
+
+class DeletePromptVersionRequest(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class GetPromptVersionRequest(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class SearchPromptVersionsRequest(_message.Message):
+    __slots__ = ("name", "max_results", "page_token")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    max_results: int
+    page_token: str
+    def __init__(self, name: _Optional[str] = ..., max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class SearchPromptVersionsResponse(_message.Message):
+    __slots__ = ("prompt_versions", "next_page_token")
+    PROMPT_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+    NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    prompt_versions: _containers.RepeatedCompositeFieldContainer[PromptVersion]
+    next_page_token: str
+    def __init__(self, prompt_versions: _Optional[_Iterable[_Union[PromptVersion, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+
+class SetPromptAliasRequest(_message.Message):
+    __slots__ = ("name", "alias", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...
+
+class DeletePromptAliasRequest(_message.Message):
+    __slots__ = ("name", "alias")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ...) -> None: ...
+
+class GetPromptVersionByAliasRequest(_message.Message):
+    __slots__ = ("name", "alias")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    ALIAS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    alias: str
+    def __init__(self, name: _Optional[str] = ..., alias: _Optional[str] = ...) -> None: ...
+
+class SetPromptTagRequest(_message.Message):
+    __slots__ = ("name", "key", "value")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    key: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class DeletePromptTagRequest(_message.Message):
+    __slots__ = ("name", "key")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    key: str
+    def __init__(self, name: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class SetPromptVersionTagRequest(_message.Message):
+    __slots__ = ("name", "version", "key", "value")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    VALUE_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    key: str
+    value: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
+
+class DeletePromptVersionTagRequest(_message.Message):
+    __slots__ = ("name", "version", "key")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    key: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class LinkPromptVersionsToModelsRequest(_message.Message):
+    __slots__ = ("prompt_versions", "model_ids")
+    PROMPT_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+    MODEL_IDS_FIELD_NUMBER: _ClassVar[int]
+    prompt_versions: _containers.RepeatedCompositeFieldContainer[PromptVersionLinkEntry]
+    model_ids: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, prompt_versions: _Optional[_Iterable[_Union[PromptVersionLinkEntry, _Mapping]]] = ..., model_ids: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class LinkPromptsToTracesRequest(_message.Message):
+    __slots__ = ("prompt_versions", "trace_ids")
+    PROMPT_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+    TRACE_IDS_FIELD_NUMBER: _ClassVar[int]
+    prompt_versions: _containers.RepeatedCompositeFieldContainer[PromptVersionLinkEntry]
+    trace_ids: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, prompt_versions: _Optional[_Iterable[_Union[PromptVersionLinkEntry, _Mapping]]] = ..., trace_ids: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class LinkPromptVersionsToRunsRequest(_message.Message):
+    __slots__ = ("prompt_versions", "run_ids")
+    PROMPT_VERSIONS_FIELD_NUMBER: _ClassVar[int]
+    RUN_IDS_FIELD_NUMBER: _ClassVar[int]
+    prompt_versions: _containers.RepeatedCompositeFieldContainer[PromptVersionLinkEntry]
+    run_ids: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, prompt_versions: _Optional[_Iterable[_Union[PromptVersionLinkEntry, _Mapping]]] = ..., run_ids: _Optional[_Iterable[str]] = ...) -> None: ...
+
+class PromptVersionLinkEntry(_message.Message):
+    __slots__ = ("name", "version")
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    VERSION_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    version: str
+    def __init__(self, name: _Optional[str] = ..., version: _Optional[str] = ...) -> None: ...

--- a/mlflow/protos/unity_catalog_prompt_service_pb2.pyi
+++ b/mlflow/protos/unity_catalog_prompt_service_pb2.pyi
@@ -1,0 +1,13 @@
+import databricks_pb2 as _databricks_pb2
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import unity_catalog_prompt_messages_pb2 as _unity_catalog_prompt_messages_pb2
+from google.protobuf import empty_pb2 as _empty_pb2
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class UnityCatalogPromptService(_service.service): ...
+
+class UnityCatalogPromptService_Stub(UnityCatalogPromptService): ...

--- a/mlflow/protos/webhooks_pb2.pyi
+++ b/mlflow/protos/webhooks_pb2.pyi
@@ -1,0 +1,179 @@
+from scalapb import scalapb_pb2 as _scalapb_pb2
+import databricks_pb2 as _databricks_pb2
+from google.protobuf.internal import containers as _containers
+from google.protobuf.internal import enum_type_wrapper as _enum_type_wrapper
+from google.protobuf import descriptor as _descriptor
+from google.protobuf import message as _message
+from google.protobuf import service as _service
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Mapping as _Mapping, Optional as _Optional, Union as _Union
+
+DESCRIPTOR: _descriptor.FileDescriptor
+
+class WebhookStatus(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    ACTIVE: _ClassVar[WebhookStatus]
+    DISABLED: _ClassVar[WebhookStatus]
+
+class WebhookEntity(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    ENTITY_UNSPECIFIED: _ClassVar[WebhookEntity]
+    REGISTERED_MODEL: _ClassVar[WebhookEntity]
+    MODEL_VERSION: _ClassVar[WebhookEntity]
+    MODEL_VERSION_TAG: _ClassVar[WebhookEntity]
+    MODEL_VERSION_ALIAS: _ClassVar[WebhookEntity]
+
+class WebhookAction(int, metaclass=_enum_type_wrapper.EnumTypeWrapper):
+    __slots__ = ()
+    ACTION_UNSPECIFIED: _ClassVar[WebhookAction]
+    CREATED: _ClassVar[WebhookAction]
+    UPDATED: _ClassVar[WebhookAction]
+    DELETED: _ClassVar[WebhookAction]
+    SET: _ClassVar[WebhookAction]
+ACTIVE: WebhookStatus
+DISABLED: WebhookStatus
+ENTITY_UNSPECIFIED: WebhookEntity
+REGISTERED_MODEL: WebhookEntity
+MODEL_VERSION: WebhookEntity
+MODEL_VERSION_TAG: WebhookEntity
+MODEL_VERSION_ALIAS: WebhookEntity
+ACTION_UNSPECIFIED: WebhookAction
+CREATED: WebhookAction
+UPDATED: WebhookAction
+DELETED: WebhookAction
+SET: WebhookAction
+
+class WebhookEvent(_message.Message):
+    __slots__ = ("entity", "action")
+    ENTITY_FIELD_NUMBER: _ClassVar[int]
+    ACTION_FIELD_NUMBER: _ClassVar[int]
+    entity: WebhookEntity
+    action: WebhookAction
+    def __init__(self, entity: _Optional[_Union[WebhookEntity, str]] = ..., action: _Optional[_Union[WebhookAction, str]] = ...) -> None: ...
+
+class Webhook(_message.Message):
+    __slots__ = ("webhook_id", "name", "description", "url", "events", "status", "creation_timestamp", "last_updated_timestamp")
+    WEBHOOK_ID_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    URL_FIELD_NUMBER: _ClassVar[int]
+    EVENTS_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    CREATION_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    LAST_UPDATED_TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
+    webhook_id: str
+    name: str
+    description: str
+    url: str
+    events: _containers.RepeatedCompositeFieldContainer[WebhookEvent]
+    status: WebhookStatus
+    creation_timestamp: int
+    last_updated_timestamp: int
+    def __init__(self, webhook_id: _Optional[str] = ..., name: _Optional[str] = ..., description: _Optional[str] = ..., url: _Optional[str] = ..., events: _Optional[_Iterable[_Union[WebhookEvent, _Mapping]]] = ..., status: _Optional[_Union[WebhookStatus, str]] = ..., creation_timestamp: _Optional[int] = ..., last_updated_timestamp: _Optional[int] = ...) -> None: ...
+
+class WebhookTestResult(_message.Message):
+    __slots__ = ("success", "response_status", "response_body", "error_message")
+    SUCCESS_FIELD_NUMBER: _ClassVar[int]
+    RESPONSE_STATUS_FIELD_NUMBER: _ClassVar[int]
+    RESPONSE_BODY_FIELD_NUMBER: _ClassVar[int]
+    ERROR_MESSAGE_FIELD_NUMBER: _ClassVar[int]
+    success: bool
+    response_status: int
+    response_body: str
+    error_message: str
+    def __init__(self, success: bool = ..., response_status: _Optional[int] = ..., response_body: _Optional[str] = ..., error_message: _Optional[str] = ...) -> None: ...
+
+class CreateWebhook(_message.Message):
+    __slots__ = ("name", "description", "url", "events", "secret", "status")
+    class Response(_message.Message):
+        __slots__ = ("webhook",)
+        WEBHOOK_FIELD_NUMBER: _ClassVar[int]
+        webhook: Webhook
+        def __init__(self, webhook: _Optional[_Union[Webhook, _Mapping]] = ...) -> None: ...
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    URL_FIELD_NUMBER: _ClassVar[int]
+    EVENTS_FIELD_NUMBER: _ClassVar[int]
+    SECRET_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    name: str
+    description: str
+    url: str
+    events: _containers.RepeatedCompositeFieldContainer[WebhookEvent]
+    secret: str
+    status: WebhookStatus
+    def __init__(self, name: _Optional[str] = ..., description: _Optional[str] = ..., url: _Optional[str] = ..., events: _Optional[_Iterable[_Union[WebhookEvent, _Mapping]]] = ..., secret: _Optional[str] = ..., status: _Optional[_Union[WebhookStatus, str]] = ...) -> None: ...
+
+class ListWebhooks(_message.Message):
+    __slots__ = ("max_results", "page_token")
+    class Response(_message.Message):
+        __slots__ = ("webhooks", "next_page_token")
+        WEBHOOKS_FIELD_NUMBER: _ClassVar[int]
+        NEXT_PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+        webhooks: _containers.RepeatedCompositeFieldContainer[Webhook]
+        next_page_token: str
+        def __init__(self, webhooks: _Optional[_Iterable[_Union[Webhook, _Mapping]]] = ..., next_page_token: _Optional[str] = ...) -> None: ...
+    MAX_RESULTS_FIELD_NUMBER: _ClassVar[int]
+    PAGE_TOKEN_FIELD_NUMBER: _ClassVar[int]
+    max_results: int
+    page_token: str
+    def __init__(self, max_results: _Optional[int] = ..., page_token: _Optional[str] = ...) -> None: ...
+
+class GetWebhook(_message.Message):
+    __slots__ = ("webhook_id",)
+    class Response(_message.Message):
+        __slots__ = ("webhook",)
+        WEBHOOK_FIELD_NUMBER: _ClassVar[int]
+        webhook: Webhook
+        def __init__(self, webhook: _Optional[_Union[Webhook, _Mapping]] = ...) -> None: ...
+    WEBHOOK_ID_FIELD_NUMBER: _ClassVar[int]
+    webhook_id: str
+    def __init__(self, webhook_id: _Optional[str] = ...) -> None: ...
+
+class UpdateWebhook(_message.Message):
+    __slots__ = ("webhook_id", "name", "description", "url", "events", "secret", "status")
+    class Response(_message.Message):
+        __slots__ = ("webhook",)
+        WEBHOOK_FIELD_NUMBER: _ClassVar[int]
+        webhook: Webhook
+        def __init__(self, webhook: _Optional[_Union[Webhook, _Mapping]] = ...) -> None: ...
+    WEBHOOK_ID_FIELD_NUMBER: _ClassVar[int]
+    NAME_FIELD_NUMBER: _ClassVar[int]
+    DESCRIPTION_FIELD_NUMBER: _ClassVar[int]
+    URL_FIELD_NUMBER: _ClassVar[int]
+    EVENTS_FIELD_NUMBER: _ClassVar[int]
+    SECRET_FIELD_NUMBER: _ClassVar[int]
+    STATUS_FIELD_NUMBER: _ClassVar[int]
+    webhook_id: str
+    name: str
+    description: str
+    url: str
+    events: _containers.RepeatedCompositeFieldContainer[WebhookEvent]
+    secret: str
+    status: WebhookStatus
+    def __init__(self, webhook_id: _Optional[str] = ..., name: _Optional[str] = ..., description: _Optional[str] = ..., url: _Optional[str] = ..., events: _Optional[_Iterable[_Union[WebhookEvent, _Mapping]]] = ..., secret: _Optional[str] = ..., status: _Optional[_Union[WebhookStatus, str]] = ...) -> None: ...
+
+class DeleteWebhook(_message.Message):
+    __slots__ = ("webhook_id",)
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    WEBHOOK_ID_FIELD_NUMBER: _ClassVar[int]
+    webhook_id: str
+    def __init__(self, webhook_id: _Optional[str] = ...) -> None: ...
+
+class TestWebhook(_message.Message):
+    __slots__ = ("webhook_id", "event")
+    class Response(_message.Message):
+        __slots__ = ("result",)
+        RESULT_FIELD_NUMBER: _ClassVar[int]
+        result: WebhookTestResult
+        def __init__(self, result: _Optional[_Union[WebhookTestResult, _Mapping]] = ...) -> None: ...
+    WEBHOOK_ID_FIELD_NUMBER: _ClassVar[int]
+    EVENT_FIELD_NUMBER: _ClassVar[int]
+    webhook_id: str
+    event: WebhookEvent
+    def __init__(self, webhook_id: _Optional[str] = ..., event: _Optional[_Union[WebhookEvent, _Mapping]] = ...) -> None: ...
+
+class WebhookService(_service.service): ...
+
+class WebhookService_Stub(WebhookService): ...


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17231?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17231/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17231/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17231/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Resolve --> N/A

### What changes are proposed in this pull request?

This PR adds functionality to generate `.pyi` stub files for protobuf definitions in the `dev/generate_protos.py` script. The changes include:

- Added a new `gen_stub_files()` function that uses protoc to generate Python stub files
- Integrated the stub generation into the main workflow to generate `.pyi` files for all MLflow protobuf definitions
- Generated stub files are placed in `mlflow/protos/` directory alongside the existing `.py` files

This improvement provides better type hints for IDE support and static type checking when working with protobuf-generated code.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manually tested by running the `dev/generate_protos.py` script and verifying that:
1. All `.pyi` stub files are generated correctly
2. The stub files contain proper type annotations
3. No existing functionality is broken

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is a developer-facing improvement that enhances the development experience but doesn't affect end users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)