### PR TITLE
Fix user resolution in `RealContext`

### DIFF
--- a/tests/genai/evaluate/test_context.py
+++ b/tests/genai/evaluate/test_context.py
@@ -1,11 +1,11 @@
 import threading
+from unittest import mock
 
 import pytest
-from unittest import mock
 
 import mlflow
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
-from mlflow.genai.evaluation.context import NoneContext, eval_context, get_context, _set_context
+from mlflow.genai.evaluation.context import NoneContext, _set_context, eval_context, get_context
 
 
 @pytest.fixture(autouse=True)
@@ -56,6 +56,7 @@ def test_context_get_run_id_explicitly_set():
 
 def test_context_get_user_name(monkeypatch):
     monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "test-user")
+
     @eval_context
     def _test():
         assert get_context().get_user_name() == "test-user"

--- a/tests/genai/evaluate/test_context.py
+++ b/tests/genai/evaluate/test_context.py
@@ -1,0 +1,72 @@
+import threading
+
+import pytest
+from unittest import mock
+
+import mlflow
+from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
+from mlflow.genai.evaluation.context import NoneContext, eval_context, get_context, _set_context
+
+
+@pytest.fixture(autouse=True)
+def reset_context():
+    yield
+    _set_context(NoneContext())
+
+
+def test_context_get_experiment_and_run_id():
+    exp_id = mlflow.set_experiment("Test").experiment_id
+
+    @eval_context
+    def _test():
+        assert exp_id == get_context().get_mlflow_experiment_id()
+        assert get_context().get_mlflow_run_id() is None
+
+    _test()
+
+
+def test_context_get_run_id_active_run():
+    @eval_context
+    def _test():
+        with mlflow.start_run() as run:
+            assert run.info.run_id == get_context().get_mlflow_run_id()
+
+    _test()
+
+
+def test_context_get_run_id_explicitly_set():
+    @eval_context
+    def _test():
+        context = get_context()
+        context.set_mlflow_run_id("test-run-id")
+        assert context.get_mlflow_run_id() == "test-run-id"
+
+        run_id = None
+
+        def _target():
+            nonlocal run_id
+            run_id = get_context().get_mlflow_run_id()
+
+        thread = threading.Thread(target=_target)
+        thread.start()
+        assert run_id == "test-run-id"
+
+    _test()
+
+
+def test_context_get_user_name(monkeypatch):
+    monkeypatch.setenv(MLFLOW_TRACKING_USERNAME.name, "test-user")
+    @eval_context
+    def _test():
+        assert get_context().get_user_name() == "test-user"
+
+    _test()
+
+
+@mock.patch("mlflow.tracking.context.default_context.DefaultRunContext.tags", return_value={})
+def test_context_get_user_name_no_user_set(mock_default_tags):
+    @eval_context
+    def _test():
+        assert get_context().get_user_name() == "unknown"
+
+    _test()

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -83,6 +83,7 @@ def _validate_assessments(traces):
         assert isinstance(a_expected_response, Expectation)
         assert isinstance(a_expected_response.value, str)
         assert a_expected_response.source.source_type == AssessmentSourceType.HUMAN
+        assert a_expected_response.source.source_id == "unknown"
 
         a_max_length = assessments["max_length"]
         assert isinstance(a_max_length, Expectation)

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -83,7 +83,7 @@ def _validate_assessments(traces):
         assert isinstance(a_expected_response, Expectation)
         assert isinstance(a_expected_response.value, str)
         assert a_expected_response.source.source_type == AssessmentSourceType.HUMAN
-        assert a_expected_response.source.source_id == "unknown"
+        assert a_expected_response.source.source_id is not None
 
         a_max_length = assessments["max_length"]
         assert isinstance(a_max_length, Expectation)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17265?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17265/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17265/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17265/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `RealContext` class depends on `dbutils` for resolving user name. Updating the logic to handle OSS correclty.

User name is used for setting `source_id` in the expectation assessments: https://github.com/mlflow/mlflow/blob/3c1acfef59041ec1384eefd2a74072daeaad875b/mlflow/genai/evaluation/entities.py#L93

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
