### PR TITLE
Only update docker latest when releasing next semantic version

### DIFF
--- a/.github/workflows/push-images.yml
+++ b/.github/workflows/push-images.yml
@@ -30,16 +30,35 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Check if should update latest tag
+        id: check_latest
+        run: |
+          CURRENT_VERSION=${GITHUB_REF_NAME#v}
+
+          HIGHEST_VERSION=$(gh release list --exclude-pre-releases --exclude-drafts --limit 100 | \
+            grep -E '^v[0-9]+\.[0-9]+\.[0-9]+\s' | \
+            awk '{print $1}' | \
+            sed 's/^v//' | \
+            sort -V | \
+            tail -n1)
+
+          if [ -z "$HIGHEST_VERSION" ] || [ "$(echo -e "$CURRENT_VERSION\n$HIGHEST_VERSION" | sort -V | tail -n1)" = "$CURRENT_VERSION" ]; then
+            echo "should_update_latest=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_update_latest=false" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Gather Docker Metadata for Tracking
         id: meta
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
-          # list of Docker images to use as base name for tags
           images: |
             ghcr.io/mlflow/mlflow
-          # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=tag
+            type=raw,value=latest,enable=${{ steps.check_latest.outputs.should_update_latest == 'true' }}
 
       - name: Build and Push Base Image
         uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3.3.1
@@ -55,12 +74,11 @@ jobs:
         id: modelmeta
         uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4.6.0
         with:
-          # list of Docker images to use as base name for tags
           images: |
             ghcr.io/mlflow/model-server
-          # generate Docker tags based on the following events/attributes
           tags: |
             type=ref,event=tag
+            type=raw,value=latest,enable=${{ steps.check_latest.outputs.should_update_latest == 'true' }}
 
       - name: Build Model Server Image
         run: |


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #17532 

### What changes are proposed in this pull request?

Updates the GHCR docker image of MLflow to `latest` when we increment a semantic version update. Currently, patch releases to old version of MLflow will reset 'latest' to an older patch version. This only updates latest if we're actually incrementing the latest release build.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
