### PR TITLE
Conditionally apply create ExperimentViewRunsTable column by selected…

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -123,9 +123,9 @@ export const ExperimentViewRunsTable = React.memo(
     // Conditionally filter keys only when there are more than 1000 metrics+params+tags
     const { filteredMetricKeyList, filteredParamKeyList, filteredTagsList } = useMemo(() => {
       if (shouldOptimize && !isComparingRuns) {
-        let filteredMetricKeyList: string[] = [];
-        let filteredParamKeyList: string[] = [];
-        let filteredTagsList: any[] = [];
+        const filteredMetricKeyList: string[] = [];
+        const filteredParamKeyList: string[] = [];
+        const filteredTagsList: any[] = [];
 
         for (const column of selectedColumns) {
           if (column.startsWith(COLUMN_TYPES.METRICS)) {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -155,7 +155,7 @@ export const ExperimentViewRunsTable = React.memo(
         filteredParamKeyList: paramKeyList,
         filteredTagsList: tagsList,
       };
-    }, [runsData, selectedColumns, shouldOptimize, isComparingRuns, metricKeyList, paramKeyList, tagsList]);
+    }, [selectedColumns, shouldOptimize, isComparingRuns, metricKeyList, paramKeyList, tagsList]);
 
     const [gridApi, setGridApi] = useState<GridApi>();
     const [columnApi, setColumnApi] = useState<ColumnApi>();

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsTable.tsx
@@ -48,6 +48,7 @@ import { useRunsHighlightTableRow } from '../../../runs-charts/hooks/useRunsHigh
 import { isEmpty } from 'lodash';
 
 const ROW_BUFFER = 101; // How many rows to keep rendered, even ones not visible
+const LARGE_COLUMN_COUNT_THRESHOLD = 1000; // Threshold to determine if we should optimize column rendering
 
 export interface ExperimentViewRunsTableProps {
   /**
@@ -109,44 +110,47 @@ export const ExperimentViewRunsTable = React.memo(
 
     const isComparingRuns = compareRunsMode !== 'TABLE';
 
-    // Performance optimization: Only extract the keys we actually need based on selectedColumns
-    const { paramKeyList, metricKeyList, tagsList } = useMemo(() => {
-      // If we're comparing runs, we don't need to filter the keys
-      if (isComparingRuns) {
-        return runsData;
-      }
+    // Determine if we should optimize by filtering columns based on count
+    const shouldOptimize = useMemo(() => {
+      const tagKeysCount = Utils.getVisibleTagKeyList(runsData.tagsList).length;
+      const totalCount = runsData.metricKeyList.length + runsData.paramKeyList.length + tagKeysCount;
+      return totalCount > LARGE_COLUMN_COUNT_THRESHOLD; // Only optimize when there are more than certain number of columns
+    }, [runsData]);
 
-      // Filter metric keys based on selected columns
-      const filteredMetricKeys = runsData.metricKeyList.filter((key) =>
-        selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.METRICS, key)),
-      );
+    // Use the original data
+    const { paramKeyList, metricKeyList, tagsList } = runsData;
 
-      // Filter param keys based on selected columns
-      const filteredParamKeys = runsData.paramKeyList.filter((key) =>
-        selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.PARAMS, key)),
-      );
-
-      // Filter tag keys based on selected columns
-      const filteredTags = runsData.tagsList.map((tags) =>
-        Object.fromEntries(
-          Object.entries(tags).filter(([key]) =>
-            selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.TAGS, key)),
+    // Conditionally filter keys only when there are more than 1000 metrics+params+tags
+    const { filteredMetricKeyList, filteredParamKeyList, filteredTagsList } = useMemo(() => {
+      if (shouldOptimize && !isComparingRuns) {
+        return {
+          filteredMetricKeyList: metricKeyList.filter((key) =>
+            selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.METRICS, key)),
           ),
-        ),
-      );
-
+          filteredParamKeyList: paramKeyList.filter((key) =>
+            selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.PARAMS, key)),
+          ),
+          filteredTagsList: tagsList.map((tags) =>
+            Object.fromEntries(
+              Object.entries(tags).filter(([key]) =>
+                selectedColumns.includes(makeCanonicalSortKey(COLUMN_TYPES.TAGS, key)),
+              ),
+            ),
+          ),
+        };
+      }
       return {
-        metricKeyList: filteredMetricKeys,
-        paramKeyList: filteredParamKeys,
-        tagsList: filteredTags,
+        filteredMetricKeyList: metricKeyList,
+        filteredParamKeyList: paramKeyList,
+        filteredTagsList: tagsList,
       };
-    }, [runsData, selectedColumns, isComparingRuns]);
+    }, [runsData, selectedColumns, shouldOptimize, isComparingRuns]);
 
     const [gridApi, setGridApi] = useState<GridApi>();
     const [columnApi, setColumnApi] = useState<ColumnApi>();
     const prevSelectRunUuids = useRef<string[]>([]);
 
-    const filteredTagKeys = useMemo(() => Utils.getVisibleTagKeyList(tagsList), [tagsList]);
+    const filteredTagKeys = useMemo(() => Utils.getVisibleTagKeyList(filteredTagsList), [filteredTagsList]);
 
     const containerElement = useRef<HTMLDivElement>(null);
     // Flag indicating if there are any rows that can be expanded
@@ -199,8 +203,8 @@ export const ExperimentViewRunsTable = React.memo(
       compareExperiments: experiments.length > 1,
       onTogglePin: togglePinnedRow,
       onToggleVisibility: toggleRowVisibility,
-      metricKeyList,
-      paramKeyList,
+      metricKeyList: filteredMetricKeyList,
+      paramKeyList: filteredParamKeyList,
       tagKeyList: filteredTagKeys,
       columnApi,
       isComparingRuns,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.enzyme.test.tsx
@@ -35,8 +35,8 @@ describe('ExperimentViewRuns column utils', () => {
       paramKeyList: MOCK_PARAMS,
       tagKeyList: MOCK_TAGS,
       onExpand: jest.fn(),
-      onSortBy: jest.fn(),
       onTogglePin: jest.fn(),
+      onToggleVisibility: jest.fn(),
       selectedColumns: createExperimentPageUIState().selectedColumns,
     });
   });
@@ -168,42 +168,37 @@ describe('ExperimentViewRuns column utils', () => {
 
     // ...but has not for the remaining columns
     expect(setColumnVisibleMock).not.toHaveBeenCalledWith(makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_2'), true);
-
     expect(setColumnVisibleMock).not.toHaveBeenCalledWith(makeCanonicalSortKey(COLUMN_TYPES.PARAMS, 'param_1'), true);
   });
 
-  test('it filters metric, param, and tag columns based on selected columns', () => {
-    // Set up selected columns
+  test('it includes all columns', () => {
     const selectedColumns = [
       makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_1'),
       makeCanonicalSortKey(COLUMN_TYPES.PARAMS, 'param_2'),
       makeCanonicalSortKey(COLUMN_TYPES.TAGS, 'tag_1'),
     ];
 
-    // Get column definitions with selected columns
+    // Get column definitions
     const columnDefinitions = getHookResult({
       ...MOCK_HOOK_PARAMS,
       selectedColumns,
       isComparingRuns: false,
     }) as unknown as ColGroupDef[];
 
-    // Find the metrics column group
+    // Find the metrics column group - should include all metrics
     const metricsGroup = columnDefinitions.find((col) => col.groupId === COLUMN_TYPES.METRICS) as ColGroupDef;
     expect(metricsGroup).toBeDefined();
-    expect(metricsGroup.children?.length).toBe(1);
-    expect((metricsGroup.children?.[0] as ColDef).colId).toBe(makeCanonicalSortKey(COLUMN_TYPES.METRICS, 'metric_1'));
+    expect(metricsGroup.children?.length).toBe(2); // All metrics
 
-    // Find the params column group
+    // Find the params column group - should include all params
     const paramsGroup = columnDefinitions.find((col) => col.groupId === COLUMN_TYPES.PARAMS) as ColGroupDef;
     expect(paramsGroup).toBeDefined();
-    expect(paramsGroup.children?.length).toBe(1);
-    expect((paramsGroup.children?.[0] as ColDef).colId).toBe(makeCanonicalSortKey(COLUMN_TYPES.PARAMS, 'param_2'));
+    expect(paramsGroup.children?.length).toBe(2); // All params
 
-    // Find the tags column group - note that in the implementation, tags use colId instead of groupId
+    // Find the tags column group - should include all tags
     const tagsGroup = columnDefinitions.find((col) => (col as any).colId === COLUMN_TYPES.TAGS) as ColGroupDef;
     expect(tagsGroup).toBeDefined();
-    expect(tagsGroup.children?.length).toBe(1);
-    expect((tagsGroup.children?.[0] as ColDef).colId).toBe(makeCanonicalSortKey(COLUMN_TYPES.TAGS, 'tag_1'));
+    expect(tagsGroup.children?.length).toBe(2); // All tags
   });
 
   test('it includes all columns when comparing runs regardless of selection', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/utils/experimentPage.column-utils.tsx
@@ -452,41 +452,35 @@ export const useRunsColumnDefinitions = ({
       columns.push({
         headerName: 'Metrics',
         groupId: COLUMN_TYPES.METRICS,
-        children: metricKeys
-          .filter((metricKey) => {
-            // Only create columns for metrics that are selected or if we're comparing runs
-            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey);
-            return isComparingRuns || selectedColumns.includes(canonicalSortKey);
-          })
-          .map((metricKey) => {
-            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey);
-            const customMetricColumnDef = customMetricBehaviorDefs[metricKey];
-            const displayName = customMetricColumnDef?.displayName ?? metricKey;
-            const fieldName = createMetricFieldName(metricKey);
-            const tooltip = getQualifiedEntityName(COLUMN_TYPES.METRICS, metricKey);
-            return {
-              headerName: displayName,
-              colId: canonicalSortKey,
-              headerTooltip: tooltip,
-              field: fieldName,
-              tooltipValueGetter: (params) => {
-                return params.data?.[fieldName];
-              },
-              initialWidth: customMetricColumnDef?.initialColumnWidth ?? 100,
-              initialHide: true,
-              sortable: true,
-              headerComponentParams: {
-                canonicalSortKey,
-              },
-              valueFormatter: customMetricColumnDef?.valueFormatter,
-              cellRendererSelector: ({ data: { groupParentInfo } }) =>
-                groupParentInfo ? { component: 'AggregateMetricValueCell' } : undefined,
-              cellClassRules: {
-                'is-previewable-cell': () => true,
-                'is-ordered-by': cellClassIsOrderedBy,
-              },
-            };
-          }),
+        children: metricKeys.map((metricKey) => {
+          const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.METRICS, metricKey);
+          const customMetricColumnDef = customMetricBehaviorDefs[metricKey];
+          const displayName = customMetricColumnDef?.displayName ?? metricKey;
+          const fieldName = createMetricFieldName(metricKey);
+          const tooltip = getQualifiedEntityName(COLUMN_TYPES.METRICS, metricKey);
+          return {
+            headerName: displayName,
+            colId: canonicalSortKey,
+            headerTooltip: tooltip,
+            field: fieldName,
+            tooltipValueGetter: (params) => {
+              return params.data?.[fieldName];
+            },
+            initialWidth: customMetricColumnDef?.initialColumnWidth ?? 100,
+            initialHide: true,
+            sortable: true,
+            headerComponentParams: {
+              canonicalSortKey,
+            },
+            valueFormatter: customMetricColumnDef?.valueFormatter,
+            cellRendererSelector: ({ data: { groupParentInfo } }) =>
+              groupParentInfo ? { component: 'AggregateMetricValueCell' } : undefined,
+            cellClassRules: {
+              'is-previewable-cell': () => true,
+              'is-ordered-by': cellClassIsOrderedBy,
+            },
+          };
+        }),
       });
     }
 
@@ -495,32 +489,26 @@ export const useRunsColumnDefinitions = ({
       columns.push({
         headerName: 'Parameters',
         groupId: COLUMN_TYPES.PARAMS,
-        children: paramKeys
-          .filter((paramKey) => {
-            // Only create columns for parameters that are selected or if we're comparing runs
-            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey);
-            return isComparingRuns || selectedColumns.includes(canonicalSortKey);
-          })
-          .map((paramKey) => {
-            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey);
-            return {
-              colId: canonicalSortKey,
-              headerName: paramKey,
-              headerTooltip: getQualifiedEntityName(COLUMN_TYPES.PARAMS, paramKey),
-              field: createParamFieldName(paramKey),
-              tooltipField: createParamFieldName(paramKey),
-              initialHide: true,
-              initialWidth: 100,
-              sortable: true,
-              headerComponentParams: {
-                canonicalSortKey,
-              },
-              cellClassRules: {
-                'is-previewable-cell': () => true,
-                'is-ordered-by': cellClassIsOrderedBy,
-              },
-            };
-          }),
+        children: paramKeys.map((paramKey) => {
+          const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.PARAMS, paramKey);
+          return {
+            colId: canonicalSortKey,
+            headerName: paramKey,
+            headerTooltip: getQualifiedEntityName(COLUMN_TYPES.PARAMS, paramKey),
+            field: createParamFieldName(paramKey),
+            tooltipField: createParamFieldName(paramKey),
+            initialHide: true,
+            initialWidth: 100,
+            sortable: true,
+            headerComponentParams: {
+              canonicalSortKey,
+            },
+            cellClassRules: {
+              'is-previewable-cell': () => true,
+              'is-ordered-by': cellClassIsOrderedBy,
+            },
+          };
+        }),
       });
     }
 
@@ -529,24 +517,18 @@ export const useRunsColumnDefinitions = ({
       columns.push({
         headerName: 'Tags',
         colId: COLUMN_TYPES.TAGS,
-        children: tagKeys
-          .filter((tagKey) => {
-            // Only create columns for tags that are selected or if we're comparing runs
-            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey);
-            return isComparingRuns || selectedColumns.includes(canonicalSortKey);
-          })
-          .map((tagKey) => {
-            const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey);
-            return {
-              colId: canonicalSortKey,
-              headerName: tagKey,
-              initialHide: true,
-              initialWidth: 100,
-              headerTooltip: getQualifiedEntityName(COLUMN_TYPES.TAGS, tagKey),
-              field: createTagFieldName(tagKey),
-              tooltipField: createTagFieldName(tagKey),
-            };
-          }),
+        children: tagKeys.map((tagKey) => {
+          const canonicalSortKey = makeCanonicalSortKey(COLUMN_TYPES.TAGS, tagKey);
+          return {
+            colId: canonicalSortKey,
+            headerName: tagKey,
+            initialHide: true,
+            initialWidth: 100,
+            headerTooltip: getQualifiedEntityName(COLUMN_TYPES.TAGS, tagKey),
+            field: createTagFieldName(tagKey),
+            tooltipField: createTagFieldName(tagKey),
+          };
+        }),
       });
     }
 
@@ -561,7 +543,6 @@ export const useRunsColumnDefinitions = ({
     onDatasetSelected,
     expandRows,
     usingCompactViewport,
-    selectedColumns,
   ]);
 
   const canonicalSortKeys = useMemo(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/wangh118/mlflow/pull/17669?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17669/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17669/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17669/merge
```

</p>
</details>

… columns

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve  https://github.com/mlflow/mlflow/pull/17481#issuecomment-3268532250

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Apply https://github.com/mlflow/mlflow/pull/16804 only when column number is over 1000. 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
* Experiment with 50 runs each run has 60 metrics. This will not apply optimization: 

https://github.com/user-attachments/assets/9ab138af-57bb-49ca-a176-528174cdebbf

* Experiment with 4 runs each run has 1024 metrics. This will apply optimization: 

https://github.com/user-attachments/assets/7df07475-40c0-431c-93bb-5cb7674b5fbd



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Create Experiment View Runs Table by selected column when the total column number is over 1000. 

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
