### PR TITLE
Judges - validate input arg types to InstructionsJudge entrypoint

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -163,6 +163,27 @@ class InstructionsJudge(Judge):
             Evaluation results
 
         """
+        if inputs is not None and not isinstance(inputs, dict):
+            raise MlflowException(
+                f"'inputs' must be a dictionary, got {type(inputs).__name__}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        if outputs is not None and not isinstance(outputs, dict):
+            raise MlflowException(
+                f"'outputs' must be a dictionary, got {type(outputs).__name__}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        if expectations is not None and not isinstance(expectations, dict):
+            raise MlflowException(
+                f"'expectations' must be a dictionary, got {type(expectations).__name__}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        if trace is not None and not isinstance(trace, Trace):
+            raise MlflowException(
+                f"'trace' must be a Trace instance, got {type(trace).__name__}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
         # Check if the input arguments match the template variables
         missing_params = []
 

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -1116,6 +1116,111 @@ def test_trace_prompt_augmentation(mock_trace, monkeypatch):
     assert "Analyze this {{trace}} for quality" in captured_prompt
 
 
+def test_judge_rejects_scalar_inputs():
+    judge = make_judge(
+        name="test_judge",
+        instructions="Check if {{inputs}} is valid",
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(MlflowException, match="'inputs' must be a dictionary, got str"):
+        judge(inputs="cat")
+
+    with pytest.raises(MlflowException, match="'inputs' must be a dictionary, got int"):
+        judge(inputs=42)
+
+    with pytest.raises(MlflowException, match="'inputs' must be a dictionary, got list"):
+        judge(inputs=["item1", "item2"])
+
+
+def test_judge_rejects_scalar_outputs():
+    judge = make_judge(
+        name="test_judge",
+        instructions="Check if {{outputs}} is valid",
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(MlflowException, match="'outputs' must be a dictionary, got str"):
+        judge(outputs="response text")
+
+    with pytest.raises(MlflowException, match="'outputs' must be a dictionary, got bool"):
+        judge(outputs=True)
+
+    with pytest.raises(MlflowException, match="'outputs' must be a dictionary, got float"):
+        judge(outputs=3.14)
+
+
+def test_judge_rejects_scalar_expectations():
+    judge = make_judge(
+        name="test_judge",
+        instructions="Compare {{outputs}} to {{expectations}}",
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(MlflowException, match="'expectations' must be a dictionary, got str"):
+        judge(outputs={"result": "test"}, expectations="expected value")
+
+    with pytest.raises(MlflowException, match="'expectations' must be a dictionary, got tuple"):
+        judge(outputs={"result": "test"}, expectations=("expected", "values"))
+
+
+def test_judge_accepts_valid_dict_inputs(mock_invoke_judge_model):
+    judge = make_judge(
+        name="test_judge",
+        instructions="Check if {{inputs}} and {{outputs}} are valid",
+        model="openai:/gpt-4",
+    )
+
+    result = judge(
+        inputs={"question": "What is MLflow?"},
+        outputs={"answer": "MLflow is an open source platform"},
+    )
+    assert isinstance(result, Feedback)
+
+    result = judge(inputs={}, outputs={})
+    assert isinstance(result, Feedback)
+
+    result = judge(
+        inputs={"nested": {"key": "value"}},
+        outputs={"response": {"status": "ok", "data": "result"}},
+    )
+    assert isinstance(result, Feedback)
+
+
+def test_judge_rejects_invalid_trace():
+    judge = make_judge(
+        name="test_judge",
+        instructions="Analyze this {{trace}}",
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(MlflowException, match="'trace' must be a Trace instance, got str"):
+        judge(trace="not a trace")
+
+    with pytest.raises(MlflowException, match="'trace' must be a Trace instance, got dict"):
+        judge(trace={"trace_data": "invalid"})
+
+    inputs_judge = make_judge(
+        name="inputs_judge",
+        instructions="Check {{inputs}}",
+        model="openai:/gpt-4",
+    )
+    with pytest.raises(MlflowException, match="Must specify 'inputs'"):
+        inputs_judge(trace=None)
+
+
+def test_judge_accepts_valid_trace(mock_trace, mock_invoke_judge_model):
+    judge = make_judge(
+        name="test_judge",
+        instructions="Analyze this {{trace}}",
+        model="openai:/gpt-4",
+    )
+
+    result = judge(trace=mock_trace)
+    assert isinstance(result, Feedback)
+    assert mock_invoke_judge_model.captured_args["trace"] == mock_trace
+
+
 def test_instructions_judge_with_chat_messages():
     captured_args = {}
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17560?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17560/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17560/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17560/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adds type validation when calling a judge.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
