### PR TITLE
Reduce number of cross version tests to run

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -811,6 +811,7 @@ gemini:
       pip install google-generativeai
       pytest tests/gemini
     test_tracing_sdk: true
+    test_every_n_versions: 10
 
 anthropic:
   package_info:
@@ -826,7 +827,7 @@ anthropic:
     run: pytest tests/anthropic
     # Our CI runs tests for every minor version of the library by default, which results in
     # many test tasks for anthropic. Reducing the number of testing only for every 5 version.
-    test_every_n_versions: 5
+    test_every_n_versions: 10
     test_tracing_sdk: true
 
 crewai:
@@ -843,6 +844,7 @@ crewai:
     requirements:
     run: pytest tests/crewai
     test_tracing_sdk: true
+    test_every_n_versions: 20
 
 agno:
   package_info:
@@ -930,6 +932,7 @@ haystack:
     requirements:
     run: pytest tests/haystack
     test_tracing_sdk: true
+    test_every_n_versions: 10
 
 mistral:
   package_info:
@@ -949,6 +952,7 @@ mistral:
     requirements:
     run: pytest tests/mistral
     test_tracing_sdk: true
+    test_every_n_versions: 10
 
 sentence_transformers:
   package_info:
@@ -1008,6 +1012,7 @@ promptflow:
       "< 1.18": ["numpy<2"]
     run: |
       pytest tests/promptflow/test_promptflow_model_export.py
+    test_every_n_versions: 10
 
 litellm:
   package_info:
@@ -1042,6 +1047,7 @@ groq:
     requirements:
     run: pytest tests/groq
     test_tracing_sdk: true
+    test_every_n_versions: 10
 
 bedrock:
   package_info:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18006?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18006/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18006/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18006/merge
```

</p>
</details>

### What changes are proposed in this pull request?

We hit the max limit for number of jobs running in cross version test.
https://github.com/mlflow/dev/actions/runs/18074733460

Some libraries upgrades minor version quite frequently, adding interval to reduce the job counts.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
