### PR TITLE
Add additional CI environment detection for telemetry exclusion

### DIFF
--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -257,7 +257,7 @@ MLflow supports opt-out telemetry through either of the following environment va
 Setting either of these will **immediately disable telemetry**, no need to re-import MLflow or restart your session.
 
 :::note
-MLflow automatically disables telemetry in the following CI environments.
+MLflow automatically disables telemetry in [some CI environments](https://github.com/mlflow/mlflow/blob/de6c11193ce6a68ffec4b33650f75bd163143178/mlflow/telemetry/utils.py#L22).
 If you'd like support for additional CI environments, please [open an issue on our GitHub repository](https://github.com/mlflow/mlflow/issues).
 
 - CI
@@ -270,6 +270,7 @@ If you'd like support for additional CI environments, please [open an issue on o
 - BitBucket
 - AWS CodeBuild
 - BuildKite
+- ...
   :::
 
 ### Scope of the setting

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -257,7 +257,7 @@ MLflow supports opt-out telemetry through either of the following environment va
 Setting either of these will **immediately disable telemetry**, no need to re-import MLflow or restart your session.
 
 :::note
-MLflow automatically disables telemetry in [some CI environments](https://github.com/mlflow/mlflow/blob/de6c11193ce6a68ffec4b33650f75bd163143178/mlflow/telemetry/utils.py#L22).
+MLflow automatically disables telemetry in [**some CI environments**](https://github.com/mlflow/mlflow/blob/de6c11193ce6a68ffec4b33650f75bd163143178/mlflow/telemetry/utils.py#L22).
 If you'd like support for additional CI environments, please [open an issue on our GitHub repository](https://github.com/mlflow/mlflow/issues).
 
 - CI

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -31,15 +31,9 @@ def _is_ci_env_or_testing() -> bool:
         "BITBUCKET_BUILD_NUMBER",  # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
         "CODEBUILD_BUILD_ARN",  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
         "BUILDKITE",  # https://buildkite.com/docs/pipelines/configure/environment-variables
-        "APPVEYOR",  # https://www.appveyor.com/docs/environment-variables/
-        "DRONE",  # https://docs.drone.io/pipeline/environment/reference/
-        "SEMAPHORE",  # https://docs.semaphoreci.com/ci-cd-environment/environment-variables/
         "TEAMCITY_VERSION",  # https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
         "BAMBOO_buildKey",  # https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html
-        "HUDSON_URL",  # Hudson (Jenkins predecessor)
-        "CODEFRESH",  # https://codefresh.io/docs/docs/pipelines/variables/
-        "SOURCEHUT",  # https://man.sr.ht/builds.sr.ht/#environment
-        "WOODPECKER_CI",  # https://woodpecker-ci.org/docs/usage/environment
+        "CLOUD_RUN_EXECUTION",  # https://cloud.google.com/run/docs/reference/container-contract#env-vars
         # runbots
         "RUNBOT_HOST_URL",
         "RUNBOT_BUILD_NAME",

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -31,6 +31,15 @@ def _is_ci_env_or_testing() -> bool:
         "BITBUCKET_BUILD_NUMBER",  # https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/
         "CODEBUILD_BUILD_ARN",  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
         "BUILDKITE",  # https://buildkite.com/docs/pipelines/configure/environment-variables
+        "APPVEYOR",  # https://www.appveyor.com/docs/environment-variables/
+        "DRONE",  # https://docs.drone.io/pipeline/environment/reference/
+        "SEMAPHORE",  # https://docs.semaphoreci.com/ci-cd-environment/environment-variables/
+        "TEAMCITY_VERSION",  # https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
+        "BAMBOO_buildKey",  # https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html
+        "HUDSON_URL",  # Hudson (Jenkins predecessor)
+        "CODEFRESH",  # https://codefresh.io/docs/docs/pipelines/variables/
+        "SOURCEHUT",  # https://man.sr.ht/builds.sr.ht/#environment
+        "WOODPECKER_CI",  # https://woodpecker-ci.org/docs/usage/environment
         # runbots
         "RUNBOT_HOST_URL",
         "RUNBOT_BUILD_NAME",

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -32,7 +32,6 @@ def _is_ci_env_or_testing() -> bool:
         "CODEBUILD_BUILD_ARN",  # https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-env-vars.html
         "BUILDKITE",  # https://buildkite.com/docs/pipelines/configure/environment-variables
         "TEAMCITY_VERSION",  # https://www.jetbrains.com/help/teamcity/predefined-build-parameters.html#Predefined+Server+Build+Parameters
-        "BAMBOO_buildKey",  # https://confluence.atlassian.com/bamboo/bamboo-variables-289277087.html
         "CLOUD_RUN_EXECUTION",  # https://cloud.google.com/run/docs/reference/container-contract#env-vars
         # runbots
         "RUNBOT_HOST_URL",


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #N/A

### What changes are proposed in this pull request?

This PR expands the list of CI environments where MLflow telemetry is automatically disabled to include additional commonly used CI platforms.

Added CI environments:
- **TeamCity** - JetBrains CI platform, popular in enterprise Python projects (uses `TEAMCITY_VERSION`)
- **Cloud Run** - Google Cloud Run execution environment for containerized applications (uses `CLOUD_RUN_EXECUTION`)

Each environment variable is documented with a link to the official documentation for verification.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

MLflow now automatically disables telemetry in additional CI environments including TeamCity and Google Cloud Run.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)