### PR TITLE
Fix usage aggregation to avoid ancestor duplication

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -231,15 +231,8 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
         else:
             roots.append(span)
 
-    visited: set[str] = set()
-
     def dfs(span: LiveSpan, ancestor_has_usage: bool) -> None:
         nonlocal input_tokens, output_tokens, total_tokens, has_usage_data
-
-        if span.span_id in visited:
-            return
-
-        visited.add(span.span_id)
 
         usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
         span_has_usage = usage is not None

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -257,11 +257,6 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
     for root in roots:
         dfs(root, False)
 
-    # Handle spans that were not reachable due to missing parents or cycles.
-    for span in spans:
-        if span.span_id not in visited:
-            dfs(span, False)
-
     # If none of the spans have token usage data, we shouldn't log token usage metadata.
     if not has_usage_data:
         return None

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -5,7 +5,7 @@ import inspect
 import json
 import logging
 import uuid
-from collections import Counter
+from collections import Counter, defaultdict
 from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
 from functools import lru_cache
@@ -221,23 +221,46 @@ def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:
     has_usage_data = False
 
     span_id_to_spans = {span.span_id: span for span in spans}
-    for span in spans:
-        # Get usage attribute from span
-        if usage := span.get_attribute(SpanAttributeKey.CHAT_USAGE):
-            # If the parent span is also LLM/Chat span and has the token usage data,
-            # it tracks the same usage data by multiple flavors e.g. LangChain ChatOpenAI
-            # and OpenAI tracing. We should avoid double counting the usage data.
-            if (
-                span.parent_id
-                and (parent_span := span_id_to_spans.get(span.parent_id))
-                and parent_span.get_attribute(SpanAttributeKey.CHAT_USAGE)
-            ):
-                continue
+    children_map: defaultdict[str, list[LiveSpan]] = defaultdict(list)
+    roots: list[LiveSpan] = []
 
+    for span in spans:
+        parent_id = span.parent_id
+        if parent_id and parent_id in span_id_to_spans:
+            children_map[parent_id].append(span)
+        else:
+            roots.append(span)
+
+    visited: set[str] = set()
+
+    def dfs(span: LiveSpan, ancestor_has_usage: bool) -> None:
+        nonlocal input_tokens, output_tokens, total_tokens, has_usage_data
+
+        if span.span_id in visited:
+            return
+
+        visited.add(span.span_id)
+
+        usage = span.get_attribute(SpanAttributeKey.CHAT_USAGE)
+        span_has_usage = usage is not None
+
+        if span_has_usage and not ancestor_has_usage:
             input_tokens += usage.get(TokenUsageKey.INPUT_TOKENS, 0)
             output_tokens += usage.get(TokenUsageKey.OUTPUT_TOKENS, 0)
             total_tokens += usage.get(TokenUsageKey.TOTAL_TOKENS, 0)
             has_usage_data = True
+
+        next_ancestor_has_usage = ancestor_has_usage or span_has_usage
+        for child in children_map.get(span.span_id, []):
+            dfs(child, next_ancestor_has_usage)
+
+    for root in roots:
+        dfs(root, False)
+
+    # Handle spans that were not reachable due to missing parents or cycles.
+    for span in spans:
+        if span.span_id not in visited:
+            dfs(span, False)
 
     # If none of the spans have token usage data, we shouldn't log token usage metadata.
     if not has_usage_data:

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -108,7 +108,9 @@ def test_aggregate_usage_from_spans_skips_descendant_usage():
             create_mock_otel_span("trace_id", span_id=3, name="grandchild", parent_id=2),
             trace_id="tr-123",
         ),
-        LiveSpan(create_mock_otel_span("trace_id", span_id=4, name="independent"), trace_id="tr-123"),
+        LiveSpan(
+            create_mock_otel_span("trace_id", span_id=4, name="independent"), trace_id="tr-123"
+        ),
     ]
 
     spans[0].set_attribute(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/17921?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17921/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17921/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17921/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Traverse the span hierarchy with DFS when aggregating usage to prevent double counting when ancestors already report usage

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
