### PR TITLE
Add Databricks Lakebase Resource

### DIFF
--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -21,6 +21,7 @@ class ResourceType(Enum):
     GENIE_SPACE = "genie_space"
     TABLE = "table"
     APP = "app"
+    LAKEBASE = "lakebase"
 
 
 class Resource(ABC):
@@ -254,6 +255,24 @@ class DatabricksApp(DatabricksResource):
     def __init__(self, app_name: str, on_behalf_of_user: bool | None = None):
         super().__init__(app_name, on_behalf_of_user)
 
+class DatabricksLakebase(DatabricksResource):
+    """
+    Defines a Databricks Lakebase Database Instance dependency for Model Serving
+
+     Args:
+         database_instance_name (str): The name of the lakebase/database instance used by the model
+         on_behalf_of_user (Optional[bool]): If True, the resource is accessed with
+        with the permission of the invoker of the model in the serving endpoint. If set to
+        None or False, the resource is accessed with the permissions of the creator
+    """
+
+    @property
+    def type(self) -> ResourceType:
+        return ResourceType.LAKEBASE
+
+    def __init__(self, database_instance_name: str, on_behalf_of_user: bool | None = None):
+        super().__init__(database_instance_name, on_behalf_of_user)
+
 
 def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
     resource_classes = {
@@ -266,6 +285,7 @@ def _get_resource_class_by_type(target_uri: str, resource_type: ResourceType):
             ResourceType.GENIE_SPACE.value: DatabricksGenieSpace,
             ResourceType.TABLE.value: DatabricksTable,
             ResourceType.APP.value: DatabricksApp,
+            ResourceType.LAKEBASE.value: DatabricksLakebase,
         }
     }
     resource = resource_classes.get(target_uri)

--- a/mlflow/models/resources.py
+++ b/mlflow/models/resources.py
@@ -255,6 +255,7 @@ class DatabricksApp(DatabricksResource):
     def __init__(self, app_name: str, on_behalf_of_user: bool | None = None):
         super().__init__(app_name, on_behalf_of_user)
 
+
 class DatabricksLakebase(DatabricksResource):
     """
     Defines a Databricks Lakebase Database Instance dependency for Model Serving

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -5,6 +5,7 @@ from mlflow.models.resources import (
     DatabricksApp,
     DatabricksFunction,
     DatabricksGenieSpace,
+    DatabricksLakebase,
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
     DatabricksTable,
@@ -142,6 +143,21 @@ def test_app(on_behalf_of_user):
     }
 
 
+@pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
+def test_lakebase(on_behalf_of_user):
+    lakebase = DatabricksLakebase(database_instance_name="lakebase_name", on_behalf_of_user=on_behalf_of_user)
+    expected = (
+        {"lakebase": [{"name": "lakebase_name"}]}
+        if on_behalf_of_user is None
+        else {"lakebase": [{"name": "lakebase_name", "on_behalf_of_user": on_behalf_of_user}]}
+    )
+    assert lakebase.to_dict() == expected
+    assert _ResourceBuilder.from_resources([lakebase]) == {
+        "api_version": DEFAULT_API_VERSION,
+        "databricks": expected,
+    }
+
+
 def test_resources():
     resources = [
         DatabricksVectorSearchIndex(index_name="rag.studio_bugbash.databricks_docs_index"),
@@ -152,6 +168,7 @@ def test_resources():
         DatabricksFunction(function_name="rag.studio.test_function_2"),
         DatabricksUCConnection(connection_name="slack_connection"),
         DatabricksApp(app_name="test_databricks_app"),
+        DatabricksLakebase(database_instance_name="test_databricks_lakebase"),
     ]
     expected = {
         "api_version": DEFAULT_API_VERSION,
@@ -168,6 +185,7 @@ def test_resources():
             ],
             "uc_connection": [{"name": "slack_connection"}],
             "app": [{"name": "test_databricks_app"}],
+            "lakebase": [{"name": "test_databricks_lakebase"}],
         },
     }
 
@@ -227,6 +245,8 @@ def test_resources_from_yaml(tmp_path):
                 function:
                 - name: rag.studio.test_function_1
                 - name: rag.studio.test_function_2
+                lakebase:
+                - name: test_databricks_lakebase
                 uc_connection:
                 - name: slack_connection
                 app:
@@ -249,6 +269,7 @@ def test_resources_from_yaml(tmp_path):
             ],
             "uc_connection": [{"name": "slack_connection"}],
             "app": [{"name": "test_databricks_app"}],
+            "lakebase": [{"name": "test_databricks_lakebase"}],
         },
     }
 

--- a/tests/models/test_resources.py
+++ b/tests/models/test_resources.py
@@ -145,7 +145,9 @@ def test_app(on_behalf_of_user):
 
 @pytest.mark.parametrize("on_behalf_of_user", [True, False, None])
 def test_lakebase(on_behalf_of_user):
-    lakebase = DatabricksLakebase(database_instance_name="lakebase_name", on_behalf_of_user=on_behalf_of_user)
+    lakebase = DatabricksLakebase(
+        database_instance_name="lakebase_name", on_behalf_of_user=on_behalf_of_user
+    )
     expected = (
         {"lakebase": [{"name": "lakebase_name"}]}
         if on_behalf_of_user is None

--- a/tests/pyfunc/test_model_export_with_class_and_artifacts.py
+++ b/tests/pyfunc/test_model_export_with_class_and_artifacts.py
@@ -42,6 +42,7 @@ from mlflow.models.resources import (
     DatabricksApp,
     DatabricksFunction,
     DatabricksGenieSpace,
+    DatabricksLakebase,
     DatabricksServingEndpoint,
     DatabricksSQLWarehouse,
     DatabricksTable,
@@ -1552,6 +1553,7 @@ def test_model_save_load_with_resources(tmp_path):
             "uc_connection": [{"name": "test_connection_1"}, {"name": "test_connection_2"}],
             "table": [{"name": "rag.studio.table_a"}, {"name": "rag.studio.table_b"}],
             "app": [{"name": "test_databricks_app"}],
+            "lakebase": [{"name": "test_databricks_lakebase"}],
         },
     }
     mlflow.pyfunc.save_model(
@@ -1573,6 +1575,7 @@ def test_model_save_load_with_resources(tmp_path):
             DatabricksTable(table_name="rag.studio.table_a"),
             DatabricksTable(table_name="rag.studio.table_b"),
             DatabricksApp(app_name="test_databricks_app"),
+            DatabricksLakebase(database_instance_name="test_databricks_lakebase"),
         ],
     )
 
@@ -1596,6 +1599,8 @@ def test_model_save_load_with_resources(tmp_path):
                 function:
                 - name: rag.studio.test_function_a
                 - name: rag.studio.test_function_b
+                lakebase:
+                - name: test_databricks_lakebase
                 genie_space:
                 - name: genie_space_id_1
                 - name: genie_space_id_2
@@ -1650,6 +1655,7 @@ def test_model_save_load_with_invokers_resources(tmp_path):
                 {"name": "rag.studio.table_b"},
             ],
             "app": [{"name": "test_databricks_app"}],
+            "lakebase": [{"name": "test_databricks_lakebase"}],
         },
     }
     mlflow.pyfunc.save_model(
@@ -1675,6 +1681,7 @@ def test_model_save_load_with_invokers_resources(tmp_path):
             DatabricksTable(table_name="rag.studio.table_a", on_behalf_of_user=True),
             DatabricksTable(table_name="rag.studio.table_b"),
             DatabricksApp(app_name="test_databricks_app"),
+            DatabricksLakebase(database_instance_name="test_databricks_lakebase"),
         ],
     )
 
@@ -1701,6 +1708,8 @@ def test_model_save_load_with_invokers_resources(tmp_path):
                 - name: rag.studio.test_function_a
                   on_behalf_of_user: True
                 - name: rag.studio.test_function_b
+                lakebase:
+                - name: test_databricks_lakebase
                 genie_space:
                 - name: genie_space_id_1
                   on_behalf_of_user: True
@@ -1864,6 +1873,7 @@ def test_model_log_with_resources(tmp_path):
             "uc_connection": [{"name": "test_connection_1"}, {"name": "test_connection_2"}],
             "table": [{"name": "rag.studio.table_a"}, {"name": "rag.studio.table_b"}],
             "app": [{"name": "test_databricks_app"}],
+            "lakebase": [{"name": "test_databricks_lakebase"}],
         },
     }
     with mlflow.start_run() as run:
@@ -1885,6 +1895,7 @@ def test_model_log_with_resources(tmp_path):
                 DatabricksTable(table_name="rag.studio.table_a"),
                 DatabricksTable(table_name="rag.studio.table_b"),
                 DatabricksApp(app_name="test_databricks_app"),
+                DatabricksLakebase(database_instance_name="test_databricks_lakebase"),
             ],
         )
     pyfunc_model_uri = f"runs:/{run.info.run_id}/{pyfunc_artifact_path}"
@@ -1909,6 +1920,8 @@ def test_model_log_with_resources(tmp_path):
                 function:
                 - name: rag.studio.test_function_a
                 - name: rag.studio.test_function_b
+                lakebase:
+                - name: test_databricks_lakebase
                 genie_space:
                 - name: genie_space_id_1
                 - name: genie_space_id_2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/jennsun/mlflow/pull/17277?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17277/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17277/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17277/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a Databricks Lakebase resource type. This will be used to auto authenticate stateful agents and other agents that can take advantage of Databricks' postgres database: https://www.databricks.com/product/lakebase

Similar to implementation adding Databricks apps https://github.com/mlflow/mlflow/pull/15867

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Validated that lakebase resource type is logged in ML Flow under Artifacts
<img width="1216" height="541" alt="image" src="https://github.com/user-attachments/assets/c9665239-2afe-4659-b12f-a54c14264b8b" />

Able to use newly added DatabricksLakebase as a resource type when deploying our agent:
<img width="1199" height="348" alt="image" src="https://github.com/user-attachments/assets/811f20a0-1858-4653-ad08-8ba4c11d8518" />

Example notebook: 
[lakebase-resource-example-agent-driver.html](https://github.com/user-attachments/files/21927641/lakebase-resource-example-agent-driver.html)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add Databricks Lakebase Resource to automatically authenticate to Databricks Lakebase from Databricks Agent Frameworks

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
