### PR TITLE
Split slow `test_predict` into focused test functions

### DIFF
--- a/tests/models/test_cli.py
+++ b/tests/models/test_cli.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 import warnings
+from dataclasses import dataclass
 from pathlib import Path
 from unittest import mock
 
@@ -62,12 +63,12 @@ install_mlflow = ["--install-mlflow"] if not no_conda else []
 extra_options = no_conda + install_mlflow
 
 
-def env_with_tracking_uri():
+def env_with_tracking_uri() -> dict[str, str]:
     return {**os.environ, "MLFLOW_TRACKING_URI": mlflow.get_tracking_uri()}
 
 
 @pytest.fixture(scope="module")
-def iris_data():
+def iris_data() -> tuple[np.ndarray, np.ndarray]:
     iris = sklearn.datasets.load_iris()
     x = iris.data[:, :2]
     y = iris.target
@@ -75,7 +76,7 @@ def iris_data():
 
 
 @pytest.fixture(scope="module")
-def sk_model(iris_data):
+def sk_model(iris_data: tuple[np.ndarray, np.ndarray]) -> sklearn.neighbors.KNeighborsClassifier:
     x, y = iris_data
     knn_model = sklearn.neighbors.KNeighborsClassifier()
     knn_model.fit(x, y)
@@ -175,179 +176,208 @@ def test_serve_uvicorn_opts(iris_data, sk_model):
         assert expected_command_pattern.search(stdout) is not None
 
 
-def test_predict(iris_data, sk_model):
-    with TempDir(chdr=True) as tmp:
-        with mlflow.start_run() as active_run:
-            mlflow.sklearn.log_model(sk_model, name="model", registered_model_name="impredicting")
-            model_uri = f"runs:/{active_run.info.run_id}/model"
-        model_registry_uri = "models:/impredicting/None"
-        input_json_path = tmp.path("input.json")
-        input_csv_path = tmp.path("input.csv")
-        output_json_path = tmp.path("output.json")
-        x, _ = iris_data
-        with open(input_json_path, "w") as f:
-            json.dump({"dataframe_split": pd.DataFrame(x).to_dict(orient="split")}, f)
+@dataclass
+class PredictTestData:
+    model_uri: str
+    model_registry_uri: str
+    input_json_path: Path
+    input_csv_path: Path
+    output_json_path: Path
+    x: np.ndarray
+    sk_model: sklearn.base.BaseEstimator
 
-        pd.DataFrame(x).to_csv(input_csv_path, index=False)
 
-        # Test with no conda & model registry URI
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "mlflow",
-                "models",
-                "predict",
-                "-m",
-                model_registry_uri,
-                "-i",
-                input_json_path,
-                "-o",
-                output_json_path,
-                "--env-manager",
-                "local",
-            ],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=env_with_tracking_uri(),
-            check=True,
-        )
-        actual = pd.read_json(output_json_path, orient="records")
-        actual = actual[actual.columns[0]].values
-        expected = sk_model.predict(x)
-        assert all(expected == actual)
+@pytest.fixture
+def predict_test_setup(
+    iris_data: tuple[np.ndarray, np.ndarray],
+    sk_model: sklearn.neighbors.KNeighborsClassifier,
+    tmp_path: Path,
+) -> PredictTestData:
+    with mlflow.start_run() as active_run:
+        mlflow.sklearn.log_model(sk_model, name="model", registered_model_name="impredicting")
+        model_uri = f"runs:/{active_run.info.run_id}/model"
 
-        # With conda + --install-mlflow
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "mlflow",
-                "models",
-                "predict",
-                "-m",
-                model_uri,
-                "-i",
-                input_json_path,
-                "-o",
-                output_json_path,
-                *extra_options,
-            ],
-            env=env_with_tracking_uri(),
-            check=True,
-        )
-        actual = pd.read_json(output_json_path, orient="records")
-        actual = actual[actual.columns[0]].values
-        expected = sk_model.predict(x)
-        assert all(expected == actual)
+    model_registry_uri = "models:/impredicting/None"
+    input_json_path = tmp_path / "input.json"
+    input_csv_path = tmp_path / "input.csv"
+    output_json_path = tmp_path / "output.json"
 
-        # explicit json format with default orient (should be split)
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "mlflow",
-                "models",
-                "predict",
-                "-m",
-                model_uri,
-                "-i",
-                input_json_path,
-                "-o",
-                output_json_path,
-                "-t",
-                "json",
-                *extra_options,
-            ],
-            env=env_with_tracking_uri(),
-            check=True,
-        )
+    x, _ = iris_data
+    with open(input_json_path, "w") as f:
+        json.dump({"dataframe_split": pd.DataFrame(x).to_dict(orient="split")}, f)
+    pd.DataFrame(x).to_csv(input_csv_path, index=False)
 
-        actual = pd.read_json(output_json_path, orient="records")
-        actual = actual[actual.columns[0]].values
-        expected = sk_model.predict(x)
-        assert all(expected == actual)
+    return PredictTestData(
+        model_uri=model_uri,
+        model_registry_uri=model_registry_uri,
+        input_json_path=input_json_path,
+        input_csv_path=input_csv_path,
+        output_json_path=output_json_path,
+        x=x,
+        sk_model=sk_model,
+    )
 
-        # explicit json format with orient==split
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "mlflow",
-                "models",
-                "predict",
-                "-m",
-                model_uri,
-                "-i",
-                input_json_path,
-                "-o",
-                output_json_path,
-                "-t",
-                "json",
-                *extra_options,
-            ],
-            env=env_with_tracking_uri(),
-            check=True,
-        )
-        actual = pd.read_json(output_json_path, orient="records")
-        actual = actual[actual.columns[0]].values
-        expected = sk_model.predict(x)
-        assert all(expected == actual)
 
-        # read from stdin, write to stdout.
-        prc = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "mlflow",
-                "models",
-                "predict",
-                "-m",
-                model_uri,
-                "-t",
-                "json",
-                *extra_options,
-            ],
-            input=Path(input_json_path).read_text(),
-            stdout=subprocess.PIPE,
-            env=env_with_tracking_uri(),
-            text=True,
-            check=True,
-        )
-        predictions = re.search(r"{\"predictions\": .*}", prc.stdout).group(0)
-        actual = pd.read_json(predictions, orient="records")
-        actual = actual[actual.columns[0]].values
-        expected = sk_model.predict(x)
-        assert all(expected == actual)
+def test_predict_with_model_registry_uri(predict_test_setup: PredictTestData) -> None:
+    setup = predict_test_setup
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "models",
+            "predict",
+            "-m",
+            setup.model_registry_uri,
+            "-i",
+            setup.input_json_path,
+            "-o",
+            setup.output_json_path,
+            "--env-manager",
+            "local",
+        ],
+        env=env_with_tracking_uri(),
+    )
+    actual = pd.read_json(setup.output_json_path, orient="records")
+    actual = actual[actual.columns[0]].values
+    expected = setup.sk_model.predict(setup.x)
+    assert all(expected == actual)
 
-        # NB: We do not test orient=records here because records may loose column ordering.
-        # orient == records is tested in other test with simpler model.
 
-        # csv
-        subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "mlflow",
-                "models",
-                "predict",
-                "-m",
-                model_uri,
-                "-i",
-                input_csv_path,
-                "-o",
-                output_json_path,
-                "-t",
-                "csv",
-                *extra_options,
-            ],
-            env=env_with_tracking_uri(),
-            check=True,
-        )
-        actual = pd.read_json(output_json_path, orient="records")
-        actual = actual[actual.columns[0]].values
-        expected = sk_model.predict(x)
-        assert all(expected == actual)
+def test_predict_with_conda_and_install_mlflow(predict_test_setup: PredictTestData) -> None:
+    setup = predict_test_setup
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "models",
+            "predict",
+            "-m",
+            setup.model_uri,
+            "-i",
+            setup.input_json_path,
+            "-o",
+            setup.output_json_path,
+            *extra_options,
+        ],
+        env=env_with_tracking_uri(),
+    )
+    actual = pd.read_json(setup.output_json_path, orient="records")
+    actual = actual[actual.columns[0]].values
+    expected = setup.sk_model.predict(setup.x)
+    assert all(expected == actual)
+
+
+def test_predict_explicit_json_format_default_orient(predict_test_setup: PredictTestData) -> None:
+    setup = predict_test_setup
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "models",
+            "predict",
+            "-m",
+            setup.model_uri,
+            "-i",
+            setup.input_json_path,
+            "-o",
+            setup.output_json_path,
+            "-t",
+            "json",
+            *extra_options,
+        ],
+        env=env_with_tracking_uri(),
+    )
+    actual = pd.read_json(setup.output_json_path, orient="records")
+    actual = actual[actual.columns[0]].values
+    expected = setup.sk_model.predict(setup.x)
+    assert all(expected == actual)
+
+
+def test_predict_explicit_json_format_split_orient(predict_test_setup: PredictTestData) -> None:
+    # Note: This test has the same command as the previous one but tests orient==split
+    # The comment in original code mentions this should be split orient
+    setup = predict_test_setup
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "models",
+            "predict",
+            "-m",
+            setup.model_uri,
+            "-i",
+            setup.input_json_path,
+            "-o",
+            setup.output_json_path,
+            "-t",
+            "json",
+            *extra_options,
+        ],
+        env=env_with_tracking_uri(),
+    )
+    actual = pd.read_json(setup.output_json_path, orient="records")
+    actual = actual[actual.columns[0]].values
+    expected = setup.sk_model.predict(setup.x)
+    assert all(expected == actual)
+
+
+def test_predict_stdin_stdout(predict_test_setup: PredictTestData) -> None:
+    setup = predict_test_setup
+    stdout = subprocess.check_output(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "models",
+            "predict",
+            "-m",
+            setup.model_uri,
+            "-t",
+            "json",
+            *extra_options,
+        ],
+        input=setup.input_json_path.read_text(),
+        env=env_with_tracking_uri(),
+        text=True,
+    )
+    predictions = re.search(r"{\"predictions\": .*}", stdout).group(0)
+    actual = pd.read_json(predictions, orient="records")
+    actual = actual[actual.columns[0]].values
+    expected = setup.sk_model.predict(setup.x)
+    assert all(expected == actual)
+    # NB: We do not test orient=records here because records may loose column ordering.
+    # orient == records is tested in other test with simpler model.
+
+
+def test_predict_csv_format(predict_test_setup: PredictTestData) -> None:
+    setup = predict_test_setup
+    subprocess.check_call(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "models",
+            "predict",
+            "-m",
+            setup.model_uri,
+            "-i",
+            setup.input_csv_path,
+            "-o",
+            setup.output_json_path,
+            "-t",
+            "csv",
+            *extra_options,
+        ],
+        env=env_with_tracking_uri(),
+    )
+    actual = pd.read_json(setup.output_json_path, orient="records")
+    actual = actual[actual.columns[0]].values
+    expected = setup.sk_model.predict(setup.x)
+    assert all(expected == actual)
 
 
 def test_predict_check_content_type(iris_data, sk_model, tmp_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17616?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17616/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17616/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17616/merge
```

</p>
</details>

### Related Issues/PRs

This addresses the extremely slow test execution time mentioned in https://github.com/mlflow/mlflow/actions/runs/17587706831/job/49960076348?pr=17613#step:11:326 where the test takes about 10 minutes to run.

```
749.06s call     tests/models/test_cli.py::test_predict  👈👈👈
340.27s call     tests/models/test_cli.py::test_build_docker[True]
181.99s call     tests/models/test_cli.py::test_build_docker_with_env_override[False]
177.72s call     tests/models/test_cli.py::test_build_docker_virtualenv
...
```

### What changes are proposed in this pull request?

This PR splits the monolithic `test_predict` function into 6 focused test functions:

1. **`test_predict_with_model_registry_uri`** - Tests model registry URI with local env manager
2. **`test_predict_with_conda_and_install_mlflow`** - Tests with conda and install options
3. **`test_predict_explicit_json_format_default_orient`** - Tests explicit JSON format
4. **`test_predict_explicit_json_format_split_orient`** - Tests JSON format with split orient  
5. **`test_predict_stdin_stdout`** - Tests stdin/stdout functionality
6. **`test_predict_csv_format`** - Tests CSV input format

**Additional improvements:**
- Added `PredictTestData` dataclass for better test data organization
- Replaced `TempDir` with pytest's `tmp_path` fixture for better integration
- Added comprehensive type hints for better code clarity
- Replaced `subprocess.run` with `subprocess.check_call`/`check_output` for cleaner code
- Better test isolation - failures are easier to debug and trace to specific functionality

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

The split tests maintain the same functionality as the original monolithic test while being more organized and maintainable. Each split test focuses on a single scenario, making it easier to identify and fix issues.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)