### PR TITLE
Fix custom prompt judge encoding bug with custom judge model

### DIFF
--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -23,7 +23,10 @@ def get_default_model() -> str:
 def format_prompt(prompt: str, **values) -> str:
     """Format double-curly variables in the prompt template."""
     for key, value in values.items():
-        prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", str(value), prompt)
+        # Escape backslashes in the replacement string to prevent re.sub from interpreting
+        # them as escape sequences (e.g., \u being treated as Unicode escape)
+        replacement = str(value).replace("\\", "\\\\")
+        prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", replacement, prompt)
     return prompt
 
 

--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -24,7 +24,7 @@ def format_prompt(prompt: str, **values) -> str:
     """Format double-curly variables in the prompt template."""
     for key, value in values.items():
         # Escape backslashes in the replacement string to prevent re.sub from interpreting
-        # them as escape sequences (e.g., \u being treated as Unicode escape)
+        # them as escape sequences (e.g. \u being treated as Unicode escape)
         replacement = str(value).replace("\\", "\\\\")
         prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", replacement, prompt)
     return prompt


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbrx-euirim/mlflow/pull/17584?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17584/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17584/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17584/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adjusts the `custom_prompt_judge` to fix an issue where using custom prompt judges with custom judge models can result in an encoding error:

```
Traceback (most recent call last):
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-d8ad2f87-32a8-4b47-a53d-f06d20221cff/lib/python3.12/site-packages/mlflow/genai/judges/custom_prompt_judge.py", line 128, in judge
    prompt = format_prompt(prompt_template, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-d8ad2f87-32a8-4b47-a53d-f06d20221cff/lib/python3.12/site-packages/mlflow/genai/judges/utils.py", line 26, in format_prompt
    prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", str(value), prompt)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 186, in sub
    return _compile(pattern, flags).sub(repl, string, count)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/__init__.py", line 334, in _compile_template
    return _sre.template(pattern, _parser.parse_template(repl, pattern))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/re/_parser.py", line 1075, in parse_template
    raise s.error('bad escape %s' % this, len(this)) from None
re.error: bad escape \u at position 2114
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
