### PR TITLE
Add type hint checking for new functions in signature checker

### DIFF
--- a/dev/check_function_signatures.py
+++ b/dev/check_function_signatures.py
@@ -381,6 +381,10 @@ def compare_signatures(base_branch: str = "master") -> list[Error]:
         if file_path.parts[0] != "mlflow":
             continue
 
+        # Ignore files in mlflow/protos directory
+        if file_path.is_relative_to("mlflow/protos"):
+            continue
+
         base_content = get_file_content_at_revision(file_path, base_branch)
 
         if not file_path.exists():

--- a/dev/check_function_signatures.py
+++ b/dev/check_function_signatures.py
@@ -312,7 +312,7 @@ class FunctionSignatureExtractor(ast.NodeVisitor):
             return True
 
         # Check if the function is in a private module
-        if any(_is_private(p) for p in self.path.parts if p != "__init__"):
+        if any(_is_private(p) for p in self.path.parts):
             return True
 
         return False

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -416,3 +416,8 @@ with contextlib.suppress(Exception):
 from mlflow.telemetry import set_telemetry_client
 
 set_telemetry_client()
+
+
+# test
+def _untyped_fn(a, b):
+    pass

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -420,7 +420,11 @@ set_telemetry_client()
 
 # test
 def _untyped_fn(a, b):
-    pass
+    return a + b
+
+
+def _partially_typed_fn(a: int, b: int):
+    return a + b
 
 
 def _typed_fn(a: int, b: int) -> int:

--- a/mlflow/__init__.py
+++ b/mlflow/__init__.py
@@ -421,3 +421,7 @@ set_telemetry_client()
 # test
 def _untyped_fn(a, b):
     pass
+
+
+def _typed_fn(a: int, b: int) -> int:
+    return a + b


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17332?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17332/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17332/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17332/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This PR enhances the `dev/check_function_signatures.py` script to flag newly created functions that are missing type hints or are partially typed. This helps enforce the coding guideline that all functions should have complete type hints.

### Changes made:
- Added `check_function_type_hints()` function to verify all parameters and return types have type annotations
- Check type hints for all functions in newly created files
- Check type hints for newly added functions in existing files  
- Renamed `ParameterError` to `SignatureWarning` to avoid confusion with Python exceptions
- Ignore test files (tests directory, test_*.py, *_test.py) from type hint checking

### Example

<img width="405" height="393" alt="image" src="https://github.com/user-attachments/assets/e70a2e26-d650-43ab-8cb4-f9925b0c3cc3" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

The script was tested locally by running `python dev/check_function_signatures.py` to ensure it runs without errors.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)