### PR TITLE
Don't copy trace if it comes from same experiment

### DIFF
--- a/tests/tracing/utils/test_copy.py
+++ b/tests/tracing/utils/test_copy.py
@@ -1,0 +1,198 @@
+from unittest.mock import MagicMock, patch
+
+from mlflow.tracing.utils.copy import copy_trace_to_experiment
+
+
+def test_copy_trace_same_experiment_returns_early():
+    """Test that copy_trace_to_experiment returns early when trace is already in target
+    experiment.
+    """
+    # Create a trace_dict with MLFLOW_EXPERIMENT location
+    trace_dict = {
+        "info": {
+            "trace_id": "existing-trace-123",
+            "trace_location": {
+                "type": "MLFLOW_EXPERIMENT",
+                "mlflow_experiment": {"experiment_id": "exp-123"},
+            },
+        },
+        "data": {
+            "spans": [
+                {
+                    "span_id": "span-1",
+                    "trace_id": "existing-trace-123",
+                    "parent_id": None,
+                    "name": "root_span",
+                    "start_time_ns": 1000000000,
+                    "end_time_ns": 2000000000,
+                    "span_type": "UNKNOWN",
+                    "inputs": {},
+                    "outputs": {},
+                    "attributes": {},
+                    "events": [],
+                }
+            ]
+        },
+    }
+
+    # Call with same experiment_id
+    result = copy_trace_to_experiment(trace_dict, experiment_id="exp-123")
+
+    # Should return the existing trace ID without creating a new trace
+    assert result == "existing-trace-123"
+
+
+def test_copy_trace_v2_same_experiment_returns_early():
+    """Test that copy_trace_to_experiment returns early for V2 trace already in target
+    experiment.
+    """
+    # Create a V2 trace_dict (has request_id field, direct experiment_id)
+    trace_dict = {
+        "info": {
+            "request_id": "existing-trace-v2-123",
+            "experiment_id": "exp-123",
+            "timestamp_ms": 1000000000,
+            "execution_time_ms": 1000,
+            "status": "OK",
+            "request_metadata": {},
+            "tags": {},
+        },
+        "data": {
+            "spans": [
+                {
+                    "span_id": "span-1",
+                    "trace_id": "existing-trace-v2-123",
+                    "parent_id": None,
+                    "name": "root_span",
+                    "start_time_ns": 1000000000,
+                    "end_time_ns": 2000000000,
+                    "span_type": "UNKNOWN",
+                    "inputs": {},
+                    "outputs": {},
+                    "attributes": {},
+                    "events": [],
+                }
+            ]
+        },
+    }
+
+    # Call with same experiment_id
+    result = copy_trace_to_experiment(trace_dict, experiment_id="exp-123")
+
+    # Should return the existing request_id (trace ID for V2)
+    assert result == "existing-trace-v2-123"
+
+
+def test_copy_trace_different_experiment_creates_new_trace():
+    """Test that copy_trace_to_experiment creates new trace when experiment IDs differ."""
+    trace_dict = {
+        "info": {
+            "trace_id": "existing-trace-123",
+            "trace_location": {
+                "type": "MLFLOW_EXPERIMENT",
+                "mlflow_experiment": {"experiment_id": "exp-123"},
+            },
+        },
+        "data": {
+            "spans": [
+                {
+                    "span_id": "span-1",
+                    "trace_id": "existing-trace-123",
+                    "parent_id": None,
+                    "name": "root_span",
+                    "start_time_ns": 1000000000,
+                    "end_time_ns": 2000000000,
+                    "span_type": "UNKNOWN",
+                    "inputs": {},
+                    "outputs": {},
+                    "attributes": {},
+                    "events": [],
+                }
+            ]
+        },
+    }
+
+    # Mock the trace manager and LiveSpan creation
+    with (
+        patch("mlflow.tracing.utils.copy.InMemoryTraceManager") as mock_manager,
+        patch("mlflow.tracing.utils.copy.LiveSpan") as mock_live_span,
+        patch("mlflow.tracing.utils.copy.Span") as mock_span,
+    ):
+        # Setup mocks
+        mock_manager.get_instance.return_value = MagicMock()
+
+        mock_span_instance = MagicMock()
+        mock_span_instance.parent_id = None
+        mock_span.from_dict.return_value = mock_span_instance
+
+        mock_new_span = MagicMock()
+        mock_new_span.trace_id = "new-trace-456"
+        mock_new_span.parent_id = None
+        mock_live_span.from_immutable_span.return_value = mock_new_span
+
+        # Call with different experiment_id
+        result = copy_trace_to_experiment(trace_dict, experiment_id="exp-456")
+
+        # Should create and return new trace ID
+        assert result == "new-trace-456"
+
+        # Verify that LiveSpan.from_immutable_span was called with correct experiment_id
+        mock_live_span.from_immutable_span.assert_called_once()
+        call_kwargs = mock_live_span.from_immutable_span.call_args[1]
+        assert call_kwargs["experiment_id"] == "exp-456"
+
+
+def test_copy_trace_non_mlflow_experiment_location_creates_new_trace():
+    """Test that copy_trace_to_experiment creates new trace when location is not
+    MLFLOW_EXPERIMENT.
+    """
+    trace_dict = {
+        "info": {
+            "trace_id": "existing-trace-123",
+            "trace_location": {
+                "type": "INFERENCE_TABLE",
+                "inference_table": {"full_table_name": "catalog.schema.table"},
+            },
+        },
+        "data": {
+            "spans": [
+                {
+                    "span_id": "span-1",
+                    "trace_id": "existing-trace-123",
+                    "parent_id": None,
+                    "name": "root_span",
+                    "start_time_ns": 1000000000,
+                    "end_time_ns": 2000000000,
+                    "span_type": "UNKNOWN",
+                    "inputs": {},
+                    "outputs": {},
+                    "attributes": {},
+                    "events": [],
+                }
+            ]
+        },
+    }
+
+    # Mock the trace manager and LiveSpan creation
+    with (
+        patch("mlflow.tracing.utils.copy.InMemoryTraceManager") as mock_manager,
+        patch("mlflow.tracing.utils.copy.LiveSpan") as mock_live_span,
+        patch("mlflow.tracing.utils.copy.Span") as mock_span,
+    ):
+        # Setup mocks
+        mock_manager.get_instance.return_value = MagicMock()
+
+        mock_span_instance = MagicMock()
+        mock_span_instance.parent_id = None
+        mock_span.from_dict.return_value = mock_span_instance
+
+        mock_new_span = MagicMock()
+        mock_new_span.trace_id = "new-trace-456"
+        mock_new_span.parent_id = None
+        mock_live_span.from_immutable_span.return_value = mock_new_span
+
+        # Call with any experiment_id
+        result = copy_trace_to_experiment(trace_dict, experiment_id="exp-456")
+
+        # Should create and return new trace ID (doesn't match, so creates new)
+        assert result == "new-trace-456"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/17815?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17815/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17815/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17815/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Today, `copy_trace_to_experiment` will copy even if the trace is from the same experiment; however, this is not necesary.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- patch -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
