### PR TITLE
Add deprecation warning to set_retriever_schema

### DIFF
--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -32,7 +32,7 @@ def set_retriever_schema(
     """
     Specify the return schema of a retriever span within your agent or generative AI app code.
 
-    .. deprecated:: 2.19.0
+    .. deprecated:: 3.3.2
         This function is deprecated and will be removed in a future version.
 
     **Note**: MLflow recommends that your retriever return the default MLflow retriever output

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import warnings
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from dataclasses import dataclass, field
@@ -30,6 +31,9 @@ def set_retriever_schema(
 ):
     """
     Specify the return schema of a retriever span within your agent or generative AI app code.
+
+    .. deprecated:: 2.19.0
+        This function is deprecated and will be removed in a future version.
 
     **Note**: MLflow recommends that your retriever return the default MLflow retriever output
     schema described in https://mlflow.org/docs/latest/tracing/tracing-schema#retriever-spans,
@@ -82,6 +86,17 @@ def set_retriever_schema(
                 name="my_custom_retriever",
             )
     """
+    warnings.warn(
+        "set_retriever_schema is deprecated and will be removed in a future version. "
+        "Please migrate to VectorSearchRetrieverTool in the 'databricks-ai-bridge' package, "
+        "or match the default schema so your retriever spans can be detected without requiring "
+        "explicit configuration. See "
+        "https://mlflow.org/docs/latest/tracing/tracing-schema#retriever-spans "
+        "for more information.",
+        category=DeprecationWarning,
+        stacklevel=2,
+    )
+    
     retriever_schemas = globals().get(DependenciesSchemasType.RETRIEVERS.value, [])
 
     # Check if a retriever schema with the same name already exists

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -88,10 +88,10 @@ def set_retriever_schema(
     """
     warnings.warn(
         "set_retriever_schema is deprecated and will be removed in a future version. "
-        "Please migrate to VectorSearchRetrieverTool in the 'databricks-ai-bridge' package, "
+        "Please migrate to use VectorSearchRetrieverTool in the 'databricks-ai-bridge' package, "
         "or match the default schema so your retriever spans can be detected without requiring "
         "explicit configuration. See "
-        "https://mlflow.org/docs/latest/tracing/tracing-schema#retriever-spans "
+        "https://mlflow.org/docs/latest/genai/data-model/traces/#retriever-spans "
         "for more information.",
         category=DeprecationWarning,
         stacklevel=2,

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -96,7 +96,7 @@ def set_retriever_schema(
         category=DeprecationWarning,
         stacklevel=2,
     )
-    
+
     retriever_schemas = globals().get(DependenciesSchemasType.RETRIEVERS.value, [])
 
     # Check if a retriever schema with the same name already exists

--- a/mlflow/models/dependencies_schemas.py
+++ b/mlflow/models/dependencies_schemas.py
@@ -36,7 +36,7 @@ def set_retriever_schema(
         This function is deprecated and will be removed in a future version.
 
     **Note**: MLflow recommends that your retriever return the default MLflow retriever output
-    schema described in https://mlflow.org/docs/latest/tracing/tracing-schema#retriever-spans,
+    schema described in https://mlflow.org/docs/latest/genai/data-model/traces/#retriever-spans,
     in which case you do not need to call `set_retriever_schema`. APIs that read MLflow traces
     and look for retriever spans, such as MLflow evaluation, will automatically detect retriever
     spans that match MLflow's default retriever schema.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/annzhang-db/mlflow/pull/17418?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17418/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17418/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17418/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

- Add deprecation warning for `set_retriever_schema` as using `set_retriever_schema` creates tags on traces that are too large
- We recommend using `VectorSearchRetrieverTool` now, which will take care of mapping/setting the correct schema

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

set_retriever_schema is deprecated and will be removed in a future version.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
