### PR TITLE
Tracing - fix server version check request timeout

### DIFF
--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Install test dependencies
         run: |
-          pip install pytest pytest-asyncio
+          pip install pytest pytest-asyncio pytest-timeout
 
       - name: Run core tracing tests
         # NB: OTLP exporter includes large dependencies, so we want to test it in a separate job

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -173,8 +173,8 @@ class RestStore(AbstractStore):
                 timeout=3,  # Short timeout to fail fast if server version API isn't available
                 # Disable non-DB SDK retries; default retry policy takes minutes, which is too long
                 max_retries=0,
-                # Disable Databricks SDK retries (0 is interpreted as 'unspecified', so we use -1)
-                retry_timeout_seconds=0.1,
+                # Approx disable DB SDK retries (0 is interpreted as 'unspecified', so use 1)
+                retry_timeout_seconds=1,
                 raise_on_status=True,
             )
             return Version(response.text)

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -171,9 +171,9 @@ class RestStore(AbstractStore):
                 endpoint="/version",
                 method="GET",
                 timeout=3,  # Short timeout to fail fast if server version API isn't available
-                # Disable retries; default retry policy takes minutes, which is too long
-                max_retries=0,  # No retries without Databricks SDK
-                # No retries with Databricks SDK (0 is interpreted as 'unspecified', so we use -1)
+                # Disable non-DB SDK retries; default retry policy takes minutes, which is too long
+                max_retries=0,
+                # Disable Databricks SDK retries (0 is interpreted as 'unspecified', so we use -1)
                 retry_timeout_seconds=0.1,
                 raise_on_status=True,
             )

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -174,7 +174,7 @@ class RestStore(AbstractStore):
                 # Disable retries; default retry policy takes minutes, which is too long
                 max_retries=0,  # No retries without Databricks SDK
                 # No retries with Databricks SDK (0 is interpreted as 'unspecified', so we use -1)
-                retry_timeout_seconds=-1,
+                retry_timeout_seconds=0.1,
                 raise_on_status=True,
             )
             return Version(response.text)

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -173,7 +173,7 @@ class RestStore(AbstractStore):
                 timeout=3,  # Short timeout to fail fast if server version API isn't available
                 # Disable non-DB SDK retries; default retry policy takes minutes, which is too long
                 max_retries=0,
-                # Approx disable DB SDK retries (0 is interpreted as 'unspecified', so use 1)
+                # Approximately disable DB SDK retries (0 is interpreted as 'unspecified', so use 1)
                 retry_timeout_seconds=1,
                 raise_on_status=True,
             )

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -171,7 +171,10 @@ class RestStore(AbstractStore):
                 endpoint="/version",
                 method="GET",
                 timeout=3,  # Short timeout to fail fast if server version API isn't available
-                max_retries=0,  # No retries - default retry policy takes minutes, which is too long
+                # Disable retries; default retry policy takes minutes, which is too long
+                max_retries=0,  # No retries without Databricks SDK
+                # No retries with Databricks SDK (0 is interpreted as 'unspecified', so we use -1)
+                retry_timeout_seconds=-1,
                 raise_on_status=True,
             )
             return Version(response.text)

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -92,7 +92,7 @@ def http_request(
             in retry_codes range and retries have been exhausted.
         respect_retry_after_header: Whether to respect Retry-After header on status codes defined
             as Retry.RETRY_AFTER_STATUS_CODES or not.
-        retry_timeout_seconds: Timeout for retires. Only effective when using Databricks SDK.
+        retry_timeout_seconds: Timeout for retries. Only effective when using Databricks SDK.
         kwargs: Additional keyword arguments to pass to `requests.Session.request()`
 
     Returns:

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -2799,6 +2799,7 @@ def test_server_version_check_caching():
             method="GET",
             timeout=3,
             max_retries=0,
+            retry_timeout_seconds=1,
             raise_on_status=True,
         )
         mock_http.assert_any_call(

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -31,18 +31,6 @@ from mlflow.tracing.provider import _get_trace_exporter
 _EXPERIMENT_ID = "dummy-experiment-id"
 
 
-@pytest.fixture(autouse=True, scope="module")
-def patch_get_server_version():
-    # When spans are logged, `_get_server_version` is called. Because `DATABRICKS_HOST` is set to
-    # a dummy value, the Databricks SDK repeatedly retries the version check, causing tests to
-    # hang for a long time. To avoid this, mock `_get_server_version`.
-    with mock.patch(
-        "mlflow.store.tracking.rest_store.RestStore._get_server_version", return_value=None
-    ) as mock_get_server_version:
-        yield
-        mock_get_server_version.assert_called()
-
-
 @mlflow.trace
 def _predict(x: str) -> str:
     with mlflow.start_span(name="child") as child_span:

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -46,7 +46,9 @@ def _flush_async_logging():
     exporter._async_queue.flush(terminate=True)
 
 
-@pytest.mark.timeout(20)  # Test must complete within 20 seconds
+# Set a test timeout of 20 seconds to catch excessive delays due to request retry loops,
+# e.g. when checking the MLflow server version
+@pytest.mark.timeout(20)
 @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
 def test_export(is_async, monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -46,6 +46,7 @@ def _flush_async_logging():
     exporter._async_queue.flush(terminate=True)
 
 
+@pytest.mark.timeout(20)  # Test must complete within 20 seconds
 @pytest.mark.parametrize("is_async", [True, False], ids=["async", "sync"])
 def test_export(is_async, monkeypatch):
     monkeypatch.setenv("DATABRICKS_HOST", "dummy-host")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/17578?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17578/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17578/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17578/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Tracing - fix server version check request timeout

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
