### PR TITLE
Forward dataset name and digest to PolarsDataset's `to_evaluation_dataset` method

### DIFF
--- a/mlflow/data/polars_dataset.py
+++ b/mlflow/data/polars_dataset.py
@@ -285,6 +285,8 @@ class PolarsDataset(Dataset, PyFuncConvertibleDatasetMixin):
             path=path,
             feature_names=feature_names,
             predictions=self._predictions,
+            name=self.name,
+            digest=self.digest,
         )
 
 

--- a/tests/data/test_pandas_dataset.py
+++ b/tests/data/test_pandas_dataset.py
@@ -236,6 +236,9 @@ def test_to_evaluation_dataset():
         name="testname",
     )
     evaluation_dataset = dataset.to_evaluation_dataset()
+
+    assert evaluation_dataset.name is not None
+    assert evaluation_dataset.digest is not None
     assert isinstance(evaluation_dataset, EvaluationDataset)
     assert evaluation_dataset.features_data.equals(df.drop("c", axis=1))
     assert np.array_equal(evaluation_dataset.labels_data, df["c"].to_numpy())

--- a/tests/data/test_polars_dataset.py
+++ b/tests/data/test_polars_dataset.py
@@ -251,6 +251,8 @@ def test_to_evaluation_dataset(source: SampleDatasetSource) -> None:
     dataset = PolarsDataset(df=df, source=source, targets="c", name="testname")
     evaluation_dataset = dataset.to_evaluation_dataset()
 
+    assert evaluation_dataset.name is not None
+    assert evaluation_dataset.digest is not None
     assert isinstance(evaluation_dataset, EvaluationDataset)
     assert isinstance(evaluation_dataset.features_data, pd.DataFrame)
     assert evaluation_dataset.features_data.equals(df.drop("c").to_pandas())


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/sadelcarpio/mlflow/pull/17886?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17886/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17886/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17886/merge
```

</p>
</details>

### Related Issues/PRs

### What changes are proposed in this pull request?

First of all, thanks for the great efforts in maintaining this awesome library! I just started using mlflow with mostly polars data, and found what I assume is a bug.
This PR attempts to fix an bug  where the dataset digest is not present when converting a `PolarsDataset` to an `EvaluationDataset` instance, leading to an error when calling `mlflow.models.evaluate(PolarsDataset, ...)`:

* Reproducible example:

```python
import polars as pl
import mlflow

df = pl.DataFrame({"a": [1, 1], "b": [2, 2], "c": [3, 3]})
dataset = mlflow.data.from_polars(df, targets="a", predictions="b", name="testname", digest="1234")
mlflow.models.evaluate(data=dataset, model_type="regressor")
```

Error:
```
Traceback (most recent call last):
...
mlflow.exceptions.MlflowException: Both dataset_name and dataset_digest must be provided if one is provided
```

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Forward dataset name and digest to PolarsDataset's `to_evaluation_dataset` method, which allows calling `mlflow.models.evaluate` on a `PolarsDataset` instance.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
