### PR TITLE
Fix InstructionsJudge template variable handling

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -106,8 +106,7 @@ class InstructionsJudge(Judge):
     @property
     def instructions(self) -> str:
         """Get the instructions of this judge."""
-        header = f"Instructions-based judge: {self.name}"
-        return f"{header}\n\nInstructions:\n-------------\n\n{self._instructions}"
+        return self._instructions
 
     def get_input_fields(self) -> list[JudgeField]:
         """
@@ -194,8 +193,16 @@ class InstructionsJudge(Judge):
             # Build the user message with variable substitutions
             template_values = {}
             if inputs is not None:
+                if self._TEMPLATE_VARIABLE_INPUTS in self.template_variables:
+                    template_values[self._TEMPLATE_VARIABLE_INPUTS] = json.dumps(
+                        inputs, default=str, indent=2
+                    )
                 template_values.update(inputs)
             if outputs is not None:
+                if self._TEMPLATE_VARIABLE_OUTPUTS in self.template_variables:
+                    template_values[self._TEMPLATE_VARIABLE_OUTPUTS] = json.dumps(
+                        outputs, default=str, indent=2
+                    )
                 template_values.update(outputs)
             if expectations is not None:
                 if self._TEMPLATE_VARIABLE_EXPECTATIONS in self.template_variables:

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -164,7 +164,6 @@ class InstructionsJudge(Judge):
 
         """
         # Check if the input arguments match the template variables
-        # If any template variables are missing, throw an MLflow exception
         missing_params = []
 
         if self._TEMPLATE_VARIABLE_INPUTS in self.template_variables and inputs is None:

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -187,13 +187,13 @@ class InstructionsJudge(Judge):
                     missing_vars.append("inputs")
                 if self._TEMPLATE_VARIABLE_OUTPUTS in self.template_variables:
                     missing_vars.append("outputs")
-                
+
                 if missing_vars:
                     missing_str = "', '".join(missing_vars)
                     error_msg = f"Must specify '{missing_str}' for field-based evaluation."
                 else:
                     error_msg = "Must specify 'inputs' or 'outputs' for field-based evaluation."
-                
+
                 raise MlflowException(
                     error_msg,
                     error_code=INVALID_PARAMETER_VALUE,

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -52,7 +52,6 @@ class InstructionsJudge(Judge):
     _model: str = PrivateAttr()
     _instructions_prompt: PromptVersion = PrivateAttr()
 
-
     def __init__(self, name: str, instructions: str, model: str | None = None, **kwargs):
         """
         Initialize the InstructionsJudge.

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -51,6 +51,7 @@ class InstructionsJudge(Judge):
     _instructions: str = PrivateAttr()
     _model: str = PrivateAttr()
     _instructions_prompt: PromptVersion = PrivateAttr()
+
     _custom_template_variables: set[str] = PrivateAttr()
 
     def __init__(self, name: str, instructions: str, model: str | None = None, **kwargs):
@@ -89,6 +90,16 @@ class InstructionsJudge(Judge):
         self._custom_template_variables = self._instructions_prompt.variables - set(
             self._RESERVED_INSTRUCTION_TEMPLATE_VARIABLES
         )
+
+        # Reject any custom template variables
+        if self._custom_template_variables:
+            allowed_vars = ", ".join(self._RESERVED_INSTRUCTION_TEMPLATE_VARIABLES)
+            raise MlflowException(
+                f"Instructions template contains unsupported variables: "
+                f"{self._custom_template_variables}. "
+                f"Only the following variables are allowed: {allowed_vars}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
 
         self._validate_model_format()
         self._validate_instructions_template()
@@ -131,10 +142,7 @@ class InstructionsJudge(Judge):
         if self._TEMPLATE_VARIABLE_TRACE in self.template_variables:
             fields.append(JudgeField(name="trace", description="Trace to evaluate"))
 
-        # Add custom template variables
-        for var in self._custom_template_variables:
-            fields.append(JudgeField(name=var, description=f"Custom variable: {var}"))
-
+        # Custom template variables are no longer supported
         return fields
 
     def __call__(
@@ -180,8 +188,6 @@ class InstructionsJudge(Judge):
 
         # Handle field-based evaluation (inputs/outputs)
         if not is_trace_based:
-            self._validate_call_args_contain_template_fields(inputs, outputs, expectations)
-
             # Build the system message with instructions template and output format
             system_content = format_prompt(
                 INSTRUCTIONS_JUDGE_SYSTEM_PROMPT, instructions=self._instructions
@@ -192,24 +198,21 @@ class InstructionsJudge(Judge):
 
             # Build the user message with variable substitutions
             template_values = {}
-            if inputs is not None:
-                if self._TEMPLATE_VARIABLE_INPUTS in self.template_variables:
-                    template_values[self._TEMPLATE_VARIABLE_INPUTS] = json.dumps(
-                        inputs, default=str, indent=2
-                    )
-                template_values.update(inputs)
-            if outputs is not None:
-                if self._TEMPLATE_VARIABLE_OUTPUTS in self.template_variables:
-                    template_values[self._TEMPLATE_VARIABLE_OUTPUTS] = json.dumps(
-                        outputs, default=str, indent=2
-                    )
-                template_values.update(outputs)
-            if expectations is not None:
-                if self._TEMPLATE_VARIABLE_EXPECTATIONS in self.template_variables:
-                    template_values[self._TEMPLATE_VARIABLE_EXPECTATIONS] = json.dumps(
-                        expectations, default=str, indent=2
-                    )
-                template_values.update(expectations)
+            if inputs is not None and self._TEMPLATE_VARIABLE_INPUTS in self.template_variables:
+                template_values[self._TEMPLATE_VARIABLE_INPUTS] = json.dumps(
+                    inputs, default=str, indent=2
+                )
+            if outputs is not None and self._TEMPLATE_VARIABLE_OUTPUTS in self.template_variables:
+                template_values[self._TEMPLATE_VARIABLE_OUTPUTS] = json.dumps(
+                    outputs, default=str, indent=2
+                )
+            if (
+                expectations is not None
+                and self._TEMPLATE_VARIABLE_EXPECTATIONS in self.template_variables
+            ):
+                template_values[self._TEMPLATE_VARIABLE_EXPECTATIONS] = json.dumps(
+                    expectations, default=str, indent=2
+                )
 
             # Create user content with the actual values for each variable
             user_message_parts = []
@@ -291,7 +294,7 @@ class InstructionsJudge(Judge):
         if not template_vars:
             raise MlflowException(
                 "Instructions template must contain at least one variable (e.g., {{inputs}}, "
-                "{{outputs}}, {{trace}}, or custom variables).",
+                "{{outputs}}, {{trace}}, or {{expectations}}).",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
@@ -308,14 +311,7 @@ class InstructionsJudge(Judge):
                     "This will be implemented in a future release.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
-            if self._custom_template_variables:
-                raise MlflowException(
-                    "When submitting a 'trace' variable, no other variables are permitted. "
-                    f"found: {self._custom_template_variables}. A submitted trace contains "
-                    "the complete context for evaluation and should not be mixed with "
-                    "other variables.",
-                    error_code=INVALID_PARAMETER_VALUE,
-                )
+            # Custom variables check is no longer needed here since they're rejected in __init__
             if has_inputs or has_outputs:
                 raise MlflowException(
                     "Instructions template cannot contain both 'trace' and 'inputs'/'outputs' "
@@ -330,40 +326,6 @@ class InstructionsJudge(Judge):
                     "(e.g., model='openai:/gpt-4o').",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
-
-    def _validate_call_args_contain_template_fields(
-        self,
-        inputs: dict[str, Any] | None = None,
-        outputs: dict[str, Any] | None = None,
-        expectations: dict[str, Any] | None = None,
-    ) -> None:
-        """
-        Validate that required template variables are present in inputs, outputs, or expectations.
-
-        Args:
-            inputs: Input dictionary to validate
-            outputs: Output dictionary to validate
-            expectations: Expectations dictionary to validate
-
-        Raises:
-            MlflowException: If any required template variable is missing
-        """
-        if not self._custom_template_variables:
-            return
-
-        input_keys = set(inputs.keys()) if inputs is not None else set()
-        output_keys = set(outputs.keys()) if outputs is not None else set()
-        expectation_keys = set(expectations.keys()) if expectations is not None else set()
-        available_vars = input_keys | output_keys | expectation_keys
-
-        missing_vars = self._custom_template_variables - available_vars
-
-        if missing_vars:
-            raise MlflowException(
-                f"Required template variables {missing_vars} are missing from inputs, outputs, "
-                "and expectations. Each variable must be present in at least one of them.",
-                error_code=INVALID_PARAMETER_VALUE,
-            )
 
     def model_dump(self, **kwargs) -> dict[str, Any]:
         """Override model_dump to serialize as a SerializedScorer."""

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -310,7 +310,6 @@ class InstructionsJudge(Judge):
                     "This will be implemented in a future release.",
                     error_code=INVALID_PARAMETER_VALUE,
                 )
-            # Custom variables check is no longer needed here since they're rejected in __init__
             if has_inputs or has_outputs:
                 raise MlflowException(
                     "Instructions template cannot contain both 'trace' and 'inputs'/'outputs' "

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -181,8 +181,21 @@ class InstructionsJudge(Judge):
         else:
             # This is a field-based judge - require inputs/outputs, ignore trace
             if inputs is None and outputs is None:
+                # Determine which parameters are expected based on template variables
+                missing_vars = []
+                if self._TEMPLATE_VARIABLE_INPUTS in self.template_variables:
+                    missing_vars.append("inputs")
+                if self._TEMPLATE_VARIABLE_OUTPUTS in self.template_variables:
+                    missing_vars.append("outputs")
+                
+                if missing_vars:
+                    missing_str = "', '".join(missing_vars)
+                    error_msg = f"Must specify '{missing_str}' for field-based evaluation."
+                else:
+                    error_msg = "Must specify 'inputs' or 'outputs' for field-based evaluation."
+                
                 raise MlflowException(
-                    "Must specify 'inputs' or 'outputs' for field-based evaluation.",
+                    error_msg,
                     error_code=INVALID_PARAMETER_VALUE,
                 )
 

--- a/tests/genai/judges/optimizers/test_simba.py
+++ b/tests/genai/judges/optimizers/test_simba.py
@@ -42,11 +42,6 @@ def test_full_alignment_workflow(mock_judge, sample_traces_with_assessments):
     # Should return an optimized judge
     assert result is not None
     assert result.model == mock_judge.model
-    # The judge instructions are formatted by make_judge with a header
-    expected_instructions = (
-        "Instructions-based judge: mock_judge\n\n"
-        "Instructions:\n"
-        "-------------\n\n"
-        "Optimized instructions with {{inputs}} and {{outputs}}"
-    )
+    # The judge instructions should be the raw optimized instructions
+    expected_instructions = "Optimized instructions with {{inputs}} and {{outputs}}"
     assert result.instructions == expected_instructions

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -112,11 +112,7 @@ def test_make_judge_creates_instructions_judge():
 
     assert isinstance(judge, InstructionsJudge)
     assert judge.name == "test_judge"
-    expected_instructions = (
-        "Instructions-based judge: test_judge\n\nInstructions:\n-------------\n\n"
-        "Check if {{text}} is formal"
-    )
-    assert judge.instructions == expected_instructions
+    assert judge.instructions == "Check if {{text}} is formal"
     assert judge.model == "openai:/gpt-4"
 
 
@@ -411,8 +407,7 @@ def test_instructions_property():
     )
 
     instructions = judge.instructions
-    assert "Instructions-based judge: test_judge" in instructions
-    assert "Check if {{text}} is formal" in instructions
+    assert instructions == "Check if {{text}} is formal"
 
 
 def test_kind_property():
@@ -568,9 +563,7 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
         model="openai:/gpt-4",
     )
 
-    formatted_instructions = judge.instructions
-    assert "Instructions-based judge: test_judge" in formatted_instructions
-    assert original_instructions in formatted_instructions
+    assert judge.instructions == original_instructions
     assert judge.model == "openai:/gpt-4"
     assert judge.template_variables == {"response"}
 
@@ -589,16 +582,14 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert retrieved_scorer is not None
     assert isinstance(retrieved_scorer, InstructionsJudge)
     assert retrieved_scorer.name == "test_judge"
-    assert retrieved_scorer.instructions == formatted_instructions
+    assert retrieved_scorer.instructions == original_instructions
     assert retrieved_scorer.model == "openai:/gpt-4"
     assert retrieved_scorer.template_variables == {"response"}
-    assert "Instructions-based judge: test_judge" in retrieved_scorer.instructions
-    assert original_instructions in retrieved_scorer.instructions
 
     deserialized = Scorer.model_validate(serialized)
     assert isinstance(deserialized, InstructionsJudge)
     assert deserialized.name == judge.name
-    assert deserialized.instructions == formatted_instructions
+    assert deserialized.instructions == original_instructions
     assert deserialized.model == judge.model
     assert deserialized.template_variables == {"response"}
 
@@ -656,21 +647,18 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     v1_scorer, v1_num = versions[0]
     assert v1_num == 1
     assert isinstance(v1_scorer, InstructionsJudge)
-    assert "Instructions-based judge: test_judge" in v1_scorer.instructions
-    assert original_instructions in v1_scorer.instructions
+    assert v1_scorer.instructions == original_instructions
     assert v1_scorer.model == "openai:/gpt-4"
 
     v2_scorer, v2_num = versions[1]
     assert v2_num == 2
     assert isinstance(v2_scorer, InstructionsJudge)
-    assert "Instructions-based judge: test_judge" in v2_scorer.instructions
-    assert v2_instructions in v2_scorer.instructions
+    assert v2_scorer.instructions == v2_instructions
     assert v2_scorer.model == "openai:/gpt-4o"
 
     latest = store.get_scorer(experiment, "test_judge")
     assert isinstance(latest, InstructionsJudge)
-    assert "Instructions-based judge: test_judge" in latest.instructions
-    assert v2_instructions in latest.instructions
+    assert latest.instructions == v2_instructions
     assert latest.model == "openai:/gpt-4o"
 
 
@@ -695,8 +683,7 @@ def test_judge_registration_preserves_custom_variables(mock_invoke_judge_model):
 
     retrieved_judge = store.get_scorer(experiment, "custom_judge", version)
     assert isinstance(retrieved_judge, InstructionsJudge)
-    assert "Instructions-based judge: custom_judge" in retrieved_judge.instructions
-    assert instructions_with_custom in retrieved_judge.instructions
+    assert retrieved_judge.instructions == instructions_with_custom
     assert retrieved_judge.template_variables == {"query", "response", "criteria", "threshold"}
 
     result = retrieved_judge(
@@ -812,8 +799,7 @@ def test_model_dump_comprehensive():
         assert isinstance(deserialized, InstructionsJudge)
         assert deserialized.name == serialized_data["name"]
         raw_instructions = serialized_data["instructions_judge_pydantic_data"]["instructions"]
-        assert raw_instructions in deserialized.instructions
-        assert f"Instructions-based judge: {deserialized.name}" in deserialized.instructions
+        assert deserialized.instructions == raw_instructions
         assert deserialized.model == serialized_data["instructions_judge_pydantic_data"]["model"]
 
 

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -107,19 +107,19 @@ def mock_trace():
 
 def test_make_judge_creates_instructions_judge():
     judge = make_judge(
-        name="test_judge", instructions="Check if {{text}} is formal", model="openai:/gpt-4"
+        name="test_judge", instructions="Check if {{outputs}} is formal", model="openai:/gpt-4"
     )
 
     assert isinstance(judge, InstructionsJudge)
     assert judge.name == "test_judge"
-    assert judge.instructions == "Check if {{text}} is formal"
+    assert judge.instructions == "Check if {{outputs}} is formal"
     assert judge.model == "openai:/gpt-4"
 
 
 def test_make_judge_with_default_model(monkeypatch):
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "http://localhost:5000")
 
-    judge = make_judge(name="test_judge", instructions="Check if {{response}} is accurate")
+    judge = make_judge(name="test_judge", instructions="Check if {{outputs}} is accurate")
 
     assert judge.model == "openai:/gpt-4.1-mini"
 
@@ -127,46 +127,70 @@ def test_make_judge_with_default_model(monkeypatch):
 def test_make_judge_with_databricks_default(monkeypatch):
     monkeypatch.setattr("mlflow.genai.judges.utils.is_databricks_uri", lambda x: True)
 
-    judge = make_judge(name="test_judge", instructions="Check if {{text}} is valid")
+    judge = make_judge(name="test_judge", instructions="Check if {{outputs}} is valid")
 
     assert judge.model == "databricks"
 
 
 @pytest.mark.parametrize(
-    ("instructions", "expected_vars", "expected_custom"),
+    ("instructions", "expected_vars"),
     [
         (
-            "Check if {{query}} is answered by {{response}} with {{tone}}",
-            {"query", "response", "tone"},
-            {"query", "response", "tone"},
+            "Check if {{inputs}} is correct",
+            {"inputs"},
         ),
         (
-            "Check {{answer}} against {{expected_answer}}",
-            {"answer", "expected_answer"},
-            {"answer", "expected_answer"},
+            "Check {{outputs}} against expectations",
+            {"outputs"},
         ),
         (
-            "Validate {{source_text}} and {{translated_text}}",
-            {"source_text", "translated_text"},
-            {"source_text", "translated_text"},
+            "Validate {{inputs}} and {{outputs}}",
+            {"inputs", "outputs"},
+        ),
+        (
+            "Check {{inputs}}, {{outputs}}, and {{expectations}}",
+            {"inputs", "outputs", "expectations"},
         ),
         (
             "Analyze this {{trace}}",
             {"trace"},
-            set(),
         ),
     ],
 )
-def test_template_variable_extraction(instructions, expected_vars, expected_custom):
+def test_template_variable_extraction(instructions, expected_vars):
     judge = make_judge(name="test_judge", instructions=instructions, model="openai:/gpt-4")
 
     assert judge.template_variables == expected_vars
 
 
 @pytest.mark.parametrize(
+    ("instructions", "error_pattern"),
+    [
+        (
+            "Check if {{query}} is answered by {{response}}",
+            "Instructions template contains unsupported variables: {'query', 'response'}",
+        ),
+        (
+            "Check {{answer}} against {{expected_answer}}",
+            "Instructions template contains unsupported variables: {'answer', 'expected_answer'}",
+        ),
+        (
+            "Validate {{custom_field}}",
+            "Instructions template contains unsupported variables: {'custom_field'}",
+        ),
+    ],
+)
+def test_custom_variables_rejected(instructions, error_pattern):
+    with pytest.raises(
+        MlflowException, match="Instructions template contains unsupported variables"
+    ):
+        make_judge(name="test_judge", instructions=instructions, model="openai:/gpt-4")
+
+
+@pytest.mark.parametrize(
     ("name", "instructions", "model", "error_pattern"),
     [
-        ("", "Check {{text}}", "openai:/gpt-4", "name must be a non-empty string"),
+        ("", "Check {{outputs}}", "openai:/gpt-4", "name must be a non-empty string"),
         ("test", "", "openai:/gpt-4", "instructions must be a non-empty string"),
         (
             "test",
@@ -176,12 +200,12 @@ def test_template_variable_extraction(instructions, expected_vars, expected_cust
         ),
         (
             "test",
-            "Check {{text}}",
+            "Check {{outputs}}",
             "invalid-model",
             "Malformed model uri 'invalid-model'",
         ),
-        ("test", "Check {{text}}", "invalid:/", "Malformed model uri 'invalid:/'"),
-        ("test", "Check {{text}}", "openai:", "Malformed model uri 'openai:'"),
+        ("test", "Check {{outputs}}", "invalid:/", "Malformed model uri 'invalid:/'"),
+        ("test", "Check {{outputs}}", "openai:", "Malformed model uri 'openai:'"),
     ],
 )
 def test_validation_errors(name, instructions, model, error_pattern):
@@ -200,7 +224,7 @@ def test_validation_errors(name, instructions, model, error_pattern):
     ],
 )
 def test_valid_model_formats(model):
-    judge = make_judge(name="test_judge", instructions="Check if {{text}} is valid", model=model)
+    judge = make_judge(name="test_judge", instructions="Check if {{outputs}} is valid", model=model)
     assert judge.model == model
 
 
@@ -210,7 +234,7 @@ def test_valid_model_formats(model):
         (
             "Analyze {{trace}} and check {{custom_field}}",
             "openai:/gpt-4",
-            "When submitting a 'trace' variable, no other variables are permitted",
+            "Instructions template contains unsupported variables",
         ),
         (
             "Analyze {{trace}} and {{inputs}}",
@@ -275,15 +299,16 @@ def test_call_with_trace_supported(mock_trace, monkeypatch):
     assert captured_args["assessment_name"] == "test_judge"
 
 
-def test_call_validates_missing_custom_variables():
-    judge = make_judge(
-        name="test_judge",
-        instructions="Check if {{query}} matches {{expected_answer}}",
-        model="openai:/gpt-4",
-    )
-
-    with pytest.raises(MlflowException, match="Required template variables .* are missing"):
-        judge(inputs={"query": "What is 2+2?"})
+def test_call_validates_missing_reserved_variables():
+    # Test that custom variables are rejected at creation time
+    with pytest.raises(
+        MlflowException, match="Instructions template contains unsupported variables"
+    ):
+        make_judge(
+            name="test_judge",
+            instructions="Check if {{query}} matches {{expected_answer}}",
+            model="openai:/gpt-4",
+        )
 
 
 def test_call_trace_based_judge_ignores_inputs_outputs(mock_trace, monkeypatch):
@@ -316,7 +341,7 @@ def test_call_trace_based_judge_ignores_inputs_outputs(mock_trace, monkeypatch):
 
 def test_call_with_no_inputs_or_outputs():
     judge = make_judge(
-        name="test_judge", instructions="Check if {{text}} is valid", model="openai:/gpt-4"
+        name="test_judge", instructions="Check if {{outputs}} is valid", model="openai:/gpt-4"
     )
 
     with pytest.raises(
@@ -328,16 +353,27 @@ def test_call_with_no_inputs_or_outputs():
 def test_call_with_valid_inputs_returns_feedback(mock_invoke_judge_model):
     judge = make_judge(
         name="formality_judge",
-        instructions="Check if {{response}} is formal",
+        instructions="Check if {{outputs}} is formal",
         model="openai:/gpt-4",
     )
 
-    result = judge(outputs={"response": "Dear Sir/Madam, I am writing to inquire..."})
+    test_output = "Dear Sir/Madam, I am writing to inquire..."
+    result = judge(outputs={"response": test_output})
 
     assert isinstance(result, Feedback)
     assert result.name == "formality_judge"
     assert result.value is True
     assert result.rationale == "The response is formal"
+
+    # Verify the prompt contains the outputs value
+    assert len(mock_invoke_judge_model.calls) == 1
+    model_uri, prompt, assessment_name = mock_invoke_judge_model.calls[0]
+    assert isinstance(prompt, list)
+    assert len(prompt) == 2
+    # Check that the user message contains the JSON-serialized outputs
+    user_msg = prompt[1]
+    assert "response" in user_msg.content
+    assert test_output in user_msg.content
 
 
 def test_call_with_expectations_as_json(monkeypatch):
@@ -352,11 +388,11 @@ def test_call_with_expectations_as_json(monkeypatch):
 
     judge = make_judge(
         name="test_judge",
-        instructions="Check {{answer}} against {{expectations}}",
+        instructions="Check {{outputs}} against {{expectations}}",
         model="openai:/gpt-4",
     )
 
-    judge(inputs={"answer": "42"}, expectations={"correct": True, "score": 100})
+    judge(outputs={"answer": "42"}, expectations={"correct": True, "score": 100})
 
     # Check that we have a list of messages
     assert isinstance(captured_messages, list)
@@ -368,7 +404,7 @@ def test_call_with_expectations_as_json(monkeypatch):
     assert '"score": 100' in user_msg.content
 
 
-def test_call_with_custom_variables_from_inputs(monkeypatch):
+def test_call_with_reserved_variables(monkeypatch):
     captured_messages = None
 
     def mock_invoke(model_uri, prompt, assessment_name):
@@ -380,11 +416,13 @@ def test_call_with_custom_variables_from_inputs(monkeypatch):
 
     judge = make_judge(
         name="test_judge",
-        instructions="Check if {{question}} meets {{criteria}}",
+        instructions="Check if {{inputs}} meets {{expectations}}",
         model="openai:/gpt-4",
     )
 
-    result = judge(inputs={"question": "What is AI?", "criteria": "technical accuracy"})
+    result = judge(
+        inputs={"question": "What is AI?"}, expectations={"criteria": "technical accuracy"}
+    )
 
     assert isinstance(result, Feedback)
     # Check that we have a list of messages
@@ -393,26 +431,28 @@ def test_call_with_custom_variables_from_inputs(monkeypatch):
 
     # Check system message has the template
     system_msg = captured_messages[0]
-    assert "Check if {{question}} meets {{criteria}}" in system_msg.content
+    assert "Check if {{inputs}} meets {{expectations}}" in system_msg.content
 
-    # Check user message has the values
+    # Check user message has the serialized inputs and expectations
     user_msg = captured_messages[1]
-    assert "criteria: technical accuracy" in user_msg.content
-    assert "question: What is AI?" in user_msg.content
+    assert "expectations:" in user_msg.content
+    assert "inputs:" in user_msg.content
+    assert "technical accuracy" in user_msg.content
+    assert "What is AI?" in user_msg.content
 
 
 def test_instructions_property():
     judge = make_judge(
-        name="test_judge", instructions="Check if {{text}} is formal", model="openai:/gpt-4"
+        name="test_judge", instructions="Check if {{outputs}} is formal", model="openai:/gpt-4"
     )
 
     instructions = judge.instructions
-    assert instructions == "Check if {{text}} is formal"
+    assert instructions == "Check if {{outputs}} is formal"
 
 
 def test_kind_property():
     judge = make_judge(
-        name="test_judge", instructions="Check if {{text}} is valid", model="openai:/gpt-4"
+        name="test_judge", instructions="Check if {{outputs}} is valid", model="openai:/gpt-4"
     )
 
     assert judge.kind == ScorerKind.CLASS
@@ -431,14 +471,14 @@ def test_call_with_various_input_combinations(
     mock_invoke_judge_model, inputs, outputs, expectations
 ):
     judge = make_judge(
-        name="test_judge", instructions="Check {{text}} and {{result}}", model="openai:/gpt-4"
+        name="test_judge", instructions="Check {{inputs}} and {{outputs}}", model="openai:/gpt-4"
     )
 
     result = judge(inputs=inputs, outputs=outputs, expectations=expectations)
     assert isinstance(result, Feedback)
 
 
-def test_prompt_formatting_with_all_variable_types(monkeypatch):
+def test_prompt_formatting_with_all_reserved_variable_types(monkeypatch):
     captured_messages = None
 
     def mock_invoke(model_uri, prompt, assessment_name):
@@ -450,11 +490,15 @@ def test_prompt_formatting_with_all_variable_types(monkeypatch):
 
     judge = make_judge(
         name="test",
-        instructions="Query: {{query}}, Response: {{response}}, Custom: {{my_var}}",
+        instructions="Inputs: {{inputs}}, Outputs: {{outputs}}, Expectations: {{expectations}}",
         model="openai:/gpt-4",
     )
 
-    judge(inputs={"query": "test", "my_var": "custom_value"}, outputs={"response": "answer"})
+    judge(
+        inputs={"query": "test", "context": "testing"},
+        outputs={"response": "answer", "score": 0.9},
+        expectations={"expected": "correct answer"},
+    )
 
     # Check that we have a list of messages
     assert isinstance(captured_messages, list)
@@ -462,13 +506,21 @@ def test_prompt_formatting_with_all_variable_types(monkeypatch):
 
     # Check system message has the template
     system_msg = captured_messages[0]
-    assert "Query: {{query}}, Response: {{response}}, Custom: {{my_var}}" in system_msg.content
+    expected_template = "Inputs: {{inputs}}, Outputs: {{outputs}}, Expectations: {{expectations}}"
+    assert expected_template in system_msg.content
 
-    # Check user message has all the values
+    # Check user message has all the serialized values
     user_msg = captured_messages[1]
-    assert "my_var: custom_value" in user_msg.content
-    assert "query: test" in user_msg.content
-    assert "response: answer" in user_msg.content
+    assert "expectations:" in user_msg.content
+    assert "inputs:" in user_msg.content
+    assert "outputs:" in user_msg.content
+    # Check the actual data is in the JSON
+    assert "query" in user_msg.content
+    assert "test" in user_msg.content
+    assert "response" in user_msg.content
+    assert "answer" in user_msg.content
+    assert "expected" in user_msg.content
+    assert "correct answer" in user_msg.content
 
 
 def test_output_format_instructions_added(monkeypatch):
@@ -483,7 +535,7 @@ def test_output_format_instructions_added(monkeypatch):
 
     judge = make_judge(
         name="test_judge",
-        instructions="Check if {{text}} is formal",
+        instructions="Check if {{outputs}} is formal",
         model="openai:/gpt-4",
     )
 
@@ -497,13 +549,14 @@ def test_output_format_instructions_added(monkeypatch):
     system_msg = captured_messages[0]
     assert system_msg.role == "system"
     assert system_msg.content.startswith(JUDGE_BASE_PROMPT)
-    assert "Check if {{text}} is formal" in system_msg.content
+    assert "Check if {{outputs}} is formal" in system_msg.content
     assert "JSON format" in system_msg.content
 
     # Check user message
     user_msg = captured_messages[1]
     assert user_msg.role == "user"
-    assert "text: Hello there" in user_msg.content
+    assert "outputs:" in user_msg.content
+    assert "Hello there" in user_msg.content
 
     assert result.value is True
     assert result.rationale == "Test rationale"
@@ -521,7 +574,7 @@ def test_output_format_instructions_with_complex_template(monkeypatch):
 
     judge = make_judge(
         name="complex_judge",
-        instructions="Evaluate {{response}} for {{criteria}} considering {{context}}",
+        instructions="Evaluate {{outputs}} considering {{inputs}} and {{expectations}}",
         model="openai:/gpt-4",
     )
 
@@ -539,15 +592,18 @@ def test_output_format_instructions_with_complex_template(monkeypatch):
     system_msg = captured_messages[0]
     assert system_msg.role == "system"
     assert system_msg.content.startswith(JUDGE_BASE_PROMPT)
-    assert "Evaluate {{response}} for {{criteria}} considering {{context}}" in system_msg.content
+    assert "Evaluate {{outputs}} considering {{inputs}} and {{expectations}}" in system_msg.content
     assert "JSON format" in system_msg.content
 
     # Check user message has all the variable values
     user_msg = captured_messages[1]
     assert user_msg.role == "user"
-    assert "context: formal business setting" in user_msg.content
-    assert "criteria: professionalism" in user_msg.content
-    assert "response: Hey what's up" in user_msg.content
+    assert "expectations:" in user_msg.content
+    assert "inputs:" in user_msg.content
+    assert "outputs:" in user_msg.content
+    assert "formal business setting" in user_msg.content
+    assert "professionalism" in user_msg.content
+    assert "Hey what's up" in user_msg.content
 
     assert result.value == "yes"
     assert result.rationale == "Test rationale"
@@ -556,7 +612,7 @@ def test_output_format_instructions_with_complex_template(monkeypatch):
 def test_judge_registration_as_scorer(mock_invoke_judge_model):
     experiment = mlflow.create_experiment("test_judge_registration")
 
-    original_instructions = "Evaluate if the response {{response}} is professional and formal."
+    original_instructions = "Evaluate if the {{outputs}} is professional and formal."
     judge = make_judge(
         name="test_judge",
         instructions=original_instructions,
@@ -565,7 +621,7 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
 
     assert judge.instructions == original_instructions
     assert judge.model == "openai:/gpt-4"
-    assert judge.template_variables == {"response"}
+    assert judge.template_variables == {"outputs"}
 
     serialized = judge.model_dump()
     assert "name" in serialized
@@ -584,14 +640,14 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert retrieved_scorer.name == "test_judge"
     assert retrieved_scorer.instructions == original_instructions
     assert retrieved_scorer.model == "openai:/gpt-4"
-    assert retrieved_scorer.template_variables == {"response"}
+    assert retrieved_scorer.template_variables == {"outputs"}
 
     deserialized = Scorer.model_validate(serialized)
     assert isinstance(deserialized, InstructionsJudge)
     assert deserialized.name == judge.name
     assert deserialized.instructions == original_instructions
     assert deserialized.model == judge.model
-    assert deserialized.template_variables == {"response"}
+    assert deserialized.template_variables == {"outputs"}
 
     test_output = {"response": "This output demonstrates professional communication."}
     result = retrieved_scorer(outputs=test_output)
@@ -610,12 +666,13 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     # Check system message
     assert prompt[0].role == "system"
     assert prompt[0].content.startswith(JUDGE_BASE_PROMPT)
-    assert "Evaluate if the response {{response}} is professional and formal." in prompt[0].content
+    assert "Evaluate if the {{outputs}} is professional and formal." in prompt[0].content
     assert "JSON format" in prompt[0].content
 
     # Check user message
     assert prompt[1].role == "user"
-    assert prompt[1].content == "response: This output demonstrates professional communication."
+    assert "outputs:" in prompt[1].content
+    assert "This output demonstrates professional communication." in prompt[1].content
 
     mock_invoke_judge_model.reset_mock()
     result2 = deserialized(outputs=test_output)
@@ -630,7 +687,8 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert len(prompt) == 2
     assert prompt[0].role == "system"
     assert prompt[1].role == "user"
-    assert prompt[1].content == "response: This output demonstrates professional communication."
+    assert "outputs:" in prompt[1].content
+    assert "This output demonstrates professional communication." in prompt[1].content
 
     v2_instructions = "Evaluate if the output {{outputs}} is professional, formal, and concise."
     judge_v2 = make_judge(
@@ -662,41 +720,41 @@ def test_judge_registration_as_scorer(mock_invoke_judge_model):
     assert latest.model == "openai:/gpt-4o"
 
 
-def test_judge_registration_preserves_custom_variables(mock_invoke_judge_model):
-    experiment = mlflow.create_experiment("test_custom_vars")
+def test_judge_registration_with_reserved_variables(mock_invoke_judge_model):
+    experiment = mlflow.create_experiment("test_reserved_vars")
 
-    instructions_with_custom = (
-        "Check if {{query}} is answered correctly by {{response}} "
-        "according to {{criteria}} with {{threshold}} accuracy"
+    instructions_with_reserved = (
+        "Check if {{inputs}} is answered correctly by {{outputs}} according to {{expectations}}"
     )
     judge = make_judge(
-        name="custom_judge",
-        instructions=instructions_with_custom,
+        name="reserved_judge",
+        instructions=instructions_with_reserved,
         model="openai:/gpt-4",
     )
 
-    assert judge.template_variables == {"query", "response", "criteria", "threshold"}
+    assert judge.template_variables == {"inputs", "outputs", "expectations"}
 
     store = _get_scorer_store()
     version = store.register_scorer(experiment, judge)
     assert version == 1
 
-    retrieved_judge = store.get_scorer(experiment, "custom_judge", version)
+    retrieved_judge = store.get_scorer(experiment, "reserved_judge", version)
     assert isinstance(retrieved_judge, InstructionsJudge)
-    assert retrieved_judge.instructions == instructions_with_custom
-    assert retrieved_judge.template_variables == {"query", "response", "criteria", "threshold"}
+    assert retrieved_judge.instructions == instructions_with_reserved
+    assert retrieved_judge.template_variables == {"inputs", "outputs", "expectations"}
 
     result = retrieved_judge(
-        inputs={"query": "What is 2+2?", "criteria": "mathematical accuracy"},
-        outputs={"response": "The answer is 4", "threshold": "95%"},
+        inputs={"query": "What is 2+2?", "context": "mathematical"},
+        outputs={"response": "The answer is 4", "confidence": 0.95},
+        expectations={"criteria": "mathematical accuracy", "threshold": "95%"},
     )
     assert isinstance(result, Feedback)
-    assert result.name == "custom_judge"
+    assert result.name == "reserved_judge"
 
     assert len(mock_invoke_judge_model.calls) == 1
     model_uri, prompt, assessment_name = mock_invoke_judge_model.calls[0]
     assert model_uri == "openai:/gpt-4"
-    assert assessment_name == "custom_judge"
+    assert assessment_name == "reserved_judge"
 
     # Check that prompt is now a list of ChatMessage objects
     assert isinstance(prompt, list)
@@ -705,27 +763,22 @@ def test_judge_registration_preserves_custom_variables(mock_invoke_judge_model):
     # Check system message
     assert prompt[0].role == "system"
     assert prompt[0].content.startswith(JUDGE_BASE_PROMPT)
-    assert "Check if {{query}} is answered correctly by {{response}}" in prompt[0].content
-    assert "according to {{criteria}} with {{threshold}} accuracy" in prompt[0].content
+    assert "Check if {{inputs}} is answered correctly by {{outputs}}" in prompt[0].content
+    assert "according to {{expectations}}" in prompt[0].content
     assert "JSON format" in prompt[0].content
 
-    # Check user message with all custom variables
+    # Check user message with all reserved variables as JSON
     assert prompt[1].role == "user"
-    expected_user_content = (
-        "criteria: mathematical accuracy\n"
-        "query: What is 2+2?\n"
-        "response: The answer is 4\n"
-        "threshold: 95%"
-    )
-    assert prompt[1].content == expected_user_content
-
-    mock_invoke_judge_model.reset_mock()
-
-    with pytest.raises(MlflowException, match="Required template variables .* are missing"):
-        retrieved_judge(
-            inputs={"query": "What is 2+2?"},
-            outputs={"response": "The answer is 4"},
-        )
+    user_content = prompt[1].content
+    assert "expectations:" in user_content
+    assert "inputs:" in user_content
+    assert "outputs:" in user_content
+    # Verify the JSON contains the actual data
+    assert "query" in user_content
+    assert "What is 2+2?" in user_content
+    assert "response" in user_content
+    assert "The answer is 4" in user_content
+    assert "mathematical accuracy" in user_content
 
 
 def test_model_dump_comprehensive():
@@ -772,14 +825,14 @@ def test_model_dump_comprehensive():
 
     complex_judge = make_judge(
         name="complex_judge",
-        instructions="Check if {{inputs}} matches {{expectations}} for {{custom_field}}",
+        instructions="Check if {{inputs}} matches {{expectations}}",
         model="anthropic:/claude-3",
     )
 
     complex_serialized = complex_judge.model_dump()
 
     assert complex_serialized["instructions_judge_pydantic_data"]["instructions"] == (
-        "Check if {{inputs}} matches {{expectations}} for {{custom_field}}"
+        "Check if {{inputs}} matches {{expectations}}"
     )
     assert complex_serialized["instructions_judge_pydantic_data"]["model"] == "anthropic:/claude-3"
 
@@ -888,7 +941,7 @@ def test_model_dump_uses_serialized_scorer_dataclass():
 def test_instructions_judge_works_with_evaluate(mock_invoke_judge_model):
     judge = make_judge(
         name="response_quality",
-        instructions="Evaluate if the {{response}} is helpful for answering the {{question}}",
+        instructions="Evaluate if the {{outputs}} is helpful given {{inputs}}",
         model="openai:/gpt-4",
         aggregations=["mean"],
     )
@@ -921,7 +974,7 @@ def test_instructions_judge_works_with_evaluate(mock_invoke_judge_model):
 def test_instructions_judge_with_no_aggregations(mock_invoke_judge_model):
     judge = make_judge(
         name="response_quality",
-        instructions="Evaluate if the {{response}} is helpful for answering the {{question}}",
+        instructions="Evaluate if the {{outputs}} is helpful given {{inputs}}",
         model="openai:/gpt-4",
     )
 
@@ -952,7 +1005,7 @@ def test_make_judge_with_aggregations_validation():
     with pytest.raises(MlflowException, match="Invalid aggregation 'invalid'"):
         make_judge(
             name="test_judge",
-            instructions="Check if {{text}} is valid",
+            instructions="Check if {{outputs}} is valid",
             model="openai:/gpt-4",
             aggregations=["mean", "invalid", "max"],
         )
@@ -960,7 +1013,7 @@ def test_make_judge_with_aggregations_validation():
     with pytest.raises(MlflowException, match="Valid aggregations are"):
         make_judge(
             name="test_judge",
-            instructions="Check if {{text}} is valid",
+            instructions="Check if {{outputs}} is valid",
             model="openai:/gpt-4",
             aggregations=["not_valid"],
         )
@@ -968,7 +1021,7 @@ def test_make_judge_with_aggregations_validation():
     with pytest.raises(MlflowException, match="Aggregation must be either a string"):
         make_judge(
             name="test_judge",
-            instructions="Check if {{text}} is valid",
+            instructions="Check if {{outputs}} is valid",
             model="openai:/gpt-4",
             aggregations=["mean", 123],
         )
@@ -978,7 +1031,7 @@ def test_make_judge_with_aggregations_validation():
 
     judge_with_custom_func = make_judge(
         name="test_judge",
-        instructions="Check if {{text}} is valid",
+        instructions="Check if {{outputs}} is valid",
         model="openai:/gpt-4",
         aggregations=["mean", custom_aggregation],
     )
@@ -988,7 +1041,7 @@ def test_make_judge_with_aggregations_validation():
     all_valid_aggregations = ["min", "max", "mean", "median", "variance", "p90"]
     judge_with_all_aggs = make_judge(
         name="test_judge",
-        instructions="Check if {{text}} is valid",
+        instructions="Check if {{outputs}} is valid",
         model="openai:/gpt-4",
         aggregations=all_valid_aggregations,
     )
@@ -998,7 +1051,7 @@ def test_make_judge_with_aggregations_validation():
 def test_make_judge_with_aggregations(mock_invoke_judge_model):
     judge_with_custom_aggs = make_judge(
         name="formal_judge",
-        instructions="Check if {{text}} is formal",
+        instructions="Check if {{outputs}} is formal",
         model="openai:/gpt-4",
         aggregations=["mean", "max", "min"],
     )
@@ -1008,7 +1061,7 @@ def test_make_judge_with_aggregations(mock_invoke_judge_model):
 
     judge_with_default_aggs = make_judge(
         name="simple_judge",
-        instructions="Check if {{text}} is valid",
+        instructions="Check if {{outputs}} is valid",
         model="openai:/gpt-4",
     )
 
@@ -1017,7 +1070,7 @@ def test_make_judge_with_aggregations(mock_invoke_judge_model):
 
     judge_with_empty_aggs = make_judge(
         name="no_aggs_judge",
-        instructions="Check if {{text}} exists",
+        instructions="Check if {{outputs}} exists",
         model="openai:/gpt-4",
         aggregations=[],
     )
@@ -1084,7 +1137,7 @@ def test_instructions_judge_with_chat_messages():
 
     judge = make_judge(
         name="response_quality",
-        instructions="Evaluate if the {{response}} is helpful for answering the {{question}}",
+        instructions="Evaluate if the {{outputs}} is helpful given {{inputs}}",
         model="openai:/gpt-4",
     )
 

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -390,7 +390,6 @@ def test_call_with_valid_outputs_returns_feedback(mock_invoke_judge_model):
     assert len(prompt) == 2
     # Check that the user message contains the JSON-serialized outputs
     user_msg = prompt[1]
-    import json
     expected_outputs_json = json.dumps({"response": test_output}, default=str, indent=2)
     assert expected_outputs_json in user_msg.content
 
@@ -415,7 +414,6 @@ def test_call_with_valid_inputs_returns_feedback(mock_invoke_judge_model):
     model_uri, prompt, assessment_name = mock_invoke_judge_model.calls[0]
     user_msg = prompt[1]
 
-    import json
     expected_inputs_json = json.dumps(test_input, default=str, indent=2)
     assert expected_inputs_json in user_msg.content
 
@@ -441,7 +439,6 @@ def test_call_with_valid_inputs_and_outputs_returns_feedback(mock_invoke_judge_m
     model_uri, prompt, assessment_name = mock_invoke_judge_model.calls[0]
     user_msg = prompt[1]
 
-    import json
     expected_inputs_json = json.dumps(test_input, default=str, indent=2)
     expected_outputs_json = json.dumps(test_output, default=str, indent=2)
     assert expected_inputs_json in user_msg.content
@@ -466,7 +463,6 @@ def test_call_with_expectations_as_json(mock_invoke_judge_capture_messages):
 
     # Expectations should be in the user message as JSON
     user_msg = captured_messages[1]
-    import json
     expected_expectations_json = json.dumps(expectations, default=str, indent=2)
     assert expected_expectations_json in user_msg.content
 
@@ -495,7 +491,6 @@ def test_call_with_reserved_variables(mock_invoke_judge_capture_messages):
 
     # Check user message has the JSON dumps of inputs and expectations
     user_msg = captured_messages[1]
-    import json
     expected_inputs_json = json.dumps(inputs_data, default=str, indent=2)
     expected_expectations_json = json.dumps(expectations_data, default=str, indent=2)
     assert expected_inputs_json in user_msg.content
@@ -566,7 +561,6 @@ def test_prompt_formatting_with_all_reserved_variable_types(mock_invoke_judge_ca
 
     # Check user message has all the JSON-serialized values
     user_msg = captured_messages[1]
-    import json
     expected_inputs_json = json.dumps(inputs_data, default=str, indent=2)
     expected_outputs_json = json.dumps(outputs_data, default=str, indent=2)
     expected_expectations_json = json.dumps(expectations_data, default=str, indent=2)

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -34,12 +34,14 @@ def mock_invoke_judge_model(monkeypatch):
         calls.append((model_uri, prompt, assessment_name))
 
         # Store latest call details in dict format
-        captured_args.update({
-            "model_uri": model_uri,
-            "prompt": prompt,
-            "assessment_name": assessment_name,
-            "trace": trace
-        })
+        captured_args.update(
+            {
+                "model_uri": model_uri,
+                "prompt": prompt,
+                "assessment_name": assessment_name,
+                "trace": trace,
+            }
+        )
 
         # Return appropriate Feedback based on whether trace is provided
         if trace is not None:
@@ -123,8 +125,6 @@ def mock_trace():
 
     trace_data = TraceData(spans=spans)
     return Trace(info=trace_info, data=trace_data)
-
-
 
 
 def test_make_judge_creates_instructions_judge():
@@ -325,10 +325,7 @@ def test_call_with_trace_supported(mock_trace, monkeypatch):
     assert captured_args["assessment_name"] == "test_judge"
 
 
-
-def test_call_trace_based_judge_ignores_inputs_outputs(
-    mock_trace, mock_invoke_judge_model
-):
+def test_call_trace_based_judge_ignores_inputs_outputs(mock_trace, mock_invoke_judge_model):
     # Test that trace-based judges ignore inputs/outputs and work with trace only
     captured_args = mock_invoke_judge_model.captured_args
 
@@ -355,9 +352,7 @@ def test_call_with_no_inputs_or_outputs():
         name="test_judge", instructions="Check if {{outputs}} is valid", model="openai:/gpt-4"
     )
 
-    with pytest.raises(
-        MlflowException, match="Must specify 'outputs' for field-based evaluation"
-    ):
+    with pytest.raises(MlflowException, match="Must specify 'outputs' for field-based evaluation"):
         judge()
 
 
@@ -439,7 +434,6 @@ def test_call_with_valid_inputs_and_outputs_returns_feedback(mock_invoke_judge_m
 
 
 def test_call_with_expectations_as_json(mock_invoke_judge_model):
-
     judge = make_judge(
         name="test_judge",
         instructions="Check {{outputs}} against {{expectations}}",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/17554?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17554/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17554/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17554/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR addresses several issues in the InstructionsJudge class marked with ALKIS comments across three phases:

**Phase 1 - Core Template Variable Fixes**:
1. **Fixed instructions property**: Now returns raw instructions instead of formatted instructions
2. **Fixed template variable handling**: Properly serializes reserved variables as JSON when they appear in templates

**Phase 2 - Restricted Template Variables**:  
3. **Restricted template variables**: Only allows reserved variables (`inputs`, `outputs`, `expectations`, `trace`) and rejects custom variables at initialization

**Phase 3 - Enhanced Test Coverage**:
4. **Improved test mocking and fixtures**: Created reusable fixtures for consistent test patterns
5. **Enhanced error messages**: Made error messages more specific about which template variables are missing
6. **Comprehensive test coverage**: Added separate tests for inputs, outputs, and combined scenarios
7. **Improved test assertions**: Enhanced JSON verification and output format validation

**Core Implementation Changes** (mlflow/genai/judges/instructions_judge/__init__.py):
- Modified `instructions` property to return raw `self._instructions` 
- Added validation to reject custom template variables at initialization
- Enhanced error messages to specify which template variables are missing
- Fixed JSON serialization for reserved template variables

**Test Updates** (tests/genai/judges/test_make_judge.py):
- Created reusable test fixtures (`mock_invoke_judge_capture_messages`, etc.)
- Added comprehensive test coverage for all template variable scenarios
- Enhanced assertions to verify proper JSON serialization
- Removed duplicate tests and redundant assertions
- All 55 tests pass successfully

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests  
- [ ] Manual tests

All 55 tests in `test_make_judge.py` pass successfully. Added comprehensive fixtures and test coverage for all template variable scenarios.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

InstructionsJudge now only accepts reserved template variables (`inputs`, `outputs`, `expectations`, `trace`) and rejects custom template variables at initialization. The `instructions` property returns raw instructions, and error messages are more specific about missing template variables. This makes the API more consistent and predictable while still allowing flexibility through the reserved variable dictionaries.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [x] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>