### PR TITLE
Include original error details in Unity Catalog model copy failure messages

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -873,7 +873,7 @@ class UcModelRegistryStore(BaseRestStore):
                     f"Unable to download model artifacts from source artifact location "
                     f"'{source}' in order to upload them to Unity Catalog. Please ensure "
                     f"the source artifact location exists and that you can download from "
-                    f"it via mlflow.artifacts.download_artifacts()"
+                    f"it via mlflow.artifacts.download_artifacts(). Original error: {e}"
                 ) from e
             try:
                 yield local_model_dir

--- a/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/uc_oss_rest_store.py
@@ -473,7 +473,7 @@ class UnityCatalogOssStore(BaseRestStore):
                     "Unable to download model artifacts from source artifact location "
                     f"'{source}' in order to upload them to Unity Catalog. Please ensure "
                     "the source artifact location exists and that you can download from "
-                    "it via mlflow.artifacts.download_artifacts()"
+                    f"it via mlflow.artifacts.download_artifacts(). Original error: {e}"
                 ) from e
             try:
                 yield local_model_dir


### PR DESCRIPTION
### Related Issues/PRs

#17648 (comment: https://github.com/mlflow/mlflow/issues/17648#issuecomment-3325536204)

### What changes are proposed in this pull request?

Improve error messages when model artifacts fail to download during copy operations to Unity Catalog by including the original error details in the exception message.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

When model artifacts fail to download during Unity Catalog copy operations, the error message now includes the original error details for better debugging.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with Claude Code