### PR TITLE
Fix human assessment name sanitization in dspy optimize

### DIFF
--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -82,8 +82,9 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
                 reverse=True,
             )
             for assessment in sorted_assessments:
+                sanitized_assessment_name = assessment.name.lower().strip()
                 if (
-                    assessment.name == sanitized_judge_name
+                    sanitized_assessment_name == sanitized_judge_name
                     and assessment.source.source_type == AssessmentSourceType.HUMAN
                 ):
                     expected_result = assessment

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -24,6 +24,13 @@ if TYPE_CHECKING:
 _logger = logging.getLogger(__name__)
 
 
+def _sanitize_assessment_name(name: str) -> str:
+    """
+    Sanitize a name by converting it to lowercase and stripping whitespace.
+    """
+    return name.lower().strip()
+
+
 def convert_mlflow_uri_to_litellm(model_uri: str) -> str:
     """
     Convert MLflow model URI format to LiteLLM format.
@@ -70,7 +77,6 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
 
         # Find human assessment for this judge
         expected_result = None
-        sanitized_judge_name = judge_name.lower().strip()
 
         if trace.info.assessments:
             # Sort assessments by creation time (most recent first) then process
@@ -82,7 +88,8 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
                 reverse=True,
             )
             for assessment in sorted_assessments:
-                sanitized_assessment_name = assessment.name.lower().strip()
+                sanitized_assessment_name = _sanitize_assessment_name(assessment.name)
+                sanitized_judge_name = _sanitize_assessment_name(judge_name)
                 if (
                     sanitized_assessment_name == sanitized_judge_name
                     and assessment.source.source_type == AssessmentSourceType.HUMAN

--- a/tests/genai/judges/optimizers/conftest.py
+++ b/tests/genai/judges/optimizers/conftest.py
@@ -61,9 +61,9 @@ def sample_trace_with_assessment():
     """Create a sample trace with human assessment for testing."""
     # Create actual trace with real MLflow objects instead of mocks
 
-    # Create a real assessment object (Feedback)
+    # Create a real assessment object (Feedback) with mixed case/whitespace to test sanitization
     assessment = Feedback(
-        name="mock_judge",
+        name="  Mock_JUDGE  ",
         value="pass",
         rationale="This looks good",
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -30,7 +30,8 @@ def test_sanitize_judge_name(sample_trace_with_assessment):
 
     with patch.dict("sys.modules", {"dspy": mock_dspy}):
         # Test with different case variations - they should all find the assessment
-        # The assessment name in the fixture is "mock_judge" in lowercase
+        # The assessment name in the fixture is "  Mock_JUDGE  " (mixed case + whitespace)
+        # These should all match because both assessment name and judge name get sanitized
         assert trace_to_dspy_example(sample_trace_with_assessment, "  mock_judge  ") is not None
         assert trace_to_dspy_example(sample_trace_with_assessment, "Mock_Judge") is not None
         assert trace_to_dspy_example(sample_trace_with_assessment, "MOCK_JUDGE") is not None


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/17595?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17595/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17595/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17595/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix human assessment name sanitization in dspy optimize
### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
