### PR TITLE
Add 'run' command to MLflow AI commands CLI

### DIFF
--- a/mlflow/ai_commands/__init__.py
+++ b/mlflow/ai_commands/__init__.py
@@ -39,3 +39,23 @@ def get_cmd(key: str) -> None:
     except FileNotFoundError as e:
         click.echo(f"Error: {e}", err=True)
         raise click.Abort()
+
+
+@commands.command("run")
+@click.argument("key")
+def run_cmd(key: str) -> None:
+    """Get a command formatted for execution by an AI assistant."""
+    try:
+        content = get_command(key)
+        _, body = parse_frontmatter(content)
+
+        # Add prefix instructing the assistant to execute the workflow
+        prefix = (
+            "The user has run an MLflow AI command via CLI. "
+            "Start executing the workflow immediately without any preamble.\n\n"
+        )
+
+        click.echo(prefix + body)
+    except FileNotFoundError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise click.Abort()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>


[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nsthorat/mlflow/pull/17598?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17598/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17598/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17598/merge
```

</p>
</details>

<img width="466" height="392" alt="image" src="https://github.com/user-attachments/assets/23dcfbfd-7887-4a95-89b6-3c57b871f842" />

### Related Issues/PRs

N/A - New feature

### What changes are proposed in this pull request?

This PR introduces a new `run` subcommand to the MLflow AI commands CLI that prepares AI command content for direct execution by AI assistants (like Claude, ChatGPT, etc.).

**Key changes:**
- Added `run_command()` function in `ai_command_utils.py` that:
  - Removes YAML frontmatter metadata from command files
  - Adds a configurable prefix (`RUN_COMMAND_PREFIX`) that instructs AI assistants to immediately execute workflows
  - Returns only the body content needed for execution

- Added new CLI command `mlflow ai-commands run <key>` that outputs workflow-ready content

- Added comprehensive test coverage for both the utility function and CLI command

**Difference between `get` and `run` commands:**
- `get`: Returns the full command content including YAML frontmatter (for human reading)
- `run`: Returns only the body with an execution prefix (for AI assistant execution)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
  - Added `test_run_command_success` and `test_run_command_not_found` in `tests/ai_commands/test_ai_command_utils.py`
  - Added `test_run_command_cli`, `test_run_invalid_command_cli`, and `test_run_command_help` in `tests/cli/test_ai_commands.py`
  - Updated existing tests to verify the `run` command appears in help output
- [x] Manual tests
  - Tested with `uv run mlflow ai-commands run genai/analyze_experiment`
  - Verified output format and prefix inclusion

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references (will need to be updated in a follow-up)
  - [ ] Instructions

Note: Documentation updates for the new `run` command should be added to explain its use case for AI assistant integration.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added a new `mlflow ai-commands run` CLI command that formats AI command workflows for direct execution by AI assistants. This command removes metadata and adds execution instructions, making it easy to pipe MLflow AI commands directly to coding assistants.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging (AI commands are part of the tracking ecosystem)
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality (AI commands work with trace analysis)

Language Interfaces

- [x] Python APIs (CLI commands implemented in Python)

Integrations

- [x] AI assistants/LLMs (new feature specifically designed for AI assistant integration)