### PR TITLE
Fix missing huey dependency in test requirements

### DIFF
--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -1,7 +1,6 @@
 syntax = "proto2";
 
 package mlflow;
-// Temporary comment to trigger CI - will be removed
 
 import "scalapb/scalapb.proto";
 import "databricks.proto";

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -1,6 +1,7 @@
 syntax = "proto2";
 
 package mlflow;
+// Temporary comment to trigger CI - will be removed
 
 import "scalapb/scalapb.proto";
 import "databricks.proto";

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -36,3 +36,5 @@ Flask-WTF<2
 polars>=1
 # required for testing mlflow.genai.optimize_prompt
 dspy
+# required for testing mlflow.server.jobs
+huey<3,>=2.5.0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/17970?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17970/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17970/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17970/merge
```

</p>
</details>

### Related Issues/PRs

Fixes test failures in GitHub Actions run #18024856363 from PR #17786

### What changes are proposed in this pull request?

This PR adds the missing `huey` package to `requirements/test-requirements.txt` to fix failing tests in the `mlflow.server.jobs` module.

**Background:**
- The `mlflow.server.jobs.job_runner` module imports `huey` (specifically `SqliteHuey`) at the module level
- The `huey` package is declared as an optional dependency in `pyproject.toml` under the `jobs` group with version constraint `huey<3,>=2.5.0`
- However, it was not included in the test requirements, causing `ModuleNotFoundError` when running tests in `tests/server/job/test_job.py`

**Fix:**
Added `huey<3,>=2.5.0` to `requirements/test-requirements.txt` with a comment explaining it's required for testing mlflow.server.jobs functionality.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing performed:**
```bash
# Test passes with huey installed
uv run --with huey pytest tests/server/job/test_job.py::test_basic_job -v
# Result: PASSED

# All tests in the module pass
uv run --with huey pytest tests/server/job/test_job.py -v
# Result: All tests PASSED
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

This is a test infrastructure fix that doesn't affect end users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)

This is a small test infrastructure fix that should be included in the next patch release.

🤖 Generated with [Claude Code](https://claude.ai/code)