### PR TITLE
Add per-file duration tracking to pytest conftest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -141,14 +141,14 @@ def generate_duration_stats() -> list[str]:
     for path, test_times in file_groups.items():
         rel_path = str(path.relative_to(Path.cwd()))
         total_dur = sum(test_times)
+        if total_dur < 1.0:
+            # Ignore files with total duration < 1s
+            continue
         test_count = len(test_times)
-        if test_times:
-            min_test = min(test_times)
-            max_test = max(test_times)
-            avg_test = sum(test_times) / len(test_times)
-            stats = f"min: {min_test:.3f}s max: {max_test:.3f}s avg: {avg_test:.3f}s"
-        else:
-            stats = "no test data"
+        min_test = min(test_times)
+        max_test = max(test_times)
+        avg_test = sum(test_times) / len(test_times)
+        stats = f"min: {min_test:.3f}s max: {max_test:.3f}s avg: {avg_test:.3f}s"
 
         rows.append((rel_path, total_dur, test_count, stats))
 

--- a/conftest.py
+++ b/conftest.py
@@ -312,8 +312,10 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         terminalreporter.write("\n")
         header = "per-file durations (sorted)"
         terminalreporter.write_sep("=", header)
+        terminalreporter.write(f"::group::{header}\n")
         for line in duration_stats:
             terminalreporter.write_line(line)
+        terminalreporter.write("::endgroup::\n")
         terminalreporter.write("\n")
 
     # If there are failed tests, display a command to run them

--- a/conftest.py
+++ b/conftest.py
@@ -309,6 +309,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
 
     # Display per-file durations
     if duration_stats := generate_duration_stats():
+        terminalreporter.write("\n")
         header = "per-file durations (sorted)"
         terminalreporter.write_sep("=", header)
         for line in duration_stats:

--- a/conftest.py
+++ b/conftest.py
@@ -134,14 +134,14 @@ def to_md_table(rows: list[list[str]]) -> str:
     rows = [r + [""] * (n - len(r)) for r in rows]
 
     # Calculate column widths
-    widths = [max(len(str(row[i])) for row in rows) for i in range(n)]
+    widths = [max(len(row[i]) for row in rows) for i in range(n)]
 
     def esc(s: str) -> str:
         return s.replace("|", r"\|").replace("\n", "<br>")
 
     # Format rows with proper padding
     def format_row(row: list[str]) -> str:
-        cells = [esc(str(cell)).ljust(widths[i]) for i, cell in enumerate(row)]
+        cells = [esc(cell).ljust(width) for cell, width in zip(row, widths)]
         return "| " + " | ".join(cells) + " |"
 
     header = format_row(rows[0])

--- a/conftest.py
+++ b/conftest.py
@@ -127,7 +127,7 @@ def pytest_sessionstart(session):
         )
 
 
-def to_md(rows: list[list[str]]) -> str:
+def to_md_table(rows: list[list[str]]) -> str:
     if not rows:
         return ""
     n = max(len(r) for r in rows)
@@ -195,7 +195,7 @@ def generate_duration_stats() -> str:
             ]
         )
 
-    return to_md(table_rows)
+    return to_md_table(table_rows)
 
 
 @pytest.hookimpl(hookwrapper=True)

--- a/conftest.py
+++ b/conftest.py
@@ -96,6 +96,16 @@ def pytest_cmdline_main(config: pytest.Config):
     return None
 
 
+@dataclass
+class TestResult:
+    path: Path
+    test_name: str
+    execution_time: float
+
+
+_test_results: list[TestResult] = []
+
+
 def pytest_sessionstart(session):
     # Clear duration tracking state at the start of each session
     _test_results.clear()
@@ -115,16 +125,6 @@ def pytest_sessionstart(session):
                 fg="red",
             )
         )
-
-
-@dataclass
-class TestResult:
-    path: Path
-    test_name: str
-    execution_time: float
-
-
-_test_results: list[TestResult] = []
 
 
 def generate_duration_stats() -> list[str]:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17689?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17689/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17689/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17689/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds comprehensive per-file test duration tracking to `conftest.py` with the following features:

- **Individual test timing**: Tracks execution time for each test including setup, call, and teardown phases using `pytest_runtest_protocol`
- **Per-file statistics**: Groups test results by file and displays total duration plus min/max/avg statistics for individual tests within each file  

Example output:
```
========== per-file durations (sorted) ==========
 1.   45.67s  tests/slow_test.py  (23 tests) [min: 0.123s max: 8.456s avg: 1.987s]
 2.   12.34s  tests/medium_test.py  (8 tests) [min: 0.456s max: 3.210s avg: 1.542s]
 3.    0.12s  tests/fast_test.py  (2 tests) [min: 0.056s max: 0.064s avg: 0.060s]
```

### Motivation

`pytest --durations` tells us slow tests, but not slow test files. For example, a test file with 100 tests and each taking a second is slow and worth optimizing.

### How is this PR tested?

- [x] Existing unit/integration tests (no breaking changes to existing functionality)
- [ ] New unit/integration tests (not needed - this is pytest infrastructure enhancement)
- [x] Manual tests (verified the duration tracking works correctly during test runs)

The feature integrates seamlessly with existing pytest infrastructure and doesn't affect test execution or results - it only adds timing information to the terminal summary.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

This is an internal testing infrastructure improvement that doesn't affect user-facing APIs or functionality.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

This is an internal development tool enhancement for the MLflow team to better understand test performance characteristics.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.ai/code)