### PR TITLE
[CLI] Add 'mlflow runs link-traces' command

### DIFF
--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -246,7 +246,7 @@ def link_traces(experiment_id: str | None, run_id: str, trace_id: tuple[str, ...
         # Set the experiment context if provided
         if experiment_id:
             mlflow.set_experiment(experiment_id=experiment_id)
-        
+
         client = MlflowClient()
         client.link_traces_to_run(trace_ids, run_id)
 

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -211,13 +211,6 @@ def create_run(
 
 @commands.command("link-traces")
 @click.option(
-    "--experiment-id",
-    "-x",
-    envvar=MLFLOW_EXPERIMENT_ID.name,
-    type=click.STRING,
-    help="ID of the experiment containing the run (optional, for validation).",
-)
-@click.option(
     "--run-id",
     type=click.STRING,
     required=True,
@@ -230,23 +223,18 @@ def create_run(
     required=True,
     help="Trace ID to link to the run. Can be specified multiple times (maximum 100 traces).",
 )
-def link_traces(experiment_id: str | None, run_id: str, trace_id: tuple[str, ...]) -> None:
+def link_traces(run_id: str, trace_id: tuple[str, ...]) -> None:
     """
     Link traces to a run.
 
     This command links one or more traces to an existing run. Traces can be
-    linked to runs to establish relationships between traces and runs within
-    the same experiment. Maximum 100 traces can be linked in a single command.
+    linked to runs to establish relationships between traces and runs.
+    Maximum 100 traces can be linked in a single command.
     """
-
     # Convert tuple to list
     trace_ids = list(trace_id)
 
     try:
-        # Set the experiment context if provided
-        if experiment_id:
-            mlflow.set_experiment(experiment_id=experiment_id)
-
         client = MlflowClient()
         client.link_traces_to_run(trace_ids, run_id)
 

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -211,6 +211,13 @@ def create_run(
 
 @commands.command("link-traces")
 @click.option(
+    "--experiment-id",
+    "-x",
+    envvar=MLFLOW_EXPERIMENT_ID.name,
+    type=click.STRING,
+    help="ID of the experiment containing the run (optional, for validation).",
+)
+@click.option(
     "--run-id",
     type=click.STRING,
     required=True,
@@ -223,7 +230,7 @@ def create_run(
     required=True,
     help="Trace ID to link to the run. Can be specified multiple times (maximum 100 traces).",
 )
-def link_traces(run_id: str, trace_id: tuple[str, ...]) -> None:
+def link_traces(experiment_id: str | None, run_id: str, trace_id: tuple[str, ...]) -> None:
     """
     Link traces to a run.
 
@@ -236,6 +243,10 @@ def link_traces(run_id: str, trace_id: tuple[str, ...]) -> None:
     trace_ids = list(trace_id)
 
     try:
+        # Set the experiment context if provided
+        if experiment_id:
+            mlflow.set_experiment(experiment_id=experiment_id)
+        
         client = MlflowClient()
         client.link_traces_to_run(trace_ids, run_id)
 

--- a/mlflow/runs.py
+++ b/mlflow/runs.py
@@ -217,13 +217,14 @@ def create_run(
     help="ID of the run to link traces to.",
 )
 @click.option(
+    "trace_ids",
     "--trace-id",
     "-t",
     multiple=True,
     required=True,
     help="Trace ID to link to the run. Can be specified multiple times (maximum 100 traces).",
 )
-def link_traces(run_id: str, trace_id: tuple[str, ...]) -> None:
+def link_traces(run_id: str, trace_ids: tuple[str, ...]) -> None:
     """
     Link traces to a run.
 
@@ -231,12 +232,9 @@ def link_traces(run_id: str, trace_id: tuple[str, ...]) -> None:
     linked to runs to establish relationships between traces and runs.
     Maximum 100 traces can be linked in a single command.
     """
-    # Convert tuple to list
-    trace_ids = list(trace_id)
-
     try:
         client = MlflowClient()
-        client.link_traces_to_run(trace_ids, run_id)
+        client.link_traces_to_run(list(trace_ids), run_id)
 
         # Output success message with count
         click.echo(f"Successfully linked {len(trace_ids)} trace(s) to run '{run_id}'")

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -218,9 +218,10 @@ def test_create_run_duplicate_tag_key():
 
 def test_link_traces_single_trace():
     mock_client = MagicMock()
-    with patch("mlflow.runs.MlflowClient", return_value=mock_client) as mock_client_class, \
-         patch("mlflow.runs.mlflow") as mock_mlflow:
-
+    with (
+        patch("mlflow.runs.MlflowClient", return_value=mock_client),
+        patch("mlflow.runs.mlflow") as mock_mlflow,
+    ):
         result = CliRunner().invoke(
             link_traces,
             ["--run-id", "test_run_123", "--trace-id", "trace_abc"],
@@ -234,9 +235,10 @@ def test_link_traces_single_trace():
 
 def test_link_traces_multiple_traces():
     mock_client = MagicMock()
-    with patch("mlflow.runs.MlflowClient", return_value=mock_client) as mock_client_class, \
-         patch("mlflow.runs.mlflow") as mock_mlflow:
-
+    with (
+        patch("mlflow.runs.MlflowClient", return_value=mock_client),
+        patch("mlflow.runs.mlflow") as mock_mlflow,
+    ):
         result = CliRunner().invoke(
             link_traces,
             [
@@ -261,9 +263,10 @@ def test_link_traces_multiple_traces():
 
 def test_link_traces_with_short_option():
     mock_client = MagicMock()
-    with patch("mlflow.runs.MlflowClient", return_value=mock_client) as mock_client_class, \
-         patch("mlflow.runs.mlflow") as mock_mlflow:
-
+    with (
+        patch("mlflow.runs.MlflowClient", return_value=mock_client),
+        patch("mlflow.runs.mlflow") as mock_mlflow,
+    ):
         result = CliRunner().invoke(
             link_traces,
             ["--run-id", "run_789", "-t", "trace_x", "-t", "trace_y"],
@@ -281,9 +284,10 @@ def test_link_traces_file_store_error():
         "Linking traces to runs is not supported in FileStore. "
         "Please use a database-backed store (e.g., SQLAlchemy store) for this feature."
     )
-    with patch("mlflow.runs.MlflowClient", return_value=mock_client) as mock_client_class, \
-         patch("mlflow.runs.mlflow") as mock_mlflow:
-
+    with (
+        patch("mlflow.runs.MlflowClient", return_value=mock_client),
+        patch("mlflow.runs.mlflow") as mock_mlflow,
+    ):
         result = CliRunner().invoke(
             link_traces,
             ["--run-id", "test_run", "--trace-id", "trace_1"],
@@ -300,9 +304,10 @@ def test_link_traces_too_many_traces_error():
     mock_client.link_traces_to_run.side_effect = MlflowException(
         "Cannot link more than 100 traces to a run in a single request. Provided 101 traces."
     )
-    with patch("mlflow.runs.MlflowClient", return_value=mock_client) as mock_client_class, \
-         patch("mlflow.runs.mlflow") as mock_mlflow:
-
+    with (
+        patch("mlflow.runs.MlflowClient", return_value=mock_client),
+        patch("mlflow.runs.mlflow") as mock_mlflow,
+    ):
         result = CliRunner().invoke(
             link_traces,
             ["--run-id", "test_run", "--trace-id", "trace_1"],
@@ -331,9 +336,10 @@ def test_link_traces_missing_trace_id():
 def test_link_traces_generic_error():
     mock_client = MagicMock()
     mock_client.link_traces_to_run.side_effect = MlflowException("Some other error")
-    with patch("mlflow.runs.MlflowClient", return_value=mock_client) as mock_client_class, \
-         patch("mlflow.runs.mlflow") as mock_mlflow:
-
+    with (
+        patch("mlflow.runs.MlflowClient", return_value=mock_client),
+        patch("mlflow.runs.mlflow") as mock_mlflow,
+    ):
         result = CliRunner().invoke(
             link_traces,
             ["--run-id", "test_run", "--trace-id", "trace_1"],
@@ -346,9 +352,10 @@ def test_link_traces_generic_error():
 
 def test_link_traces_with_experiment_id():
     mock_client = MagicMock()
-    with patch("mlflow.runs.MlflowClient", return_value=mock_client) as mock_client_class, \
-         patch("mlflow.runs.mlflow") as mock_mlflow:
-
+    with (
+        patch("mlflow.runs.MlflowClient", return_value=mock_client),
+        patch("mlflow.runs.mlflow") as mock_mlflow,
+    ):
         result = CliRunner().invoke(
             link_traces,
             ["--experiment-id", "exp_123", "--run-id", "run_456", "--trace-id", "trace_abc"],

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -3,13 +3,15 @@ import logging
 import os
 import textwrap
 from unittest import mock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
 
 import mlflow
 from mlflow import experiments
-from mlflow.runs import create_run, list_run
+from mlflow.exceptions import MlflowException
+from mlflow.runs import create_run, link_traces, list_run
 
 
 @pytest.fixture(autouse=True)
@@ -212,3 +214,128 @@ def test_create_run_duplicate_tag_key():
     )
     assert result.exit_code != 0
     assert "Duplicate tag key" in result.output
+
+
+def test_link_traces_single_trace():
+    with patch("mlflow.MlflowClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.link_traces_to_run.return_value = None
+
+        result = CliRunner().invoke(
+            link_traces,
+            ["--run-id", "test_run_123", "--trace-id", "trace_abc"],
+        )
+
+        assert result.exit_code == 0
+        assert "Successfully linked 1 trace(s) to run 'test_run_123'" in result.output
+        mock_client.link_traces_to_run.assert_called_once_with(["trace_abc"], "test_run_123")
+
+
+def test_link_traces_multiple_traces():
+    with patch("mlflow.MlflowClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.link_traces_to_run.return_value = None
+
+        result = CliRunner().invoke(
+            link_traces,
+            [
+                "--run-id",
+                "test_run_456",
+                "--trace-id",
+                "trace_1",
+                "--trace-id",
+                "trace_2",
+                "--trace-id",
+                "trace_3",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert "Successfully linked 3 trace(s) to run 'test_run_456'" in result.output
+        mock_client.link_traces_to_run.assert_called_once_with(
+            ["trace_1", "trace_2", "trace_3"], "test_run_456"
+        )
+
+
+def test_link_traces_with_short_option():
+    with patch("mlflow.MlflowClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.link_traces_to_run.return_value = None
+
+        result = CliRunner().invoke(
+            link_traces,
+            ["--run-id", "run_789", "-t", "trace_x", "-t", "trace_y"],
+        )
+
+        assert result.exit_code == 0
+        assert "Successfully linked 2 trace(s) to run 'run_789'" in result.output
+        mock_client.link_traces_to_run.assert_called_once_with(["trace_x", "trace_y"], "run_789")
+
+
+def test_link_traces_file_store_error():
+    with patch("mlflow.MlflowClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.link_traces_to_run.side_effect = MlflowException(
+            "Linking traces to runs is not supported in FileStore. "
+            "Please use a database-backed store (e.g., SQLAlchemy store) for this feature."
+        )
+
+        result = CliRunner().invoke(
+            link_traces,
+            ["--run-id", "test_run", "--trace-id", "trace_1"],
+        )
+
+        assert result.exit_code != 0
+        assert "Failed to link traces" in result.output
+        assert "not supported in FileStore" in result.output
+
+
+def test_link_traces_too_many_traces_error():
+    with patch("mlflow.MlflowClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.link_traces_to_run.side_effect = MlflowException(
+            "Cannot link more than 100 traces to a run in a single request. Provided 101 traces."
+        )
+
+        result = CliRunner().invoke(
+            link_traces,
+            ["--run-id", "test_run", "--trace-id", "trace_1"],
+        )
+
+        assert result.exit_code != 0
+        assert "Failed to link traces" in result.output
+        assert "100" in result.output
+
+
+def test_link_traces_missing_run_id():
+    result = CliRunner().invoke(link_traces, ["--trace-id", "trace_1"])
+
+    assert result.exit_code != 0
+    assert "Missing option '--run-id'" in result.output
+
+
+def test_link_traces_missing_trace_id():
+    result = CliRunner().invoke(link_traces, ["--run-id", "test_run"])
+
+    assert result.exit_code != 0
+    assert "Missing option '--trace-id'" in result.output
+
+
+def test_link_traces_generic_error():
+    with patch("mlflow.MlflowClient") as mock_client_class:
+        mock_client = MagicMock()
+        mock_client_class.return_value = mock_client
+        mock_client.link_traces_to_run.side_effect = MlflowException("Some other error")
+
+        result = CliRunner().invoke(
+            link_traces,
+            ["--run-id", "test_run", "--trace-id", "trace_1"],
+        )
+
+        assert result.exit_code != 0
+        assert "Failed to link traces: Some other error" in result.output


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR adds a new CLI command `mlflow runs link-traces` to link traces to runs, enabling users to establish relationships between traces and runs within the same experiment via the command line interface.

- Added `link-traces` command to `mlflow/runs.py` that allows linking one or more traces to an existing run
- Supports both long form (`--trace-id`) and short form (`-t`) options for specifying trace IDs  
- Can link up to 100 traces in a single command (API limitation documented in help text)
- Returns a success message with the count of traces linked
- Added comprehensive test coverage in `tests/test_runs.py`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

#### New Unit Tests
Added extensive test coverage in `tests/test_runs.py`:
- `test_link_traces_single_trace`: Tests linking a single trace
- `test_link_traces_multiple_traces`: Tests linking multiple traces
- `test_link_traces_with_short_option`: Tests using the `-t` short option
- `test_link_traces_file_store_error`: Tests error handling for unsupported FileStore
- `test_link_traces_too_many_traces_error`: Tests error when exceeding 100 trace limit
- `test_link_traces_missing_run_id`: Tests validation for missing run ID
- `test_link_traces_missing_trace_id`: Tests validation for missing trace IDs
- `test_link_traces_generic_error`: Tests generic error handling

#### Manual Testing
Tested manually with a Databricks tracking server:

1. Created a new run:
```bash
export DATABRICKS_HOST=https://[REDACTED].cloud.databricks.com
export DATABRICKS_TOKEN=[REDACTED]
export MLFLOW_TRACKING_URI=databricks
export MLFLOW_EXPERIMENT_ID=2178582188830602

mlflow runs create --experiment-id $MLFLOW_EXPERIMENT_ID --run-name "test-link-traces-cli"
# Output: {"run_id": "37ba9f983ca840a08d40f2d5750c7939", ...}
```

2. Found existing traces in the experiment:
```bash
mlflow traces search --experiment-id 2178582188830602 --max-results 5
# Listed traces including: tr-6fb236e9e5ecdc6b2de7e3fbe6857137
```

3. Linked a single trace to the run:
```bash
mlflow runs link-traces --run-id 37ba9f983ca840a08d40f2d5750c7939 --trace-id tr-6fb236e9e5ecdc6b2de7e3fbe6857137
# Output: Successfully linked 1 trace(s) to run '37ba9f983ca840a08d40f2d5750c7939'
```

4. Linked multiple traces using short option:
```bash
mlflow runs link-traces --run-id 37ba9f983ca840a08d40f2d5750c7939 -t tr-10cb247de042863645f08fcb56d868b3 -t tr-8086573c30ff0cc4163bdb5d52781436
# Output: Successfully linked 2 trace(s) to run '37ba9f983ca840a08d40f2d5750c7939'
```

5. Verified traces are linked by searching with run_id filter:
```bash
mlflow traces search --experiment-id 2178582188830602 --filter-string "run_id = '37ba9f983ca840a08d40f2d5750c7939'" --max-results 10
# Showed all 3 linked traces
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

Updated docstrings and CLI help text in the code. Full documentation updates may be needed as a follow-up.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a new CLI command `mlflow runs link-traces` to link traces to runs, allowing users to establish relationships between traces and runs within the same experiment.

Example usage:
```bash
# Link a single trace
mlflow runs link-traces --run-id <run-id> --trace-id <trace-id>

# Link multiple traces
mlflow runs link-traces --run-id <run-id> --trace-id <trace1> --trace-id <trace2>

# Using short option
mlflow runs link-traces --run-id <run-id> -t <trace1> -t <trace2>

# Using short options
mlflow runs link-traces -x <exp-id> --run-id <run-id> -t <trace1> -t <trace2>
```

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)