### PR TITLE
[OTel UI] Minor fixes and refactors

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/RunViewEvaluationsTab.tsx
@@ -28,6 +28,7 @@ import {
   useTableSort,
   TOKENS_COLUMN_ID,
   invalidateMlflowSearchTracesCache,
+  TRACE_ID_COLUMN_ID,
 } from '@databricks/web-shared/genai-traces-table';
 import { useRunLoggedTraceTableArtifacts } from './hooks/useRunLoggedTraceTableArtifacts';
 import { useMarkdownConverter } from '../../../common/utils/MarkdownUtils';
@@ -39,7 +40,6 @@ import { useGetExperimentRunColor } from '../experiment-page/hooks/useExperiment
 import { useQueryClient } from '@databricks/web-shared/query-client';
 import { useSearchRunsQuery } from '../run-page/hooks/useSearchRunsQuery';
 import { checkColumnContents } from '../experiment-page/components/traces-v3/utils/columnUtils';
-import { TRACE_ID_COLUMN_ID } from '@mlflow/mlflow/src/shared/web-shared/genai-traces-table/hooks/useTableColumns';
 
 const RunViewEvaluationsTabInner = ({
   experimentId,
@@ -81,22 +81,25 @@ const RunViewEvaluationsTabInner = ({
   const getRunColor = useGetExperimentRunColor();
   const queryClient = useQueryClient();
 
-  const defaultSelectedColumns = useCallback((columns: TracesTableColumn[]) => {
-    const { responseHasContent, inputHasContent, tokensHasContent } = checkColumnContents(
-      evaluatedTraces.concat(otherEvaluatedTraces),
-    );
+  const defaultSelectedColumns = useCallback(
+    (columns: TracesTableColumn[]) => {
+      const { responseHasContent, inputHasContent, tokensHasContent } = checkColumnContents(
+        evaluatedTraces.concat(otherEvaluatedTraces),
+      );
 
-    return columns.filter(
-      (col) =>
-        col.type === TracesTableColumnType.ASSESSMENT ||
-        col.type === TracesTableColumnType.EXPECTATION ||
-        (inputHasContent && col.type === TracesTableColumnType.INPUT) ||
-        (responseHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) ||
-        (tokensHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === TOKENS_COLUMN_ID) ||
-        (col.type === TracesTableColumnType.TRACE_INFO &&
-          [TRACE_ID_COLUMN_ID, EXECUTION_DURATION_COLUMN_ID, STATE_COLUMN_ID].includes(col.id)),
-    );
-  }, []);
+      return columns.filter(
+        (col) =>
+          col.type === TracesTableColumnType.ASSESSMENT ||
+          col.type === TracesTableColumnType.EXPECTATION ||
+          (inputHasContent && col.type === TracesTableColumnType.INPUT) ||
+          (responseHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) ||
+          (tokensHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === TOKENS_COLUMN_ID) ||
+          (col.type === TracesTableColumnType.TRACE_INFO &&
+            [TRACE_ID_COLUMN_ID, EXECUTION_DURATION_COLUMN_ID, STATE_COLUMN_ID].includes(col.id)),
+      );
+    },
+    [evaluatedTraces, otherEvaluatedTraces],
+  );
 
   const { selectedColumns, toggleColumns, setSelectedColumns } = useSelectedColumns(
     experimentId,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.intg.test.tsx
@@ -13,12 +13,12 @@ import {
   useMlflowTracesTableMetadata,
   useSearchMlflowTraces,
   useSelectedColumns,
+  convertTraceInfoV3ToRunEvalEntry,
 } from '@databricks/web-shared/genai-traces-table';
 
 import { getUser } from '@databricks/web-shared/global-settings';
 import type { NetworkRequestError } from '@databricks/web-shared/errors';
 import { TestRouter, testRoute, waitForRoutesToBeRendered } from '@mlflow/mlflow/src/common/utils/RoutingTestUtils';
-import { convertTraceInfoV3ToRunEvalEntry } from '@mlflow/mlflow/src/shared/web-shared/genai-traces-table/utils/TraceUtils';
 
 // Mock the virtualizer to render all rows in tests
 jest.mock('@tanstack/react-virtual', () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.tsx
@@ -20,6 +20,7 @@ import {
   useMlflowTracesTableMetadata,
   TOKENS_COLUMN_ID,
   invalidateMlflowSearchTracesCache,
+  TRACE_ID_COLUMN_ID,
 } from '@databricks/web-shared/genai-traces-table';
 import { useMarkdownConverter } from '@mlflow/mlflow/src/common/utils/MarkdownUtils';
 import { shouldEnableTraceInsights } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
@@ -30,7 +31,6 @@ import { getTrace } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtil
 import { TracesV3EmptyState } from './TracesV3EmptyState';
 import { useQueryClient } from '@databricks/web-shared/query-client';
 import { useSetInitialTimeFilter } from './hooks/useSetInitialTimeFilter';
-import { TRACE_ID_COLUMN_ID } from '@mlflow/mlflow/src/shared/web-shared/genai-traces-table/hooks/useTableColumns';
 import { checkColumnContents } from './utils/columnUtils';
 
 const TracesV3LogsImpl = React.memo(
@@ -70,23 +70,26 @@ const TracesV3LogsImpl = React.memo(
     const [filters, setFilters] = useFilters();
     const queryClient = useQueryClient();
 
-    const defaultSelectedColumns = useCallback((allColumns: TracesTableColumn[]) => {
-      const { responseHasContent, inputHasContent, tokensHasContent } = checkColumnContents(evaluatedTraces);
+    const defaultSelectedColumns = useCallback(
+      (allColumns: TracesTableColumn[]) => {
+        const { responseHasContent, inputHasContent, tokensHasContent } = checkColumnContents(evaluatedTraces);
 
-      return allColumns.filter(
-        (col) =>
-          col.type === TracesTableColumnType.ASSESSMENT ||
-          col.type === TracesTableColumnType.EXPECTATION ||
-          (inputHasContent && col.type === TracesTableColumnType.INPUT) ||
-          (responseHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) ||
-          (tokensHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === TOKENS_COLUMN_ID) ||
-          (col.type === TracesTableColumnType.TRACE_INFO &&
-            [TRACE_ID_COLUMN_ID, EXECUTION_DURATION_COLUMN_ID, REQUEST_TIME_COLUMN_ID, STATE_COLUMN_ID].includes(
-              col.id,
-            )) ||
-          col.type === TracesTableColumnType.INTERNAL_MONITOR_REQUEST_TIME,
-      );
-    }, []);
+        return allColumns.filter(
+          (col) =>
+            col.type === TracesTableColumnType.ASSESSMENT ||
+            col.type === TracesTableColumnType.EXPECTATION ||
+            (inputHasContent && col.type === TracesTableColumnType.INPUT) ||
+            (responseHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === RESPONSE_COLUMN_ID) ||
+            (tokensHasContent && col.type === TracesTableColumnType.TRACE_INFO && col.id === TOKENS_COLUMN_ID) ||
+            (col.type === TracesTableColumnType.TRACE_INFO &&
+              [TRACE_ID_COLUMN_ID, EXECUTION_DURATION_COLUMN_ID, REQUEST_TIME_COLUMN_ID, STATE_COLUMN_ID].includes(
+                col.id,
+              )) ||
+            col.type === TracesTableColumnType.INTERNAL_MONITOR_REQUEST_TIME,
+        );
+      },
+      [evaluatedTraces],
+    );
 
     const { selectedColumns, toggleColumns, setSelectedColumns } = useSelectedColumns(
       experimentId,

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/utils/columnUtils.ts
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/utils/columnUtils.ts
@@ -1,8 +1,5 @@
-import { RunEvaluationTracesDataEntry } from '@mlflow/mlflow/src/shared/web-shared/genai-traces-table/types';
-import {
-  getTraceInfoInputs,
-  getTraceInfoOutputs,
-} from '@mlflow/mlflow/src/shared/web-shared/genai-traces-table/utils/TraceUtils';
+import type { RunEvaluationTracesDataEntry } from '@databricks/web-shared/genai-traces-table';
+import { getTraceInfoInputs, getTraceInfoOutputs } from '@databricks/web-shared/genai-traces-table';
 
 export const checkColumnContents = (
   evalRows: RunEvaluationTracesDataEntry[],
@@ -11,10 +8,10 @@ export const checkColumnContents = (
   let inputHasContent = false;
   let tokensHasContent = false;
 
-  evalRows.forEach((evalRow) => {
+  for (const evalRow of evalRows) {
     const traceInfo = evalRow.traceInfo;
     if (!traceInfo) {
-      return;
+      continue;
     }
     if (getTraceInfoInputs(traceInfo)) {
       inputHasContent = true;
@@ -26,7 +23,7 @@ export const checkColumnContents = (
     if (evalRow.traceInfo?.trace_metadata?.['mlflow.trace.tokenUsage']) {
       tokensHasContent = true;
     }
-  });
+  }
 
   return { responseHasContent, inputHasContent, tokensHasContent };
 };

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/index.ts
@@ -66,7 +66,12 @@ export {
   RUN_EVALUATION_RESULTS_TAB_SINGLE_RUN,
 } from './utils/EvaluationLogging';
 
-export { getTracesTagKeys } from './utils/TraceUtils';
+export {
+  getTracesTagKeys,
+  getTraceInfoInputs,
+  getTraceInfoOutputs,
+  convertTraceInfoV3ToRunEvalEntry,
+} from './utils/TraceUtils';
 
 export {
   REQUEST_TIME_COLUMN_ID,
@@ -75,6 +80,7 @@ export {
   TAGS_COLUMN_ID,
   RESPONSE_COLUMN_ID,
   TOKENS_COLUMN_ID,
+  TRACE_ID_COLUMN_ID,
 } from './hooks/useTableColumns';
 
 // Test utilities

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test-utils.ts
@@ -484,6 +484,9 @@ export const MOCK_LLAMA_INDEX_CHAT_OUTPUT = {
   },
 };
 
+export const MOCK_CHAT_MESSAGES = MOCK_OPENAI_CHAT_INPUT.messages as ModelTraceChatMessage[];
+export const MOCK_CHAT_TOOLS = MOCK_OPENAI_CHAT_INPUT.tools as ModelTraceChatTool[];
+
 export const MOCK_CHAT_SPAN: ModelTraceSpanNode = {
   ...commonSpanParts,
   attributes: {},
@@ -493,13 +496,12 @@ export const MOCK_CHAT_SPAN: ModelTraceSpanNode = {
   end: 8.1 * 1e6,
   inputs: MOCK_LANGCHAIN_CHAT_INPUT,
   outputs: MOCK_LANGCHAIN_CHAT_OUTPUT,
+  chatMessages: MOCK_CHAT_MESSAGES,
+  chatTools: MOCK_CHAT_TOOLS,
   type: ModelSpanType.CHAT_MODEL,
   assessments: [],
   traceId: '',
 };
-
-export const MOCK_CHAT_MESSAGES = MOCK_OPENAI_CHAT_INPUT.messages as ModelTraceChatMessage[];
-export const MOCK_CHAT_TOOLS = MOCK_OPENAI_CHAT_INPUT.tools as ModelTraceChatTool[];
 
 export const MOCK_CHAT_TOOL_CALL_SPAN: ModelTraceSpanV2 = {
   ...commonSpanParts,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.test-utils.ts
@@ -582,3 +582,65 @@ export const MOCK_TRACE_INFO_V2: ModelTraceInfo = {
   ],
   tags: [],
 };
+
+export const MOCK_OTEL_TRACE: ModelTrace = {
+  data: {
+    spans: [
+      {
+        trace_id: 'tLdfEcjATdf92uVsKMbM/Q==',
+        span_id: 'i8XoH5ibpGc=',
+        trace_state: '',
+        parent_span_id: '',
+        name: 'conversation_turn',
+        start_time_unix_nano: '1757912311704325000',
+        end_time_unix_nano: '1757912313258527000',
+        attributes: {
+          'input.value': 'Now multiply that result by 3',
+          'output.value': 'Multiplying 25 by 3 gives you 75.',
+          'mlflow.traceRequestId': 'tr-b4b75f11c8c04dd7fddae56c28c6ccfd',
+        },
+        status: {
+          code: 'STATUS_CODE_UNSET',
+        },
+      },
+      {
+        trace_id: 'tLdfEcjATdf92uVsKMbM/Q==',
+        span_id: 'yuhZxKf3p8w=',
+        trace_state: '',
+        parent_span_id: 'i8XoH5ibpGc=',
+        name: 'tool_execution',
+        start_time_unix_nano: '1757912312585773000',
+        end_time_unix_nano: '1757912312586234000',
+        attributes: {
+          'tool_call.function.name': 'calculate',
+          'output.value': 'Result: 75',
+          'mlflow.traceRequestId': 'tr-b4b75f11c8c04dd7fddae56c28c6ccfd',
+          'openinference.span.kind': 'TOOL',
+          'tool_call.function.arguments': '{"expression": "25 * 3"}',
+        },
+        status: {
+          code: 'STATUS_CODE_UNSET',
+        },
+      },
+    ],
+  },
+  info: {
+    trace_id: 'tr-b4b75f11c8c04dd7fddae56c28c6ccfd',
+    trace_location: {
+      type: 'MLFLOW_EXPERIMENT',
+      mlflow_experiment: {
+        experiment_id: '1',
+      },
+    },
+    request_time: '2025-09-15T04:58:31.704Z',
+    execution_duration: '1.554s',
+    state: 'OK',
+    trace_metadata: {
+      'mlflow.trace_schema.version': '3',
+    },
+    tags: {
+      'mlflow.artifactLocation': 'mlflow-artifacts:/1/traces/tr-b4b75f11c8c04dd7fddae56c28c6ccfd/artifacts',
+      'mlflow.trace.spansLocation': 'tracking_store',
+    },
+  },
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -3,9 +3,11 @@ import { describe, expect, it } from '@jest/globals';
 import { ModelSpanType } from './ModelTrace.types';
 import type { ModelTraceChatMessage, ModelTraceSpanNode, RawModelTraceChatMessage } from './ModelTrace.types';
 import {
+  MOCK_CHAT_SPAN,
   MOCK_CHAT_TOOL_CALL_SPAN,
   MOCK_OPENAI_CHAT_INPUT,
   MOCK_OPENAI_CHAT_OUTPUT,
+  MOCK_OTEL_TRACE,
   MOCK_OVERRIDDING_ASSESSMENT,
   MOCK_ROOT_ASSESSMENT,
   MOCK_SPAN_ASSESSMENT,
@@ -28,6 +30,7 @@ import {
   isModelTraceChatMessage,
   getAssessmentMap,
   decodeSpanId,
+  getDefaultActiveTab,
 } from './ModelTraceExplorer.utils';
 import { TEST_SPAN_FILTER_STATE } from './timeline-tree/TimelineTree.test-utils';
 
@@ -633,5 +636,21 @@ describe('isModelTrace', () => {
     { data: { spans: [] }, info: { trace_metadata: [] } },
   ])("should return false if the object doesn't have the required fields", (trace) => {
     expect(isModelTrace(trace)).toBe(false);
+  });
+});
+
+describe('getDefaultActiveTab', () => {
+  it('should return chat if the node has chat messages', () => {
+    expect(getDefaultActiveTab(MOCK_CHAT_SPAN)).toBe('chat');
+  });
+
+  it('should return content if the node has inputs or outputs', () => {
+    const normalSpan = normalizeNewSpanData(MOCK_V3_SPANS[0], 0, 0, [], {}, '');
+    expect(getDefaultActiveTab(normalSpan)).toBe('content');
+  });
+
+  it('should return attributes if the node has no chat messages or inputs or outputs', () => {
+    const otelSpan = parseModelTraceToTree(MOCK_OTEL_TRACE) as ModelTraceSpanNode;
+    expect(getDefaultActiveTab(otelSpan)).toBe('attributes');
   });
 });


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/17756?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17756/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17756/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17756/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

I was a little too trigger-happy merging the stack earlier. This PR contains some fixes:

1. resolve `useMemo` lint warnings (missing dependencies)
2. correct import paths (need to import from `@databricks/web-shared/genai-traces-table`)
3. replace `x.forEach(y => ...)` with `for (const y of x)`
4. add test for trace UI default tab selection

There should be no functional changes

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/4a9d434f-bc48-4514-abb2-23e68721eb54



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
