### PR TITLE
Simplify cross-version-tests workflow using YAML anchors

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -132,7 +132,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix1) }}
-    steps:
+    steps: &test-steps
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
@@ -198,58 +198,4 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.set-matrix.outputs.matrix2) }}
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: ${{ github.event_name == 'schedule' && 'mlflow/mlflow' || github.event.inputs.repository }}
-          ref: ${{ github.event.inputs.ref }}
-      - uses: ./.github/actions/free-disk-space
-        if: matrix.free_disk_space
-      - uses: ./.github/actions/setup-python
-        with:
-          python-version: ${{ matrix.python }}
-      - uses: ./.github/actions/setup-pyenv
-      - uses: ./.github/actions/setup-java
-        with:
-          java-version: ${{ matrix.java }}
-      - name: Remove constraints
-        run: |
-          # Remove any constraints for the current package to prevent installation conflicts
-          sed -i '/^${{ matrix.package }}/d' requirements/constraints.txt
-
-          if ! git diff --exit-code requirements/constraints.txt; then
-            git diff
-            git config user.name 'mlflow-app[bot]'
-            git config user.email 'mlflow-app[bot]@users.noreply.github.com'
-            git add requirements/constraints.txt
-            git commit -m "Remove constraints for testing"
-          fi
-      - name: Install mlflow & test dependencies
-        run: |
-          pip install -U pip wheel setuptools
-          # For tracing SDK test, install the tracing package from the local path and minimal test dependencies
-          if [[ "${{ matrix.category }}" == "tracing-sdk" ]]; then
-            pip install libs/tracing
-            pip install pytest pytest-asyncio pytest-cov
-          # Other two categories of tests (model/autologging)
-          else
-            pip install .[extras]
-            pip install -r requirements/test-requirements.txt
-          fi
-      - name: Install ${{ matrix.package }} ${{ matrix.version }}
-        run: |
-          ${{ matrix.install }}
-      - uses: ./.github/actions/show-versions
-      - uses: ./.github/actions/pipdeptree
-      - name: Pre-test
-        if: matrix.pre_test
-        run: |
-          ${{ matrix.pre_test }}
-      - name: Run tests
-        env:
-          MLFLOW_CONDA_HOME: /usr/share/miniconda
-          SPARK_LOCAL_IP: localhost
-          JOHNSNOWLABS_LICENSE_JSON: ${{ secrets.JOHNSNOWLABS_LICENSE_JSON }}
-          HF_HUB_ENABLE_HF_TRANSFER: 1
-        run: |
-          ${{ matrix.run }}
+    steps: *test-steps

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -784,31 +784,11 @@ def split(matrix, n):
         yield chunk
 
 
-def validate_action_config(num_jobs: int):
-    with open(".github/workflows/cross-version-tests.yml") as f:
-        s = f.read()
-    s = re.sub(
-        r"needs\.set-matrix\.outputs\.matrix\d",
-        "needs.set-matrix.outputs.matrix",
-        s,
-    )
-    s = re.sub(
-        r"needs\.set-matrix\.outputs\.is_matrix\d_empty",
-        "needs.set-matrix.outputs.is_matrix_empty",
-        s,
-    )
-    jobs = yaml.safe_load(s)["jobs"]
-    jobs = [v for name, v in jobs.items() if name.startswith("test")]
-    assert len(jobs) == num_jobs, f"Expected {num_jobs} jobs, but got {len(jobs)}"
-    assert all(jobs[0] == j for j in jobs[1:]), "All jobs must have the same configuration"
-
-
 def main(args):
     # https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#usage-limits
     # > A job matrix can generate a maximum of 256 jobs per workflow run.
     MAX_ITEMS = 256
     NUM_JOBS = 2
-    validate_action_config(NUM_JOBS)
 
     print(divider("Parameters"))
     print(json.dumps(args, indent=2))


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR simplifies the cross-version-tests workflow by leveraging YAML anchors, a new feature announced in GitHub Actions on [September 18, 2025](https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/):

- Use YAML anchor (`&test-steps`) to eliminate ~50 lines of duplicated steps between test1 and test2 jobs
- Remove redundant `validate_action_config` function since YAML anchors guarantee job consistency by design
- Maintain identical functionality while improving maintainability

This takes advantage of the newly released YAML anchors support in GitHub Actions to reduce workflow duplication.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual validation that the workflow syntax is correct

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with [Claude Code](https://claude.ai/code)