### PR TITLE
remove warnings from trace template - based judges

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -211,6 +211,11 @@ class InstructionsJudge(Judge):
         trace: Trace | None,
     ) -> None:
         """Warn about parameters that were provided but aren't used."""
+        # Don't warn about unused parameters when using trace-based evaluation
+        # since these parameters may be extracted from the trace for context
+        if self._TEMPLATE_VARIABLE_TRACE in self.template_variables:
+            return
+
         unused_params = []
         if inputs is not None and self._TEMPLATE_VARIABLE_INPUTS not in self.template_variables:
             unused_params.append("inputs")

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -1601,15 +1601,18 @@ def test_unused_parameters_warning(
     with patch("mlflow.genai.judges.instructions_judge._logger") as mock_logger:
         judge(**provided_params)
 
-        assert mock_logger.warning.called
+        if "{{ trace }}" in instructions:
+            assert not mock_logger.warning.called
+        else:
+            assert mock_logger.warning.called
 
-        warning_call_args = mock_logger.warning.call_args
-        assert warning_call_args is not None
+            warning_call_args = mock_logger.warning.call_args
+            assert warning_call_args is not None
 
-        warning_msg = warning_call_args[0][0]
+            warning_msg = warning_call_args[0][0]
 
-        assert "parameters were provided but are not used" in warning_msg
-        assert expected_warning in warning_msg
+            assert "parameters were provided but are not used" in warning_msg
+            assert expected_warning in warning_msg
 
 
 def test_context_labels_added_to_interpolated_values(mock_invoke_judge_model):
@@ -2365,14 +2368,13 @@ def test_no_warning_for_trace_based_judge_with_extra_fields(mock_invoke_judge_mo
     )
     trace = Trace(
         info=TraceInfo(
-            request_id="test_trace",
-            experiment_id="0",
-            timestamp_ms=0,
-            execution_time_ms=100,
-            status=TraceState.OK,
-            request_metadata={},
+            trace_id="test_trace",
+            trace_location=TraceLocation.from_experiment_id("0"),
+            request_time=1234567890,
+            execution_duration=100,
+            state=TraceState.OK,
+            trace_metadata={},
             tags={},
-            trace_location=TraceLocation.create(),
         ),
         data=TraceData(spans=[span_mock]),
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17685?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17685/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17685/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17685/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

When a trace-based judge template is used, we should not be warning for extra parameters being provided since the agentic judge will introduce a lot of these warnings while it is iterating, causing very annoying behavior in stdout.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
