### PR TITLE
Fix Spark UDF `uv` env_manager

### DIFF
--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -165,7 +165,7 @@ class LocalBackend(AbstractBackend):
                 local_model_path=work_dir_path,
                 python_env=python_env,
                 env_dir=env_dir,
-                python_installation_dir=pyenv_root_dir,
+                python_install_dir=pyenv_root_dir,
                 env_manager=env_manager,
                 extra_env=env_vars,
             )

--- a/mlflow/projects/backend/local.py
+++ b/mlflow/projects/backend/local.py
@@ -165,7 +165,7 @@ class LocalBackend(AbstractBackend):
                 local_model_path=work_dir_path,
                 python_env=python_env,
                 env_dir=env_dir,
-                pyenv_root_dir=pyenv_root_dir,
+                python_installation_dir=pyenv_root_dir,
                 env_manager=env_manager,
                 extra_env=env_vars,
             )

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -296,7 +296,6 @@ def _create_virtualenv(
             env_dir,
         ),
     ):
-
         _exec_cmd(
             env_creation_cmd,
             capture_output=capture_output,

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -296,7 +296,7 @@ def _create_virtualenv(
         _exec_cmd(
             env_creation_cmd,
             capture_output=capture_output,
-            extra_env={"UV_PYTHON_INSTALL_DIR": os.path.join(pyenv_root_dir, "uv_python_install")},
+            extra_env={"UV_PYTHON_INSTALL_DIR": pyenv_root_dir},
         )
 
         _logger.info("Installing dependencies")
@@ -420,10 +420,9 @@ def _get_or_create_virtualenv(
         virtual_envs_root_path = Path(_get_mlflow_virtualenv_root())
     else:
         virtual_envs_root_path = Path(env_root_dir) / _VIRTUALENV_ENVS_DIR
-        if env_manager == em.VIRTUALENV:
-            pyenv_root_path = Path(env_root_dir) / _PYENV_ROOT_DIR
-            pyenv_root_path.mkdir(parents=True, exist_ok=True)
-            pyenv_root_dir = str(pyenv_root_path)
+        pyenv_root_path = Path(env_root_dir) / _PYENV_ROOT_DIR
+        pyenv_root_path.mkdir(parents=True, exist_ok=True)
+        pyenv_root_dir = str(pyenv_root_path)
 
     virtual_envs_root_path.mkdir(parents=True, exist_ok=True)
     env_name = _get_virtualenv_name(python_env, local_model_path, env_id)

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -365,6 +365,7 @@ def _get_virtualenv_extra_env_vars(env_root_dir=None):
     if env_root_dir is not None:
         # Note: Both conda pip and virtualenv can use the pip cache directory.
         extra_env["PIP_CACHE_DIR"] = os.path.join(env_root_dir, _PIP_CACHE_DIR)
+        extra_env["UV_CACHE_DIR"] = os.path.join(env_root_dir, "uv_cache")
     return extra_env
 
 

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -365,7 +365,7 @@ def _get_virtualenv_extra_env_vars(env_root_dir=None):
     if env_root_dir is not None:
         # Note: Both conda pip and virtualenv can use the pip cache directory.
         extra_env["PIP_CACHE_DIR"] = os.path.join(env_root_dir, _PIP_CACHE_DIR)
-        extra_env["UV_CACHE_DIR"] = os.path.join(env_root_dir, "uv_cache")
+        extra_env["UV_PYTHON_INSTALL_DIR"] = os.path.join(env_root_dir, "uv_python_install")
     return extra_env
 
 

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -261,6 +261,7 @@ def _create_virtualenv(
         _logger.info(f"Environment {env_dir} already exists")
         return activate_cmd
 
+    extra_env = {}
     if env_manager == em.VIRTUALENV:
         python_bin_path = _install_python(
             python_env.python, pyenv_root=pyenv_root_dir, capture_output=capture_output
@@ -282,6 +283,8 @@ def _create_virtualenv(
         )
         env_creation_cmd = ["uv", "venv", env_dir, f"--python={python_env.python}"]
         install_deps_cmd_prefix = "uv pip install"
+        if pyenv_root_dir:
+            extra_env["UV_PYTHON_INSTALL_DIR"] = pyenv_root_dir
         if _MLFLOW_TESTING.get():
             os.environ["RUST_LOG"] = "uv=debug"
     with remove_on_error(
@@ -293,10 +296,10 @@ def _create_virtualenv(
             env_dir,
         ),
     ):
+
         _exec_cmd(
             env_creation_cmd,
             capture_output=capture_output,
-            extra_env={"UV_PYTHON_INSTALL_DIR": pyenv_root_dir},
         )
 
         _logger.info("Installing dependencies")
@@ -415,9 +418,9 @@ def _get_or_create_virtualenv(
     local_model_path = Path(local_model_path)
     python_env = _get_python_env(local_model_path)
 
-    pyenv_root_dir = None
     if env_root_dir is None:
         virtual_envs_root_path = Path(_get_mlflow_virtualenv_root())
+        pyenv_root_dir = None
     else:
         virtual_envs_root_path = Path(env_root_dir) / _VIRTUALENV_ENVS_DIR
         pyenv_root_path = Path(env_root_dir) / _PYENV_ROOT_DIR

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -261,7 +261,7 @@ def _create_virtualenv(
         _logger.info(f"Environment {env_dir} already exists")
         return activate_cmd
 
-    extra_env = {}
+    env_creation_extra_env = {}
     if env_manager == em.VIRTUALENV:
         python_bin_path = _install_python(
             python_env.python, pyenv_root=pyenv_root_dir, capture_output=capture_output
@@ -284,7 +284,7 @@ def _create_virtualenv(
         env_creation_cmd = ["uv", "venv", env_dir, f"--python={python_env.python}"]
         install_deps_cmd_prefix = "uv pip install"
         if pyenv_root_dir:
-            extra_env["UV_PYTHON_INSTALL_DIR"] = pyenv_root_dir
+            env_creation_extra_env["UV_PYTHON_INSTALL_DIR"] = pyenv_root_dir
         if _MLFLOW_TESTING.get():
             os.environ["RUST_LOG"] = "uv=debug"
     with remove_on_error(
@@ -300,6 +300,7 @@ def _create_virtualenv(
         _exec_cmd(
             env_creation_cmd,
             capture_output=capture_output,
+            extra_env=env_creation_extra_env,
         )
 
         _logger.info("Installing dependencies")

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -244,7 +244,7 @@ def _create_virtualenv(
     local_model_path: Path,
     python_env: _PythonEnv,
     env_dir: Path,
-    python_installation_dir: str | None = None,
+    python_install_dir: str | None = None,
     env_manager: Literal["virtualenv", "uv"] = em.UV,
     extra_env: dict[str, str] | None = None,
     capture_output: bool = False,
@@ -264,7 +264,7 @@ def _create_virtualenv(
     env_creation_extra_env = {}
     if env_manager == em.VIRTUALENV:
         python_bin_path = _install_python(
-            python_env.python, pyenv_root=python_installation_dir, capture_output=capture_output
+            python_env.python, pyenv_root=python_install_dir, capture_output=capture_output
         )
         _logger.info(f"Creating a new environment in {env_dir} with {python_bin_path}")
         env_creation_cmd = [
@@ -283,10 +283,10 @@ def _create_virtualenv(
         )
         env_creation_cmd = ["uv", "venv", env_dir, f"--python={python_env.python}"]
         install_deps_cmd_prefix = "uv pip install"
-        if python_installation_dir:
+        if python_install_dir:
             # Setting `UV_PYTHON_INSTALL_DIR` to make `uv env` install python into
             # the directory it points to.
-            env_creation_extra_env["UV_PYTHON_INSTALL_DIR"] = python_installation_dir
+            env_creation_extra_env["UV_PYTHON_INSTALL_DIR"] = python_install_dir
         if _MLFLOW_TESTING.get():
             os.environ["RUST_LOG"] = "uv=debug"
     with remove_on_error(
@@ -422,12 +422,12 @@ def _get_or_create_virtualenv(
 
     if env_root_dir is None:
         virtual_envs_root_path = Path(_get_mlflow_virtualenv_root())
-        python_installation_dir = None
+        python_install_dir = None
     else:
         virtual_envs_root_path = Path(env_root_dir) / _VIRTUALENV_ENVS_DIR
         pyenv_root_path = Path(env_root_dir) / _PYENV_ROOT_DIR
         pyenv_root_path.mkdir(parents=True, exist_ok=True)
-        python_installation_dir = str(pyenv_root_path)
+        python_install_dir = str(pyenv_root_path)
 
     virtual_envs_root_path.mkdir(parents=True, exist_ok=True)
     env_name = _get_virtualenv_name(python_env, local_model_path, env_id)
@@ -459,7 +459,7 @@ def _get_or_create_virtualenv(
         local_model_path=local_model_path,
         python_env=python_env,
         env_dir=env_dir,
-        python_installation_dir=python_installation_dir,
+        python_install_dir=python_install_dir,
         env_manager=env_manager,
         extra_env=extra_envs,
         capture_output=capture_output,

--- a/mlflow/utils/virtualenv.py
+++ b/mlflow/utils/virtualenv.py
@@ -296,6 +296,7 @@ def _create_virtualenv(
         _exec_cmd(
             env_creation_cmd,
             capture_output=capture_output,
+            extra_env={"UV_PYTHON_INSTALL_DIR": os.path.join(pyenv_root_dir, "uv_python_install")},
         )
 
         _logger.info("Installing dependencies")
@@ -365,7 +366,6 @@ def _get_virtualenv_extra_env_vars(env_root_dir=None):
     if env_root_dir is not None:
         # Note: Both conda pip and virtualenv can use the pip cache directory.
         extra_env["PIP_CACHE_DIR"] = os.path.join(env_root_dir, _PIP_CACHE_DIR)
-        extra_env["UV_PYTHON_INSTALL_DIR"] = os.path.join(env_root_dir, "uv_python_install")
     return extra_env
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/17489?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17489/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17489/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17489/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

By default, `uv venv` command creates a python environment which links to the original python binary files under the directory `$HOME/.local/share/uv/python/`, **NOTE** that this is a local directory,
but MLflow spark udf (driver part code) needs to prepare the python environment in NFS directory first, then Spark UDF code loads the python environment from NFS directory.  The  local directory `$HOME/.local/share/uv/python/` makes the routine broken.

To address it, we need to set `UV_PYTHON_INSTALL_DIR` environment variable (pointing to the NFS directory) for `uv venv` command, so that the `uv venv` will put python installation files under NFS directory.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual test:
https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/565304605570746?o=6051921418418893

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
