### PR TITLE
Add model_id param to update_current_trace

### DIFF
--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -26,6 +26,7 @@ from mlflow.tracing.constant import (
     STREAM_CHUNK_EVENT_NAME_FORMAT,
     STREAM_CHUNK_EVENT_VALUE_KEY,
     SpanAttributeKey,
+    TraceMetadataKey,
 )
 from mlflow.tracing.destination import TraceDestination
 from mlflow.tracing.provider import is_tracing_enabled, safe_set_span_in_context
@@ -979,6 +980,7 @@ def update_current_trace(
     request_preview: str | None = None,
     response_preview: str | None = None,
     state: TraceState | str | None = None,
+    model_id: str | None = None,
 ):
     """
     Update the current active trace with the given options.
@@ -1001,6 +1003,8 @@ def update_current_trace(
         state: The state to set on the trace. Can be a TraceState enum value or string.
             Only "OK" and "ERROR" are allowed. This overrides the overall trace state without
             affecting the status of the current span.
+        model_id: The ID of the model to associate with the trace. If not set, the active
+            model ID is associated with the trace.
 
     Example:
 
@@ -1094,8 +1098,14 @@ def update_current_trace(
                 f"{non_string_items}"
             )
 
-    _warn_non_string_values(tags or {}, "tags")
-    _warn_non_string_values(metadata or {}, "metadata")
+    tags = tags or {}
+    metadata = metadata or {}
+
+    if model_id:
+        metadata[TraceMetadataKey.MODEL_ID] = model_id
+
+    _warn_non_string_values(tags, "tags")
+    _warn_non_string_values(metadata, "metadata")
 
     # Update tags and client request ID for the trace stored in-memory rather than directly
     # updating the backend store. The in-memory trace will be exported when it is ended.
@@ -1130,8 +1140,8 @@ def update_current_trace(
 
             trace.info.state = TraceState(state) if isinstance(state, str) else state
 
-        trace.info.tags.update(tags or {})
-        trace.info.trace_metadata.update(metadata or {})
+        trace.info.tags.update(tags)
+        trace.info.trace_metadata.update(metadata)
         if client_request_id is not None:
             trace.info.client_request_id = str(client_request_id)
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1571,6 +1571,15 @@ def test_update_current_trace_with_metadata():
 
 
 @skip_when_testing_trace_sdk
+def test_update_current_trace_with_model_id():
+    with mlflow.start_span("test_span"):
+        mlflow.update_current_trace(model_id="model-123")
+
+    trace = get_traces()[0]
+    assert trace.info.trace_metadata[TraceMetadataKey.MODEL_ID] == "model-123"
+
+
+@skip_when_testing_trace_sdk
 def test_update_current_trace_should_not_raise_during_model_logging():
     """
     Tracing is disabled while model logging. When the model includes


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18021?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18021/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18021/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18021/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Title. To allow setting model ID on trace while it is in-progress.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
