### PR TITLE
Make Spark Datasource failures silent

### DIFF
--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
@@ -118,7 +118,6 @@ object ReplAwareDatasourceAttributeExtractor extends DatasourceAttributeExtracto
     }
   }
 
-  // Attempts to apply redaction to sensitive data within datasource paths (e.g. S3 keys)
   private def tryRedactString(value: String): String = {
     try {
       val redactor = ReflectionUtils.getScalaObjectByName(
@@ -126,10 +125,10 @@ object ReplAwareDatasourceAttributeExtractor extends DatasourceAttributeExtracto
       ReflectionUtils.callMethod(redactor, "redact", Seq(value)).asInstanceOf[String]
     } catch {
       case NonFatal(e) =>
-        val msg = ExceptionUtils.getUnexpectedExceptionMessage(e, "while applying redaction to " +
-          "datasource paths")
-        logger.error(msg)
-        throw e
+        if (logger.isTraceEnabled) {
+          logger.trace(s"Redaction not available, using original value: ${e.getMessage}")
+        }
+        value
     }
   }
 

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ExceptionUtils.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ExceptionUtils.scala
@@ -20,13 +20,25 @@ private[autologging] object ExceptionUtils {
       s"${ExceptionUtils.serializeException(exc)}"
   }
 
+  def tryAndLogSilently(logger: Logger, errorMsg: String, fn: => Any): Unit = {
+    try {
+      fn
+    } catch {
+      case NonFatal(e) =>
+        if (logger.isTraceEnabled) {
+          logger.trace(s"Skipping operation $errorMsg: ${e.getMessage}")
+        }
+    }
+  }
 
   def tryAndLogUnexpectedError(logger: Logger, errorMsg: String, fn: => Any): Unit = {
     try {
       fn
     } catch {
       case NonFatal(e) =>
-        logger.error(getUnexpectedExceptionMessage(e, errorMsg))
+        if (logger.isTraceEnabled) {
+          logger.trace(getUnexpectedExceptionMessage(e, errorMsg))
+        }
     }
   }
 

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
@@ -134,9 +134,11 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
             s"removing it")
           Seq(replId)
         case NonFatal(e) =>
-          val msg = ExceptionUtils.getUnexpectedExceptionMessage(e, "while checking health " +
-            s"of subscriber with repl ID $replId, removing it")
-          logger.error(msg)
+          if (logger.isTraceEnabled) {
+            val msg = ExceptionUtils.getUnexpectedExceptionMessage(e, "while checking health " +
+              s"of subscriber with repl ID $replId, removing it")
+            logger.trace(msg)
+          }
           Seq(replId)
       }
     }
@@ -166,8 +168,10 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
               listener.notify(path, version.getOrElse("unknown"), format.getOrElse("unknown"))
             } catch {
               case NonFatal(e) =>
-                logger.error(s"Unable to forward event to listener with repl ID $replId. " +
-                  s"Exception:\n${ExceptionUtils.serializeException(e)}")
+                if (logger.isTraceEnabled) {
+                  logger.trace(s"Unable to forward event to listener with repl ID $replId. " +
+                    s"Exception:\n${ExceptionUtils.serializeException(e)}")
+                }
             }
           }
         }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
@@ -3,6 +3,7 @@ package org.mlflow.spark.autologging
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 import org.slf4j.LoggerFactory
+import scala.util.control.NonFatal
 
 
 /**
@@ -28,16 +29,12 @@ class SparkDataSourceListener(
   override def onOtherEvent(event: SparkListenerEvent): Unit = {
     event match {
       case e: SparkListenerSQLExecutionEnd =>
-        // Defensively catch exceptions while attempting to extract datasource read information
-        // from the SparkListenerSQLExecutionEnd event. In particular, we do this to defend
-        // against changes in the internal APIs we access (e.g. changes in Delta table classnames
-        // or removal of the QueryExecution field from SparkListenerSQLExecutionEnd) in future
-        // Spark versions. As of the time of writing, Spark seems to also catch these exceptions,
-        // but we defensively catch here to be safe & give the user a better error message.
-        ExceptionUtils.tryAndLogUnexpectedError(
-          logger, "when attempting to handle SparkListenerSQLExecutionEnd event", {
+        try {
           onSQLExecutionEnd(e)
-        })
+        } catch {
+          case NonFatal(ex) =>
+            logger.trace(s"Skipping datasource autolog: ${ex.getMessage}")
+        }
       case _ =>
     }
   }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17741?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17741/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17741/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17741/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The red-herring nature for when this warning is triggered leads users who have issues in Structured Streaming jobs (due to how the injected listener resides within the call stack) think that the root cause of their issue is related to MLflow's dataset association logic. 
This PR makes these listener APIs fail silently to avoid confusing users who are not using MLflow.

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
