### PR TITLE
Fix an issue with 'aggregations' being applied to a legacy scorer interface

### DIFF
--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -259,8 +259,9 @@ def _convert_scorer_to_legacy_metric(scorer: Scorer) -> EvaluationMetric:
     metric_instance = metric(
         eval_fn=eval_fn,
         name=scorer.name,
-        aggregations=scorer.aggregations,
     )
+    # Add aggregations as an attribute since the metric decorator doesn't accept it
+    metric_instance.aggregations = scorer.aggregations
     # Add attribute to indicate if this is a built-in scorer
     metric_instance._is_builtin_scorer = isinstance(scorer, BuiltInScorer)
 

--- a/tests/genai/evaluate/test_utils.py
+++ b/tests/genai/evaluate/test_utils.py
@@ -429,16 +429,17 @@ def test_convert_scorer_to_legacy_metric_aggregations_attribute():
 
     sys.modules["databricks.agents.evals"] = Mock(metric=mock_metric_decorator)
 
-    mock_scorer = Mock()
-    mock_scorer.name = "test_scorer"
-    mock_scorer.aggregations = ["mean", "max", "p90"]
-    mock_scorer.run = Mock(return_value={"score": 1.0})
+    try:
+        mock_scorer = Mock()
+        mock_scorer.name = "test_scorer"
+        mock_scorer.aggregations = ["mean", "max", "p90"]
+        mock_scorer.run = Mock(return_value={"score": 1.0})
 
-    result = _convert_scorer_to_legacy_metric(mock_scorer)
+        result = _convert_scorer_to_legacy_metric(mock_scorer)
 
-    assert result.aggregations == ["mean", "max", "p90"]
-
-    del sys.modules["databricks.agents.evals"]
+        assert result.aggregations == ["mean", "max", "p90"]
+    finally:
+        del sys.modules["databricks.agents.evals"]
 
 
 @databricks_only


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17596?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17596/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17596/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17596/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

If the `aggregations` attribute is applied to a scorer (like the basic example in the UI shows), the decorator in use by databricks-agents doesn't support passing this value in through the constructor, causing an exception to be thrown. 
This PR applies the property directly if passed in via the signature.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
