### PR TITLE
Fix pytest import errors by removing pythonpath configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,7 +407,6 @@ extend-ignore-re = [
 
 [tool.pytest.ini_options]
 addopts = "-p no:legacypath --strict-markers --color=yes --durations=10 --showlocals -v"
-pythonpath = ["."]
 filterwarnings = [
   # Prevent deprecated numpy type aliases from being used
   "error:^`np\\.[a-z]+` is a deprecated alias for.+:DeprecationWarning:mlflow",


### PR DESCRIPTION
### Related Issues/PRs

#17791

### What changes are proposed in this pull request?

Remove `pythonpath = ["."]` from `pyproject.toml`'s pytest.ini_options configuration to fix ModuleNotFoundError during test collection.

The issue occurs because this configuration makes `importlib_metadata` incorrectly detect that `mlflow` is installed when it's not actually installed, which sets `IS_TRACING_SDK_ONLY` to `False`. This leads to import errors for dependencies like `sqlparse` during test collection.

**Error details:** https://github.com/mlflow/mlflow/actions/runs/17816905145/job/50651985644?pr=17791

```
ImportError while loading conftest '/home/runner/work/mlflow/mlflow/tests/conftest.py'.
tests/__init__.py:1: in <module>
    from mlflow.utils.logging_utils import _configure_mlflow_loggers
mlflow/__init__.py:44: in <module>
    from mlflow import (
mlflow/artifacts/__init__.py:14: in <module>
    from mlflow.tracking import _get_store
mlflow/tracking/__init__.py:28: in <module>
    from mlflow.tracking._model_registry.utils import (
mlflow/tracking/_model_registry/utils.py:8: in <module>
    from mlflow.store.model_registry.file_store import FileStore
mlflow/store/model_registry/file_store.py:59: in <module>
    from mlflow.utils.search_utils import SearchModelUtils, SearchModelVersionUtils, SearchUtils
mlflow/utils/search_utils.py:11: in <module>
    import sqlparse
E   ModuleNotFoundError: No module named 'sqlparse'
```

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No