### PR TITLE
[OTel UI] Hide empty tabs in trace UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/components/GenAiEvaluationTracesReview.utils.tsx
@@ -625,7 +625,11 @@ export const getEvaluationResultTitle = (evaluation: RunEvaluationTracesDataEntr
     title = stringifyValue(evaluation.inputs);
   }
 
-  return title ?? evaluation.evaluationId;
+  if (isNil(title) || title === '') {
+    title = evaluation.evaluationId;
+  }
+
+  return title;
 };
 
 /**

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.tsx
@@ -104,7 +104,7 @@ const ContextProviders = ({ children }: { traceId: string; children: React.React
 export const ModelTraceExplorerImpl = ({
   modelTrace: initialModelTrace,
   className,
-  initialActiveView = 'summary',
+  initialActiveView,
   selectedSpanId,
   onSelectSpan,
 }: {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -1048,3 +1048,22 @@ export const prettyPrintChatMessage = (message: RawModelTraceChatMessage): Model
     tool_calls: message.tool_calls?.map(prettyPrintToolCall),
   };
 };
+
+export const getDefaultActiveTab = (
+  selectedNode: ModelTraceSpanNode | undefined,
+): 'chat' | 'content' | 'attributes' | 'events' => {
+  if (isNil(selectedNode)) {
+    return 'content';
+  }
+
+  if (selectedNode.chatMessages) {
+    return 'chat';
+  }
+
+  const hasInputsOrOutputs = !isNil(selectedNode.inputs) || !isNil(selectedNode.outputs);
+  if (hasInputsOrOutputs) {
+    return 'content';
+  }
+
+  return 'attributes';
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorerDetailView.tsx
@@ -86,8 +86,6 @@ export const ModelTraceExplorerDetailView = ({
 
   const onSelectNode = (node?: ModelTraceSpanNode) => {
     setSelectedNode(node);
-    // Open left most tab when a span is clicked
-    setActiveTab(node?.chatMessages ? 'chat' : 'content');
     if (isString(node?.key)) {
       onSelectSpan?.(node?.key);
     }

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerRightPaneTabs.tsx
@@ -47,6 +47,8 @@ function ModelTraceExplorerRightPaneTabsImpl({
 
   const exceptionCount = getSpanExceptionCount(activeSpan);
   const hasException = exceptionCount > 0;
+  const hasInputsOrOutputs = !isNil(activeSpan?.inputs) || !isNil(activeSpan?.outputs);
+
   const tabContent = (
     <Tabs.Root
       componentId="shared.model-trace-explorer.right-pane-tabs"
@@ -84,12 +86,14 @@ function ModelTraceExplorerRightPaneTabsImpl({
             <FormattedMessage defaultMessage="Chat" description="Label for the chat tab of the model trace explorer." />
           </Tabs.Trigger>
         )}
-        <Tabs.Trigger value="content">
-          <FormattedMessage
-            defaultMessage="Inputs / Outputs"
-            description="Label for the inputs and outputs tab of the model trace explorer."
-          />
-        </Tabs.Trigger>
+        {hasInputsOrOutputs && (
+          <Tabs.Trigger value="content">
+            <FormattedMessage
+              defaultMessage="Inputs / Outputs"
+              description="Label for the inputs and outputs tab of the model trace explorer."
+            />
+          </Tabs.Trigger>
+        )}
         {/* no i18n for attributes and events as these are properties specified by code,
             and it might be confusing for users to have different labels here */}
         <Tabs.Trigger value="attributes">Attributes</Tabs.Trigger>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/17733?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17733/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17733/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17733/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently the trace UI relies heavily on `spanInputs` / `spanOutputs` to render content. However, in OTel traces, these trace metadata will not be set. To prevent a weird experience for users, this PR hides empty tabs in the trace UI, and defaults the view to "detail view" when there is no input/output in the root span.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/37698d43-f03f-4936-86e8-4cf67c5c9ae4



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
