### PR TITLE
Add helper function for genai evaluate

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -89,6 +89,33 @@ def evaluate(
             scorers=[Correctness(), Safety()],
         )
 
+    If you need to extract the request and response from the root span in a custom way,
+    you can use `convert_trace_df_to_eval_dataset` to convert the trace dataframe to an
+    evaluation dataset.
+
+    .. code-block:: python
+
+        from mlflow.genai.evaluation.utils import convert_trace_df_to_eval_dataset
+
+
+        # Define a function to extract the request and response from the root span
+        def extract_func(
+            root_span_attributes: dict[str, Any], key: Literal["request", "response"]
+        ) -> Any:
+            if key == "request":
+                return json.loads(root_span_attributes.get("traceloop.entity.input")).get(
+                    "inputs"
+                )
+            if key == "response":
+                return json.loads(root_span_attributes.get("traceloop.entity.output")).get(
+                    "outputs"
+                )
+
+
+        trace_df = mlflow.search_traces(model_id="<my-model-id>")
+        eval_data = convert_trace_df_to_eval_dataset(trace_df, extract_func=extract_func)
+        mlflow.genai.evaluate(eval_data, scorers=[Correctness(), Safety()])
+
     Built-in scorers will understand the model inputs, outputs, and other intermediate
     information e.g. retrieved context, from the trace object. You can also access to
     the trace object from the custom scorer function by using the `trace` parameter.

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -46,7 +46,7 @@ class EvalItem:
         """
         Create an EvalItem from a row of input Pandas Dataframe row.
         """
-        if inputs := row.get(InputDatasetColumn.INPUTS):
+        if (inputs := row.get(InputDatasetColumn.INPUTS)) is not None:
             inputs = cls._parse_inputs(inputs)
         else:
             raise MlflowException.invalid_parameter_value(

--- a/mlflow/genai/evaluation/entities.py
+++ b/mlflow/genai/evaluation/entities.py
@@ -46,7 +46,12 @@ class EvalItem:
         """
         Create an EvalItem from a row of input Pandas Dataframe row.
         """
-        inputs = cls._parse_inputs(row.get(InputDatasetColumn.INPUTS))
+        if inputs := row.get(InputDatasetColumn.INPUTS):
+            inputs = cls._parse_inputs(inputs)
+        else:
+            raise MlflowException.invalid_parameter_value(
+                "Dataset row must contain 'inputs' or 'request' key"
+            )
         outputs = row.get(InputDatasetColumn.OUTPUTS)
 
         # Get the request ID from the row, or generate a new unique ID if not present.

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -407,12 +407,12 @@ def complete_eval_futures_with_progress_base(futures: list[Future]) -> list["Eva
 
 @experimental(version="3.5.0")
 def convert_trace_df_to_eval_dataset(
-    df: pd.DataFrame,
+    df: "pd.DataFrame",
     request_key: str | None = None,
     response_key: str | None = None,
     extract_func: Callable[[dict[str, Any], Literal["request", "response"]], dict[str, Any]]
     | None = None,
-) -> pd.DataFrame:
+) -> "pd.DataFrame":
     """
     Convert a dataframe of traces to the format that mlflow.genai.evaluate() expects.
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -222,6 +222,9 @@ def parse_outputs_to_str(value: Any) -> str:
 
     value = _to_dict(value)
 
+    if not isinstance(value, dict):
+        return json.dumps(value, cls=TraceJSONEncoder)
+
     # Special handling for chat response
     if _is_chat_choices(value.get(_CHOICES_KEY)):
         content = value[_CHOICES_KEY][0][_MESSAGE_KEY][_CONTENT_KEY]

--- a/tests/genai/evaluation/test_entities.py
+++ b/tests/genai/evaluation/test_entities.py
@@ -1,0 +1,88 @@
+import pandas as pd
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.evaluation.entities import EvalItem, InputDatasetColumn
+
+
+@pytest.mark.parametrize(
+    ("row_data", "expected_inputs", "expected_outputs", "expected_request_id", "check_request_id"),
+    [
+        (
+            {
+                InputDatasetColumn.INPUTS: {"prompt": "test"},
+                InputDatasetColumn.OUTPUTS: {"response": "output"},
+                InputDatasetColumn.REQUEST_ID: "req_123",
+            },
+            {"prompt": "test"},
+            {"response": "output"},
+            "req_123",
+            True,
+        ),
+        (
+            {
+                InputDatasetColumn.INPUTS: '"valid json string"',
+                InputDatasetColumn.OUTPUTS: "simple output",
+            },
+            "valid json string",
+            "simple output",
+            None,
+            False,
+        ),
+    ],
+)
+def test_eval_item_from_dataset_row_valid(
+    row_data, expected_inputs, expected_outputs, expected_request_id, check_request_id
+):
+    row = pd.Series(row_data)
+    eval_item = EvalItem.from_dataset_row(row)
+
+    assert eval_item.inputs == expected_inputs
+    assert eval_item.outputs == expected_outputs
+
+    if check_request_id:
+        assert eval_item.request_id == expected_request_id
+    else:
+        # When request_id is not provided, it should be auto-generated
+        assert eval_item.request_id is not None
+        assert isinstance(eval_item.request_id, str)
+        assert len(eval_item.request_id) > 0
+
+
+@pytest.mark.parametrize(
+    ("row_data", "error_match"),
+    [
+        (
+            {
+                InputDatasetColumn.INPUTS: None,
+                InputDatasetColumn.OUTPUTS: {"response": "output"},
+            },
+            "Dataset row must contain 'inputs' or 'request' key",
+        ),
+        (
+            {
+                InputDatasetColumn.OUTPUTS: {"response": "output"},
+            },
+            "Dataset row must contain 'inputs' or 'request' key",
+        ),
+        (
+            {
+                InputDatasetColumn.INPUTS: {},
+                InputDatasetColumn.OUTPUTS: {"response": "output"},
+            },
+            "Dataset row must contain 'inputs' or 'request' key",
+        ),
+        (
+            {
+                InputDatasetColumn.INPUTS: "invalid json string",
+                InputDatasetColumn.OUTPUTS: "simple output",
+            },
+            "Failed to parse inputs as JSON",
+        ),
+    ],
+)
+def test_eval_item_from_dataset_row_invalid(row_data, error_match):
+    row = pd.Series(row_data)
+
+    with pytest.raises(MlflowException, match=error_match):
+        EvalItem.from_dataset_row(row)

--- a/tests/genai/evaluation/test_entities.py
+++ b/tests/genai/evaluation/test_entities.py
@@ -67,13 +67,6 @@ def test_eval_item_from_dataset_row_valid(
         ),
         (
             {
-                InputDatasetColumn.INPUTS: {},
-                InputDatasetColumn.OUTPUTS: {"response": "output"},
-            },
-            "Dataset row must contain 'inputs' or 'request' key",
-        ),
-        (
-            {
                 InputDatasetColumn.INPUTS: "invalid json string",
                 InputDatasetColumn.OUTPUTS: "simple output",
             },

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -487,6 +487,29 @@ def test_parse_outputs_to_str(output_data, expected):
     assert parse_outputs_to_str(output_data) == expected
 
 
+def test_parse_outputs_to_str_with_non_dict_after_to_dict():
+    class CustomObject:
+        def to_dict(self):
+            return ["list", "not", "dict"]
+
+    result = parse_outputs_to_str(CustomObject())
+    assert result == '["list", "not", "dict"]'
+
+    class AnotherObject:
+        def to_dict(self):
+            return 42
+
+    result = parse_outputs_to_str(AnotherObject())
+    assert result == "42"
+
+    class StringObject:
+        def to_dict(self):
+            return "just a string"
+
+    result = parse_outputs_to_str(StringObject())
+    assert result == '"just a string"'
+
+
 @pytest.mark.parametrize(
     ("input_value", "expected"),
     [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/17746?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17746/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17746/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17746/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
When we support general OTel traces ingestion, the trace request/response is not the same attribute as MLflow traces, as a result the default returned value for `mlflow.search_traces` doesn't work with `mlflow.genai.evaluate`.
For general OTel traces eval support, I added a helper function `convert_trace_df_to_eval_dataset` to allow users:
1. pass request/response keys if they are the attribute value of root span
2. pass a custom extract_func with a specific signature, so users can control how to extract the nested request/response in attributes
Both are valid scenarios for different OTel clients.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
