### PR TITLE
Judges: Fix race condition for unsupported response format handling

### DIFF
--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -220,7 +220,9 @@ def _invoke_litellm(
             # In LiteLLM version 1.55.3+, max_retries is stacked on top of retry_policy.
             # To avoid double-retry, we set max_retries=0
             "max_retries": 0,
-            # Drop any parameters that are known to be unsupported by the LLM
+            # Drop any parameters that are known to be unsupported by the LLM.
+            # This is important for compatibility with certain models that don't support
+            # certain call parameters (e.g. GPT-4 doesn't support 'response_format')
             "drop_params": True,
         }
         if include_response_format:
@@ -232,18 +234,18 @@ def _invoke_litellm(
         try:
             try:
                 response = _make_completion_request(include_response_format=include_response_format)
-            except litellm.BadRequestError as e:
+            except (litellm.BadRequestError, litellm.UnsupportedParamsError) as e:
                 # Check whether the request attempted to use structured outputs, rather than
                 # checking whether the model supports structured outputs in the capabilities cache,
                 # since the capabilities cache may have been updated between the time that
                 # include_response_format was set and the request was made
                 if include_response_format:
-                    # Retry without response_format if the request failed due to bad request.
+                    # Retry without response_format if the request failed due to unsupported params.
                     # Some models don't support structured outputs (response_format) at all,
                     # and some models don't support both tool calling and structured outputs.
                     _logger.debug(
                         f"Model {litellm_model_uri} may not support structured outputs or combined "
-                        f"tool calling + structured outputs. BadRequestError: {e}. "
+                        f"tool calling + structured outputs. Error: {e}. "
                         f"Falling back to unstructured response."
                     )
                     # Cache the capability for future calls
@@ -251,7 +253,7 @@ def _invoke_litellm(
                     include_response_format = False
                     response = _make_completion_request(include_response_format=False)
                 else:
-                    # Already tried without response_format and still got BadRequestError
+                    # Already tried without response_format and still got error
                     raise
 
             message = response.choices[0].message

--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -235,7 +235,7 @@ def _invoke_litellm(
             except litellm.BadRequestError as e:
                 # Check whether the request attempted to use structured outputs, rather than
                 # checking whether the model supports structured outputs in the capabilities cache,
-                # since the capabilities cache may have been update between the time that
+                # since the capabilities cache may have been updated between the time that
                 # include_response_format was set and the request was made
                 if include_response_format:
                     # Retry without response_format if the request failed due to bad request.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/17566?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17566/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17566/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17566/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Judges: Fix race condition for unsupported response format handling

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
