### PR TITLE
When logging a model with prompts, link the prompts to the model

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -1309,11 +1309,21 @@ class Model:
                     client.delete_logged_model_tag(model.model_id, MLFLOW_MODEL_IS_EXTERNAL)
                 # client.finalize_logged_model(model.model_id, status=LoggedModelStatus.READY)
 
-                # Associate prompts to the model Run
-                if prompts and run_id:
+                # Associate prompts to the model Run and LoggedModel
+                if prompts:
                     client = mlflow.MlflowClient()
-                    for prompt in prompts:
-                        client.link_prompt_version_to_run(run_id, prompt)
+                    for prompt_uri in prompts:
+                        # Link to run (handles both URIs and PromptVersion objects)
+                        if run_id:
+                            client.link_prompt_version_to_run(run_id, prompt_uri)
+
+                        # Link to LoggedModel - load prompt to get name/version
+                        prompt_obj = client.load_prompt(prompt_uri)
+                        client.link_prompt_version_to_model(
+                            name=prompt_obj.name,
+                            version=prompt_obj.version,
+                            model_id=model.model_id,
+                        )
 
                 # if the model_config kwarg is passed in, then log the model config as an params
                 if model_config := kwargs.get("model_config"):

--- a/tests/models/test_model.py
+++ b/tests/models/test_model.py
@@ -715,6 +715,36 @@ def test_logged_model_status():
     assert logged_model.status == "FAILED"
 
 
+def test_model_log_links_prompts_to_logged_model():
+    """Test that Model.log links prompts to the run when prompts are provided."""
+    client = mlflow.MlflowClient()
+
+    # Create actual prompts in the registry
+    client.create_prompt(name="test_prompt_1")
+    prompt_1 = client.create_prompt_version(name="test_prompt_1", template="Hello {{name}}")
+    client.create_prompt(name="test_prompt_2")
+    prompt_2 = client.create_prompt_version(name="test_prompt_2", template="Goodbye {{name}}")
+
+    with mlflow.start_run() as run:
+        model_info = Model.log("model", TestFlavor, prompts=[prompt_1, prompt_2])
+
+    # Verify prompts were linked to the run
+    run_data = client.get_run(run.info.run_id)
+    linked_prompts_tag = run_data.data.tags.get("mlflow.linkedPrompts")
+    assert linked_prompts_tag is not None
+    linked_prompts = json.loads(linked_prompts_tag)
+    assert len(linked_prompts) == 2
+    assert {p["name"] for p in linked_prompts} == {"test_prompt_1", "test_prompt_2"}
+
+    # Verify prompts were linked to the LoggedModel
+    logged_model = client.get_logged_model(model_info.model_id)
+    model_linked_prompts_tag = logged_model.tags.get("mlflow.linkedPrompts")
+    assert model_linked_prompts_tag is not None
+    model_linked_prompts = json.loads(model_linked_prompts_tag)
+    assert len(model_linked_prompts) == 2
+    assert {p["name"] for p in model_linked_prompts} == {"test_prompt_1", "test_prompt_2"}
+
+
 def test_get_model_info_with_logged_model():
     def model(model_input: list[str]) -> list[str]:
         return model_input


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/17624?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17624/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17624/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17624/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

When logging a model with prompts, link the prompts to the model

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
