### PR TITLE
Fix CrewAI autolog tests for version compatibility

### DIFF
--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -1,3 +1,4 @@
+from typing import Any
 from unittest.mock import patch
 
 import crewai
@@ -19,7 +20,7 @@ _FINAL_ANSWER_KEYWORD = "Final Answer:"
 _LLM_ANSWER = "What about Tokyo?"
 
 
-def create_sample_llm_response(content):
+def create_sample_llm_response(content: str) -> Any:
     from litellm import ModelResponse
 
     return ModelResponse(
@@ -71,11 +72,32 @@ _EMBEDDING = {
 
 
 class AnyInt(int):
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         return isinstance(other, int)
 
 
+class TaskNameMatcher:
+    """Matcher that accepts both None (older CrewAI) and description (newer CrewAI)."""
+    
+    def __init__(self, description: str) -> None:
+        self.description = description
+    
+    def __eq__(self, other: Any) -> bool:
+        return other is None or other == self.description
+    
+    def __repr__(self) -> str:
+        return f"TaskNameMatcher({self.description!r})"
+
+
 ANY_INT = AnyInt()
+
+# CrewAI >= 0.175.0 changed behavior: TaskOutput.name falls back to description when None
+# See: https://github.com/crewAIInc/crewAI/pull/3382
+_TASK_DESCRIPTION = "Analyze and select the best city for the trip"
+_TASK_DESCRIPTION_2 = "Compile an in-depth guide"
+
+_TASK_NAME = TaskNameMatcher(_TASK_DESCRIPTION)
+_TASK_NAME_2 = TaskNameMatcher(_TASK_DESCRIPTION_2)
 
 _CREW_OUTPUT = {
     "json_dict": None,
@@ -84,8 +106,8 @@ _CREW_OUTPUT = {
     "tasks_output": [
         {
             "agent": "City Selection Expert",
-            "name": None,
-            "description": "Analyze and select the best city for the trip",
+            "name": _TASK_NAME,
+            "description": _TASK_DESCRIPTION,
             "expected_output": "Detailed report on the chosen city",
             "json_dict": None,
             "pydantic": None,
@@ -245,7 +267,7 @@ def test_kickoff_enable_disable_autolog(simple_agent_1, task_1, autolog):
         "description": "Analyze and select the best city for the trip",
         "expected_output": "Detailed report on the chosen city",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,
@@ -382,7 +404,7 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
         "description": "Analyze and select the best city for the trip",
         "expected_output": "Detailed report on the chosen city",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,
@@ -455,7 +477,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
         "tasks_output": [
             {
                 "agent": "City Selection Expert",
-                "name": None,
+                "name": _TASK_NAME,
                 "description": "Analyze and select the best city for the trip",
                 "expected_output": "Detailed report on the chosen city",
                 "json_dict": None,
@@ -469,7 +491,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
                 "description": "Compile an in-depth guide",
                 "expected_output": "Comprehensive city guide",
                 "json_dict": None,
-                "name": None,
+                "name": _TASK_NAME_2,
                 "output_format": "raw",
                 "pydantic": None,
                 "raw": _LLM_ANSWER,
@@ -498,7 +520,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
         "description": "Analyze and select the best city for the trip",
         "expected_output": "Detailed report on the chosen city",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,
@@ -550,7 +572,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
         "description": "Compile an in-depth guide",
         "expected_output": "Comprehensive city guide",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME_2,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,
@@ -632,7 +654,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
         "description": "Analyze and select the best city for the trip",
         "expected_output": "Detailed report on the chosen city",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,
@@ -691,13 +713,32 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
     assert span_7.name == "ShortTermMemory.save"
     assert span_7.span_type == SpanType.MEMORY
     assert span_7.parent_id is span_2.span_id
-    assert span_7.inputs == {
-        "agent": "City Selection Expert",
-        "metadata": {
-            "observation": "Analyze and select the best city for the trip",
-        },
-        "value": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
-    }
+    # CrewAI changed the memory save input format - agent field was removed in newer versions
+    # Use a flexible matcher that handles both cases
+    class MemoryInputMatcher:
+        def __eq__(self, other: Any) -> bool:
+            if not isinstance(other, dict):
+                return False
+
+            expected_base = {
+                "metadata": {
+                    "observation": "Analyze and select the best city for the trip",
+                },
+                "value": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
+            }
+
+            # Check if base fields match
+            for key, value in expected_base.items():
+                if other.get(key) != value:
+                    return False
+
+            # Allow agent field to be present or absent
+            if "agent" in other:
+                return other["agent"] == "City Selection Expert"
+
+            return True
+
+    assert span_7.inputs == MemoryInputMatcher()
     assert span_7.outputs is None
 
     # Create Long Term Memory
@@ -762,7 +803,7 @@ def test_knowledge(simple_agent_1, task_1, monkeypatch, autolog):
         "description": "Analyze and select the best city for the trip",
         "expected_output": "Detailed report on the chosen city",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,
@@ -855,7 +896,7 @@ def test_kickoff_for_each(simple_agent_1, task_1, autolog):
         "description": "Analyze and select the best city for the trip",
         "expected_output": "Detailed report on the chosen city",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,
@@ -944,7 +985,7 @@ def test_flow(simple_agent_1, task_1, autolog):
         "description": "Analyze and select the best city for the trip",
         "expected_output": "Detailed report on the chosen city",
         "json_dict": None,
-        "name": None,
+        "name": _TASK_NAME,
         "output_format": "raw",
         "pydantic": None,
         "raw": _LLM_ANSWER,

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -1,4 +1,3 @@
-from typing import Any
 from unittest.mock import patch
 
 import crewai
@@ -20,7 +19,7 @@ _FINAL_ANSWER_KEYWORD = "Final Answer:"
 _LLM_ANSWER = "What about Tokyo?"
 
 
-def create_sample_llm_response(content: str) -> Any:
+def create_sample_llm_response(content):
     from litellm import ModelResponse
 
     return ModelResponse(
@@ -72,7 +71,7 @@ _EMBEDDING = {
 
 
 class AnyInt(int):
-    def __eq__(self, other: Any) -> bool:
+    def __eq__(self, other):
         return isinstance(other, int)
 
 
@@ -80,13 +79,14 @@ ANY_INT = AnyInt()
 
 # CrewAI >= 0.175.0 changed behavior: TaskOutput.name falls back to description when None
 # See: https://github.com/crewAIInc/crewAI/pull/3382
+_CREWAI_VERSION = Version(crewai.__version__)
 _TASK_DESCRIPTION = "Analyze and select the best city for the trip"
 _TASK_DESCRIPTION_2 = "Compile an in-depth guide"
 
 
-def _get_expected_task_name(description: str) -> str:
+def _get_expected_task_name(description: str) -> str | None:
     """Get expected task name based on CrewAI version."""
-    return description if Version(crewai.__version__) >= Version("0.175.0") else None
+    return description if _CREWAI_VERSION >= Version("0.175.0") else None
 
 
 _TASK_NAME = _get_expected_task_name(_TASK_DESCRIPTION)
@@ -714,7 +714,7 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
         "value": f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}",
     }
     # Add agent field for older CrewAI versions
-    if Version(crewai.__version__) < Version("0.175.0"):
+    if _CREWAI_VERSION < Version("0.175.0"):
         expected_memory_inputs["agent"] = "City Selection Expert"
 
     assert span_7.inputs == expected_memory_inputs

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -83,9 +83,11 @@ ANY_INT = AnyInt()
 _TASK_DESCRIPTION = "Analyze and select the best city for the trip"
 _TASK_DESCRIPTION_2 = "Compile an in-depth guide"
 
+
 def _get_expected_task_name(description: str) -> str:
     """Get expected task name based on CrewAI version."""
     return description if Version(crewai.__version__) >= Version("0.175.0") else None
+
 
 _TASK_NAME = _get_expected_task_name(_TASK_DESCRIPTION)
 _TASK_NAME_2 = _get_expected_task_name(_TASK_DESCRIPTION_2)


### PR DESCRIPTION
### Related Issues/PRs

None

### What changes are proposed in this pull request?

This PR fixes CrewAI autolog test failures that occur due to version compatibility issues between CrewAI < 0.175.0 and >= 0.175.0.

Failed run: https://github.com/mlflow/dev/actions/runs/17645642195/job/50174072150

```
    {
        'json_dict': None,
        'pydantic': None,
        'raw': 'What about Tokyo?',
        'tasks_output': [
            {
                'agent': 'City Selection Expert',
                'description': 'Analyze and select the best city for the trip',
                'expected_output': 'Detailed report on the chosen city',
                'json_dict': None,
  -             'name': None,
  +             'name': 'Analyze and select the best city for the trip',
                'output_format': 'raw',
                'pydantic': None,
                'raw': 'What about Tokyo?',
                'summary': 'Analyze and select the best city for the trip...',
            },
        ],
```

**Root Cause:**

CrewAI made breaking changes in version 0.175.0:
- **TaskOutput.name behavior**: Changed from `None` to fallback to `description` value ([CrewAI PR #3382](https://github.com/crewAIInc/crewAI/pull/3382/files#diff-61c1f3538241ba71061953a951b8d3e243d76da7c5ebbb5aa1a7ce9cfcf81e81R436))
- **Memory save inputs**: Removed the `agent` field from memory save operations

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with [Claude Code](https://claude.ai/code)