### PR TITLE
Fix expectation rendering

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.test.ts
@@ -115,6 +115,103 @@ describe('convertTraceInfoV3ToModelTraceInfo', () => {
 });
 
 describe('applyTraceInfoV3ToEvalEntry', () => {
+  const traceInfoWithExpectations: TraceInfoV3 = {
+    trace_id: 'trace123',
+    trace_location: {
+      type: 'MLFLOW_EXPERIMENT',
+      mlflow_experiment: { experiment_id: 'exp123' },
+    },
+    request_time: '2023-10-01T00:00:00Z',
+    state: 'OK',
+    client_request_id: 'client456',
+    request: '{"messages": [{"content": "Hello"}]}',
+    response: '{"data": "output"}',
+    tags: { key1: 'value1' },
+    assessments: [
+      {
+        assessment_id: 'a-fe16ebce1999476c95d5b73cf78e47f8',
+        assessment_name: 'json_array_expect',
+        trace_id: 'tr-2f6e2efbac5d2eb3f9b46a67e973a533',
+        source: {
+          source_type: 'HUMAN',
+          source_id: 'test',
+        },
+        create_time: '2025-09-17T04:13:36.753Z',
+        last_update_time: '2025-09-17T04:13:36.753Z',
+        expectation: {
+          serialized_value: {
+            serialization_format: 'JSON_FORMAT',
+            value: '["str", 123, {"nested": "obj"}]',
+          },
+        },
+        rationale: '',
+      },
+      {
+        assessment_id: 'a-4eb4ea163a9a4b41935f953a63a36706',
+        assessment_name: 'number_expect',
+        trace_id: 'tr-2f6e2efbac5d2eb3f9b46a67e973a533',
+        source: {
+          source_type: 'HUMAN',
+          source_id: 'test',
+        },
+        create_time: '2025-09-17T04:13:58.740Z',
+        last_update_time: '2025-09-17T04:13:58.740Z',
+        expectation: {
+          value: 1234,
+        },
+        rationale: '',
+      },
+      {
+        assessment_id: 'a-c180c83a996042a99b735540292b30ba',
+        assessment_name: 'json_obj_expect',
+        trace_id: 'tr-2f6e2efbac5d2eb3f9b46a67e973a533',
+        source: {
+          source_type: 'HUMAN',
+          source_id: 'test',
+        },
+        create_time: '2025-09-17T04:13:12.356Z',
+        last_update_time: '2025-09-17T04:13:12.356Z',
+        expectation: {
+          serialized_value: {
+            serialization_format: 'JSON_FORMAT',
+            value: '{"test": "value"}',
+          },
+        },
+        rationale: '',
+      },
+      {
+        assessment_id: 'a-5ebe632dbdd8489ebb1b2c3a3f703632',
+        assessment_name: 'str_expect',
+        trace_id: 'tr-2f6e2efbac5d2eb3f9b46a67e973a533',
+        source: {
+          source_type: 'HUMAN',
+          source_id: 'test',
+        },
+        create_time: '2025-09-17T04:14:11.445Z',
+        last_update_time: '2025-09-17T04:14:11.445Z',
+        expectation: {
+          value: 'test',
+        },
+        rationale: '',
+      },
+      {
+        assessment_id: 'a-2243eda2cc5644109ebbc8c3271266cc',
+        assessment_name: 'bool_expect',
+        trace_id: 'tr-2f6e2efbac5d2eb3f9b46a67e973a533',
+        source: {
+          source_type: 'HUMAN',
+          source_id: 'test',
+        },
+        create_time: '2025-09-17T04:10:11.897Z',
+        last_update_time: '2025-09-17T04:10:11.897Z',
+        expectation: {
+          value: true,
+        },
+        rationale: '',
+      },
+    ],
+  } as TraceInfoV3;
+
   const dummyTraceInfo: TraceInfoV3 = {
     trace_id: 'trace123',
     trace_location: {
@@ -314,6 +411,21 @@ describe('applyTraceInfoV3ToEvalEntry', () => {
     };
 
     expect(result[0]).toEqual(expected);
+  });
+
+  it('should correctly convert TraceInfoV3 expectations', () => {
+    const input: RunEvaluationTracesDataEntry[] = [{ ...baseEvalEntry, traceInfo: traceInfoWithExpectations }];
+    const result = applyTraceInfoV3ToEvalEntry(input);
+
+    expect(result[0].targets).toEqual({
+      // JSON should be parsed
+      json_array_expect: ['str', 123, { nested: 'obj' }],
+      json_obj_expect: { test: 'value' },
+      // primitives should remain as primitives
+      number_expect: 1234,
+      str_expect: 'test',
+      bool_expect: true,
+    });
   });
 });
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/TraceUtils.ts
@@ -115,7 +115,7 @@ function processExpectationAssessment(assessment: AssessmentV3, targets: Record<
   } else if (typeof assessmentValue === 'string') {
     targets[assessmentName] = safelyParseValue(assessmentValue);
   } else {
-    targets[assessmentName] = [];
+    targets[assessmentName] = assessmentValue;
   }
 }
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/17785?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17785/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17785/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17785/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Right now, any non-string / JSON value in an expectation renders incorrectly in the trace table. This is because we're explicitly ignoring them. This PR changes the logic to not ignore them.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Add unit test

Displays properly now:

<img width="1405" height="990" alt="Screenshot 2025-09-17 at 1 24 32 PM" src="https://github.com/user-attachments/assets/bfc52187-a353-4d11-b82b-15a2292d4e08" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
