### PR TITLE
Add documentation for updating signatures on Databricks registered models

### DIFF
--- a/docs/docs/classic-ml/model/signatures/index.mdx
+++ b/docs/docs/classic-ml/model/signatures/index.mdx
@@ -1070,7 +1070,7 @@ assert get_model_info(model_uri).signature == signature
 
 ### Working with Model Registry
 
-For registered models, update the source and create a new version:
+For registered models not on Databricks, update the source and create a new version:
 
 ```python
 from mlflow.client import MlflowClient
@@ -1088,6 +1088,54 @@ set_signature(mv.source, signature)
 
 # Create new model version with updated signature
 client.create_model_version(name=model_name, source=mv.source, run_id=mv.run_id)
+```
+
+### Working with Model Registry in Databricks
+
+For models registered on Databricks, the underlying model version artifacts 
+are immutable, so we need to load the model artifacts and create a new 
+version with the signature:
+
+```python
+from mlflow.client import MlflowClient
+
+client = MlflowClient()
+model_name = "my_registered_model"
+model_version = 1
+
+# Get existing model version
+mv = client.get_model_version(name=model_name, version=model_version)
+# Load the model, be sure to match the flavor of the original model.
+# Can use a snippet like this to get the original flavor:
+'''
+model_info = mlflow.models.get_model_info(mv.source)
+print(f"Original flavor: {list(model_info.flavors.keys())}")
+'''
+loaded_model = mlflow.sklearn.load_model(mv.source)
+
+# Provide signature, e.g. via infer_signature on dataset
+signature = infer_signature(X_test, predictions)
+
+with mlflow.start_run() as r:
+    model_info = mlflow.sklearn.log_model(
+        loaded_model,
+        name="my_model",
+        signature=signature,
+    )
+    # Create new model version with updated signature
+    client.create_model_version(name=model_name, source=model_info.model_uri)
+```
+
+NOTE: For `pyfunc` models, you will need to unwrap the model as follows:
+```python
+with mlflow.start_run() as r:
+    model_info = mlflow.pyfunc.log_model(
+        python_model=loaded.unwrap_python_model(),
+        name="my_model",
+        signature=signature,
+    )
+    # Create new model version with updated signature
+    client.create_model_version(name=model_name, source=model_info.model_uri)
 ```
 
   </TabItem>

--- a/docs/docs/classic-ml/model/signatures/index.mdx
+++ b/docs/docs/classic-ml/model/signatures/index.mdx
@@ -1092,7 +1092,7 @@ loaded_model = mlflow.sklearn.load_model(mv.source)
 # Provide signature, e.g. via infer_signature on dataset
 signature = infer_signature(X_test, predictions)
 
-with mlflow.start_run() as r:
+with mlflow.start_run():
     model_info = mlflow.sklearn.log_model(
         loaded_model,
         name="my_model",
@@ -1105,7 +1105,7 @@ with mlflow.start_run() as r:
 NOTE: For `pyfunc` models, you will need to unwrap the model as follows:
 
 ```python
-with mlflow.start_run() as r:
+with mlflow.start_run():
     model_info = mlflow.pyfunc.log_model(
         python_model=loaded.unwrap_python_model(),
         name="my_model",

--- a/docs/docs/classic-ml/model/signatures/index.mdx
+++ b/docs/docs/classic-ml/model/signatures/index.mdx
@@ -1107,10 +1107,10 @@ model_version = 1
 mv = client.get_model_version(name=model_name, version=model_version)
 # Load the model, be sure to match the flavor of the original model.
 # Can use a snippet like this to get the original flavor:
-'''
+"""
 model_info = mlflow.models.get_model_info(mv.source)
 print(f"Original flavor: {list(model_info.flavors.keys())}")
-'''
+"""
 loaded_model = mlflow.sklearn.load_model(mv.source)
 
 # Provide signature, e.g. via infer_signature on dataset

--- a/docs/docs/classic-ml/model/signatures/index.mdx
+++ b/docs/docs/classic-ml/model/signatures/index.mdx
@@ -1068,33 +1068,9 @@ from mlflow.models.model import get_model_info
 assert get_model_info(model_uri).signature == signature
 ```
 
-### Working with Model Registry
+### Adding Signatures to Registered Model Versions
 
-For registered models not on Databricks, update the source and create a new version:
-
-```python
-from mlflow.client import MlflowClient
-
-client = MlflowClient()
-model_name = "my_registered_model"
-model_version = 1
-
-# Get existing model version
-mv = client.get_model_version(name=model_name, version=model_version)
-
-# Update signature on source artifacts
-signature = infer_signature(X_test, predictions)
-set_signature(mv.source, signature)
-
-# Create new model version with updated signature
-client.create_model_version(name=model_name, source=mv.source, run_id=mv.run_id)
-```
-
-### Working with Model Registry in Databricks
-
-For models registered on Databricks, the underlying model version artifacts 
-are immutable, so we need to load the model artifacts and create a new 
-version with the signature:
+For registered model versions, the underlying artifacts are immutable, so we need to load the model artifacts and create a new version with the signature:
 
 ```python
 from mlflow.client import MlflowClient
@@ -1127,6 +1103,7 @@ with mlflow.start_run() as r:
 ```
 
 NOTE: For `pyfunc` models, you will need to unwrap the model as follows:
+
 ```python
 with mlflow.start_run() as r:
     model_info = mlflow.pyfunc.log_model(

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -589,10 +589,10 @@ def set_signature(
 
     Furthermore, as model registry artifacts are read-only, model artifacts located in the
     model registry and represented by ``models:/`` URI schemes are not compatible with this API.
-    To set a signature on a model version, first set the signature on the source model artifacts.
-    Following this, generate a new model version using the updated model artifacts. For more
-    information about setting signatures on model versions, see
-    `this doc section <https://www.mlflow.org/docs/latest/models.html#set-signature-on-mv>`_.
+    To set a signature on a model version, first load the source model artifacts. Following this, 
+    generate a new model version using the loaded model artifacts and a corresponding signature. 
+    For more information about setting signatures on model versions, see
+    `this doc section <https://mlflow.org/docs/latest/ml/model/signatures/#adding-signatures-to-registered-model-versions>`_.
 
     Args:
         model_uri: The location, in URI format, of the MLflow model. For example:

--- a/mlflow/models/signature.py
+++ b/mlflow/models/signature.py
@@ -589,8 +589,8 @@ def set_signature(
 
     Furthermore, as model registry artifacts are read-only, model artifacts located in the
     model registry and represented by ``models:/`` URI schemes are not compatible with this API.
-    To set a signature on a model version, first load the source model artifacts. Following this, 
-    generate a new model version using the loaded model artifacts and a corresponding signature. 
+    To set a signature on a model version, first load the source model artifacts. Following this,
+    generate a new model version using the loaded model artifacts and a corresponding signature.
     For more information about setting signatures on model versions, see
     `this doc section <https://mlflow.org/docs/latest/ml/model/signatures/#adding-signatures-to-registered-model-versions>`_.
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests
Docs look as expected
<img width="950" height="897" alt="Screenshot 2025-08-27 at 2 28 23 PM" src="https://github.com/user-attachments/assets/9f836ec8-1282-4a7e-a147-927f175daad3" />

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [X] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Add documentation for updating signatures on Databricks registered models

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [X] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
