### PR TITLE
Drop langchain 0.2.x support

### DIFF
--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -97,7 +97,7 @@ genai = [
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
-langchain = ["langchain>=0.2.16,<=0.3.27"]
+langchain = ["langchain>=0.3.0,<=0.3.27"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -593,7 +593,7 @@ langchain:
       pip install git+https://github.com/langchain-ai/langchain#subdirectory=libs/langchain
   models:
     # Where the large package update was made (langchain-core, community, ...)
-    minimum: "0.2.16"
+    minimum: "0.3.0"
     maximum: "0.3.27"
     requirements:
       ">= 0.0.0": [
@@ -634,15 +634,8 @@ langchain:
       pip install './libs/skinny'
       # Run all langchain tests except autologging
       pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
-      # test both pydantic v1 and v2
-      PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
-      if [[ $PYDANTIC_VERSION == 1.* ]]; then
-        pip install 'pydantic>=2' 'fastapi>=0.100.0'
-        echo "Testing langchain model export with pydantic v2"
-        pytest tests/langchain --ignore tests/langchain/test_langchain_autolog.py
-      fi
   autologging:
-    minimum: "0.2.16"
+    minimum: "0.3.0"
     maximum: "0.3.27"
     requirements:
       ">= 0.0.0": [
@@ -656,7 +649,6 @@ langchain:
           # Some model logging/loading requires langchain community
           "langchain-community",
         ]
-      "< 0.3.0": ["langchain_openai<0.2.0"]
       ">= 0.3.0": [
           # Need to bump FasAPI version to support pydantic v2
           "fastapi>=0.100.0",
@@ -668,13 +660,6 @@ langchain:
       pip install --no-deps --force-reinstall pyspark
     run: |
       pytest tests/langchain/test_langchain_autolog.py
-      # test both pydantic v1 and v2
-      PYDANTIC_VERSION=$(python -c "import pydantic; print(pydantic.__version__)")
-      if [[ $PYDANTIC_VERSION == 1.* ]]; then
-        pip install 'pydantic>=2' 'fastapi>=0.100.0'
-        echo "Testing langchain autolog with pydantic v2"
-        pytest tests/langchain/test_langchain_autolog.py
-      fi
 
       echo "Testing langchain autolog and evaluation with langchain-community"
       # Install with 'langchain' to ensure the compatible version is installed

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -42,11 +42,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "langchain"
         },
         "models": {
-            "minimum": "0.2.16",
+            "minimum": "0.3.0",
             "maximum": "0.3.27"
         },
         "autologging": {
-            "minimum": "0.2.16",
+            "minimum": "0.3.0",
             "maximum": "0.3.27"
         }
     },

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -97,7 +97,7 @@ genai = [
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
-langchain = ["langchain>=0.2.16,<=0.3.27"]
+langchain = ["langchain>=0.3.0,<=0.3.27"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,7 @@ genai = [
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]
-langchain = ["langchain>=0.2.16,<=0.3.27"]
+langchain = ["langchain>=0.3.0,<=0.3.27"]
 auth = ["Flask-WTF<2"]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -3355,7 +3355,7 @@ requires-dist = [
     { name = "gunicorn", marker = "sys_platform != 'win32'", specifier = "<24" },
     { name = "importlib-metadata", specifier = ">=3.7.0,!=4.7.0,<9" },
     { name = "kubernetes", marker = "extra == 'extras'" },
-    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.2.16,<=0.3.27" },
+    { name = "langchain", marker = "extra == 'langchain'", specifier = ">=0.3.0,<=0.3.27" },
     { name = "matplotlib", specifier = "<4" },
     { name = "mlflow-dbstore", marker = "extra == 'sqlserver'" },
     { name = "mlflow-jfrog-plugin", marker = "extra == 'jfrog'" },


### PR DESCRIPTION
### What changes are proposed in this pull request?

Drop support for langchain 0.2.x and bump minimum version to 0.3.0.

Langchain 0.3.0 was released in September 2024 (over a year ago) with Pydantic v2 as a requirement. This PR:
- Bumps minimum langchain version from 0.2.16 to 0.3.0
- Removes conditional Pydantic v1/v2 testing logic
- Removes version-specific langchain_openai constraints
- Simplifies test configuration

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

<!-- patch -->

- [x] No (this PR will be included in the next minor release)

🤖 Generated with Claude Code