### PR TITLE
Attempt at "move to top" and "move to bottom"

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridContext.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/RunsChartsDraggableCardsGridContext.tsx
@@ -71,6 +71,27 @@ export const RunsChartsDraggableCardsGridContextProvider = ({
         }
 
         const indexSource = newChartsOrder.findIndex((c) => c.uuid === sourceChartUuid);
+
+        // Handle "Move to Top" / "Move to Bottom" special uuid
+        if (targetChartUuid === '__TOP__') {
+          if (indexSource < 0) {
+            return current;
+          }
+          const sourceChart = newChartsOrder[indexSource];
+          newChartsOrder.splice(indexSource, 1);
+          newChartsOrder.unshift(sourceChart);
+          return { ...current, compareRunCharts: newChartsOrder };
+        }
+        if (targetChartUuid === '__BOTTOM__') {
+          if (indexSource < 0) {
+            return current;
+          }
+          const sourceChart = newChartsOrder[indexSource];
+          newChartsOrder.splice(indexSource, 1);
+          newChartsOrder.push(sourceChart);
+          return { ...current, compareRunCharts: newChartsOrder };
+        }
+
         const indexTarget = newChartsOrder.findIndex((c) => c.uuid === targetChartUuid);
 
         // If one of the charts is not found, do nothing

--- a/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/ChartCard.common.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/runs-charts/components/cards/ChartCard.common.tsx
@@ -116,6 +116,14 @@ const RunsChartCardWrapperRaw = ({
     () => onReorderWith(uuid || '', nextChartUuid || ''),
     [onReorderWith, uuid, nextChartUuid],
   );
+  const onMoveToTop = useCallback(
+    () => onReorderWith(uuid || '', '__TOP__'),
+    [onReorderWith, uuid],
+  );
+  const onMoveToBottom = useCallback(
+    () => onReorderWith(uuid || '', '__BOTTOM__'),
+    [onReorderWith, uuid],
+  );
 
   const usingCustomTitle = React.isValidElement(title);
 
@@ -281,6 +289,16 @@ const RunsChartCardWrapperRaw = ({
             )}
             <DropdownMenu.Separator />
             <DropdownMenu.Item
+              componentId="codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_move_to_top"
+              onClick={onMoveToTop}
+              data-testid="experiment-view-compare-runs-move-to-top"
+            >
+              <FormattedMessage
+                defaultMessage="Move to top"
+                description="Experiment page > compare runs tab > chart header > move to top option"
+              />
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
               componentId="codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_334"
               disabled={!canMoveUp}
               onClick={onMoveUp}
@@ -300,6 +318,16 @@ const RunsChartCardWrapperRaw = ({
               <FormattedMessage
                 defaultMessage="Move down"
                 description="Experiment page > compare runs tab > chart header > move down option"
+              />
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              componentId="codegen_mlflow_app_src_experiment-tracking_components_runs-charts_components_cards_chartcard.common.tsx_move_to_top"
+              onClick={onMoveToBottom}
+              data-testid="experiment-view-compare-runs-move-to-bottom"
+            >
+              <FormattedMessage
+                defaultMessage="Move to bottom"
+                description="Experiment page > compare runs tab > chart header > move to bottom option"
               />
             </DropdownMenu.Item>
             {additionalMenuContent}


### PR DESCRIPTION
### Related Issues/PRs

An attempt at #17413

### What changes are proposed in this pull request?

Add "move to top" and "move to bottom" to chart cards.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add "Move to top" and "Move to bottom" to chart cards' context menu. They move the selected chart to either the top or bottom of the section, regardless of the current search filter.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
