### PR TITLE
Update spans table definition and migration for PG 11 and lower 

### DIFF
--- a/docs/docs/classic-ml/tracking/backend-stores/index.mdx
+++ b/docs/docs/classic-ml/tracking/backend-stores/index.mdx
@@ -136,12 +136,26 @@ pip --no-cache-dir install --force-reinstall -I pyyaml
 
 ## Troubleshooting Database Migrations
 
+:::info Database Compatibility
+**The issues described in this section are specific to PostgreSQL 11 and earlier.**
+
+Users of the following databases are **NOT affected**:
+- ✅ PostgreSQL 12 and later
+- ✅ MySQL (all versions)
+- ✅ SQLite (all versions)
+- ✅ MS SQL Server (all versions)
+
+If you're using PostgreSQL 11 or earlier with MLflow 3.3.x, you may encounter migration issues that require manual intervention.
+:::
+
 ### PostgreSQL 11 Compatibility Issue
 
 :::warning postgresql-11-generated-columns
 **Error: "syntax error at or near '(' ... duration_ns BIGINT GENERATED ALWAYS AS"**
 
-If you encounter this error when running MLflow with PostgreSQL 11:
+**⚠️ This issue ONLY affects PostgreSQL version 11 and earlier. Users of PostgreSQL 12+, MySQL, SQLite, or MS SQL Server are NOT affected.**
+
+If you encounter this error when running MLflow 3.3.x with PostgreSQL 11:
 
 ```
 sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near "("
@@ -149,7 +163,7 @@ LINE 12: duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano ...
                                                  ^
 ```
 
-This occurs because PostgreSQL 11 doesn't support GENERATED columns (introduced in PostgreSQL 12). MLflow 3.3.1+ automatically detects your PostgreSQL version and uses alternative methods for PostgreSQL 11.
+This occurs because PostgreSQL 11 doesn't support GENERATED columns (introduced in PostgreSQL 12). MLflow 3.4.0+ will automatically detect your PostgreSQL version and use alternative methods for PostgreSQL 11.
 
 **Solution for existing installations:**
 
@@ -213,6 +227,8 @@ ON CONFLICT DO NOTHING;
 :::warning downgrade-with-database
 **Error: "No such revision or branch" when downgrading**
 
+**Note:** This is most commonly encountered by PostgreSQL 11 users trying to downgrade from MLflow 3.3.x to 3.2.0 after the spans table migration failed. Other database users (PostgreSQL 12+, MySQL, SQLite, MS SQL) typically don't need to downgrade.
+
 If you're downgrading MLflow (e.g., from 3.3.x to 3.2.0) and encounter:
 
 ```
@@ -233,12 +249,13 @@ This occurs because your database has migrations from the newer version that don
 2. **Remove migrations that don't exist in the target version:**
 
    ```sql
-   -- For downgrading from 3.3.x to 3.2.0, remove these migrations:
+   -- For downgrading from 3.3.x to 3.2.0:
+   -- Remove migrations that were added in 3.3.0
+
    DELETE FROM alembic_version WHERE version_num IN (
      '1a0cddfcaa16',  -- webhooks (3.3.0)
-     '534353b11cbc',  -- scorer tables (3.3.0)
-     '71994744cf8e',  -- evaluation datasets (3.3.0)
-     'e2c54d7e0d3f'   -- PostgreSQL 11 fix (3.3.1)
+     'a1b2c3d4e5f6',  -- spans table (3.3.0 - may have failed on PostgreSQL 11)
+     '770bee3ae1dd'   -- assessments table (3.3.0)
    );
 
    -- Set to the last migration in 3.2.0
@@ -250,14 +267,14 @@ This occurs because your database has migrations from the newer version that don
 3. **Clean up tables created by newer migrations (optional but recommended):**
 
    ```sql
-   -- Drop tables that were added after 3.2.0
+   -- Drop tables that were added in 3.3.0
    DROP TABLE IF EXISTS webhook_events CASCADE;
    DROP TABLE IF EXISTS webhooks CASCADE;
-   DROP TABLE IF EXISTS scorer_versions CASCADE;
-   DROP TABLE IF EXISTS scorers CASCADE;
-   DROP TABLE IF EXISTS evaluation_dataset_records CASCADE;
-   DROP TABLE IF EXISTS evaluation_dataset_tags CASCADE;
-   DROP TABLE IF EXISTS evaluation_datasets CASCADE;
+   DROP TABLE IF EXISTS assessments CASCADE;
+   DROP TABLE IF EXISTS spans CASCADE;
+
+   -- Note: The spans table may not exist if its creation failed on PostgreSQL 11
+   -- The DROP IF EXISTS will handle this gracefully
    ```
 
 4. **Start MLflow with the older version:**

--- a/docs/docs/classic-ml/tracking/backend-stores/index.mdx
+++ b/docs/docs/classic-ml/tracking/backend-stores/index.mdx
@@ -140,6 +140,7 @@ pip --no-cache-dir install --force-reinstall -I pyyaml
 **The issues described in this section are specific to PostgreSQL 11 and earlier.**
 
 Users of the following databases are **NOT affected**:
+
 - ✅ PostgreSQL 12 and later
 - ✅ MySQL (all versions)
 - ✅ SQLite (all versions)

--- a/docs/docs/classic-ml/tracking/backend-stores/index.mdx
+++ b/docs/docs/classic-ml/tracking/backend-stores/index.mdx
@@ -153,7 +153,10 @@ This occurs because PostgreSQL 11 doesn't support GENERATED columns (introduced 
 
 **Solution for existing installations:**
 
-If you're upgrading MLflow and encounter this error, run the following SQL commands directly on your database:
+If you're upgrading MLflow and encounter this error, you have two options:
+
+**Option 1: Fix the database schema (Recommended)**
+Run the following SQL commands directly on your database:
 
 ```sql
 -- Add the missing column
@@ -187,11 +190,82 @@ INSERT INTO alembic_version (version_num) VALUES ('a1b2c3d4e5f6')
 ON CONFLICT DO NOTHING;
 ```
 
+**Option 2: Skip the problematic migration (if Option 1 doesn't work)**
+If you're completely blocked and need to bypass the spans table creation:
+
+```sql
+-- Mark the migration as complete without creating the table
+-- WARNING: This will skip spans/tracing functionality
+INSERT INTO alembic_version (version_num) VALUES ('a1b2c3d4e5f6')
+ON CONFLICT DO NOTHING;
+```
+
 **Recommendations:**
+
 - **Upgrade PostgreSQL**: Consider upgrading to PostgreSQL 12 or later for full feature support.
 - **Fresh installations**: MLflow automatically handles PostgreSQL 11 compatibility.
 - **Report issues**: If you continue experiencing problems, please [report them on GitHub](https://github.com/mlflow/mlflow/issues).
 
+:::
+
+### Downgrading MLflow with Database Backend
+
+:::warning downgrade-with-database
+**Error: "No such revision or branch" when downgrading**
+
+If you're downgrading MLflow (e.g., from 3.3.x to 3.2.0) and encounter:
+
+```
+alembic.script.revision.ResolutionError: No such revision or branch '1a0cddfcaa16'
+```
+
+This occurs because your database has migrations from the newer version that don't exist in the older version.
+
+**Solution:**
+
+1. **Identify the last migration that exists in your target version:**
+
+   ```sql
+   -- Check current migrations in your database
+   SELECT * FROM alembic_version;
+   ```
+
+2. **Remove migrations that don't exist in the target version:**
+
+   ```sql
+   -- For downgrading from 3.3.x to 3.2.0, remove these migrations:
+   DELETE FROM alembic_version WHERE version_num IN (
+     '1a0cddfcaa16',  -- webhooks (3.3.0)
+     '534353b11cbc',  -- scorer tables (3.3.0)
+     '71994744cf8e',  -- evaluation datasets (3.3.0)
+     'e2c54d7e0d3f'   -- PostgreSQL 11 fix (3.3.1)
+   );
+
+   -- Set to the last migration in 3.2.0
+   INSERT INTO alembic_version (version_num)
+   SELECT 'de4033877273'  -- entity_associations (last in 3.2.0)
+   WHERE NOT EXISTS (SELECT 1 FROM alembic_version WHERE version_num = 'de4033877273');
+   ```
+
+3. **Clean up tables created by newer migrations (optional but recommended):**
+
+   ```sql
+   -- Drop tables that were added after 3.2.0
+   DROP TABLE IF EXISTS webhook_events CASCADE;
+   DROP TABLE IF EXISTS webhooks CASCADE;
+   DROP TABLE IF EXISTS scorer_versions CASCADE;
+   DROP TABLE IF EXISTS scorers CASCADE;
+   DROP TABLE IF EXISTS evaluation_dataset_records CASCADE;
+   DROP TABLE IF EXISTS evaluation_dataset_tags CASCADE;
+   DROP TABLE IF EXISTS evaluation_datasets CASCADE;
+   ```
+
+4. **Start MLflow with the older version:**
+   ```bash
+   mlflow server --backend-store-uri <your-database-uri>
+   ```
+
+**Important:** Always backup your database before downgrading!
 :::
 
 ### General Migration Issues

--- a/docs/docs/classic-ml/tracking/backend-stores/index.mdx
+++ b/docs/docs/classic-ml/tracking/backend-stores/index.mdx
@@ -133,3 +133,81 @@ After installing LibYAML, you need to reinstall PyYAML:
 # Reinstall PyYAML
 pip --no-cache-dir install --force-reinstall -I pyyaml
 ```
+
+## Troubleshooting Database Migrations
+
+### PostgreSQL 11 Compatibility Issue
+
+:::warning postgresql-11-generated-columns
+**Error: "syntax error at or near '(' ... duration_ns BIGINT GENERATED ALWAYS AS"**
+
+If you encounter this error when running MLflow with PostgreSQL 11:
+
+```
+sqlalchemy.exc.ProgrammingError: (psycopg2.errors.SyntaxError) syntax error at or near "("
+LINE 12: duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano ...
+                                                 ^
+```
+
+This occurs because PostgreSQL 11 doesn't support GENERATED columns (introduced in PostgreSQL 12). MLflow 3.3.1+ automatically detects your PostgreSQL version and uses alternative methods for PostgreSQL 11.
+
+**Solution for existing installations:**
+
+If you're upgrading MLflow and encounter this error, run the following SQL commands directly on your database:
+
+```sql
+-- Add the missing column
+ALTER TABLE spans ADD COLUMN IF NOT EXISTS duration_ns BIGINT;
+
+-- Create trigger to maintain the column
+CREATE OR REPLACE FUNCTION update_span_duration()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.end_time_unix_nano IS NOT NULL THEN
+        NEW.duration_ns = NEW.end_time_unix_nano - NEW.start_time_unix_nano;
+    ELSE
+        NEW.duration_ns = NULL;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER span_duration_trigger
+BEFORE INSERT OR UPDATE OF end_time_unix_nano, start_time_unix_nano ON spans
+FOR EACH ROW
+EXECUTE FUNCTION update_span_duration();
+
+-- Update existing rows
+UPDATE spans
+SET duration_ns = end_time_unix_nano - start_time_unix_nano
+WHERE end_time_unix_nano IS NOT NULL AND duration_ns IS NULL;
+
+-- Mark migration as complete
+INSERT INTO alembic_version (version_num) VALUES ('a1b2c3d4e5f6')
+ON CONFLICT DO NOTHING;
+```
+
+**Recommendations:**
+- **Upgrade PostgreSQL**: Consider upgrading to PostgreSQL 12 or later for full feature support.
+- **Fresh installations**: MLflow automatically handles PostgreSQL 11 compatibility.
+- **Report issues**: If you continue experiencing problems, please [report them on GitHub](https://github.com/mlflow/mlflow/issues).
+
+:::
+
+### General Migration Issues
+
+If you encounter other database migration errors:
+
+1. **Always backup your database** before running migrations
+2. **Check your database version** compatibility:
+   - PostgreSQL: 11+ (12+ recommended)
+   - MySQL: 5.7+
+   - SQLite: 3.7.0+
+3. **Run migrations manually** if automatic migration fails:
+   ```bash
+   mlflow db upgrade [your-database-uri]
+   ```
+4. **Check migration status**:
+   ```sql
+   SELECT * FROM alembic_version;
+   ```

--- a/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
+++ b/mlflow/store/db_migrations/versions/a1b2c3d4e5f6_add_spans_table.py
@@ -17,31 +17,69 @@ branch_labels = None
 depends_on = None
 
 
+def _get_postgres_version():
+    """Get PostgreSQL major version number."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return None
+
+    try:
+        from sqlalchemy import text
+
+        result = bind.execute(text("SELECT version()"))
+        version_str = result.scalar()
+        import re
+
+        match = re.search(r"PostgreSQL (\d+)", version_str)
+        if match:
+            return int(match.group(1))
+    except Exception:
+        pass
+    return None
+
+
 def upgrade():
-    op.create_table(
-        SqlSpan.__tablename__,
+    bind = op.get_bind()
+
+    use_generated_column = True
+
+    if bind.dialect.name == "postgresql":
+        pg_version = _get_postgres_version()
+        if pg_version and pg_version < 12:
+            use_generated_column = False
+
+    columns = [
         sa.Column("trace_id", sa.String(length=50), nullable=False),
         sa.Column("experiment_id", sa.Integer(), nullable=False),
         sa.Column("span_id", sa.String(length=50), nullable=False),
         sa.Column("parent_span_id", sa.String(length=50), nullable=True),
         sa.Column("name", sa.Text(), nullable=True),
-        # Use String instead of Text for type column to support MSSQL indexes.
-        # MSSQL doesn't allow TEXT columns in indexes. Limited to 500 chars
+        # NB: MSSQL doesn't allow TEXT columns in indexes. Limited to 500 chars
         # to stay within MySQL's max index key length of 3072 bytes.
         sa.Column("type", sa.String(length=500), nullable=True),
         sa.Column("status", sa.String(length=50), nullable=False),
         sa.Column("start_time_unix_nano", sa.BigInteger(), nullable=False),
         sa.Column("end_time_unix_nano", sa.BigInteger(), nullable=True),
-        sa.Column(
-            "duration_ns",
-            sa.BigInteger(),
-            sa.Computed("end_time_unix_nano - start_time_unix_nano", persisted=True),
-            nullable=True,
-        ),
-        # Use LONGTEXT for MySQL to support large span content (up to 4GB).
-        # Standard TEXT in MySQL is limited to 64KB which is insufficient for
-        # spans with extensive attributes, events, or nested data structures.
-        sa.Column("content", sa.Text().with_variant(LONGTEXT, "mysql"), nullable=False),
+    ]
+
+    if use_generated_column:
+        columns.append(
+            sa.Column(
+                "duration_ns",
+                sa.BigInteger(),
+                sa.Computed("end_time_unix_nano - start_time_unix_nano", persisted=True),
+                nullable=True,
+            )
+        )
+    else:
+        columns.append(sa.Column("duration_ns", sa.BigInteger(), nullable=True))
+
+    # NB: LONGTEXT required for MySQL to support large span content (>64KB)
+    columns.append(sa.Column("content", sa.Text().with_variant(LONGTEXT, "mysql"), nullable=False))
+
+    op.create_table(
+        SqlSpan.__tablename__,
+        *columns,
         sa.ForeignKeyConstraint(
             ["trace_id"],
             ["trace_info.request_id"],
@@ -56,23 +94,54 @@ def upgrade():
         sa.PrimaryKeyConstraint("trace_id", "span_id", name="spans_pk"),
     )
 
+    if bind.dialect.name == "postgresql" and not use_generated_column:
+        from sqlalchemy import text
+
+        op.execute(
+            text(
+                """
+            CREATE OR REPLACE FUNCTION update_span_duration()
+            RETURNS TRIGGER AS $$
+            BEGIN
+                IF NEW.end_time_unix_nano IS NOT NULL THEN
+                    NEW.duration_ns = NEW.end_time_unix_nano - NEW.start_time_unix_nano;
+                ELSE
+                    NEW.duration_ns = NULL;
+                END IF;
+                RETURN NEW;
+            END;
+            $$ LANGUAGE plpgsql;
+            """
+            )
+        )
+
+        op.execute(
+            text(
+                """
+            CREATE TRIGGER span_duration_trigger
+            BEFORE INSERT OR UPDATE OF end_time_unix_nano, start_time_unix_nano ON spans
+            FOR EACH ROW
+            EXECUTE FUNCTION update_span_duration();
+            """
+            )
+        )
+
     with op.batch_alter_table(SqlSpan.__tablename__, schema=None) as batch_op:
         batch_op.create_index(
             f"index_{SqlSpan.__tablename__}_experiment_id",
             ["experiment_id"],
             unique=False,
         )
-        # Two indexes needed to support both filter patterns efficiently:
         batch_op.create_index(
             f"index_{SqlSpan.__tablename__}_experiment_id_status_type",
             ["experiment_id", "status", "type"],
             unique=False,
-        )  # For status-only and status+type filters
+        )
         batch_op.create_index(
             f"index_{SqlSpan.__tablename__}_experiment_id_type_status",
             ["experiment_id", "type", "status"],
             unique=False,
-        )  # For type-only and type+status filters
+        )
         batch_op.create_index(
             f"index_{SqlSpan.__tablename__}_experiment_id_duration",
             ["experiment_id", "duration_ns"],
@@ -81,4 +150,12 @@ def upgrade():
 
 
 def downgrade():
+    bind = op.get_bind()
+
+    if bind.dialect.name == "postgresql":
+        from sqlalchemy import text
+
+        op.execute(text("DROP TRIGGER IF EXISTS span_duration_trigger ON spans CASCADE"))
+        op.execute(text("DROP FUNCTION IF EXISTS update_span_duration() CASCADE"))
+
     op.drop_table(SqlSpan.__tablename__)

--- a/mlflow/store/db_migrations/versions/e2c54d7e0d3f_fix_spans_duration_postgresql11.py
+++ b/mlflow/store/db_migrations/versions/e2c54d7e0d3f_fix_spans_duration_postgresql11.py
@@ -5,6 +5,7 @@ Revises: de4033877273
 Create Date: 2024-01-10 00:00:00.000000
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 
@@ -58,7 +59,7 @@ def upgrade():
     """
     Fix for PostgreSQL 11 users who failed to create spans table due to
     GENERATED column syntax not being supported.
-    
+
     This migration:
     1. Detects if running on PostgreSQL < 12
     2. Checks if spans table exists but duration_ns is missing (migration failed)
@@ -129,7 +130,7 @@ def upgrade():
     op.execute(
         text(
             """
-        UPDATE spans 
+        UPDATE spans
         SET duration_ns = end_time_unix_nano - start_time_unix_nano
         WHERE end_time_unix_nano IS NOT NULL AND duration_ns IS NULL;
         """

--- a/mlflow/store/db_migrations/versions/e2c54d7e0d3f_fix_spans_duration_postgresql11.py
+++ b/mlflow/store/db_migrations/versions/e2c54d7e0d3f_fix_spans_duration_postgresql11.py
@@ -1,0 +1,158 @@
+"""Fix spans duration column for PostgreSQL 11 compatibility
+
+Revision ID: e2c54d7e0d3f
+Revises: de4033877273
+Create Date: 2024-01-10 00:00:00.000000
+
+"""
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e2c54d7e0d3f"
+down_revision = "71994744cf8e"
+branch_labels = None
+depends_on = None
+
+
+def _get_postgres_version():
+    """Get PostgreSQL major version number."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return None
+
+    try:
+        from sqlalchemy import text
+
+        result = bind.execute(text("SELECT version()"))
+        version_str = result.scalar()
+        import re
+
+        match = re.search(r"PostgreSQL (\d+)", version_str)
+        if match:
+            return int(match.group(1))
+    except Exception:
+        pass
+    return None
+
+
+def _column_exists(table_name, column_name):
+    """Check if a column exists in the table."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    try:
+        columns = [col["name"] for col in inspector.get_columns(table_name)]
+        return column_name in columns
+    except Exception:
+        return False
+
+
+def _table_exists(table_name):
+    """Check if a table exists."""
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return table_name in inspector.get_table_names()
+
+
+def upgrade():
+    """
+    Fix for PostgreSQL 11 users who failed to create spans table due to
+    GENERATED column syntax not being supported.
+    
+    This migration:
+    1. Detects if running on PostgreSQL < 12
+    2. Checks if spans table exists but duration_ns is missing (migration failed)
+    3. Adds the column as regular column with trigger if needed
+    4. Updates existing rows to populate duration_ns
+    """
+    bind = op.get_bind()
+
+    if bind.dialect.name != "postgresql":
+        return
+
+    pg_version = _get_postgres_version()
+
+    if pg_version and pg_version >= 12:
+        return
+
+    if not _table_exists("spans"):
+        return
+
+    if _column_exists("spans", "duration_ns"):
+        return
+
+    # NB: PostgreSQL < 12 with spans table but missing duration_ns column
+    from sqlalchemy import text
+
+    with op.batch_alter_table("spans", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("duration_ns", sa.BigInteger(), nullable=True))
+
+        try:
+            batch_op.create_index(
+                "index_spans_experiment_id_duration",
+                ["experiment_id", "duration_ns"],
+                unique=False,
+            )
+        except Exception:
+            pass
+
+    op.execute(
+        text(
+            """
+        CREATE OR REPLACE FUNCTION update_span_duration()
+        RETURNS TRIGGER AS $$
+        BEGIN
+            IF NEW.end_time_unix_nano IS NOT NULL THEN
+                NEW.duration_ns = NEW.end_time_unix_nano - NEW.start_time_unix_nano;
+            ELSE
+                NEW.duration_ns = NULL;
+            END IF;
+            RETURN NEW;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+        )
+    )
+
+    op.execute(
+        text(
+            """
+        DROP TRIGGER IF EXISTS span_duration_trigger ON spans;
+        CREATE TRIGGER span_duration_trigger
+        BEFORE INSERT OR UPDATE OF end_time_unix_nano, start_time_unix_nano ON spans
+        FOR EACH ROW
+        EXECUTE FUNCTION update_span_duration();
+        """
+        )
+    )
+
+    op.execute(
+        text(
+            """
+        UPDATE spans 
+        SET duration_ns = end_time_unix_nano - start_time_unix_nano
+        WHERE end_time_unix_nano IS NOT NULL AND duration_ns IS NULL;
+        """
+        )
+    )
+
+
+def downgrade():
+    """
+    Downgrade only affects PostgreSQL < 12 where we added the fix.
+    """
+    bind = op.get_bind()
+
+    if bind.dialect.name != "postgresql":
+        return
+
+    pg_version = _get_postgres_version()
+    if pg_version and pg_version >= 12:
+        return
+
+    from sqlalchemy import text
+
+    op.execute(text("DROP TRIGGER IF EXISTS span_duration_trigger ON spans CASCADE"))
+    op.execute(text("DROP FUNCTION IF EXISTS update_span_duration() CASCADE"))
+
+    # NB: We don't remove the duration_ns column as it may contain data

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -16,6 +16,20 @@ CREATE TABLE entity_associations (
 )
 
 
+CREATE TABLE evaluation_datasets (
+	dataset_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	schema TEXT,
+	profile TEXT,
+	digest VARCHAR(64),
+	created_time BIGINT,
+	last_update_time BIGINT,
+	created_by VARCHAR(255),
+	last_updated_by VARCHAR(255),
+	CONSTRAINT evaluation_datasets_pk PRIMARY KEY (dataset_id)
+)
+
+
 CREATE TABLE experiments (
 	experiment_id INTEGER NOT NULL,
 	name VARCHAR(256) NOT NULL,
@@ -83,6 +97,35 @@ CREATE TABLE datasets (
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
 	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE evaluation_dataset_records (
+	dataset_record_id VARCHAR(36) NOT NULL,
+	dataset_id VARCHAR(36) NOT NULL,
+	inputs JSON NOT NULL,
+	expectations JSON,
+	tags JSON,
+	source JSON,
+	source_id VARCHAR(36),
+	source_type VARCHAR(255),
+	created_time BIGINT,
+	last_update_time BIGINT,
+	created_by VARCHAR(255),
+	last_updated_by VARCHAR(255),
+	input_hash VARCHAR(64) NOT NULL,
+	CONSTRAINT evaluation_dataset_records_pk PRIMARY KEY (dataset_record_id),
+	CONSTRAINT fk_evaluation_dataset_records_dataset_id FOREIGN KEY(dataset_id) REFERENCES evaluation_datasets (dataset_id) ON DELETE CASCADE,
+	CONSTRAINT unique_dataset_input UNIQUE (dataset_id, input_hash)
+)
+
+
+CREATE TABLE evaluation_dataset_tags (
+	dataset_id VARCHAR(36) NOT NULL,
+	key VARCHAR(255) NOT NULL,
+	value VARCHAR(5000),
+	CONSTRAINT evaluation_dataset_tags_pk PRIMARY KEY (dataset_id, key),
+	CONSTRAINT fk_evaluation_dataset_tags_dataset_id FOREIGN KEY(dataset_id) REFERENCES evaluation_datasets (dataset_id) ON DELETE CASCADE
 )
 
 
@@ -170,6 +213,15 @@ CREATE TABLE runs (
 	CONSTRAINT runs_lifecycle_stage CHECK (lifecycle_stage IN ('active', 'deleted')),
 	CONSTRAINT source_type CHECK (source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')),
 	CHECK (status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING', 'KILLED'))
+)
+
+
+CREATE TABLE scorers (
+	experiment_id INTEGER NOT NULL,
+	scorer_name VARCHAR(256) NOT NULL,
+	scorer_id VARCHAR(36) NOT NULL,
+	CONSTRAINT scorer_pk PRIMARY KEY (scorer_id),
+	CONSTRAINT fk_scorers_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -300,6 +352,16 @@ CREATE TABLE params (
 	run_uuid VARCHAR(32) NOT NULL,
 	CONSTRAINT param_pk PRIMARY KEY (key, run_uuid),
 	FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+)
+
+
+CREATE TABLE scorer_versions (
+	scorer_id VARCHAR(36) NOT NULL,
+	scorer_version INTEGER NOT NULL,
+	serialized_scorer TEXT NOT NULL,
+	creation_time BIGINT,
+	CONSTRAINT scorer_version_pk PRIMARY KEY (scorer_id, scorer_version),
+	CONSTRAINT fk_scorer_versions_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -16,20 +16,6 @@ CREATE TABLE entity_associations (
 )
 
 
-CREATE TABLE evaluation_datasets (
-	dataset_id VARCHAR(36) NOT NULL,
-	name VARCHAR(255) NOT NULL,
-	schema TEXT,
-	profile TEXT,
-	digest VARCHAR(64),
-	created_time BIGINT,
-	last_update_time BIGINT,
-	created_by VARCHAR(255),
-	last_updated_by VARCHAR(255),
-	CONSTRAINT evaluation_datasets_pk PRIMARY KEY (dataset_id)
-)
-
-
 CREATE TABLE experiments (
 	experiment_id INTEGER NOT NULL,
 	name VARCHAR(256) NOT NULL,
@@ -97,35 +83,6 @@ CREATE TABLE datasets (
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
 	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
-)
-
-
-CREATE TABLE evaluation_dataset_records (
-	dataset_record_id VARCHAR(36) NOT NULL,
-	dataset_id VARCHAR(36) NOT NULL,
-	inputs JSON NOT NULL,
-	expectations JSON,
-	tags JSON,
-	source JSON,
-	source_id VARCHAR(36),
-	source_type VARCHAR(255),
-	created_time BIGINT,
-	last_update_time BIGINT,
-	created_by VARCHAR(255),
-	last_updated_by VARCHAR(255),
-	input_hash VARCHAR(64) NOT NULL,
-	CONSTRAINT evaluation_dataset_records_pk PRIMARY KEY (dataset_record_id),
-	CONSTRAINT fk_evaluation_dataset_records_dataset_id FOREIGN KEY(dataset_id) REFERENCES evaluation_datasets (dataset_id) ON DELETE CASCADE,
-	CONSTRAINT unique_dataset_input UNIQUE (dataset_id, input_hash)
-)
-
-
-CREATE TABLE evaluation_dataset_tags (
-	dataset_id VARCHAR(36) NOT NULL,
-	key VARCHAR(255) NOT NULL,
-	value VARCHAR(5000),
-	CONSTRAINT evaluation_dataset_tags_pk PRIMARY KEY (dataset_id, key),
-	CONSTRAINT fk_evaluation_dataset_tags_dataset_id FOREIGN KEY(dataset_id) REFERENCES evaluation_datasets (dataset_id) ON DELETE CASCADE
 )
 
 
@@ -213,15 +170,6 @@ CREATE TABLE runs (
 	CONSTRAINT runs_lifecycle_stage CHECK (lifecycle_stage IN ('active', 'deleted')),
 	CONSTRAINT source_type CHECK (source_type IN ('NOTEBOOK', 'JOB', 'LOCAL', 'UNKNOWN', 'PROJECT')),
 	CHECK (status IN ('SCHEDULED', 'FAILED', 'FINISHED', 'RUNNING', 'KILLED'))
-)
-
-
-CREATE TABLE scorers (
-	experiment_id INTEGER NOT NULL,
-	scorer_name VARCHAR(256) NOT NULL,
-	scorer_id VARCHAR(36) NOT NULL,
-	CONSTRAINT scorer_pk PRIMARY KEY (scorer_id),
-	CONSTRAINT fk_scorers_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -352,16 +300,6 @@ CREATE TABLE params (
 	run_uuid VARCHAR(32) NOT NULL,
 	CONSTRAINT param_pk PRIMARY KEY (key, run_uuid),
 	FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
-)
-
-
-CREATE TABLE scorer_versions (
-	scorer_id VARCHAR(36) NOT NULL,
-	scorer_version INTEGER NOT NULL,
-	serialized_scorer TEXT NOT NULL,
-	creation_time BIGINT,
-	CONSTRAINT scorer_version_pk PRIMARY KEY (scorer_id, scorer_version),
-	CONSTRAINT fk_scorer_versions_scorer_id FOREIGN KEY(scorer_id) REFERENCES scorers (scorer_id) ON DELETE CASCADE
 )
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17548?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17548/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17548/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17548/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #17539 

### What changes are proposed in this pull request?

Adds a new migration to fix an incompatibility with postgres 11 and lower DBs for the spans table introduced in MLflow 3.3

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

Verified downgrade operations work with this update for an incomplete state (on sqllite) where the alembic migration is removed from the migration table and the guidance in the docs allows for safe recovery. Running upgrade again with the new migration file allows for proper table creation and downgrade as needed.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
