### PR TITLE
Fix error suppression during prompt alias resolution when `allow_missing` is set

### DIFF
--- a/mlflow/prompt/registry_utils.py
+++ b/mlflow/prompt/registry_utils.py
@@ -171,7 +171,9 @@ def translate_prompt_exception(func):
             )
 
             if new_message != original_message:
-                raise MlflowException(new_message) from e
+                new_exc = MlflowException(new_message)
+                new_exc.error_code = e.error_code  # Preserve original error code
+                raise new_exc from e
             else:
                 raise e
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -738,7 +738,7 @@ class MlflowClient:
         except MlflowException as exc:
             if allow_missing and exc.error_code in (
                 ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),
-                ErrorCode.Name(INVALID_PARAMETER_VALUE),  # missing alias (file/sql registry)
+                ErrorCode.Name(INVALID_PARAMETER_VALUE),  # Missing alias (file/sql registry only)
                 ErrorCode.Name(NOT_FOUND),
             ):
                 return None

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -738,10 +738,10 @@ class MlflowClient:
             else:
                 return registry_client.get_prompt_version(name, version_or_alias)
         except MlflowException as exc:
-            if allow_missing and exc.error_code in [
+            if allow_missing and exc.error_code in (
                 ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),
                 ErrorCode.Name(INVALID_PARAMETER_VALUE),
-            ]:
+            ):
                 return None
             raise
 

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -41,12 +41,7 @@ from mlflow.entities import (
     Trace,
     ViewType,
 )
-from mlflow.entities.model_registry import (
-    ModelVersion,
-    Prompt,
-    PromptVersion,
-    RegisteredModel,
-)
+from mlflow.entities.model_registry import ModelVersion, Prompt, PromptVersion, RegisteredModel
 from mlflow.entities.model_registry.model_version_stages import ALL_STAGES
 from mlflow.entities.span import NO_OP_SPAN_TRACE_ID, NoOpSpan
 from mlflow.entities.trace_status import TraceStatus
@@ -92,10 +87,7 @@ from mlflow.store.model_registry import (
     SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT,
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
 )
-from mlflow.store.tracking import (
-    SEARCH_MAX_RESULTS_DEFAULT,
-    SEARCH_TRACES_DEFAULT_MAX_RESULTS,
-)
+from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT, SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing.client import TracingClient
 from mlflow.tracing.constant import TRACE_REQUEST_ID_PREFIX
 from mlflow.tracing.display import get_display_handler

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -739,8 +739,8 @@ class MlflowClient:
                 return registry_client.get_prompt_version(name, version_or_alias)
         except MlflowException as exc:
             if allow_missing and exc.error_code in (
-                ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),
-                ErrorCode.Name(INVALID_PARAMETER_VALUE),
+                ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),  # missing prompt/version
+                ErrorCode.Name(INVALID_PARAMETER_VALUE),  # missing alias
             ):
                 return None
             raise

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -75,6 +75,7 @@ from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     FEATURE_DISABLED,
     INVALID_PARAMETER_VALUE,
+    NOT_FOUND,
     RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
@@ -739,8 +740,9 @@ class MlflowClient:
                 return registry_client.get_prompt_version(name, version_or_alias)
         except MlflowException as exc:
             if allow_missing and exc.error_code in (
-                ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),  # missing prompt/version
-                ErrorCode.Name(INVALID_PARAMETER_VALUE),  # missing alias
+                ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),
+                ErrorCode.Name(INVALID_PARAMETER_VALUE),  # missing alias - file store only
+                ErrorCode.Name(NOT_FOUND),
             ):
                 return None
             raise

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -725,15 +725,12 @@ class MlflowClient:
 
         try:
             if parsed_name_or_uri.startswith("prompts:/"):
-                # URI case: parse the URI to extract name and version (resolving alias if provided)
                 name, version_or_alias = self.parse_prompt_uri(parsed_name_or_uri)
             else:
-                # Name case: use the name and provided version
                 name = parsed_name_or_uri
                 version_or_alias = parsed_version
 
             registry_client = self._get_registry_client()
-            # If version_or_alias is not a digit, treat as alias
             if isinstance(version_or_alias, str) and not version_or_alias.isdigit():
                 return registry_client.get_prompt_version_by_alias(name, version_or_alias)
             else:
@@ -741,7 +738,7 @@ class MlflowClient:
         except MlflowException as exc:
             if allow_missing and exc.error_code in (
                 ErrorCode.Name(RESOURCE_DOES_NOT_EXIST),
-                ErrorCode.Name(INVALID_PARAMETER_VALUE),  # missing alias - file store only
+                ErrorCode.Name(INVALID_PARAMETER_VALUE),  # missing alias (file/sql registry)
                 ErrorCode.Name(NOT_FOUND),
             ):
                 return None

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2400,7 +2400,7 @@ def test_load_prompt_allow_missing_name_version(tracking_uri):
     assert result is None
 
     # Non-existent prompt by name+version should raise exception when allow_missing=False
-    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+    with pytest.raises(MlflowException, match="Prompt with name=nonexistent_prompt not found"):
         client.load_prompt("nonexistent_prompt", version=1, allow_missing=False)
 
     # Existing prompt with non-existent version should return None when allow_missing=True
@@ -2409,7 +2409,9 @@ def test_load_prompt_allow_missing_name_version(tracking_uri):
     assert result is None
 
     # Existing prompt with non-existent version should raise exception when allow_missing=False
-    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+    with pytest.raises(
+        MlflowException, match=r"Prompt \(name=existing_prompt, version=999\) not found"
+    ):
         client.load_prompt("existing_prompt", version=999, allow_missing=False)
 
 
@@ -2421,7 +2423,7 @@ def test_load_prompt_allow_missing_uri_version(tracking_uri):
     assert result is None
 
     # Non-existent prompt by URI+version should raise exception when allow_missing=False
-    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+    with pytest.raises(MlflowException, match="Prompt with name=nonexistent_prompt not found"):
         client.load_prompt("prompts:/nonexistent_prompt/1", allow_missing=False)
 
     # Existing prompt with non-existent version via URI should return None when allow_missing=True
@@ -2430,7 +2432,9 @@ def test_load_prompt_allow_missing_uri_version(tracking_uri):
     assert result is None
 
     # Existing prompt with non-existent version via URI should raise when allow_missing=False
-    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+    with pytest.raises(
+        MlflowException, match=r"Prompt \(name=existing_prompt, version=999\) not found"
+    ):
         client.load_prompt("prompts:/existing_prompt/999", allow_missing=False)
 
 
@@ -2442,7 +2446,7 @@ def test_load_prompt_allow_missing_uri_alias(tracking_uri):
     assert result is None
 
     # Non-existent prompt with alias should raise exception when allow_missing=False
-    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+    with pytest.raises(MlflowException, match="Prompt with name=nonexistent_prompt not found"):
         client.load_prompt("prompts:/nonexistent_prompt@production", allow_missing=False)
 
     # Existing prompt with non-existent alias should return None when allow_missing=True
@@ -2451,7 +2455,7 @@ def test_load_prompt_allow_missing_uri_alias(tracking_uri):
     assert result is None
 
     # Existing prompt with non-existent alias should raise exception when allow_missing=False
-    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+    with pytest.raises(MlflowException, match="Prompt alias nonexistent_alias not found"):
         client.load_prompt("prompts:/existing_prompt@nonexistent_alias", allow_missing=False)
 
 

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2392,6 +2392,28 @@ def test_load_prompt_with_alias_uri(tracking_uri):
     assert prompt.template == "Hello, {{name}}!"
 
 
+def test_load_prompt_with_alias_uri_allow_missing(tracking_uri):
+    """Test that load_prompt with URI+alias respects allow_missing parameter."""
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    # Non-existent prompt with alias should return None when allow_missing=True
+    result = client.load_prompt("prompts:/nonexistent_prompt@production", allow_missing=True)
+    assert result is None
+
+    # Non-existent prompt with alias should raise exception when allow_missing=False
+    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+        client.load_prompt("prompts:/nonexistent_prompt@production", allow_missing=False)
+
+    # Existing prompt with non-existent alias should return None when allow_missing=True
+    client.register_prompt(name="existing_prompt", template="Hello, world!")
+    result = client.load_prompt("prompts:/existing_prompt@nonexistent_alias", allow_missing=True)
+    assert result is None
+
+    # Existing prompt with non-existent alias should raise exception when allow_missing=False
+    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+        client.load_prompt("prompts:/existing_prompt@nonexistent_alias", allow_missing=False)
+
+
 def test_create_prompt_chat_format_client_integration():
     """Test client-level integration with chat prompts."""
     chat_template = [

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2393,7 +2393,6 @@ def test_load_prompt_with_alias_uri(tracking_uri):
 
 
 def test_load_prompt_allow_missing_name_version(tracking_uri):
-    """Test that load_prompt with name+version respects allow_missing parameter."""
     client = MlflowClient(tracking_uri=tracking_uri)
 
     # Non-existent prompt by name+version should return None when allow_missing=True
@@ -2415,7 +2414,6 @@ def test_load_prompt_allow_missing_name_version(tracking_uri):
 
 
 def test_load_prompt_allow_missing_uri_version(tracking_uri):
-    """Test that load_prompt with URI+version respects allow_missing parameter."""
     client = MlflowClient(tracking_uri=tracking_uri)
 
     # Non-existent prompt by URI+version should return None when allow_missing=True
@@ -2437,7 +2435,6 @@ def test_load_prompt_allow_missing_uri_version(tracking_uri):
 
 
 def test_load_prompt_allow_missing_uri_alias(tracking_uri):
-    """Test that load_prompt with URI+alias respects allow_missing parameter."""
     client = MlflowClient(tracking_uri=tracking_uri)
 
     # Non-existent prompt with alias should return None when allow_missing=True

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2392,7 +2392,51 @@ def test_load_prompt_with_alias_uri(tracking_uri):
     assert prompt.template == "Hello, {{name}}!"
 
 
-def test_load_prompt_with_alias_uri_allow_missing(tracking_uri):
+def test_load_prompt_allow_missing_name_version(tracking_uri):
+    """Test that load_prompt with name+version respects allow_missing parameter."""
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    # Non-existent prompt by name+version should return None when allow_missing=True
+    result = client.load_prompt("nonexistent_prompt", version=1, allow_missing=True)
+    assert result is None
+
+    # Non-existent prompt by name+version should raise exception when allow_missing=False
+    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+        client.load_prompt("nonexistent_prompt", version=1, allow_missing=False)
+
+    # Existing prompt with non-existent version should return None when allow_missing=True
+    client.register_prompt(name="existing_prompt", template="Hello, world!")
+    result = client.load_prompt("existing_prompt", version=999, allow_missing=True)
+    assert result is None
+
+    # Existing prompt with non-existent version should raise exception when allow_missing=False
+    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+        client.load_prompt("existing_prompt", version=999, allow_missing=False)
+
+
+def test_load_prompt_allow_missing_uri_version(tracking_uri):
+    """Test that load_prompt with URI+version respects allow_missing parameter."""
+    client = MlflowClient(tracking_uri=tracking_uri)
+
+    # Non-existent prompt by URI+version should return None when allow_missing=True
+    result = client.load_prompt("prompts:/nonexistent_prompt/1", allow_missing=True)
+    assert result is None
+
+    # Non-existent prompt by URI+version should raise exception when allow_missing=False
+    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+        client.load_prompt("prompts:/nonexistent_prompt/1", allow_missing=False)
+
+    # Existing prompt with non-existent version via URI should return None when allow_missing=True
+    client.register_prompt(name="existing_prompt", template="Hello, world!")
+    result = client.load_prompt("prompts:/existing_prompt/999", allow_missing=True)
+    assert result is None
+
+    # Existing prompt with non-existent version via URI should raise when allow_missing=False
+    with pytest.raises(MlflowException, match=r"Prompt.*does not exist|not found"):
+        client.load_prompt("prompts:/existing_prompt/999", allow_missing=False)
+
+
+def test_load_prompt_allow_missing_uri_alias(tracking_uri):
     """Test that load_prompt with URI+alias respects allow_missing parameter."""
     client = MlflowClient(tracking_uri=tracking_uri)
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mr-brobot/mlflow/pull/17541?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17541/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17541/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17541/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #17495

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

- suppress `NOT_FOUND` errors during prompt alias resolution when `allow_missing` is set
- preserve error codes in `translate_prompt_exception`

this call stack passes through `MlflowClient.get_prompt_version_by_alias`, which is decorated with `translate_prompt_exception`. that decorator was dropping error codes (only when the message was transformed)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
