### PR TITLE
Judges - support aligning judges that read fields from traces, include expectations

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import PrivateAttr
 
 import mlflow
+from mlflow.entities.assessment import Feedback
 from mlflow.entities.model_registry.prompt_version import PromptVersion
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
@@ -336,7 +337,7 @@ class InstructionsJudge(Judge):
         outputs: Any = None,
         expectations: dict[str, Any] | None = None,
         trace: Trace | None = None,
-    ) -> Any:
+    ) -> Feedback:
         """
         Evaluate the provided data using the judge's instructions.
 

--- a/mlflow/genai/judges/optimizers/dspy.py
+++ b/mlflow/genai/judges/optimizers/dspy.py
@@ -175,7 +175,7 @@ class DSPyAlignmentOptimizer(AlignmentOptimizer):
                 # Convert traces to DSPy format
                 dspy_examples = []
                 for trace in traces:
-                    example = trace_to_dspy_example(trace, judge.name)
+                    example = trace_to_dspy_example(trace, judge)
                     if example is not None:
                         dspy_examples.append(example)
 

--- a/mlflow/genai/judges/optimizers/dspy.py
+++ b/mlflow/genai/judges/optimizers/dspy.py
@@ -123,10 +123,6 @@ class DSPyAlignmentOptimizer(AlignmentOptimizer):
                 else:
                     judge_model = self._judge_model
 
-                # Ensure outputs is provided (use empty string if not)
-                if "outputs" not in kwargs:
-                    kwargs["outputs"] = ""
-
                 judge: Judge = make_judge(
                     name=self._judge_name,
                     instructions=self.signature.instructions,

--- a/mlflow/genai/judges/optimizers/dspy.py
+++ b/mlflow/genai/judges/optimizers/dspy.py
@@ -9,9 +9,11 @@ from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.judges import make_judge
 from mlflow.genai.judges.base import AlignmentOptimizer, Judge
+from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.optimizers.dspy_utils import (
     agreement_metric,
     construct_dspy_lm,
+    convert_litellm_to_mlflow_uri,
     create_dspy_signature,
     trace_to_dspy_example,
 )
@@ -104,16 +106,27 @@ class DSPyAlignmentOptimizer(AlignmentOptimizer):
 
             def __init__(self, judge):
                 super().__init__(create_dspy_signature(judge))
-                self._lm = construct_dspy_lm(judge.model)
-                self._judge_model = judge.model
-                self._judge_name = judge.name
+                self._judge_model: str = judge.model
+                self._judge_name: str = judge.name
 
             def forward(self, *args, **kwargs):
-                # For now, just use the judge's original model
+                # If an LLM is supplied via kwargs, extract the model URI and use it,
+                # else use self._judge_model
+                dspy_lm: dspy.LM = kwargs.pop("lm", None)
+                if dspy_lm is not None:
+                    if dspy_lm.model == _DATABRICKS_DEFAULT_JUDGE_MODEL:
+                        # The databricks default judge model is a special sentinel value
+                        # and is not a valid LiteLLM model identifier
+                        judge_model = _DATABRICKS_DEFAULT_JUDGE_MODEL
+                    else:
+                        judge_model = convert_litellm_to_mlflow_uri(dspy_lm.model)
+                else:
+                    judge_model = self._judge_model
+
                 judge: Judge = make_judge(
                     name=self._judge_name,
                     instructions=self.signature.instructions,
-                    model=self._judge_model,
+                    model=judge_model,
                 )
                 feedback: Feedback = judge(**kwargs)
                 return dspy.Prediction(

--- a/mlflow/genai/judges/optimizers/dspy.py
+++ b/mlflow/genai/judges/optimizers/dspy.py
@@ -123,6 +123,10 @@ class DSPyAlignmentOptimizer(AlignmentOptimizer):
                 else:
                     judge_model = self._judge_model
 
+                # Ensure outputs is provided (use empty string if not)
+                if "outputs" not in kwargs:
+                    kwargs["outputs"] = ""
+
                 judge: Judge = make_judge(
                     name=self._judge_name,
                     instructions=self.signature.instructions,

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -195,7 +195,7 @@ def convert_litellm_to_mlflow_uri(litellm_model: str) -> str:
         raise MlflowException(f"Failed to convert LiteLLM format to MLflow URI: {e}")
 
 
-def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Example"]:
+def trace_to_dspy_example(trace: Trace, judge: "Judge") -> Optional["dspy.Example"]:
     """
     Convert MLflow trace to DSPy example format.
 
@@ -206,7 +206,7 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
 
     Args:
         trace: MLflow trace object
-        judge_name: Name of the judge to find assessments for
+        judge: Judge instance to find assessments for
 
     Returns:
         DSPy example object or None if conversion fails
@@ -234,7 +234,7 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
             )
             for assessment in sorted_assessments:
                 sanitized_assessment_name = _sanitize_assessment_name(assessment.name)
-                sanitized_judge_name = _sanitize_assessment_name(judge_name)
+                sanitized_judge_name = _sanitize_assessment_name(judge.name)
                 if (
                     sanitized_assessment_name == sanitized_judge_name
                     and assessment.source.source_type == AssessmentSourceType.HUMAN
@@ -244,7 +244,7 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
 
         if not expected_result:
             _logger.warning(
-                f"No human assessment found for judge '{judge_name}' in trace {trace.info.trace_id}"
+                f"No human assessment found for judge '{judge.name}' in trace {trace.info.trace_id}"
             )
             return None
 

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -253,13 +253,20 @@ def trace_to_dspy_example(trace: Trace, judge: "Judge") -> Optional["dspy.Exampl
             return None
 
         # Create DSPy example
+        judge_input_fields = judge.get_input_fields()
+        example_kwargs = {}
+        if any(field.name == "trace" for field in judge_input_fields):
+            example_kwargs["trace"] = trace
+        if any(field.name == "inputs" for field in judge_input_fields):
+            example_kwargs["inputs"] = request
+        if any(field.name == "outputs" for field in judge_input_fields):
+            example_kwargs["outputs"] = response
+        if any(field.name == "expectations" for field in judge_input_fields):
+            example_kwargs["expectations"] = extract_expectations_from_trace(trace)
         example = dspy.Example(
-            trace=trace,
-            inputs=request,
-            outputs=response,
-            expectations=extract_expectations_from_trace(trace),
             result=str(expected_result.feedback.value).lower(),
             rationale=expected_result.rationale if expected_result.rationale else "",
+            **example_kwargs,
         )
 
         # Set inputs (what the model should use as input)

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -263,7 +263,7 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
         )
 
         # Set inputs (what the model should use as input)
-        return example.with_inputs("trace", "inputs", "outputs")
+        return example.with_inputs("trace", "inputs", "outputs", "expectations")
 
     except Exception as e:
         _logger.error(f"Failed to create DSPy example from trace: {e}")

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -230,13 +230,20 @@ def trace_to_dspy_example(trace: Trace, judge: Judge) -> Optional["dspy.Example"
         response = extract_response_from_trace(trace)
         expectations = extract_expectations_from_trace(trace)
 
-        if request is None and judge_requires_inputs:
+        # Check for missing required fields - treat None or whitespace-only strings as missing
+        if (
+            not request or (isinstance(request, str) and request.strip() == "")
+        ) and judge_requires_inputs:
             _logger.warning(f"Missing required request in trace {trace.info.trace_id}")
             return None
-        elif response is None and judge_requires_outputs:
+        elif (
+            not response or (isinstance(response, str) and response.strip() == "")
+        ) and judge_requires_outputs:
             _logger.warning(f"Missing required response in trace {trace.info.trace_id}")
             return None
-        elif expectations is None and judge_requires_expectations:
+        elif (
+            not expectations or (isinstance(expectations, str) and expectations.strip() == "")
+        ) and judge_requires_expectations:
             _logger.warning(f"Missing required expectations in trace {trace.info.trace_id}")
             return None
 

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -230,20 +230,14 @@ def trace_to_dspy_example(trace: Trace, judge: Judge) -> Optional["dspy.Example"
         response = extract_response_from_trace(trace)
         expectations = extract_expectations_from_trace(trace)
 
-        # Check for missing required fields - treat None or whitespace-only strings as missing
-        if (
-            not request or (isinstance(request, str) and request.strip() == "")
-        ) and judge_requires_inputs:
+        # Check for missing required fields
+        if not request and judge_requires_inputs:
             _logger.warning(f"Missing required request in trace {trace.info.trace_id}")
             return None
-        elif (
-            not response or (isinstance(response, str) and response.strip() == "")
-        ) and judge_requires_outputs:
+        elif not response and judge_requires_outputs:
             _logger.warning(f"Missing required response in trace {trace.info.trace_id}")
             return None
-        elif (
-            not expectations or (isinstance(expectations, str) and expectations.strip() == "")
-        ) and judge_requires_expectations:
+        elif not expectations and judge_requires_expectations:
             _logger.warning(f"Missing required expectations in trace {trace.info.trace_id}")
             return None
 

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
+from mlflow.genai.judges.base import Judge
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.utils import call_chat_completions
 from mlflow.genai.utils.trace_utils import (
@@ -195,7 +196,7 @@ def convert_litellm_to_mlflow_uri(litellm_model: str) -> str:
         raise MlflowException(f"Failed to convert LiteLLM format to MLflow URI: {e}")
 
 
-def trace_to_dspy_example(trace: Trace, judge: "Judge") -> Optional["dspy.Example"]:
+def trace_to_dspy_example(trace: Trace, judge: Judge) -> Optional["dspy.Example"]:
     """
     Convert MLflow trace to DSPy example format.
 

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -9,6 +9,7 @@ from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.utils import call_chat_completions
 from mlflow.genai.utils.trace_utils import (
+    extract_expectations_from_trace,
     extract_request_from_trace,
     extract_response_from_trace,
 )
@@ -256,6 +257,7 @@ def trace_to_dspy_example(trace: Trace, judge_name: str) -> Optional["dspy.Examp
             trace=trace,
             inputs=request,
             outputs=response,
+            expectations=extract_expectations_from_trace(trace),
             result=str(expected_result.feedback.value).lower(),
             rationale=expected_result.rationale if expected_result.rationale else "",
         )

--- a/mlflow/genai/judges/optimizers/dspy_utils.py
+++ b/mlflow/genai/judges/optimizers/dspy_utils.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional
 
 from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.entities.trace import Trace
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import INVALID_PARAMETER_VALUE, MlflowException
 from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.utils import call_chat_completions
 from mlflow.genai.utils.trace_utils import (
@@ -186,7 +186,8 @@ def convert_litellm_to_mlflow_uri(litellm_model: str) -> str:
         if not provider or not model:
             raise MlflowException(
                 f"Invalid LiteLLM model format: '{litellm_model}'. "
-                "Both provider and model name must be non-empty"
+                "Both provider and model name must be non-empty",
+                error_code=INVALID_PARAMETER_VALUE,
             )
         return f"{provider}:/{model}"
     except ValueError as e:

--- a/tests/genai/judges/optimizers/conftest.py
+++ b/tests/genai/judges/optimizers/conftest.py
@@ -2,6 +2,7 @@
 
 import json
 import time
+from typing import Any
 from unittest.mock import Mock
 
 import dspy
@@ -52,13 +53,13 @@ class MockJudge(Judge):
 
 
 def _create_trace_helper(
-    trace_id,
-    assessments=None,
-    inputs=None,
-    outputs=None,
-    context_trace_id=12345,
-    context_span_id=111,
-):
+    trace_id: str,
+    assessments: list[Feedback] | None = None,
+    inputs: dict[str, Any] | None = None,
+    outputs: dict[str, Any] | None = None,
+    context_trace_id: int = 12345,
+    context_span_id: int = 111,
+) -> Trace:
     """Helper function to create traces with less duplication."""
     current_time_ns = int(time.time() * 1e9)
 

--- a/tests/genai/judges/optimizers/conftest.py
+++ b/tests/genai/judges/optimizers/conftest.py
@@ -46,10 +46,8 @@ class MockJudge(Judge):
     def get_input_fields(self) -> list[JudgeField]:
         """Get the input fields for this mock judge."""
         return [
-            JudgeField(name="trace", description="Test trace"),
             JudgeField(name="inputs", description="Test inputs"),
             JudgeField(name="outputs", description="Test outputs"),
-            JudgeField(name="expectations", description="Test expectations"),
         ]
 
 

--- a/tests/genai/judges/optimizers/conftest.py
+++ b/tests/genai/judges/optimizers/conftest.py
@@ -51,6 +51,57 @@ class MockJudge(Judge):
         ]
 
 
+def _create_trace_helper(
+    trace_id,
+    assessments=None,
+    inputs=None,
+    outputs=None,
+    context_trace_id=12345,
+    context_span_id=111,
+):
+    """Helper function to create traces with less duplication."""
+    current_time_ns = int(time.time() * 1e9)
+
+    # Build attributes dict
+    attributes = {"mlflow.traceRequestId": json.dumps(trace_id)}
+    if inputs is not None:
+        attributes["mlflow.spanInputs"] = json.dumps(inputs)
+    if outputs is not None:
+        attributes["mlflow.spanOutputs"] = json.dumps(outputs)
+    attributes["mlflow.spanType"] = json.dumps("CHAIN")
+
+    # Create OpenTelemetry span
+    otel_span = OTelReadableSpan(
+        name="root_span",
+        context=build_otel_context(context_trace_id, context_span_id),
+        parent=None,
+        start_time=current_time_ns,
+        end_time=current_time_ns + 1000000,
+        attributes=attributes,
+    )
+
+    # Create real Span object
+    real_span = Span(otel_span)
+
+    # Create real TraceInfo
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=TraceLocation.from_experiment_id("0"),
+        request_time=int(time.time() * 1000),
+        state=TraceState.OK,
+        execution_duration=1000,
+        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
+        tags={},
+        assessments=assessments or [],
+        request_preview=json.dumps(inputs) if inputs else None,
+        response_preview=json.dumps(outputs) if outputs else None,
+    )
+
+    # Create real TraceData and Trace
+    trace_data = TraceData(spans=[real_span])
+    return Trace(info=trace_info, data=trace_data)
+
+
 @pytest.fixture
 def mock_judge():
     """Create a mock judge for testing."""
@@ -60,8 +111,6 @@ def mock_judge():
 @pytest.fixture
 def sample_trace_with_assessment():
     """Create a sample trace with human assessment for testing."""
-    # Create actual trace with real MLflow objects instead of mocks
-
     # Create a real assessment object (Feedback) with mixed case/whitespace to test sanitization
     assessment = Feedback(
         name="  Mock_JUDGE  ",
@@ -70,87 +119,27 @@ def sample_trace_with_assessment():
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
     )
 
-    # Create OpenTelemetry span with proper attributes
-    current_time_ns = int(time.time() * 1e9)
-    otel_span = OTelReadableSpan(
-        name="root_span",
-        context=build_otel_context(12345, 111),
-        parent=None,
-        start_time=current_time_ns,
-        end_time=current_time_ns + 1000000,
-        attributes={
-            "mlflow.traceRequestId": json.dumps("test_trace_001"),
-            "mlflow.spanInputs": json.dumps({"inputs": "test input"}),
-            "mlflow.spanOutputs": json.dumps({"outputs": "test output"}),
-            "mlflow.spanType": json.dumps("CHAIN"),
-        },
-    )
-
-    # Create real Span object
-    real_span = Span(otel_span)
-
-    # Create real TraceInfo
-    trace_info = TraceInfo(
+    return _create_trace_helper(
         trace_id="test_trace_001",
-        trace_location=TraceLocation.from_experiment_id("0"),
-        request_time=int(time.time() * 1000),
-        state=TraceState.OK,
-        execution_duration=1000,
-        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
-        tags={},
         assessments=[assessment],
-        request_preview='{"inputs": "test input"}',
-        response_preview='{"outputs": "test output"}',
+        inputs={"inputs": "test input"},
+        outputs={"outputs": "test output"},
+        context_trace_id=12345,
+        context_span_id=111,
     )
-
-    # Create real TraceData
-    trace_data = TraceData(spans=[real_span])
-
-    # Create real Trace object
-    return Trace(info=trace_info, data=trace_data)
 
 
 @pytest.fixture
 def sample_trace_without_assessment():
     """Create a sample trace without human assessment for testing."""
-    # Create OpenTelemetry span
-    current_time_ns = int(time.time() * 1e9)
-    otel_span = OTelReadableSpan(
-        name="root_span",
-        context=build_otel_context(12346, 112),
-        parent=None,
-        start_time=current_time_ns,
-        end_time=current_time_ns + 1000000,
-        attributes={
-            "mlflow.traceRequestId": json.dumps("test_trace_001"),
-            "mlflow.spanInputs": json.dumps({"inputs": "test input"}),
-            "mlflow.spanOutputs": json.dumps({"outputs": "test output"}),
-            "mlflow.spanType": json.dumps("CHAIN"),
-        },
-    )
-
-    # Create real Span object
-    real_span = Span(otel_span)
-
-    # Create real TraceInfo without assessments
-    trace_info = TraceInfo(
+    return _create_trace_helper(
         trace_id="test_trace_001",
-        trace_location=TraceLocation.from_experiment_id("0"),
-        request_time=int(time.time() * 1000),
-        state=TraceState.OK,
-        execution_duration=1000,
-        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
-        tags={},
         assessments=[],  # No assessments
-        request_preview='{"inputs": "test input"}',
-        response_preview='{"outputs": "test output"}',
+        inputs={"inputs": "test input"},
+        outputs={"outputs": "test output"},
+        context_trace_id=12346,
+        context_span_id=112,
     )
-
-    # Create real TraceData
-    trace_data = TraceData(spans=[real_span])
-
-    # Create real Trace object
-    return Trace(info=trace_info, data=trace_data)
 
 
 @pytest.fixture
@@ -158,7 +147,7 @@ def trace_with_expectations():
     """Create a trace with expectations."""
     from mlflow.entities import Expectation
 
-    # Create a real assessment object
+    # Create assessments
     judge_assessment = Feedback(
         name="mock_judge",
         value="pass",
@@ -166,7 +155,6 @@ def trace_with_expectations():
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
     )
 
-    # Create expectation assessments
     expectation1 = Expectation(
         trace_id="test_trace_with_expectations",
         name="accuracy",
@@ -181,50 +169,19 @@ def trace_with_expectations():
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
     )
 
-    # Create OpenTelemetry span with inputs and outputs
-    current_time_ns = int(time.time() * 1e9)
-    otel_span = OTelReadableSpan(
-        name="root_span",
-        context=build_otel_context(12352, 118),
-        parent=None,
-        start_time=current_time_ns,
-        end_time=current_time_ns + 1000000,
-        attributes={
-            "mlflow.traceRequestId": json.dumps("test_trace_with_expectations"),
-            "mlflow.spanInputs": json.dumps({"inputs": "test input"}),
-            "mlflow.spanOutputs": json.dumps({"outputs": "test output"}),
-            "mlflow.spanType": json.dumps("CHAIN"),
-        },
-    )
-
-    # Create real Span object
-    real_span = Span(otel_span)
-
-    # Create real TraceInfo
-    trace_info = TraceInfo(
+    return _create_trace_helper(
         trace_id="test_trace_with_expectations",
-        trace_location=TraceLocation.from_experiment_id("0"),
-        request_time=int(time.time() * 1000),
-        state=TraceState.OK,
-        execution_duration=1000,
-        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
-        tags={},
         assessments=[judge_assessment, expectation1, expectation2],
-        request_preview='{"inputs": "test input"}',
-        response_preview='{"outputs": "test output"}',
+        inputs={"inputs": "test input"},
+        outputs={"outputs": "test output"},
+        context_trace_id=12352,
+        context_span_id=118,
     )
-
-    # Create real TraceData
-    trace_data = TraceData(spans=[real_span])
-
-    # Create real Trace object
-    return Trace(info=trace_info, data=trace_data)
 
 
 @pytest.fixture
 def trace_without_inputs():
     """Create a trace without inputs (only outputs)."""
-    # Create a real assessment object
     assessment = Feedback(
         name="mock_judge",
         value="pass",
@@ -232,50 +189,19 @@ def trace_without_inputs():
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
     )
 
-    # Create OpenTelemetry span without inputs
-    current_time_ns = int(time.time() * 1e9)
-    otel_span = OTelReadableSpan(
-        name="root_span",
-        context=build_otel_context(12350, 116),
-        parent=None,
-        start_time=current_time_ns,
-        end_time=current_time_ns + 1000000,
-        attributes={
-            "mlflow.traceRequestId": json.dumps("test_trace_no_inputs"),
-            # No mlflow.spanInputs attribute
-            "mlflow.spanOutputs": json.dumps({"outputs": "test output"}),
-            "mlflow.spanType": json.dumps("CHAIN"),
-        },
-    )
-
-    # Create real Span object
-    real_span = Span(otel_span)
-
-    # Create real TraceInfo
-    trace_info = TraceInfo(
+    return _create_trace_helper(
         trace_id="test_trace_no_inputs",
-        trace_location=TraceLocation.from_experiment_id("0"),
-        request_time=int(time.time() * 1000),
-        state=TraceState.OK,
-        execution_duration=1000,
-        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
-        tags={},
         assessments=[assessment],
-        request_preview=None,  # No request preview
-        response_preview='{"outputs": "test output"}',
+        inputs=None,  # No inputs
+        outputs={"outputs": "test output"},
+        context_trace_id=12350,
+        context_span_id=116,
     )
-
-    # Create real TraceData
-    trace_data = TraceData(spans=[real_span])
-
-    # Create real Trace object
-    return Trace(info=trace_info, data=trace_data)
 
 
 @pytest.fixture
 def trace_without_outputs():
     """Create a trace without outputs (only inputs)."""
-    # Create a real assessment object
     assessment = Feedback(
         name="mock_judge",
         value="pass",
@@ -283,52 +209,19 @@ def trace_without_outputs():
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
     )
 
-    # Create OpenTelemetry span without outputs
-    current_time_ns = int(time.time() * 1e9)
-    otel_span = OTelReadableSpan(
-        name="root_span",
-        context=build_otel_context(12351, 117),
-        parent=None,
-        start_time=current_time_ns,
-        end_time=current_time_ns + 1000000,
-        attributes={
-            "mlflow.traceRequestId": json.dumps("test_trace_no_outputs"),
-            "mlflow.spanInputs": json.dumps({"inputs": "test input"}),
-            # No mlflow.spanOutputs attribute
-            "mlflow.spanType": json.dumps("CHAIN"),
-        },
-    )
-
-    # Create real Span object
-    real_span = Span(otel_span)
-
-    # Create real TraceInfo
-    trace_info = TraceInfo(
+    return _create_trace_helper(
         trace_id="test_trace_no_outputs",
-        trace_location=TraceLocation.from_experiment_id("0"),
-        request_time=int(time.time() * 1000),
-        state=TraceState.OK,
-        execution_duration=1000,
-        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
-        tags={},
         assessments=[assessment],
-        request_preview='{"inputs": "test input"}',
-        response_preview=None,  # No response preview
+        inputs={"inputs": "test input"},
+        outputs=None,  # No outputs
+        context_trace_id=12351,
+        context_span_id=117,
     )
-
-    # Create real TraceData
-    trace_data = TraceData(spans=[real_span])
-
-    # Create real Trace object
-    return Trace(info=trace_info, data=trace_data)
 
 
 @pytest.fixture
 def trace_with_nested_request_response():
     """Create a trace with nested request/response structure."""
-    # Create actual trace with real MLflow objects
-
-    # Create a real assessment object (Feedback)
     assessment = Feedback(
         name="mock_judge",
         value="pass",
@@ -337,47 +230,17 @@ def trace_with_nested_request_response():
         create_time_ms=int(time.time() * 1000),
     )
 
-    # Create OpenTelemetry span with nested structure
-    current_time_ns = int(time.time() * 1e9)
     nested_inputs = {"query": {"text": "nested input", "context": {"key": "value"}}}
     nested_outputs = {"result": {"answer": "nested output", "metadata": {"score": 0.9}}}
 
-    otel_span = OTelReadableSpan(
-        name="root_span",
-        context=build_otel_context(12347, 113),
-        parent=None,
-        start_time=current_time_ns,
-        end_time=current_time_ns + 1000000,
-        attributes={
-            "mlflow.traceRequestId": json.dumps("test_trace_nested"),
-            "mlflow.spanInputs": json.dumps(nested_inputs),
-            "mlflow.spanOutputs": json.dumps(nested_outputs),
-            "mlflow.spanType": json.dumps("CHAIN"),
-        },
-    )
-
-    # Create real Span object
-    real_span = Span(otel_span)
-
-    # Create real TraceInfo
-    trace_info = TraceInfo(
+    return _create_trace_helper(
         trace_id="test_trace_nested",
-        trace_location=TraceLocation.from_experiment_id("0"),
-        request_time=int(time.time() * 1000),
-        state=TraceState.OK,
-        execution_duration=1000,
-        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
-        tags={},
         assessments=[assessment],
-        request_preview=json.dumps(nested_inputs),
-        response_preview=json.dumps(nested_outputs),
+        inputs=nested_inputs,
+        outputs=nested_outputs,
+        context_trace_id=12347,
+        context_span_id=113,
     )
-
-    # Create real TraceData
-    trace_data = TraceData(spans=[real_span])
-
-    # Create real Trace object
-    return Trace(info=trace_info, data=trace_data)
 
 
 @pytest.fixture

--- a/tests/genai/judges/optimizers/conftest.py
+++ b/tests/genai/judges/optimizers/conftest.py
@@ -154,6 +154,74 @@ def sample_trace_without_assessment():
 
 
 @pytest.fixture
+def trace_with_expectations():
+    """Create a trace with expectations."""
+    from mlflow.entities import Expectation
+
+    # Create a real assessment object
+    judge_assessment = Feedback(
+        name="mock_judge",
+        value="pass",
+        rationale="Meets expectations",
+        source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
+    )
+
+    # Create expectation assessments
+    expectation1 = Expectation(
+        trace_id="test_trace_with_expectations",
+        name="accuracy",
+        value="Should be at least 90% accurate",
+        source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
+    )
+
+    expectation2 = Expectation(
+        trace_id="test_trace_with_expectations",
+        name="format",
+        value="Should return JSON format",
+        source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="test_user"),
+    )
+
+    # Create OpenTelemetry span with inputs and outputs
+    current_time_ns = int(time.time() * 1e9)
+    otel_span = OTelReadableSpan(
+        name="root_span",
+        context=build_otel_context(12352, 118),
+        parent=None,
+        start_time=current_time_ns,
+        end_time=current_time_ns + 1000000,
+        attributes={
+            "mlflow.traceRequestId": json.dumps("test_trace_with_expectations"),
+            "mlflow.spanInputs": json.dumps({"inputs": "test input"}),
+            "mlflow.spanOutputs": json.dumps({"outputs": "test output"}),
+            "mlflow.spanType": json.dumps("CHAIN"),
+        },
+    )
+
+    # Create real Span object
+    real_span = Span(otel_span)
+
+    # Create real TraceInfo
+    trace_info = TraceInfo(
+        trace_id="test_trace_with_expectations",
+        trace_location=TraceLocation.from_experiment_id("0"),
+        request_time=int(time.time() * 1000),
+        state=TraceState.OK,
+        execution_duration=1000,
+        trace_metadata={TRACE_SCHEMA_VERSION_KEY: str(TRACE_SCHEMA_VERSION)},
+        tags={},
+        assessments=[judge_assessment, expectation1, expectation2],
+        request_preview='{"inputs": "test input"}',
+        response_preview='{"outputs": "test output"}',
+    )
+
+    # Create real TraceData
+    trace_data = TraceData(spans=[real_span])
+
+    # Create real Trace object
+    return Trace(info=trace_info, data=trace_data)
+
+
+@pytest.fixture
 def trace_without_inputs():
     """Create a trace without inputs (only outputs)."""
     # Create a real assessment object

--- a/tests/genai/judges/optimizers/conftest.py
+++ b/tests/genai/judges/optimizers/conftest.py
@@ -46,7 +46,10 @@ class MockJudge(Judge):
     def get_input_fields(self) -> list[JudgeField]:
         """Get the input fields for this mock judge."""
         return [
+            JudgeField(name="trace", description="Test trace"),
             JudgeField(name="inputs", description="Test inputs"),
+            JudgeField(name="outputs", description="Test outputs"),
+            JudgeField(name="expectations", description="Test expectations"),
         ]
 
 

--- a/tests/genai/judges/optimizers/test_dspy_base.py
+++ b/tests/genai/judges/optimizers/test_dspy_base.py
@@ -9,14 +9,15 @@ import pytest
 
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
-from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.optimizers.dspy import DSPyAlignmentOptimizer
 from mlflow.genai.judges.optimizers.dspy_utils import AgentEvalLM, convert_mlflow_uri_to_litellm
 
 from tests.genai.judges.optimizers.conftest import MockDSPyLM, MockJudge
 
 
-def create_mock_make_judge(expected_model=None, track_calls=None):
+def create_mock_make_judge(
+    expected_model: str | None = None, track_calls: list[str] | None = None
+) -> Callable[[str, str, str], MagicMock]:
     """Create a mock make_judge function for testing.
 
     Args:
@@ -31,7 +32,6 @@ def create_mock_make_judge(expected_model=None, track_calls=None):
     mock_feedback.rationale = "Test rationale"
 
     def mock_make_judge(name, instructions, model):
-        # Track which model was used if tracking is enabled
         if track_calls is not None and model == expected_model:
             track_calls.append(model)
         return MagicMock(return_value=mock_feedback)
@@ -48,7 +48,6 @@ class ConcreteDSPyOptimizer(DSPyAlignmentOptimizer):
         examples: Collection["dspy.Example"],
         metric_fn: Callable[["dspy.Example", Any, Any | None], bool],
     ) -> "dspy.Module":
-        # Mock implementation for testing
         mock_program = Mock()
         mock_program.signature = Mock()
         mock_program.signature.instructions = (
@@ -81,21 +80,16 @@ def test_concrete_implementation_works():
 
 def test_align_success(sample_traces_with_assessments):
     """Test successful alignment process."""
-    # Create a mock judge with model attribute
     mock_judge = MockJudge(name="mock_judge", model="openai:/gpt-4")
 
     with patch("dspy.LM", MagicMock()):
-        # Setup concrete optimizer
         optimizer = ConcreteDSPyOptimizer()
 
-        # Mock get_min_traces_required to work with 5 traces from fixture
         with patch.object(ConcreteDSPyOptimizer, "get_min_traces_required", return_value=5):
             result = optimizer.align(mock_judge, sample_traces_with_assessments)
 
-    # Should return an optimized judge
     assert result is not None
     assert result.model == mock_judge.model
-    # The instructions are wrapped by make_judge with a header and formatting
     assert "Optimized instructions with {{inputs}} and {{outputs}}" in result.instructions
 
 
@@ -106,9 +100,7 @@ def test_align_no_traces(mock_judge):
     with pytest.raises(MlflowException, match="Alignment optimization failed") as exc_info:
         optimizer.align(mock_judge, [])
 
-    # Check that the main error message includes the exception details
     assert "No traces provided" in str(exc_info.value)
-    # Check that the chained exception has the expected message
     assert exc_info.value.__cause__ is not None
     assert "No traces provided" in str(exc_info.value.__cause__)
 
@@ -120,9 +112,7 @@ def test_align_no_valid_examples(mock_judge, sample_trace_without_assessment):
         with pytest.raises(MlflowException, match="Alignment optimization failed") as exc_info:
             optimizer.align(mock_judge, [sample_trace_without_assessment])
 
-        # Check that the main error message includes the exception details
         assert "No valid examples could be created" in str(exc_info.value)
-        # Check that the chained exception has the expected message
         assert exc_info.value.__cause__ is not None
         assert "No valid examples could be created" in str(exc_info.value.__cause__)
 
@@ -132,14 +122,11 @@ def test_align_insufficient_examples(mock_judge, sample_trace_with_assessment):
     optimizer = ConcreteDSPyOptimizer()
     min_traces = optimizer.get_min_traces_required()
 
-    # Mock dspy first to avoid import errors
     with patch("dspy.LM", MagicMock()):
         with pytest.raises(MlflowException, match="Alignment optimization failed") as exc_info:
             optimizer.align(mock_judge, [sample_trace_with_assessment])
 
-        # Check that the main error message includes the exception details
         assert f"At least {min_traces} valid traces are required" in str(exc_info.value)
-        # Check that the chained exception has the expected message
         assert exc_info.value.__cause__ is not None
         assert f"At least {min_traces} valid traces are required" in str(exc_info.value.__cause__)
 
@@ -149,7 +136,6 @@ def _create_mock_dspy_lm_factory(optimizer_lm, judge_lm):
 
     def mock_lm_factory(model=None, **kwargs):
         """Internal factory method to carry the input models"""
-        # Choose the appropriate tracking list based on model
         if model == optimizer_lm.model:
             return optimizer_lm
         elif model == judge_lm.model:
@@ -162,29 +148,20 @@ def _create_mock_dspy_lm_factory(optimizer_lm, judge_lm):
 
 def test_optimizer_and_judge_use_different_models(sample_traces_with_assessments):
     """Test that optimizer uses its own model while judge program uses judge's model."""
-    # Setup models
     judge_model = "openai:/gpt-4"
     optimizer_model = "anthropic:/claude-3"
 
-    # Create judge and traces
     mock_judge = MockJudge(name="mock_judge", model=judge_model)
     traces = sample_traces_with_assessments
 
-    # Track LM calls and what models they use in context
-    # The MockDSPyLM should be initialized with the converted LiteLLM format
-    # since that's what will be passed to the mock factory
     optimizer_lm = MockDSPyLM(convert_mlflow_uri_to_litellm(optimizer_model))
     judge_lm = MockDSPyLM(convert_mlflow_uri_to_litellm(judge_model))
 
-    # Create LM factory that tracks calls to the underlying mocked LMs
     mock_lm_factory = _create_mock_dspy_lm_factory(optimizer_lm, judge_lm)
-
-    # Use the utility function to create mock make_judge
     mock_make_judge = create_mock_make_judge(
         expected_model=judge_model, track_calls=judge_lm.context_calls
     )
 
-    # Direct patching approach: patch only LM, use real DSPy otherwise
     with (
         patch.object(dspy, "LM", side_effect=mock_lm_factory),
         patch("mlflow.genai.judges.optimizers.dspy.make_judge", side_effect=mock_make_judge),
@@ -200,29 +177,20 @@ def test_optimizer_and_judge_use_different_models(sample_traces_with_assessments
                 lm_in_context = dspy.settings.lm
                 assert lm_in_context == optimizer_lm
 
-                # Simulate calling the program (which represents the judge)
-                # This should happen with the judge's model context
-                # Note: Must provide outputs parameter as it's required
                 program(inputs=examples[0].inputs, outputs=examples[0].outputs)
 
-                # Return optimized program as usual
                 return super()._dspy_optimize(program, examples, metric_fn)
 
-        # Create optimizer with different model
         optimizer = TestDSPyOptimizer(model=optimizer_model)
 
-        # Run alignment with mocked min traces requirement
         with patch.object(TestDSPyOptimizer, "get_min_traces_required", return_value=5):
             optimizer.align(mock_judge, traces)
 
-        # Verify that the judge's LM was actually called during program execution
-        # This ensures that the program call used the judge's model
         assert len(judge_lm.context_calls) > 0, (
             f"Expected judge LM to be called, but got {len(judge_lm.context_calls)} calls. "
             f"Optimizer calls: {len(optimizer_lm.context_calls)}"
         )
 
-        # Verify that the optimizer's LM was not called
         assert len(optimizer_lm.context_calls) == 0, (
             f"Expected optimizer LM to not be called, but got "
             f"{len(optimizer_lm.context_calls)} calls. "
@@ -268,7 +236,6 @@ def test_mlflow_to_litellm_uri_conversion_in_optimizer(sample_traces_with_assess
 
     mock_judge = MockJudge(name="mock_judge", model=judge_model)
 
-    # Track what models are passed to dspy.LM
     lm_calls = []
 
     def mock_lm_init(model=None, **kwargs):
@@ -277,42 +244,33 @@ def test_mlflow_to_litellm_uri_conversion_in_optimizer(sample_traces_with_assess
 
     with patch("dspy.LM", side_effect=mock_lm_init):
         optimizer = ConcreteDSPyOptimizer(model=optimizer_model)
-        # Mock get_min_traces_required to work with 5 traces from fixture
         with patch.object(ConcreteDSPyOptimizer, "get_min_traces_required", return_value=5):
             optimizer.align(mock_judge, sample_traces_with_assessments)
 
-    # Check that URIs were converted to LiteLLM format (slash instead of colon-slash)
     assert lm_calls == ["anthropic/claude-3.5-sonnet"]
 
 
 def test_mlflow_to_litellm_uri_conversion_in_judge_program():
     """Test that judge's model URI is converted when creating DSPy program."""
-    # Create mock judge with MLflow URI format
     mock_judge = MockJudge(name="test_judge", model="openai:/gpt-4o-mini")
 
     optimizer = ConcreteDSPyOptimizer()
 
-    # Track what models are passed to make_judge
     make_judge_calls = []
     mock_make_judge = create_mock_make_judge(
         expected_model=mock_judge.model, track_calls=make_judge_calls
     )
 
-    # Create the program
     program = optimizer._get_dspy_program_from_judge(mock_judge)
 
-    # Call the program to trigger judge creation
     with patch("mlflow.genai.judges.optimizers.dspy.make_judge", side_effect=mock_make_judge):
-        # Create a mock dspy.LM with the expected converted model
         mock_lm = MagicMock()
         mock_lm.model = convert_mlflow_uri_to_litellm(mock_judge.model)
 
-        # Call the program with the mock LM
         program.forward(inputs="test", outputs="test", lm=mock_lm)
 
-    # Verify that make_judge was called with the converted URI
     assert len(make_judge_calls) == 1
-    assert make_judge_calls[0] == mock_judge.model  # Should use original MLflow URI format
+    assert make_judge_calls[0] == mock_judge.model
 
 
 def test_dspy_align_litellm_nonfatal_error_messages_suppressed():
@@ -320,11 +278,9 @@ def test_dspy_align_litellm_nonfatal_error_messages_suppressed():
     suppression_state_during_call = {}
 
     def mock_dspy_optimize(program, examples, metric_fn):
-        # Capture the state of litellm flags during the DSPy optimization call
         suppression_state_during_call["set_verbose"] = litellm.set_verbose
         suppression_state_during_call["suppress_debug_info"] = litellm.suppress_debug_info
 
-        # Return a mock optimized program
         mock_program = Mock()
         mock_program.signature = Mock()
         mock_program.signature.instructions = "Optimized instructions"
@@ -343,7 +299,6 @@ def test_dspy_align_litellm_nonfatal_error_messages_suppressed():
     ):
         optimizer.align(mock_judge, mock_traces)
 
-        # Verify suppression was active during the DSPy optimization call
         assert suppression_state_during_call["set_verbose"] is False
         assert suppression_state_during_call["suppress_debug_info"] is True
 
@@ -353,7 +308,6 @@ def test_align_configures_databricks_lm_in_context(sample_traces_with_assessment
     mock_judge = MockJudge(name="mock_judge", model="openai:/gpt-4")
     optimizer = ConcreteDSPyOptimizer(model="databricks")
 
-    # This is necessary because the LM is set in a specific context within `align`
     def check_context(*args, **kwargs):
         assert isinstance(dspy.settings["lm"], AgentEvalLM)
         return MagicMock()
@@ -371,7 +325,6 @@ def test_align_configures_openai_lm_in_context(sample_traces_with_assessments):
     mock_judge = MockJudge(name="mock_judge", model="openai:/gpt-4")
     optimizer = ConcreteDSPyOptimizer(model="openai:/gpt-4.1")
 
-    # This is necessary because the LM is set in a specific context within `align`
     def check_context(*args, **kwargs):
         assert isinstance(dspy.settings["lm"], dspy.LM)
         assert dspy.settings["lm"].model == "openai/gpt-4.1"
@@ -397,25 +350,12 @@ def test_align_configures_openai_lm_in_context(sample_traces_with_assessments):
     ],
 )
 def test_custom_predict_forward_lm_parameter_handling(lm_value, lm_model, expected_judge_model):
-    """Test that CustomPredict.forward handles the lm parameter correctly in all cases.
-
-    Args:
-        lm_value: Whether to pass an lm parameter (None or "mock_lm")
-        lm_model: The model string to set on the mock lm object
-        expected_judge_model: The expected model that should be passed to make_judge
-    """
-    # Ensure databricks constant matches our test expectation
-    assert _DATABRICKS_DEFAULT_JUDGE_MODEL == "databricks"
-
-    # Create a mock judge with a default model
     original_judge_model = "openai:/gpt-4"
     mock_judge = MockJudge(name="test_judge", model=original_judge_model)
 
-    # Create optimizer and program
     optimizer = ConcreteDSPyOptimizer()
     program = optimizer._get_dspy_program_from_judge(mock_judge)
 
-    # Track what models are passed to make_judge
     make_judge_calls = []
 
     def track_make_judge(name, instructions, model):
@@ -426,20 +366,13 @@ def test_custom_predict_forward_lm_parameter_handling(lm_value, lm_model, expect
         return MagicMock(return_value=mock_feedback)
 
     with patch("mlflow.genai.judges.optimizers.dspy.make_judge", side_effect=track_make_judge):
-        # Prepare the lm parameter based on test case
         kwargs = {"inputs": "test", "outputs": "test"}
         if lm_value == "mock_lm":
             mock_lm = MagicMock()
             mock_lm.model = lm_model
             kwargs["lm"] = mock_lm
 
-        # Call forward with or without lm parameter
         program.forward(**kwargs)
 
-        # Verify the correct model was passed to make_judge
-        assert len(make_judge_calls) == 1, (
-            f"Expected 1 call to make_judge, got {len(make_judge_calls)}"
-        )
-        assert make_judge_calls[0] == expected_judge_model, (
-            f"Expected {expected_judge_model}, got {make_judge_calls[0]}"
-        )
+        assert len(make_judge_calls) == 1
+        assert make_judge_calls[0] == expected_judge_model

--- a/tests/genai/judges/optimizers/test_dspy_base.py
+++ b/tests/genai/judges/optimizers/test_dspy_base.py
@@ -384,23 +384,19 @@ def test_custom_predict_forward_lm_parameter_handling(lm_value, lm_model, expect
         assert captured_args["instructions"] == mock_judge.instructions
 
 
-def test_custom_predict_uses_optimized_instructions():
+def test_custom_predict_uses_optimized_instructions(sample_traces_with_assessments):
     """Test that CustomPredict uses optimized instructions after DSPy optimization."""
-    original_instructions = "Original judge instructions for evaluation"
-    optimized_instructions = "Optimized instructions after DSPy alignment"
-
-    mock_judge = MockJudge(
-        name="optimization_test_judge", model="openai:/gpt-4", instructions=original_instructions
+    original_instructions = (
+        "Original judge instructions for evaluation of {{inputs}} and {{outputs}}"
+    )
+    optimized_instructions = (
+        "Optimized instructions after DSPy alignment for {{inputs}} and {{outputs}}"
     )
 
-    optimizer = ConcreteDSPyOptimizer()
-    program = optimizer._get_dspy_program_from_judge(mock_judge)
-
-    # Verify initial instructions are from the judge
-    assert program.signature.instructions == original_instructions
-
-    # Simulate DSPy optimization updating the signature instructions
-    program.signature.instructions = optimized_instructions
+    # Use the same judge name as in the fixture assessments
+    mock_judge = MockJudge(
+        name="mock_judge", model="openai:/gpt-4", instructions=original_instructions
+    )
 
     captured_instructions = None
 
@@ -412,8 +408,28 @@ def test_custom_predict_uses_optimized_instructions():
         mock_feedback.rationale = "Test"
         return MagicMock(return_value=mock_feedback)
 
-    with patch("mlflow.genai.judges.optimizers.dspy.make_judge", side_effect=capture_make_judge):
-        program.forward(inputs="test input", outputs="test output")
+    # Override the _dspy_optimize to modify instructions and verify they're used
+    class TestOptimizer(ConcreteDSPyOptimizer):
+        def _dspy_optimize(self, program, examples, metric_fn):
+            # Simulate DSPy optimization by modifying the program's instructions
+            program.signature.instructions = optimized_instructions
 
-        # Should use the optimized instructions, not the original
+            # Call the program to trigger make_judge and capture instructions
+            with patch(
+                "mlflow.genai.judges.optimizers.dspy.make_judge", side_effect=capture_make_judge
+            ):
+                program.forward(inputs="test input", outputs="test output")
+
+            return program
+
+    optimizer = TestOptimizer()
+
+    with (
+        patch("dspy.LM", MagicMock()),
+        patch.object(TestOptimizer, "get_min_traces_required", return_value=5),
+    ):
+        # Run align which will call _dspy_optimize internally
+        optimizer.align(mock_judge, sample_traces_with_assessments)
+
+        # Verify that the optimized instructions were used
         assert captured_instructions == optimized_instructions

--- a/tests/genai/judges/optimizers/test_dspy_base.py
+++ b/tests/genai/judges/optimizers/test_dspy_base.py
@@ -15,7 +15,7 @@ from mlflow.genai.judges.optimizers.dspy_utils import AgentEvalLM, convert_mlflo
 from tests.genai.judges.optimizers.conftest import MockDSPyLM, MockJudge
 
 
-def create_mock_make_judge(
+def make_judge_mock_builder(
     expected_model: str | None = None, track_calls: list[str] | None = None
 ) -> Callable[[str, str, str], MagicMock]:
     """Create a mock make_judge function for testing.
@@ -158,7 +158,7 @@ def test_optimizer_and_judge_use_different_models(sample_traces_with_assessments
     judge_lm = MockDSPyLM(convert_mlflow_uri_to_litellm(judge_model))
 
     mock_lm_factory = _create_mock_dspy_lm_factory(optimizer_lm, judge_lm)
-    mock_make_judge = create_mock_make_judge(
+    mock_make_judge = make_judge_mock_builder(
         expected_model=judge_model, track_calls=judge_lm.context_calls
     )
 
@@ -257,7 +257,7 @@ def test_mlflow_to_litellm_uri_conversion_in_judge_program():
     optimizer = ConcreteDSPyOptimizer()
 
     make_judge_calls = []
-    mock_make_judge = create_mock_make_judge(
+    mock_make_judge = make_judge_mock_builder(
         expected_model=mock_judge.model, track_calls=make_judge_calls
     )
 

--- a/tests/genai/judges/optimizers/test_dspy_base.py
+++ b/tests/genai/judges/optimizers/test_dspy_base.py
@@ -9,6 +9,7 @@ import pytest
 
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
 from mlflow.genai.judges.optimizers.dspy import DSPyAlignmentOptimizer
 from mlflow.genai.judges.optimizers.dspy_utils import AgentEvalLM, convert_mlflow_uri_to_litellm
 
@@ -388,36 +389,21 @@ def test_align_configures_openai_lm_in_context(sample_traces_with_assessments):
 
 
 @pytest.mark.parametrize(
-    ("lm_value", "lm_model", "expected_judge_model", "test_description"),
+    ("lm_value", "lm_model", "expected_judge_model"),
     [
-        (None, None, "openai:/gpt-4", "No lm parameter - should use original judge model"),
-        (
-            "mock_lm",
-            "anthropic/claude-3",
-            "anthropic:/claude-3",
-            "Regular model - should convert from LiteLLM to MLflow format",
-        ),
-        (
-            "mock_lm",
-            "databricks",
-            "databricks",
-            "Databricks default - should use directly without conversion",
-        ),
+        (None, None, "openai:/gpt-4"),
+        ("mock_lm", "anthropic/claude-3", "anthropic:/claude-3"),
+        ("mock_lm", "databricks", "databricks"),
     ],
 )
-def test_custom_predict_forward_lm_parameter_handling(
-    lm_value, lm_model, expected_judge_model, test_description
-):
+def test_custom_predict_forward_lm_parameter_handling(lm_value, lm_model, expected_judge_model):
     """Test that CustomPredict.forward handles the lm parameter correctly in all cases.
 
     Args:
         lm_value: Whether to pass an lm parameter (None or "mock_lm")
         lm_model: The model string to set on the mock lm object
         expected_judge_model: The expected model that should be passed to make_judge
-        test_description: Description of what this test case is testing
     """
-    from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
-
     # Ensure databricks constant matches our test expectation
     assert _DATABRICKS_DEFAULT_JUDGE_MODEL == "databricks"
 
@@ -455,5 +441,5 @@ def test_custom_predict_forward_lm_parameter_handling(
             f"Expected 1 call to make_judge, got {len(make_judge_calls)}"
         )
         assert make_judge_calls[0] == expected_judge_model, (
-            f"{test_description}: Expected {expected_judge_model}, got {make_judge_calls[0]}"
+            f"Expected {expected_judge_model}, got {make_judge_calls[0]}"
         )

--- a/tests/genai/judges/optimizers/test_dspy_base.py
+++ b/tests/genai/judges/optimizers/test_dspy_base.py
@@ -349,7 +349,7 @@ def test_align_configures_openai_lm_in_context(sample_traces_with_assessments):
         ("mock_lm", "databricks", "databricks"),
     ],
 )
-def test_custom_predict_forward_lm_parameter_handling(lm_value, lm_model, expected_judge_model):
+def test_dspy_program_forward_lm_parameter_handling(lm_value, lm_model, expected_judge_model):
     original_judge_model = "openai:/gpt-4"
     mock_judge = MockJudge(name="test_judge", model=original_judge_model)
 
@@ -384,7 +384,7 @@ def test_custom_predict_forward_lm_parameter_handling(lm_value, lm_model, expect
         assert captured_args["instructions"] == mock_judge.instructions
 
 
-def test_custom_predict_uses_optimized_instructions(sample_traces_with_assessments):
+def test_dspy_program_uses_make_judge_with_optimized_instructions(sample_traces_with_assessments):
     """Test that CustomPredict uses optimized instructions after DSPy optimization."""
     original_instructions = (
         "Original judge instructions for evaluation of {{inputs}} and {{outputs}}"

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -217,19 +217,14 @@ def test_convert_litellm_to_mlflow_uri_invalid(invalid_model):
     """Test conversion with invalid LiteLLM model strings."""
     from mlflow.exceptions import MlflowException
 
-    if invalid_model is None:
-        # Special case for None - will fail on string operations
-        with pytest.raises((MlflowException, TypeError)):
-            convert_litellm_to_mlflow_uri(invalid_model)
-    else:
-        with pytest.raises(MlflowException, match="LiteLLM|empty") as exc_info:
-            convert_litellm_to_mlflow_uri(invalid_model)
+    with pytest.raises(MlflowException, match="LiteLLM|empty|None") as exc_info:
+        convert_litellm_to_mlflow_uri(invalid_model)
 
-        # Check that the error message is informative
-        if invalid_model == "":
-            assert "cannot be empty" in str(exc_info.value)
-        elif "/" not in invalid_model:
-            assert "Expected format: 'provider/model'" in str(exc_info.value)
+    # Check that the error message is informative
+    if invalid_model is None or invalid_model == "":
+        assert "cannot be empty or None" in str(exc_info.value)
+    elif "/" not in invalid_model:
+        assert "Expected format: 'provider/model'" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -12,19 +12,18 @@ from mlflow.genai.judges.optimizers.dspy_utils import (
     trace_to_dspy_example,
 )
 from mlflow.genai.utils.trace_utils import (
+    extract_expectations_from_trace,
     extract_request_from_trace,
     extract_response_from_trace,
 )
+
+from tests.genai.judges.optimizers.conftest import MockJudge
 
 
 def test_sanitize_judge_name(sample_trace_with_assessment, mock_judge):
     """Test judge name sanitization in trace_to_dspy_example."""
     # The sanitization is now done inside trace_to_dspy_example
     # Test that it correctly handles different judge name formats
-    from mlflow.genai.judges.optimizers.dspy_utils import trace_to_dspy_example
-
-    # Import MockJudge from conftest
-    from tests.genai.judges.optimizers.conftest import MockJudge
 
     # Mock dspy module
     mock_dspy = MagicMock()
@@ -86,8 +85,6 @@ def test_trace_to_dspy_example_success(sample_trace_with_assessment, mock_judge)
     assert isinstance(result, dspy.Example)
 
     # Construct an expected example and assert that the result is the same
-    from mlflow.genai.utils.trace_utils import extract_expectations_from_trace
-
     expected_example = dspy.Example(
         trace=trace,
         inputs=extract_request_from_trace(trace),

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -103,7 +103,6 @@ def test_trace_to_dspy_example_human_vs_llm_priority(
     ],
 )
 def test_trace_to_dspy_example_success(request, trace_fixture, required_fields, expected_inputs):
-    """Test successful conversion of trace to DSPy example with various field requirements."""
     dspy = pytest.importorskip("dspy", reason="DSPy not installed")
 
     # Get the trace fixture dynamically
@@ -317,7 +316,6 @@ def test_convert_mlflow_uri_to_litellm_invalid(invalid_uri):
     ],
 )
 def test_convert_litellm_to_mlflow_uri(litellm_model, expected_uri):
-    """Test conversion from LiteLLM format to MLflow URI format."""
     result = convert_litellm_to_mlflow_uri(litellm_model)
     assert result == expected_uri
 
@@ -334,7 +332,6 @@ def test_convert_litellm_to_mlflow_uri(litellm_model, expected_uri):
     ],
 )
 def test_convert_litellm_to_mlflow_uri_invalid(invalid_model):
-    """Test conversion with invalid LiteLLM model strings."""
     with pytest.raises(MlflowException, match="LiteLLM|empty|None") as exc_info:
         convert_litellm_to_mlflow_uri(invalid_model)
 
@@ -355,7 +352,6 @@ def test_convert_litellm_to_mlflow_uri_invalid(invalid_model):
     ],
 )
 def test_mlflow_to_litellm_uri_round_trip_conversion(mlflow_uri):
-    """Test that converting MLflow URI -> LiteLLM URI -> MLflow URI preserves original format."""
     # Convert MLflow -> LiteLLM
     litellm_format = convert_mlflow_uri_to_litellm(mlflow_uri)
     # Convert LiteLLM -> MLflow

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -226,22 +226,23 @@ def test_convert_litellm_to_mlflow_uri_invalid(invalid_model):
             assert "Expected format: 'provider/model'" in str(exc_info.value)
 
 
-def test_round_trip_conversion():
-    """Test that converting MLflow -> LiteLLM -> MLflow preserves the original format."""
-    test_cases = [
+@pytest.mark.parametrize(
+    "mlflow_uri",
+    [
         "openai:/gpt-4",
         "anthropic:/claude-3.5-sonnet",
         "cohere:/command",
         "databricks:/dbrx",
-    ]
-
-    for mlflow_uri in test_cases:
-        # Convert MLflow -> LiteLLM
-        litellm_format = convert_mlflow_uri_to_litellm(mlflow_uri)
-        # Convert LiteLLM -> MLflow
-        result = convert_litellm_to_mlflow_uri(litellm_format)
-        # Should get back the original
-        assert result == mlflow_uri, f"Round-trip failed for {mlflow_uri}"
+    ],
+)
+def test_mlflow_to_litellm_uri_round_trip_conversion(mlflow_uri):
+    """Test that converting MLflow URI -> LiteLLM URI -> MLflow URI preserves original format."""
+    # Convert MLflow -> LiteLLM
+    litellm_format = convert_mlflow_uri_to_litellm(mlflow_uri)
+    # Convert LiteLLM -> MLflow
+    result = convert_litellm_to_mlflow_uri(litellm_format)
+    # Should get back the original
+    assert result == mlflow_uri, f"Round-trip failed for {mlflow_uri}"
 
 
 @pytest.mark.parametrize(

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -4,8 +4,12 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.base import JudgeField
 from mlflow.genai.judges.optimizers.dspy_utils import (
+    AgentEvalLM,
     agreement_metric,
+    construct_dspy_lm,
     convert_litellm_to_mlflow_uri,
     convert_mlflow_uri_to_litellm,
     create_dspy_signature,
@@ -101,7 +105,6 @@ def test_trace_to_dspy_example_human_vs_llm_priority(
 def test_trace_to_dspy_example_success(request, trace_fixture, required_fields, expected_inputs):
     """Test successful conversion of trace to DSPy example with various field requirements."""
     dspy = pytest.importorskip("dspy", reason="DSPy not installed")
-    from mlflow.genai.judges.base import JudgeField
 
     # Get the trace fixture dynamically
     trace = request.getfixturevalue(trace_fixture)
@@ -192,8 +195,6 @@ def test_trace_to_dspy_example_missing_required_fields(
     request, trace_fixture, required_fields, warning_pattern, caplog
 ):
     """Test that trace_to_dspy_example returns None when required fields are missing."""
-    from mlflow.genai.judges.base import JudgeField
-
     # Get the trace fixture dynamically
     trace = request.getfixturevalue(trace_fixture)
 
@@ -300,8 +301,6 @@ def test_convert_mlflow_uri_to_litellm(mlflow_uri, expected_litellm_uri):
 )
 def test_convert_mlflow_uri_to_litellm_invalid(invalid_uri):
     """Test conversion with invalid URIs."""
-    from mlflow.exceptions import MlflowException
-
     with pytest.raises(MlflowException, match="Failed to convert MLflow URI"):
         convert_mlflow_uri_to_litellm(invalid_uri)
 
@@ -336,8 +335,6 @@ def test_convert_litellm_to_mlflow_uri(litellm_model, expected_uri):
 )
 def test_convert_litellm_to_mlflow_uri_invalid(invalid_model):
     """Test conversion with invalid LiteLLM model strings."""
-    from mlflow.exceptions import MlflowException
-
     with pytest.raises(MlflowException, match="LiteLLM|empty|None") as exc_info:
         convert_litellm_to_mlflow_uri(invalid_model)
 
@@ -378,8 +375,6 @@ def test_mlflow_to_litellm_uri_round_trip_conversion(mlflow_uri):
 def test_construct_dspy_lm_utility_method(model, expected_type):
     """Test the construct_dspy_lm utility method with different model types."""
     import dspy
-
-    from mlflow.genai.judges.optimizers.dspy_utils import AgentEvalLM, construct_dspy_lm
 
     result = construct_dspy_lm(model)
 

--- a/tests/genai/judges/optimizers/test_dspy_utils.py
+++ b/tests/genai/judges/optimizers/test_dspy_utils.py
@@ -12,7 +12,6 @@ from mlflow.genai.judges.optimizers.dspy_utils import (
     trace_to_dspy_example,
 )
 from mlflow.genai.utils.trace_utils import (
-    extract_expectations_from_trace,
     extract_request_from_trace,
     extract_response_from_trace,
 )
@@ -86,13 +85,11 @@ def test_trace_to_dspy_example_success(sample_trace_with_assessment, mock_judge)
 
     # Construct an expected example and assert that the result is the same
     expected_example = dspy.Example(
-        trace=trace,
         inputs=extract_request_from_trace(trace),
         outputs=extract_response_from_trace(trace),
-        expectations=extract_expectations_from_trace(trace),
         result="pass",
         rationale="This looks good",
-    ).with_inputs("trace", "inputs", "outputs", "expectations")
+    ).with_inputs("inputs", "outputs")
 
     # Compare the examples
     assert result == expected_example


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/17703?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17703/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17703/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17703/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Judges - support aligning judges that read fields from traces

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
