### PR TITLE
Remove Tool.run dependency

### DIFF
--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -27,9 +27,17 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
         "pydantic_ai.Agent": ["run", "run_sync"],
         "pydantic_ai.models.instrumented.InstrumentedModel": ["request"],
         "pydantic_ai._tool_manager.ToolManager": ["handle_call"],
-        "pydantic_ai.Tool": ["run"],
         "pydantic_ai.mcp.MCPServer": ["call_tool", "list_tools"],
     }
+
+    try:
+        from pydantic_ai.Tool import Tool
+
+        # Tool.run method is removed in recent versions
+        if hasattr(Tool, "run"):
+            class_map["pydantic_ai.Tool"] = ["run"]
+    except ImportError:
+        pass
 
     for cls_path, methods in class_map.items():
         module_name, class_name = cls_path.rsplit(".", 1)

--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -31,7 +31,7 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
     }
 
     try:
-        from pydantic_ai.Tool import Tool
+        from pydantic_ai import Tool
 
         # Tool.run method is removed in recent versions
         if hasattr(Tool, "run"):

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -6,7 +6,7 @@ from packaging.version import Version
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.instrumented import InstrumentedModel
-from pydantic_ai.usage import Usage
+from pydantic_ai.usage import RequestUsage, Usage
 
 import mlflow
 import mlflow.pydantic_ai  # ensure the integration module is importable
@@ -23,7 +23,10 @@ PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
 def _make_dummy_response_without_tool():
     parts = [TextPart(content=_FINAL_ANSWER_WITHOUT_TOOL)]
     resp = ModelResponse(parts=parts)
-    usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
+    else:
+        usage = RequestUsage(input_tokens=1, output_tokens=1)
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         return ModelResponse(parts=parts, usage=usage)
     else:
@@ -33,8 +36,13 @@ def _make_dummy_response_without_tool():
 def _make_dummy_response_with_tool():
     call_parts = [ToolCallPart(tool_name="roulette_wheel", args={"square": 18})]
     final_parts = [TextPart(content=_FINAL_ANSWER_WITH_TOOL)]
-    usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
-    usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
+
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
+        usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
+    else:
+        usage_call = RequestUsage(input_tokens=10, output_tokens=20)
+        usage_final = RequestUsage(input_tokens=100, output_tokens=200)
 
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         call_resp = ModelResponse(parts=call_parts, usage=usage_call)

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -18,19 +18,21 @@ _FINAL_ANSWER_WITHOUT_TOOL = "Paris"
 _FINAL_ANSWER_WITH_TOOL = "winner"
 
 PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
+# Usage was deprecated in favor of RequestUsage in 0.7.3
+IS_USAGE_DEPRECATED = PYDANTIC_AI_VERSION >= Version("0.7.3")
 
 
 def _make_dummy_response_without_tool():
-    # Usage was deprecated in favor of RequestUsage in 0.7.3
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+    if IS_USAGE_DEPRECATED:
         from pydantic_ai.usage import RequestUsage
 
     parts = [TextPart(content=_FINAL_ANSWER_WITHOUT_TOOL)]
     resp = ModelResponse(parts=parts)
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
-        usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
-    else:
+    if IS_USAGE_DEPRECATED:
         usage = RequestUsage(input_tokens=1, output_tokens=1)
+    else:
+        usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
+
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         return ModelResponse(parts=parts, usage=usage)
     else:
@@ -39,18 +41,18 @@ def _make_dummy_response_without_tool():
 
 def _make_dummy_response_with_tool():
     # Usage was deprecated in favor of RequestUsage in 0.7.3
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+    if IS_USAGE_DEPRECATED:
         from pydantic_ai.usage import RequestUsage
 
     call_parts = [ToolCallPart(tool_name="roulette_wheel", args={"square": 18})]
     final_parts = [TextPart(content=_FINAL_ANSWER_WITH_TOOL)]
 
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
-        usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
-        usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
-    else:
+    if IS_USAGE_DEPRECATED:
         usage_call = RequestUsage(input_tokens=10, output_tokens=20)
         usage_final = RequestUsage(input_tokens=100, output_tokens=200)
+    else:
+        usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
+        usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
 
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         call_resp = ModelResponse(parts=call_parts, usage=usage_call)

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -40,7 +40,6 @@ def _make_dummy_response_without_tool():
 
 
 def _make_dummy_response_with_tool():
-    # Usage was deprecated in favor of RequestUsage in 0.7.3
     if IS_USAGE_DEPRECATED:
         from pydantic_ai.usage import RequestUsage
 

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -163,7 +163,8 @@ def test_agent_run_sync_enable_disable_fluent_autolog_with_tool(agent_with_tool)
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    assert len(spans) == 5
+    # TOOL span may be missing in newer versions of pydantic-ai
+    assert 4 <= len(spans) <= 5
 
     assert spans[0].name == "Agent.run_sync"
     assert spans[0].span_type == SpanType.AGENT
@@ -176,14 +177,17 @@ def test_agent_run_sync_enable_disable_fluent_autolog_with_tool(agent_with_tool)
     assert span2.span_type == SpanType.LLM
     assert span2.parent_id == spans[1].span_id
 
-    span3 = spans[3]
-    assert span3.span_type == SpanType.TOOL
-    assert span3.parent_id == spans[1].span_id
+    if len(spans) == 5:
+        span3 = spans[3]
+        assert span3.span_type == SpanType.TOOL
+        assert span3.parent_id == spans[1].span_id
+        last_span = spans[4]
+    else:
+        last_span = spans[3]
 
-    span4 = spans[4]
-    assert span4.name == "InstrumentedModel.request_2"
-    assert span4.span_type == SpanType.LLM
-    assert span4.parent_id == spans[1].span_id
+    assert last_span.name == "InstrumentedModel.request_2"
+    assert last_span.span_type == SpanType.LLM
+    assert last_span.parent_id == spans[1].span_id
 
 
 @pytest.mark.asyncio
@@ -203,7 +207,7 @@ async def test_agent_run_enable_disable_fluent_autolog_with_tool(agent_with_tool
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    assert len(spans) == 4
+    assert 3 <= len(spans) <= 4
 
     assert spans[0].name == "Agent.run"
     assert spans[0].span_type == SpanType.AGENT
@@ -213,11 +217,14 @@ async def test_agent_run_enable_disable_fluent_autolog_with_tool(agent_with_tool
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
-    span2 = spans[2]
-    assert span2.span_type == SpanType.TOOL
-    assert span2.parent_id == spans[0].span_id
+    if len(spans) == 4:
+        span2 = spans[2]
+        assert span2.span_type == SpanType.TOOL
+        assert span2.parent_id == spans[0].span_id
+        last_span = spans[3]
+    else:
+        last_span = spans[2]
 
-    span3 = spans[3]
-    assert span3.name == "InstrumentedModel.request_2"
-    assert span3.span_type == SpanType.LLM
-    assert span3.parent_id == spans[0].span_id
+    assert last_span.name == "InstrumentedModel.request_2"
+    assert last_span.span_type == SpanType.LLM
+    assert last_span.parent_id == spans[0].span_id

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -163,8 +163,7 @@ def test_agent_run_sync_enable_disable_fluent_autolog_with_tool(agent_with_tool)
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    # TOOL span may be missing in newer versions of pydantic-ai
-    assert 4 <= len(spans) <= 5
+    assert len(spans) == 5
 
     assert spans[0].name == "Agent.run_sync"
     assert spans[0].span_type == SpanType.AGENT
@@ -177,17 +176,14 @@ def test_agent_run_sync_enable_disable_fluent_autolog_with_tool(agent_with_tool)
     assert span2.span_type == SpanType.LLM
     assert span2.parent_id == spans[1].span_id
 
-    if len(spans) == 5:
-        span3 = spans[3]
-        assert span3.span_type == SpanType.TOOL
-        assert span3.parent_id == spans[1].span_id
-        last_span = spans[4]
-    else:
-        last_span = spans[3]
+    span3 = spans[3]
+    assert span3.span_type == SpanType.TOOL
+    assert span3.parent_id == spans[1].span_id
 
-    assert last_span.name == "InstrumentedModel.request_2"
-    assert last_span.span_type == SpanType.LLM
-    assert last_span.parent_id == spans[1].span_id
+    span4 = spans[4]
+    assert span4.name == "InstrumentedModel.request_2"
+    assert span4.span_type == SpanType.LLM
+    assert span4.parent_id == spans[1].span_id
 
 
 @pytest.mark.asyncio
@@ -207,7 +203,7 @@ async def test_agent_run_enable_disable_fluent_autolog_with_tool(agent_with_tool
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    assert 3 <= len(spans) <= 4
+    assert len(spans) == 4
 
     assert spans[0].name == "Agent.run"
     assert spans[0].span_type == SpanType.AGENT
@@ -217,14 +213,11 @@ async def test_agent_run_enable_disable_fluent_autolog_with_tool(agent_with_tool
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
-    if len(spans) == 4:
-        span2 = spans[2]
-        assert span2.span_type == SpanType.TOOL
-        assert span2.parent_id == spans[0].span_id
-        last_span = spans[3]
-    else:
-        last_span = spans[2]
+    span2 = spans[2]
+    assert span2.span_type == SpanType.TOOL
+    assert span2.parent_id == spans[0].span_id
 
-    assert last_span.name == "InstrumentedModel.request_2"
-    assert last_span.span_type == SpanType.LLM
-    assert last_span.parent_id == spans[0].span_id
+    span3 = spans[3]
+    assert span3.name == "InstrumentedModel.request_2"
+    assert span3.span_type == SpanType.LLM
+    assert span3.parent_id == spans[0].span_id

--- a/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_fluent_tracing.py
@@ -6,7 +6,7 @@ from packaging.version import Version
 from pydantic_ai import Agent, RunContext
 from pydantic_ai.messages import ModelResponse, TextPart, ToolCallPart
 from pydantic_ai.models.instrumented import InstrumentedModel
-from pydantic_ai.usage import RequestUsage, Usage
+from pydantic_ai.usage import Usage
 
 import mlflow
 import mlflow.pydantic_ai  # ensure the integration module is importable
@@ -21,6 +21,10 @@ PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
 
 
 def _make_dummy_response_without_tool():
+    # Usage was deprecated in favor of RequestUsage in 0.7.3
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        from pydantic_ai.usage import RequestUsage
+
     parts = [TextPart(content=_FINAL_ANSWER_WITHOUT_TOOL)]
     resp = ModelResponse(parts=parts)
     if PYDANTIC_AI_VERSION < Version("0.7.3"):
@@ -34,6 +38,10 @@ def _make_dummy_response_without_tool():
 
 
 def _make_dummy_response_with_tool():
+    # Usage was deprecated in favor of RequestUsage in 0.7.3
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        from pydantic_ai.usage import RequestUsage
+
     call_parts = [ToolCallPart(tool_name="roulette_wheel", args={"square": 18})]
     final_parts = [TextPart(content=_FINAL_ANSWER_WITH_TOOL)]
 

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -15,6 +15,8 @@ from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from tests.tracing.helper import get_traces
 
 PYDANTIC_AI_VERSION = Version(importlib.metadata.version("pydantic_ai"))
+# Usage was deprecated in favor of RequestUsage in 0.7.3
+IS_USAGE_DEPRECATED = PYDANTIC_AI_VERSION >= Version("0.7.3")
 
 _FINAL_ANSWER_WITHOUT_TOOL = "Paris"
 _FINAL_ANSWER_WITH_TOOL = "winner"
@@ -22,14 +24,14 @@ _FINAL_ANSWER_WITH_TOOL = "winner"
 
 def _make_dummy_response_without_tool():
     # Usage was deprecated in favor of RequestUsage in 0.7.3
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+    if IS_USAGE_DEPRECATED:
         from pydantic_ai.usage import RequestUsage
 
     parts = [TextPart(content=_FINAL_ANSWER_WITHOUT_TOOL)]
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
-        usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
-    else:
+    if IS_USAGE_DEPRECATED:
         usage = RequestUsage(input_tokens=1, output_tokens=1)
+    else:
+        usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         return ModelResponse(parts=parts, usage=usage)
     else:
@@ -39,17 +41,17 @@ def _make_dummy_response_without_tool():
 
 def _make_dummy_response_with_tool():
     # Usage was deprecated in favor of RequestUsage in 0.7.3
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+    if IS_USAGE_DEPRECATED:
         from pydantic_ai.usage import RequestUsage
 
     call_parts = [ToolCallPart(tool_name="roulette_wheel", args={"square": 18})]
     final_parts = [TextPart(content=_FINAL_ANSWER_WITH_TOOL)]
-    if PYDANTIC_AI_VERSION < Version("0.7.3"):
-        usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
-        usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
-    else:
+    if IS_USAGE_DEPRECATED:
         usage_call = RequestUsage(input_tokens=10, output_tokens=20)
         usage_final = RequestUsage(input_tokens=100, output_tokens=200)
+    else:
+        usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
+        usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
 
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         call_resp = ModelResponse(parts=call_parts, usage=usage_call)

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -196,7 +196,7 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool):
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    assert 4 <= len(spans) <= 5
+    assert len(spans) == 5
 
     assert spans[0].name == "Agent.run_sync"
     assert spans[0].span_type == SpanType.AGENT
@@ -209,17 +209,14 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool):
     assert span2.span_type == SpanType.LLM
     assert span2.parent_id == spans[1].span_id
 
-    if len(spans) == 5:
-        span3 = spans[3]
-        assert span3.span_type == SpanType.TOOL
-        assert span3.parent_id == spans[1].span_id
-        last_span = spans[4]
-    else:
-        last_span = spans[3]
+    span3 = spans[3]
+    assert span3.span_type == SpanType.TOOL
+    assert span3.parent_id == spans[1].span_id
 
-    assert last_span.name == "InstrumentedModel.request_2"
-    assert last_span.span_type == SpanType.LLM
-    assert last_span.parent_id == spans[1].span_id
+    span4 = spans[4]
+    assert span4.name == "InstrumentedModel.request_2"
+    assert span4.span_type == SpanType.LLM
+    assert span4.parent_id == spans[1].span_id
 
     assert span2.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 10,
@@ -227,7 +224,7 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool):
         TokenUsageKey.TOTAL_TOKENS: 30,
     }
 
-    assert last_span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+    assert span4.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 100,
         TokenUsageKey.OUTPUT_TOKENS: 200,
         TokenUsageKey.TOTAL_TOKENS: 300,
@@ -259,7 +256,7 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool):
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    assert 3 <= len(spans) <= 4
+    assert len(spans) == 4
 
     assert spans[0].name == "Agent.run"
     assert spans[0].span_type == SpanType.AGENT
@@ -269,17 +266,14 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool):
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
-    if len(spans) == 4:
-        span2 = spans[2]
-        assert span2.span_type == SpanType.TOOL
-        assert span2.parent_id == spans[0].span_id
-        last_span = spans[3]
-    else:
-        last_span = spans[2]
+    span2 = spans[2]
+    assert span2.span_type == SpanType.TOOL
+    assert span2.parent_id == spans[0].span_id
 
-    assert last_span.name == "InstrumentedModel.request_2"
-    assert last_span.span_type == SpanType.LLM
-    assert last_span.parent_id == spans[0].span_id
+    span3 = spans[3]
+    assert span3.name == "InstrumentedModel.request_2"
+    assert span3.span_type == SpanType.LLM
+    assert span3.parent_id == spans[0].span_id
 
     assert span1.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 10,
@@ -287,7 +281,7 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool):
         TokenUsageKey.TOTAL_TOKENS: 30,
     }
 
-    assert last_span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+    assert span3.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 100,
         TokenUsageKey.OUTPUT_TOKENS: 200,
         TokenUsageKey.TOTAL_TOKENS: 300,

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -196,7 +196,7 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool):
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    assert len(spans) == 5
+    assert 4 <= len(spans) <= 5
 
     assert spans[0].name == "Agent.run_sync"
     assert spans[0].span_type == SpanType.AGENT
@@ -209,14 +209,17 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool):
     assert span2.span_type == SpanType.LLM
     assert span2.parent_id == spans[1].span_id
 
-    span3 = spans[3]
-    assert span3.span_type == SpanType.TOOL
-    assert span3.parent_id == spans[1].span_id
+    if len(spans) == 5:
+        span3 = spans[3]
+        assert span3.span_type == SpanType.TOOL
+        assert span3.parent_id == spans[1].span_id
+        last_span = spans[4]
+    else:
+        last_span = spans[3]
 
-    span4 = spans[4]
-    assert span4.name == "InstrumentedModel.request_2"
-    assert span4.span_type == SpanType.LLM
-    assert span4.parent_id == spans[1].span_id
+    assert last_span.name == "InstrumentedModel.request_2"
+    assert last_span.span_type == SpanType.LLM
+    assert last_span.parent_id == spans[1].span_id
 
     assert span2.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 10,
@@ -224,7 +227,7 @@ def test_agent_run_sync_enable_disable_autolog_with_tool(agent_with_tool):
         TokenUsageKey.TOTAL_TOKENS: 30,
     }
 
-    assert span4.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+    assert last_span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 100,
         TokenUsageKey.OUTPUT_TOKENS: 200,
         TokenUsageKey.TOTAL_TOKENS: 300,
@@ -256,7 +259,7 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool):
     assert len(traces) == 1
     spans = traces[0].data.spans
 
-    assert len(spans) == 4
+    assert 3 <= len(spans) <= 4
 
     assert spans[0].name == "Agent.run"
     assert spans[0].span_type == SpanType.AGENT
@@ -266,14 +269,17 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool):
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == spans[0].span_id
 
-    span2 = spans[2]
-    assert span2.span_type == SpanType.TOOL
-    assert span2.parent_id == spans[0].span_id
+    if len(spans) == 4:
+        span2 = spans[2]
+        assert span2.span_type == SpanType.TOOL
+        assert span2.parent_id == spans[0].span_id
+        last_span = spans[3]
+    else:
+        last_span = spans[2]
 
-    span3 = spans[3]
-    assert span3.name == "InstrumentedModel.request_2"
-    assert span3.span_type == SpanType.LLM
-    assert span3.parent_id == spans[0].span_id
+    assert last_span.name == "InstrumentedModel.request_2"
+    assert last_span.span_type == SpanType.LLM
+    assert last_span.parent_id == spans[0].span_id
 
     assert span1.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 10,
@@ -281,7 +287,7 @@ async def test_agent_run_enable_disable_autolog_with_tool(agent_with_tool):
         TokenUsageKey.TOTAL_TOKENS: 30,
     }
 
-    assert span3.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
+    assert last_span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 100,
         TokenUsageKey.OUTPUT_TOKENS: 200,
         TokenUsageKey.TOTAL_TOKENS: 300,

--- a/tests/pydantic_ai/test_pydanticai_tracing.py
+++ b/tests/pydantic_ai/test_pydanticai_tracing.py
@@ -21,8 +21,15 @@ _FINAL_ANSWER_WITH_TOOL = "winner"
 
 
 def _make_dummy_response_without_tool():
+    # Usage was deprecated in favor of RequestUsage in 0.7.3
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        from pydantic_ai.usage import RequestUsage
+
     parts = [TextPart(content=_FINAL_ANSWER_WITHOUT_TOOL)]
-    usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        usage = Usage(requests=1, request_tokens=1, response_tokens=1, total_tokens=2)
+    else:
+        usage = RequestUsage(input_tokens=1, output_tokens=1)
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         return ModelResponse(parts=parts, usage=usage)
     else:
@@ -31,10 +38,18 @@ def _make_dummy_response_without_tool():
 
 
 def _make_dummy_response_with_tool():
+    # Usage was deprecated in favor of RequestUsage in 0.7.3
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        from pydantic_ai.usage import RequestUsage
+
     call_parts = [ToolCallPart(tool_name="roulette_wheel", args={"square": 18})]
     final_parts = [TextPart(content=_FINAL_ANSWER_WITH_TOOL)]
-    usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
-    usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
+    if PYDANTIC_AI_VERSION < Version("0.7.3"):
+        usage_call = Usage(requests=0, request_tokens=10, response_tokens=20, total_tokens=30)
+        usage_final = Usage(requests=1, request_tokens=100, response_tokens=200, total_tokens=300)
+    else:
+        usage_call = RequestUsage(input_tokens=10, output_tokens=20)
+        usage_final = RequestUsage(input_tokens=100, output_tokens=200)
 
     if PYDANTIC_AI_VERSION >= Version("0.2.0"):
         call_resp = ModelResponse(parts=call_parts, usage=usage_call)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17299?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17299/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17299/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17299/merge
```

</p>
</details>

### Related Issues/PRs

Fix https://github.com/mlflow/mlflow/issues/17271

### What changes are proposed in this pull request?

The `Tool.run` method is removed in Pydantic AI. MLflow tries to patch the method and shows an error log.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Confirmed `mlflow.pydantic_ai.autolog` doesn't show the error log.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
