### PR TITLE
Add MLflow traces CLI command with comprehensive search and management capabilities

### DIFF
--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -706,6 +706,11 @@ cli.add_command(mlflow.store.artifact.cli.commands)
 cli.add_command(mlflow.runs.commands)
 cli.add_command(mlflow.db.commands)
 
+# Add traces CLI commands
+from mlflow.cli import traces
+
+cli.add_command(traces.commands)
+
 # We are conditional loading these commands since the skinny client does
 # not support them due to the pandas and numpy dependencies of MLflow Models
 try:

--- a/mlflow/cli/traces.py
+++ b/mlflow/cli/traces.py
@@ -1,0 +1,738 @@
+"""
+Comprehensive MLflow Traces CLI for managing trace data, assessments, and metadata.
+
+This module provides a complete command-line interface for working with MLflow traces,
+including search, retrieval, deletion, tagging, and assessment management. It supports
+both table and JSON output formats with flexible field selection capabilities.
+
+AVAILABLE COMMANDS:
+    search              Search traces with filtering, sorting, and field selection
+    get                 Retrieve detailed trace information as JSON
+    delete              Delete traces by ID or timestamp criteria
+    set-tag             Add tags to traces
+    delete-tag          Remove tags from traces
+    log-feedback        Log evaluation feedback/scores to traces
+    log-expectation     Log ground truth expectations to traces
+    get-assessment      Retrieve assessment details
+    update-assessment   Modify existing assessments
+    delete-assessment   Remove assessments from traces
+
+EXAMPLE USAGE:
+    # Search traces across multiple experiments
+    mlflow traces search --experiment-ids 1,2,3 --max-results 50
+
+    # Filter traces by status and timestamp
+    mlflow traces search --experiment-ids 1 \
+        --filter-string "status = 'OK' AND timestamp_ms > 1700000000000"
+
+    # Get specific fields in JSON format
+    mlflow traces search --experiment-ids 1 \
+        --extract-fields "info.trace_id,info.assessments.*,data.spans.*.name" \
+        --output json
+
+    # Get full trace details
+    mlflow traces get --trace-id tr-1234567890abcdef
+
+    # Log feedback to a trace
+    mlflow traces log-feedback --trace-id tr-abc123 \
+        --name relevance --value 0.9 \
+        --source-type HUMAN --source-id reviewer@example.com \
+        --rationale "Highly relevant response"
+
+    # Delete old traces
+    mlflow traces delete --experiment-ids 1 \
+        --max-timestamp-millis 1700000000000 --max-traces 100
+
+    # Add custom tags
+    mlflow traces set-tag --trace-id tr-abc123 \
+        --key environment --value production
+
+ASSESSMENT TYPES:
+    • Feedback: Evaluation scores, ratings, or judgments
+    • Expectations: Ground truth labels or expected outputs
+    • Sources: HUMAN, LLM_JUDGE, or CODE with source identification
+
+For detailed help on any command, use:
+    mlflow traces COMMAND --help
+"""
+
+import json
+
+import click
+
+from mlflow.entities import AssessmentSource, AssessmentSourceType
+from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID
+from mlflow.tracing.assessment import (
+    log_expectation as _log_expectation,
+)
+from mlflow.tracing.assessment import (
+    log_feedback as _log_feedback,
+)
+from mlflow.tracing.client import TracingClient
+from mlflow.utils.jsonpath_utils import (
+    filter_json_by_fields,
+    jsonpath_extract_values,
+    validate_field_paths,
+)
+from mlflow.utils.string_utils import _create_table, format_table_cell_value
+
+# Define reusable options following mlflow/runs.py pattern
+EXPERIMENT_ID = click.option(
+    "--experiment-id",
+    "-x",
+    envvar=MLFLOW_EXPERIMENT_ID.name,
+    type=click.STRING,
+    required=True,
+    help="Experiment ID to search within. Can be set via MLFLOW_EXPERIMENT_ID env var.",
+)
+TRACE_ID = click.option("--trace-id", type=click.STRING, required=True)
+
+
+@click.group("traces")
+def commands():
+    """
+    Manage traces. To manage traces associated with a tracking server, set the
+    MLFLOW_TRACKING_URI environment variable to the URL of the desired server.
+
+    TRACE SCHEMA:
+    info.trace_id                           # Unique trace identifier
+    info.experiment_id                      # MLflow experiment ID
+    info.request_time                       # Request timestamp (milliseconds)
+    info.execution_duration                 # Total execution time (milliseconds)
+    info.state                              # Trace status: OK, ERROR, etc.
+    info.client_request_id                  # Optional client-provided request ID
+    info.request_preview                    # Truncated request preview
+    info.response_preview                   # Truncated response preview
+    info.trace_metadata.mlflow.*           # MLflow-specific metadata
+    info.trace_metadata.*                  # Custom metadata fields
+    info.tags.mlflow.traceName             # Trace name tag
+    info.tags.<key>                         # Custom tags
+    info.assessments.*.assessment_id        # Assessment identifiers
+    info.assessments.*.feedback.name        # Feedback names
+    info.assessments.*.feedback.value       # Feedback scores/values
+    info.assessments.*.feedback.rationale   # Feedback explanations
+    info.assessments.*.expectation.name     # Ground truth names
+    info.assessments.*.expectation.value    # Expected values
+    info.assessments.*.source.source_type   # HUMAN, LLM_JUDGE, CODE
+    info.assessments.*.source.source_id     # Source identifier
+    info.token_usage                        # Token usage (property, not searchable via fields)
+    data.spans.*.span_id                    # Individual span IDs
+    data.spans.*.name                       # Span operation names
+    data.spans.*.parent_id                  # Parent span relationships
+    data.spans.*.start_time                 # Span start timestamps
+    data.spans.*.end_time                   # Span end timestamps
+    data.spans.*.status_code                # Span status codes
+    data.spans.*.attributes.mlflow.spanType # AGENT, TOOL, LLM, etc.
+    data.spans.*.attributes.<key>           # Custom span attributes
+    data.spans.*.events.*.name              # Event names
+    data.spans.*.events.*.timestamp         # Event timestamps
+    data.spans.*.events.*.attributes.<key>  # Event attributes
+
+    For additional details, see:
+    https://mlflow.org/docs/latest/genai/tracing/concepts/trace/#traceinfo-metadata-and-context
+
+    \b
+    FIELD SELECTION:
+    Use --extract-fields with dot notation to select specific fields.
+
+    \b
+    Examples:
+      info.trace_id                           # Single field
+      info.assessments.*                      # All assessment data
+      info.assessments.*.feedback.value       # Just feedback scores
+      info.assessments.*.source.source_type   # Assessment sources
+      info.trace_metadata.mlflow.traceInputs  # Original inputs
+      info.trace_metadata.mlflow.source.type  # Source type
+      info.tags.mlflow.traceName              # Trace name
+      data.spans.*                            # All span data
+      data.spans.*.name                       # Span operation names
+      data.spans.*.attributes.mlflow.spanType # Span types
+      data.spans.*.events.*.name              # Event names
+      info.trace_id,info.state,info.execution_duration  # Multiple fields
+    """
+
+
+@commands.command("search")
+@EXPERIMENT_ID
+@click.option(
+    "--filter-string",
+    type=click.STRING,
+    help="""Filter string for trace search.
+
+Examples:
+- Filter by run ID: "run_id = '123abc'"
+- Filter by status: "status = 'OK'"
+- Filter by timestamp: "timestamp_ms > 1700000000000"
+- Filter by metadata: "metadata.`mlflow.modelId` = 'model123'"
+- Filter by tags: "tags.environment = 'production'"
+- Multiple conditions: "run_id = '123' AND status = 'OK'"
+
+Available fields:
+- run_id: Associated MLflow run ID
+- status: Trace status (OK, ERROR, etc.)
+- timestamp_ms: Trace timestamp in milliseconds
+- execution_time_ms: Trace execution time in milliseconds
+- name: Trace name
+- metadata.<key>: Custom metadata fields (use backticks for keys with dots)
+- tags.<key>: Custom tag fields""",
+)
+@click.option(
+    "--max-results",
+    type=click.INT,
+    default=100,
+    help="Maximum number of traces to return (default: 100)",
+)
+@click.option(
+    "--order-by",
+    type=click.STRING,
+    help="Comma-separated list of fields to order by (e.g., 'timestamp_ms DESC, status')",
+)
+@click.option("--page-token", type=click.STRING, help="Token for pagination from previous search")
+@click.option(
+    "--run-id",
+    type=click.STRING,
+    help="Filter traces by run ID (convenience option, adds to filter-string)",
+)
+@click.option(
+    "--include-spans/--no-include-spans",
+    default=True,
+    help="Include span data in results (default: include)",
+)
+@click.option("--model-id", type=click.STRING, help="Filter traces by model ID")
+@click.option(
+    "--sql-warehouse-id",
+    type=click.STRING,
+    help="SQL warehouse ID for searching inference tables (Databricks only)",
+)
+@click.option(
+    "--output",
+    type=click.Choice(["table", "json"]),
+    default="table",
+    help="Output format: 'table' for formatted table (default) or 'json' for JSON format",
+)
+@click.option(
+    "--extract-fields",
+    type=click.STRING,
+    help="Filter and select specific fields using dot notation. "
+    "Examples: 'info.trace_id', 'info.assessments.*', 'data.spans.*.name'. "
+    "Comma-separated for multiple fields. "
+    "Defaults to standard columns for table mode, all fields for JSON mode.",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Show all available fields in error messages when invalid fields are specified.",
+)
+def search_traces(
+    experiment_id,
+    filter_string,
+    max_results,
+    order_by,
+    page_token,
+    run_id,
+    include_spans,
+    model_id,
+    sql_warehouse_id,
+    output,
+    extract_fields,
+    verbose,
+):
+    """
+    Search for traces in the specified experiment.
+
+    Examples:
+
+    \b
+    # Search all traces in experiment 1
+    mlflow traces search --experiment-id 1
+
+    \b
+    # Using environment variable
+    export MLFLOW_EXPERIMENT_ID=1
+    mlflow traces search --max-results 50
+
+    \b
+    # Filter traces by run ID
+    mlflow traces search --experiment-id 1 --run-id abc123def
+
+    \b
+    # Use filter string for complex queries
+    mlflow traces search --experiment-id 1 \\
+        --filter-string "run_id = 'abc123' AND timestamp_ms > 1700000000000"
+
+    \b
+    # Order results and use pagination
+    mlflow traces search --experiment-id 1 \\
+        --order-by "timestamp_ms DESC" \\
+        --max-results 10 \\
+        --page-token <token_from_previous>
+
+    \b
+    # Search without span data (faster for metadata-only queries)
+    mlflow traces search --experiment-id 1 --no-include-spans
+    """
+    client = TracingClient()
+    order_by_list = order_by.split(",") if order_by else None
+
+    traces = client.search_traces(
+        experiment_ids=[experiment_id],
+        filter_string=filter_string,
+        max_results=max_results,
+        order_by=order_by_list,
+        page_token=page_token,
+        run_id=run_id,
+        include_spans=include_spans,
+        model_id=model_id,
+        sql_warehouse_id=sql_warehouse_id,
+    )
+
+    # Determine which fields to show
+    if extract_fields:
+        field_list = [f.strip() for f in extract_fields.split(",")]
+        # Validate fields against actual trace data
+        if traces:
+            try:
+                validate_field_paths(field_list, traces[0].to_dict(), verbose=verbose)
+            except ValueError as e:
+                raise click.UsageError(str(e))
+    elif output == "json":
+        # JSON mode defaults to all fields (full trace data)
+        field_list = None  # Will output full JSON
+    else:
+        # Table mode defaults to standard columns
+        field_list = [
+            "info.trace_id",
+            "info.request_time",
+            "info.state",
+            "info.execution_duration",
+            "info.request_preview",
+            "info.response_preview",
+        ]
+
+    if output == "json":
+        if field_list is None:
+            # Full JSON output
+            result = {
+                "traces": [trace.to_dict() for trace in traces],
+                "next_page_token": traces.token,
+            }
+        else:
+            # Custom fields JSON output - filter original structure
+            traces_data = []
+            for trace in traces:
+                trace_dict = trace.to_dict()
+                filtered_trace = filter_json_by_fields(trace_dict, field_list)
+                traces_data.append(filtered_trace)
+            result = {"traces": traces_data, "next_page_token": traces.token}
+        click.echo(json.dumps(result, indent=2))
+    else:
+        # Table output format
+        table = []
+        for trace in traces:
+            trace_dict = trace.to_dict()
+            row = []
+
+            for field in field_list:
+                values = jsonpath_extract_values(trace_dict, field)
+                cell_value = format_table_cell_value(field, None, values)
+                row.append(cell_value)
+
+            table.append(row)
+
+        click.echo(_create_table(table, headers=field_list))
+
+        if traces.token:
+            click.echo(f"\nNext page token: {traces.token}")
+
+
+@commands.command("get")
+@TRACE_ID
+@click.option(
+    "--extract-fields",
+    type=click.STRING,
+    help="Filter and select specific fields using dot notation. "
+    "Examples: 'info.trace_id', 'info.assessments.*', 'data.spans.*.name'. "
+    "Comma-separated for multiple fields. "
+    "If not specified, returns all trace data.",
+)
+@click.option(
+    "--verbose",
+    is_flag=True,
+    help="Show all available fields in error messages when invalid fields are specified.",
+)
+def get_trace(trace_id, extract_fields, verbose):
+    """
+    All trace details will print to stdout as JSON format.
+
+    \b
+    Examples:
+    # Get full trace
+    mlflow traces get --trace-id tr-1234567890abcdef
+
+    \b
+    # Get specific fields only
+    mlflow traces get --trace-id tr-1234567890abcdef \\
+        --extract-fields "info.trace_id,info.assessments.*,data.spans.*.name"
+    """
+    client = TracingClient()
+    trace = client.get_trace(trace_id)
+    trace_dict = trace.to_dict()
+
+    if extract_fields:
+        field_list = [f.strip() for f in extract_fields.split(",")]
+        # Validate fields against trace data
+        try:
+            validate_field_paths(field_list, trace_dict, verbose=verbose)
+        except ValueError as e:
+            raise click.UsageError(str(e))
+        # Filter to selected fields only
+        filtered_trace = filter_json_by_fields(trace_dict, field_list)
+        json_trace = json.dumps(filtered_trace, indent=4)
+    else:
+        # Return full trace
+        json_trace = json.dumps(trace_dict, indent=4)
+
+    click.echo(json_trace)
+
+
+@commands.command("delete")
+@EXPERIMENT_ID
+@click.option("--trace-ids", type=click.STRING, help="Comma-separated list of trace IDs to delete")
+@click.option(
+    "--max-timestamp-millis",
+    type=click.INT,
+    help="Delete traces older than this timestamp (milliseconds since epoch)",
+)
+@click.option("--max-traces", type=click.INT, help="Maximum number of traces to delete")
+def delete_traces(experiment_id, trace_ids, max_timestamp_millis, max_traces):
+    """
+    Delete traces from an experiment.
+
+    Either --trace-ids or timestamp criteria can be specified, but not both.
+
+    \b
+    Examples:
+    # Delete specific traces
+    mlflow traces delete --experiment-id 1 --trace-ids tr-abc123,tr-def456
+
+    \b
+    # Delete traces older than a timestamp
+    mlflow traces delete --experiment-id 1 --max-timestamp-millis 1700000000000
+
+    \b
+    # Delete up to 100 old traces
+    mlflow traces delete --experiment-id 1 --max-timestamp-millis 1700000000000 --max-traces 100
+    """
+    client = TracingClient()
+    trace_id_list = trace_ids.split(",") if trace_ids else None
+
+    count = client.delete_traces(
+        experiment_id=experiment_id,
+        trace_ids=trace_id_list,
+        max_timestamp_millis=max_timestamp_millis,
+        max_traces=max_traces,
+    )
+    click.echo(f"Deleted {count} trace(s) from experiment {experiment_id}.")
+
+
+@commands.command("set-tag")
+@TRACE_ID
+@click.option("--key", type=click.STRING, required=True, help="Tag key")
+@click.option("--value", type=click.STRING, required=True, help="Tag value")
+def set_tag(trace_id, key, value):
+    """
+    Set a tag on a trace.
+
+    \b
+    Example:
+    mlflow traces set-tag --trace-id tr-abc123 --key environment --value production
+    """
+    client = TracingClient()
+    client.set_trace_tag(trace_id, key, value)
+    click.echo(f"Set tag '{key}' on trace {trace_id}.")
+
+
+@commands.command("delete-tag")
+@TRACE_ID
+@click.option("--key", type=click.STRING, required=True, help="Tag key to delete")
+def delete_tag(trace_id, key):
+    """
+    Delete a tag from a trace.
+
+    \b
+    Example:
+    mlflow traces delete-tag --trace-id tr-abc123 --key environment
+    """
+    client = TracingClient()
+    client.delete_trace_tag(trace_id, key)
+    click.echo(f"Deleted tag '{key}' from trace {trace_id}.")
+
+
+@commands.command("log-feedback")
+@TRACE_ID
+@click.option(
+    "--name", type=click.STRING, default="feedback", help="Feedback name (default: 'feedback')"
+)
+@click.option(
+    "--value",
+    type=click.STRING,
+    help="Feedback value (number, string, bool, or JSON for complex values)",
+)
+@click.option(
+    "--source-type",
+    type=click.Choice(
+        [AssessmentSourceType.HUMAN, AssessmentSourceType.LLM_JUDGE, AssessmentSourceType.CODE]
+    ),
+    help="Source type of the feedback",
+)
+@click.option(
+    "--source-id",
+    type=click.STRING,
+    help="Source identifier (e.g., email for HUMAN, model name for LLM)",
+)
+@click.option("--rationale", type=click.STRING, help="Explanation/justification for the feedback")
+@click.option("--metadata", type=click.STRING, help="Additional metadata as JSON string")
+@click.option("--span-id", type=click.STRING, help="Associate feedback with a specific span ID")
+def log_feedback(trace_id, name, value, source_type, source_id, rationale, metadata, span_id):
+    """
+    Log feedback (evaluation score) to a trace.
+
+    \b
+    Examples:
+    # Simple numeric feedback
+    mlflow traces log-feedback --trace-id tr-abc123 \\
+        --name relevance --value 0.9 \\
+        --rationale "Highly relevant response"
+
+    \b
+    # Human feedback with source
+    mlflow traces log-feedback --trace-id tr-abc123 \\
+        --name quality --value good \\
+        --source-type HUMAN --source-id reviewer@example.com
+
+    \b
+    # Complex feedback with JSON value and metadata
+    mlflow traces log-feedback --trace-id tr-abc123 \\
+        --name metrics \\
+        --value '{"accuracy": 0.95, "f1": 0.88}' \\
+        --metadata '{"model": "gpt-4", "temperature": 0.7}'
+
+    \b
+    # LLM judge feedback
+    mlflow traces log-feedback --trace-id tr-abc123 \\
+        --name faithfulness --value 0.85 \\
+        --source-type LLM_JUDGE --source-id gpt-4 \\
+        --rationale "Response is faithful to context"
+    """
+    # Parse value if it's JSON
+    if value:
+        try:
+            value = json.loads(value)
+        except json.JSONDecodeError:
+            pass  # Keep as string
+
+    # Parse metadata
+    metadata_dict = json.loads(metadata) if metadata else None
+
+    # Create source if provided
+    source = None
+    if source_type and source_id:
+        # Map CLI choices to AssessmentSourceType constants
+        source_type_value = getattr(AssessmentSourceType, source_type)
+        source = AssessmentSource(
+            source_type=source_type_value,
+            source_id=source_id,
+        )
+
+    assessment = _log_feedback(
+        trace_id=trace_id,
+        name=name,
+        value=value,
+        source=source,
+        rationale=rationale,
+        metadata=metadata_dict,
+        span_id=span_id,
+    )
+    click.echo(
+        f"Logged feedback '{name}' to trace {trace_id}. Assessment ID: {assessment.assessment_id}"
+    )
+
+
+@commands.command("log-expectation")
+@TRACE_ID
+@click.option(
+    "--name",
+    type=click.STRING,
+    required=True,
+    help="Expectation name (e.g., 'expected_answer', 'ground_truth')",
+)
+@click.option(
+    "--value",
+    type=click.STRING,
+    required=True,
+    help="Expected value (string or JSON for complex values)",
+)
+@click.option(
+    "--source-type",
+    type=click.Choice(
+        [AssessmentSourceType.HUMAN, AssessmentSourceType.LLM_JUDGE, AssessmentSourceType.CODE]
+    ),
+    help="Source type of the expectation",
+)
+@click.option("--source-id", type=click.STRING, help="Source identifier")
+@click.option("--metadata", type=click.STRING, help="Additional metadata as JSON string")
+@click.option("--span-id", type=click.STRING, help="Associate expectation with a specific span ID")
+def log_expectation(trace_id, name, value, source_type, source_id, metadata, span_id):
+    """
+    Log an expectation (ground truth label) to a trace.
+
+    \b
+    Examples:
+    # Simple expected answer
+    mlflow traces log-expectation --trace-id tr-abc123 \\
+        --name expected_answer --value "Paris"
+
+    \b
+    # Human-annotated ground truth
+    mlflow traces log-expectation --trace-id tr-abc123 \\
+        --name ground_truth --value "positive" \\
+        --source-type HUMAN --source-id annotator@example.com
+
+    \b
+    # Complex expected output with metadata
+    mlflow traces log-expectation --trace-id tr-abc123 \\
+        --name expected_response \\
+        --value '{"answer": "42", "confidence": 0.95}' \\
+        --metadata '{"dataset": "test_set_v1", "difficulty": "hard"}'
+    """
+    # Parse value if it's JSON
+    try:
+        value = json.loads(value)
+    except json.JSONDecodeError:
+        pass  # Keep as string
+
+    # Parse metadata
+    metadata_dict = json.loads(metadata) if metadata else None
+
+    # Create source if provided
+    source = None
+    if source_type and source_id:
+        # Map CLI choices to AssessmentSourceType constants
+        source_type_value = getattr(AssessmentSourceType, source_type)
+        source = AssessmentSource(
+            source_type=source_type_value,
+            source_id=source_id,
+        )
+
+    assessment = _log_expectation(
+        trace_id=trace_id,
+        name=name,
+        value=value,
+        source=source,
+        metadata=metadata_dict,
+        span_id=span_id,
+    )
+    click.echo(
+        f"Logged expectation '{name}' to trace {trace_id}. "
+        f"Assessment ID: {assessment.assessment_id}"
+    )
+
+
+@commands.command("get-assessment")
+@TRACE_ID
+@click.option("--assessment-id", type=click.STRING, required=True, help="Assessment ID")
+def get_assessment(trace_id, assessment_id):
+    """
+    Get assessment details as JSON.
+
+    \b
+    Example:
+    mlflow traces get-assessment --trace-id tr-abc123 --assessment-id asmt-def456
+    """
+    client = TracingClient()
+    assessment = client.get_assessment(trace_id, assessment_id)
+    json_assessment = json.dumps(assessment.to_dictionary(), indent=4)
+    click.echo(json_assessment)
+
+
+@commands.command("update-assessment")
+@TRACE_ID
+@click.option("--assessment-id", type=click.STRING, required=True, help="Assessment ID to update")
+@click.option("--value", type=click.STRING, help="Updated assessment value (JSON)")
+@click.option("--rationale", type=click.STRING, help="Updated rationale")
+@click.option("--metadata", type=click.STRING, help="Updated metadata as JSON")
+def update_assessment(trace_id, assessment_id, value, rationale, metadata):
+    """
+    Update an existing assessment.
+
+    NOTE: Assessment names cannot be changed once set. Only value, rationale,
+    and metadata can be updated.
+
+    \b
+    Examples:
+    # Update feedback value and rationale
+    mlflow traces update-assessment --trace-id tr-abc123 --assessment-id asmt-def456 \\
+        --value '{"accuracy": 0.98}' --rationale "Updated after review"
+
+    \b
+    # Update only the rationale
+    mlflow traces update-assessment --trace-id tr-abc123 --assessment-id asmt-def456 \\
+        --rationale "Revised evaluation"
+    """
+    client = TracingClient()
+
+    # Get the existing assessment first
+    existing = client.get_assessment(trace_id, assessment_id)
+
+    # Parse value if provided
+    parsed_value = value
+    if value:
+        try:
+            parsed_value = json.loads(value)
+        except json.JSONDecodeError:
+            pass  # Keep as string
+
+    # Parse metadata if provided
+    parsed_metadata = metadata
+    if metadata:
+        parsed_metadata = json.loads(metadata)
+
+    # Create updated assessment - determine if it's feedback or expectation
+    if hasattr(existing, "feedback"):
+        # It's feedback
+        from mlflow.entities import Feedback
+
+        updated_assessment = Feedback(
+            name=existing.name,  # Always use existing name (cannot be changed)
+            value=parsed_value if value else existing.value,
+            rationale=rationale if rationale is not None else existing.rationale,
+            metadata=parsed_metadata if metadata else existing.metadata,
+        )
+    else:
+        # It's expectation
+        from mlflow.entities import Expectation
+
+        updated_assessment = Expectation(
+            name=existing.name,  # Always use existing name (cannot be changed)
+            value=parsed_value if value else existing.value,
+            metadata=parsed_metadata if metadata else existing.metadata,
+        )
+
+    client.update_assessment(trace_id, assessment_id, updated_assessment)
+    click.echo(f"Updated assessment {assessment_id} in trace {trace_id}.")
+
+
+@commands.command("delete-assessment")
+@TRACE_ID
+@click.option("--assessment-id", type=click.STRING, required=True, help="Assessment ID to delete")
+def delete_assessment(trace_id, assessment_id):
+    """
+    Delete an assessment from a trace.
+
+    \b
+    Example:
+    mlflow traces delete-assessment --trace-id tr-abc123 --assessment-id asmt-def456
+    """
+    client = TracingClient()
+    client.delete_assessment(trace_id, assessment_id)
+    click.echo(f"Deleted assessment {assessment_id} from trace {trace_id}.")

--- a/mlflow/utils/jsonpath_utils.py
+++ b/mlflow/utils/jsonpath_utils.py
@@ -1,0 +1,332 @@
+"""
+JSONPath utilities for navigating and manipulating nested JSON structures.
+
+This module provides a simplified JSONPath-like implementation without adding
+external dependencies to MLflow. Instead of using a full JSONPath library,
+we implement a lightweight subset focused on trace data navigation using
+dot notation with wildcard support.
+
+The implementation supports:
+- Dot notation path traversal (e.g., "info.trace_id")
+- Wildcard expansion (e.g., "info.assessments.*")
+- Array/list navigation with numeric indices
+- Structure-preserving filtering
+- Path validation with helpful error messages
+
+This approach keeps MLflow dependencies minimal while providing the essential
+functionality needed for trace field selection and data manipulation.
+
+Note: This is NOT a complete JSONPath implementation. It's a custom solution
+tailored specifically for MLflow trace data structures.
+"""
+
+from typing import Any
+
+
+def split_path_respecting_backticks(path: str) -> list[str]:
+    """
+    Split path on dots, but keep backticked segments intact.
+
+    Args:
+        path: Path string like 'info.tags.`mlflow.traceName`'
+
+    Returns:
+        List of path segments, e.g., ['info', 'tags', 'mlflow.traceName']
+    """
+    parts = []
+    i = 0
+    current = ""
+
+    while i < len(path):
+        if i < len(path) and path[i] == "`":
+            # Start of backticked segment - read until closing backtick
+            i += 1  # Skip opening backtick
+            while i < len(path) and path[i] != "`":
+                current += path[i]
+                i += 1
+            if i < len(path):
+                i += 1  # Skip closing backtick
+        elif path[i] == ".":
+            if current:
+                parts.append(current)
+                current = ""
+            i += 1
+        else:
+            current += path[i]
+            i += 1
+
+    if current:
+        parts.append(current)
+
+    return parts
+
+
+def jsonpath_extract_values(obj: dict[str, Any], path: str) -> list[Any]:
+    """
+    Extract values from nested dict using JSONPath-like dot notation with * wildcard support.
+
+    Supports backtick escaping for field names containing dots:
+        'info.tags.`mlflow.traceName`' - treats 'mlflow.traceName' as a single field
+
+    Args:
+        obj: The dictionary/object to traverse
+        path: Dot-separated path like 'info.trace_id' or 'data.spans.*.name'
+              Can use backticks for fields with dots: 'info.tags.`mlflow.traceName`'
+
+    Returns:
+        List of values found at the path. Returns empty list if path not found.
+
+    Examples:
+        >>> data = {"info": {"trace_id": "tr-123", "status": "OK"}}
+        >>> jsonpath_extract_values(data, "info.trace_id")
+        ['tr-123']
+        >>> jsonpath_extract_values(data, "info.*")
+        ['tr-123', 'OK']
+        >>> data = {"tags": {"mlflow.traceName": "test"}}
+        >>> jsonpath_extract_values(data, "tags.`mlflow.traceName`")
+        ['test']
+    """
+    parts = split_path_respecting_backticks(path)
+
+    def traverse(current, parts_remaining):
+        if not parts_remaining:
+            return [current]
+
+        part = parts_remaining[0]
+        rest = parts_remaining[1:]
+
+        if part == "*":
+            # Wildcard - expand all keys at this level
+            if isinstance(current, dict):
+                results = []
+                for key, value in current.items():
+                    results.extend(traverse(value, rest))
+                return results
+            elif isinstance(current, list):
+                results = []
+                for item in current:
+                    results.extend(traverse(item, rest))
+                return results
+            else:
+                return []
+        else:
+            # Regular key
+            if isinstance(current, dict) and part in current:
+                return traverse(current[part], rest)
+            else:
+                return []
+
+    return traverse(obj, parts)
+
+
+def filter_json_by_fields(data: dict[str, Any], field_paths: list[str]) -> dict[str, Any]:
+    """
+    Filter a JSON dict to only include fields specified by the field paths.
+    Expands wildcards but preserves original JSON structure.
+
+    Args:
+        data: Original JSON dictionary
+        field_paths: List of dot-notation paths like ['info.trace_id', 'info.assessments.*']
+
+    Returns:
+        Filtered dictionary with original structure preserved
+    """
+    result = {}
+
+    # Collect all actual paths by expanding wildcards
+    expanded_paths = set()
+    for field_path in field_paths:
+        if "*" in field_path:
+            # Find all actual paths that match this wildcard pattern
+            matching_paths = find_matching_paths(data, field_path)
+            expanded_paths.update(matching_paths)
+        else:
+            # Direct path
+            expanded_paths.add(field_path)
+
+    # Build the result by including only the specified paths
+    for path in expanded_paths:
+        parts = split_path_respecting_backticks(path)
+        set_nested_value(result, parts, get_nested_value_safe(data, parts))
+
+    return result
+
+
+def find_matching_paths(data: dict[str, Any], wildcard_path: str) -> list[str]:
+    """Find all actual paths in data that match a wildcard pattern."""
+    parts = split_path_respecting_backticks(wildcard_path)
+
+    def find_paths(current_data, current_parts, current_path=""):
+        if not current_parts:
+            return [current_path.lstrip(".")]
+
+        part = current_parts[0]
+        remaining = current_parts[1:]
+
+        if part == "*":
+            paths = []
+            if isinstance(current_data, dict):
+                for key in current_data.keys():
+                    new_path = f"{current_path}.{key}"
+                    paths.extend(find_paths(current_data[key], remaining, new_path))
+            elif isinstance(current_data, list):
+                for i, item in enumerate(current_data):
+                    new_path = f"{current_path}.{i}"
+                    paths.extend(find_paths(item, remaining, new_path))
+            return paths
+        else:
+            if isinstance(current_data, dict) and part in current_data:
+                new_path = f"{current_path}.{part}"
+                return find_paths(current_data[part], remaining, new_path)
+            return []
+
+    return find_paths(data, parts)
+
+
+def get_nested_value_safe(data: dict[str, Any], parts: list[str]):
+    """Safely get nested value, returning None if path doesn't exist."""
+    current = data
+    for part in parts:
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        elif isinstance(current, list) and part.isdigit() and int(part) < len(current):
+            current = current[int(part)]
+        else:
+            return None
+    return current
+
+
+def set_nested_value(data: dict[str, Any], parts: list[str], value):
+    """Set a nested value in a dictionary, creating intermediate dicts/lists as needed."""
+    if value is None:
+        return
+
+    current = data
+    for i, part in enumerate(parts[:-1]):
+        if part.isdigit() and isinstance(current, list):
+            # Handle array index
+            idx = int(part)
+            while len(current) <= idx:
+                current.append({})
+            current = current[idx]
+        else:
+            # Handle object key
+            if not isinstance(current, dict):
+                return  # Can't set object key on non-dict
+            if part not in current:
+                # Look ahead to see if next part is a number (array index)
+                next_part = parts[i + 1] if i + 1 < len(parts) else None
+                if next_part and next_part.isdigit():
+                    current[part] = []
+                else:
+                    current[part] = {}
+            current = current[part]
+
+    if parts:
+        final_part = parts[-1]
+        if final_part.isdigit() and isinstance(current, list):
+            # Extend list if needed
+            idx = int(final_part)
+            while len(current) <= idx:
+                current.append(None)
+            current[idx] = value
+        elif isinstance(current, dict):
+            current[final_part] = value
+
+
+def validate_field_paths(
+    field_paths: list[str], sample_data: dict[str, Any], verbose: bool = False
+):
+    """Validate that field paths exist in the data structure.
+
+    Args:
+        field_paths: List of field paths to validate
+        sample_data: Sample data to validate against
+        verbose: If True, show all available fields instead of truncated list
+    """
+    invalid_paths = []
+
+    for path in field_paths:
+        # Skip validation for paths with wildcards - they'll be expanded later
+        if "*" in path:
+            continue
+
+        # Test if the path exists by trying to extract values
+        values = jsonpath_extract_values(sample_data, path)
+        if not values:  # Empty list means path doesn't exist
+            invalid_paths.append(path)
+
+    if invalid_paths:
+        available_fields = get_available_field_suggestions(sample_data)
+
+        # Create a nice error message
+        error_msg = "❌ Invalid field path(s):\n"
+        for path in invalid_paths:
+            error_msg += f"   • {path}\n"
+
+        error_msg += "\n💡 Use dot notation to specify nested fields:"
+        error_msg += "\n   Examples: info.trace_id, info.state, info.assessments.*"
+
+        if available_fields:
+            error_msg += "\n\n📋 Available fields in this data:\n"
+
+            if verbose:
+                # In verbose mode, show ALL available fields organized by category
+                info_fields = [f for f in available_fields if f.startswith("info.")]
+                data_fields = [f for f in available_fields if f.startswith("data.")]
+
+                if info_fields:
+                    error_msg += "   Info fields:\n"
+                    for field in sorted(info_fields):
+                        error_msg += f"     • {field}\n"
+
+                if data_fields:
+                    error_msg += "   Data fields:\n"
+                    for field in sorted(data_fields):
+                        error_msg += f"     • {field}\n"
+            else:
+                # Non-verbose mode: show truncated list
+                # Group by top-level key for better readability
+                info_fields = [f for f in available_fields if f.startswith("info.")]
+                data_fields = [f for f in available_fields if f.startswith("data.")]
+
+                if info_fields:
+                    error_msg += f"   info.*: {', '.join(info_fields[:8])}"
+                    if len(info_fields) > 8:
+                        error_msg += f", ... (+{len(info_fields) - 8} more)"
+                    error_msg += "\n"
+
+                if data_fields:
+                    error_msg += f"   data.*: {', '.join(data_fields[:5])}"
+                    if len(data_fields) > 5:
+                        error_msg += f", ... (+{len(data_fields) - 5} more)"
+                    error_msg += "\n"
+
+                error_msg += "\n💡 Tip: Use --verbose flag to see all available fields"
+
+        raise ValueError(error_msg)
+
+
+def get_available_field_suggestions(data: dict[str, Any], prefix: str = "") -> list[str]:
+    """Get a list of available field paths for suggestions."""
+    paths = []
+
+    def collect_paths(obj, current_path=""):
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                path = f"{current_path}.{key}" if current_path else key
+                paths.append(path)
+                # Only go 2 levels deep for suggestions to keep it manageable
+                if current_path.count(".") < 2:
+                    collect_paths(value, path)
+        elif isinstance(obj, list) and obj:
+            # Show array notation but don't expand all indices
+            path = f"{current_path}.*" if current_path else "*"
+            if path not in paths:
+                paths.append(path)
+            # Sample first item if it's an object
+            if isinstance(obj[0], dict):
+                collect_paths(obj[0], f"{current_path}.*" if current_path else "*")
+
+    collect_paths(data, prefix)
+    return sorted(set(paths))

--- a/mlflow/utils/string_utils.py
+++ b/mlflow/utils/string_utils.py
@@ -1,5 +1,7 @@
 import re
 import shlex
+from datetime import datetime
+from typing import Any
 
 from mlflow.utils.os import is_windows
 
@@ -136,3 +138,54 @@ def _backtick_quote(s: str) -> str:
     Quotes the given string with backticks if it is not already quoted with backticks.
     """
     return f"`{s}`" if not (s.startswith("`") and s.endswith("`")) else s
+
+
+def format_table_cell_value(field: str, cell_value, values: list[Any] | None = None):
+    """
+    Format cell values for table display with field-specific formatting.
+
+    Args:
+        field: The field name (e.g., "info.request_time")
+        cell_value: The value to format
+        values: List of extracted values (for multiple values handling)
+
+    Returns:
+        Formatted string value suitable for table display
+    """
+    if values is None:
+        values = [cell_value] if cell_value is not None else []
+
+    # Handle empty/missing values
+    if not values:
+        return "N/A"
+    elif len(values) == 1:
+        cell_value = values[0]
+    else:
+        # Multiple values - join them
+        cell_value = ", ".join(str(v) for v in values[:3])  # Limit to first 3
+        if len(values) > 3:
+            cell_value += f", ... (+{len(values) - 3} more)"
+
+    # Format specific fields
+    if field == "info.request_time" and cell_value != "N/A":
+        # Convert ISO timestamp to readable format
+        try:
+            dt = datetime.fromisoformat(str(cell_value).replace("Z", "+00:00"))
+            cell_value = dt.strftime("%Y-%m-%d %H:%M:%S %Z")
+        except Exception:
+            pass  # Keep original if conversion fails
+    elif field == "info.execution_duration_ms" and cell_value != "N/A" and cell_value is not None:
+        try:
+            duration_ms = float(cell_value)
+            if duration_ms < 1000:
+                cell_value = f"{int(duration_ms)}ms"
+            else:
+                cell_value = f"{duration_ms / 1000:.1f}s"
+        except (ValueError, TypeError):
+            pass  # Keep original if conversion fails
+    elif field in ["info.request_preview", "info.response_preview"]:
+        # Truncate previews to keep table readable
+        if len(str(cell_value)) > 20:
+            cell_value = str(cell_value)[:17] + "..."
+
+    return str(cell_value)

--- a/tests/cli/test_traces.py
+++ b/tests/cli/test_traces.py
@@ -1,0 +1,251 @@
+import json
+from unittest import mock
+
+import pytest
+from click.testing import CliRunner
+
+from mlflow.cli.traces import commands
+from mlflow.entities import AssessmentSourceType
+
+# Table cell formatting tests are in tests/utils/test_string_utils.py
+
+
+@pytest.fixture
+def runner():
+    """Provide a CLI runner for testing."""
+    return CliRunner()
+
+
+def test_commands_group_exists():
+    """Test that the traces command group is properly defined."""
+    assert commands.name == "traces"
+    assert commands.help is not None
+
+
+def test_search_command_params():
+    """Test that search command has all required parameters."""
+    search_cmd = None
+    for cmd in commands.commands.values():
+        if cmd.name == "search":
+            search_cmd = cmd
+            break
+
+    assert search_cmd is not None
+    param_names = [p.name for p in search_cmd.params]
+
+    # Check for required params
+    assert "experiment_id" in param_names
+    assert "filter_string" in param_names
+    assert "max_results" in param_names
+    assert "order_by" in param_names
+    assert "page_token" in param_names
+    assert "output" in param_names
+    assert "extract_fields" in param_names
+
+
+def test_get_command_params():
+    """Test that get command has all required parameters."""
+    get_cmd = None
+    for cmd in commands.commands.values():
+        if cmd.name == "get":
+            get_cmd = cmd
+            break
+
+    assert get_cmd is not None
+    param_names = [p.name for p in get_cmd.params]
+
+    # Check for required params
+    assert "trace_id" in param_names
+    assert "extract_fields" in param_names
+
+
+def test_assessment_source_type_choices():
+    """Test that assessment commands use dynamic enum values."""
+    log_feedback_cmd = None
+    for cmd in commands.commands.values():
+        if cmd.name == "log-feedback":
+            log_feedback_cmd = cmd
+            break
+
+    assert log_feedback_cmd is not None
+
+    # Find source_type param
+    source_type_param = None
+    for param in log_feedback_cmd.params:
+        if param.name == "source_type":
+            source_type_param = param
+            break
+
+    assert source_type_param is not None
+
+    # Check that choices include the enum values
+    assert AssessmentSourceType.HUMAN in source_type_param.type.choices
+    assert AssessmentSourceType.LLM_JUDGE in source_type_param.type.choices
+    assert AssessmentSourceType.CODE in source_type_param.type.choices
+
+
+def test_search_command_with_fields(runner):
+    """Test search command with field selection."""
+    mock_trace = {
+        "info": {
+            "trace_id": "tr-123",
+            "state": "OK",
+            "request_time": 1700000000000,
+            "execution_duration": 1234,
+            "request_preview": "test request",
+            "response_preview": "test response",
+        }
+    }
+
+    # Create a mock trace object with a to_dict method
+    mock_trace_obj = mock.Mock()
+    mock_trace_obj.to_dict.return_value = mock_trace
+
+    # Create a mock result that acts like a list but also has a token attribute
+    mock_result = mock.Mock()
+    mock_result.__iter__ = lambda self: iter([mock_trace_obj])
+    mock_result.__getitem__ = lambda self, i: mock_trace_obj if i == 0 else None
+    mock_result.__len__ = lambda self: 1
+    mock_result.__bool__ = lambda self: True
+    mock_result.token = None
+
+    # Patch the TracingClient at the module level where it's imported
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        mock_instance = mock.Mock()
+        mock_client.return_value = mock_instance
+        mock_instance.search_traces.return_value = mock_result
+
+        result = runner.invoke(
+            commands,
+            ["search", "--experiment-id", "1", "--extract-fields", "info.trace_id,info.state"],
+        )
+
+        assert result.exit_code == 0
+        # Check that either the table output or the values appear in output
+        assert "tr-123" in result.output
+        assert "OK" in result.output
+
+
+def test_get_command_with_fields(runner):
+    """Test get command with field selection."""
+    mock_trace = {
+        "info": {"trace_id": "tr-123", "state": "OK"},
+        "data": {"spans": [{"name": "test_span"}]},
+    }
+
+    # Create a mock trace object with a to_dict method
+    mock_trace_obj = mock.Mock()
+    mock_trace_obj.to_dict.return_value = mock_trace
+
+    # Patch the TracingClient at the module level where it's imported
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        mock_instance = mock.Mock()
+        mock_client.return_value = mock_instance
+        mock_instance.get_trace.return_value = mock_trace_obj
+
+        result = runner.invoke(
+            commands,
+            ["get", "--trace-id", "tr-123", "--extract-fields", "info.trace_id"],
+        )
+
+        assert result.exit_code == 0
+
+        # Parse JSON output
+        output_json = json.loads(result.output)
+        assert output_json == {"info": {"trace_id": "tr-123"}}
+
+
+def test_delete_command(runner):
+    """Test delete command."""
+    # Patch the TracingClient at the module level where it's imported
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        mock_instance = mock.Mock()
+        mock_client.return_value = mock_instance
+        mock_instance.delete_traces.return_value = 5
+
+        result = runner.invoke(
+            commands,
+            ["delete", "--experiment-id", "1", "--trace-ids", "tr-1,tr-2,tr-3"],
+        )
+
+        assert result.exit_code == 0
+        assert "Deleted 5 trace(s)" in result.output
+
+
+def test_field_validation_error(runner):
+    """Test that invalid fields produce helpful error messages."""
+    mock_trace = {"info": {"trace_id": "tr-123"}}
+
+    # Create a mock trace object with a to_dict method
+    mock_trace_obj = mock.Mock()
+    mock_trace_obj.to_dict.return_value = mock_trace
+
+    # Create a mock result that acts like a list but also has a token attribute
+    mock_result = mock.Mock()
+    mock_result.__iter__ = lambda self: iter([mock_trace_obj])
+    mock_result.__getitem__ = lambda self, i: mock_trace_obj if i == 0 else None
+    mock_result.__len__ = lambda self: 1
+    mock_result.__bool__ = lambda self: True
+    mock_result.token = None
+
+    # Patch the TracingClient at the module level where it's imported
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        mock_instance = mock.Mock()
+        mock_client.return_value = mock_instance
+        mock_instance.search_traces.return_value = mock_result
+
+        result = runner.invoke(
+            commands,
+            ["search", "--experiment-id", "1", "--extract-fields", "invalid.field"],
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid field path" in result.output
+        # Check for the tip about verbose mode
+        assert "--verbose" in result.output
+
+
+def test_field_validation_error_verbose_mode(runner):
+    """Test that verbose mode shows all available fields."""
+    mock_trace = {
+        "info": {
+            "trace_id": "tr-123",
+            "state": "OK",
+            "request_time": 1700000000000,
+            "assessments": [{"id": "a1"}],
+        },
+        "data": {"spans": [{"name": "span1"}]},
+    }
+
+    # Create a mock trace object with a to_dict method
+    mock_trace_obj = mock.Mock()
+    mock_trace_obj.to_dict.return_value = mock_trace
+
+    # Create a mock result that acts like a list but also has a token attribute
+    mock_result = mock.Mock()
+    mock_result.__iter__ = lambda self: iter([mock_trace_obj])
+    mock_result.__getitem__ = lambda self, i: mock_trace_obj if i == 0 else None
+    mock_result.__len__ = lambda self: 1
+    mock_result.__bool__ = lambda self: True
+    mock_result.token = None
+
+    # Patch the TracingClient at the module level where it's imported
+    with mock.patch("mlflow.cli.traces.TracingClient") as mock_client:
+        mock_instance = mock.Mock()
+        mock_client.return_value = mock_instance
+        mock_instance.search_traces.return_value = mock_result
+
+        # Use --verbose flag
+        result = runner.invoke(
+            commands,
+            ["search", "--experiment-id", "1", "--extract-fields", "invalid.field", "--verbose"],
+        )
+
+        assert result.exit_code != 0
+        assert "Invalid field path" in result.output
+        # In verbose mode, we should see ALL the fields listed
+        assert "info.trace_id" in result.output
+        assert "info.state" in result.output
+        assert "info.request_time" in result.output
+        # Should NOT show the tip about --verbose since we're already using it
+        assert "Tip: Use --verbose" not in result.output

--- a/tests/utils/test_jsonpath_utils.py
+++ b/tests/utils/test_jsonpath_utils.py
@@ -1,0 +1,288 @@
+import pytest
+
+from mlflow.utils.jsonpath_utils import (
+    filter_json_by_fields,
+    jsonpath_extract_values,
+    split_path_respecting_backticks,
+    validate_field_paths,
+)
+
+
+def test_jsonpath_extract_values_simple():
+    """Test simple field extraction."""
+    data = {"info": {"trace_id": "tr-123", "state": "OK"}}
+    values = jsonpath_extract_values(data, "info.trace_id")
+    assert values == ["tr-123"]
+
+
+def test_jsonpath_extract_values_nested():
+    """Test nested field extraction."""
+    data = {"info": {"metadata": {"user": "test@example.com"}}}
+    values = jsonpath_extract_values(data, "info.metadata.user")
+    assert values == ["test@example.com"]
+
+
+def test_jsonpath_extract_values_wildcard_array():
+    """Test wildcard extraction from arrays."""
+    data = {"info": {"assessments": [{"feedback": {"value": 0.8}}, {"feedback": {"value": 0.9}}]}}
+    values = jsonpath_extract_values(data, "info.assessments.*.feedback.value")
+    assert values == [0.8, 0.9]
+
+
+def test_jsonpath_extract_values_wildcard_dict():
+    """Test wildcard extraction from dictionaries."""
+    data = {"data": {"spans": {"span1": {"name": "first"}, "span2": {"name": "second"}}}}
+    values = jsonpath_extract_values(data, "data.spans.*.name")
+    assert set(values) == {"first", "second"}  # Order may vary with dict
+
+
+def test_jsonpath_extract_values_missing_field():
+    """Test extraction of missing fields."""
+    data = {"info": {"trace_id": "tr-123"}}
+    values = jsonpath_extract_values(data, "info.nonexistent")
+    assert values == []
+
+
+def test_jsonpath_extract_values_partial_path_missing():
+    """Test extraction when part of path is missing."""
+    data = {"info": {"trace_id": "tr-123"}}
+    values = jsonpath_extract_values(data, "info.metadata.user")
+    assert values == []
+
+
+def test_split_path_respecting_backticks():
+    """Test splitting paths with backtick-escaped segments."""
+    # Simple path without backticks
+    assert split_path_respecting_backticks("info.trace_id") == ["info", "trace_id"]
+
+    # Path with backticked segment containing dots
+    assert split_path_respecting_backticks("info.tags.`mlflow.traceName`") == [
+        "info",
+        "tags",
+        "mlflow.traceName",
+    ]
+
+    # Multiple backticked segments
+    assert split_path_respecting_backticks("`field.one`.middle.`field.two`") == [
+        "field.one",
+        "middle",
+        "field.two",
+    ]
+
+    # Backticks at the beginning
+    assert split_path_respecting_backticks("`mlflow.traceName`.value") == [
+        "mlflow.traceName",
+        "value",
+    ]
+
+    # Backticks at the end
+    assert split_path_respecting_backticks("info.`mlflow.traceName`") == [
+        "info",
+        "mlflow.traceName",
+    ]
+
+
+def test_jsonpath_extract_values_with_backticks():
+    """Test extraction with backtick-escaped field names containing dots."""
+    # Field name with dot
+    data = {"tags": {"mlflow.traceName": "test_trace"}}
+    values = jsonpath_extract_values(data, "tags.`mlflow.traceName`")
+    assert values == ["test_trace"]
+
+    # Nested structure with dotted field names
+    data = {"info": {"tags": {"mlflow.traceName": "my_trace", "user.id": "user123"}}}
+    assert jsonpath_extract_values(data, "info.tags.`mlflow.traceName`") == ["my_trace"]
+    assert jsonpath_extract_values(data, "info.tags.`user.id`") == ["user123"]
+
+    # Mixed regular and backticked fields
+    data = {"metadata": {"mlflow.source.type": "NOTEBOOK", "regular_field": "value"}}
+    assert jsonpath_extract_values(data, "metadata.`mlflow.source.type`") == ["NOTEBOOK"]
+    assert jsonpath_extract_values(data, "metadata.regular_field") == ["value"]
+
+
+def test_jsonpath_extract_values_empty_array():
+    """Test extraction from empty arrays."""
+    data = {"info": {"assessments": []}}
+    values = jsonpath_extract_values(data, "info.assessments.*.feedback.value")
+    assert values == []
+
+
+def test_jsonpath_extract_values_mixed_types():
+    """Test extraction from mixed data types."""
+    data = {
+        "data": {
+            "spans": [
+                {"attributes": {"key1": "value1"}},
+                {"attributes": {"key1": 42}},
+                {"attributes": {"key1": True}},
+            ]
+        }
+    }
+    values = jsonpath_extract_values(data, "data.spans.*.attributes.key1")
+    assert values == ["value1", 42, True]
+
+
+def test_filter_json_by_fields_single_field():
+    """Test filtering JSON by a single field."""
+    data = {"info": {"trace_id": "tr-123", "state": "OK"}, "data": {"spans": []}}
+    filtered = filter_json_by_fields(data, ["info.trace_id"])
+    expected = {"info": {"trace_id": "tr-123"}}
+    assert filtered == expected
+
+
+def test_filter_json_by_fields_multiple_fields():
+    """Test filtering JSON by multiple fields."""
+    data = {
+        "info": {"trace_id": "tr-123", "state": "OK", "unused": "value"},
+        "data": {"spans": [], "metadata": {}},
+    }
+    filtered = filter_json_by_fields(data, ["info.trace_id", "info.state"])
+    expected = {"info": {"trace_id": "tr-123", "state": "OK"}}
+    assert filtered == expected
+
+
+def test_filter_json_by_fields_wildcards():
+    """Test filtering with wildcards preserves structure."""
+    data = {
+        "info": {
+            "assessments": [
+                {"feedback": {"value": 0.8}, "unused": "data"},
+                {"feedback": {"value": 0.9}, "unused": "data"},
+            ]
+        }
+    }
+    filtered = filter_json_by_fields(data, ["info.assessments.*.feedback.value"])
+    expected = {
+        "info": {"assessments": [{"feedback": {"value": 0.8}}, {"feedback": {"value": 0.9}}]}
+    }
+    assert filtered == expected
+
+
+def test_filter_json_by_fields_nested_arrays():
+    """Test filtering nested arrays and objects."""
+    data = {
+        "data": {
+            "spans": [
+                {
+                    "name": "span1",
+                    "events": [
+                        {"name": "event1", "data": "d1"},
+                        {"name": "event2", "data": "d2"},
+                    ],
+                    "unused": "value",
+                }
+            ]
+        }
+    }
+    filtered = filter_json_by_fields(data, ["data.spans.*.events.*.name"])
+    expected = {"data": {"spans": [{"events": [{"name": "event1"}, {"name": "event2"}]}]}}
+    assert filtered == expected
+
+
+def test_filter_json_by_fields_missing_paths():
+    """Test filtering with paths that don't exist."""
+    data = {"info": {"trace_id": "tr-123"}}
+    filtered = filter_json_by_fields(data, ["info.nonexistent", "missing.path"])
+    assert filtered == {}
+
+
+def test_filter_json_by_fields_partial_matches():
+    """Test filtering with mix of existing and non-existing paths."""
+    data = {"info": {"trace_id": "tr-123", "state": "OK"}}
+    filtered = filter_json_by_fields(data, ["info.trace_id", "info.nonexistent"])
+    expected = {"info": {"trace_id": "tr-123"}}
+    assert filtered == expected
+
+
+def test_validate_field_paths_valid():
+    """Test validation of valid field paths."""
+    data = {"info": {"trace_id": "tr-123", "assessments": [{"feedback": {"value": 0.8}}]}}
+    # Should not raise any exception
+    validate_field_paths(["info.trace_id", "info.assessments.*.feedback.value"], data)
+
+
+def test_validate_field_paths_invalid():
+    """Test validation of invalid field paths."""
+    data = {"info": {"trace_id": "tr-123"}}
+
+    with pytest.raises(ValueError, match="Invalid field path") as exc_info:
+        validate_field_paths(["info.nonexistent"], data)
+
+    assert "Invalid field path" in str(exc_info.value)
+    assert "info.nonexistent" in str(exc_info.value)
+
+
+def test_validate_field_paths_multiple_invalid():
+    """Test validation with multiple invalid paths."""
+    data = {"info": {"trace_id": "tr-123"}}
+
+    with pytest.raises(ValueError, match="Invalid field path") as exc_info:
+        validate_field_paths(["info.missing", "other.invalid"], data)
+
+    error_msg = str(exc_info.value)
+    assert "Invalid field path" in error_msg
+    # Should mention both invalid paths
+    assert "info.missing" in error_msg or "other.invalid" in error_msg
+
+
+def test_validate_field_paths_suggestions():
+    """Test that validation provides helpful suggestions."""
+    data = {"info": {"trace_id": "tr-123", "assessments": [], "metadata": {}}}
+
+    with pytest.raises(ValueError, match="Invalid field path") as exc_info:
+        validate_field_paths(["info.traces"], data)  # Close to "trace_id"
+
+    error_msg = str(exc_info.value)
+    assert "Available fields" in error_msg
+    assert "info.trace_id" in error_msg
+
+
+def test_complex_trace_structure():
+    """Test with realistic trace data structure."""
+    trace_data = {
+        "info": {
+            "trace_id": "tr-abc123def",
+            "state": "OK",
+            "execution_duration": 1500,
+            "assessments": [
+                {
+                    "assessment_id": "a-123",
+                    "feedback": {"value": 0.85},
+                    "source": {"source_type": "HUMAN", "source_id": "user@example.com"},
+                }
+            ],
+            "tags": {"environment": "production", "mlflow.traceName": "test_trace"},
+        },
+        "data": {
+            "spans": [
+                {
+                    "span_id": "span-1",
+                    "name": "root_span",
+                    "attributes": {"mlflow.spanType": "AGENT"},
+                    "events": [{"name": "start", "attributes": {"key": "value"}}],
+                }
+            ]
+        },
+    }
+
+    # Test various field extractions
+    assert jsonpath_extract_values(trace_data, "info.trace_id") == ["tr-abc123def"]
+    assert jsonpath_extract_values(trace_data, "info.assessments.*.feedback.value") == [0.85]
+    assert jsonpath_extract_values(trace_data, "data.spans.*.name") == ["root_span"]
+    assert jsonpath_extract_values(trace_data, "data.spans.*.events.*.name") == ["start"]
+
+    # Test filtering preserves structure
+    filtered = filter_json_by_fields(
+        trace_data, ["info.trace_id", "info.assessments.*.feedback.value", "data.spans.*.name"]
+    )
+
+    assert "info" in filtered
+    assert filtered["info"]["trace_id"] == "tr-abc123def"
+    assert len(filtered["info"]["assessments"]) == 1
+    assert filtered["info"]["assessments"][0]["feedback"]["value"] == 0.85
+    assert "data" in filtered
+    assert len(filtered["data"]["spans"]) == 1
+    assert filtered["data"]["spans"][0]["name"] == "root_span"
+    # Should not contain other fields
+    assert "source" not in filtered["info"]["assessments"][0]
+    assert "attributes" not in filtered["data"]["spans"][0]

--- a/tests/utils/test_string_utils.py
+++ b/tests/utils/test_string_utils.py
@@ -1,6 +1,12 @@
 import pytest
 
-from mlflow.utils.string_utils import is_string_type, mslex_quote, strip_prefix, strip_suffix
+from mlflow.utils.string_utils import (
+    format_table_cell_value,
+    is_string_type,
+    mslex_quote,
+    strip_prefix,
+    strip_suffix,
+)
 
 
 @pytest.mark.parametrize(
@@ -36,3 +42,62 @@ def test_mslex_quote():
     assert mslex_quote("abc") == "abc"
     assert mslex_quote("a b c") == '"a b c"'
     assert mslex_quote("C:\\path\\to\\file") == "C:\\path\\to\\file"
+
+
+def test_format_table_cell_value_basic():
+    """Test basic cell value formatting."""
+    result = format_table_cell_value("field", "value")
+    assert result == "value"
+
+
+def test_format_table_cell_value_empty():
+    """Test formatting of empty values."""
+    result = format_table_cell_value("field", None, [])
+    assert result == "N/A"
+
+
+def test_format_table_cell_value_multiple():
+    """Test formatting of multiple values."""
+    values = ["a", "b", "c", "d", "e"]
+    result = format_table_cell_value("field", None, values)
+    assert result == "a, b, c, ... (+2 more)"
+
+
+def test_format_table_cell_value_timestamp():
+    """Test timestamp formatting."""
+    timestamp = "2025-01-15T10:31:24.123Z"
+    result = format_table_cell_value("info.request_time", timestamp)
+    assert "2025-01-15" in result
+    assert "10:31:24" in result
+
+
+def test_format_table_cell_value_duration_ms():
+    """Test duration formatting in milliseconds."""
+    result = format_table_cell_value("info.execution_duration_ms", 500)
+    assert result == "500ms"
+
+
+def test_format_table_cell_value_duration_seconds():
+    """Test duration formatting in seconds."""
+    result = format_table_cell_value("info.execution_duration_ms", 2500)
+    assert result == "2.5s"
+
+
+def test_format_table_cell_value_preview_truncation():
+    """Test preview field truncation."""
+    long_text = "This is a very long preview text that should be truncated"
+    result = format_table_cell_value("info.request_preview", long_text)
+    assert result == "This is a very lo..."
+    assert len(result) == 20
+
+
+def test_format_table_cell_value_invalid_timestamp():
+    """Test handling of invalid timestamp values."""
+    result = format_table_cell_value("info.request_time", "invalid-timestamp")
+    assert result == "invalid-timestamp"  # Should return original
+
+
+def test_format_table_cell_value_invalid_duration():
+    """Test handling of invalid duration values."""
+    result = format_table_cell_value("info.execution_duration_ms", "not-a-number")
+    assert result == "not-a-number"  # Should return original


### PR DESCRIPTION
## Summary

This PR introduces a new `mlflow traces` CLI module that provides comprehensive trace management capabilities for MLflow users. The implementation adds powerful search, filtering, and management operations for traces stored in MLflow experiments.

**Note**: This PR also includes the integration of Claude Code functionality into the CLI structure. The `claude_code` module has been moved from `mlflow/claude_code/` to `mlflow/cli/claude_code/` to better organize CLI-related functionality. This provides the `mlflow autolog claude` command for setting up automatic Claude Code conversation tracing.

## Key Features

### 🔍 **Trace Search & Discovery**
- Search traces across experiments with advanced filtering options
- Support for complex field selection using JSONPath-like dot notation
- Wildcard support for exploring nested structures (`data.spans.*.name`)
- Multiple output formats (table/JSON) with customizable field selection

### 📊 **Comprehensive Schema Documentation** 
- Detailed trace schema documentation built into CLI help
- Examples for field selection patterns and common use cases
- Clear documentation of trace structure (info, data, spans, assessments)

### 🔍 **Field Selection for Get Command**
- Consistent JSONPath-like field selection in both `search` and `get` commands
- Filter specific fields from trace data using dot notation and wildcards
- Reduces output size and focuses on relevant data for analysis

### 🏷️ **Assessment Management**
- Log feedback scores and expectations to traces
- Get, update, and delete assessments with full metadata support
- Support for human annotations, LLM judgments, and automated evaluations

### 🏷️ **Tag Operations**
- Set and delete custom tags on traces
- Support for both user-defined and system tags

### 🗑️ **Cleanup Operations**
- Delete traces from multiple experiments with proper iteration
- Bulk operations for efficient trace management

### 🤖 **Claude Code Integration**
- `mlflow autolog claude` command for setting up automatic conversation tracing
- Hooks and configuration management for Claude Code sessions
- Automatic trace creation for Claude conversations with detailed span data

## 📋 Traces Operations

### Search

Search for traces across experiments with advanced filtering and field selection capabilities.

**Command:**
```bash
mlflow traces search --experiment-ids 1 --max-results 5
```

**Output:**
```
info.trace_id                          info.request_time      info.state  info.execution_duration_ms  info.request_preview     info.response_preview
-------------------------------------  ---------------------  ----------  --------------------------  -----------------------  -----------------------
tr-68530fa07f39aa34985035f66b034b1d   2025-01-15 10:31:24   OK          29074                       How do I optimize my...  I've optimized your...
tr-95847bc12a8df567321abc9012def456   2025-01-15 10:28:15   OK          15432                       What is machine lear...  Machine learning is...
tr-123def45678901234567890abcdef12    2025-01-15 10:25:03   ERROR       8901                        Complex analysis req...  Processing failed d...
tr-456abc78901234567890def123456789   2025-01-15 10:22:41   OK          12355                       Explain neural netwo...  Neural networks are...
tr-789def01234567890abcdef456789012   2025-01-15 10:19:30   OK          6789                        How to use MLflow?       MLflow is an open s...
```

**With Field Selection:**
```bash
mlflow traces search --experiment-ids 1 --fields "info.trace_id,info.state,data.spans.*.name" --max-results 3
```

**Output:**
```
info.trace_id                          info.state  data.spans.*.name
-------------------------------------  ----------  ---------------------------------------------------------
tr-68530fa07f39aa34985035f66b034b1d   OK          databricks_agent, query_analysis, optimization
tr-95847bc12a8df567321abc9012def456   OK          chat_completion, llm_call
tr-123def45678901234567890abcdef12    ERROR       failed_request, processing
```

**JSON Output with Custom Fields:**
```bash
mlflow traces search --experiment-ids 1 --fields "info.trace_id,info.assessments.*.feedback.value" --output json --max-results 2
```

**Output:**
```json
{
  "traces": [
    {
      "info": {
        "trace_id": "tr-68530fa07f39aa34985035f66b034b1d",
        "assessments": [
          {"feedback": {"value": 0.85}},
          {"feedback": {"value": 0.92}}
        ]
      }
    },
    {
      "info": {
        "trace_id": "tr-95847bc12a8df567321abc9012def456",
        "assessments": [
          {"feedback": {"value": "good"}}
        ]
      }
    }
  ],
  "next_page_token": null
}
```

### Get

Retrieve detailed information about a specific trace including all spans, metadata, and assessments. Now supports field selection for focused data extraction.

**Command:**
```bash
mlflow traces get --trace-id tr-68530fa07f39aa34985035f66b034b1d
```

**Output:** (Full trace JSON - same as before)

**With Field Selection:**
```bash
mlflow traces get --trace-id tr-68530fa07f39aa34985035f66b034b1d \
    --fields "info.trace_id,info.assessments.*,data.spans.*.name"
```

**Output:**
```json
{
    "info": {
        "trace_id": "tr-68530fa07f39aa34985035f66b034b1d",
        "assessments": [
            {
                "assessment_id": "a-f8e7d6c5b4a3",
                "assessment_name": "quality_score",
                "trace_id": "tr-68530fa07f39aa34985035f66b034b1d",
                "feedback": {
                    "value": 0.85
                },
                "source": {
                    "source_type": "HUMAN",
                    "source_id": "reviewer@example.com"
                },
                "rationale": "Accurate SQL explanation with good detail",
                "create_time": "2025-01-15T10:45:12Z",
                "valid": true
            }
        ]
    },
    "data": {
        "spans": [
            {"name": "databricks_agent"},
            {"name": "query_analysis"},
            {"name": "optimization"}
        ]
    }
}
```

### Delete

Remove traces from experiments with confirmation and iteration support.

**Command:**
```bash
mlflow traces delete --experiment-ids 1,2,3 --max-timestamp-millis 1736937000000 --max-traces 10
```

**Output:**
```
Deleted 7 trace(s) from experiment 1.
Deleted 3 trace(s) from experiment 2.
Deleted 5 trace(s) from experiment 3.
Total: Deleted 15 trace(s) from 3 experiment(s).
```

**Delete Specific Traces:**
```bash
mlflow traces delete --experiment-ids 1 --trace-ids tr-123def45678901234567890abcdef12
```

**Output:**
```
Deleted 1 trace(s) from experiment 1.
```

## 🎯 Assessments Operations

### Log Feedback

Add evaluation scores and feedback to traces for quality assessment.

**Command:**
```bash
mlflow traces log-feedback --trace-id tr-68530fa07f39aa34985035f66b034b1d \
    --name "quality_score" --value 0.85 \
    --source-type HUMAN --source-id reviewer@example.com \
    --rationale "Accurate SQL explanation with good detail"
```

**Output:**
```
Logged feedback 'quality_score' to trace tr-68530fa07f39aa34985035f66b034b1d. Assessment ID: a-f8e7d6c5b4a394857263b9c8e7f6d5a4
```

### Log Expectation

Add ground truth labels for evaluation.

**Command:**
```bash
mlflow traces log-expectation --trace-id tr-95847bc12a8df567321abc9012def456 \
    --name "expected_category" --value "technical" \
    --source-type HUMAN --source-id annotator@example.com
```

**Output:**
```
Logged expectation 'expected_category' to trace tr-95847bc12a8df567321abc9012def456. Assessment ID: a-9c8e7f6d5a4b3a2f1e0d
```

### Get Assessment

Retrieve detailed assessment information.

**Command:**
```bash
mlflow traces get-assessment --trace-id tr-68530fa07f39aa34985035f66b034b1d \
    --assessment-id a-f8e7d6c5b4a394857263b9c8e7f6d5a4
```

**Output:**
```json
{
    "assessment_id": "a-f8e7d6c5b4a394857263b9c8e7f6d5a4",
    "trace_id": "tr-68530fa07f39aa34985035f66b034b1d",
    "assessment_name": "quality_score",
    "feedback": {
        "value": 0.85
    },
    "source": {
        "source_type": "HUMAN",
        "source_id": "reviewer@example.com"
    },
    "rationale": "Accurate SQL explanation with good detail",
    "metadata": {},
    "create_time": "2025-01-15T10:45:12.123Z",
    "last_update_time": "2025-01-15T10:45:12.123Z",
    "valid": true
}
```

### Update Assessment

Modify existing assessment values.

**Command:**
```bash
mlflow traces update-assessment --trace-id tr-68530fa07f39aa34985035f66b034b1d \
    --assessment-id a-f8e7d6c5b4a394857263b9c8e7f6d5a4 \
    --value 0.92 --rationale "Updated after further review"
```

**Output:**
```
Updated assessment a-f8e7d6c5b4a394857263b9c8e7f6d5a4 in trace tr-68530fa07f39aa34985035f66b034b1d.
```

### Delete Assessment

Remove assessments from traces.

**Command:**
```bash
mlflow traces delete-assessment --trace-id tr-68530fa07f39aa34985035f66b034b1d \
    --assessment-id a-f8e7d6c5b4a394857263b9c8e7f6d5a4
```

**Output:**
```
Deleted assessment a-f8e7d6c5b4a394857263b9c8e7f6d5a4 from trace tr-68530fa07f39aa34985035f66b034b1d.
```

## 🏷️ Tags Operations

### Set Tag

Add custom metadata tags to traces.

**Command:**
```bash
mlflow traces set-tag --trace-id tr-68530fa07f39aa34985035f66b034b1d \
    --key "environment" --value "production"
```

**Output:**
```
Set tag 'environment' on trace tr-68530fa07f39aa34985035f66b034b1d.
```

### Delete Tag

Remove tags from traces.

**Command:**
```bash
mlflow traces delete-tag --trace-id tr-68530fa07f39aa34985035f66b034b1d --key "environment"
```

**Output:**
```
Deleted tag 'environment' from trace tr-68530fa07f39aa34985035f66b034b1d.
```

## 🤖 Claude Code Integration

### Setup Autolog

Configure automatic tracing for Claude Code conversations.

**Command:**
```bash
mlflow autolog claude ~/my-project -u databricks -e 123456789
```

**Output:**
```
Configuring Claude tracing in: /Users/username/my-project
✅ Claude Code hooks configured

==================================================
🎯 Claude Tracing Setup Complete!
==================================================
📁 Directory: /Users/username/my-project
📊 Tracking URI: databricks
🔬 Experiment ID: 123456789

==============================
🚀 Next Steps:
==============================
cd /Users/username/my-project
claude -p 'your prompt here'

💡 View your traces in your Databricks workspace

🔧 To disable tracing later:
   mlflow autolog claude --disable
```

**Check Status:**
```bash
mlflow autolog claude --status
```

**Disable:**
```bash
mlflow autolog claude --disable
```

## Filter String Reference

The CLI now uses the correct public API field names:

| Field | Description | Example |
|-------|-------------|---------|
| `run_id` | Associated MLflow run ID | `run_id = '123abc'` |
| `status` | Trace status | `status = 'OK'` |
| `timestamp_ms` | Trace timestamp | `timestamp_ms > 1700000000000` |
| `execution_time_ms` | Execution duration | `execution_time_ms < 5000` |
| `name` | Trace name | `name = 'chat_completion'` |
| `metadata.<key>` | Custom metadata | `metadata.user_id = 'user123'` |
| `tags.<key>` | Custom tags | `tags.environment = 'prod'` |

## Architecture Changes

### CLI Structure
- **Main traces CLI**: `mlflow/cli/traces.py` - Core trace management commands
- **Claude Code integration**: `mlflow/cli/claude_code/` - Claude Code autolog functionality
  - `__init__.py` - CLI commands for `mlflow autolog claude`
  - `config.py` - Configuration management
  - `hooks.py` - Hook handlers for Claude Code
  - `tracing.py` - Trace processing logic
- **Utilities**: `mlflow/utils/jsonpath_utils.py` - JSONPath field extraction
- **String utilities**: Enhanced `mlflow/utils/string_utils.py` for table formatting

### Integration Points
- CLI registration in `mlflow/cli/__init__.py`
- Backward compatibility maintained for existing `mlflow.db`, `mlflow.experiments`, `mlflow.runs` modules
- Test coverage for both traces and Claude Code functionality

## Validation

✅ Successfully tested against live MLflow tracking server  
✅ Field filtering and JSONPath extraction working correctly  
✅ All CLI commands integrated and functional  
✅ Assessment source types aligned with public API  
✅ Filter string fields match public API documentation  
✅ Delete command properly handles multiple experiments  
✅ Field selection now available in both search and get commands  
✅ Pagination token naming improved for clarity  
✅ Claude Code autolog functionality fully tested and working  
✅ CLI structure reorganized with proper module separation  

## Testing the CLI from this Branch

You can test the new traces CLI directly from this branch using `uvx`:

```bash
# Set up environment (use your own Databricks workspace)
export DATABRICKS_HOST=https://your-workspace.cloud.databricks.com
export DATABRICKS_TOKEN=<your-token>
export MLFLOW_TRACKING_URI=databricks
export MLFLOW_EXPERIMENT_ID=<your-experiment-id>

# Run traces CLI commands directly from this branch
uvx --with 'mlflow @ git+https://github.com/nsthorat/mlflow.git@master' mlflow traces search --max-results 2 \
  --output json --fields "info.trace_id,info.assessments.*"

mlflow traces search --max-results 5
mlflow traces get --trace-id tr-abc123def
mlflow traces get --trace-id tr-abc123def --fields "info.trace_id,info.assessments.*"
mlflow traces set-tag --trace-id tr-abc123def --key environment --value production

# Test Claude Code autolog
mlflow autolog claude --help
mlflow autolog claude ~/test-project -n "test-experiment"
mlflow autolog claude ~/test-project --status
```

You can tell claude to run:
```
uvx --with 'mlflow @ git+https://github.com/nsthorat/mlflow.git@master' mlflow traces --help
```