### PR TITLE
Fix Issue 17348: Support basic auth in TypeScript SDK

### DIFF
--- a/docs/docs/genai/tracing/quickstart/typescript-openai.mdx
+++ b/docs/docs/genai/tracing/quickstart/typescript-openai.mdx
@@ -98,6 +98,19 @@ _You can leave the `Artifact Location` field blank for now. It is an advanced co
     });
     ```
 
+    If [authentication](/ml/auth) is enabled on the tracking server, you can pass the credential through `trackingServerUsername` and `trackingServerPassword`.
+
+    ```typescript
+    import { init } from "mlflow-tracing";
+
+    init({
+        trackingUri: "<your-tracking-server-uri>",
+        experimentId: "<your-experiment-id>",
+        trackingServerUsername: "<your-tracking-server-username>",
+        trackingServerPassword: "<your-tracking-server-password>",
+    });
+    ```
+
     </TabItem>
 
     <TabItem value="remote" label="Remote MLflow Server">
@@ -110,6 +123,19 @@ _You can leave the `Artifact Location` field blank for now. It is an advanced co
     init({
         trackingUri: "<remote-tracking-server-uri>",
         experimentId: "<your-experiment-id>",
+    });
+    ```
+
+    If [authentication](/ml/auth) is enabled on the tracking server, you can pass the credential through `trackingServerUsername` and `trackingServerPassword`.
+
+    ```typescript
+    import { init } from "mlflow-tracing";
+
+    init({
+        trackingUri: "<remote-tracking-server-uri>",
+        experimentId: "<your-experiment-id>",
+        trackingServerUsername: "<remote-tracking-server-username>",
+        trackingServerPassword: "<remote-tracking-server-password>",
     });
     ```
 

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -20,7 +20,13 @@ export class MlflowClient {
   /** `password` for basic auth */
   private password?: string;
 
-  constructor(options: { trackingUri: string; host: string; databricksToken?: string; username?: string; password?: string }) {
+  constructor(options: {
+    trackingUri: string;
+    host: string;
+    databricksToken?: string;
+    username?: string;
+    password?: string;
+  }) {
     this.host = options.host;
     this.databricksToken = options.databricksToken;
     this.username = options.username;
@@ -117,6 +123,11 @@ export class MlflowClient {
   async deleteExperiment(experimentId: string): Promise<void> {
     const url = DeleteExperiment.getEndpoint(this.host);
     const payload: DeleteExperiment.Request = { experiment_id: experimentId };
-    await makeRequest<void>('POST', url, getRequestHeaders(this.databricksToken, this.username, this.password), payload);
+    await makeRequest<void>(
+      'POST',
+      url,
+      getRequestHeaders(this.databricksToken, this.username, this.password),
+      payload
+    );
   }
 }

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -15,22 +15,22 @@ export class MlflowClient {
   private databricksToken?: string;
   /** Client implementation to upload/download trace data artifacts */
   private artifactsClient: ArtifactsClient;
-  /** `username` for basic auth */
-  private username?: string;
-  /** `password` for basic auth */
-  private password?: string;
+  /** The tracking server username for basic auth */
+  private trackingServerUsername?: string;
+  /** The tracking server password for basic auth */
+  private trackingServerPassword?: string;
 
   constructor(options: {
     trackingUri: string;
     host: string;
     databricksToken?: string;
-    username?: string;
-    password?: string;
+    trackingServerUsername?: string;
+    trackingServerPassword?: string;
   }) {
     this.host = options.host;
     this.databricksToken = options.databricksToken;
-    this.username = options.username;
-    this.password = options.password;
+    this.trackingServerUsername = options.trackingServerUsername;
+    this.trackingServerPassword = options.trackingServerPassword;
     this.artifactsClient = getArtifactsClient({
       trackingUri: options.trackingUri,
       host: options.host,
@@ -52,7 +52,7 @@ export class MlflowClient {
     const response = await makeRequest<StartTraceV3.Response>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken, this.username, this.password),
+      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword),
       payload
     );
     return TraceInfo.fromJson(response.trace.trace_info);
@@ -79,7 +79,7 @@ export class MlflowClient {
     const response = await makeRequest<GetTraceInfoV3.Response>(
       'GET',
       url,
-      getRequestHeaders(this.databricksToken, this.username, this.password)
+      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword)
     );
 
     // The V3 API returns a Trace object with trace_info field
@@ -111,7 +111,7 @@ export class MlflowClient {
     const response = await makeRequest<CreateExperiment.Response>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken, this.username, this.password),
+      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword),
       payload
     );
     return response.experiment_id;
@@ -126,7 +126,7 @@ export class MlflowClient {
     await makeRequest<void>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken, this.username, this.password),
+      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword),
       payload
     );
   }

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -15,10 +15,16 @@ export class MlflowClient {
   private databricksToken?: string;
   /** Client implementation to upload/download trace data artifacts */
   private artifactsClient: ArtifactsClient;
+  /** `username` for basic auth */
+  private username?: string;
+  /** `password` for basic auth */
+  private password?: string;
 
-  constructor(options: { trackingUri: string; host: string; databricksToken?: string }) {
+  constructor(options: { trackingUri: string; host: string; databricksToken?: string; username?: string; password?: string }) {
     this.host = options.host;
     this.databricksToken = options.databricksToken;
+    this.username = options.username;
+    this.password = options.password;
     this.artifactsClient = getArtifactsClient({
       trackingUri: options.trackingUri,
       host: options.host,
@@ -40,7 +46,7 @@ export class MlflowClient {
     const response = await makeRequest<StartTraceV3.Response>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken),
+      getRequestHeaders(this.databricksToken, this.username, this.password),
       payload
     );
     return TraceInfo.fromJson(response.trace.trace_info);
@@ -67,7 +73,7 @@ export class MlflowClient {
     const response = await makeRequest<GetTraceInfoV3.Response>(
       'GET',
       url,
-      getRequestHeaders(this.databricksToken)
+      getRequestHeaders(this.databricksToken, this.username, this.password)
     );
 
     // The V3 API returns a Trace object with trace_info field
@@ -99,7 +105,7 @@ export class MlflowClient {
     const response = await makeRequest<CreateExperiment.Response>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken),
+      getRequestHeaders(this.databricksToken, this.username, this.password),
       payload
     );
     return response.experiment_id;
@@ -111,6 +117,6 @@ export class MlflowClient {
   async deleteExperiment(experimentId: string): Promise<void> {
     const url = DeleteExperiment.getEndpoint(this.host);
     const payload: DeleteExperiment.Request = { experiment_id: experimentId };
-    await makeRequest<void>('POST', url, getRequestHeaders(this.databricksToken), payload);
+    await makeRequest<void>('POST', url, getRequestHeaders(this.databricksToken, this.username, this.password), payload);
   }
 }

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -52,7 +52,11 @@ export class MlflowClient {
     const response = await makeRequest<StartTraceV3.Response>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword),
+      getRequestHeaders(
+        this.databricksToken,
+        this.trackingServerUsername,
+        this.trackingServerPassword
+      ),
       payload
     );
     return TraceInfo.fromJson(response.trace.trace_info);
@@ -79,7 +83,11 @@ export class MlflowClient {
     const response = await makeRequest<GetTraceInfoV3.Response>(
       'GET',
       url,
-      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword)
+      getRequestHeaders(
+        this.databricksToken,
+        this.trackingServerUsername,
+        this.trackingServerPassword
+      )
     );
 
     // The V3 API returns a Trace object with trace_info field
@@ -111,7 +119,11 @@ export class MlflowClient {
     const response = await makeRequest<CreateExperiment.Response>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword),
+      getRequestHeaders(
+        this.databricksToken,
+        this.trackingServerUsername,
+        this.trackingServerPassword
+      ),
       payload
     );
     return response.experiment_id;
@@ -126,7 +138,11 @@ export class MlflowClient {
     await makeRequest<void>(
       'POST',
       url,
-      getRequestHeaders(this.databricksToken, this.trackingServerUsername, this.trackingServerPassword),
+      getRequestHeaders(
+        this.databricksToken,
+        this.trackingServerUsername,
+        this.trackingServerPassword
+      ),
       payload
     );
   }

--- a/libs/typescript/core/src/clients/utils.ts
+++ b/libs/typescript/core/src/clients/utils.ts
@@ -1,16 +1,21 @@
 import { JSONBig } from '../core/utils/json';
 
 /**
- * Get the request headers for the given token.
+ * Get the request headers for the given token or basic auth credentials.
+ * Token will be used if provided, otherwise basic auth credentials will be used.
  *
  * @param token - The token to use to authenticate the request.
+ * @param username - The username to use to authenticate the request with basic auth.
+ * @param password - The password to use to authenticate the request with basic auth.
  * @returns The request headers.
  */
-export function getRequestHeaders(token?: string): Record<string, string> {
+export function getRequestHeaders(token?: string, username?: string, password?: string): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
+  } else if (username && password) {
+    headers['Authorization'] = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
   }
 
   return headers;

--- a/libs/typescript/core/src/clients/utils.ts
+++ b/libs/typescript/core/src/clients/utils.ts
@@ -9,7 +9,11 @@ import { JSONBig } from '../core/utils/json';
  * @param password - The password to use to authenticate the request with basic auth.
  * @returns The request headers.
  */
-export function getRequestHeaders(token?: string, username?: string, password?: string): Record<string, string> {
+export function getRequestHeaders(
+  token?: string,
+  username?: string,
+  password?: string
+): Record<string, string> {
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
   if (token) {

--- a/libs/typescript/core/src/core/config.ts
+++ b/libs/typescript/core/src/core/config.ts
@@ -57,14 +57,14 @@ export interface MLflowTracingConfig {
   databricksToken?: string;
 
   /**
-   * The `username` for basic auth when it's enabled.
+   * The tracking server username for basic auth.
    */
-  username?: string;
+  trackingServerUsername?: string;
 
   /**
-   * The `password` for basic auth when it's enabled.
+   * The tracking server password for basic auth.
    */
-  password?: string;
+  trackingServerPassword?: string;
 }
 
 /**

--- a/libs/typescript/core/src/core/config.ts
+++ b/libs/typescript/core/src/core/config.ts
@@ -55,6 +55,16 @@ export interface MLflowTracingConfig {
    * The Databricks token. If not provided, the token will be read from the Databricks config file.
    */
   databricksToken?: string;
+
+  /**
+   * The `username` for basic auth when it's enabled.
+   */
+  username?: string;
+
+  /**
+   * The `password` for basic auth when it's enabled.
+   */
+  password?: string;
 }
 
 /**

--- a/libs/typescript/core/src/core/provider.ts
+++ b/libs/typescript/core/src/core/provider.ts
@@ -26,8 +26,8 @@ export function initializeSDK(): void {
       trackingUri: hostConfig.trackingUri,
       host: hostConfig.host,
       databricksToken: hostConfig.databricksToken,
-      username: hostConfig.username,
-      password: hostConfig.password
+      trackingServerUsername: hostConfig.trackingServerUsername,
+      trackingServerPassword: hostConfig.trackingServerPassword
     });
     const exporter = new MlflowSpanExporter(client);
     processor = new MlflowSpanProcessor(exporter);

--- a/libs/typescript/core/src/core/provider.ts
+++ b/libs/typescript/core/src/core/provider.ts
@@ -25,7 +25,9 @@ export function initializeSDK(): void {
     const client = new MlflowClient({
       trackingUri: hostConfig.trackingUri,
       host: hostConfig.host,
-      databricksToken: hostConfig.databricksToken
+      databricksToken: hostConfig.databricksToken,
+      username: hostConfig.username,
+      password: hostConfig.password
     });
     const exporter = new MlflowSpanExporter(client);
     processor = new MlflowSpanProcessor(exporter);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kevin-lyn/mlflow/pull/17436?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17436/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17436/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17436/merge
```

</p>
</details>

### Related Issues/PRs

#17348 

### What changes are proposed in this pull request?

Expose `username` and `password` in `MlflowClient` and the global config.
So that the TS SDK can surface the `username` and `password` in the header.

### How is this PR tested?

Manual tests with spinning up local server with `basic-auth` enabled.

### Does this PR require documentation update?

No

### Release Notes

Expose `username` and `password` in the TypeScript SDK.

#### Is this a user-facing change?

TypeScript SDK can now use the following to authenticate when basic auth is enabled in the tracking server:
```
import { init } from "mlflow-tracing";

init({
    trackingUri: "<your-tracking-server-uri>",
    experimentId: "<your-experiment-id>",
    username: "<your-username>",
    password: "<your-password>",
});
```

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
