### PR TITLE
Strands test fix

### DIFF
--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -1,12 +1,7 @@
 import json
-from unittest.mock import patch
 
 from strands import Agent
-from strands.agent.agent import run_tool
-from strands.agent.agent_result import AgentResult
 from strands.models.model import Model
-from strands.telemetry.metrics import EventLoopMetrics, Trace
-from strands.tools.executor import run_tools
 from strands.tools.tools import PythonAgentTool
 
 import mlflow
@@ -41,8 +36,11 @@ tool = PythonAgentTool(
 )
 
 
-class _DummyModel(Model):
-    def __init__(self):
+class DummyModel(Model):
+    def __init__(self, response_text, in_tokens=1, out_tokens=1):
+        self.response_text = response_text
+        self.in_tokens = in_tokens
+        self.out_tokens = out_tokens
         self.config = {}
 
     def update_config(self, **model_config):
@@ -56,37 +54,100 @@ class _DummyModel(Model):
             yield {}
 
     async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+        yield {"messageStart": {"role": "assistant"}}
+        yield {"contentBlockStart": {"start": {}}}
+        yield {"contentBlockDelta": {"delta": {"text": self.response_text}}}
+        yield {"contentBlockStop": {}}
+        yield {"messageStop": {"stopReason": "end_turn"}}
+        yield {
+            "metadata": {
+                "usage": {
+                    "inputTokens": self.in_tokens,
+                    "outputTokens": self.out_tokens,
+                    "totalTokens": self.in_tokens + self.out_tokens,
+                },
+                "metrics": {"latencyMs": 0},
+            }
+        }
+
+
+class ToolCallingModel(Model):
+    def __init__(self, response_text, tool_input=None, tool_name="sum"):
+        self.response_text = response_text
+        self.tool_input = tool_input or {"a": 1, "b": 2}
+        self.tool_name = tool_name
+        self.config = {}
+        self._call_count = 0
+
+    def update_config(self, **model_config):
+        self.config.update(model_config)
+
+    def get_config(self):
+        return self.config
+
+    async def structured_output(self, output_model, prompt, system_prompt=None, **kwargs):
         if False:
             yield {}
 
-
-def _build_agent_result(text: str, in_tokens: int = 1, out_tokens: int = 1):
-    metrics = EventLoopMetrics()
-    metrics.accumulated_usage["inputTokens"] = in_tokens
-    metrics.accumulated_usage["outputTokens"] = out_tokens
-    metrics.accumulated_usage["totalTokens"] = in_tokens + out_tokens
-    message = {"role": "assistant", "content": [{"text": text}]}
-    return AgentResult("end_turn", message, metrics, state={})
+    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+        if self._call_count == 0:
+            self._call_count += 1
+            yield {"messageStart": {"role": "assistant"}}
+            yield {
+                "contentBlockStart": {
+                    "start": {
+                        "toolUse": {
+                            "toolUseId": "tool-1",
+                            "name": self.tool_name,
+                        }
+                    }
+                }
+            }
+            yield {
+                "contentBlockDelta": {"delta": {"toolUse": {"input": json.dumps(self.tool_input)}}}
+            }
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "tool_use"}}
+            yield {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 1,
+                        "outputTokens": 1,
+                        "totalTokens": 2,
+                    },
+                    "metrics": {"latencyMs": 0},
+                }
+            }
+        else:
+            yield {"messageStart": {"role": "assistant"}}
+            yield {"contentBlockStart": {"start": {}}}
+            yield {"contentBlockDelta": {"delta": {"text": self.response_text}}}
+            yield {"contentBlockStop": {}}
+            yield {"messageStop": {"stopReason": "end_turn"}}
+            yield {
+                "metadata": {
+                    "usage": {
+                        "inputTokens": 1,
+                        "outputTokens": 1,
+                        "totalTokens": 2,
+                    },
+                    "metrics": {"latencyMs": 0},
+                }
+            }
 
 
 def test_strands_autolog_single_trace():
     mlflow.strands.autolog()
 
-    agent = Agent(model=_DummyModel(), name="agent")
-    result = _build_agent_result("hi", 1, 2)
-
-    async def new_run_loop(self, message, invocation_state):
-        yield {"stop": (result.stop_reason, result.message, result.metrics, result.state)}
-
-    with patch.object(Agent, "_run_loop", new_run_loop):
-        agent("hello")
+    agent = Agent(model=DummyModel("hi", 1, 2), name="agent")
+    agent("hello")
 
     traces = get_traces()
     assert len(traces) == 1
     span = traces[0].data.spans[0]
     assert span.span_type == SpanType.AGENT
     assert span.inputs == [{"role": "user", "content": [{"text": "hello"}]}]
-    assert span.outputs == "hi\n"
+    assert span.outputs.strip() == "hi"
     assert span.attributes[SpanAttributeKey.CHAT_USAGE] == {
         "input_tokens": 1,
         "output_tokens": 2,
@@ -94,132 +155,87 @@ def test_strands_autolog_single_trace():
     }
 
     mlflow.strands.autolog(disable=True)
-    with patch.object(Agent, "_run_loop", new_run_loop):
-        agent("bye")
-        assert len(get_traces()) == 1
+    agent("bye")
+    assert len(get_traces()) == 1
 
 
 def test_function_calling_creates_single_trace():
     mlflow.strands.autolog()
 
-    agent = Agent(model=_DummyModel(), tools=[tool], name="agent")
-    result = _build_agent_result("3", 1, 1)
-
-    async def new_run_loop(self, message, invocation_state):
-        tool_use = {"toolUseId": "tool-1", "name": "sum", "input": {"a": 1, "b": 2}}
-        tool_events = run_tools(
-            handler=lambda tool_use: run_tool(self, tool_use, invocation_state),
-            tool_uses=[tool_use],
-            event_loop_metrics=self.event_loop_metrics,
-            invalid_tool_use_ids=[],
-            tool_results=[],
-            cycle_trace=Trace("cycle"),
-            parent_span=self.trace_span,
-        )
-        async for _ in tool_events:
-            pass
-        yield {"stop": (result.stop_reason, result.message, result.metrics, result.state)}
-
-    with patch.object(Agent, "_run_loop", new_run_loop):
-        agent("add numbers 1 2 1 2")
+    agent = Agent(model=ToolCallingModel("3"), tools=[tool], name="agent")
+    agent("add numbers 1 2 1 2")
 
     traces = get_traces()
     assert len(traces) == 1
     spans = traces[0].data.spans
-    assert spans[0].span_type == SpanType.AGENT
-    assert spans[1].span_type == SpanType.TOOL
-    assert spans[0].inputs == [{"role": "user", "content": [{"text": "add numbers 1 2 1 2"}]}]
-    assert spans[0].outputs == 3
-    assert spans[1].inputs == [{"role": "tool", "content": {"a": 1, "b": 2}}]
-    assert spans[1].outputs == [{"json": 3}]
+    agent_span = spans[0]
+    assert agent_span.span_type == SpanType.AGENT
+    tool_span = spans[3]
+    assert tool_span.span_type == SpanType.TOOL
+    assert agent_span.inputs == [{"role": "user", "content": [{"text": "add numbers 1 2 1 2"}]}]
+    assert agent_span.outputs == 3
+    assert tool_span.inputs == [{"role": "tool", "content": {"a": 1, "b": 2}}]
+    assert tool_span.outputs == [{"json": 3}]
 
 
 def test_multiple_agents_single_trace():
     mlflow.strands.autolog()
 
-    agent1 = Agent(model=_DummyModel(), tools=[tool], name="agent1")
-    agent2 = Agent(model=_DummyModel(), name="agent2")
+    agent2 = Agent(model=DummyModel("hi"), name="agent2")
 
-    res1 = _build_agent_result("3", 1, 1)
-    res2 = _build_agent_result("hi", 1, 1)
+    async def sum_and_call_agent2(tool_use, **_):
+        a = tool_use["input"]["a"]
+        b = tool_use["input"]["b"]
+        await agent2.invoke_async("hello")
+        return {
+            "toolUseId": tool_use["toolUseId"],
+            "status": "success",
+            "content": [{"json": a + b}],
+        }
 
-    async def new_run_loop(self, message, invocation_state):
-        if self is agent1:
-            tool_use = {"toolUseId": "tool-1", "name": "sum", "input": {"a": 1, "b": 2}}
-            tool_events = run_tools(
-                handler=lambda tool_use: run_tool(self, tool_use, invocation_state),
-                tool_uses=[tool_use],
-                event_loop_metrics=self.event_loop_metrics,
-                invalid_tool_use_ids=[],
-                tool_results=[],
-                cycle_trace=Trace("cycle"),
-                parent_span=self.trace_span,
-            )
-            async for _ in tool_events:
-                pass
-            await agent2.invoke_async("hello")
-            yield {"stop": (res1.stop_reason, res1.message, res1.metrics, res1.state)}
-        else:
-            yield {"stop": (res2.stop_reason, res2.message, res2.metrics, res2.state)}
+    tool_with_agent2 = PythonAgentTool(
+        "sum",
+        {
+            "name": "sum",
+            "description": "add numbers 1 2",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"a": {"type": "number"}, "b": {"type": "number"}},
+                "required": ["a", "b"],
+            },
+        },
+        sum_and_call_agent2,
+    )
 
-    with patch.object(Agent, "_run_loop", new_run_loop):
-        agent1("add numbers 1 2")
+    agent1 = Agent(model=ToolCallingModel("3"), tools=[tool_with_agent2], name="agent1")
+    agent1("add numbers 1 2")
 
     traces = get_traces()
     assert len(traces) == 1
     spans = traces[0].data.spans
-    assert spans[0].span_type == SpanType.AGENT
-    assert spans[0].inputs == [{"role": "user", "content": [{"text": "add numbers 1 2"}]}]
-    assert spans[0].outputs == 3
-    assert spans[1].span_type == SpanType.TOOL
-    assert spans[1].inputs == [{"role": "tool", "content": {"a": 1, "b": 2}}]
-    assert spans[1].outputs == [{"json": 3}]
-    assert spans[2].span_type == SpanType.AGENT
-    assert spans[2].inputs == [{"role": "user", "content": [{"text": "hello"}]}]
-    assert spans[2].outputs == "hi\n"
-
-
-def test_span_records_multiple_messages():
-    mlflow.strands.autolog()
-
-    agent = Agent(model=_DummyModel(), name="agent")
-    result = _build_agent_result("hi", 1, 2)
-    second_msg = [{"text": "hi again"}]
-
-    async def new_run_loop(self, message, invocation_state):
-        self.trace_span.add_event("gen_ai.user.message", {"content": json.dumps(second_msg)})
-        yield {"stop": (result.stop_reason, result.message, result.metrics, result.state)}
-
-    with patch.object(Agent, "_run_loop", new_run_loop):
-        agent("hello")
-
-    traces = get_traces()
-    assert len(traces) == 1
-    span = traces[0].data.spans[0]
-    assert span.inputs == [
-        {"role": "user", "content": [{"text": "hello"}]},
-        {"role": "user", "content": second_msg},
-    ]
+    agent1_span = spans[0]
+    assert agent1_span.name == "invoke_agent agent1"
+    tool_span = spans[3]
+    assert tool_span.span_type == SpanType.TOOL
+    agent2_span = spans[4]
+    assert agent2_span.name == "invoke_agent agent2"
+    assert agent1_span.inputs == [{"role": "user", "content": [{"text": "add numbers 1 2"}]}]
+    assert agent1_span.outputs == 3
+    assert tool_span.inputs == [{"role": "tool", "content": {"a": 1, "b": 2}}]
+    assert tool_span.outputs == [{"json": 3}]
+    assert agent2_span.inputs == [{"role": "user", "content": [{"text": "hello"}]}]
+    assert agent2_span.outputs.strip() == "hi"
 
 
 def test_autolog_disable_prevents_new_traces():
     mlflow.strands.autolog()
 
-    agent1 = Agent(model=_DummyModel(), name="agent1")
-    agent2 = Agent(model=_DummyModel(), name="agent2")
+    agent1 = Agent(model=DummyModel("hi"), name="agent1")
+    agent2 = Agent(model=DummyModel("cya"), name="agent2")
 
-    res1 = _build_agent_result("hi", 1, 1)
-    res2 = _build_agent_result("cya", 1, 1)
-
-    async def new_run_loop(self, message, invocation_state):
-        result = res1 if self is agent1 else res2
-        yield {"stop": (result.stop_reason, result.message, result.metrics, result.state)}
-
-    with patch.object(Agent, "_run_loop", new_run_loop):
-        agent1("hello")
-        assert len(get_traces()) == 1
+    agent1("hello")
+    assert len(get_traces()) == 1
 
     mlflow.strands.autolog(disable=True)
-    with patch.object(Agent, "_run_loop", new_run_loop):
-        agent2("bye")
-        assert len(get_traces()) == 1
+    agent2("bye")
+    assert len(get_traces()) == 1

--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -1,4 +1,6 @@
 import json
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
 
 from strands import Agent
 from strands.models.model import Model
@@ -37,7 +39,7 @@ tool = PythonAgentTool(
 
 
 class DummyModel(Model):
-    def __init__(self, response_text, in_tokens=1, out_tokens=1):
+    def __init__(self, response_text: str, in_tokens: int = 1, out_tokens: int = 1):
         self.response_text = response_text
         self.in_tokens = in_tokens
         self.out_tokens = out_tokens
@@ -53,7 +55,13 @@ class DummyModel(Model):
         if False:
             yield {}
 
-    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+    async def stream(
+        self,
+        messages: Sequence[dict[str, Any]],
+        tool_specs: Any | None = None,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
         yield {"messageStart": {"role": "assistant"}}
         yield {"contentBlockStart": {"start": {}}}
         yield {"contentBlockDelta": {"delta": {"text": self.response_text}}}
@@ -72,24 +80,41 @@ class DummyModel(Model):
 
 
 class ToolCallingModel(Model):
-    def __init__(self, response_text, tool_input=None, tool_name="sum"):
+    def __init__(
+        self,
+        response_text: str,
+        tool_input: dict[str, Any] | None = None,
+        tool_name: str = "sum",
+    ):
         self.response_text = response_text
         self.tool_input = tool_input or {"a": 1, "b": 2}
         self.tool_name = tool_name
         self.config = {}
         self._call_count = 0
 
-    def update_config(self, **model_config):
+    def update_config(self, **model_config: Any) -> None:
         self.config.update(model_config)
 
-    def get_config(self):
+    def get_config(self) -> dict[str, object]:
         return self.config
 
-    async def structured_output(self, output_model, prompt, system_prompt=None, **kwargs):
+    async def structured_output(
+        self,
+        output_model: Any,
+        prompt: Any,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
         if False:
             yield {}
 
-    async def stream(self, messages, tool_specs=None, system_prompt=None, **kwargs):
+    async def stream(
+        self,
+        messages: Sequence[dict[str, Any]],
+        tool_specs: Any | None = None,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[dict[str, Any]]:
         if self._call_count == 0:
             self._call_count += 1
             yield {"messageStart": {"role": "assistant"}}
@@ -183,7 +208,10 @@ def test_multiple_agents_single_trace():
 
     agent2 = Agent(model=DummyModel("hi"), name="agent2")
 
-    async def sum_and_call_agent2(tool_use, **_):
+    async def sum_and_call_agent2(
+        tool_use: dict[str, Any],
+        **_: Any,
+    ) -> dict[str, Any]:
         a = tool_use["input"]["a"]
         b = tool_use["input"]["b"]
         await agent2.invoke_async("hello")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/17666?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17666/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17666/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17666/merge
```

</p>
</details>

### Related Issues/PRs

Fix #17476 

### What changes are proposed in this pull request?

Since strands-agents >= 1.6, the following functions are removed:

```
        from strands.agent.agent import run_tool
        from strands.tools.executor import run_tools

```

In this PR, instead of using the internal functions, I have created a dummy model and a tool-calling model that simulate model behavior and tool invocation, where the dummy model simply streams back a fixed response, while the tool-calling model first emits a tool call with predefined inputs and then returns a response.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
