### PR TITLE
Add 'mlflow runs create' CLI command for programmatic run creation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,7 @@ See `mlflow/server/js/` for frontend development.
 
 ## Code Style
 
-- Do not add docstrings to test functions that simply repeat the test name
+- Do not add docstrings to functions that simply repeat the function name
 - Prefer using `pytest.mark.parametrize` for tests with similar logic but different parameters
 - Use match statements (Python 3.10+) for cleaner pattern matching where appropriate
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,12 @@ cd docs && yarn serve --port 8080
 
 See `mlflow/server/js/` for frontend development.
 
+## Code Style
+
+- Do not add docstrings to test functions that simply repeat the test name
+- Prefer using `pytest.mark.parametrize` for tests with similar logic but different parameters
+- Use match statements (Python 3.10+) for cleaner pattern matching where appropriate
+
 ## Git Workflow
 
 ### Committing Changes

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -192,14 +192,15 @@ def create_run(
     tags_dict = {}
     if tags:
         for tag in tags:
-            if "=" not in tag:
-                raise click.UsageError(
-                    f"Invalid tag format: '{tag}'. Tags must be in key=value format."
-                )
-            key, value = tag.split("=", 1)
-            if key in tags_dict:
-                raise click.UsageError(f"Duplicate tag key: '{key}'")
-            tags_dict[key] = value
+            match tag.split("=", 1):
+                case [key, value]:
+                    if key in tags_dict:
+                        raise click.UsageError(f"Duplicate tag key: '{key}'")
+                    tags_dict[key] = value
+                case _:
+                    raise click.UsageError(
+                        f"Invalid tag format: '{tag}'. Tags must be in key=value format."
+                    )
 
     # Set the experiment if using experiment_name
     if experiment_name:

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -2,8 +2,6 @@
 CLI for runs
 """
 
-from __future__ import annotations
-
 import json
 
 import click
@@ -133,18 +131,6 @@ def describe_run(run_id: str) -> None:
     type=click.STRING,
     help="ID of the parent run for nested runs (optional).",
 )
-@click.option(
-    "--nested",
-    is_flag=True,
-    default=False,
-    help="Create a nested run within the current active run.",
-)
-@click.option(
-    "--log-system-metrics",
-    is_flag=True,
-    default=None,
-    help="Enable system metrics logging (CPU/GPU utilization).",
-)
 def create_run(
     experiment_id: str | None,
     experiment_name: str | None,
@@ -153,8 +139,6 @@ def create_run(
     tags: tuple[str, ...],
     status: str,
     parent_run_id: str | None,
-    nested: bool,
-    log_system_metrics: bool | None,
 ) -> None:
     """
     Create a new MLflow run and immediately end it with the specified status.
@@ -174,8 +158,6 @@ def create_run(
             multiple tags. Format: key=value (e.g., env=prod, model=xgboost, version=1.0).
         status: Final status of the run. Options: FINISHED (default), FAILED, or KILLED.
         parent_run_id: Optional ID of a parent run to create a nested run under.
-        nested: If True, create as a nested run within the currently active run.
-        log_system_metrics: If True, enable logging of system metrics (CPU/GPU utilization).
 
     Raises:
         UsageError: If both or neither experiment_id and experiment_name are specified,
@@ -213,11 +195,10 @@ def create_run(
         active_run = mlflow.start_run(
             experiment_id=experiment_id,
             run_name=run_name,
-            nested=nested,
+            nested=bool(parent_run_id),
             parent_run_id=parent_run_id,
             tags=tags_dict,
             description=description,
-            log_system_metrics=log_system_metrics,
         )
         run_id = active_run.info.run_id
         actual_experiment_id = active_run.info.experiment_id

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -2,12 +2,16 @@
 CLI for runs
 """
 
+from __future__ import annotations
+
 import json
 
 import click
 
-from mlflow.entities import ViewType
-from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID
+import mlflow
+from mlflow.entities import RunStatus, ViewType
+from mlflow.environment_variables import MLFLOW_EXPERIMENT_ID, MLFLOW_EXPERIMENT_NAME
+from mlflow.exceptions import MlflowException
 from mlflow.tracking import _get_store
 from mlflow.utils.string_utils import _create_table
 from mlflow.utils.time import conv_longdate_to_str
@@ -38,7 +42,7 @@ def commands():
     help="Select view type for list experiments. Valid view types are "
     "'active_only' (default), 'deleted_only', and 'all'.",
 )
-def list_run(experiment_id, view):
+def list_run(experiment_id: str, view: str) -> None:
     """
     List all runs of the specified experiment in the configured tracking server.
     """
@@ -54,7 +58,7 @@ def list_run(experiment_id, view):
 
 @commands.command("delete")
 @RUN_ID
-def delete_run(run_id):
+def delete_run(run_id: str) -> None:
     """
     Mark a run for deletion. Return an error if the run does not exist or
     is already marked. You can restore a marked run with ``restore_run``,
@@ -67,7 +71,7 @@ def delete_run(run_id):
 
 @commands.command("restore")
 @RUN_ID
-def restore_run(run_id):
+def restore_run(run_id: str) -> None:
     """
     Restore a deleted run.
     Returns an error if the run is active or has been permanently deleted.
@@ -79,7 +83,7 @@ def restore_run(run_id):
 
 @commands.command("describe")
 @RUN_ID
-def describe_run(run_id):
+def describe_run(run_id: str) -> None:
     """
     All of run details will print to the stdout as JSON format.
     """
@@ -87,3 +91,150 @@ def describe_run(run_id):
     run = store.get_run(run_id)
     json_run = json.dumps(run.to_dictionary(), indent=4)
     click.echo(json_run)
+
+
+@commands.command("create")
+@click.option(
+    "--experiment-id",
+    envvar=MLFLOW_EXPERIMENT_ID.name,
+    type=click.STRING,
+    help="ID of the experiment under which to create the run.",
+)
+@click.option(
+    "--experiment-name",
+    envvar=MLFLOW_EXPERIMENT_NAME.name,
+    type=click.STRING,
+    help="Name of the experiment under which to create the run.",
+)
+@click.option(
+    "--run-name",
+    type=click.STRING,
+    help="Name to give the run (optional).",
+)
+@click.option(
+    "--description",
+    type=click.STRING,
+    help="Description for the run (optional).",
+)
+@click.option(
+    "--tags",
+    "-t",
+    multiple=True,
+    help="Tags for the run in key=value format. Can be specified multiple times.",
+)
+@click.option(
+    "--status",
+    type=click.Choice(["FINISHED", "FAILED", "KILLED"], case_sensitive=False),
+    default="FINISHED",
+    help="Status to set when ending the run. Default is FINISHED.",
+)
+@click.option(
+    "--parent-run-id",
+    type=click.STRING,
+    help="ID of the parent run for nested runs (optional).",
+)
+@click.option(
+    "--nested",
+    is_flag=True,
+    default=False,
+    help="Create a nested run within the current active run.",
+)
+@click.option(
+    "--log-system-metrics",
+    is_flag=True,
+    default=None,
+    help="Enable system metrics logging (CPU/GPU utilization).",
+)
+def create_run(
+    experiment_id: str | None,
+    experiment_name: str | None,
+    run_name: str | None,
+    description: str | None,
+    tags: tuple[str, ...],
+    status: str,
+    parent_run_id: str | None,
+    nested: bool,
+    log_system_metrics: bool | None,
+) -> None:
+    """
+    Create a new MLflow run and immediately end it with the specified status.
+
+    This command is useful for creating runs programmatically for testing, scripting,
+    or recording completed experiments. The run will be created and immediately closed
+    with the specified status (FINISHED, FAILED, or KILLED).
+
+    Args:
+        experiment_id: ID of the experiment under which to create the run.
+            Must specify either this or experiment_name.
+        experiment_name: Name of the experiment under which to create the run.
+            Must specify either this or experiment_id.
+        run_name: Optional human-readable name for the run (e.g., "baseline-model-v1").
+        description: Optional longer description of what this run represents.
+        tags: Key-value pairs to categorize and filter runs. Use multiple times for
+            multiple tags. Format: key=value (e.g., env=prod, model=xgboost, version=1.0).
+        status: Final status of the run. Options: FINISHED (default), FAILED, or KILLED.
+        parent_run_id: Optional ID of a parent run to create a nested run under.
+        nested: If True, create as a nested run within the currently active run.
+        log_system_metrics: If True, enable logging of system metrics (CPU/GPU utilization).
+
+    Raises:
+        UsageError: If both or neither experiment_id and experiment_name are specified,
+            or if tags are in invalid format.
+        ClickException: If run creation fails.
+    """
+    # Validate that exactly one of experiment_id or experiment_name is provided
+    if (experiment_id is not None and experiment_name is not None) or (
+        experiment_id is None and experiment_name is None
+    ):
+        raise click.UsageError("Must specify exactly one of --experiment-id or --experiment-name.")
+
+    # Parse tags from key=value format
+    tags_dict = {}
+    if tags:
+        for tag in tags:
+            if "=" not in tag:
+                raise click.UsageError(
+                    f"Invalid tag format: '{tag}'. Tags must be in key=value format."
+                )
+            key, value = tag.split("=", 1)
+            if key in tags_dict:
+                raise click.UsageError(f"Duplicate tag key: '{key}'")
+            tags_dict[key] = value
+
+    # Set the experiment if using experiment_name
+    if experiment_name:
+        experiment = mlflow.set_experiment(experiment_name=experiment_name)
+        experiment_id = experiment.experiment_id
+
+    # Start the run with the specified parameters
+    try:
+        # Start the run
+        active_run = mlflow.start_run(
+            experiment_id=experiment_id,
+            run_name=run_name,
+            nested=nested,
+            parent_run_id=parent_run_id,
+            tags=tags_dict,
+            description=description,
+            log_system_metrics=log_system_metrics,
+        )
+        run_id = active_run.info.run_id
+        actual_experiment_id = active_run.info.experiment_id
+
+        # End the run with the specified status
+        mlflow.end_run(status=RunStatus.to_string(getattr(RunStatus, status.upper())))
+
+        # Output the created run information
+        output = {
+            "run_id": run_id,
+            "experiment_id": actual_experiment_id,
+            "status": status.upper(),
+            "run_name": run_name,
+        }
+
+        click.echo(json.dumps(output, indent=2))
+
+    except MlflowException as e:
+        raise click.ClickException(f"Failed to create run: {e.message}")
+    except Exception as e:
+        raise click.ClickException(f"Unexpected error creating run: {e!s}")

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -96,40 +96,43 @@ def describe_run(run_id: str) -> None:
     "--experiment-id",
     envvar=MLFLOW_EXPERIMENT_ID.name,
     type=click.STRING,
-    help="ID of the experiment under which to create the run.",
+    help="ID of the experiment under which to create the run. "
+    "Must specify either this or --experiment-name.",
 )
 @click.option(
     "--experiment-name",
     envvar=MLFLOW_EXPERIMENT_NAME.name,
     type=click.STRING,
-    help="Name of the experiment under which to create the run.",
+    help="Name of the experiment under which to create the run. "
+    "Must specify either this or --experiment-id.",
 )
 @click.option(
     "--run-name",
     type=click.STRING,
-    help="Name to give the run (optional).",
+    help="Optional human-readable name for the run (e.g., 'baseline-model-v1').",
 )
 @click.option(
     "--description",
     type=click.STRING,
-    help="Description for the run (optional).",
+    help="Optional longer description of what this run represents.",
 )
 @click.option(
     "--tags",
     "-t",
     multiple=True,
-    help="Tags for the run in key=value format. Can be specified multiple times.",
+    help="Key-value pairs to categorize and filter runs. Use multiple times for "
+    "multiple tags. Format: key=value (e.g., env=prod, model=xgboost, version=1.0).",
 )
 @click.option(
     "--status",
     type=click.Choice(["FINISHED", "FAILED", "KILLED"], case_sensitive=False),
     default="FINISHED",
-    help="Status to set when ending the run. Default is FINISHED.",
+    help="Final status of the run. Options: FINISHED (default), FAILED, or KILLED.",
 )
 @click.option(
     "--parent-run-id",
     type=click.STRING,
-    help="ID of the parent run for nested runs (optional).",
+    help="Optional ID of a parent run to create a nested run under.",
 )
 def create_run(
     experiment_id: str | None,
@@ -146,23 +149,6 @@ def create_run(
     This command is useful for creating runs programmatically for testing, scripting,
     or recording completed experiments. The run will be created and immediately closed
     with the specified status (FINISHED, FAILED, or KILLED).
-
-    Args:
-        experiment_id: ID of the experiment under which to create the run.
-            Must specify either this or experiment_name.
-        experiment_name: Name of the experiment under which to create the run.
-            Must specify either this or experiment_id.
-        run_name: Optional human-readable name for the run (e.g., "baseline-model-v1").
-        description: Optional longer description of what this run represents.
-        tags: Key-value pairs to categorize and filter runs. Use multiple times for
-            multiple tags. Format: key=value (e.g., env=prod, model=xgboost, version=1.0).
-        status: Final status of the run. Options: FINISHED (default), FAILED, or KILLED.
-        parent_run_id: Optional ID of a parent run to create a nested run under.
-
-    Raises:
-        UsageError: If both or neither experiment_id and experiment_name are specified,
-            or if tags are in invalid format.
-        ClickException: If run creation fails.
     """
     # Validate that exactly one of experiment_id or experiment_name is provided
     if (experiment_id is not None and experiment_name is not None) or (

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -1,3 +1,4 @@
+import json
 import os
 import textwrap
 from unittest import mock
@@ -7,7 +8,7 @@ from click.testing import CliRunner
 
 import mlflow
 from mlflow import experiments
-from mlflow.runs import list_run
+from mlflow.runs import create_run, list_run
 
 
 def test_list_run():
@@ -57,3 +58,179 @@ def test_csv_generation(tmp_path):
         )
         with open(result_filename) as fd:
             assert expected_csv == fd.read()
+
+
+def test_create_run_with_experiment_id():
+    """Test creating a run with experiment ID."""
+    mlflow.create_experiment("test_create_run_exp")
+    exp = mlflow.get_experiment_by_name("test_create_run_exp")
+
+    result = CliRunner().invoke(create_run, ["--experiment-id", exp.experiment_id])
+    assert result.exit_code == 0
+
+    output = json.loads(result.output)
+    assert "run_id" in output
+    assert output["experiment_id"] == exp.experiment_id
+    assert output["status"] == "FINISHED"
+
+    # Verify the run was created
+    run = mlflow.get_run(output["run_id"])
+    assert run.info.experiment_id == exp.experiment_id
+    assert run.info.status == "FINISHED"
+
+
+def test_create_run_with_experiment_name():
+    """Test creating a run with experiment name."""
+    exp_name = "test_create_run_by_name"
+
+    result = CliRunner().invoke(create_run, ["--experiment-name", exp_name])
+    assert result.exit_code == 0
+
+    # Extract JSON from output (it may be mixed with logs)
+    lines = result.output.strip().split("\n")
+    json_output = None
+    for i in range(len(lines)):
+        if lines[i].strip() == "{":
+            # Found start of JSON, collect until closing brace
+            json_lines = []
+            for j in range(i, len(lines)):
+                json_lines.append(lines[j])
+                if lines[j].strip() == "}":
+                    json_output = "\n".join(json_lines)
+                    break
+            break
+
+    assert json_output is not None, "No JSON output found"
+    output = json.loads(json_output)
+    assert "run_id" in output
+    assert output["status"] == "FINISHED"
+
+    # Verify experiment was created
+    exp = mlflow.get_experiment_by_name(exp_name)
+    assert exp is not None
+    assert output["experiment_id"] == exp.experiment_id
+
+
+def test_create_run_with_custom_name_and_description():
+    """Test creating a run with custom name and description."""
+    mlflow.create_experiment("test_run_with_details")
+    exp = mlflow.get_experiment_by_name("test_run_with_details")
+
+    run_name = "my-custom-run"
+    description = "This is a test run"
+
+    result = CliRunner().invoke(
+        create_run,
+        [
+            "--experiment-id",
+            exp.experiment_id,
+            "--run-name",
+            run_name,
+            "--description",
+            description,
+        ],
+    )
+    assert result.exit_code == 0
+
+    output = json.loads(result.output)
+    assert output["run_name"] == run_name
+
+    # Verify run details
+    run = mlflow.get_run(output["run_id"])
+    assert run.data.tags.get("mlflow.note.content") == description
+    assert run.info.run_name == run_name
+
+
+def test_create_run_with_tags():
+    """Test creating a run with tags."""
+    mlflow.create_experiment("test_run_with_tags")
+    exp = mlflow.get_experiment_by_name("test_run_with_tags")
+
+    result = CliRunner().invoke(
+        create_run,
+        [
+            "--experiment-id",
+            exp.experiment_id,
+            "--tags",
+            "env=test",
+            "--tags",
+            "model=linear",
+            "--tags",
+            "version=1.0",
+        ],
+    )
+    assert result.exit_code == 0
+
+    output = json.loads(result.output)
+    run = mlflow.get_run(output["run_id"])
+
+    assert run.data.tags["env"] == "test"
+    assert run.data.tags["model"] == "linear"
+    assert run.data.tags["version"] == "1.0"
+
+
+def test_create_run_with_different_status():
+    """Test creating runs with different end statuses."""
+    mlflow.create_experiment("test_run_statuses")
+    exp = mlflow.get_experiment_by_name("test_run_statuses")
+
+    # Test FAILED status
+    result = CliRunner().invoke(
+        create_run, ["--experiment-id", exp.experiment_id, "--status", "FAILED"]
+    )
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output["status"] == "FAILED"
+
+    run = mlflow.get_run(output["run_id"])
+    assert run.info.status == "FAILED"
+
+    # Test KILLED status
+    result = CliRunner().invoke(
+        create_run, ["--experiment-id", exp.experiment_id, "--status", "KILLED"]
+    )
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert output["status"] == "KILLED"
+
+    run = mlflow.get_run(output["run_id"])
+    assert run.info.status == "KILLED"
+
+
+def test_create_run_missing_experiment():
+    """Test error when neither experiment-id nor experiment-name is provided."""
+    result = CliRunner().invoke(create_run, [])
+    assert result.exit_code != 0
+    assert "Must specify exactly one of --experiment-id or --experiment-name" in result.output
+
+
+def test_create_run_both_experiment_params():
+    """Test error when both experiment-id and experiment-name are provided."""
+    result = CliRunner().invoke(create_run, ["--experiment-id", "0", "--experiment-name", "test"])
+    assert result.exit_code != 0
+    assert "Must specify exactly one of --experiment-id or --experiment-name" in result.output
+
+
+def test_create_run_invalid_tag_format():
+    """Test error with invalid tag format."""
+    mlflow.create_experiment("test_invalid_tag")
+    exp = mlflow.get_experiment_by_name("test_invalid_tag")
+
+    result = CliRunner().invoke(
+        create_run, ["--experiment-id", exp.experiment_id, "--tags", "invalid-tag"]
+    )
+    assert result.exit_code != 0
+    assert "Invalid tag format" in result.output
+
+
+def test_create_run_duplicate_tag_key():
+    """Test error with duplicate tag keys."""
+    mlflow.create_experiment("test_duplicate_tag")
+    exp = mlflow.get_experiment_by_name("test_duplicate_tag")
+
+    result = CliRunner().invoke(
+        create_run,
+        ["--experiment-id", exp.experiment_id, "--tags", "env=test", "--tags", "env=prod"],
+    )
+    assert result.exit_code != 0
+    assert "Duplicate tag key" in result.output


### PR DESCRIPTION
Motivation: the analyze traces claude code slash command will create a run, link traces to it , and then log the markdown to the run as an artifact

### Related Issues/PRs

N/A - This is a new feature addition

### What changes are proposed in this pull request?

This PR adds a new CLI command `mlflow runs create` that allows users to programmatically create and immediately end runs without needing to write Python code. This is useful for automation scenarios, testing, and CI/CD pipelines.

The command supports:
- Creating runs by experiment ID or name
- Setting custom run names and descriptions  
- Adding tags with key=value pairs
- Controlling final run status (FINISHED, FAILED, KILLED)
- Parent run IDs for nested runs
- System metrics logging
- JSON output for easy parsing in scripts

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Added 9 comprehensive test cases covering:
- Basic run creation with experiment ID
- Run creation with experiment name (auto-creates experiment)
- Custom run names and descriptions
- Tag handling (parsing, validation, duplicate detection)
- Different run statuses (FINISHED, FAILED, KILLED)
- Error cases (missing experiment, invalid tags, both experiment params)
- JSON output parsing

Manual testing performed:
```bash
# Created run, logged artifacts, and verified retrieval
mlflow runs create --experiment-id 0 --run-name test-run
mlflow artifacts log-artifact --run-id <run-id> --local-file test.txt
mlflow artifacts list --run-id <run-id>
mlflow artifacts download --run-id <run-id> --dst-path ./downloaded
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

The CLI command includes comprehensive help text accessible via `mlflow runs create --help`

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added new `mlflow runs create` CLI command for programmatically creating and immediately ending runs with custom names, tags, and status.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)