### PR TITLE
Fix program hanging problem

### DIFF
--- a/mlflow/genai/experimental/databricks_trace_exporter.py
+++ b/mlflow/genai/experimental/databricks_trace_exporter.py
@@ -163,6 +163,13 @@ class DatabricksDeltaArchivalMixin:
             # For async mode, the flush will be handled by the async queue
             # which runs in the background.
             stream.flush()
+            _logger.debug("Flushed stream")
+
+            # Shut down the factory to prevent the program from hanging,
+            # caused by non-daemon receiver threads in the stream
+            # TODO: this may slows down a bit for sync logging, update if we find a better solution
+            factory.shutdown()
+            _logger.debug("Shut down stream")
 
         except Exception as e:
             _logger.warning(f"Failed to send trace to Databricks Delta: {e}")
@@ -281,6 +288,7 @@ class MlflowV3DeltaSpanExporter(MlflowV3SpanExporter, DatabricksDeltaArchivalMix
 
         # Archive trace to Delta table using mixin functionality
         try:
+            _logger.debug("Archiving trace to Databricks Delta")
             self.archive_trace(trace)
         except Exception as e:
             _logger.warning(f"Failed to archive trace to Databricks Delta: {e}")

--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -87,6 +87,7 @@ class MlflowV3SpanExporter(SpanExporter):
         """
         try:
             if trace:
+                _logger.debug("Logging trace to MLflow backend")
                 add_size_stats_to_trace_metadata(trace)
                 returned_trace_info = self._client.start_trace(trace.info)
                 self._client._upload_trace_data(returned_trace_info, trace.data)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
When enabling delta table archival for sync trace logging, the program hangs. The reason is that the `IngestApiStream` creates several tasks, including two non-daemon threads (__receiver and __server_unresponsiveness_detection), so after the stream is flushed the non-daemon threads are preventing program from exiting. 
`atexit.register(cls.reset)` in `IngestStreamFactory` doesn't work because it's not even triggered, so we need to explicitly shutdown the stream before program exits.
The temporary solution in this PR is to always shutdown the stream after it's flushed, and this may slows down trace logging a bit. --> **A better approach is to fix it in ingest_api_sdk, convert __receiver and __server_unresponsiveness_detection to daemon threads.**

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
