### PR TITLE
Fix langchain test failure with langchain-core 0.3.76

### DIFF
--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -939,7 +939,13 @@ def test_langchain_auto_tracing_work_when_langchain_parent_package_not_installed
     original_import = __import__
 
     def _mock_import(name, *args):
-        if name.startswith("langchain."):
+        # Allow langchain.globals and its dependencies for langchain-core 0.3.76 compatibility
+        allowed_langchain_modules = {
+            "langchain.globals",
+            "langchain._api",
+            "langchain._api.interactive_env",
+        }
+        if name.startswith("langchain.") and name not in allowed_langchain_modules:
             raise ImportError("No module named 'langchain'")
         return original_import(name, *args)
 


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix the test failure in `test_langchain_auto_tracing_work_when_langchain_parent_package_not_installed` when using langchain-core version 0.3.76.

The issue occurred because langchain-core 0.3.76 introduced new dependencies where `langchain_core.globals.get_verbose()` accesses `langchain.verbose`, which triggers imports of `langchain.globals` and `langchain._api.interactive_env`. The existing mock was too broad and blocked all imports starting with "langchain.", including these required dependencies.

**Changes:**
- Updated the mock import function in `tests/langchain/test_langchain_autolog.py` to allow specific required langchain modules (`langchain.globals`, `langchain._api`, `langchain._api.interactive_env`) while still blocking the main langchain functionality
- Maintains backward compatibility with langchain-core 0.3.75
- Preserves the test's purpose of verifying auto-tracing works when langchain parent package is not installed

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Testing performed:**
- Verified test passes with langchain-core 0.3.76 (the problematic version)
- Verified test passes with langchain-core 0.3.75 (backward compatibility)
- Ran full langchain autolog test suite (247/250 tests pass, 3 unrelated failures due to missing dependencies)
- Code passes ruff linting and formatting checks
- All pre-commit hooks pass successfully

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- This is an internal test fix that doesn't affect user-facing functionality -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)