### PR TITLE
Allow caller to disable eval logging

### DIFF
--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -236,7 +236,7 @@ class MlflowCallback(BaseCallback):
         if callback_metadata := inputs.get("callback_metadata"):
             if "metric_key" in callback_metadata:
                 key = callback_metadata["metric_key"]
-            if callback_metadata.get("disable"):
+            if callback_metadata.get("disable_logging"):
                 self._disabled_eval_call_ids.add(call_id)
                 return
         if self.optimizer_stack_level > 0:

--- a/mlflow/dspy/callback.py
+++ b/mlflow/dspy/callback.py
@@ -267,7 +267,7 @@ class MlflowCallback(BaseCallback):
         if not get_autologging_config(FLAVOR_NAME, "log_evals"):
             return
         if call_id in self._disabled_eval_call_ids:
-            self._disabled_eval_call_ids.remove(call_id)
+            self._disabled_eval_call_ids.discard(call_id)
             return
         if exception:
             mlflow.end_run(status=RunStatus.to_string(RunStatus.FAILED))

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -756,7 +756,7 @@ def test_autolog_log_evals_disable_by_caller():
     evaluator = Evaluate(devset=examples, metric=answer_exact_match)
     program = Predict("question -> answer")
     with dspy.context(lm=DummyLM([{"answer": "2"}])):
-        evaluator(program, devset=examples, callback_metadata={"disable": True})
+        evaluator(program, devset=examples, callback_metadata={"disable_logging": True})
 
     assert mlflow.last_active_run() is None
 

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -748,6 +748,21 @@ def test_autolog_log_evals(
 
 @skip_when_testing_trace_sdk
 @skip_if_evaluate_callback_unavailable
+def test_autolog_log_evals_disable_by_caller():
+    mlflow.dspy.autolog(log_evals=True)
+    examples = [
+        Example(question="What is 1 + 1?", answer="2").with_inputs("question"),
+    ]
+    evaluator = Evaluate(devset=examples, metric=answer_exact_match)
+    program = Predict("question -> answer")
+    with dspy.context(lm=DummyLM([{"answer": "2"}])):
+        evaluator(program, devset=examples, callback_metadata={"disable": True})
+
+    assert mlflow.last_active_run() is None
+
+
+@skip_when_testing_trace_sdk
+@skip_if_evaluate_callback_unavailable
 def test_autolog_nested_evals():
     lm = DummyLM(
         {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/17835?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17835/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17835/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17835/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Some DSPy optimizers like GEPA run evals many times with a few samples. This PR allows callers to control the eval behavior using callback metadata.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
