### PR TITLE
Fix scorer status for MLflow tracking backend

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -126,10 +126,7 @@ class Scorer(BaseModel):
         if self._registered_backend is None:
             return ScorerStatus.UNREGISTERED
 
-        if self._registered_backend == "tracking":
-            return ScorerStatus.STOPPED
-
-        return ScorerStatus.STARTED if self.sample_rate > 0 else ScorerStatus.STOPPED
+        return ScorerStatus.STARTED if (self.sample_rate or 0) > 0 else ScorerStatus.STOPPED
 
     def __repr__(self) -> str:
         # Get the standard representation from the parent class
@@ -473,7 +470,7 @@ class Scorer(BaseModel):
                 )
         """
         # Get the current tracking store
-        from mlflow.genai.scorers.registry import _get_scorer_store, DatabricksStore, MlflowTrackingStore
+        from mlflow.genai.scorers.registry import DatabricksStore, _get_scorer_store
 
         self._check_can_be_registered()
         store = _get_scorer_store()

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -104,6 +104,7 @@ class Scorer(BaseModel):
 
     _cached_dump: dict[str, Any] | None = PrivateAttr(default=None)
     _sampling_config: ScorerSamplingConfig | None = PrivateAttr(default=None)
+    _registered_backend: str | None = PrivateAttr(default=None)
 
     @property
     @experimental(version="3.2.0")
@@ -122,8 +123,11 @@ class Scorer(BaseModel):
     def status(self) -> ScorerStatus:
         """Get the status of this scorer, using only the local state."""
 
-        if self.sample_rate is None:
+        if self._registered_backend is None:
             return ScorerStatus.UNREGISTERED
+
+        if self._registered_backend == "tracking":
+            return ScorerStatus.STOPPED
 
         return ScorerStatus.STARTED if self.sample_rate > 0 else ScorerStatus.STOPPED
 
@@ -469,7 +473,7 @@ class Scorer(BaseModel):
                 )
         """
         # Get the current tracking store
-        from mlflow.genai.scorers.registry import _get_scorer_store
+        from mlflow.genai.scorers.registry import _get_scorer_store, DatabricksStore, MlflowTrackingStore
 
         self._check_can_be_registered()
         store = _get_scorer_store()
@@ -484,6 +488,11 @@ class Scorer(BaseModel):
                 new_scorer._cached_dump["name"] = name
 
         store.register_scorer(experiment_id, new_scorer)
+
+        if isinstance(store, DatabricksStore):
+            new_scorer._registered_backend = "databricks"
+        else:
+            new_scorer._registered_backend = "tracking"
         return new_scorer
 
     @experimental(version="3.2.0")

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -22,7 +22,9 @@ def test_mlflow_backend_scorer_operations():
 
     assert test_mlflow_scorer_v1.status == ScorerStatus.UNREGISTERED
     # Test register operation
-    registered_scorer_v1 = test_mlflow_scorer_v1.register(experiment_id=experiment_id, name="test_mlflow_scorer")
+    registered_scorer_v1 = test_mlflow_scorer_v1.register(
+        experiment_id=experiment_id, name="test_mlflow_scorer"
+    )
 
     assert registered_scorer_v1.status == ScorerStatus.STOPPED
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/17379?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17379/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17379/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17379/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix scorer status for MLflow tracking backend.

After the scorer is registered, the scorer status should be `STOPPED`. (and in follow-up PR, I will make it support `scorer.start` functionality for MLflow tracking backend) 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
