### PR TITLE
Adjust Delta test to not focus on testing functionality of Delta

### DIFF
--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -108,7 +108,13 @@ def test_conversion_to_json_delta_dataset_source(spark_session, tmp_path, df):
     assert parsed_json["digest"] == dataset.digest
     assert parsed_json["source"] == dataset.source.to_json()
     assert parsed_json["source_type"] == dataset.source._get_source_type()
-    assert parsed_json["profile"] == json.dumps(dataset.profile)
+    
+    # On Windows with certain PySpark versions, Delta tables may return "unknown" for approx_count
+    # instead of the actual count. We should check that the profile is valid JSON and contains
+    # the expected key, but not assert on the exact value.
+    profile_data = json.loads(parsed_json["profile"])
+    assert "approx_count" in profile_data
+    assert profile_data["approx_count"] in [2, "unknown"]
 
     schema_json = json.dumps(json.loads(parsed_json["schema"])["mlflow_colspec"])
     assert Schema.from_json(schema_json) == dataset.schema

--- a/tests/data/test_spark_dataset.py
+++ b/tests/data/test_spark_dataset.py
@@ -108,7 +108,7 @@ def test_conversion_to_json_delta_dataset_source(spark_session, tmp_path, df):
     assert parsed_json["digest"] == dataset.digest
     assert parsed_json["source"] == dataset.source.to_json()
     assert parsed_json["source_type"] == dataset.source._get_source_type()
-    
+
     # On Windows with certain PySpark versions, Delta tables may return "unknown" for approx_count
     # instead of the actual count. We should check that the profile is valid JSON and contains
     # the expected key, but not assert on the exact value.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17657?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17657/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17657/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17657/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

PySpark 4.0.1 introduced a correctness issue bug for Windows that has not been addressed properly for getting approximate counts of the size of Delta tables. We should not be testing the internal functionality so specifically of what Delta will return based on the platform that it is running on, rather that we're able to serialize the metadata. 
This adjustment loosens the validation in our test to validate MLflow's role in serializing to JSON metadata associated with a dataset source.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
