### PR TITLE
Refactor constraint removal logic in cross-version tests to prevent installation conflicts

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -148,13 +148,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Remove constraints
         run: |
-          if [ "${{ matrix.package }}" = "pyspark" ]; then
-            # TODO: Remove once we remove the pyspark constraint in requirements/constraints.txt
-            sed -i '/^pyspark/d' requirements/constraints.txt
-          elif [ "${{ matrix.package }}" = "transformers" ]; then
-            # TODO: Remove once https://github.com/huggingface/transformers/issues/39115 is resolved
-            sed -i '/^transformers</d' requirements/constraints.txt
-          fi
+          # Remove any constraints for the current package to prevent installation conflicts
+          sed -i '/^${{ matrix.package }}/d' requirements/constraints.txt
 
           if ! git diff --exit-code requirements/constraints.txt; then
             git diff

--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -214,13 +214,8 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Remove constraints
         run: |
-          if [ "${{ matrix.package }}" = "pyspark" ]; then
-            # TODO: Remove once we remove the pyspark constraint in requirements/constraints.txt
-            sed -i '/^pyspark/d' requirements/constraints.txt
-          elif [ "${{ matrix.package }}" = "transformers" ]; then
-            # TODO: Remove once https://github.com/huggingface/transformers/issues/39115 is resolved
-            sed -i '/^transformers</d' requirements/constraints.txt
-          fi
+          # Remove any constraints for the current package to prevent installation conflicts
+          sed -i '/^${{ matrix.package }}/d' requirements/constraints.txt
 
           if ! git diff --exit-code requirements/constraints.txt; then
             git diff


### PR DESCRIPTION
…

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Constraints in `requirements/constraints.txt` sometimes conflict with cross-version tests. This PR refactors the `Remove constraints` step to remove any constraints for the package being tested.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
