### PR TITLE
Prevent duplicate redirects from being registered for docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -33,6 +33,7 @@ const config: Config = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
   onBrokenAnchors: 'throw',
+  onDuplicateRoutes: 'throw', // Fail build on duplicate redirects
 
   // Even if you don't use internationalization, you can use this field to set
   // useful metadata like html lang. For example, if your site is Chinese, you


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17737?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17737/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17737/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17737/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fails the docusaurus build if there are duplicate redirects defined.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

```bash
[ERROR] Error: Unable to build website for locale en.
    at tryToBuildLocale (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:78:15)
    at async /Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:34:9
    at async mapAsyncSequential (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/utils/lib/jsUtils.js:21:24)
    at async Command.build (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/lib/commands/build/build.js:33:5)
    at async Promise.all (index 0)
    at async runCLI (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/lib/commands/cli.js:56:5)
    at async file:///Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/bin/docusaurus.mjs:44:3 {
  [cause]: Error: @docusaurus/plugin-client-redirects: multiple redirects are created with the same "from" pathname: "/genai/data-model"
  It is not possible to redirect the same pathname to multiple destinations:
  - {"from":"/genai/data-model","to":"/genai/"}
  - {"from":"/genai/data-model","to":"/genai/"}
      at throwError (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/logger/lib/logger.js:80:11)
      at /Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/plugin-client-redirects/lib/collectRedirects.js:128:81
      at Array.forEach (<anonymous>)
      at filterUnwantedRedirects (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/plugin-client-redirects/lib/collectRedirects.js:126:86)
      at collectRedirects (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/plugin-client-redirects/lib/collectRedirects.js:40:12)
      at Object.postBuild (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/plugin-client-redirects/lib/index.js:34:62)
      at /Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:105:22
      at Array.map (<anonymous>)
      at executePluginsPostBuild (/Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:101:31)
      at /Users/benjamin.wilson/repos/mlflow-fork/mlflow/docs/node_modules/@docusaurus/core/lib/commands/build/buildLocale.js:91:58
}
```

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
