### PR TITLE
Fix substitution of escape sequences in genai format_prompt

### DIFF
--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -23,7 +23,7 @@ def get_default_model() -> str:
 def format_prompt(prompt: str, **values) -> str:
     """Format double-curly variables in the prompt template."""
     for key, value in values.items():
-        prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", str(value), prompt)
+        prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", lambda _: str(value), prompt)
     return prompt
 
 

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -6,7 +6,7 @@ from litellm.types.utils import ModelResponse
 
 from mlflow.entities.assessment import AssessmentSourceType
 from mlflow.exceptions import MlflowException
-from mlflow.genai.judges.utils import CategoricalRating, invoke_judge_model
+from mlflow.genai.judges.utils import CategoricalRating, format_prompt, invoke_judge_model
 
 
 def test_invoke_judge_model_successful_with_litellm():
@@ -77,3 +77,13 @@ def test_invoke_judge_model_invalid_json_response():
             invoke_judge_model(
                 model_uri="openai:/gpt-4", prompt="Test prompt", assessment_name="test"
             )
+
+
+def test_format_prompt_substitution():
+    """Test that format_prompt correctly substitutes variables and handles escape sequences."""
+    prompt_template = "Evaluate the following context: {{context}}"
+    test_context = "The quick brown fox jumps over the lazy dog. Test escape sequences: \\x \\u"
+    expected_prompt = f"Evaluate the following context: {test_context}"
+
+    formatted_prompt = format_prompt(prompt_template, context=test_context)
+    assert formatted_prompt == expected_prompt


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ptc-swalk/mlflow/pull/17543?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17543/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17543/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17543/merge
```

</p>
</details>

### What changes are proposed in this pull request?

In mlflow.genai.judges.utils.format_prompt, a string is used as the replacement argument for re.sub. This leads to escape sequences being interpreted which seems to be undesirable (for example, when the function is used to judge retrieval sufficiency, a literal `\n` (backslash followed by n) in the retrieval context would be replaced by a newline). Also, unknown escape sequences such as `\x` or `\u` lead to judge errors since re.sub throws an exception when they are encountered.

Fix this by using the function-call form for the replacement argument which uses the string literally.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix genai retrieval judge error if escape sequences are in the retrieval context.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
