### PR TITLE
Create/Add MLflow Client Version Header for Requests

### DIFF
--- a/mlflow/tracking/request_header/default_request_header_provider.py
+++ b/mlflow/tracking/request_header/default_request_header_provider.py
@@ -2,7 +2,12 @@ from mlflow import __version__
 from mlflow.tracking.request_header.abstract_request_header_provider import RequestHeaderProvider
 
 _USER_AGENT = "User-Agent"
-_DEFAULT_HEADERS = {_USER_AGENT: f"mlflow-python-client/{__version__}"}
+_CLIENT_VERSION = "X-MLflow-Client-Version"
+# We need to specify client version in separate header as user agent is overwritten in SDK call path
+_DEFAULT_HEADERS = {
+    _USER_AGENT: f"mlflow-python-client/{__version__}",
+    _CLIENT_VERSION: f"{__version__}",
+}
 
 
 class DefaultRequestHeaderProvider(RequestHeaderProvider):

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -110,6 +110,12 @@ def http_request(
         MLFLOW_HTTP_REQUEST_BACKOFF_JITTER.get() if backoff_jitter is None else backoff_jitter
     )
 
+    from mlflow.tracking.request_header.registry import resolve_request_headers
+
+    headers = dict(**resolve_request_headers())
+    if extra_headers:
+        headers = dict(**headers, **extra_headers)
+
     if host_creds.use_databricks_sdk:
         from databricks.sdk.errors import DatabricksError
 
@@ -134,7 +140,7 @@ def http_request(
                 raw_response = ws_client.api_client.do(
                     method=method,
                     path=endpoint,
-                    headers=extra_headers,
+                    headers=headers,
                     raw=True,
                     query=kwargs.get("params"),
                     body=kwargs.get("json"),
@@ -203,12 +209,6 @@ def http_request(
             f"'{MLFLOW_ENABLE_DB_SDK.name}' to true",
             error_code=CUSTOMER_UNAUTHORIZED,
         )
-
-    from mlflow.tracking.request_header.registry import resolve_request_headers
-
-    headers = dict(**resolve_request_headers())
-    if extra_headers:
-        headers = dict(**headers, **extra_headers)
 
     if auth_str:
         headers["Authorization"] = auth_str

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -14,6 +14,7 @@ from mlflow.protos.databricks_pb2 import ENDPOINT_NOT_FOUND, ErrorCode
 from mlflow.protos.service_pb2 import GetRun
 from mlflow.pyfunc.scoring_server import NumpyEncoder
 from mlflow.tracking.request_header.default_request_header_provider import (
+    _CLIENT_VERSION,
     _USER_AGENT,
     DefaultRequestHeaderProvider,
 )
@@ -318,7 +319,7 @@ def test_http_request_request_headers(request):
 
 
 @mock.patch("requests.Session.request")
-def test_http_request_request_headers_user_agent(request):
+def test_http_request_request_headers_default(request):
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
 
     from mlflow_test_plugin.request_header_provider import PluginRequestHeaderProvider
@@ -331,14 +332,16 @@ def test_http_request_request_headers_user_agent(request):
         mock.patch.object(
             PluginRequestHeaderProvider,
             "request_headers",
-            return_value={_USER_AGENT: "test_user_agent"},
+            return_value={_USER_AGENT: "test_user_agent", _CLIENT_VERSION: "test_client_version"},
         ),
     ):
         host_only = MlflowHostCreds("http://my-host", server_cert_path="/some/path")
+        default_headers = DefaultRequestHeaderProvider().request_headers()
         expected_headers = {
-            _USER_AGENT: "{} {}".format(
-                DefaultRequestHeaderProvider().request_headers()[_USER_AGENT], "test_user_agent"
-            )
+            _USER_AGENT: "{} {}".format(default_headers[_USER_AGENT], "test_user_agent"),
+            _CLIENT_VERSION: "{} {}".format(
+                default_headers[_CLIENT_VERSION], "test_client_version"
+            ),
         }
 
         response = mock.MagicMock()
@@ -356,7 +359,7 @@ def test_http_request_request_headers_user_agent(request):
 
 
 @mock.patch("requests.Session.request")
-def test_http_request_request_headers_user_agent_and_extra_header(request):
+def test_http_request_request_headers_default_and_extra_header(request):
     """This test requires the package in tests/resources/mlflow-test-plugin to be installed"""
 
     from mlflow_test_plugin.request_header_provider import PluginRequestHeaderProvider
@@ -369,13 +372,19 @@ def test_http_request_request_headers_user_agent_and_extra_header(request):
         mock.patch.object(
             PluginRequestHeaderProvider,
             "request_headers",
-            return_value={_USER_AGENT: "test_user_agent", "header": "value"},
+            return_value={
+                _USER_AGENT: "test_user_agent",
+                _CLIENT_VERSION: "test_client_version",
+                "header": "value",
+            },
         ),
     ):
         host_only = MlflowHostCreds("http://my-host", server_cert_path="/some/path")
+        default_headers = DefaultRequestHeaderProvider().request_headers()
         expected_headers = {
-            _USER_AGENT: "{} {}".format(
-                DefaultRequestHeaderProvider().request_headers()[_USER_AGENT], "test_user_agent"
+            _USER_AGENT: "{} {}".format(default_headers[_USER_AGENT], "test_user_agent"),
+            _CLIENT_VERSION: "{} {}".format(
+                default_headers[_CLIENT_VERSION], "test_client_version"
             ),
             "header": "value",
         }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/raymondzhou-db/mlflow/pull/17449?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17449/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17449/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17449/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Update the MLflow client to include the client version in a separate header. Currently we only set this header under `user-agent`, and this is only included in the non-SDK path. Even if we include the existing `user-agent` in the SDK path, it is overwritten, so we need a new header

Motivation here is to understand MLflow 3 adoption, which we can get from the client version. See [Databricks PR](https://github.com/databricks-eng/universe/pull/1266325) for usage

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Manually confirmed that this header is visible in the Databricks backend (e.g. 3.3.1.dev0) for both the SDK and non-SDK paths

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
