### PR TITLE
Fix Visualizations in UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.tsx
@@ -66,4 +66,34 @@ describe('CompareRunView', () => {
       expect(screen.getByText(/Comparing 0 Runs/)).toBeInTheDocument();
     });
   });
+
+  test('Displays visualizations section with parallel coordinates plot by default', async () => {
+    render(
+      <MockedReduxStoreProvider
+        state={
+          {
+            compareExperiments: {},
+            comparedExperiments: {},
+            entities: {
+              experimentsById: { exp_1: {} },
+              runInfosByUuid: { run_1: { runUuid: 'run_1' }, run_2: { runUuid: 'run_2' } },
+              paramsByRunUuid: { run_1: {}, run_2: {} },
+              latestMetricsByRunUuid: { run_1: {}, run_2: {} },
+              tagsByRunUuid: { run_1: {}, run_2: {} },
+            },
+          } as any
+        }
+      >
+        <CompareRunView experimentIds={['exp_1']} runUuids={['run_1', 'run_2']} />
+      </MockedReduxStoreProvider>,
+      {
+        wrapper,
+      },
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText(/Visualizations/i)).toBeInTheDocument();
+      expect(screen.getByText(/Parallel Coordinates Plot/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.tsx
@@ -447,6 +447,65 @@ class CompareRunView extends Component<CompareRunViewProps, CompareRunViewState>
         <PageHeader title={title} breadcrumbs={breadcrumbs} spacerSize="xs" />
         <CollapsibleSection
           title={this.props.intl.formatMessage({
+            defaultMessage: 'Visualizations',
+            description: 'Tabs title for plots on the compare runs page',
+          })}
+        >
+          <LegacyTabs>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Parallel Coordinates Plot"
+                  // eslint-disable-next-line max-len
+                  description="Tab pane title for parallel coordinate plots on the compare runs page"
+                />
+              }
+              key="parallel-coordinates-plot"
+            >
+              <ParallelCoordinatesPlotPanel runUuids={this.props.runUuids} />
+            </TabPane>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Scatter Plot"
+                  description="Tab pane title for scatterplots on the compare runs page"
+                />
+              }
+              key="scatter-plot"
+            >
+              <CompareRunScatter runUuids={this.props.runUuids} runDisplayNames={this.props.runDisplayNames} />
+            </TabPane>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Box Plot"
+                  description="Tab pane title for box plot on the compare runs page"
+                />
+              }
+              key="box-plot"
+            >
+              <CompareRunBox
+                runUuids={runUuids}
+                runInfos={runInfos}
+                paramLists={paramLists}
+                metricLists={metricLists}
+              />
+            </TabPane>
+            <TabPane
+              tab={
+                <FormattedMessage
+                  defaultMessage="Contour Plot"
+                  description="Tab pane title for contour plots on the compare runs page"
+                />
+              }
+              key="contour-plot"
+            >
+              <CompareRunContour runUuids={this.props.runUuids} runDisplayNames={this.props.runDisplayNames} />
+            </TabPane>
+          </LegacyTabs>
+        </CollapsibleSection>
+        <CollapsibleSection
+          title={this.props.intl.formatMessage({
             defaultMessage: 'Run details',
             description: 'Compare table title on the compare runs page',
           })}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1202,6 +1202,10 @@
     "defaultMessage": "No attributes found",
     "description": "Empty state for the attributes tab in the model trace explorer. Attributes are properties of a span that the user defines."
   },
+  "B80MC6": {
+    "defaultMessage": "Contour Plot",
+    "description": "Tab pane title for contour plots on the compare runs page"
+  },
   "B8RvlZ": {
     "defaultMessage": "Comparing version {baseline} with version {compared}",
     "description": "Label for comparing prompt versions in the prompt comparison view. Variables {baseline} and {compared} are numeric version numbers being compared."
@@ -2326,6 +2330,10 @@
     "defaultMessage": "Close",
     "description": "Error modal close button text"
   },
+  "OimAJb": {
+    "defaultMessage": "Scatter Plot",
+    "description": "Tab pane title for scatterplots on the compare runs page"
+  },
   "Oj2ENw": {
     "defaultMessage": "No models registered yet. <link>Learn more about registering models</link>.",
     "description": "Models table > no models present yet"
@@ -2544,6 +2552,10 @@
   "RzZVxC": {
     "defaultMessage": "An error occurred while rendering this component.",
     "description": "Description of error fallback component"
+  },
+  "S7ESYH": {
+    "defaultMessage": "Visualizations",
+    "description": "Tabs title for plots on the compare runs page"
   },
   "SCYMXw": {
     "defaultMessage": "Cancel",
@@ -5046,6 +5058,10 @@
   "sOQcFW": {
     "defaultMessage": "None",
     "description": "Label for the button disabling grouping in the logged model list page"
+  },
+  "sTp/V3": {
+    "defaultMessage": "Parallel Coordinates Plot",
+    "description": "Tab pane title for parallel coordinate plots on the compare runs page"
   },
   "sWbj1n": {
     "defaultMessage": "Apply filters",


### PR DESCRIPTION
### Related Issues/PRs

Fix #17388 

### What changes are proposed in this pull request?

Upon UI sync #17092 , the Visualizations section was removed when we compare different run. This PR restores the removed Visualizations section

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1519" height="939" alt="Screenshot 2025-09-14 at 2 21 10 PM" src="https://github.com/user-attachments/assets/ea653600-5f8b-4441-8c08-e910789faf1c" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
