### PR TITLE
Fix the slowness of dspy tracing

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -378,6 +378,7 @@ class MlflowCallback(BaseCallback):
 
     def _unpack_kwargs(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Unpacks the kwargs from the inputs dictionary"""
+        # NB: Not using pop() to avoid modifying the original inputs dictionary
         kwargs = inputs.get("kwargs", {})
         inputs_wo_kwargs = {k: v for k, v in inputs.items() if k != "kwargs"}
         merged = {**inputs_wo_kwargs, **kwargs}

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -371,10 +371,17 @@ class MlflowCallback(BaseCallback):
 
     def _unpack_kwargs(self, inputs: dict[str, Any]) -> dict[str, Any]:
         """Unpacks the kwargs from the inputs dictionary"""
-        # NB: Not using pop() to avoid modifying the original inputs dictionary
+
+        def convert_signature(val):
+            # serialization of dspy.Signature is quite slow, so we should convert it to string here
+            if isinstance(val, type) and issubclass(val, dspy.Signature):
+                return repr(val)
+            return val
+
         kwargs = inputs.get("kwargs", {})
         inputs_wo_kwargs = {k: v for k, v in inputs.items() if k != "kwargs"}
-        return {**inputs_wo_kwargs, **kwargs}
+        merged = {**inputs_wo_kwargs, **kwargs}
+        return {k: convert_signature(v) for k, v in merged.items()}
 
     def _generate_result_table(
         self, outputs: list[tuple[dspy.Example, dspy.Prediction, Any]]

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -81,9 +81,7 @@ def test_autolog_cot():
     )
 
     cot = dspy.ChainOfThought("question -> answer", n=3)
-    expected_signature = (
-        "question -> answer" if _DSPY_UNDER_2_6 else "question -> reasoning, answer"
-    )
+
     result = cot(question="How are you?")
     assert result["answer"] == "test output"
     assert result["reasoning"] == "No more responses"
@@ -101,8 +99,11 @@ def test_autolog_cot():
     assert spans[0].status.status_code == "OK"
     assert spans[0].inputs == {"question": "How are you?"}
     assert spans[0].outputs == {"answer": "test output", "reasoning": "No more responses"}
-
-    assert spans[0].attributes["signature"] == expected_signature
+    assert (
+        spans[0].attributes["signature"] == "question -> answer"
+        if _DSPY_UNDER_2_6
+        else "question -> reasoning, answer"
+    )
     assert spans[1].name == "Predict.forward"
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].inputs["question"] == "How are you?"
@@ -127,7 +128,7 @@ def test_autolog_cot():
     for i in range(3):
         assert spans[4 + i].name == f"ChatAdapter.parse_{i + 1}"
         assert spans[4 + i].span_type == SpanType.PARSER
-        assert expected_signature in spans[4 + i].inputs["signature"]
+        assert "question -> reasoning, answer" in spans[4 + i].inputs["signature"]
 
 
 def test_mlflow_callback_exception():

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -125,6 +125,7 @@ def test_autolog_cot():
     for i in range(3):
         assert spans[4 + i].name == f"ChatAdapter.parse_{i + 1}"
         assert spans[4 + i].span_type == SpanType.PARSER
+        assert spans[4 + i].inputs["signature"] == repr(cot.predict.signature)
 
 
 def test_mlflow_callback_exception():

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -81,6 +81,9 @@ def test_autolog_cot():
     )
 
     cot = dspy.ChainOfThought("question -> answer", n=3)
+    expected_signature = (
+        "question -> answer" if _DSPY_UNDER_2_6 else "question -> reasoning, answer"
+    )
     result = cot(question="How are you?")
     assert result["answer"] == "test output"
     assert result["reasoning"] == "No more responses"
@@ -98,9 +101,8 @@ def test_autolog_cot():
     assert spans[0].status.status_code == "OK"
     assert spans[0].inputs == {"question": "How are you?"}
     assert spans[0].outputs == {"answer": "test output", "reasoning": "No more responses"}
-    assert spans[0].attributes["signature"] == (
-        "question -> answer" if _DSPY_UNDER_2_6 else "question -> reasoning, answer"
-    )
+
+    assert spans[0].attributes["signature"] == expected_signature
     assert spans[1].name == "Predict.forward"
     assert spans[1].span_type == SpanType.LLM
     assert spans[1].inputs["question"] == "How are you?"
@@ -125,7 +127,7 @@ def test_autolog_cot():
     for i in range(3):
         assert spans[4 + i].name == f"ChatAdapter.parse_{i + 1}"
         assert spans[4 + i].span_type == SpanType.PARSER
-        assert spans[4 + i].inputs["signature"] == repr(cot.predict.signature)
+        assert expected_signature in spans[4 + i].inputs["signature"]
 
 
 def test_mlflow_callback_exception():


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR fixes the high latency observed when dspy auto-tracing is on. The root cause is the serialization of signature that takes time to be serializes by TraceJSONEncoder.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the high latency issue of dspy auto-tracing.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
