### PR TITLE
Revert "Make Spark Datasource failures silent"

### DIFF
--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ExceptionUtils.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ExceptionUtils.scala
@@ -20,25 +20,13 @@ private[autologging] object ExceptionUtils {
       s"${ExceptionUtils.serializeException(exc)}"
   }
 
-  def tryAndLogSilently(logger: Logger, errorMsg: String, fn: => Any): Unit = {
-    try {
-      fn
-    } catch {
-      case NonFatal(e) =>
-        if (logger.isTraceEnabled) {
-          logger.trace(s"Skipping operation $errorMsg: ${e.getMessage}")
-        }
-    }
-  }
 
   def tryAndLogUnexpectedError(logger: Logger, errorMsg: String, fn: => Any): Unit = {
     try {
       fn
     } catch {
       case NonFatal(e) =>
-        if (logger.isTraceEnabled) {
-          logger.trace(getUnexpectedExceptionMessage(e, errorMsg))
-        }
+        logger.error(getUnexpectedExceptionMessage(e, errorMsg))
     }
   }
 

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/MlflowAutologEventPublisher.scala
@@ -134,11 +134,9 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
             s"removing it")
           Seq(replId)
         case NonFatal(e) =>
-          if (logger.isTraceEnabled) {
-            val msg = ExceptionUtils.getUnexpectedExceptionMessage(e, "while checking health " +
-              s"of subscriber with repl ID $replId, removing it")
-            logger.trace(msg)
-          }
+          val msg = ExceptionUtils.getUnexpectedExceptionMessage(e, "while checking health " +
+            s"of subscriber with repl ID $replId, removing it")
+          logger.error(msg)
           Seq(replId)
       }
     }
@@ -168,10 +166,8 @@ private[autologging] trait MlflowAutologEventPublisherImpl {
               listener.notify(path, version.getOrElse("unknown"), format.getOrElse("unknown"))
             } catch {
               case NonFatal(e) =>
-                if (logger.isTraceEnabled) {
-                  logger.trace(s"Unable to forward event to listener with repl ID $replId. " +
-                    s"Exception:\n${ExceptionUtils.serializeException(e)}")
-                }
+                logger.error(s"Unable to forward event to listener with repl ID $replId. " +
+                  s"Exception:\n${ExceptionUtils.serializeException(e)}")
             }
           }
         }

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/ReplAwareSparkDataSourceListener.scala
@@ -28,14 +28,20 @@ class ReplAwareSparkDataSourceListener(
   override def onJobStart(event: SparkListenerJobStart): Unit = {
     val properties = getProperties(event)
     val executionIdOpt = properties.get(SQLExecution.EXECUTION_ID_KEY).map(_.toLong)
-    val replIdOpt = properties.get("spark.databricks.replId")
-
-    (executionIdOpt, replIdOpt) match {
-      case (Some(executionId), Some(replId)) =>
-        executionIdToReplId.put(executionId, replId)
-      case _ =>
-        logger.trace(s"Skipping datasource autolog - required properties not available")
+    if (executionIdOpt.isEmpty) {
+      logger.warn(s"Unable to find execution ID of current Spark Job, " +
+        s"refusing to autolog datasource reads performed within current Spark job")
+      return
     }
+    val executionId = executionIdOpt.get
+    val replIdOpt = properties.get("spark.databricks.replId")
+    if (replIdOpt.isEmpty) {
+      logger.warn(s"Unable to find ID of REPL that triggered current Spark Job (execution ID " +
+        s"$executionId), " +
+        s"refusing to autolog datasource reads performed within current Spark job")
+      return
+    }
+    executionIdToReplId.put(executionId, replIdOpt.get)
   }
 
   protected[autologging] override def onSQLExecutionEnd(event: SparkListenerSQLExecutionEnd): Unit = {

--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/SparkDataSourceListener.scala
@@ -3,7 +3,6 @@ package org.mlflow.spark.autologging
 import org.apache.spark.scheduler._
 import org.apache.spark.sql.execution.ui.SparkListenerSQLExecutionEnd
 import org.slf4j.LoggerFactory
-import scala.util.control.NonFatal
 
 
 /**
@@ -29,12 +28,16 @@ class SparkDataSourceListener(
   override def onOtherEvent(event: SparkListenerEvent): Unit = {
     event match {
       case e: SparkListenerSQLExecutionEnd =>
-        try {
+        // Defensively catch exceptions while attempting to extract datasource read information
+        // from the SparkListenerSQLExecutionEnd event. In particular, we do this to defend
+        // against changes in the internal APIs we access (e.g. changes in Delta table classnames
+        // or removal of the QueryExecution field from SparkListenerSQLExecutionEnd) in future
+        // Spark versions. As of the time of writing, Spark seems to also catch these exceptions,
+        // but we defensively catch here to be safe & give the user a better error message.
+        ExceptionUtils.tryAndLogUnexpectedError(
+          logger, "when attempting to handle SparkListenerSQLExecutionEnd event", {
           onSQLExecutionEnd(e)
-        } catch {
-          case NonFatal(ex) =>
-            logger.trace(s"Skipping datasource autolog: ${ex.getMessage}")
-        }
+        })
       case _ =>
     }
   }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17751?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17751/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17751/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17751/merge
```

</p>
</details>

Reverts mlflow/mlflow#17741