### PR TITLE
[ML-57379] Prevent scorers with non-databricks custom judge models from being registered in Databricks

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -721,9 +721,11 @@ class Scorer(BaseModel):
             raise MlflowException.invalid_parameter_value(error_message)
 
         store = _get_scorer_store()
-        if isinstance(store, DatabricksStore)(
-            model := getattr(self, "model", None)
-        ) and model.startswith("databricks"):
+        if (
+            isinstance(store, DatabricksStore)
+            and (model := getattr(self, "model", None))
+            and not model.startswith("databricks")
+        ):
             raise MlflowException.invalid_parameter_value(
                 "The scorer's judge model must use Databricks as a model provider "
                 "in order to be registered or updated. Please use the default judge model or "

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -721,14 +721,17 @@ class Scorer(BaseModel):
             raise MlflowException.invalid_parameter_value(error_message)
 
         store = _get_scorer_store()
-        if isinstance(store, DatabricksStore) and not getattr(
-            self, "model", "databricks"
-        ).startswith("databricks"):
+        model = getattr(self, "model", None)
+        if (
+            isinstance(store, DatabricksStore)
+            and model is not None
+            and not model.startswith("databricks")
+        ):
             error_message = (
                 "The scorer's judge model must use Databricks as a model provider "
                 "in order to be registered or updated. Please use the default judge model or "
                 "specify a model value starting with `databricks:/`. "
-                f"Got {getattr(self, 'model', None)}."
+                f"Got {model}."
             )
             raise MlflowException.invalid_parameter_value(error_message)
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -726,8 +726,8 @@ class Scorer(BaseModel):
         ).startswith("databricks"):
             error_message = (
                 "The scorer's judge model must use Databricks as a model provider "
-                "in order to be registered. Please use the default judge model or specify a model "
-                "value starting with `databricks:/`. "
+                "in order to be registered or updated. Please use the default judge model or "
+                "specify a model value starting with `databricks:/`. "
                 f"Got {getattr(self, 'model', None)}."
             )
             raise MlflowException.invalid_parameter_value(error_message)

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -727,13 +727,12 @@ class Scorer(BaseModel):
             and model is not None
             and not model.startswith("databricks")
         ):
-            error_message = (
+            raise MlflowException.invalid_parameter_value(
                 "The scorer's judge model must use Databricks as a model provider "
                 "in order to be registered or updated. Please use the default judge model or "
                 "specify a model value starting with `databricks:/`. "
                 f"Got {model}."
             )
-            raise MlflowException.invalid_parameter_value(error_message)
 
 
 @experimental(version="3.0.0")

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -721,12 +721,9 @@ class Scorer(BaseModel):
             raise MlflowException.invalid_parameter_value(error_message)
 
         store = _get_scorer_store()
-        model = getattr(self, "model", None)
-        if (
-            isinstance(store, DatabricksStore)
-            and model is not None
-            and not model.startswith("databricks")
-        ):
+        if isinstance(store, DatabricksStore)(
+            model := getattr(self, "model", None)
+        ) and model.startswith("databricks"):
             raise MlflowException.invalid_parameter_value(
                 "The scorer's judge model must use Databricks as a model provider "
                 "in order to be registered or updated. Please use the default judge model or "

--- a/tests/genai/scorers/test_builtin_scorers_registration.py
+++ b/tests/genai/scorers/test_builtin_scorers_registration.py
@@ -1,0 +1,128 @@
+"""Tests for builtin scorer registration validation with custom judge models."""
+
+from unittest.mock import patch
+
+import pytest
+
+import mlflow
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers import RetrievalRelevance, Safety
+from mlflow.genai.scorers.base import ScorerSamplingConfig
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+def test_safety_with_non_databricks_model_cannot_register(_):
+    """Test that Safety scorer with non-databricks model cannot be registered."""
+    # OpenAI model
+    scorer = Safety(model="openai:/gpt-4")
+    with pytest.raises(
+        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
+    ):
+        scorer.register()
+
+    # Anthropic model
+    scorer = Safety(model="anthropic:/claude-3-opus")
+    with pytest.raises(
+        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
+    ):
+        scorer.register()
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+def test_retrieval_relevance_with_non_databricks_model_cannot_register(_):
+    """Test that RetrievalRelevance scorer with non-databricks model cannot be registered."""
+    scorer = RetrievalRelevance(model="openai:/gpt-4")
+    with pytest.raises(
+        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
+    ):
+        scorer.register()
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+@patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer")
+def test_safety_with_databricks_model_can_register(mock_add, _):
+    """Test that Safety scorer with databricks model can be registered."""
+    scorer = Safety(model="databricks:/my-judge-model")
+    registered = scorer.register()
+
+    assert registered.name == "safety"
+    mock_add.assert_called_once()
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+@patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer")
+def test_builtin_scorer_without_custom_model_can_register(mock_add, _):
+    """Test that builtin scorers without custom models can be registered."""
+    # Safety with default model (None)
+    scorer = Safety()
+    registered = scorer.register()
+    assert registered.name == "safety"
+    mock_add.assert_called_once()
+
+    mock_add.reset_mock()
+
+    # RetrievalRelevance with default model (None)
+    scorer = RetrievalRelevance()
+    registered = scorer.register()
+    assert registered.name == "retrieval_relevance"
+    mock_add.assert_called_once()
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+def test_scorer_start_with_non_databricks_model_fails(_):
+    """Test that start() method also validates model provider."""
+    scorer = Safety(model="openai:/gpt-4")
+    with pytest.raises(
+        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
+    ):
+        scorer.start(sampling_config=ScorerSamplingConfig(sample_rate=0.5))
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+def test_scorer_update_with_non_databricks_model_fails(_):
+    """Test that update() method also validates model provider."""
+    scorer = Safety(model="anthropic:/claude-3")
+    with pytest.raises(
+        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
+    ):
+        scorer.update(sampling_config=ScorerSamplingConfig(sample_rate=0.3))
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+def test_scorer_stop_with_non_databricks_model_fails(_):
+    """Test that stop() method also validates model provider."""
+    scorer = RetrievalRelevance(model="openai:/gpt-4")
+    with pytest.raises(
+        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
+    ):
+        scorer.stop()
+
+
+def test_non_databricks_backend_allows_any_model():
+    """Test that non-databricks backends allow any model provider."""
+    experiment_id = mlflow.create_experiment("test_any_model_allowed")
+
+    # OpenAI model should work with MLflow backend
+    scorer = Safety(model="openai:/gpt-4")
+    registered = scorer.register(experiment_id=experiment_id)
+    assert registered.name == "safety"
+
+    # Anthropic model should work with MLflow backend
+    scorer = RetrievalRelevance(model="anthropic:/claude-3-opus")
+    registered = scorer.register(experiment_id=experiment_id)
+    assert registered.name == "retrieval_relevance"
+
+    # Clean up
+    mlflow.delete_experiment(experiment_id)
+
+
+@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
+def test_error_message_shows_actual_model(_):
+    """Test that error message includes the actual model that was rejected."""
+    model = "openai:/gpt-4-turbo"
+    scorer = Safety(model=model)
+
+    with pytest.raises(MlflowException, match=f"Got {model}") as exc_info:
+        scorer.register()
+
+    assert f"Got {model}" in str(exc_info.value)

--- a/tests/genai/scorers/test_builtin_scorers_registration.py
+++ b/tests/genai/scorers/test_builtin_scorers_registration.py
@@ -1,5 +1,6 @@
 """Tests for builtin scorer registration validation with custom judge models."""
 
+from unittest import mock
 from unittest.mock import patch
 
 import pytest
@@ -10,114 +11,123 @@ from mlflow.genai.scorers import RetrievalRelevance, Safety
 from mlflow.genai.scorers.base import ScorerSamplingConfig
 
 
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_safety_with_non_databricks_model_cannot_register(_):
-    """Test that Safety scorer with non-databricks model cannot be registered."""
-    # OpenAI model
-    scorer = Safety(model="openai:/gpt-4")
+@pytest.fixture
+def mock_databricks_tracking_uri():
+    """Module-level fixture to mock Databricks tracking URI for tests that need it."""
+    with patch(
+        "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
+    ) as mock_uri:
+        yield mock_uri
+
+
+@pytest.mark.parametrize(
+    ("scorer_class", "model"),
+    [
+        (Safety, "openai:/gpt-4"),
+        (Safety, "anthropic:/claude-3-opus"),
+        (RetrievalRelevance, "openai:/gpt-4"),
+        (RetrievalRelevance, "anthropic:/claude-3"),
+    ],
+)
+def test_non_databricks_model_cannot_register(
+    scorer_class, model, mock_databricks_tracking_uri: mock.Mock
+):
+    """Test that scorers with non-databricks models cannot be registered."""
+    scorer = scorer_class(model=model)
     with pytest.raises(
         MlflowException, match="The scorer's judge model must use Databricks as a model provider"
     ):
         scorer.register()
-
-    # Anthropic model
-    scorer = Safety(model="anthropic:/claude-3-opus")
-    with pytest.raises(
-        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
-    ):
-        scorer.register()
+    mock_databricks_tracking_uri.assert_called()
 
 
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_retrieval_relevance_with_non_databricks_model_cannot_register(_):
-    """Test that RetrievalRelevance scorer with non-databricks model cannot be registered."""
-    scorer = RetrievalRelevance(model="openai:/gpt-4")
-    with pytest.raises(
-        MlflowException, match="The scorer's judge model must use Databricks as a model provider"
-    ):
-        scorer.register()
-
-
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-@patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer")
-def test_safety_with_databricks_model_can_register(mock_add, _):
+def test_safety_with_databricks_model_can_register(mock_databricks_tracking_uri: mock.Mock):
     """Test that Safety scorer with databricks model can be registered."""
-    scorer = Safety(model="databricks:/my-judge-model")
-    registered = scorer.register()
+    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
+        scorer = Safety(model="databricks:/my-judge-model")
+        registered = scorer.register()
 
-    assert registered.name == "safety"
-    mock_add.assert_called_once()
+        assert registered.name == "safety"
+        mock_add.assert_called_once()
+        mock_databricks_tracking_uri.assert_called()
 
 
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-@patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer")
-def test_builtin_scorer_without_custom_model_can_register(mock_add, _):
+def test_builtin_scorer_without_custom_model_can_register(mock_databricks_tracking_uri: mock.Mock):
     """Test that builtin scorers without custom models can be registered."""
-    # Safety with default model (None)
-    scorer = Safety()
-    registered = scorer.register()
-    assert registered.name == "safety"
-    mock_add.assert_called_once()
+    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
+        # Safety with default model (None)
+        scorer = Safety()
+        registered = scorer.register()
+        assert registered.name == "safety"
+        mock_add.assert_called_once()
 
-    mock_add.reset_mock()
+        mock_add.reset_mock()
 
-    # RetrievalRelevance with default model (None)
-    scorer = RetrievalRelevance()
-    registered = scorer.register()
-    assert registered.name == "retrieval_relevance"
-    mock_add.assert_called_once()
+        # RetrievalRelevance with default model (None)
+        scorer = RetrievalRelevance()
+        registered = scorer.register()
+        assert registered.name == "retrieval_relevance"
+        mock_add.assert_called_once()
+        mock_databricks_tracking_uri.assert_called()
 
 
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_scorer_start_with_non_databricks_model_fails(_):
+def test_scorer_start_with_non_databricks_model_fails(mock_databricks_tracking_uri: mock.Mock):
     """Test that start() method also validates model provider."""
     scorer = Safety(model="openai:/gpt-4")
     with pytest.raises(
         MlflowException, match="The scorer's judge model must use Databricks as a model provider"
     ):
         scorer.start(sampling_config=ScorerSamplingConfig(sample_rate=0.5))
+    mock_databricks_tracking_uri.assert_called()
 
 
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_scorer_update_with_non_databricks_model_fails(_):
+def test_scorer_update_with_non_databricks_model_fails(mock_databricks_tracking_uri: mock.Mock):
     """Test that update() method also validates model provider."""
     scorer = Safety(model="anthropic:/claude-3")
     with pytest.raises(
         MlflowException, match="The scorer's judge model must use Databricks as a model provider"
     ):
         scorer.update(sampling_config=ScorerSamplingConfig(sample_rate=0.3))
+    mock_databricks_tracking_uri.assert_called()
 
 
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_scorer_stop_with_non_databricks_model_fails(_):
+def test_scorer_stop_with_non_databricks_model_fails(mock_databricks_tracking_uri: mock.Mock):
     """Test that stop() method also validates model provider."""
     scorer = RetrievalRelevance(model="openai:/gpt-4")
     with pytest.raises(
         MlflowException, match="The scorer's judge model must use Databricks as a model provider"
     ):
         scorer.stop()
+    mock_databricks_tracking_uri.assert_called()
 
 
-def test_non_databricks_backend_allows_any_model():
+def test_non_databricks_backend_allows_any_model(tmp_path):
     """Test that non-databricks backends allow any model provider."""
-    experiment_id = mlflow.create_experiment("test_any_model_allowed")
+    # Ensure we're not using databricks backend for this test
+    import tempfile
 
-    # OpenAI model should work with MLflow backend
-    scorer = Safety(model="openai:/gpt-4")
-    registered = scorer.register(experiment_id=experiment_id)
-    assert registered.name == "safety"
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tracking_uri = f"sqlite:///{tmpdir}/test.db"
+        mlflow.set_tracking_uri(tracking_uri)
 
-    # Anthropic model should work with MLflow backend
-    scorer = RetrievalRelevance(model="anthropic:/claude-3-opus")
-    registered = scorer.register(experiment_id=experiment_id)
-    assert registered.name == "retrieval_relevance"
+        with patch(
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri",
+            return_value=tracking_uri,
+        ):
+            experiment_id = mlflow.create_experiment("test_any_model_allowed")
 
-    # Clean up
-    mlflow.delete_experiment(experiment_id)
+            # OpenAI model should work with MLflow backend
+            scorer = Safety(model="openai:/gpt-4")
+            registered = scorer.register(experiment_id=experiment_id)
+            assert registered.name == "safety"
+
+            # Anthropic model should work with MLflow backend
+            scorer = RetrievalRelevance(model="anthropic:/claude-3-opus")
+            registered = scorer.register(experiment_id=experiment_id)
+            assert registered.name == "retrieval_relevance"
 
 
-@patch("mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks")
-def test_error_message_shows_actual_model(_):
+def test_error_message_shows_actual_model(mock_databricks_tracking_uri: mock.Mock):
     """Test that error message includes the actual model that was rejected."""
     model = "openai:/gpt-4-turbo"
     scorer = Safety(model=model)
@@ -126,3 +136,4 @@ def test_error_message_shows_actual_model(_):
         scorer.register()
 
     assert f"Got {model}" in str(exc_info.value)
+    mock_databricks_tracking_uri.assert_called()

--- a/tests/genai/scorers/test_builtin_scorers_registration.py
+++ b/tests/genai/scorers/test_builtin_scorers_registration.py
@@ -2,7 +2,6 @@
 
 import tempfile
 from unittest import mock
-from unittest.mock import patch
 
 import pytest
 
@@ -15,7 +14,7 @@ from mlflow.genai.scorers.base import ScorerSamplingConfig
 @pytest.fixture
 def mock_databricks_tracking_uri():
     """Module-level fixture to mock Databricks tracking URI for tests that need it."""
-    with patch(
+    with mock.patch(
         "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
     ) as mock_uri:
         yield mock_uri
@@ -44,18 +43,22 @@ def test_non_databricks_model_cannot_register(
 
 def test_safety_with_databricks_model_can_register(mock_databricks_tracking_uri: mock.Mock):
     """Test that Safety scorer with databricks model can be registered."""
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
+    with mock.patch(
+        "mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"
+    ) as mock_add:
         scorer = Safety(model="databricks:/my-judge-model")
         registered = scorer.register()
 
-        assert registered.name == "safety"
-        mock_add.assert_called_once()
-        mock_databricks_tracking_uri.assert_called()
+    assert registered.name == "safety"
+    mock_add.assert_called_once()
+    mock_databricks_tracking_uri.assert_called()
 
 
 def test_builtin_scorer_without_custom_model_can_register(mock_databricks_tracking_uri: mock.Mock):
     """Test that builtin scorers without custom models can be registered."""
-    with patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add:
+    with mock.patch(
+        "mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"
+    ) as mock_add:
         # Safety with default model (None)
         scorer = Safety()
         registered = scorer.register()
@@ -67,9 +70,10 @@ def test_builtin_scorer_without_custom_model_can_register(mock_databricks_tracki
         # RetrievalRelevance with default model (None)
         scorer = RetrievalRelevance()
         registered = scorer.register()
-        assert registered.name == "retrieval_relevance"
-        mock_add.assert_called_once()
-        mock_databricks_tracking_uri.assert_called()
+
+    assert registered.name == "retrieval_relevance"
+    mock_add.assert_called_once()
+    mock_databricks_tracking_uri.assert_called()
 
 
 def test_scorer_start_with_non_databricks_model_fails(mock_databricks_tracking_uri: mock.Mock):
@@ -108,7 +112,7 @@ def test_non_databricks_backend_allows_any_model(tmp_path):
         tracking_uri = f"sqlite:///{tmpdir}/test.db"
         mlflow.set_tracking_uri(tracking_uri)
 
-        with patch(
+        with mock.patch(
             "mlflow.tracking._tracking_service.utils.get_tracking_uri",
             return_value=tracking_uri,
         ):

--- a/tests/genai/scorers/test_builtin_scorers_registration.py
+++ b/tests/genai/scorers/test_builtin_scorers_registration.py
@@ -1,5 +1,6 @@
 """Tests for builtin scorer registration validation with custom judge models."""
 
+import tempfile
 from unittest import mock
 from unittest.mock import patch
 
@@ -103,9 +104,6 @@ def test_scorer_stop_with_non_databricks_model_fails(mock_databricks_tracking_ur
 
 def test_non_databricks_backend_allows_any_model(tmp_path):
     """Test that non-databricks backends allow any model provider."""
-    # Ensure we're not using databricks backend for this test
-    import tempfile
-
     with tempfile.TemporaryDirectory() as tmpdir:
         tracking_uri = f"sqlite:///{tmpdir}/test.db"
         mlflow.set_tracking_uri(tracking_uri)

--- a/tests/genai/scorers/test_registered_scorers_scheduling.py
+++ b/tests/genai/scorers/test_registered_scorers_scheduling.py
@@ -29,7 +29,7 @@ def test_scorer_register(mock_add, mock_get_tracking_uri):
     my_scorer = length_check
     registered = my_scorer.register(name="my_length_check")
 
-    mock_get_tracking_uri.assert_called_once()
+    mock_get_tracking_uri.assert_called()
 
     # Check immutability - returns new instance
     assert registered is not my_scorer
@@ -81,7 +81,7 @@ def test_scorer_start(mock_update, mock_get_tracking_uri):
         sampling_config=ScorerSamplingConfig(sample_rate=0.5, filter_string="trace.status = 'OK'")
     )
 
-    mock_get_tracking_uri.assert_called_once()
+    mock_get_tracking_uri.assert_called()
 
     # Check immutability
     assert started is not my_scorer
@@ -141,7 +141,7 @@ def test_scorer_update(mock_update, mock_get_tracking_uri):
         sampling_config=ScorerSamplingConfig(sample_rate=0.4, filter_string="old filter")
     )
 
-    mock_get_tracking_uri.assert_called_once()
+    mock_get_tracking_uri.assert_called()
 
     assert updated._sampling_config.sample_rate == 0.4
     assert updated._sampling_config.filter_string == "old filter"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbrx-euirim/mlflow/pull/17553?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17553/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17553/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17553/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

As titled, this PR prevents scorers allowing custom judge models from being registered with the `DatabricksStore` if they use custom judge models from a non-databricks model provider.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
