### PR TITLE
Fix tag display as column in experiment overview

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.enzyme.test.tsx
@@ -7,6 +7,8 @@ import { MemoryRouter } from '../../../../../common/utils/RoutingUtils';
 import { createExperimentPageUIState } from '../../models/ExperimentPageUIState';
 import { createExperimentPageSearchFacetsState } from '../../models/ExperimentPageSearchFacetsState';
 import { MockedReduxStoreProvider } from '../../../../../common/utils/TestUtils';
+import { makeCanonicalSortKey } from '../../utils/experimentPage.common-utils';
+import { COLUMN_TYPES } from '../../../../constants';
 
 /**
  * Mock all expensive utility functions
@@ -126,6 +128,16 @@ describe('ExperimentViewRunsTable', () => {
         columnApi: expect.anything(),
       }),
     );
+  });
+
+  test('should pass selected tag columns to column definitions', () => {
+    const tagKey = mockTagKeys[0];
+    createWrapper({
+      uiState: Object.assign(createExperimentPageUIState(), {
+        selectedColumns: [makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey)],
+      }),
+    });
+    expect(useRunsColumnDefinitions).toHaveBeenCalledWith(expect.objectContaining({ tagKeyList: [tagKey] }));
   });
 
   test('should properly generate new column data on the new runs data', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -128,9 +128,11 @@ export const ExperimentViewRunsTable = React.memo(
       );
 
       // Filter tag keys based on selected columns
-      const filteredTags = Object.fromEntries(
-        Object.entries(runsData.tagsList).filter(([key]) =>
-          selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.TAGS, key)),
+      const filteredTags = runsData.tagsList.map((tags) =>
+        Object.fromEntries(
+          Object.entries(tags).filter(([key]) =>
+            selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.TAGS, key)),
+          ),
         ),
       );
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/17296?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17296/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17296/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17296/merge
```

</p>
</details>

### Related Issues/PRs

Fix #17279 

### What changes are proposed in this pull request?

Fix tag display as column in experiment overview. filteredTags must be list of objects to correctly displayed in the UI. Here its a single object only. Hence it broke the UI.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1516" height="767" alt="Screenshot 2025-08-19 at 8 07 37 PM" src="https://github.com/user-attachments/assets/763dab64-1556-4665-8879-fc7a367bbf09" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix tag display as column in experiment overview.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
