### PR TITLE
Fix LC cross version test

### DIFF
--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -470,7 +470,8 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch, use_partner_packag
     if use_partner_package:
         from databricks_langchain import ChatDatabricks
 
-        # ChatDatabricks instantiate workspace client in __init__ which requires Databricks creds
+        # in databricks-langchain > 0.7.0, ChatDatabricks instantiates
+        # workspace client in __init__ which requires Databricks creds
         monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
         monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -1,3 +1,4 @@
+import importlib
 from collections import Counter, defaultdict
 from unittest import mock
 
@@ -470,6 +471,10 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch, use_partner_packag
     if use_partner_package:
         from databricks_langchain import ChatDatabricks
 
+        # ChatDatabricks instantiate workspace client in __init__ which requires Databricks creds
+        if Version(importlib.metadata.version("databricks-langchain")) >= Version("0.7.0"):
+            monkeypatch.setattr("databricks_langchain.utils.get_openai_client", mock.MagicMock())
+
         remove_langchain_community(monkeypatch)
         with pytest.raises(ImportError, match="No module named 'langchain_community"):
             from langchain_community.chat_models import ChatDatabricks
@@ -489,6 +494,10 @@ def test_parsing_dependency_from_databricks(monkeypatch, use_partner_package):
     if use_partner_package:
         from databricks_langchain import ChatDatabricks
 
+        # ChatDatabricks instantiate workspace client in __init__ which requires Databricks creds
+        if Version(importlib.metadata.version("databricks-langchain")) >= Version("0.7.0"):
+            monkeypatch.setattr("databricks_langchain.utils.get_openai_client", mock.MagicMock())
+
         remove_langchain_community(monkeypatch)
         with pytest.raises(ImportError, match="No module named 'langchain_community"):
             from langchain_community.chat_models import ChatDatabricks
@@ -502,6 +511,7 @@ def test_parsing_dependency_from_databricks(monkeypatch, use_partner_package):
         has_embedding_endpoint=True,
     )
     retriever = vectorstore.as_retriever()
+
     llm = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
     llm2 = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -1,4 +1,3 @@
-import importlib
 from collections import Counter, defaultdict
 from unittest import mock
 
@@ -472,10 +471,8 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch, use_partner_packag
         from databricks_langchain import ChatDatabricks
 
         # ChatDatabricks instantiate workspace client in __init__ which requires Databricks creds
-        if Version(importlib.metadata.version("databricks-langchain")) >= Version("0.7.0"):
-            monkeypatch.setattr(
-                "databricks_langchain.chat_models.get_openai_client", mock.MagicMock()
-            )
+        monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
+        monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
 
         remove_langchain_community(monkeypatch)
         with pytest.raises(ImportError, match="No module named 'langchain_community"):
@@ -496,11 +493,10 @@ def test_parsing_dependency_from_databricks(monkeypatch, use_partner_package):
     if use_partner_package:
         from databricks_langchain import ChatDatabricks
 
-        # ChatDatabricks instantiate workspace client in __init__ which requires Databricks creds
-        if Version(importlib.metadata.version("databricks-langchain")) >= Version("0.7.0"):
-            monkeypatch.setattr(
-                "databricks_langchain.chat_models.get_openai_client", mock.MagicMock()
-            )
+        # in databricks-langchain > 0.7.0, ChatDatabricks instantiates
+        # workspace client in __init__ which requires Databricks creds
+        monkeypatch.setenv("DATABRICKS_HOST", "my-default-host")
+        monkeypatch.setenv("DATABRICKS_TOKEN", "my-default-token")
 
         remove_langchain_community(monkeypatch)
         with pytest.raises(ImportError, match="No module named 'langchain_community"):
@@ -515,7 +511,6 @@ def test_parsing_dependency_from_databricks(monkeypatch, use_partner_package):
         has_embedding_endpoint=True,
     )
     retriever = vectorstore.as_retriever()
-
     llm = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
     llm2 = ChatDatabricks(endpoint="databricks-llama-2-70b-chat", max_tokens=500)
 

--- a/tests/langchain/test_langchain_databricks_dependency_extraction.py
+++ b/tests/langchain/test_langchain_databricks_dependency_extraction.py
@@ -473,7 +473,9 @@ def test_parsing_dependency_from_databricks_chat(monkeypatch, use_partner_packag
 
         # ChatDatabricks instantiate workspace client in __init__ which requires Databricks creds
         if Version(importlib.metadata.version("databricks-langchain")) >= Version("0.7.0"):
-            monkeypatch.setattr("databricks_langchain.utils.get_openai_client", mock.MagicMock())
+            monkeypatch.setattr(
+                "databricks_langchain.chat_models.get_openai_client", mock.MagicMock()
+            )
 
         remove_langchain_community(monkeypatch)
         with pytest.raises(ImportError, match="No module named 'langchain_community"):
@@ -496,7 +498,9 @@ def test_parsing_dependency_from_databricks(monkeypatch, use_partner_package):
 
         # ChatDatabricks instantiate workspace client in __init__ which requires Databricks creds
         if Version(importlib.metadata.version("databricks-langchain")) >= Version("0.7.0"):
-            monkeypatch.setattr("databricks_langchain.utils.get_openai_client", mock.MagicMock())
+            monkeypatch.setattr(
+                "databricks_langchain.chat_models.get_openai_client", mock.MagicMock()
+            )
 
         remove_langchain_community(monkeypatch)
         with pytest.raises(ImportError, match="No module named 'langchain_community"):

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -69,10 +69,6 @@ def test_save_and_load_chat_databricks(model_path):
 
     mlflow.langchain.save_model(chain, path=model_path)
 
-    with model_path.joinpath("requirements.txt").open() as f:
-        reqs = {req.split("==")[0] for req in f.read().split("\n")}
-    assert "databricks-langchain" in reqs
-
     loaded_model = mlflow.langchain.load_model(model_path)
     assert loaded_model == chain
 

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -20,7 +20,7 @@ _MOCK_CHAT_RESPONSE = {
         {
             "index": 0,
             "message": {
-                "role": "assistant",
+                "role": "user",
                 "content": "What is MLflow?",
             },
             "finish_reason": "stop",

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -20,7 +20,7 @@ _MOCK_CHAT_RESPONSE = {
         {
             "index": 0,
             "message": {
-                "role": "user",
+                "role": "assistant",
                 "content": "What is MLflow?",
             },
             "finish_reason": "stop",

--- a/tests/langchain/test_langchain_databricks_integration.py
+++ b/tests/langchain/test_langchain_databricks_integration.py
@@ -32,7 +32,7 @@ _MOCK_CHAT_RESPONSE = {
 
 
 @pytest.fixture(autouse=True)
-def mock_client() -> Generator:
+def mock_client(monkeypatch) -> Generator:
     # In databricks-langchain <= 0.7.0, ChatDatabricks uses MLflow deployment client
     deploy_client = mock.MagicMock()
     deploy_client.predict.return_value = _MOCK_CHAT_RESPONSE
@@ -44,7 +44,9 @@ def mock_client() -> Generator:
 
     with (
         mock.patch("mlflow.deployments.get_deploy_client", return_value=deploy_client),
-        mock.patch("databricks_langchain.utils.get_openai_client", return_value=openai_client),
+        mock.patch(
+            "databricks_langchain.chat_models.get_openai_client", return_value=openai_client
+        ),
     ):
         yield
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17301?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17301/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17301/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17301/merge
```

</p>
</details>

### What changes are proposed in this pull request?

`databricks-langchain` package started to use OpenAI client (from Databricks workspace client) within `ChatDatabricks` since a recent commit: https://github.com/databricks/databricks-ai-bridge/commit/1034fb233925e381d701887ab5149a9da485341c
. The client intialization requires databricks creds and caused test failures like this: https://github.com/mlflow/dev/actions/runs/17070736695/job/48398769881#step:13:1402

This PR mocks the client to workaround the auth error.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
