### PR TITLE
Fix: Ensure databricks-connect and databricks-agents are uninstalled before pyspark installation

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -82,6 +82,9 @@ jobs:
           source ./dev/install-common-deps.sh --ml
           # transformers doesn't support Keras 3 yet. tf-keras needs to be installed as a workaround.
           pip install tf-keras
+          # Ensure `databricks-connect` and `databricks-agents` are not installed
+          pip uninstall -y databricks-connect databricks-agents
+          pip install --no-deps --force-reinstall pyspark
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Import check


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds explicit uninstall steps for `databricks-connect` and `databricks-agents` packages before reinstalling `pyspark` in the CI workflow. This prevents potential import conflicts that can occur when these packages are present during pyspark initialization.

Changes:
- Add `pip uninstall -y databricks-connect databricks-agents` before pyspark installation
- Use `pip install --no-deps --force-reinstall pyspark` to ensure clean pyspark installation

### How is this PR tested?

- [x] Existing unit/integration tests

The changes are in CI configuration and will be tested by the existing CI pipeline.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with Claude Code