### PR TITLE
Fix basic-auth with uvicorn by leveraging env var(#17324)

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -945,3 +945,9 @@ _MLFLOW_TELEMETRY_SESSION_ID = _EnvironmentVariable("_MLFLOW_TELEMETRY_SESSION_I
 #: Internal flag to enable telemetry logging
 #: (default: ``False``)
 _MLFLOW_TELEMETRY_LOGGING = _BooleanEnvironmentVariable("_MLFLOW_TELEMETRY_LOGGING", False)
+
+#: Internal environment variable to indicate which SGI is being used,
+#: e.g. "uvicorn" or "gunicorn".
+#: This should never be set by users or explicitly.
+#: (default: ``None``)
+_MLFLOW_SGI_NAME = _EnvironmentVariable("_MLFLOW_SGI_NAME", str, None)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -10,7 +10,7 @@ import warnings
 from flask import Flask, Response, send_from_directory
 from packaging.version import Version
 
-from mlflow.environment_variables import MLFLOW_FLASK_SERVER_SECRET_KEY
+from mlflow.environment_variables import _MLFLOW_SGI_NAME, MLFLOW_FLASK_SERVER_SECRET_KEY
 from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.server.handlers import (
@@ -321,6 +321,13 @@ def _run_server(
     using_gunicorn = gunicorn_opts is not None
     using_waitress = waitress_opts is not None
     using_uvicorn = not using_gunicorn and not using_waitress
+
+    if using_uvicorn:
+        env_map[_MLFLOW_SGI_NAME.name] = "uvicorn"
+    elif using_waitress:
+        env_map[_MLFLOW_SGI_NAME.name] = "waitress"
+    elif using_gunicorn:
+        env_map[_MLFLOW_SGI_NAME.name] = "gunicorn"
 
     if app_name is None:
         is_factory = False

--- a/mlflow/server/auth/__init__.py
+++ b/mlflow/server/auth/__init__.py
@@ -30,7 +30,7 @@ from mlflow import MlflowException
 from mlflow.entities import Experiment
 from mlflow.entities.logged_model import LoggedModel
 from mlflow.entities.model_registry import RegisteredModel
-from mlflow.environment_variables import MLFLOW_FLASK_SERVER_SECRET_KEY
+from mlflow.environment_variables import _MLFLOW_SGI_NAME, MLFLOW_FLASK_SERVER_SECRET_KEY
 from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     INTERNAL_ERROR,
@@ -116,6 +116,7 @@ from mlflow.server.auth.routes import (
     UPDATE_USER_PASSWORD,
 )
 from mlflow.server.auth.sqlalchemy_store import SqlAlchemyStore
+from mlflow.server.fastapi_app import create_fastapi_app
 from mlflow.server.handlers import (
     _get_model_registry_store,
     _get_request_message,
@@ -1223,4 +1224,7 @@ def create_app(app: Flask = app):
     app.before_request(_before_request)
     app.after_request(_after_request)
 
-    return app
+    if _MLFLOW_SGI_NAME.get() == "uvicorn":
+        return create_fastapi_app(app)
+    else:
+        return app

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -8,13 +8,14 @@ to FastAPI endpoints.
 
 from fastapi import FastAPI
 from fastapi.middleware.wsgi import WSGIMiddleware
+from flask import Flask
 
 from mlflow.server import app as flask_app
 from mlflow.server.otel_api import otel_router
 from mlflow.version import VERSION
 
 
-def create_fastapi_app():
+def create_fastapi_app(flask_app: Flask = flask_app):
     """
     Create a FastAPI application that wraps the existing Flask app.
 

--- a/tests/server/test_init.py
+++ b/tests/server/test_init.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 from mlflow import server
+from mlflow.environment_variables import _MLFLOW_SGI_NAME
 from mlflow.exceptions import MlflowException
 
 
@@ -159,4 +160,6 @@ def test_run_server_with_uvicorn(mock_exec_cmd):
         "4",
         "mlflow.server.fastapi_app:app",
     ]
-    mock_exec_cmd.assert_called_once_with(expected_command, extra_env={}, capture_output=False)
+    mock_exec_cmd.assert_called_once_with(
+        expected_command, extra_env={_MLFLOW_SGI_NAME.name: "uvicorn"}, capture_output=False
+    )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kevin-lyn/mlflow/pull/17523?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17523/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17523/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17523/merge
```

</p>
</details>

### Related Issues/PRs

#17324

### What changes are proposed in this pull request?

`basic-auth` was broken when FastAPI + uvicorn was introduced - implementation of basic auth app was not updated according to the changes. This PR fixes it by reading env var to understand if the basic auth app is initialized in the context of uvicorn and return a FastAPI wrapper if needed.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

`mlflow server --app-name basic-auth` won't reproduce the error reported in #17324.

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
