### PR TITLE
Add `__repr__` for Judges

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -32,7 +32,7 @@ from mlflow.genai.utils.trace_utils import (
     extract_inputs_from_trace,
     extract_outputs_from_trace,
 )
-from mlflow.prompt.constants import PROMPT_TEMPLATE_VARIABLE_PATTERN
+from mlflow.prompt.constants import PROMPT_TEMPLATE_VARIABLE_PATTERN, PROMPT_TEXT_DISPLAY_LIMIT
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.utils.annotations import experimental
 
@@ -427,6 +427,19 @@ class InstructionsJudge(Judge):
                 "{{ outputs }}, {{ trace }}, or {{ expectations }}).",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+
+    def __repr__(self) -> str:
+        """Return string representation of the InstructionsJudge."""
+        instructions_preview = (
+            self._instructions[:PROMPT_TEXT_DISPLAY_LIMIT] + "..."
+            if len(self._instructions) > PROMPT_TEXT_DISPLAY_LIMIT
+            else self._instructions
+        )
+        return (
+            f"InstructionsJudge(name='{self.name}', model='{self._model}', "
+            f"instructions='{instructions_preview}', "
+            f"template_variables={sorted(self.template_variables)})"
+        )
 
     def model_dump(self, **kwargs) -> dict[str, Any]:
         """Override model_dump to serialize as a SerializedScorer."""

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -2436,12 +2436,14 @@ def test_instructions_judge_repr():
     long_instructions = (
         "This is a very long instruction that will be truncated {{ inputs }} and {{ outputs }}"
     )
-    judge_long = make_judge(name="long_judge", instructions=long_instructions, model="databricks")
+    judge_long = make_judge(
+        name="long_judge", instructions=long_instructions, model="openai:/gpt-4"
+    )
 
     repr_long = repr(judge_long)
     assert "InstructionsJudge" in repr_long
     assert "name='long_judge'" in repr_long
-    assert "model='databricks'" in repr_long
+    assert "model='openai:/gpt-4'" in repr_long
     # Should show first 30 characters + "..."
     assert "instructions='This is a very long instructio..." in repr_long
     assert "template_variables=['inputs', 'outputs']" in repr_long

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -2418,4 +2418,30 @@ def test_no_duplicate_output_fields_in_system_message():
     assert trace_system_msg.count("- rationale:") == 1
 
     assert "Please provide your assessment in the following JSON format" not in trace_system_msg
-    assert "You *must* format your evaluation rating as a JSON object" in trace_system_msg
+
+
+def test_instructions_judge_repr():
+    # Test short instructions that fit within display limit
+    short_instructions = "Check {{ outputs }}"
+    judge = make_judge(name="test_judge", instructions=short_instructions, model="openai:/gpt-4")
+
+    repr_str = repr(judge)
+    assert "InstructionsJudge" in repr_str
+    assert "name='test_judge'" in repr_str
+    assert "model='openai:/gpt-4'" in repr_str
+    assert f"instructions='{short_instructions}'" in repr_str
+    assert "template_variables=['outputs']" in repr_str
+
+    # Test long instructions that exceed PROMPT_TEXT_DISPLAY_LIMIT (30 chars)
+    long_instructions = (
+        "This is a very long instruction that will be truncated {{ inputs }} and {{ outputs }}"
+    )
+    judge_long = make_judge(name="long_judge", instructions=long_instructions, model="databricks")
+
+    repr_long = repr(judge_long)
+    assert "InstructionsJudge" in repr_long
+    assert "name='long_judge'" in repr_long
+    assert "model='databricks'" in repr_long
+    # Should show first 30 characters + "..."
+    assert "instructions='This is a very long instructio..." in repr_long
+    assert "template_variables=['inputs', 'outputs']" in repr_long


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17794?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17794/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17794/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17794/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Based on testing feedback, add the __repr__ capability to InstructionsJudge to easily view the state of the Judge object.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
