### PR TITLE
Add validation for databricks-only scorer

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -20,7 +20,7 @@ from mlflow.utils.uri import is_databricks_uri
 GENAI_CONFIG_NAME = "databricks-agent"
 
 
-def _validate_databricks_tracking_uri(scorer_name: str) -> None:
+def _validate_tracking_uri_is_databricks(scorer_name: str) -> None:
     """Validate that the current tracking URI is set to Databricks.
 
     Args:
@@ -148,7 +148,7 @@ class RetrievalRelevance(BuiltInScorer):
     required_columns: set[str] = {"inputs", "trace"}
 
     def __init__(self, /, **kwargs):
-        _validate_databricks_tracking_uri("RetrievalRelevance")
+        _validate_tracking_uri_is_databricks("RetrievalRelevance")
         super().__init__(**kwargs)
 
     def __call__(self, *, trace: Trace) -> Feedback:
@@ -676,7 +676,7 @@ class Safety(BuiltInScorer):
     required_columns: set[str] = {"inputs", "outputs"}
 
     def __init__(self, /, **kwargs):
-        _validate_databricks_tracking_uri("Safety")
+        _validate_tracking_uri_is_databricks("Safety")
         super().__init__(**kwargs)
 
     def __call__(self, *, outputs: Any) -> Feedback:
@@ -841,7 +841,7 @@ def get_all_scorers() -> list[BuiltInScorer]:
     ]
     # TODO: Open-source these two scorers
     if is_databricks_uri(mlflow.get_tracking_uri()):
-        scorers.extend(Safety(), RetrievalRelevance())
+        scorers.extend([Safety(), RetrievalRelevance()])
     return scorers
 
 

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -39,7 +39,6 @@ def is_in_databricks(request):
     with (
         mock.patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=request.param),
         mock.patch("mlflow.genai.judges.utils.is_databricks_uri", return_value=request.param),
-        mock.patch("mlflow.genai.scorers.builtin_scorers.is_databricks_uri", return_value=request.param),
     ):
         yield request.param
 

--- a/tests/genai/conftest.py
+++ b/tests/genai/conftest.py
@@ -39,6 +39,7 @@ def is_in_databricks(request):
     with (
         mock.patch("mlflow.genai.evaluation.base.is_databricks_uri", return_value=request.param),
         mock.patch("mlflow.genai.judges.utils.is_databricks_uri", return_value=request.param),
+        mock.patch("mlflow.genai.scorers.builtin_scorers.is_databricks_uri", return_value=request.param),
     ):
         yield request.param
 

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -14,7 +14,7 @@ from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import create_dataset
 from mlflow.genai.scorers.base import scorer
-from mlflow.genai.scorers.builtin_scorers import Safety
+from mlflow.genai.scorers.builtin_scorers import RelevanceToQuery
 from mlflow.tracing.constant import TraceMetadataKey
 
 from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
@@ -471,7 +471,7 @@ def test_trace_input_can_contain_string_input(pass_full_dataframe, is_in_databri
         traces = traces[["trace"]]
 
     # Harness should run without an error
-    mlflow.genai.evaluate(data=traces, scorers=[Safety()])
+    mlflow.genai.evaluate(data=traces, scorers=[RelevanceToQuery()])
 
 
 def test_max_workers_env_var(is_in_databricks, monkeypatch):
@@ -490,7 +490,7 @@ def test_max_workers_env_var(is_in_databricks, monkeypatch):
                         "outputs": "MLflow is a tool for ML",
                     }
                 ],
-                scorers=[Safety()],
+                scorers=[RelevanceToQuery()],
             )
             # ThreadPoolExecutor is called twice in OSS (harness + scorers)
             first_call = mock_executor.call_args_list[0]

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -15,7 +15,7 @@ from mlflow.genai.evaluation.utils import (
     _convert_scorer_to_legacy_metric,
     _convert_to_eval_set,
 )
-from mlflow.genai.scorers.builtin_scorers import Safety
+from mlflow.genai.scorers.builtin_scorers import RelevanceToQuery
 from mlflow.utils.spark_utils import is_spark_connect_mode
 
 from tests.genai.conftest import databricks_only
@@ -320,7 +320,7 @@ def test_input_is_required_if_trace_is_not_provided(is_in_databricks):
         with pytest.raises(MlflowException, match="inputs.*required"):
             mlflow.genai.evaluate(
                 data=pd.DataFrame({"outputs": ["Paris"]}),
-                scorers=[Safety()],
+                scorers=[RelevanceToQuery()],
             )
 
         mock_evaluate.assert_not_called()
@@ -329,7 +329,7 @@ def test_input_is_required_if_trace_is_not_provided(is_in_databricks):
             data=pd.DataFrame(
                 {"inputs": [{"question": "What is the capital of France?"}], "outputs": ["Paris"]}
             ),
-            scorers=[Safety()],
+            scorers=[RelevanceToQuery()],
         )
         mock_evaluate.assert_called_once()
 
@@ -348,7 +348,7 @@ def test_input_is_optional_if_trace_is_provided(is_in_databricks):
     with patch(mock_module) as mock_evaluate:
         mlflow.genai.evaluate(
             data=pd.DataFrame({"trace": [trace]}),
-            scorers=[Safety()],
+            scorers=[RelevanceToQuery()],
         )
 
         mock_evaluate.assert_called_once()
@@ -419,7 +419,7 @@ def test_predict_fn_receives_correct_data(data_fixture, request, is_in_databrick
 def test_convert_scorer_to_legacy_metric():
     """Test that _convert_scorer_to_legacy_metric correctly sets _is_builtin_scorer attribute."""
     # Test with a built-in scorer
-    builtin_scorer = Safety()
+    builtin_scorer = RelevanceToQuery()
     legacy_metric = _convert_scorer_to_legacy_metric(builtin_scorer)
 
     # Verify the metric has the _is_builtin_scorer attribute set to True
@@ -459,7 +459,7 @@ def test_scorer_pass_through_aggregations(aggregations):
     assert legacy_metric_custom.name == "custom_scorer"
     assert legacy_metric_custom.aggregations == aggregations
 
-    builtin_scorer = Safety(aggregations=aggregations)
+    builtin_scorer = RelevanceToQuery(aggregations=aggregations)
     legacy_metric_builtin = _convert_scorer_to_legacy_metric(builtin_scorer)
-    assert legacy_metric_builtin.name == "safety"
+    assert legacy_metric_builtin.name == "relevance_to_query"
     assert legacy_metric_builtin.aggregations == builtin_scorer.aggregations

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -428,9 +428,12 @@ def test_correctness(mock_is_correct):
     )
 
 
-def test_get_all_scorers(is_in_databricks):
+@pytest.mark.parametrize("tracking_uri", ["file://test", "databricks"])
+def test_get_all_scorers_oss(tracking_uri):
+    mlflow.set_tracking_uri(tracking_uri)
+
     scorers = get_all_scorers()
 
     # Safety and RetrievalRelevance are only available in Databricks
-    assert len(scorers) == (7 if is_in_databricks else 5)
+    assert len(scorers) == (7 if tracking_uri == "databricks" else 5)
     assert all(isinstance(scorer, Scorer) for scorer in scorers)

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -361,7 +361,7 @@ def test_relevance_to_query(mock_is_context_relevant):
 
 def test_safety(is_in_databricks):
     if not is_databricks_uri(mlflow.get_tracking_uri()):
-        with pytest.raises(MlflowException, match=r"The Safety scorer is currently only"):
+        with pytest.raises(MlflowException, match=r"The Safety scorer is only available"):
             Safety()
         return
 

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -11,8 +11,8 @@ from mlflow.genai.scorers.builtin_scorers import (
     Correctness,
     ExpectationsGuidelines,
     Guidelines,
+    RelevanceToQuery,
     RetrievalGroundedness,
-    RetrievalRelevance,
     RetrievalSufficiency,
     get_all_scorers,
 )
@@ -34,7 +34,7 @@ def test_validate_scorers_valid():
 
     scorers = validate_scorers(
         [
-            RetrievalRelevance(),
+            RelevanceToQuery(),
             Correctness(),
             Guidelines(guidelines=["Be polite", "Be kind"]),
             custom_scorer,
@@ -79,16 +79,16 @@ def test_validate_scorers_invalid_all_scorers():
 
     # Special case 2: List of list of all scorers + custom scorers
     with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
-        validate_scorers([get_all_scorers(), RetrievalRelevance(), Correctness()])
+        validate_scorers([get_all_scorers(), RelevanceToQuery(), Correctness()])
 
     assert "an invalid item with type: list" in str(e.value)
     assert "Hint: Use `scorers=[*get_all_scorers(), scorer1, scorer2]` to pass all" in str(e.value)
 
     # Special case 3: List of classes (not instances)
     with pytest.raises(MlflowException, match="The `scorers` argument must be a list") as e:
-        validate_scorers([RetrievalRelevance])
+        validate_scorers([RelevanceToQuery])
 
-    assert "Correct way to pass scorers is `scorers=[RetrievalRelevance()]`." in str(e.value)
+    assert "Correct way to pass scorers is `scorers=[RelevanceToQuery()]`." in str(e.value)
 
 
 def test_validate_data(mock_logger, sample_rag_trace):
@@ -104,7 +104,7 @@ def test_validate_data(mock_logger, sample_rag_trace):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            RetrievalRelevance(),
+            RelevanceToQuery(),
             RetrievalGroundedness(),
             Guidelines(guidelines=["Be polite", "Be kind"]),
         ],
@@ -130,7 +130,7 @@ def test_validate_data_with_expectations(mock_logger, sample_rag_trace):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            RetrievalRelevance(),
+            RelevanceToQuery(),
             RetrievalSufficiency(),  # requires expected_response in expectations
             ExpectationsGuidelines(),  # requires guidelines in expectations
         ],
@@ -195,7 +195,7 @@ def test_validate_data_missing_columns(mock_logger):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            RetrievalRelevance(),
+            RelevanceToQuery(),
             RetrievalGroundedness(),
             Guidelines(guidelines=["Be polite", "Be kind"]),
         ],
@@ -203,8 +203,8 @@ def test_validate_data_missing_columns(mock_logger):
 
     mock_logger.info.assert_called_once()
     msg = mock_logger.info.call_args[0][0]
-    assert " - `outputs` column is required by [guidelines]." in msg
-    assert " - `trace` column is required by [retrieval_relevance, retrieval_groundedness]." in msg
+    assert " - `outputs` column is required by [relevance_to_query, guidelines]." in msg
+    assert " - `trace` column is required by [retrieval_groundedness]." in msg
 
 
 def test_validate_data_with_trace(mock_logger):
@@ -221,7 +221,7 @@ def test_validate_data_with_trace(mock_logger):
     valid_data_for_builtin_scorers(
         data=converted_date,
         builtin_scorers=[
-            RetrievalRelevance(),
+            RelevanceToQuery(),
             RetrievalGroundedness(),
             Guidelines(guidelines=["Be polite", "Be kind"]),
         ],
@@ -241,7 +241,7 @@ def test_validate_data_with_predict_fn(mock_logger):
             # Requires "outputs" but predict_fn will provide it
             Guidelines(guidelines=["Be polite", "Be kind"]),
             # Requires "retrieved_context" but predict_fn will provide it
-            RetrievalRelevance(),
+            RelevanceToQuery(),
         ],
     )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17238?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17238/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17238/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17238/merge
```

</p>
</details>

### What changes are proposed in this pull request?

`Safety` and `RetrievalRelevance` scorers are not open-sourced yet (due to complexity). Adding an explicit validation so that users can know that before running the evaluation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
