### PR TITLE
Allow built-in scorers to utilize traces for evaluation

### DIFF
--- a/docs/docs/genai/eval-monitor/index.mdx
+++ b/docs/docs/genai/eval-monitor/index.mdx
@@ -17,6 +17,7 @@ This documentation covers MLflow's **GenAI evaluation system** which uses:
 - `mlflow.genai.evaluate()` for evaluation
 - `Scorer` objects for metrics
 - Built-in and custom LLM judges
+- **MLflow >= 3.5.0**: Universal trace support for all predefined scorers with agent-based analysis capabilities
 
 **Note**: This system is separate from the [classic ML evaluation](/ml/evaluation) system that uses `mlflow.evaluate()` and `EvaluationMetric`. The two systems serve different purposes and are not interoperable.
 :::

--- a/docs/docs/genai/eval-monitor/quickstart.mdx
+++ b/docs/docs/genai/eval-monitor/quickstart.mdx
@@ -87,7 +87,9 @@ The dataset can be a list of dictionaries, a pandas DataFrame, a spark DataFrame
 
 :::note[Static Data vs Traces]
 
-This quickstart uses static evaluation data. Some advanced scorers (like retrieval or agent behavior scorers) require execution traces and won't work with static datasets. See the [Scorer Data Requirements](/genai/eval-monitor/scorers#scorer-data-requirements) for details.
+This quickstart uses static evaluation data. Some advanced scorers (like retrieval or agent behavior scorers) require execution traces and won't work with static datasets.
+
+**MLflow >= 3.5.0:** All predefined scorers support trace-based evaluation with automatic mode detection! Scorers automatically choose between field extraction and deep trace analysis based on the arguments you provide. See [Trace Support](/genai/eval-monitor/scorers/llm-judge/predefined#trace-support) for details.
 
 :::
 

--- a/docs/docs/genai/eval-monitor/running-evaluation/traces.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/traces.mdx
@@ -13,6 +13,16 @@ import ServerSetup from "@site/src/content/setup_server.mdx";
 
 [Traces](/genai/tracing) are the core data of MLflow. They capture the complete execution flow of your LLM applications. Evaluating traces is a powerful way to understand the performance of your LLM applications and get insights for quality improvement.
 
+:::info Enhanced Trace Support
+In MLflow >= 3.5.0, all predefined scorers support enhanced trace evaluation! You can:
+
+- **Pass traces directly** to any scorer for automatic field extraction from root spans
+- **Enable agent mode** (`enable_trace_agent=True`) for deep analysis of intermediate spans
+- **Combine traces with static data** for hybrid evaluation workflows
+
+See the examples below for how to leverage these capabilities.
+:::
+
 Evaluating traces is also a useful trick for offline evaluation. Instead of running prediction on every evaluation run, you can generate traces at once and re-use them for multiple evaluation runs, to reduce the computation and LLM costs.
 
 <ImageBox src="/images/mlflow-3/eval-monitor/trace-evaluation-hero.png" alt="Evaluate traces overview" width="95%"/>
@@ -232,6 +242,40 @@ email_scorers = [
     ),
 ]
 ```
+
+#### Advanced: Deep Trace Analysis (MLflow >= 3.5.0)
+
+For comprehensive trace analysis, use scorers with only traces (no other fields) to enable deep analysis:
+
+```python
+from mlflow.genai.scorers import Correctness, RelevanceToQuery
+
+# Pure trace-based evaluation - uses judge with analysis tools
+trace_scorers = [
+    Correctness(),  # Will use deep trace analysis when called with trace only
+    RelevanceToQuery(),  # Same automatic behavior
+]
+
+# In evaluation, pass traces without other fields for deep analysis
+results = mlflow.genai.evaluate(
+    data=traces,  # DataFrame with trace column
+    scorers=trace_scorers,  # Will automatically use trace analysis mode
+)
+
+# Or manually trigger trace analysis mode:
+trace = mlflow.get_trace("your-trace-id")
+result = Correctness()(
+    trace=trace
+)  # Pure trace analysis - no inputs/outputs/expectations
+```
+
+:::info Automatic Mode Selection
+Scorers automatically choose the evaluation approach:
+
+- **Deep trace analysis**: When only trace is provided
+- **Field extraction**: When trace + other fields are provided
+- **Traditional**: When inputs/outputs/expectations are provided without trace
+  :::
 
 :::tip Scoring Intermediate Information in Traces
 

--- a/docs/docs/genai/eval-monitor/scorers/index.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/index.mdx
@@ -12,10 +12,11 @@ Scorers can be considered as **metrics** in the traditional ML sense. However, t
 
 ## Key Features of MLflow Scorers
 
-MLflow scorers have two powerful capabilities that distinguish them from traditional metrics:
+MLflow scorers have powerful capabilities that distinguish them from traditional metrics:
 
 1. **Agent-as-a-Judge Evaluation**: Scorers can act as autonomous agents with tool-calling capabilities, enabling deep analysis of execution traces and multi-step workflows
 2. **Human Preference Alignment**: Scorers can be automatically aligned with human feedback to improve their accuracy and match your domain-specific quality standards
+3. **Universal Trace Support** (MLflow >= 3.5.0): All predefined scorers support trace-based evaluation with automatic field extraction or agent-based analysis modes
 
 ## How scorers work
 
@@ -49,12 +50,12 @@ Not all scorers work with static datasets. Some scorers are designed specificall
 
 ### Scorer Compatibility Matrix
 
-| Scorer Category              | Trace Required                | Example Scorers                                                             |
-| ---------------------------- | ----------------------------- | --------------------------------------------------------------------------- |
-| **Field-based Scorers**      | ❌ No                         | `Correctness`, `RelevanceToQuery`, `Safety`, custom scorers using `@scorer` |
-| **Agent-as-a-Judge Scorers** | ✅ Yes                        | Scorers analyzing execution flow, tool usage patterns, span attributes      |
-| **Retrieval Scorers**        | ✅ Yes (with RETRIEVER spans) | `RetrievalGroundedness`, `RetrievalRelevance`, `RetrievalSufficiency`       |
-| **Agent-as-a-Judge**         | ✅ Yes                        | Custom judges analyzing multi-step workflows, agent reasoning, performance  |
+| Scorer Category                    | Trace Required                | Example Scorers                                                             | MLflow >= 3.5.0 Enhancement                     |
+| ---------------------------------- | ----------------------------- | --------------------------------------------------------------------------- | ----------------------------------------------- |
+| **Field-based Scorers**            | ❌ No                         | `Correctness`, `RelevanceToQuery`, `Safety`, custom scorers using `@scorer` | ✅ Now support trace field extraction           |
+| **Predefined Scorers with Traces** | 🔄 Optional                   | All predefined scorers with automatic mode detection                        | ✅ Automatic field extraction or trace analysis |
+| **Retrieval Scorers**              | ✅ Yes (with RETRIEVER spans) | `RetrievalGroundedness`, `RetrievalRelevance`, `RetrievalSufficiency`       | Require RETRIEVER spans                         |
+| **Custom Agent-as-a-Judge**        | ✅ Yes                        | Custom judges analyzing multi-step workflows, agent reasoning, performance  | Use `make_judge()` with trace template variable |
 
 ### Working with Traces
 

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
@@ -8,6 +8,10 @@ import { Hammer, Bot, GitBranch } from "lucide-react";
 
 MLflow provides several pre-configured LLM judge scorers optimized for common evaluation scenarios.
 
+:::info Trace Support Available
+In MLflow >= 3.5.0, all predefined scorers support trace-based evaluation! You can pass traces directly to scorers for automatic field extraction or enable agent-based analysis for deeper insights. See [Trace Support](#trace-support) below.
+:::
+
 :::tip
 
 Typically, you can get started with evaluation using predefined scorers. However, every AI application is unique and has domain-specific quality criteria. At some point, you'll need to create your own custom LLM scorers.
@@ -82,6 +86,55 @@ results = mlflow.genai.evaluate(
 :::note Availability
 Safety and RetrievalRelevance scorers are currently only available in [Databricks managed MLflow](https://docs.databricks.com/mlflow3/genai/eval-monitor/) and will be open-sourced soon.
 :::
+
+## Trace Support
+
+**Available in MLflow >= 3.5.0:** All predefined scorers support enhanced trace-based evaluation with two modes:
+
+The behavior automatically adapts based on what you provide:
+
+### Field Extraction Mode
+
+When you provide a trace along with other fields, or when fields can be extracted:
+
+```python
+from mlflow.genai.scorers import Correctness
+
+# Mixed: trace + explicit expectations
+scorer = Correctness()
+trace = mlflow.get_trace("<your-trace-id>")
+result = scorer(
+    trace=trace, expectations={"expected_facts": ["fact1", "fact2"]}
+)  # Extracts inputs/outputs from trace, uses provided expectations
+
+# Pure field-based (traditional approach)
+result = scorer(
+    inputs={"question": "What is 2+2?"},
+    outputs="4",
+    expectations={"expected_response": "4"},
+)
+```
+
+### Trace-Based Analysis Mode
+
+When you provide only a trace (no other fields), uses deep trace analysis:
+
+```python
+from mlflow.genai.scorers import Correctness
+
+# Pure trace-based evaluation
+scorer = Correctness()
+trace = mlflow.get_trace("<your-trace-id>")
+result = scorer(trace=trace)  # Uses judge with trace analysis tools
+```
+
+:::info Automatic Mode Detection
+The scorer automatically determines the evaluation approach:
+
+- **Pure trace**: `scorer(trace=my_trace)` → Uses trace-based judge with analysis tools
+- **Mixed**: `scorer(trace=my_trace, expectations=...)` → Extracts fields from trace, uses field-based evaluation
+- **Traditional**: `scorer(inputs=..., outputs=..., expectations=...)` → Standard field-based evaluation
+  :::
 
 :::warning[Retrieval Scorers Require Traces]
 

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1,11 +1,20 @@
-from unittest.mock import call, patch
+import json
+from typing import Any
+from unittest.mock import MagicMock, call, patch
 
 import pytest
+from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 
 import mlflow
-from mlflow.entities.assessment import Feedback
+from mlflow.entities.assessment import Expectation, Feedback
 from mlflow.entities.assessment_error import AssessmentError
-from mlflow.entities.span import SpanType
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.entities.span import Span, SpanType
+from mlflow.entities.trace import Trace, TraceInfo
+from mlflow.entities.trace_data import TraceData
+from mlflow.entities.trace_location import TraceLocation
+from mlflow.entities.trace_state import TraceState
+from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.builtin import CategoricalRating
 from mlflow.genai.scorers import (
     Correctness,
@@ -19,6 +28,12 @@ from mlflow.genai.scorers import (
 )
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.builtin_scorers import get_all_scorers
+from mlflow.genai.utils.trace_utils import (
+    extract_expectations_from_trace,
+    extract_inputs_from_trace,
+    extract_outputs_from_trace,
+)
+from mlflow.tracing.utils import build_otel_context
 from mlflow.utils.uri import is_databricks_uri
 
 from tests.genai.conftest import databricks_only
@@ -310,86 +325,6 @@ def test_retrieval_sufficiency_with_custom_expectations(
     )
 
 
-@patch("mlflow.genai.judges.meets_guidelines")
-def test_guidelines(mock_guidelines):
-    # 1. Called with per-row guidelines
-    ExpectationsGuidelines()(
-        inputs={"question": "query"},
-        outputs="answer",
-        expectations={"guidelines": ["guideline1", "guideline2"]},
-    )
-
-    mock_guidelines.assert_called_once_with(
-        guidelines=["guideline1", "guideline2"],
-        context={"request": "{'question': 'query'}", "response": "answer"},
-        name="expectations_guidelines",
-        model=None,
-    )
-    mock_guidelines.reset_mock()
-
-    # 2. Called with global guidelines
-    is_english = Guidelines(
-        name="is_english",
-        guidelines=["The response should be in English."],
-        model="openai:/gpt-4.1-mini",
-    )
-    is_english(inputs={"question": "query"}, outputs="answer")
-
-    mock_guidelines.assert_called_once_with(
-        guidelines=["The response should be in English."],
-        context={"request": "{'question': 'query'}", "response": "answer"},
-        name="is_english",
-        model="openai:/gpt-4.1-mini",
-    )
-    mock_guidelines.reset_mock()
-
-    # 3. Test with string input (should wrap in list)
-    is_polite = Guidelines(
-        name="is_polite",
-        guidelines="Be polite and respectful.",
-        model="openai:/gpt-4.1-mini",
-    )
-    is_polite(inputs={"question": "query"}, outputs="answer")
-
-    mock_guidelines.assert_called_once_with(
-        guidelines="Be polite and respectful.",
-        context={"request": "{'question': 'query'}", "response": "answer"},
-        name="is_polite",
-        model="openai:/gpt-4.1-mini",
-    )
-
-
-@patch("mlflow.genai.judges.is_context_relevant")
-def test_relevance_to_query(mock_is_context_relevant):
-    # 1. Test with default scorer
-    RelevanceToQuery()(
-        inputs={"question": "query"},
-        outputs="answer",
-    )
-
-    mock_is_context_relevant.assert_called_once_with(
-        request="{'question': 'query'}",
-        context="answer",
-        name="relevance_to_query",
-        model=None,
-    )
-    mock_is_context_relevant.reset_mock()
-
-    # 2. Test with custom model parameter
-    relevance_custom = RelevanceToQuery(
-        name="custom_relevance",
-        model="openai:/gpt-4.1-mini",
-    )
-    relevance_custom(inputs={"question": "query"}, outputs="answer")
-
-    mock_is_context_relevant.assert_called_once_with(
-        request="{'question': 'query'}",
-        context="answer",
-        name="custom_relevance",
-        model="openai:/gpt-4.1-mini",
-    )
-
-
 @databricks_only
 def test_safety_databricks():
     # String output
@@ -462,46 +397,6 @@ def test_safety_with_custom_model_and_name(monkeypatch: pytest.MonkeyPatch):
         assert result.value == "no"
 
 
-@patch("mlflow.genai.judges.is_correct")
-def test_correctness(mock_is_correct):
-    # 1. Test with expected_facts
-    Correctness()(
-        inputs={"question": "query"},
-        outputs="answer",
-        expectations={"expected_facts": ["fact1", "fact2"]},
-    )
-
-    mock_is_correct.assert_called_once_with(
-        request="{'question': 'query'}",
-        response="answer",
-        expected_facts=["fact1", "fact2"],
-        expected_response=None,
-        name="correctness",
-        model=None,
-    )
-    mock_is_correct.reset_mock()
-
-    # 2. Test with custom model parameter
-    correctness_custom = Correctness(
-        name="custom_correctness",
-        model="openai:/gpt-4.1-mini",
-    )
-    correctness_custom(
-        inputs={"question": "query"},
-        outputs="answer",
-        expectations={"expected_response": "expected answer"},
-    )
-
-    mock_is_correct.assert_called_once_with(
-        request="{'question': 'query'}",
-        response="answer",
-        expected_facts=None,
-        expected_response="expected answer",
-        name="custom_correctness",
-        model="openai:/gpt-4.1-mini",
-    )
-
-
 @pytest.mark.parametrize("tracking_uri", ["file://test", "databricks"])
 def test_get_all_scorers_oss(tracking_uri):
     mlflow.set_tracking_uri(tracking_uri)
@@ -541,7 +436,7 @@ def test_guidelines_get_input_fields():
     """Test that Guidelines get_input_fields method returns expected field names."""
     guidelines = Guidelines(name="test", guidelines=["Be helpful"])
     field_names = [field.name for field in guidelines.get_input_fields()]
-    assert field_names == ["inputs", "outputs"]
+    assert field_names == ["trace", "inputs", "outputs"]
 
 
 def test_expectations_guidelines_get_input_fields():
@@ -555,7 +450,7 @@ def test_relevance_to_query_get_input_fields():
     """Test that RelevanceToQuery get_input_fields method returns expected field names."""
     relevance_query = RelevanceToQuery(name="test")
     field_names = [field.name for field in relevance_query.get_input_fields()]
-    assert field_names == ["inputs", "outputs"]
+    assert field_names == ["trace", "inputs", "outputs"]
 
 
 def test_safety_get_input_fields():
@@ -567,7 +462,633 @@ def test_safety_get_input_fields():
 
 
 def test_correctness_get_input_fields():
-    """Test that Correctness get_input_fields method returns expected field names."""
     correctness = Correctness(name="test")
     field_names = [field.name for field in correctness.get_input_fields()]
-    assert field_names == ["inputs", "outputs", "expectations"]
+    assert field_names == ["trace", "inputs", "outputs", "expectations"]
+
+
+from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
+
+from mlflow.exceptions import MlflowException
+from mlflow.tracing.utils import build_otel_context
+
+
+@pytest.fixture
+def mock_trace():
+    root_span = Span(
+        OTelReadableSpan(
+            name="root",
+            context=build_otel_context(trace_id=12345, span_id=67890),
+            parent=None,
+            start_time=0,
+            end_time=100,
+            attributes={
+                "mlflow.spanInputs": json.dumps({"question": "What is MLflow?"}),
+                "mlflow.spanOutputs": json.dumps(
+                    {"answer": "MLflow is an open source platform for ML lifecycle"}
+                ),
+            },
+        )
+    )
+
+    trace_info = TraceInfo(
+        trace_id="test-trace-123",
+        trace_location=TraceLocation.from_experiment_id("0"),
+        request_time=0,
+        execution_duration=100,
+        state=TraceState.OK,
+    )
+
+    trace_data = TraceData(spans=[root_span])
+    return Trace(info=trace_info, data=trace_data)
+
+
+@pytest.fixture
+def mock_trace_with_expectations(mock_trace):
+    from mlflow.entities.assessment import Expectation
+
+    trace = mock_trace
+    # Add expectation assessment
+    expectation = Expectation(
+        name="expected_response",
+        value="MLflow is a platform for ML lifecycle",
+        source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+    )
+    # Mock the search_assessments method to return expectations
+    trace.search_assessments = MagicMock(return_value=[expectation])
+    return trace
+
+
+def test_correctness_missing_requirements_error():
+    scorer = Correctness()
+
+    # Should raise error when neither trace nor required fields are provided
+    with pytest.raises(MlflowException, match="Correctness scorer requires either"):
+        scorer()
+
+    # Should raise error when trace is None and fields are incomplete
+    with pytest.raises(MlflowException, match="Correctness scorer requires either"):
+        scorer(inputs={"q": "test"})  # Missing outputs and expectations
+
+
+# ============================================================================
+# Real Trace Tests for Field Extraction and Override Behavior
+# ============================================================================
+
+
+@pytest.fixture
+def simple_qa_trace() -> Trace:
+    @mlflow.trace(name="qa_chain", span_type=SpanType.CHAIN)
+    def qa_function(question: str) -> str:
+        return f"The answer to '{question}' is 42"
+
+    qa_function("What is the meaning of life?")
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    trace.info.assessments = [
+        Expectation(
+            name="expected_response",
+            value="The answer is 42",
+            source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        ),
+        Expectation(
+            name="expected_facts",
+            value=["42 is the answer", "from Hitchhiker's Guide"],
+            source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        ),
+    ]
+    return trace
+
+
+@pytest.fixture
+def chat_trace() -> Trace:
+    @mlflow.trace(name="chat_bot", span_type=SpanType.CHAT_MODEL)
+    def chat_function(messages: list[dict[str, Any]]) -> dict[str, Any]:
+        return {
+            "choices": [
+                {"message": {"role": "assistant", "content": "Paris is the capital of France."}}
+            ]
+        }
+
+    messages = [{"role": "user", "content": "What is the capital of France?"}]
+    chat_function(messages)
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    trace.info.assessments = [
+        Expectation(
+            name="expected_response",
+            value="The capital of France is Paris",
+            source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        ),
+    ]
+    return trace
+
+
+@pytest.fixture
+def nested_trace() -> Trace:
+    @mlflow.trace(name="main_chain", span_type=SpanType.CHAIN)
+    def main_function(query: str) -> str:
+        preprocessed = preprocess(query)
+        result = process(preprocessed)
+        return postprocess(result)
+
+    @mlflow.trace(name="preprocess", span_type=SpanType.CHAIN)
+    def preprocess(text: str) -> str:
+        return text.lower().strip()
+
+    @mlflow.trace(name="process", span_type=SpanType.LLM)
+    def process(text: str) -> str:
+        return f"Processed: {text}"
+
+    @mlflow.trace(name="postprocess", span_type=SpanType.CHAIN)
+    def postprocess(text: str) -> str:
+        return text.upper()
+
+    main_function("Tell me about MLflow")
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    trace.info.assessments = [
+        Expectation(
+            name="expected_facts",
+            value=["MLflow is a platform", "manages ML lifecycle"],
+            source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        ),
+        Expectation(
+            name="guidelines",
+            value=["Be concise", "Use technical terms appropriately"],
+            source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        ),
+    ]
+    return trace
+
+
+@pytest.fixture
+def trace_without_expectations() -> Trace:
+    @mlflow.trace(name="simple", span_type=SpanType.CHAIN)
+    def simple_function(input_text: str) -> str:
+        return f"Output: {input_text}"
+
+    simple_function("test input")
+    return mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+
+@pytest.fixture
+def complex_io_trace() -> Trace:
+    @mlflow.trace(name="complex", span_type=SpanType.CHAIN)
+    def complex_function(data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "status": "success",
+            "results": [
+                {"id": 1, "value": data.get("query")},
+                {"id": 2, "value": "additional data"},
+            ],
+            "metadata": {"processed": True},
+        }
+
+    complex_function({"query": "complex query", "filters": ["a", "b"]})
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    trace.info.assessments = [
+        Expectation(
+            name="expected_response",
+            value=json.dumps({"status": "success", "results": ["some", "data"]}),
+            source=AssessmentSource(source_type=AssessmentSourceType.HUMAN),
+        ),
+    ]
+    return trace
+
+
+def test_correctness_extraction_from_simple_trace(simple_qa_trace):
+    scorer = Correctness()
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(
+            name="correctness", value=True, rationale="Correct based on trace"
+        )
+
+        result = scorer(trace=simple_qa_trace)
+
+        mock_is_correct.assert_called_once()
+        call_args = mock_is_correct.call_args[1]
+
+        assert "What is the meaning of life?" in call_args["request"]
+        assert "The answer to 'What is the meaning of life?' is 42" in call_args["response"]
+        assert call_args["expected_response"] == "The answer is 42"
+        assert call_args["expected_facts"] == ["42 is the answer", "from Hitchhiker's Guide"]
+        assert result.value is True
+
+
+def test_correctness_with_override_outputs(simple_qa_trace):
+    scorer = Correctness()
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(
+            name="correctness", value=False, rationale="Override output incorrect"
+        )
+
+        custom_output = "This is a custom wrong answer"
+        result = scorer(trace=simple_qa_trace, outputs=custom_output)
+
+        call_args = mock_is_correct.call_args[1]
+        assert call_args["response"] == custom_output
+        assert "What is the meaning of life?" in call_args["request"]
+        assert call_args["expected_response"] == "The answer is 42"
+        assert result.value is False
+
+
+def test_correctness_with_override_expectations(simple_qa_trace):
+    scorer = Correctness()
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(
+            name="correctness", value=True, rationale="Custom expectations"
+        )
+
+        custom_expectations = {
+            "expected_response": "Custom expected answer",
+            "expected_facts": ["custom", "facts"],
+        }
+        scorer(trace=simple_qa_trace, expectations=custom_expectations)
+
+        call_args = mock_is_correct.call_args[1]
+        assert call_args["expected_response"] == "Custom expected answer"
+        assert call_args["expected_facts"] == ["custom", "facts"]
+        assert "What is the meaning of life?" in call_args["request"]
+        assert "The answer to 'What is the meaning of life?' is 42" in call_args["response"]
+
+
+def test_correctness_llm_fallback_for_missing_expectations(trace_without_expectations):
+    scorer = Correctness()
+
+    with patch.object(scorer, "_extract_missing_fields_with_llm") as mock_extract:
+        mock_extract.return_value = {
+            "expected_response": "LLM extracted response",
+            "expected_facts": ["LLM", "extracted", "facts"],
+        }
+
+        with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+            mock_is_correct.return_value = Feedback(
+                name="correctness", value=True, rationale="LLM extraction worked"
+            )
+
+            scorer(trace=trace_without_expectations)
+            mock_extract.assert_called_once()
+
+            call_args = mock_is_correct.call_args[1]
+            assert call_args["expected_response"] == "LLM extracted response"
+            assert call_args["expected_facts"] == ["LLM", "extracted", "facts"]
+
+
+def test_correctness_with_chat_trace(chat_trace):
+    scorer = Correctness()
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(
+            name="correctness", value=True, rationale="Chat format handled"
+        )
+
+        scorer(trace=chat_trace)
+        call_args = mock_is_correct.call_args[1]
+
+        assert "What is the capital of France?" in call_args["request"]
+        assert "Paris is the capital of France" in call_args["response"]
+        assert call_args["expected_response"] == "The capital of France is Paris"
+
+
+def test_guidelines_extraction_from_trace(simple_qa_trace):
+    scorer = Guidelines(guidelines=["Be helpful", "Be accurate"])
+
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="guidelines", value=True)
+
+        result = scorer(trace=simple_qa_trace)
+        call_args = mock_meets.call_args[1]
+
+        assert "What is the meaning of life?" in call_args["context"]["request"]
+        assert (
+            "The answer to 'What is the meaning of life?' is 42" in call_args["context"]["response"]
+        )
+        assert call_args["guidelines"] == ["Be helpful", "Be accurate"]
+        assert result.value is True
+
+
+def test_guidelines_with_override_inputs(simple_qa_trace):
+    scorer = Guidelines(guidelines=["Test guideline"])
+
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="guidelines", value=False)
+
+        custom_inputs = {"question": "Custom question"}
+        scorer(trace=simple_qa_trace, inputs=custom_inputs)
+
+        call_args = mock_meets.call_args[1]
+        assert "Custom question" in call_args["context"]["request"]
+        assert (
+            "The answer to 'What is the meaning of life?' is 42" in call_args["context"]["response"]
+        )
+
+
+def test_guidelines_with_nested_trace(nested_trace):
+    scorer = Guidelines(guidelines=["Be technical"])
+
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="guidelines", value=True)
+
+        scorer(trace=nested_trace)
+        call_args = mock_meets.call_args[1]
+
+        assert "Tell me about MLflow" in call_args["context"]["request"]
+        assert "PROCESSED: TELL ME ABOUT MLFLOW" in call_args["context"]["response"]
+
+
+def test_relevance_extraction_from_trace(simple_qa_trace):
+    scorer = RelevanceToQuery()
+
+    with patch("mlflow.genai.judges.is_context_relevant") as mock_relevant:
+        mock_relevant.return_value = Feedback(name="relevance_to_query", value=True)
+
+        result = scorer(trace=simple_qa_trace)
+        call_args = mock_relevant.call_args[1]
+
+        assert "What is the meaning of life?" in call_args["request"]
+        assert "The answer to 'What is the meaning of life?' is 42" == call_args["context"]
+        assert result.value is True
+
+
+def test_relevance_with_complex_io(complex_io_trace):
+    scorer = RelevanceToQuery()
+
+    with patch("mlflow.genai.judges.is_context_relevant") as mock_relevant:
+        mock_relevant.return_value = Feedback(name="relevance_to_query", value=True)
+
+        scorer(trace=complex_io_trace)
+        call_args = mock_relevant.call_args[1]
+
+        assert "complex query" in call_args["request"]
+        assert call_args["context"]["status"] == "success"
+        assert "results" in call_args["context"]
+
+
+def test_relevance_mixed_override(simple_qa_trace):
+    scorer = RelevanceToQuery()
+
+    with patch("mlflow.genai.judges.is_context_relevant") as mock_relevant:
+        mock_relevant.return_value = Feedback(name="relevance_to_query", value=False)
+
+        custom_outputs = "Irrelevant response about weather"
+        result = scorer(trace=simple_qa_trace, outputs=custom_outputs)
+
+        call_args = mock_relevant.call_args[1]
+        assert call_args["context"] == custom_outputs
+        assert "What is the meaning of life?" in call_args["request"]
+        assert result.value is False
+
+
+def test_safety_extraction_from_trace(simple_qa_trace):
+    if not mlflow.get_tracking_uri().startswith("databricks"):
+        pytest.skip("Safety scorer requires Databricks environment")
+
+    scorer = Safety()
+
+    with patch("databricks.agents.evals.judges.safety") as mock_safety:
+        mock_safety.return_value = Feedback(name="safety", value=True)
+
+        result = scorer(trace=simple_qa_trace)
+        call_args = mock_safety.call_args[1]
+
+        assert "The answer to 'What is the meaning of life?' is 42" in call_args["response"]
+        assert result.value is True
+
+
+def test_safety_with_override(simple_qa_trace):
+    if not mlflow.get_tracking_uri().startswith("databricks"):
+        pytest.skip("Safety scorer requires Databricks environment")
+
+    scorer = Safety()
+
+    with patch("databricks.agents.evals.judges.safety") as mock_safety:
+        mock_safety.return_value = Feedback(name="safety", value=False)
+
+        unsafe_output = "This contains unsafe content"
+        result = scorer(trace=simple_qa_trace, outputs=unsafe_output)
+
+        call_args = mock_safety.call_args[1]
+        assert call_args["response"] == unsafe_output
+        assert result.value is False
+
+
+def test_expectations_guidelines_extraction(nested_trace):
+    scorer = ExpectationsGuidelines()
+
+    inputs = extract_inputs_from_trace(nested_trace)
+    outputs = extract_outputs_from_trace(nested_trace)
+    expectations = extract_expectations_from_trace(nested_trace)
+
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="expectations_guidelines", value=True)
+
+        result = scorer(inputs=inputs, outputs=outputs, expectations=expectations)
+        call_args = mock_meets.call_args[1]
+
+        assert call_args["guidelines"] == ["Be concise", "Use technical terms appropriately"]
+        assert result.value is True
+
+
+def test_scorer_with_malformed_trace():
+    @mlflow.trace(name="malformed", span_type=SpanType.CHAIN)
+    def malformed_function():
+        pass
+
+    malformed_function()
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    scorer = Guidelines(guidelines=["Some guideline"])
+
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="guidelines", value=True)
+
+        scorer(trace=trace)
+        call_args = mock_meets.call_args[1]
+
+        assert "context" in call_args
+        assert "request" in call_args["context"]
+        assert "response" in call_args["context"]
+        assert isinstance(call_args["context"]["request"], str)
+        assert isinstance(call_args["context"]["response"], str)
+
+
+def test_all_fields_provided_ignores_trace(simple_qa_trace):
+    scorer = Correctness()
+
+    direct_inputs = {"q": "Direct question"}
+    direct_outputs = "Direct answer"
+    direct_expectations = {"expected_response": "Direct expected"}
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(name="correctness", value=True)
+
+        scorer(
+            trace=simple_qa_trace,
+            inputs=direct_inputs,
+            outputs=direct_outputs,
+            expectations=direct_expectations,
+        )
+
+        call_args = mock_is_correct.call_args[1]
+
+        assert "Direct question" in call_args["request"]
+        assert call_args["response"] == "Direct answer"
+        assert call_args["expected_response"] == "Direct expected"
+        assert "What is the meaning of life?" not in call_args["request"]
+        assert "42" not in call_args["response"]
+
+
+def test_correctness_with_different_expectation_types():
+    scorer = Correctness()
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(name="correctness", value=True)
+
+        scorer(
+            inputs={"question": "query"},
+            outputs="answer",
+            expectations={"expected_facts": ["fact1", "fact2"]},
+        )
+
+        call_args = mock_is_correct.call_args[1]
+        assert call_args["expected_facts"] == ["fact1", "fact2"]
+        assert call_args["expected_response"] is None
+
+        mock_is_correct.reset_mock()
+
+        scorer(
+            inputs={"question": "query"},
+            outputs="answer",
+            expectations={"expected_response": "expected answer"},
+        )
+
+        call_args = mock_is_correct.call_args[1]
+        assert call_args["expected_response"] == "expected answer"
+        assert call_args.get("expected_facts") is None
+
+
+def test_correctness_with_custom_model():
+    correctness_custom = Correctness(name="custom_correctness", model="openai:/gpt-4")
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(name="custom_correctness", value=False)
+
+        correctness_custom(
+            inputs={"question": "test"},
+            outputs="test answer",
+            expectations={"expected_response": "different"},
+        )
+
+        call_args = mock_is_correct.call_args[1]
+        assert call_args["name"] == "custom_correctness"
+        assert call_args["model"] == "openai:/gpt-4"
+
+
+def test_partial_override_scenario(chat_trace):
+    scorer = Correctness()
+
+    custom_expectations = {"expected_facts": ["Paris", "France", "capital"]}
+
+    with patch("mlflow.genai.judges.is_correct") as mock_is_correct:
+        mock_is_correct.return_value = Feedback(name="correctness", value=True)
+
+        scorer(trace=chat_trace, expectations=custom_expectations)
+        call_args = mock_is_correct.call_args[1]
+
+        assert "What is the capital of France?" in call_args["request"]
+        assert "Paris is the capital of France" in call_args["response"]
+        assert call_args["expected_facts"] == ["Paris", "France", "capital"]
+        assert call_args.get("expected_response") is None
+
+
+def test_verify_extraction_utilities_work(simple_qa_trace):
+    inputs = extract_inputs_from_trace(simple_qa_trace)
+    assert inputs == {"question": "What is the meaning of life?"}
+
+    outputs = extract_outputs_from_trace(simple_qa_trace)
+    assert outputs == "The answer to 'What is the meaning of life?' is 42"
+
+    expectations = extract_expectations_from_trace(simple_qa_trace)
+    assert expectations["expected_response"] == "The answer is 42"
+    assert expectations["expected_facts"] == ["42 is the answer", "from Hitchhiker's Guide"]
+
+
+def test_verify_chat_extraction(chat_trace):
+    inputs = extract_inputs_from_trace(chat_trace)
+    assert "messages" in inputs or isinstance(inputs, list)
+    if "messages" in inputs:
+        assert inputs["messages"][0]["content"] == "What is the capital of France?"
+    else:
+        assert inputs[0]["content"] == "What is the capital of France?"
+
+    outputs = extract_outputs_from_trace(chat_trace)
+    assert "Paris is the capital of France" in str(outputs)
+
+
+def test_guidelines_different_configurations():
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="expectations_guidelines", value=True)
+
+        ExpectationsGuidelines()(
+            inputs={"question": "query"},
+            outputs="answer",
+            expectations={"guidelines": ["guideline1", "guideline2"]},
+        )
+
+        call_args = mock_meets.call_args[1]
+        assert call_args["guidelines"] == ["guideline1", "guideline2"]
+        assert call_args["name"] == "expectations_guidelines"
+
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="is_english", value=True)
+
+        is_english = Guidelines(
+            name="is_english",
+            guidelines=["The response should be in English."],
+            model="openai:/gpt-4",
+        )
+        is_english(inputs={"question": "query"}, outputs="answer")
+
+        call_args = mock_meets.call_args[1]
+        assert call_args["guidelines"] == ["The response should be in English."]
+        assert call_args["name"] == "is_english"
+        assert call_args["model"] == "openai:/gpt-4"
+
+    with patch("mlflow.genai.judges.meets_guidelines") as mock_meets:
+        mock_meets.return_value = Feedback(name="is_polite", value=True)
+
+        is_polite = Guidelines(
+            name="is_polite", guidelines="Be polite and respectful.", model="openai:/gpt-4"
+        )
+        is_polite(inputs={"question": "query"}, outputs="answer")
+
+        call_args = mock_meets.call_args[1]
+        assert call_args["guidelines"] == "Be polite and respectful."
+        assert call_args["name"] == "is_polite"
+
+
+def test_relevance_with_custom_model():
+    with patch("mlflow.genai.judges.is_context_relevant") as mock_relevant:
+        mock_relevant.return_value = Feedback(name="relevance_to_query", value=True)
+
+        RelevanceToQuery()(inputs={"question": "query"}, outputs="answer")
+
+        call_args = mock_relevant.call_args[1]
+        assert call_args["request"] == "{'question': 'query'}"
+        assert call_args["context"] == "answer"
+        assert call_args["name"] == "relevance_to_query"
+        assert call_args["model"] is None
+
+        mock_relevant.reset_mock()
+
+        relevance_custom = RelevanceToQuery(name="custom_relevance", model="openai:/gpt-4")
+        relevance_custom(inputs={"question": "query"}, outputs="answer")
+
+        call_args = mock_relevant.call_args[1]
+        assert call_args["name"] == "custom_relevance"
+        assert call_args["model"] == "openai:/gpt-4"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/17934?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17934/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17934/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17934/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Allows for traces to be used for required field extraction for built-in scorers that do not already require traces as input. This aligns the built-in scorers to the functionality provided through make_judge() and the InstructionsJudge API (although without the agent-based judge functionality). 

This feature performs staged-extraction by way of:

1. If a trace is provided to these scorers, first attempt code-based field extraction from the trace to extract the expected required inputs
2. If this fails, use make_judge() to build a simple agent interface whose sole purposes is to 'find' the required data based on the needs of the scorer with a standard output format
3. If this fails, raise 

built-in scorers that do not supply a trace have no material impact to their previous behavior.

### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [X] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
