### PR TITLE
Fix `copy_model_version` failure when model_id lookup fails

### DIFF
--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -680,7 +680,17 @@ class Model:
         model metadata.
         """
         if logged_model is None and self.model_id is not None:
-            logged_model = mlflow.get_logged_model(model_id=self.model_id)
+            try:
+                logged_model = mlflow.get_logged_model(model_id=self.model_id)
+            except Exception as e:
+                _logger.warning(
+                    "Fetching logged model with model_id=%s failed. "
+                    "Returning ModelInfo without logged model metadata. "
+                    "Exception: %s",
+                    self.model_id,
+                    e,
+                )
+                logged_model = None
         return ModelInfo(
             artifact_path=self.artifact_path,
             flavors=self.flavors,

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -680,14 +680,19 @@ class Model:
         model metadata.
         """
         if logged_model is None and self.model_id is not None:
+            # A short-term workaround for https://github.com/mlflow/mlflow/issues/17648
             try:
                 logged_model = mlflow.get_logged_model(model_id=self.model_id)
-            except Exception as e:
+            except MlflowException as e:
                 _logger.warning(
-                    "Fetching logged model with model_id=%s failed. "
-                    "Returning ModelInfo without logged model metadata. "
-                    "Exception: %s",
+                    (
+                        "Failed to fetch logged model metadata for model_id %s. "
+                        "Returning model info without logged model metadata. "
+                        "Tracking URI: %s. "
+                        "Exception: %s"
+                    ),
                     self.model_id,
+                    mlflow.get_tracking_uri(),
                     e,
                 )
                 logged_model = None

--- a/mlflow/models/model.py
+++ b/mlflow/models/model.py
@@ -688,12 +688,16 @@ class Model:
                     (
                         "Failed to fetch logged model metadata for model_id %s. "
                         "Returning model info without logged model metadata. "
+                        "Set logging level to DEBUG via "
+                        '`logging.getLogger("mlflow").setLevel(logging.DEBUG)` '
+                        "to see the full traceback. "
                         "Tracking URI: %s. "
                         "Exception: %s"
                     ),
                     self.model_id,
                     mlflow.get_tracking_uri(),
                     e,
+                    exc_info=_logger.isEnabledFor(logging.DEBUG),
                 )
                 logged_model = None
         return ModelInfo(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/17774?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17774/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17774/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17774/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #17648

### What changes are proposed in this pull request?

This PR fixes a bug in `copy_model_version` where the operation fails when trying to copy models from Unity Catalog in CI/CD pipelines. The issue occurs in `Model.get_model_info()` when it attempts to reload model metadata using 

The fix adds a try-catch block around the `mlflow.get_logged_model()` call, gracefully handling the case where model metadata cannot be fetched and allowing the operation to continue with a warning instead of failing completely.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixes `copy_model_version` failures when copying models from Unity Catalog in CI/CD environments where model metadata lookup fails.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)