### PR TITLE
Add MLflow OSS telemetry for invoke_custom_judge_model

### DIFF
--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -226,6 +226,11 @@ For events with None in the `Tracked Parameters` column, only the event name is 
       <td>Information on whether metrics, parameters, or tags are logged, and the logging mode</td>
       <td>`{"metrics": False, "params": True, "tags": False, "synchronous": False}`</td>
     </tr>
+    <tr>
+      <td>invoke_custom_judge_model</td>
+      <td>Judge model provider</td>
+      <td>`{"model_provider": "databricks"}`</td>
+    </tr>
   </tbody>
 </Table>
 

--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -7,6 +7,8 @@ from mlflow.entities.assessment_source import AssessmentSource, AssessmentSource
 from mlflow.exceptions import MlflowException
 from mlflow.genai.utils.enum_utils import StrEnum
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.telemetry.events import InvokeCustomJudgeModelEvent
+from mlflow.telemetry.track import record_usage_event
 from mlflow.utils.uri import is_databricks_uri
 
 # "endpoints" is a special case for Databricks model serving endpoints.
@@ -32,6 +34,7 @@ def _sanitize_justification(justification: str) -> str:
     return justification.replace("Let's think step by step. ", "")
 
 
+@record_usage_event(InvokeCustomJudgeModelEvent)
 def invoke_judge_model(
     model_uri: str, prompt: str, assessment_name: str, num_retries: int = 10
 ) -> Feedback:

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Any
 
+from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.telemetry.constant import GENAI_MODULES, MODULES_TO_CHECK_IMPORT
 
 
@@ -209,3 +210,16 @@ class McpRunEvent(Event):
 
 class GitModelVersioningEvent(Event):
     name: str = "git_model_versioning"
+
+
+class InvokeCustomJudgeModelEvent(Event):
+    name: str = "invoke_custom_judge_model"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        model_uri = arguments.get("model_uri")
+        if not model_uri:
+            return {"model_provider": None}
+
+        model_provider, _ = _parse_model_uri(model_uri)
+        return {"model_provider": model_provider}

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,7 +1,6 @@
 import sys
 from typing import Any
 
-from mlflow.metrics.genai.model_utils import _parse_model_uri
 from mlflow.telemetry.constant import GENAI_MODULES, MODULES_TO_CHECK_IMPORT
 
 
@@ -217,6 +216,8 @@ class InvokeCustomJudgeModelEvent(Event):
 
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        from mlflow.metrics.genai.model_utils import _parse_model_uri
+
         model_uri = arguments.get("model_uri")
         if not model_uri:
             return {"model_provider": None}

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -30,6 +30,7 @@ from mlflow.telemetry.events import (
     GenAIEvaluateEvent,
     GetLoggedModelEvent,
     GitModelVersioningEvent,
+    InvokeCustomJudgeModelEvent,
     LogAssessmentEvent,
     LogBatchEvent,
     LogDatasetEvent,
@@ -614,3 +615,88 @@ def test_git_model_versioning(mock_requests, mock_telemetry_client):
 
     mock_telemetry_client.flush()
     validate_telemetry_record(mock_telemetry_client, mock_requests, GitModelVersioningEvent.name)
+
+
+def test_invoke_custom_judge_model(mock_requests, mock_telemetry_client: TelemetryClient):
+    from mlflow.genai.judges.utils import invoke_judge_model
+
+    # Mock response that simulates the JSON response from the judge model
+    mock_response = json.dumps({"result": 0.8, "rationale": "Test rationale"})
+
+    # Test with Databricks model URI
+    with mock.patch("mlflow.genai.judges.utils._is_litellm_available", return_value=True):
+        with mock.patch("mlflow.genai.judges.utils._invoke_litellm", return_value=mock_response):
+            invoke_judge_model(
+                model_uri="databricks:/llama-3.1-70b",
+                prompt="Test prompt",
+                assessment_name="test_assessment",
+            )
+
+            expected_params = {"model_provider": "databricks"}
+            validate_telemetry_record(
+                mock_telemetry_client,
+                mock_requests,
+                InvokeCustomJudgeModelEvent.name,
+                expected_params,
+            )
+
+    # Test with OpenAI model URI
+    with mock.patch("mlflow.genai.judges.utils._is_litellm_available", return_value=True):
+        with mock.patch("mlflow.genai.judges.utils._invoke_litellm", return_value=mock_response):
+            invoke_judge_model(
+                model_uri="openai:/gpt-4o-mini",
+                prompt="Test prompt",
+                assessment_name="test_assessment",
+            )
+
+            expected_params = {"model_provider": "openai"}
+            validate_telemetry_record(
+                mock_telemetry_client,
+                mock_requests,
+                InvokeCustomJudgeModelEvent.name,
+                expected_params,
+            )
+
+    # Test with endpoints model URI (using native provider path)
+    with mock.patch("mlflow.genai.judges.utils._is_litellm_available", return_value=False):
+        # We need to import and patch score_model_on_payload and get_endpoint_type properly
+        with mock.patch.object(
+            __import__("mlflow.metrics.genai.model_utils", fromlist=["score_model_on_payload"]),
+            "score_model_on_payload",
+            return_value=mock_response,
+        ):
+            with mock.patch.object(
+                __import__("mlflow.metrics.genai.model_utils", fromlist=["get_endpoint_type"]),
+                "get_endpoint_type",
+                return_value="llm/v1/chat",
+            ):
+                invoke_judge_model(
+                    model_uri="endpoints:/my-endpoint",
+                    prompt="Test prompt",
+                    assessment_name="test_assessment",
+                )
+
+                expected_params = {"model_provider": "endpoints"}
+                validate_telemetry_record(
+                    mock_telemetry_client,
+                    mock_requests,
+                    InvokeCustomJudgeModelEvent.name,
+                    expected_params,
+                )
+
+    # Test with anthropic model URI (non-native provider, requires litellm)
+    with mock.patch("mlflow.genai.judges.utils._is_litellm_available", return_value=True):
+        with mock.patch("mlflow.genai.judges.utils._invoke_litellm", return_value=mock_response):
+            invoke_judge_model(
+                model_uri="anthropic:/claude-3-opus",
+                prompt="Test prompt",
+                assessment_name="test_assessment",
+            )
+
+            expected_params = {"model_provider": "anthropic"}
+            validate_telemetry_record(
+                mock_telemetry_client,
+                mock_requests,
+                InvokeCustomJudgeModelEvent.name,
+                expected_params,
+            )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbrx-euirim/mlflow/pull/17585?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17585/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17585/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17585/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a new MLflow OSS telemetry event called `invoke_custom_judge_model` that records the model provider. The event is fired when `invoke_judge_model` is called.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add telemetry for when a judge model is invoked.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
