### PR TITLE
Skip test_build_image on PR to speed up CI

### DIFF
--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -96,7 +96,7 @@ def test_build_image(tmp_path, params):
         content = content.replace(VERSION, get_released_mlflow_version())
         dockerfile.write_text(content)
         shutil.copytree(context_dir, dst_dir)
-        # Build the image if the slow--tests flag is enabled
+        # Build the image if the slow-tests flag is enabled
         if _MLFLOW_RUN_SLOW_TESTS.get():
             for _ in range(3):
                 try:

--- a/tests/pyfunc/docker/test_docker.py
+++ b/tests/pyfunc/docker/test_docker.py
@@ -10,6 +10,7 @@ import sklearn
 import sklearn.neighbors
 
 import mlflow
+from mlflow.environment_variables import _MLFLOW_RUN_SLOW_TESTS
 from mlflow.models import Model
 from mlflow.models.docker_utils import build_image_from_context
 from mlflow.models.flavor_backend_registry import get_flavor_backend
@@ -94,17 +95,18 @@ def test_build_image(tmp_path, params):
         content = dockerfile.read_text()
         content = content.replace(VERSION, get_released_mlflow_version())
         dockerfile.write_text(content)
-
         shutil.copytree(context_dir, dst_dir)
-        for _ in range(3):
-            try:
-                # Docker image build is unstable on GitHub Actions, retry up to 3 times
-                build_image_from_context(context_dir, image_name)
-                break
-            except RuntimeError:
-                pass
-        else:
-            raise RuntimeError("Docker image build failed.")
+        # Build the image if the slow--tests flag is enabled
+        if _MLFLOW_RUN_SLOW_TESTS.get():
+            for _ in range(3):
+                try:
+                    # Docker image build is unstable on GitHub Actions, retry up to 3 times
+                    build_image_from_context(context_dir, image_name)
+                    break
+                except RuntimeError:
+                    pass
+            else:
+                raise RuntimeError("Docker image build failed.")
 
     dst_dir = tmp_path / "context"
     with mock.patch(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17612?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17612/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17612/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17612/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR skips the `test_build_image` test on PRs to speed up CI. This test builds Docker images which is time-consuming and can be unstable on GitHub Actions. The test will only run when the `MLFLOW_RUN_SLOW_TESTS` environment variable is set.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with Claude Code