### PR TITLE
remove double serialization from attributes

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -487,6 +487,7 @@ mlflow.entities.Trace.to_proto
 mlflow.entities.TraceData
 mlflow.entities.TraceData.from_dict
 mlflow.entities.TraceData.to_dict
+mlflow.entities.TraceData.to_dict_for_export
 mlflow.entities.TraceInfo
 mlflow.entities.TraceInfo.from_dict
 mlflow.entities.TraceInfo.from_proto

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -347,7 +347,10 @@ class Span:
             end_time_unix_nano=end_time_unix_nano,
             events=[event.to_proto() for event in self.events],
             status=status,
-            attributes={k: ParseDict(json.loads(v) if isinstance(v, str) else v, Value()) for k, v in self._span.attributes.items()},
+            attributes={
+                k: ParseDict(json.loads(v) if isinstance(v, str) else v, Value())
+                for k, v in self._span.attributes.items()
+            },
         )
 
     @classmethod

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -347,7 +347,7 @@ class Span:
             end_time_unix_nano=end_time_unix_nano,
             events=[event.to_proto() for event in self.events],
             status=status,
-            attributes={k: ParseDict(v, Value()) for k, v in self._span.attributes.items()},
+            attributes={k: ParseDict(json.loads(v) if isinstance(v, str) else v, Value()) for k, v in self._span.attributes.items()},
         )
 
     @classmethod

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -347,10 +347,7 @@ class Span:
             end_time_unix_nano=end_time_unix_nano,
             events=[event.to_proto() for event in self.events],
             status=status,
-            attributes={
-                k: ParseDict(json.loads(v) if isinstance(v, str) else v, Value())
-                for k, v in self._span.attributes.items()
-            },
+            attributes={k: ParseDict(v, Value()) for k, v in self._span.attributes.items()},
         )
 
     @classmethod

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -3008,11 +3008,16 @@ def get_trace_artifact_handler():
         )
 
     trace_info = _get_tracking_store().get_trace_info(request_id)
-    trace_data = _get_trace_artifact_repo(trace_info).download_trace_data()
+    trace_data_dict = _get_trace_artifact_repo(trace_info).download_trace_data()
+
+    from mlflow.entities.trace_data import TraceData
+
+    trace_data = TraceData.from_dict(trace_data_dict)
+    trace_data_export = trace_data.to_dict_for_export()
 
     # Write data to a BytesIO buffer instead of needing to save a temp file
     buf = io.BytesIO()
-    buf.write(json.dumps(trace_data).encode())
+    buf.write(json.dumps(trace_data_export).encode())
     buf.seek(0)
 
     file_sender_response = send_file(

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -581,14 +581,14 @@ def test_span_attributes_not_double_stringified():
 
     attributes = span_dict["attributes"]
 
-    assert attributes[SpanAttributeKey.INPUTS] == test_input
+    assert attributes[SpanAttributeKey.INPUTS] == json.dumps(test_input)
     assert isinstance(attributes[SpanAttributeKey.INPUTS], str)
 
-    assert attributes[SpanAttributeKey.OUTPUTS] == test_output
-    assert isinstance(attributes[SpanAttributeKey.OUTPUTS], dict)
+    assert attributes[SpanAttributeKey.OUTPUTS] == json.dumps(test_output)
+    assert isinstance(attributes[SpanAttributeKey.OUTPUTS], str)
 
     trace_data = TraceData(spans=[span])
-    trace_dict = trace_data.to_dict()
+    trace_dict = trace_data.to_dict_for_export()
 
     trace_json = json.dumps(trace_dict)
 

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -5116,20 +5116,12 @@ async def test_log_spans(store: SqlAlchemyStore, is_async: bool):
         # Check the computed duration
         assert saved_span.duration_ns == (span.end_time_ns - span.start_time_ns)
 
-        # Verify the content is properly serialized
         content_dict = json.loads(saved_span.content)
         assert content_dict["name"] == "test_span"
-        # Inputs and outputs are stored in attributes as strings
-        assert content_dict["attributes"]["mlflow.spanInputs"] == json.dumps(
-            {"input": "test_input"}, cls=TraceJSONEncoder
-        )
-        assert content_dict["attributes"]["mlflow.spanOutputs"] == json.dumps(
-            {"output": "test_output"}, cls=TraceJSONEncoder
-        )
+        assert content_dict["attributes"]["mlflow.spanInputs"] == {"input": "test_input"}
+        assert content_dict["attributes"]["mlflow.spanOutputs"] == {"output": "test_output"}
         expected_type = "LLM" if not is_async else "CHAIN"
-        assert content_dict["attributes"]["mlflow.spanType"] == json.dumps(
-            expected_type, cls=TraceJSONEncoder
-        )
+        assert content_dict["attributes"]["mlflow.spanType"] == expected_type
 
 
 @pytest.mark.asyncio

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -5118,10 +5118,16 @@ async def test_log_spans(store: SqlAlchemyStore, is_async: bool):
 
         content_dict = json.loads(saved_span.content)
         assert content_dict["name"] == "test_span"
-        assert content_dict["attributes"]["mlflow.spanInputs"] == {"input": "test_input"}
-        assert content_dict["attributes"]["mlflow.spanOutputs"] == {"output": "test_output"}
+        assert content_dict["attributes"]["mlflow.spanInputs"] == json.dumps(
+            {"input": "test_input"}, cls=TraceJSONEncoder
+        )
+        assert content_dict["attributes"]["mlflow.spanOutputs"] == json.dumps(
+            {"output": "test_output"}, cls=TraceJSONEncoder
+        )
         expected_type = "LLM" if not is_async else "CHAIN"
-        assert content_dict["attributes"]["mlflow.spanType"] == expected_type
+        assert content_dict["attributes"]["mlflow.spanType"] == json.dumps(
+            expected_type, cls=TraceJSONEncoder
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2793,9 +2793,18 @@ def test_get_trace_artifact_handler(mlflow_client):
     assert response.status_code == 200
     assert response.headers["Content-Disposition"] == "attachment; filename=traces.json"
 
-    # Validate content
     trace_data = TraceData.from_dict(json.loads(response.text))
-    assert trace_data.spans[0].to_dict() == span.to_dict()
+    exported_span_dict = trace_data.spans[0].to_dict()
+    original_span_dict = span.to_dict()
+
+    assert exported_span_dict["name"] == original_span_dict["name"]
+    assert exported_span_dict["span_id"] == original_span_dict["span_id"]
+    assert exported_span_dict["trace_id"] == original_span_dict["trace_id"]
+
+    assert exported_span_dict["attributes"]["mlflow.spanType"] == "UNKNOWN"
+    assert original_span_dict["attributes"]["mlflow.spanType"] == '"UNKNOWN"'
+
+    assert exported_span_dict["attributes"]["fruit"] == original_span_dict["attributes"]["fruit"]
 
 
 def test_link_traces_to_run_and_search_traces(mlflow_client):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17622?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17622/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17622/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17622/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Addresses an issue where span attributes are JSON encoded twice, causing attributes rendering issues when retrieved via API.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
