### PR TITLE
Change default tab to Traces when it is GenAI eval run

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -35,6 +35,7 @@ from mlflow.tracing.utils.copy import copy_trace_to_experiment
 from mlflow.tracking.client import MlflowClient
 from mlflow.tracking.fluent import _set_active_model
 from mlflow.utils.annotations import experimental
+from mlflow.utils.mlflow_tags import MLFLOW_GENAI_EVAL_RUN
 from mlflow.utils.uri import is_databricks_uri
 
 if TYPE_CHECKING:
@@ -294,6 +295,11 @@ def _evaluate_oss(data, scorers, predict_fn, model_id):
         _start_run_or_reuse_active_run() as run_id,
         _set_active_model(model_id=model_id) if model_id else nullcontext(),
     ):
+        # Set a special tag to indicate the run is GenAI eval run. This is used as a temporary
+        # workaround for UI to default to the "Traces" tab, until the new evaluation run UI
+        # is available.
+        mlflow.set_tag(MLFLOW_GENAI_EVAL_RUN, "true")
+
         _log_dataset_input(mlflow_dataset, run_id, model_id)
 
         return harness.run(

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunPage.tsx
@@ -1,7 +1,7 @@
 import { DangerIcon, Empty, ParagraphSkeleton, TitleSkeleton, useDesignSystemTheme } from '@databricks/design-system';
 import { useSelector } from 'react-redux';
 import invariant from 'invariant';
-import { useMemo, useState } from 'react';
+import { useMemo, useState, useEffect, useRef } from 'react';
 
 import { PageContainer } from '../../../common/components/PageContainer';
 import { useNavigate, useParams } from '../../../common/utils/RoutingUtils';
@@ -55,6 +55,7 @@ export const RunPage = () => {
   const { theme } = useDesignSystemTheme();
   const [renameModalVisible, setRenameModalVisible] = useState(false);
   const [deleteModalVisible, setDeleteModalVisible] = useState(false);
+  const hasRedirectedRef = useRef(false);
 
   invariant(runUuid, '[RunPage] Run UUID route param not provided');
   invariant(experimentId, '[RunPage] Experiment ID route param not provided');
@@ -96,6 +97,14 @@ export const RunPage = () => {
   );
 
   const activeTab = useRunViewActiveTab();
+
+  // Check for mlflow.genai.evalRun tag and redirect to traces tab if present on initial load
+  useEffect(() => {
+    if (tags && tags['mlflow.genai.evalRun'] && activeTab === RunPageTabName.OVERVIEW && !hasRedirectedRef.current) {
+      hasRedirectedRef.current = true;
+      navigate(Routes.getRunPageTabRoute(experimentId, runUuid, 'traces'));
+    }
+  }, [tags, activeTab, navigate, experimentId, runUuid]);
 
   const isUsingGetLoggedModelsApi = shouldUseGetLoggedModelsBatchAPI();
 

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -30,6 +30,8 @@ MLFLOW_AUTOLOGGING = "mlflow.autologging"
 MLFLOW_LOGGED_ARTIFACTS = "mlflow.loggedArtifacts"
 MLFLOW_LOGGED_IMAGES = "mlflow.loggedImages"
 MLFLOW_RUN_SOURCE_TYPE = "mlflow.runSourceType"
+# Indicates the run is created from mlflow.genai.evaluate()
+MLFLOW_GENAI_EVAL_RUN = "mlflow.genai.evalRun"
 
 MLFLOW_DATABRICKS_NOTEBOOK_ID = "mlflow.databricks.notebookID"
 MLFLOW_DATABRICKS_NOTEBOOK_PATH = "mlflow.databricks.notebookPath"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17232?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17232/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17232/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17232/merge
```

</p>
</details>

### What changes are proposed in this pull request?

GenAI eval result is available at "Traces" tab in the run page, but it is not very obvious to users.

This PR changes the default tab for GenAI eval Run (determined by a tag) to Traces table, as a band-aiding solution until the new eval Run UI becomes available.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
