### PR TITLE
Fix DSPy prompt display

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.test.ts
@@ -22,7 +22,8 @@ const MOCK_DSPY_OUTPUT = [
 
 describe('normalizeConversation', () => {
   it('should handle dspy input', () => {
-    expect(normalizeConversation(MOCK_DSPY_INPUT, 'dspy')).toEqual([
+    const conv = normalizeConversation(MOCK_DSPY_INPUT, 'dspy');
+    expect(conv).toEqual([
       expect.objectContaining({
         role: 'system',
         content: expect.stringContaining('Your input fields are:'),
@@ -32,14 +33,18 @@ describe('normalizeConversation', () => {
         content: expect.stringContaining('[[ ## passage ## ]]'),
       }),
     ]);
+    // Ensure single newlines are converted to hard breaks for markdown rendering
+    expect(conv?.[0].content).toContain('  \n');
   });
 
   it('should handle dspy output', () => {
-    expect(normalizeConversation(MOCK_DSPY_OUTPUT, 'dspy')).toEqual([
+    const conv = normalizeConversation(MOCK_DSPY_OUTPUT, 'dspy');
+    expect(conv).toEqual([
       expect.objectContaining({
         content: expect.stringContaining('[[ ## reasoning ## ]]'),
         role: 'assistant',
       }),
     ]);
+    expect(conv?.[0].content).toContain('  \n');
   });
 });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -35,5 +35,8 @@ export const normalizeDspyChatOutput = (obj: unknown): ModelTraceChatMessage[] |
 
 // Markdown treats single newlines as spaces. For DSPy prompts that are plain text
 // we convert single newlines into hard line breaks while preserving paragraphs.
+// Only the single line break will bre updated, for example, 
+// - "foo\nbar" -> "foo\n\nbar" (a new line inserted)
+// - "foo\n\nbar" -> "foo\n\nbar" (no change)
 const toMarkdownWithHardBreaks = (text: string) =>
   text.replace(/\r\n/g, '\n').replace(/(^|[^\n])\n(?!\n)/g, (_m, p1) => `${p1}  \n`);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -35,7 +35,7 @@ export const normalizeDspyChatOutput = (obj: unknown): ModelTraceChatMessage[] |
 
 // Markdown treats single newlines as spaces. For DSPy prompts that are plain text
 // we convert single newlines into hard line breaks while preserving paragraphs.
-// Only the single line break will bre updated, for example, 
+// Only the single line break will bre updated, for example,
 // - "foo\nbar" -> "foo\n\nbar" (a new line inserted)
 // - "foo\n\nbar" -> "foo\n\nbar" (no change)
 const toMarkdownWithHardBreaks = (text: string) =>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -36,7 +36,7 @@ export const normalizeDspyChatOutput = (obj: unknown): ModelTraceChatMessage[] |
 // Markdown treats single newlines as spaces. For DSPy prompts that are plain text
 // we convert single newlines into hard line breaks while preserving paragraphs.
 // Only the single line break will bre updated, for example,
-// - "foo\nbar" -> "foo\n\nbar" (a new line inserted)
+// - "foo\nbar" -> "foo  \nbar" (a new line inserted)
 // - "foo\n\nbar" -> "foo\n\nbar" (no change)
 const toMarkdownWithHardBreaks = (text: string) =>
   text.replace(/\r\n/g, '\n').replace(/(^|[^\n])\n(?!\n)/g, (_m, p1) => `${p1}  \n`);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -8,7 +8,13 @@ export const normalizeDspyChatInput = (obj: unknown): ModelTraceChatMessage[] | 
   if (has(obj, 'messages') && isArray((obj as any).messages)) {
     const messages = (obj as any).messages;
     return messages
-      .map((msg: any) => prettyPrintChatMessage({ type: 'message', content: msg.content, role: msg.role }))
+      .map((msg: any) =>
+        prettyPrintChatMessage({
+          type: 'message',
+          content: isString(msg.content) ? toMarkdownWithHardBreaks(msg.content) : msg.content,
+          role: msg.role,
+        }),
+      )
       .filter(Boolean);
   }
 
@@ -19,10 +25,15 @@ export const normalizeDspyChatOutput = (obj: unknown): ModelTraceChatMessage[] |
   // Handle DSPy format with array output
   if (isArray(obj) && obj.length > 0 && obj.every(isString)) {
     // Join all output strings into one assistant message
-    const content = obj.join('\n');
+    const content = toMarkdownWithHardBreaks(obj.join('\n'));
     const message = prettyPrintChatMessage({ type: 'message', content, role: 'assistant' });
     return message && [message];
   }
 
   return null;
 };
+
+// Markdown treats single newlines as spaces. For DSPy prompts that are plain text
+// we convert single newlines into hard line breaks while preserving paragraphs.
+const toMarkdownWithHardBreaks = (text: string) =>
+  text.replace(/\r\n/g, '\n').replace(/(^|[^\n])\n(?!\n)/g, (_m, p1) => `${p1}  \n`);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/dspy.ts
@@ -35,8 +35,8 @@ export const normalizeDspyChatOutput = (obj: unknown): ModelTraceChatMessage[] |
 
 // Markdown treats single newlines as spaces. For DSPy prompts that are plain text
 // we convert single newlines into hard line breaks while preserving paragraphs.
-// Only the single line break will bre updated, for example,
-// - "foo\nbar" -> "foo  \nbar" (a new line inserted)
+// Only the single line break will be updated, for example,
+// - "foo\nbar" -> "foo  \nbar" (two spaces inserted before \n)
 // - "foo\n\nbar" -> "foo\n\nbar" (no change)
 const toMarkdownWithHardBreaks = (text: string) =>
   text.replace(/\r\n/g, '\n').replace(/(^|[^\n])\n(?!\n)/g, (_m, p1) => `${p1}  \n`);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/17988?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17988/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/17988/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/17988/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Fix https://github.com/mlflow/mlflow/issues/17940

DSPy prompt is not markdown, but the chat UI tries to render it as markdown. This causes a problem in rendering new line, because single new line `\n` doesn't create line break in markdown. For example,

```
[[ ## library ## ]]
mlflow
```

is rendered as 
```
[[ ## library ## ]] mlflow
```

This PR applies a fix to replace single new line `\n` to double `\n\n`, when parsing chat-style message from DSPy LLM span.

Note that non-markdown prompt is not only the case for DSPy, e.g., some LLM prefer xml format. However, it is challenging to accurately determine if the input is markdown or not.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Before**
<img width="902" height="255" alt="Screenshot 2025-09-27 at 21 37 58" src="https://github.com/user-attachments/assets/47785139-4685-479a-93b2-ac051b9ef28f" />

**After**
<img width="908" height="296" alt="Screenshot 2025-09-27 at 21 37 43" src="https://github.com/user-attachments/assets/7842313b-995b-465b-83fa-06a597ec9199" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix chat UI new line rendering issue for DSPy prompt.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
