### PR TITLE
Add autologging event

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,14 +102,7 @@ jobs:
           source dev/setup-ssh.sh
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
             --ignore-flavors --ignore=tests/examples --ignore=tests/evaluate \
-            --ignore tests/genai --ignore tests/telemetry tests
-
-      - name: Run telemetry tests
-        run: |
-          source .venv/bin/activate
-          # Run telemetry tests in a separate job because some tests (e.g. autologging) cannot
-          # be run together with spark tests
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/telemetry
+            --ignore tests/genai tests
 
       # TODO: Remove this step once support for pydantic v1 is dropped
       # - name: Run gateway tests with pydantic v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -102,7 +102,14 @@ jobs:
           source dev/setup-ssh.sh
           pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
             --ignore-flavors --ignore=tests/examples --ignore=tests/evaluate \
-            --ignore tests/genai tests
+            --ignore tests/genai --ignore tests/telemetry tests
+
+      - name: Run telemetry tests
+        run: |
+          source .venv/bin/activate
+          # Run telemetry tests in a separate job because some tests (e.g. autologging) cannot
+          # be run together with spark tests
+          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/telemetry
 
       # TODO: Remove this step once support for pydantic v1 is dropped
       # - name: Run gateway tests with pydantic v1

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -241,6 +241,11 @@ For events with None in the `Tracked Parameters` column, only the event name is 
       <td>Number of traces provided and optimizer type</td>
       <td>`{"trace_count": 100, "optimizer_type": "AlignmentOptimizer"}`</td>
     </tr>
+    <tr>
+      <td>autologging</td>
+      <td>Flavor and metadata</td>
+      <td>`{"flavor": "openai", "log_traces": True, "disable": False}`</td>
+    </tr>
   </tbody>
 </Table>
 

--- a/mlflow/ag2/__init__.py
+++ b/mlflow/ag2/__init__.py
@@ -1,3 +1,5 @@
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration
 
@@ -54,3 +56,6 @@ def _autolog(
     mentioned in the comment above. Note that this function MUST declare the same signature as the
     autolog(), otherwise the annotation will not work properly.
     """
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/agno/__init__.py
+++ b/mlflow/agno/__init__.py
@@ -2,6 +2,8 @@ import inspect
 import logging
 
 from mlflow.agno.autolog import patched_async_class_call, patched_class_call
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
@@ -76,3 +78,7 @@ def autolog(*, log_traces: bool = True, disable: bool = False, silent: bool = Fa
                 _logger.debug(
                     "Agno autologging: cannot patch %s.%s – %s", cls_path, method_name, exc
                 )
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/anthropic/__init__.py
+++ b/mlflow/anthropic/__init__.py
@@ -5,6 +5,8 @@ from mlflow.anthropic.autolog import (
     patched_class_call,
     patched_claude_sdk_init,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "anthropic"
@@ -58,3 +60,6 @@ def autolog(
         )
     except ImportError:
         _logger.debug("Claude Agent SDK not installed, skipping Claude Code SDK patching")
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/autogen/__init__.py
+++ b/mlflow/autogen/__init__.py
@@ -6,6 +6,8 @@ from pydantic import BaseModel
 import mlflow
 from mlflow.autogen.chat import log_tools
 from mlflow.entities import SpanType
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
 from mlflow.tracing.utils import construct_full_inputs
 from mlflow.utils.autologging_utils import (
@@ -103,6 +105,10 @@ def autolog(
 
     for cls in _get_all_subclasses(ChatCompletionClient):
         safe_patch(FLAVOR_NAME, cls, "create", patched_completion)
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )
 
 
 def _convert_value_to_dict(value):

--- a/mlflow/bedrock/__init__.py
+++ b/mlflow/bedrock/__init__.py
@@ -1,5 +1,7 @@
 import logging
 
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 _logger = logging.getLogger(__name__)
@@ -41,3 +43,7 @@ def autolog(
             "service clients that are created after this call. If you have already "
             "created one, please recreate the client by calling `boto3.client`."
         )
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/crewai/__init__.py
+++ b/mlflow/crewai/__init__.py
@@ -10,6 +10,8 @@ from packaging.version import Version
 from mlflow.crewai.autolog import (
     patched_class_call,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 _logger = logging.getLogger(__name__)
@@ -78,3 +80,7 @@ def autolog(
                 )
     except (AttributeError, ModuleNotFoundError) as e:
         _logger.error("An exception happens when applying auto-tracing to crewai. Exception: %s", e)
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -4,6 +4,8 @@ from packaging.version import Version
 
 import mlflow
 from mlflow.dspy.constant import FLAVOR_NAME
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.tracing.provider import trace_disabled
 from mlflow.tracing.utils import construct_full_inputs
 from mlflow.utils.autologging_utils import (
@@ -173,6 +175,10 @@ def autolog(
             call_patch,
             patch_fn,
         )
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )
 
 
 # This is required by mlflow.autolog()

--- a/mlflow/gemini/__init__.py
+++ b/mlflow/gemini/__init__.py
@@ -7,6 +7,8 @@ from mlflow.gemini.autolog import (
     patched_class_call,
     patched_module_call,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "gemini"
@@ -90,3 +92,7 @@ def autolog(
         )
     except ImportError:
         pass
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/groq/__init__.py
+++ b/mlflow/groq/__init__.py
@@ -3,6 +3,8 @@ The ``mlflow.groq`` module provides an API for logging and loading Groq models.
 """
 
 from mlflow.groq._groq_autolog import patched_call
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "groq"
@@ -38,3 +40,7 @@ def autolog(
             "create",
             patched_call,
         )
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/langchain/autolog.py
+++ b/mlflow/langchain/autolog.py
@@ -1,6 +1,8 @@
 import logging
 
 from mlflow.langchain.constant import FLAVOR_NAME
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration
 from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 from mlflow.utils.autologging_utils.safety import safe_patch
@@ -67,6 +69,10 @@ def autolog(
         )
     except Exception:
         logger.debug("Failed to patch RunnableSequence or BaseCallbackManager.", exc_info=True)
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )
 
 
 def _patched_callback_manager_init(original, self, *args, **kwargs):

--- a/mlflow/litellm/__init__.py
+++ b/mlflow/litellm/__init__.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Callable
 
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "litellm"
@@ -53,6 +55,10 @@ def autolog(
         # Callback also needs to be removed from 'callbacks' as litellm adds
         # success/failure callbacks to there as well.
         litellm.callbacks = _remove_mlflow_callbacks(litellm.callbacks)
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )
 
 
 # This is required by mlflow.autolog()

--- a/mlflow/llama_index/autolog.py
+++ b/mlflow/llama_index/autolog.py
@@ -1,4 +1,6 @@
 from mlflow.llama_index.constant import FLAVOR_NAME
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration
 
 
@@ -51,3 +53,6 @@ def _autolog(
     """
     TODO: Implement patching logic for autologging models and artifacts.
     """
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/mistral/__init__.py
+++ b/mlflow/mistral/__init__.py
@@ -1,4 +1,6 @@
 from mlflow.mistral.autolog import async_patched_class_call, patched_class_call
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
 FLAVOR_NAME = "mistral"
@@ -36,4 +38,7 @@ def autolog(
         Chat,
         "complete_async",
         async_patched_class_call,
+    )
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
     )

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -13,6 +13,8 @@ from mlflow.entities.span_status import SpanStatusCode
 from mlflow.exceptions import MlflowException
 from mlflow.openai.constant import FLAVOR_NAME
 from mlflow.openai.utils.chat_schema import set_span_chat_attributes
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_NAME_FORMAT,
     STREAM_CHUNK_EVENT_VALUE_KEY,
@@ -93,6 +95,10 @@ def autolog(
             remove_mlflow_trace_processor()
     except ImportError:
         pass
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )
 
 
 # This is required by mlflow.autolog()

--- a/mlflow/pydantic_ai/__init__.py
+++ b/mlflow/pydantic_ai/__init__.py
@@ -5,6 +5,8 @@ from mlflow.pydantic_ai.autolog import (
     patched_async_class_call,
     patched_class_call,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
@@ -64,3 +66,7 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
                 )
             except AttributeError as e:
                 _logger.error("Error patching %s.%s: %s", cls_path, method, e)
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/semantic_kernel/__init__.py
+++ b/mlflow/semantic_kernel/__init__.py
@@ -6,6 +6,8 @@ from mlflow.semantic_kernel.tracing_utils import (
     patched_kernel_entry_point,
     semantic_kernel_diagnostics_wrapper,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
@@ -56,3 +58,7 @@ def autolog(
             method_name,
             semantic_kernel_diagnostics_wrapper,
         )
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/smolagents/__init__.py
+++ b/mlflow/smolagents/__init__.py
@@ -7,6 +7,8 @@ import logging
 from mlflow.smolagents.autolog import (
     patched_class_call,
 )
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration, safe_patch
 
@@ -64,3 +66,7 @@ def autolog(
         _logger.error(
             "An exception happens when applying auto-tracing to smolagents. Exception: %s", e
         )
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )

--- a/mlflow/strands/__init__.py
+++ b/mlflow/strands/__init__.py
@@ -1,6 +1,8 @@
 import logging
 
 from mlflow.strands.autolog import setup_strands_tracing, teardown_strands_tracing
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils import autologging_integration
 
@@ -23,6 +25,10 @@ def autolog(log_traces: bool = True, disable: bool = False, silent: bool = False
         teardown_strands_tracing()
     else:
         setup_strands_tracing()
+
+    _record_event(
+        AutologgingEvent, {"flavor": FLAVOR_NAME, "log_traces": log_traces, "disable": disable}
+    )
 
 
 # This is required by mlflow.autolog()

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -263,3 +263,7 @@ class AlignJudgeEvent(Event):
             result["optimizer_type"] = "default"
 
         return result
+
+
+class AutologgingEvent(Event):
+    name: str = "autologging"

--- a/mlflow/telemetry/track.py
+++ b/mlflow/telemetry/track.py
@@ -35,13 +35,7 @@ def record_usage_event(event: type[Event]) -> Callable[[Callable[P, R]], Callabl
             finally:
                 try:
                     duration_ms = int((time.time() - start_time) * 1000)
-                    client = get_telemetry_client()
-                    if client and (
-                        record := _generate_telemetry_record(
-                            func, args, kwargs, success, duration_ms, event, result
-                        )
-                    ):
-                        client.add_record(record)
+                    _add_telemetry_record(func, args, kwargs, success, duration_ms, event, result)
                 except Exception as e:
                     _log_error(f"Failed to record telemetry event {event.name}: {e}")
 
@@ -50,7 +44,7 @@ def record_usage_event(event: type[Event]) -> Callable[[Callable[P, R]], Callabl
     return decorator
 
 
-def _generate_telemetry_record(
+def _add_telemetry_record(
     func: Callable[..., Any],
     args: tuple[Any, ...],
     kwargs: dict[str, Any],
@@ -58,34 +52,53 @@ def _generate_telemetry_record(
     duration_ms: int,
     event: type[Event],
     result: Any,
-) -> Record | None:
+) -> None:
     try:
-        signature = inspect.signature(func)
-        bound_args = signature.bind(*args, **kwargs)
-        bound_args.apply_defaults()
+        if client := get_telemetry_client():
+            signature = inspect.signature(func)
+            bound_args = signature.bind(*args, **kwargs)
+            bound_args.apply_defaults()
 
-        arguments = dict(bound_args.arguments)
-        arguments.pop("self", None)
+            arguments = dict(bound_args.arguments)
+            arguments.pop("self", None)
 
-        params = list(arguments.keys())
-        if params and params[0] == "cls" and isinstance(arguments["cls"], type):
-            del arguments["cls"]
+            params = list(arguments.keys())
+            if params and params[0] == "cls" and isinstance(arguments["cls"], type):
+                del arguments["cls"]
 
-        record_params = event.parse(arguments) or {}
-        if hasattr(event, "parse_result"):
-            record_params.update(event.parse_result(result))
-        if experiment_id := MLFLOW_EXPERIMENT_ID.get():
-            record_params["mlflow_experiment_id"] = experiment_id
-        return Record(
-            event_name=event.name,
-            timestamp_ns=time.time_ns(),
-            params=record_params or None,
-            status=Status.SUCCESS if success else Status.FAILURE,
-            duration_ms=duration_ms,
-        )
+            record_params = event.parse(arguments) or {}
+            if hasattr(event, "parse_result"):
+                record_params.update(event.parse_result(result))
+            if experiment_id := MLFLOW_EXPERIMENT_ID.get():
+                record_params["mlflow_experiment_id"] = experiment_id
+            record = Record(
+                event_name=event.name,
+                timestamp_ns=time.time_ns(),
+                params=record_params or None,
+                status=Status.SUCCESS if success else Status.FAILURE,
+                duration_ms=duration_ms,
+            )
+            client.add_record(record)
     except Exception as e:
         _log_error(f"Failed to generate telemetry record for event {event.name}: {e}")
-        return
+
+
+def _record_event(event: type[Event], params: dict[str, Any] | None = None) -> None:
+    try:
+        if client := get_telemetry_client():
+            if experiment_id := MLFLOW_EXPERIMENT_ID.get():
+                params["mlflow_experiment_id"] = experiment_id
+            client.add_record(
+                Record(
+                    event_name=event.name,
+                    params=params,
+                    timestamp_ns=time.time_ns(),
+                    status=Status.SUCCESS,
+                    duration_ms=0,
+                )
+            )
+    except Exception as e:
+        _log_error(f"Failed to record telemetry event {event.name}: {e}")
 
 
 def _is_telemetry_disabled_for_event(event: type[Event]) -> bool:

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -45,6 +45,8 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
 )
 from mlflow.store.tracking import SEARCH_MAX_RESULTS_DEFAULT
+from mlflow.telemetry.events import AutologgingEvent
+from mlflow.telemetry.track import _record_event
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
@@ -3316,6 +3318,8 @@ def autolog(
             register_post_import_hook(setup_autologging, "pyspark", overwrite=True)
         if "pyspark.ml" in target_library_and_module:
             register_post_import_hook(setup_autologging, "pyspark.ml", overwrite=True)
+
+    _record_event(AutologgingEvent, {"flavor": "all", "log_traces": log_traces, "disable": disable})
 
 
 _active_model_id_env_lock = threading.Lock()

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -22,6 +22,7 @@ from mlflow.pyfunc.model import ResponsesAgent, ResponsesAgentRequest, Responses
 from mlflow.telemetry.client import TelemetryClient
 from mlflow.telemetry.events import (
     AlignJudgeEvent,
+    AutologgingEvent,
     CreateDatasetEvent,
     CreateExperimentEvent,
     CreateLoggedModelEvent,
@@ -758,3 +759,17 @@ def test_align_judge(mock_requests, mock_telemetry_client: TelemetryClient):
     validate_telemetry_record(
         mock_telemetry_client, mock_requests, AlignJudgeEvent.name, expected_params
     )
+
+
+def test_autologging(mock_requests, mock_telemetry_client: TelemetryClient):
+    mlflow.openai.autolog()
+
+    mlflow.autolog()
+    mock_telemetry_client.flush()
+    data = [record["data"] for record in mock_requests]
+    params = [event["params"] for event in data if event["event_name"] == AutologgingEvent.name]
+    assert (
+        json.dumps({"flavor": mlflow.openai.FLAVOR_NAME, "log_traces": True, "disable": False})
+        in params
+    )
+    assert json.dumps({"flavor": "all", "log_traces": True, "disable": False}) in params

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -773,3 +773,4 @@ def test_autologging(mock_requests, mock_telemetry_client: TelemetryClient):
         in params
     )
     assert json.dumps({"flavor": "all", "log_traces": True, "disable": False}) in params
+    mlflow.autolog(disable=True)

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -762,15 +762,17 @@ def test_align_judge(mock_requests, mock_telemetry_client: TelemetryClient):
 
 
 def test_autologging(mock_requests, mock_telemetry_client: TelemetryClient):
-    mlflow.openai.autolog()
+    try:
+        mlflow.openai.autolog()
 
-    mlflow.autolog()
-    mock_telemetry_client.flush()
-    data = [record["data"] for record in mock_requests]
-    params = [event["params"] for event in data if event["event_name"] == AutologgingEvent.name]
-    assert (
-        json.dumps({"flavor": mlflow.openai.FLAVOR_NAME, "log_traces": True, "disable": False})
-        in params
-    )
-    assert json.dumps({"flavor": "all", "log_traces": True, "disable": False}) in params
-    mlflow.autolog(disable=True)
+        mlflow.autolog()
+        mock_telemetry_client.flush()
+        data = [record["data"] for record in mock_requests]
+        params = [event["params"] for event in data if event["event_name"] == AutologgingEvent.name]
+        assert (
+            json.dumps({"flavor": mlflow.openai.FLAVOR_NAME, "log_traces": True, "disable": False})
+            in params
+        )
+        assert json.dumps({"flavor": "all", "log_traces": True, "disable": False}) in params
+    finally:
+        mlflow.autolog(disable=True)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/17975?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17975/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17975/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17975/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
https://github.com/mlflow/mlflow/pull/17760 reverted the previous PR due to test issue.
This PR adds the event back, run telemetry tests standalone to prevent any side effect.
The original root cause is that if `mlflow.<xxx>.autolog` runs together with spark test, then there's a race condition, reproducible without telemetry:
`uv run --with scikit-learn --with=pyspark pytest tests/sklearn/test_sklearn_autolog.py::test_autolog_does_not_terminate_active_run tests/types/test_schema.py::test_spark_type_mapping`
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
