### PR TITLE
Markdown UI fix

### DIFF
--- a/mlflow/server/js/src/common/components/EditableNote.test.tsx
+++ b/mlflow/server/js/src/common/components/EditableNote.test.tsx
@@ -58,4 +58,11 @@ describe('EditableNote', () => {
     expect(mockSubmit).toHaveBeenCalledTimes(1);
     expect(screen.getByText('Failed to submit')).toBeInTheDocument();
   });
+  test('updates displayed description when defaultMarkdown changes', () => {
+    const { rerender } = renderWithIntl(<EditableNote {...minimalProps} defaultMarkdown="first description" />);
+    expect(screen.getByText('first description')).toBeInTheDocument();
+
+    rerender(<EditableNote {...minimalProps} defaultMarkdown="second description" />);
+    expect(screen.getByText('second description')).toBeInTheDocument();
+  });
 });

--- a/mlflow/server/js/src/common/components/EditableNote.tsx
+++ b/mlflow/server/js/src/common/components/EditableNote.tsx
@@ -60,6 +60,18 @@ export class EditableNoteImpl extends Component<EditableNoteImplProps, EditableN
 
   converter = getMarkdownConverter();
 
+  componentDidUpdate(prevProps: EditableNoteImplProps) {
+    if (
+      prevProps.defaultMarkdown !== this.props.defaultMarkdown ||
+      prevProps.defaultSelectedTab !== this.props.defaultSelectedTab
+    ) {
+      this.setState({
+        markdown: this.props.defaultMarkdown,
+        selectedTab: this.props.defaultSelectedTab,
+      });
+    }
+  }
+
   handleMdeValueChange = (markdown: any) => {
     this.setState({ markdown });
   };


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/17725?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17725/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17725/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17725/merge
```

</p>
</details>

### Related Issues/PRs

Fix #17694 

### What changes are proposed in this pull request?

Fix description not updating on parent run. Updated the `EditableNote` component to reset its internal markdown and tab state whenever the description or selected tab props change, ensuring run descriptions refresh correctly when navigating between runs

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/aaf48d96-3612-4d21-8095-f3d4502a5a28


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix description not updating on parent run.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
