### PR TITLE
Add fix for telemetry test suite flakiness

### DIFF
--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -354,9 +354,6 @@ def test_log_suppression_in_consumer_thread(mock_requests, capsys, mock_telemetr
 
     # Log from main thread - this should be captured
     logger = logging.getLogger("mlflow.telemetry.client")
-    # Temporarily set level to INFO to ensure messages are logged
-    original_level = logger.level
-    logger.setLevel(logging.INFO)
     logger.info("TEST LOG FROM MAIN THREAD")
 
     original_process = mock_telemetry_client._process_records
@@ -384,9 +381,6 @@ def test_log_suppression_in_consumer_thread(mock_requests, capsys, mock_telemetr
     # Verify that the consumer thread log was suppressed
     assert "TEST LOG FROM CONSUMER THREAD" not in captured.err
 
-    # Restore original level
-    logger.setLevel(original_level)
-
 
 def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_client):
     """Test that consumer thread produces no stderr output at all."""
@@ -395,9 +389,6 @@ def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_
 
     # Log from main thread - this should be captured
     logger = logging.getLogger("mlflow.telemetry.client")
-    # Temporarily set level to INFO to ensure messages are logged
-    original_level = logger.level
-    logger.setLevel(logging.INFO)
     logger.info("MAIN THREAD LOG BEFORE CLIENT")
 
     # Clear output after client initialization to focus on consumer thread output
@@ -427,9 +418,6 @@ def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_
     logger.info("MAIN THREAD LOG AFTER PROCESSING")
     captured_after = capsys.readouterr()
     assert "MAIN THREAD LOG AFTER PROCESSING" in captured_after.err
-
-    # Restore original level
-    logger.setLevel(original_level)
 
 
 def test_batch_time_interval(mock_requests, monkeypatch):

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -354,6 +354,9 @@ def test_log_suppression_in_consumer_thread(mock_requests, capsys, mock_telemetr
 
     # Log from main thread - this should be captured
     logger = logging.getLogger("mlflow.telemetry.client")
+    # Temporarily set level to INFO to ensure messages are logged
+    original_level = logger.level
+    logger.setLevel(logging.INFO)
     logger.info("TEST LOG FROM MAIN THREAD")
 
     original_process = mock_telemetry_client._process_records
@@ -381,6 +384,9 @@ def test_log_suppression_in_consumer_thread(mock_requests, capsys, mock_telemetr
     # Verify that the consumer thread log was suppressed
     assert "TEST LOG FROM CONSUMER THREAD" not in captured.err
 
+    # Restore original level
+    logger.setLevel(original_level)
+
 
 def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_client):
     """Test that consumer thread produces no stderr output at all."""
@@ -389,6 +395,9 @@ def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_
 
     # Log from main thread - this should be captured
     logger = logging.getLogger("mlflow.telemetry.client")
+    # Temporarily set level to INFO to ensure messages are logged
+    original_level = logger.level
+    logger.setLevel(logging.INFO)
     logger.info("MAIN THREAD LOG BEFORE CLIENT")
 
     # Clear output after client initialization to focus on consumer thread output
@@ -418,6 +427,9 @@ def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_
     logger.info("MAIN THREAD LOG AFTER PROCESSING")
     captured_after = capsys.readouterr()
     assert "MAIN THREAD LOG AFTER PROCESSING" in captured_after.err
+
+    # Restore original level
+    logger.setLevel(original_level)
 
 
 def test_batch_time_interval(mock_requests, monkeypatch):

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -801,7 +801,7 @@ def test_databricks_tracking_uri_scheme(mock_requests, tracking_uri_scheme, term
 
 
 @pytest.mark.no_mock_requests_get
-def test_disable_events(mock_requests):
+def test_disable_events(mock_requests, bypass_env_check):
     with mock.patch("mlflow.telemetry.client.requests.get") as mock_requests_get:
         mock_requests_get.return_value = mock.Mock(
             status_code=200,
@@ -822,6 +822,7 @@ def test_disable_events(mock_requests):
                 "mlflow.telemetry.track.get_telemetry_client", return_value=telemetry_client
             ),
         ):
+            telemetry_client._config_thread.join(timeout=3)
             mlflow.create_external_model(name="model")
             mlflow.initialize_logged_model(name="model", tags={"key": "value"})
             mlflow.pyfunc.log_model(name="model", python_model=lambda x: x, input_example=["a"])

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -59,12 +59,6 @@ def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
     stream2 = SampleStream()
     message_content = "test message"
 
-    # Set logger level to INFO if it's a logger method to ensure output
-    original_level = None
-    if hasattr(logging_fn, "__self__") and isinstance(logging_fn.__self__, logging.Logger):
-        original_level = logging_fn.__self__.level
-        logging_fn.__self__.setLevel(logging.INFO)
-
     sys.stderr = stream1
     assert stream1.content is None
     logging_fn(message_content)
@@ -78,22 +72,12 @@ def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
     assert message_content in stream2.content
     assert stream1.content is None
 
-    # Restore original level
-    if original_level is not None:
-        logging_fn.__self__.setLevel(original_level)
-
 
 @pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
 def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
     stream = SampleStream()
     sys.stderr = stream
     message_content = "test message"
-
-    # Set logger level to INFO if it's a logger method to ensure output
-    original_level = None
-    if hasattr(logging_fn, "__self__") and isinstance(logging_fn.__self__, logging.Logger):
-        original_level = logging_fn.__self__.level
-        logging_fn.__self__.setLevel(logging.INFO)
 
     assert stream.content is None
     logging_fn(message_content)
@@ -109,10 +93,6 @@ def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
     assert stream.content is None
     logging_fn(message_content)
     assert message_content in stream.content
-
-    # Restore original level
-    if original_level is not None:
-        logging_fn.__self__.setLevel(original_level)
 
 
 def test_event_logging_stream_flushes_properly():

--- a/tests/utils/test_logging_utils.py
+++ b/tests/utils/test_logging_utils.py
@@ -59,6 +59,12 @@ def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
     stream2 = SampleStream()
     message_content = "test message"
 
+    # Set logger level to INFO if it's a logger method to ensure output
+    original_level = None
+    if hasattr(logging_fn, "__self__") and isinstance(logging_fn.__self__, logging.Logger):
+        original_level = logging_fn.__self__.level
+        logging_fn.__self__.setLevel(logging.INFO)
+
     sys.stderr = stream1
     assert stream1.content is None
     logging_fn(message_content)
@@ -72,12 +78,22 @@ def test_event_logging_apis_respect_stderr_reassignment(logging_fn):
     assert message_content in stream2.content
     assert stream1.content is None
 
+    # Restore original level
+    if original_level is not None:
+        logging_fn.__self__.setLevel(original_level)
+
 
 @pytest.mark.parametrize("logging_fn", LOGGING_FNS_TO_TEST)
 def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
     stream = SampleStream()
     sys.stderr = stream
     message_content = "test message"
+
+    # Set logger level to INFO if it's a logger method to ensure output
+    original_level = None
+    if hasattr(logging_fn, "__self__") and isinstance(logging_fn.__self__, logging.Logger):
+        original_level = logging_fn.__self__.level
+        logging_fn.__self__.setLevel(logging.INFO)
 
     assert stream.content is None
     logging_fn(message_content)
@@ -93,6 +109,10 @@ def test_event_logging_apis_respect_stream_disablement_enablement(logging_fn):
     assert stream.content is None
     logging_fn(message_content)
     assert message_content in stream.content
+
+    # Restore original level
+    if original_level is not None:
+        logging_fn.__self__.setLevel(original_level)
 
 
 def test_event_logging_stream_flushes_properly():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17278?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17278/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17278/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17278/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The `test_disable_events` telemetry client test in the `test_client.py` suite has a flaky behavior in running the full test locally. The mocked client, when not given enough time to await configuration setup, has shown consistent failures with missing some configuration items.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
