### PR TITLE
Fix double counting strands tracing

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/strands.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/strands.mdx
@@ -100,10 +100,6 @@ for span in trace.data.spans:
   Total tokens: 2660
 
 == Detailed usage for each LLM call: ==
-invoke_agent Strands Agents:
-  Input tokens: 2629
-  Output tokens: 31
-  Total tokens: 2660
 chat_1:
   Input tokens: 1301
   Output tokens: 16

--- a/docs/docs/genai/tracing/integrations/listing/strands.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/strands.mdx
@@ -95,9 +95,9 @@ for span in trace.data.spans:
 
 ```bash
 == Total token usage: ==
-  Input tokens: 5258
-  Output tokens: 62
-  Total tokens: 5320
+  Input tokens: 2629
+  Output tokens: 31
+  Total tokens: 2660
 
 == Detailed usage for each LLM call: ==
 invoke_agent Strands Agents:

--- a/mlflow/strands/autolog.py
+++ b/mlflow/strands/autolog.py
@@ -121,6 +121,11 @@ def _set_inputs_outputs(mlflow_span: LiveSpan, span: OTelReadableSpan) -> None:
 
 
 def _set_token_usage(mlflow_span: LiveSpan, span: OTelReadableSpan) -> None:
+    # Strands agents contain complete token usage information in the AGENT span
+    # We don't need to set token usage for the AGENT span to avoid double counting
+    if mlflow_span.get_attribute(SpanAttributeKey.SPAN_TYPE) == SpanType.AGENT:
+        return
+
     usage = {}
     if (v := span.attributes.get("gen_ai.usage.input_tokens")) is not None:
         usage[TokenUsageKey.INPUT_TOKENS] = v


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/17855?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17855/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17855/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17855/merge
```

</p>
</details>

### Related Issues/PRs

Fix #17852 

### What changes are proposed in this pull request?

In Strands Agents tracing, the root agent span currently includes the total token count, which causes token usage metrics to be counted twice. This PR resolves the issue by excluding the root agent span’s token count, ensuring that tokens are not double-counted.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
