### PR TITLE
Judges - Fix number of brackets around "trace" in instructions judge prompt

### DIFF
--- a/mlflow/genai/judges/instructions_judge/constants.py
+++ b/mlflow/genai/judges/instructions_judge/constants.py
@@ -26,12 +26,12 @@ itself, all intermediate steps, decisions, and outputs. Each step in a trace is 
 metadata.
 
 The instructions containing the evaluation criteria and methodology are provided below, and they
-refer to a placeholder called {{ trace }}. To read the actual trace, you will need to use the tools
-provided to you. These tools enable you to 1. fetch trace metadata, timing, & execution details,
-2. list all spans in the trace with inputs and outputs, 3. search for specific text or patterns
-across the entire trace, and much more. These tools do *not* require you to specify a particular
-trace; the tools will select the relevant trace automatically (however, you *will* need to specify
-*span* IDs when retrieving specific spans).
+refer to a placeholder called {{{{ trace }}}}. To read the actual trace, you will need to use the
+tools provided to you. These tools enable you to 1. fetch trace metadata, timing, & execution
+details, 2. list all spans in the trace with inputs and outputs, 3. search for specific text or
+patterns across the entire trace, and much more. These tools do *not* require you to specify a
+particular trace; the tools will select the relevant trace automatically (however, you *will* need
+to specify *span* IDs when retrieving specific spans).
 
 In order to follow the instructions precisely and correctly, you must think methodically and act
 step-by-step:

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -1312,6 +1312,7 @@ def test_trace_prompt_augmentation(mock_trace, monkeypatch):
 
     assert "expert judge" in captured_prompt
     assert "step-by-step record" in captured_prompt
+    assert "refer to a placeholder called {{ trace }}" in captured_prompt
     assert "provided to you" in captured_prompt
     assert "Evaluation Rating Fields" in captured_prompt
     assert "- result: The evaluation rating/result" in captured_prompt


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/17644?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17644/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17644/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17644/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Judges - Fix number of brackets around "trace" in instructions judge prompt

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
