### PR TITLE
Add --env-file flag to all MLflow CLI commands

### DIFF
--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
   "packaging<26",
   "protobuf<7,>=3.12.0",
   "pydantic<3,>=1.10.8",
+  "python-dotenv<2,>=0.19.0",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "sqlparse<1,>=0.4.0",

--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -64,7 +64,7 @@ def _load_env_file(ctx: click.Context, param: click.Parameter, value: str | None
         load_dotenv(env_path, override=False)
 
         # Log that we've loaded the env file (using click.echo for CLI output)
-        click.echo(f"Loaded environment variables from: {value}", err=True)
+        click.echo(f"Loaded environment variables from: {value}")
 
     return value
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dependencies = [
   "protobuf<7,>=3.12.0",
   "pyarrow<22,>=4.0.0",
   "pydantic<3,>=1.10.8",
+  "python-dotenv<2,>=0.19.0",
   "pyyaml<7,>=5.1",
   "requests<3,>=2.17.3",
   "scikit-learn<2",

--- a/requirements/skinny-requirements.yaml
+++ b/requirements/skinny-requirements.yaml
@@ -13,6 +13,11 @@ cloudpickle:
   pip_release: cloudpickle
   max_major_version: 3
 
+python-dotenv:
+  pip_release: python-dotenv
+  minimum: "0.19.0"
+  max_major_version: 1
+
 gitpython:
   pip_release: gitpython
   minimum: "3.1.9"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -746,8 +746,9 @@ def test_doctor():
 
 def test_env_file_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Setup: Create an experiment using the Python SDK
-    # Use os.path.join for proper cross-platform path handling
-    test_tracking_uri = os.path.join(str(tmp_path), "mlruns")
+    # Use file:// URI format for cross-platform compatibility
+    mlruns_path = tmp_path / "mlruns"
+    test_tracking_uri = mlruns_path.as_uri()  # This creates proper file:// URI
     test_experiment_name = "test_experiment_from_env"
 
     # Create experiment using SDK

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from pathlib import Path
 from unittest import mock
 from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
@@ -743,7 +744,7 @@ def test_doctor():
     assert res.exit_code == 0
 
 
-def test_env_file_loading(tmp_path, monkeypatch):
+def test_env_file_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Setup: Create an experiment using the Python SDK
     test_tracking_uri = f"file://{tmp_path}/mlruns"
     test_experiment_name = "test_experiment_from_env"
@@ -779,6 +780,10 @@ def test_env_file_loading(tmp_path, monkeypatch):
     # Verify the loading message
     assert "Loaded environment variables from:" in result.stderr
     assert str(env_file_path) in result.stderr
+
+
+def test_env_file_loading_invalid_path() -> None:
+    runner = CliRunner()
 
     # Test error handling for non-existent file
     result = runner.invoke(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -778,8 +778,8 @@ def test_env_file_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> No
     assert test_experiment_name in result.output
 
     # Verify the loading message
-    assert "Loaded environment variables from:" in result.stderr
-    assert str(env_file_path) in result.stderr
+    assert "Loaded environment variables from:" in result.output
+    assert str(env_file_path) in result.output
 
 
 def test_env_file_loading_invalid_path() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -802,7 +802,7 @@ def test_env_file_loading(tmp_path, monkeypatch):
     assert "Environment file 'nonexistent.env' does not exist" in result.output
 
     # Test that existing environment variables are not overridden
-    existing_tracking_uri = "databricks://existing"
+    existing_tracking_uri = "databricks"
     monkeypatch.setenv("MLFLOW_TRACKING_URI", existing_tracking_uri)
 
     captured_env_override = {}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -768,7 +768,7 @@ def test_env_file_loading(tmp_path, monkeypatch):
     # Use a custom command that captures environment
     captured_env = {}
 
-    def capture_env_command():
+    def capture_env_command() -> int:
         """Helper command to capture environment variables."""
         captured_env.update(os.environ.copy())
         click.echo("Environment captured")
@@ -807,7 +807,7 @@ def test_env_file_loading(tmp_path, monkeypatch):
 
     captured_env_override = {}
 
-    def capture_env_override():
+    def capture_env_override() -> int:
         captured_env_override.update(os.environ.copy())
         return 0
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -746,7 +746,8 @@ def test_doctor():
 
 def test_env_file_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Setup: Create an experiment using the Python SDK
-    test_tracking_uri = f"file://{tmp_path}/mlruns"
+    # Use local path directly instead of file:// URI to avoid Windows issues
+    test_tracking_uri = str(tmp_path / "mlruns")
     test_experiment_name = "test_experiment_from_env"
 
     # Create experiment using SDK

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -746,8 +746,8 @@ def test_doctor():
 
 def test_env_file_loading(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     # Setup: Create an experiment using the Python SDK
-    # Use local path directly instead of file:// URI to avoid Windows issues
-    test_tracking_uri = str(tmp_path / "mlruns")
+    # Use os.path.join for proper cross-platform path handling
+    test_tracking_uri = os.path.join(str(tmp_path), "mlruns")
     test_experiment_name = "test_experiment_from_env"
 
     # Create experiment using SDK

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -744,86 +744,83 @@ def test_doctor():
     assert res.exit_code == 0
 
 
-def test_env_file_loading():
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Create a test .env file
-        env_file_path = os.path.join(temp_dir, "test.env")
-        test_tracking_uri = f"file://{temp_dir}/mlruns"
-        test_experiment_name = "test_experiment_from_env"
+def test_env_file_loading(tmp_path):
+    # Create a test .env file
+    env_file_path = tmp_path / "test.env"
+    test_tracking_uri = f"file://{tmp_path}/mlruns"
+    test_experiment_name = "test_experiment_from_env"
 
-        with open(env_file_path, "w") as f:
-            f.write(f"MLFLOW_TRACKING_URI={test_tracking_uri}\n")
-            f.write(f"MLFLOW_EXPERIMENT_NAME={test_experiment_name}\n")
+    env_file_path.write_text(
+        f"MLFLOW_TRACKING_URI={test_tracking_uri}\nMLFLOW_EXPERIMENT_NAME={test_experiment_name}\n"
+    )
 
-        runner = CliRunner()
+    runner = CliRunner()
 
-        # Clear environment to ensure we're testing the loading
-        with mock.patch.dict(os.environ, {}, clear=True):
-            # Ensure variables are not set before running command
-            assert "MLFLOW_TRACKING_URI" not in os.environ
-            assert "MLFLOW_EXPERIMENT_NAME" not in os.environ
+    # Clear environment to ensure we're testing the loading
+    with mock.patch.dict(os.environ, {}, clear=True):
+        # Ensure variables are not set before running command
+        assert "MLFLOW_TRACKING_URI" not in os.environ
+        assert "MLFLOW_EXPERIMENT_NAME" not in os.environ
 
-            # We need to capture the environment variables set during command execution
-            # Use a custom command that captures environment
-            captured_env = {}
+        # We need to capture the environment variables set during command execution
+        # Use a custom command that captures environment
+        captured_env = {}
 
-            def capture_env_command():
-                """Helper command to capture environment variables."""
-                captured_env.update(os.environ.copy())
-                click.echo("Environment captured")
-                return 0
+        def capture_env_command():
+            """Helper command to capture environment variables."""
+            captured_env.update(os.environ.copy())
+            click.echo("Environment captured")
+            return 0
 
-            # Add our test command to the CLI
-            cli.command(name="test-env")(capture_env_command)
+        # Add our test command to the CLI
+        cli.command(name="test-env")(capture_env_command)
 
-            try:
-                result = runner.invoke(
-                    cli, ["--env-file", env_file_path, "test-env"], catch_exceptions=False
-                )
+        try:
+            result = runner.invoke(
+                cli, ["--env-file", str(env_file_path), "test-env"], catch_exceptions=False
+            )
 
-                # Check that the command executed successfully
-                assert result.exit_code == 0
+            # Check that the command executed successfully
+            assert result.exit_code == 0
 
-                # Verify the MLflow environment variables were actually loaded
-                assert captured_env.get("MLFLOW_TRACKING_URI") == test_tracking_uri
-                assert captured_env.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
+            # Verify the MLflow environment variables were actually loaded
+            assert captured_env.get("MLFLOW_TRACKING_URI") == test_tracking_uri
+            assert captured_env.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
 
-                # Verify the loading message
-                assert "Loaded environment variables from:" in result.stderr
-                assert env_file_path in result.stderr
-            finally:
-                # Clean up the test command
-                cli.commands.pop("test-env", None)
+            # Verify the loading message
+            assert "Loaded environment variables from:" in result.stderr
+            assert str(env_file_path) in result.stderr
+        finally:
+            # Clean up the test command
+            cli.commands.pop("test-env", None)
 
-        # Test error handling for non-existent file
-        result = runner.invoke(
-            cli, ["--env-file", "nonexistent.env", "doctor"], catch_exceptions=False
-        )
-        assert result.exit_code != 0
-        assert "Environment file 'nonexistent.env' does not exist" in result.output
+    # Test error handling for non-existent file
+    result = runner.invoke(cli, ["--env-file", "nonexistent.env", "doctor"], catch_exceptions=False)
+    assert result.exit_code != 0
+    assert "Environment file 'nonexistent.env' does not exist" in result.output
 
-        # Test that existing environment variables are not overridden
-        existing_tracking_uri = "databricks://existing"
-        with mock.patch.dict(os.environ, {"MLFLOW_TRACKING_URI": existing_tracking_uri}):
-            captured_env_override = {}
+    # Test that existing environment variables are not overridden
+    existing_tracking_uri = "databricks://existing"
+    with mock.patch.dict(os.environ, {"MLFLOW_TRACKING_URI": existing_tracking_uri}):
+        captured_env_override = {}
 
-            def capture_env_override():
-                captured_env_override.update(os.environ.copy())
-                return 0
+        def capture_env_override():
+            captured_env_override.update(os.environ.copy())
+            return 0
 
-            cli.command(name="test-env-override")(capture_env_override)
+        cli.command(name="test-env-override")(capture_env_override)
 
-            try:
-                result = runner.invoke(
-                    cli, ["--env-file", env_file_path, "test-env-override"], catch_exceptions=False
-                )
+        try:
+            result = runner.invoke(
+                cli, ["--env-file", str(env_file_path), "test-env-override"], catch_exceptions=False
+            )
 
-                # Verify existing MLFLOW_TRACKING_URI was NOT overridden
-                assert captured_env_override.get("MLFLOW_TRACKING_URI") == existing_tracking_uri
-                # But MLFLOW_EXPERIMENT_NAME should still be loaded since it wasn't set
-                assert captured_env_override.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
-            finally:
-                cli.commands.pop("test-env-override", None)
+            # Verify existing MLFLOW_TRACKING_URI was NOT overridden
+            assert captured_env_override.get("MLFLOW_TRACKING_URI") == existing_tracking_uri
+            # But MLFLOW_EXPERIMENT_NAME should still be loaded since it wasn't set
+            assert captured_env_override.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
+        finally:
+            cli.commands.pop("test-env-override", None)
 
 
 def test_mlflow_gc_with_datasets(sqlite_store):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -9,6 +9,7 @@ from unittest import mock
 from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
+import click
 import numpy as np
 import pandas as pd
 import pytest
@@ -769,8 +770,6 @@ def test_env_file_loading():
 
             def capture_env_command():
                 """Helper command to capture environment variables."""
-                import click
-
                 captured_env.update(os.environ.copy())
                 click.echo("Environment captured")
                 return 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -744,7 +744,7 @@ def test_doctor():
     assert res.exit_code == 0
 
 
-def test_env_file_loading(tmp_path):
+def test_env_file_loading(tmp_path, monkeypatch):
     # Create a test .env file
     env_file_path = tmp_path / "test.env"
     test_tracking_uri = f"file://{tmp_path}/mlruns"
@@ -756,43 +756,45 @@ def test_env_file_loading(tmp_path):
 
     runner = CliRunner()
 
-    # Clear environment to ensure we're testing the loading
-    with mock.patch.dict(os.environ, {}, clear=True):
-        # Ensure variables are not set before running command
-        assert "MLFLOW_TRACKING_URI" not in os.environ
-        assert "MLFLOW_EXPERIMENT_NAME" not in os.environ
+    # Clear the MLflow environment variables to ensure we're testing the loading
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+    monkeypatch.delenv("MLFLOW_EXPERIMENT_NAME", raising=False)
 
-        # We need to capture the environment variables set during command execution
-        # Use a custom command that captures environment
-        captured_env = {}
+    # Ensure variables are not set before running command
+    assert "MLFLOW_TRACKING_URI" not in os.environ
+    assert "MLFLOW_EXPERIMENT_NAME" not in os.environ
 
-        def capture_env_command():
-            """Helper command to capture environment variables."""
-            captured_env.update(os.environ.copy())
-            click.echo("Environment captured")
-            return 0
+    # We need to capture the environment variables set during command execution
+    # Use a custom command that captures environment
+    captured_env = {}
 
-        # Add our test command to the CLI
-        cli.command(name="test-env")(capture_env_command)
+    def capture_env_command():
+        """Helper command to capture environment variables."""
+        captured_env.update(os.environ.copy())
+        click.echo("Environment captured")
+        return 0
 
-        try:
-            result = runner.invoke(
-                cli, ["--env-file", str(env_file_path), "test-env"], catch_exceptions=False
-            )
+    # Add our test command to the CLI
+    cli.command(name="test-env")(capture_env_command)
 
-            # Check that the command executed successfully
-            assert result.exit_code == 0
+    try:
+        result = runner.invoke(
+            cli, ["--env-file", str(env_file_path), "test-env"], catch_exceptions=False
+        )
 
-            # Verify the MLflow environment variables were actually loaded
-            assert captured_env.get("MLFLOW_TRACKING_URI") == test_tracking_uri
-            assert captured_env.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
+        # Check that the command executed successfully
+        assert result.exit_code == 0
 
-            # Verify the loading message
-            assert "Loaded environment variables from:" in result.stderr
-            assert str(env_file_path) in result.stderr
-        finally:
-            # Clean up the test command
-            cli.commands.pop("test-env", None)
+        # Verify the MLflow environment variables were actually loaded
+        assert captured_env.get("MLFLOW_TRACKING_URI") == test_tracking_uri
+        assert captured_env.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
+
+        # Verify the loading message
+        assert "Loaded environment variables from:" in result.stderr
+        assert str(env_file_path) in result.stderr
+    finally:
+        # Clean up the test command
+        cli.commands.pop("test-env", None)
 
     # Test error handling for non-existent file
     result = runner.invoke(cli, ["--env-file", "nonexistent.env", "doctor"], catch_exceptions=False)
@@ -801,26 +803,27 @@ def test_env_file_loading(tmp_path):
 
     # Test that existing environment variables are not overridden
     existing_tracking_uri = "databricks://existing"
-    with mock.patch.dict(os.environ, {"MLFLOW_TRACKING_URI": existing_tracking_uri}):
-        captured_env_override = {}
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", existing_tracking_uri)
 
-        def capture_env_override():
-            captured_env_override.update(os.environ.copy())
-            return 0
+    captured_env_override = {}
 
-        cli.command(name="test-env-override")(capture_env_override)
+    def capture_env_override():
+        captured_env_override.update(os.environ.copy())
+        return 0
 
-        try:
-            result = runner.invoke(
-                cli, ["--env-file", str(env_file_path), "test-env-override"], catch_exceptions=False
-            )
+    cli.command(name="test-env-override")(capture_env_override)
 
-            # Verify existing MLFLOW_TRACKING_URI was NOT overridden
-            assert captured_env_override.get("MLFLOW_TRACKING_URI") == existing_tracking_uri
-            # But MLFLOW_EXPERIMENT_NAME should still be loaded since it wasn't set
-            assert captured_env_override.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
-        finally:
-            cli.commands.pop("test-env-override", None)
+    try:
+        result = runner.invoke(
+            cli, ["--env-file", str(env_file_path), "test-env-override"], catch_exceptions=False
+        )
+
+        # Verify existing MLFLOW_TRACKING_URI was NOT overridden
+        assert captured_env_override.get("MLFLOW_TRACKING_URI") == existing_tracking_uri
+        # But MLFLOW_EXPERIMENT_NAME should still be loaded since it wasn't set
+        assert captured_env_override.get("MLFLOW_EXPERIMENT_NAME") == test_experiment_name
+    finally:
+        cli.commands.pop("test-env-override", None)
 
 
 def test_mlflow_gc_with_datasets(sqlite_store):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -745,7 +745,6 @@ def test_doctor():
 
 
 def test_env_file_loading():
-    """Test that --env-file flag loads environment variables from a dotenv file."""
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create a test .env file
         env_file_path = os.path.join(temp_dir, "test.env")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nsthorat/mlflow/pull/17509?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17509/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17509/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17509/merge
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

This PR adds a global `--env-file` flag to all MLflow CLI commands, allowing users to load environment variables from a dotenv file before executing any command. This provides a convenient way to manage environment configurations without having to set them in the shell or pass them individually.

**Key changes:**
- Added `python-dotenv` dependency to `skinny-requirements.yaml` (included in both skinny and full MLflow packages)
- Added a global `--env-file` option to the root CLI group in `mlflow/cli/__init__.py`
- The option uses Click's eager callback mechanism to load environment variables before any command execution
- Environment variables from the file do not override existing environment variables (standard dotenv behavior)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing performed:**
```bash
# Created a .env file with various MLflow environment variables
echo "MLFLOW_TRACKING_URI=databricks" > .env
echo "DATABRICKS_HOST=https://workspace.databricks.com" >> .env
echo "DATABRICKS_TOKEN=token123" >> .env

# Tested with various commands
mlflow --env-file .env experiments search
mlflow --env-file .env traces search --experiment-id 123
mlflow --env-file .env server

# Verified error handling for non-existent files
mlflow --env-file nonexistent.env --help
# Error: Invalid value for '--env-file': Environment file 'nonexistent.env' does not exist.
```

All pre-commit hooks pass successfully.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

The `--help` text for the CLI now includes the `--env-file` option documentation. Additional documentation updates may be needed in the MLflow documentation pages to describe this feature.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a global `--env-file` flag to all MLflow CLI commands that allows loading environment variables from a dotenv file. This simplifies configuration management by enabling users to store their MLflow settings (tracking URI, credentials, etc.) in a `.env` file and load them with any command: `mlflow --env-file .env server`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)