### PR TITLE
Escape backslash in PromptVersion.format

### DIFF
--- a/mlflow/genai/judges/custom_prompt_judge.py
+++ b/mlflow/genai/judges/custom_prompt_judge.py
@@ -6,10 +6,10 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.utils import (
-    format_prompt,
     get_default_model,
     invoke_judge_model,
 )
+from mlflow.genai.prompts.utils import format_prompt
 from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring
 

--- a/mlflow/genai/judges/prompts/context_sufficiency.py
+++ b/mlflow/genai/judges/prompts/context_sufficiency.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from mlflow.genai.judges.utils import format_prompt
+from mlflow.genai.prompts.utils import format_prompt
 
 # NB: User-facing name for the is_context_sufficient assessment.
 CONTEXT_SUFFICIENCY_FEEDBACK_NAME = "context_sufficiency"

--- a/mlflow/genai/judges/prompts/correctness.py
+++ b/mlflow/genai/judges/prompts/correctness.py
@@ -1,4 +1,4 @@
-from mlflow.genai.judges.utils import format_prompt
+from mlflow.genai.prompts.utils import format_prompt
 
 # NB: User-facing name for the is_correct assessment.
 CORRECTNESS_FEEDBACK_NAME = "correctness"

--- a/mlflow/genai/judges/prompts/groundedness.py
+++ b/mlflow/genai/judges/prompts/groundedness.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from mlflow.genai.judges.utils import format_prompt
+from mlflow.genai.prompts.utils import format_prompt
 
 # NB: User-facing name for the is_grounded assessment.
 GROUNDEDNESS_FEEDBACK_NAME = "groundedness"

--- a/mlflow/genai/judges/prompts/guidelines.py
+++ b/mlflow/genai/judges/prompts/guidelines.py
@@ -1,4 +1,4 @@
-from mlflow.genai.judges.utils import format_prompt
+from mlflow.genai.prompts.utils import format_prompt
 
 GUIDELINES_FEEDBACK_NAME = "guidelines"
 

--- a/mlflow/genai/judges/prompts/relevance_to_query.py
+++ b/mlflow/genai/judges/prompts/relevance_to_query.py
@@ -1,4 +1,4 @@
-from mlflow.genai.judges.utils import format_prompt
+from mlflow.genai.prompts.utils import format_prompt
 
 # NB: User-facing name for the is_context_relevant assessment.
 RELEVANCE_TO_QUERY_ASSESSMENT_NAME = "relevance_to_context"

--- a/mlflow/genai/judges/prompts/retrieval_relevance.py
+++ b/mlflow/genai/judges/prompts/retrieval_relevance.py
@@ -1,4 +1,4 @@
-from mlflow.genai.judges.utils import format_prompt
+from mlflow.genai.prompts.utils import format_prompt
 
 RETRIEVAL_RELEVANCE_PROMPT = """\
 Consider the following question and document. You must determine whether the document provides information that is (fully or partially) relevant to the question. Do not focus on the correctness or completeness of the document. Do not make assumptions, approximations, or bring in external knowledge.

--- a/mlflow/genai/judges/prompts/safety.py
+++ b/mlflow/genai/judges/prompts/safety.py
@@ -1,4 +1,4 @@
-from mlflow.genai.judges.utils import format_prompt
+from mlflow.genai.prompts.utils import format_prompt
 
 # NB: User-facing name for the safety assessment.
 SAFETY_ASSESSMENT_NAME = "safety"

--- a/mlflow/genai/judges/utils.py
+++ b/mlflow/genai/judges/utils.py
@@ -1,5 +1,4 @@
 import json
-import re
 
 import mlflow
 from mlflow.entities.assessment import Feedback
@@ -20,16 +19,6 @@ def get_default_model() -> str:
         return "databricks"
     else:
         return "openai:/gpt-4.1-mini"
-
-
-def format_prompt(prompt: str, **values) -> str:
-    """Format double-curly variables in the prompt template."""
-    for key, value in values.items():
-        # Escape backslashes in the replacement string to prevent re.sub from interpreting
-        # them as escape sequences (e.g. \u being treated as Unicode escape)
-        replacement = str(value).replace("\\", "\\\\")
-        prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", replacement, prompt)
-    return prompt
 
 
 def _sanitize_justification(justification: str) -> str:

--- a/mlflow/genai/prompts/utils.py
+++ b/mlflow/genai/prompts/utils.py
@@ -1,0 +1,11 @@
+import re
+
+
+def format_prompt(prompt: str, **values) -> str:
+    """Format double-curly variables in the prompt template."""
+    for key, value in values.items():
+        # Escape backslashes in the replacement string to prevent re.sub from interpreting
+        # them as escape sequences (e.g. \u being treated as Unicode escape)
+        replacement = str(value).replace("\\", "\\\\")
+        prompt = re.sub(r"\{\{\s*" + key + r"\s*\}\}", replacement, prompt)
+    return prompt

--- a/mlflow/genai/prompts/utils.py
+++ b/mlflow/genai/prompts/utils.py
@@ -1,7 +1,8 @@
 import re
+from typing import Any
 
 
-def format_prompt(prompt: str, **values) -> str:
+def format_prompt(prompt: str, **values: Any) -> str:
     """Format double-curly variables in the prompt template."""
     for key, value in values.items():
         # Escape backslashes in the replacement string to prevent re.sub from interpreting

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -75,6 +75,60 @@ def test_prompt_format():
     assert result == "Hello, 1 True!"
 
 
+@pytest.mark.parametrize(
+    ("path_value", "unicode_value", "expected"),
+    [
+        ("C:\\Users\\test\\file.txt", "test", "Path: C:\\Users\\test\\file.txt, Unicode: test"),
+        ("test", "\\u0041\\u0042", "Path: test, Unicode: \\u0041\\u0042"),
+        ("line1\nline2", "test", "Path: line1\nline2, Unicode: test"),
+        ("test[0-9]+", "test", "Path: test[0-9]+, Unicode: test"),
+        (
+            "C:\\Users\\test[0-9]+\\file.txt",
+            "\\u0041\\u0042",
+            "Path: C:\\Users\\test[0-9]+\\file.txt, Unicode: \\u0041\\u0042",
+        ),
+        ('test"quoted"', "test", 'Path: test"quoted", Unicode: test'),
+        ("test(1)", "test", "Path: test(1), Unicode: test"),
+        ("$100", "test", "Path: $100, Unicode: test"),
+    ],
+)
+def test_prompt_format_backslash_escape(path_value, unicode_value, expected):
+    prompt = PromptVersion(name="test", version=1, template="Path: {{path}}, Unicode: {{unicode}}")
+    result = prompt.format(path=path_value, unicode=unicode_value)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    ("style", "question", "expected_content"),
+    [
+        ("helpful", "What is C:\\Users\\test?", "What is C:\\Users\\test?"),
+        ("helpful", "Unicode: \\u0041\\u0042", "Unicode: \\u0041\\u0042"),
+        ("friendly", "Line 1\nLine 2", "Line 1\nLine 2"),
+        ("professional", "Pattern: [0-9]+", "Pattern: [0-9]+"),
+        (
+            "expert",
+            "Path: C:\\Users\\test[0-9]+\\file.txt",
+            "Path: C:\\Users\\test[0-9]+\\file.txt",
+        ),
+        ("casual", 'He said "Hello"', 'He said "Hello"'),
+    ],
+)
+def test_prompt_format_chat_backslash_escape(style, question, expected_content):
+    """Test that PromptVersion.format correctly handles backslashes in chat prompts."""
+    chat_template = [
+        {"role": "system", "content": "You are a {{style}} assistant."},
+        {"role": "user", "content": "{{question}}"},
+    ]
+    prompt = PromptVersion(name="test", version=1, template=chat_template)
+
+    result = prompt.format(style=style, question=question)
+    expected = [
+        {"role": "system", "content": f"You are a {style} assistant."},
+        {"role": "user", "content": expected_content},
+    ]
+    assert result == expected
+
+
 def test_prompt_from_model_version():
     model_version = ModelVersion(
         name="my-prompt",

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -92,7 +92,7 @@ def test_prompt_format():
         ("$100", "test", "Path: $100, Unicode: test"),
     ],
 )
-def test_prompt_format_backslash_escape(path_value, unicode_value, expected):
+def test_prompt_format_backslash_escape(path_value: str, unicode_value: str, expected: str):
     prompt = PromptVersion(name="test", version=1, template="Path: {{path}}, Unicode: {{unicode}}")
     result = prompt.format(path=path_value, unicode=unicode_value)
     assert result == expected
@@ -113,7 +113,7 @@ def test_prompt_format_backslash_escape(path_value, unicode_value, expected):
         ("casual", 'He said "Hello"', 'He said "Hello"'),
     ],
 )
-def test_prompt_format_chat_backslash_escape(style, question, expected_content):
+def test_prompt_format_chat_backslash_escape(style: str, question: str, expected_content: str):
     """Test that PromptVersion.format correctly handles backslashes in chat prompts."""
     chat_template = [
         {"role": "system", "content": "You are a {{style}} assistant."},

--- a/tests/genai/judges/test_judge_utils.py
+++ b/tests/genai/judges/test_judge_utils.py
@@ -6,7 +6,7 @@ from litellm.types.utils import ModelResponse
 
 from mlflow.entities.assessment import AssessmentSourceType
 from mlflow.exceptions import MlflowException
-from mlflow.genai.judges.utils import CategoricalRating, format_prompt, invoke_judge_model
+from mlflow.genai.judges.utils import CategoricalRating, invoke_judge_model
 
 
 @pytest.mark.parametrize("num_retries", [None, 3])
@@ -97,32 +97,3 @@ def test_invoke_judge_model_invalid_json_response():
             invoke_judge_model(
                 model_uri="openai:/gpt-4", prompt="Test prompt", assessment_name="test"
             )
-
-
-@pytest.mark.parametrize(
-    ("prompt_template", "values", "expected"),
-    [
-        # Test with Unicode escape-like sequences
-        (
-            "User input: {{ user_text }}",
-            {"user_text": r"Path is C:\users\john"},
-            r"User input: Path is C:\users\john",
-        ),
-        # Test with newlines and tabs
-        (
-            "Data: {{ data }}",
-            {"data": "Line1\\nLine2\\tTabbed"},
-            "Data: Line1\\nLine2\\tTabbed",
-        ),
-        # Test with multiple variables
-        (
-            "Path: {{ path }}, Command: {{ cmd }}",
-            {"path": r"C:\temp", "cmd": r"echo \u0041"},
-            r"Path: C:\temp, Command: echo \u0041",
-        ),
-    ],
-)
-def test_format_prompt_with_backslashes(prompt_template, values, expected):
-    """Test that format_prompt correctly handles values containing backslashes."""
-    result = format_prompt(prompt_template, **values)
-    assert result == expected

--- a/tests/genai/prompts/test_prompts.py
+++ b/tests/genai/prompts/test_prompts.py
@@ -292,7 +292,9 @@ def test_register_prompt_with_nested_variables():
         ),
     ],
 )
-def test_format_prompt_with_backslashes(prompt_template, values, expected):
+def test_format_prompt_with_backslashes(
+    prompt_template: str, values: dict[str, str], expected: str
+):
     """Test that format_prompt correctly handles values containing backslashes."""
     result = format_prompt(prompt_template, **values)
     assert result == expected


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/17586?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17586/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17586/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17586/merge
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/pull/17584

### What changes are proposed in this pull request?

This PR extracts the prompt format logic under genai/judge to genai/prompts to be shared, and use it in `PromptVersion.format` for fixing the backslash issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
