### PR TITLE
Add retry policy support to _invoke_litellm for improved reliability

### DIFF
--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -46,7 +46,6 @@ def invoke_judge_model(
         prompt: The prompt to evaluate.
         assessment_name: The name of the assessment.
         num_retries: Number of retries on transient failures when using litellm.
-                     Defaults to 7 to match MLflow's http_request utility defaults.
     """
     from mlflow.metrics.genai.model_utils import (
         _parse_model_uri,

--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -33,7 +33,7 @@ def _sanitize_justification(justification: str) -> str:
 
 
 def invoke_judge_model(
-    model_uri: str, prompt: str, assessment_name: str, num_retries: int = 7
+    model_uri: str, prompt: str, assessment_name: str, num_retries: int = 10
 ) -> Feedback:
     """
     Invoke the judge model.

--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -32,7 +32,9 @@ def _sanitize_justification(justification: str) -> str:
     return justification.replace("Let's think step by step. ", "")
 
 
-def invoke_judge_model(model_uri: str, prompt: str, assessment_name: str) -> Feedback:
+def invoke_judge_model(
+    model_uri: str, prompt: str, assessment_name: str, num_retries: int = 7
+) -> Feedback:
     """
     Invoke the judge model.
 
@@ -43,6 +45,8 @@ def invoke_judge_model(model_uri: str, prompt: str, assessment_name: str) -> Fee
         model_uri: The model URI.
         prompt: The prompt to evaluate.
         assessment_name: The name of the assessment.
+        num_retries: Number of retries on transient failures when using litellm.
+                     Defaults to 7 to match MLflow's http_request utility defaults.
     """
     from mlflow.metrics.genai.model_utils import (
         _parse_model_uri,
@@ -54,7 +58,7 @@ def invoke_judge_model(model_uri: str, prompt: str, assessment_name: str) -> Fee
 
     # Try litellm first for better performance.
     if _is_litellm_available():
-        response = _invoke_litellm(provider, model_name, prompt)
+        response = _invoke_litellm(provider, model_name, prompt, num_retries)
     elif provider in _NATIVE_PROVIDERS:
         response = score_model_on_payload(
             model_uri=model_uri,
@@ -97,18 +101,65 @@ def _is_litellm_available() -> bool:
         return False
 
 
-def _invoke_litellm(provider: str, model_name: str, prompt: str) -> str:
-    """Invoke the judge model via litellm."""
+def _invoke_litellm(provider: str, model_name: str, prompt: str, num_retries: int = 7) -> str:
+    """
+    Invoke the judge model via litellm with retry support.
+
+    Args:
+        provider: The provider name (e.g., 'openai', 'anthropic').
+        model_name: The model name.
+        prompt: The prompt to send to the model.
+        num_retries: Number of retries with exponential backoff on transient failures.
+
+    Returns:
+        The model's response content.
+
+    Raises:
+        MlflowException: If the request fails after all retries.
+    """
     import litellm
 
     litellm_model_uri = f"{provider}/{model_name}"
+
     try:
         response = litellm.completion(
-            model=litellm_model_uri, messages=[{"role": "user", "content": prompt}]
+            model=litellm_model_uri,
+            messages=[{"role": "user", "content": prompt}],
+            retry_policy=_get_litellm_retry_policy(num_retries),
+            retry_strategy="exponential_backoff_retry",
+            # In LiteLLM version 1.55.3+, max_retries is stacked on top of retry_policy.
+            # To avoid double-retry, we set max_retries=0
+            max_retries=0,
         )
         return response.choices[0].message.content
     except Exception as e:
         raise MlflowException("Failed to invoke the judge model via litellm.") from e
+
+
+def _get_litellm_retry_policy(num_retries: int):
+    """
+    Get a LiteLLM retry policy for retrying requests when transient API errors occur.
+
+    Args:
+        num_retries: The number of times to retry a request if it fails transiently due to
+                     network error, rate limiting, etc. Requests are retried with exponential
+                     backoff.
+
+    Returns:
+        A LiteLLM RetryPolicy instance.
+    """
+    from litellm import RetryPolicy
+
+    return RetryPolicy(
+        TimeoutErrorRetries=num_retries,
+        RateLimitErrorRetries=num_retries,
+        InternalServerErrorRetries=num_retries,
+        ContentPolicyViolationErrorRetries=num_retries,
+        # We don't retry on errors that are unlikely to be transient
+        # (e.g. bad request, invalid auth credentials)
+        BadRequestErrorRetries=0,
+        AuthenticationErrorRetries=0,
+    )
 
 
 class CategoricalRating(StrEnum):

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -26,7 +26,6 @@ def test_invoke_judge_model_successful_with_litellm(num_retries):
 
         feedback = invoke_judge_model(**kwargs)
 
-    # Create expected retry policy manually
     from litellm import RetryPolicy
     expected_retries = 7 if num_retries is None else num_retries
     expected_retry_policy = RetryPolicy(

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -26,6 +26,7 @@ def test_invoke_judge_model_successful_with_litellm(num_retries):
         feedback = invoke_judge_model(**kwargs)
 
     from litellm import RetryPolicy
+
     expected_retries = 7 if num_retries is None else num_retries
     expected_retry_policy = RetryPolicy(
         TimeoutErrorRetries=expected_retries,

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -15,7 +15,6 @@ def test_invoke_judge_model_successful_with_litellm(num_retries):
     mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
-        # Build kwargs dict
         kwargs = {
             "model_uri": "openai:/gpt-4",
             "prompt": "Evaluate this response",

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -98,28 +98,3 @@ def test_invoke_judge_model_invalid_json_response():
             invoke_judge_model(
                 model_uri="openai:/gpt-4", prompt="Test prompt", assessment_name="test"
             )
-
-
-def test_invoke_judge_model_retry_policy():
-    """Test that retry policy is passed with correct configuration."""
-    mock_content = json.dumps({"result": "yes", "rationale": "Success with retry."})
-    mock_response = ModelResponse(choices=[{"message": {"content": mock_content}}])
-
-    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
-        invoke_judge_model(
-            model_uri="openai:/gpt-4",
-            prompt="Evaluate this response",
-            assessment_name="quality_check",
-            num_retries=5,
-        )
-
-    # Verify retry parameters are passed correctly
-    call_args = mock_litellm.call_args
-    assert call_args[1]["retry_strategy"] == "exponential_backoff_retry"
-    assert call_args[1]["max_retries"] == 0
-
-    # Verify retry policy has the specified retry count
-    retry_policy = call_args[1]["retry_policy"]
-    assert retry_policy.TimeoutErrorRetries == 5
-    assert retry_policy.RateLimitErrorRetries == 5
-    assert retry_policy.BadRequestErrorRetries == 0  # Non-transient errors not retried

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -23,7 +23,7 @@ def test_invoke_judge_model_successful_with_litellm(num_retries):
         }
         if num_retries is not None:
             kwargs["num_retries"] = num_retries
-        
+
         feedback = invoke_judge_model(**kwargs)
 
     # Create expected retry policy manually
@@ -37,7 +37,7 @@ def test_invoke_judge_model_successful_with_litellm(num_retries):
         BadRequestErrorRetries=0,
         AuthenticationErrorRetries=0,
     )
-    
+
     mock_litellm.assert_called_once_with(
         model="openai/gpt-4",
         messages=[{"role": "user", "content": "Evaluate this response"}],

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -27,7 +27,7 @@ def test_invoke_judge_model_successful_with_litellm(num_retries):
 
     from litellm import RetryPolicy
 
-    expected_retries = 7 if num_retries is None else num_retries
+    expected_retries = 10 if num_retries is None else num_retries
     expected_retry_policy = RetryPolicy(
         TimeoutErrorRetries=expected_retries,
         RateLimitErrorRetries=expected_retries,


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add retry policy support to `_invoke_litellm` for improved custom judge reliability. Currently, custom judge models fail if backends transiently return 429s for rate limiting, etc.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

LLM judges with custom models now retry transient errors with exponential backoff

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
