### PR TITLE
Fix `mlflow server` exiting immediately when optional `huey` package is missing

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -404,10 +404,9 @@ def _run_server(
                 "MLflow job backend requires 'huey<3,>=2.5.0' package but it is not installed. "
                 "Skip launching the job runner."
             )
-            return
+        else:
+            from mlflow.server.jobs import _launch_job_backend
 
-        from mlflow.server.jobs import _launch_job_backend
-
-        _launch_job_backend(file_store_path, env_map, server_proc.pid)
+            _launch_job_backend(file_store_path, env_map, server_proc.pid)
 
     server_proc.wait()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18016?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18016/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18016/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18016/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Fix server startup bug when the optional `huey` package is missing. Previously, the server would exit unexpectedly because `server_proc.wait()` was never reached when huey was unavailable.

🤖 Generated with Claude Code

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed server startup issue when the optional huey job backend package is not installed.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)