### PR TITLE
Pass sql warehouse Id to GetTraces

### DIFF
--- a/mlflow/cli/traces.py
+++ b/mlflow/cli/traces.py
@@ -62,6 +62,8 @@ For detailed help on any command, use:
 """
 
 import json
+import os
+import warnings
 
 import click
 
@@ -208,6 +210,7 @@ Available fields:
     "--sql-warehouse-id",
     type=click.STRING,
     help=(
+        "DEPRECATED. Use the `MLFLOW_TRACING_SQL_WAREHOUSE_ID` environment variable instead.",
         "SQL warehouse ID (only needed when searching for traces by model "
         "stored in Databricks Unity Catalog)"
     ),
@@ -283,6 +286,15 @@ def search_traces(
     client = TracingClient()
     order_by_list = order_by.split(",") if order_by else None
 
+    # Set the sql_warehouse_id in the environment variable
+    if sql_warehouse_id is not None:
+        warnings.warn(
+            "The `sql_warehouse_id` parameter is deprecated. Please use the "
+            "`MLFLOW_TRACING_SQL_WAREHOUSE_ID` environment variable instead.",
+            category=FutureWarning,
+        )
+        os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = sql_warehouse_id
+
     traces = client.search_traces(
         locations=[experiment_id],
         filter_string=filter_string,
@@ -292,7 +304,6 @@ def search_traces(
         run_id=run_id,
         include_spans=include_spans,
         model_id=model_id,
-        sql_warehouse_id=sql_warehouse_id,
     )
 
     # Determine which fields to show

--- a/mlflow/cli/traces.py
+++ b/mlflow/cli/traces.py
@@ -210,7 +210,7 @@ Available fields:
     "--sql-warehouse-id",
     type=click.STRING,
     help=(
-        "DEPRECATED. Use the `MLFLOW_TRACING_SQL_WAREHOUSE_ID` environment variable instead.",
+        "DEPRECATED. Use the `MLFLOW_TRACING_SQL_WAREHOUSE_ID` environment variable instead."
         "SQL warehouse ID (only needed when searching for traces by model "
         "stored in Databricks Unity Catalog)"
     ),

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -323,9 +323,17 @@ class AbstractStore:
         """
         raise NotImplementedError
 
-    def get_traces(self, trace_ids: list[str]) -> list[Trace]:
+    def get_traces(self, trace_ids: list[str], sql_warehouse_id: str | None = None) -> list[Trace]:
         """
         Get complete traces with spans for given trace ids.
+
+        Args:
+            trace_ids: List of trace IDs to fetch.
+            sql_warehouse_id: SQL warehouse ID to use for fetching trace data.
+                Only used in Databricks.
+
+        Returns:
+            List of Trace objects.
         """
         # raise MlflowException so this can be captured by the handlers
         # instead of default internal server error and retry

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -323,14 +323,12 @@ class AbstractStore:
         """
         raise NotImplementedError
 
-    def get_traces(self, trace_ids: list[str], sql_warehouse_id: str | None = None) -> list[Trace]:
+    def get_traces(self, trace_ids: list[str]) -> list[Trace]:
         """
         Get complete traces with spans for given trace ids.
 
         Args:
             trace_ids: List of trace IDs to fetch.
-            sql_warehouse_id: SQL warehouse ID to use for fetching trace data.
-                Only used in Databricks.
 
         Returns:
             List of Trace objects.
@@ -343,7 +341,6 @@ class AbstractStore:
     def get_online_trace_details(
         self,
         trace_id: str,
-        sql_warehouse_id: str,
         source_inference_table: str,
         source_databricks_request_id: str,
     ) -> str:
@@ -359,7 +356,6 @@ class AbstractStore:
         order_by: list[str] | None = None,
         page_token: str | None = None,
         model_id: str | None = None,
-        sql_warehouse_id: str | None = None,
         locations: list[str] | None = None,
     ) -> tuple[list[TraceInfo], str | None]:
         """
@@ -373,8 +369,6 @@ class AbstractStore:
             page_token: Token specifying the next page of results. It should be obtained from
                 a ``search_traces`` call.
             model_id: If specified, return traces associated with the model ID.
-            sql_warehouse_id: Only used in Databricks. The ID of the SQL warehouse to use for
-                searching traces in inference tables.
             locations: A list of locations to search over.
 
         Returns:

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -126,12 +126,13 @@ class DatabricksTracingRestStore(RestStore):
             else:
                 raise
 
-    def get_traces(self, trace_ids: list[str]) -> list[Trace]:
+    def get_traces(self, trace_ids: list[str], sql_warehouse_id: str | None = None) -> list[Trace]:
         """
         Get complete traces with spans for given trace ids.
 
         Args:
             trace_ids: List of trace IDs to fetch.
+            sql_warehouse_id: SQL warehouse ID to use for fetching trace data.
 
         Returns:
             List of Trace objects.

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -314,7 +314,6 @@ class DatabricksTracingRestStore(RestStore):
             return self._search_unified_traces(
                 model_id=model_id,
                 locations=locations,
-                sql_warehouse_id=MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),
                 filter_string=filter_string,
                 max_results=max_results,
                 order_by=order_by,

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -2152,7 +2152,6 @@ class FileStore(AbstractStore):
         order_by: list[str] | None = None,
         page_token: str | None = None,
         model_id: str | None = None,
-        sql_warehouse_id: str | None = None,
         locations: list[str] | None = None,
     ) -> tuple[list[TraceInfo], str | None]:
         """
@@ -2168,8 +2167,6 @@ class FileStore(AbstractStore):
             page_token: Token specifying the next page of results. It should be obtained from
                 a ``search_traces`` call.
             model_id: If specified, return traces associated with the model ID.
-            sql_warehouse_id: Only used in Databricks. The ID of the SQL warehouse to use for
-                searching traces in inference tables.
             locations: A list of locations to search over. To search over experiments, provide
                 a list of experiment IDs.
 

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -73,7 +73,6 @@ from mlflow.protos.service_pb2 import (
     GetExperimentByName,
     GetLoggedModel,
     GetMetricHistory,
-    GetOnlineTraceDetails,
     GetRun,
     GetScorer,
     GetTraceInfo,
@@ -441,23 +440,6 @@ class RestStore(AbstractStore):
         response_proto = self._call_endpoint(GetTraceInfo, req_body, endpoint=endpoint)
         return TraceInfoV2.from_proto(response_proto.trace_info).to_v3()
 
-    def get_online_trace_details(
-        self,
-        trace_id: str,
-        sql_warehouse_id: str,
-        source_inference_table: str,
-        source_databricks_request_id: str,
-    ):
-        req = GetOnlineTraceDetails(
-            trace_id=trace_id,
-            sql_warehouse_id=sql_warehouse_id,
-            source_inference_table=source_inference_table,
-            source_databricks_request_id=source_databricks_request_id,
-        )
-        req_body = message_to_json(req)
-        response_proto = self._call_endpoint(GetOnlineTraceDetails, req_body)
-        return response_proto.trace_data
-
     def search_traces(
         self,
         experiment_ids: list[str] | None = None,
@@ -466,7 +448,6 @@ class RestStore(AbstractStore):
         order_by: list[str] | None = None,
         page_token: str | None = None,
         model_id: str | None = None,
-        sql_warehouse_id: str | None = None,
         locations: list[str] | None = None,
     ):
         locations = _resolve_experiment_ids_and_locations(experiment_ids, locations)

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2582,7 +2582,6 @@ class SqlAlchemyStore(AbstractStore):
         order_by: list[str] | None = None,
         page_token: str | None = None,
         model_id: str | None = None,
-        sql_warehouse_id: str | None = None,
         locations: list[str] | None = None,
     ) -> tuple[list[TraceInfo], str | None]:
         """
@@ -2596,8 +2595,6 @@ class SqlAlchemyStore(AbstractStore):
             page_token: Token specifying the next page of results. It should be obtained from
                 a ``search_traces`` call.
             model_id: If specified, search traces associated with the given model ID.
-            sql_warehouse_id: Only used in Databricks. The ID of the SQL warehouse to use for
-                searching traces in inference tables.
             locations: A list of locations to search over. To search over experiments, provide
                 a list of experiment IDs.
 

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -12,7 +12,10 @@ from mlflow.entities.trace import Trace
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_location import UCSchemaLocation
-from mlflow.environment_variables import MLFLOW_SEARCH_TRACES_MAX_THREADS
+from mlflow.environment_variables import (
+    MLFLOW_SEARCH_TRACES_MAX_THREADS,
+    MLFLOW_TRACING_SQL_WAREHOUSE_ID,
+)
 from mlflow.exceptions import (
     MlflowException,
     MlflowTraceDataCorrupted,
@@ -169,12 +172,10 @@ class TracingClient:
         else:
             return self._get_traces_from_tracking_store([trace_id])[0]
 
-    def _get_traces_from_tracking_store(
-        self, trace_ids: list[str], sql_warehouse_id: str | None = None
-    ) -> list[Trace]:
+    def _get_traces_from_tracking_store(self, trace_ids: list[str]) -> list[Trace]:
         if not trace_ids:
             return []
-        if traces := self.store.get_traces(trace_ids, sql_warehouse_id=sql_warehouse_id):
+        if traces := self.store.get_traces(trace_ids):
             return traces
         else:
             trace_ids_str = ", ".join(trace_ids)
@@ -188,13 +189,11 @@ class TracingClient:
     def get_online_trace_details(
         self,
         trace_id: str,
-        sql_warehouse_id: str,
         source_inference_table: str,
         source_databricks_request_id: str,
     ) -> str:
         return self.store.get_online_trace_details(
             trace_id=trace_id,
-            sql_warehouse_id=sql_warehouse_id,
             source_inference_table=source_inference_table,
             source_databricks_request_id=source_databricks_request_id,
         )
@@ -207,7 +206,6 @@ class TracingClient:
         order_by: list[str] | None = None,
         page_token: str | None = None,
         model_id: str | None = None,
-        sql_warehouse_id: str | None = None,
         locations: list[str] | None = None,
     ):
         return self.store.search_traces(
@@ -217,7 +215,6 @@ class TracingClient:
             order_by=order_by,
             page_token=page_token,
             model_id=model_id,
-            sql_warehouse_id=sql_warehouse_id,
             locations=locations,
         )
 
@@ -231,7 +228,6 @@ class TracingClient:
         run_id: str | None = None,
         include_spans: bool = True,
         model_id: str | None = None,
-        sql_warehouse_id: str | None = None,
         locations: list[str] | None = None,
     ) -> PagedList[Trace]:
         """
@@ -252,8 +248,6 @@ class TracingClient:
                 the trace metadata is returned, e.g., trace ID, start time, end time, etc,
                 without any spans.
             model_id: If specified, return traces associated with the model ID.
-            sql_warehouse_id: Only used in Databricks. The ID of the SQL warehouse to use for
-                searching traces in inference tables.
             locations: A list of locations to search over. To search over experiments, provide
                 a list of experiment IDs. To search over UC tables on databricks, provide
                 a list of locations in the format `<catalog_name>.<schema_name>`.
@@ -278,7 +272,7 @@ class TracingClient:
 
             filter_string = (
                 f"request_metadata.`mlflow.modelId` = '{model_id}'"
-                if sql_warehouse_id is None
+                if MLFLOW_TRACING_SQL_WAREHOUSE_ID.get() is None
                 else None
             )
 
@@ -323,7 +317,6 @@ class TracingClient:
                     # For online traces, get data from the online API
                     trace_data = self.get_online_trace_details(
                         trace_id=trace_info.trace_id,
-                        sql_warehouse_id=sql_warehouse_id,
                         source_inference_table=trace_info.request_metadata.get(
                             "mlflow.sourceTable"
                         ),
@@ -366,7 +359,6 @@ class TracingClient:
                     order_by=order_by,
                     page_token=next_token,
                     model_id=model_id,
-                    sql_warehouse_id=sql_warehouse_id,
                     locations=locations,
                 )
 
@@ -375,7 +367,6 @@ class TracingClient:
                     traces.extend(
                         self._get_traces_from_tracking_store(
                             [t.trace_id for t in trace_info_groups.tracking_store_trace_infos],
-                            sql_warehouse_id=sql_warehouse_id,
                         )
                     )
 

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -169,10 +169,12 @@ class TracingClient:
         else:
             return self._get_traces_from_tracking_store([trace_id])[0]
 
-    def _get_traces_from_tracking_store(self, trace_ids: list[str]) -> list[Trace]:
+    def _get_traces_from_tracking_store(
+        self, trace_ids: list[str], sql_warehouse_id: str | None = None
+    ) -> list[Trace]:
         if not trace_ids:
             return []
-        if traces := self.store.get_traces(trace_ids):
+        if traces := self.store.get_traces(trace_ids, sql_warehouse_id=sql_warehouse_id):
             return traces
         else:
             trace_ids_str = ", ".join(trace_ids)
@@ -372,7 +374,8 @@ class TracingClient:
                     trace_info_groups = self._group_trace_infos_by_storage(trace_infos)
                     traces.extend(
                         self._get_traces_from_tracking_store(
-                            [t.trace_id for t in trace_info_groups.tracking_store_trace_infos]
+                            [t.trace_id for t in trace_info_groups.tracking_store_trace_infos],
+                            sql_warehouse_id=sql_warehouse_id,
                         )
                     )
 

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -6,6 +6,8 @@ import importlib
 import inspect
 import json
 import logging
+import os
+import warnings
 from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any, Callable, Generator, Literal
 
@@ -722,8 +724,9 @@ def search_traces(
             - `"list"`: Returns a list of :py:class:`Trace <mlflow.entities.Trace>` objects.
 
         model_id: If specified, search traces associated with the given model ID.
-        sql_warehouse_id: Only used in Databricks. The ID of the SQL warehouse to use for
-            searching traces in inference tables or UC tables.
+        sql_warehouse_id: DEPRECATED. Use the `MLFLOW_TRACING_SQL_WAREHOUSE_ID` environment
+            variable instead. The ID of the SQL warehouse to use for
+            searching traces in inference tables or UC tables. Only used in Databricks.
 
         include_spans: If ``True``, include spans in the returned traces. Otherwise, only
             the trace metadata is returned, e.g., trace ID, start time, end time, etc,
@@ -789,6 +792,14 @@ def search_traces(
     """
     from mlflow.tracking.fluent import _get_experiment_id
 
+    if sql_warehouse_id is not None:
+        warnings.warn(
+            "The `sql_warehouse_id` parameter is deprecated. Please use the "
+            "`MLFLOW_TRACING_SQL_WAREHOUSE_ID` environment variable instead.",
+            category=FutureWarning,
+        )
+        os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] = sql_warehouse_id
+
     # Default to "pandas" only if the pandas library is installed
     if return_type is None:
         try:
@@ -835,7 +846,6 @@ def search_traces(
             order_by=order_by,
             page_token=next_page_token,
             model_id=model_id,
-            sql_warehouse_id=sql_warehouse_id,
             include_spans=include_spans,
             locations=locations,
         )

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -1131,7 +1131,6 @@ class MlflowClient:
         run_id: str | None = None,
         include_spans: bool = True,
         model_id: str | None = None,
-        sql_warehouse_id: str | None = None,
         locations: list[str] | None = None,
     ) -> PagedList[Trace]:
         """
@@ -1151,8 +1150,6 @@ class MlflowClient:
                 the trace metadata is returned, e.g., trace ID, start time, end time, etc,
                 without any spans.
             model_id: If specified, return traces associated with the model ID.
-            sql_warehouse_id: Only used in Databricks. The ID of the SQL warehouse to use for
-                searching traces in inference tables.
             locations: A list of locations to search over. To search over experiments, provide
                 a list of experiment IDs. To search over UC tables on databricks, provide
                 a list of locations in the format `<catalog_name>.<schema_name>`.
@@ -1174,7 +1171,6 @@ class MlflowClient:
             run_id=run_id,
             include_spans=include_spans,
             model_id=model_id,
-            sql_warehouse_id=sql_warehouse_id,
             locations=locations,
         )
 

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -427,7 +427,8 @@ def test_delete_trace_tag_fallback():
         assert result is None
 
 
-def test_get_traces(monkeypatch):
+@pytest.mark.parametrize("sql_warehouse_id", [None, "warehouse_override"])
+def test_get_traces(monkeypatch, sql_warehouse_id):
     monkeypatch.setenv(MLFLOW_TRACING_SQL_WAREHOUSE_ID.name, "test-warehouse")
     with mlflow.start_span(name="test_span_1") as span1:
         span1.set_inputs({"input": "test_value_1"})

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -788,7 +788,6 @@ def test_search_unified_traces():
     max_results = 10
     order_by = ["timestamp_ms DESC"]
     page_token = "12345abcde"
-    sql_warehouse_id = "warehouse123"
     model_id = "model123"
 
     with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
@@ -798,7 +797,6 @@ def test_search_unified_traces():
             max_results=max_results,
             order_by=order_by,
             page_token=page_token,
-            sql_warehouse_id=sql_warehouse_id,
             model_id=model_id,
         )
 

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -929,7 +929,6 @@ def test_search_traces(return_type, mock_client):
         order_by=["timestamp DESC"],
         page_token=None,
         model_id=None,
-        sql_warehouse_id=None,
         include_spans=True,
         locations=["1"],
     )
@@ -969,7 +968,6 @@ def test_search_traces_with_pagination(mock_client):
         "order_by": None,
         "include_spans": True,
         "model_id": None,
-        "sql_warehouse_id": None,
         "locations": ["1"],
     }
     mock_client.search_traces.assert_has_calls(
@@ -994,7 +992,6 @@ def test_search_traces_with_default_experiment_id(mock_client):
         order_by=None,
         page_token=None,
         model_id=None,
-        sql_warehouse_id=None,
         include_spans=True,
         locations=["123"],
     )

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import threading
 import time
 import uuid
@@ -2225,8 +2226,9 @@ def test_search_traces_with_sql_warehouse_id(mock_client):
     # Verify that search_traces was called with sql_warehouse_id
     mock_client.search_traces.assert_called_once()
     call_kwargs = mock_client.search_traces.call_args.kwargs
-    assert call_kwargs["sql_warehouse_id"] == "warehouse456"
     assert call_kwargs["locations"] == ["123"]
+    assert "sql_warehouse_id" not in call_kwargs
+    assert os.environ["MLFLOW_TRACING_SQL_WAREHOUSE_ID"] == "warehouse456"
 
 
 @skip_when_testing_trace_sdk

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -258,7 +258,7 @@ def test_client_get_trace(mock_store, mock_artifact_repo):
         return_value=False,
     ):
         trace = MlflowClient().get_trace(trace_id)
-        mock_store.get_traces.assert_called_once_with([trace_id], sql_warehouse_id=None)
+        mock_store.get_traces.assert_called_once_with([trace_id])
         mock_store.get_trace_info.assert_called_once_with(trace_id)
         mock_artifact_repo.download_trace_data.assert_not_called()
 
@@ -403,7 +403,8 @@ def test_client_search_traces_with_get_traces(mock_store, mock_artifact_repo, in
         return_value=mock_traces,
     ) as mock_get_traces:
         results = MlflowClient().search_traces(
-            experiment_ids=["1", "2", "3"], include_spans=include_spans, sql_warehouse_id="123"
+            experiment_ids=["1", "2", "3"],
+            include_spans=include_spans,
         )
 
     mock_store.search_traces.assert_called_once_with(
@@ -413,12 +414,11 @@ def test_client_search_traces_with_get_traces(mock_store, mock_artifact_repo, in
         order_by=None,
         page_token=None,
         model_id=None,
-        sql_warehouse_id="123",
         locations=["1", "2", "3"],
     )
     assert len(results) == 2
     if include_spans:
-        mock_get_traces.assert_called_once_with(["tr-1234567", "tr-8910"], sql_warehouse_id="123")
+        mock_get_traces.assert_called_once_with(["tr-1234567", "tr-8910"])
     else:
         mock_get_traces.assert_not_called()
     mock_artifact_repo.download_trace_data.assert_not_called()
@@ -465,12 +465,11 @@ def test_client_search_traces_mixed(mock_store, mock_artifact_repo, include_span
         order_by=None,
         page_token=None,
         model_id=None,
-        sql_warehouse_id=None,
         locations=["1", "catalog.schema"],
     )
     assert len(results) == 2
     if include_spans:
-        mock_store.get_traces.assert_called_once_with(["1234567"], sql_warehouse_id=None)
+        mock_store.get_traces.assert_called_once_with(["1234567"])
         mock_artifact_repo.download_trace_data.assert_called()
     else:
         mock_store.get_traces.assert_not_called()
@@ -508,7 +507,6 @@ def test_client_search_traces_with_artifact_repo(mock_store, mock_artifact_repo,
         order_by=None,
         page_token=None,
         model_id=None,
-        sql_warehouse_id=None,
         locations=["1", "2", "3"],
     )
     assert len(results) == 2

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -258,7 +258,7 @@ def test_client_get_trace(mock_store, mock_artifact_repo):
         return_value=False,
     ):
         trace = MlflowClient().get_trace(trace_id)
-        mock_store.get_traces.assert_called_once_with([trace_id])
+        mock_store.get_traces.assert_called_once_with([trace_id], sql_warehouse_id=None)
         mock_store.get_trace_info.assert_called_once_with(trace_id)
         mock_artifact_repo.download_trace_data.assert_not_called()
 
@@ -470,7 +470,7 @@ def test_client_search_traces_mixed(mock_store, mock_artifact_repo, include_span
     )
     assert len(results) == 2
     if include_spans:
-        mock_store.get_traces.assert_called_once_with(["1234567"])
+        mock_store.get_traces.assert_called_once_with(["1234567"], sql_warehouse_id=None)
         mock_artifact_repo.download_trace_data.assert_called()
     else:
         mock_store.get_traces.assert_not_called()

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -403,7 +403,7 @@ def test_client_search_traces_with_get_traces(mock_store, mock_artifact_repo, in
         return_value=mock_traces,
     ) as mock_get_traces:
         results = MlflowClient().search_traces(
-            experiment_ids=["1", "2", "3"], include_spans=include_spans
+            experiment_ids=["1", "2", "3"], include_spans=include_spans, sql_warehouse_id="123"
         )
 
     mock_store.search_traces.assert_called_once_with(
@@ -413,12 +413,12 @@ def test_client_search_traces_with_get_traces(mock_store, mock_artifact_repo, in
         order_by=None,
         page_token=None,
         model_id=None,
-        sql_warehouse_id=None,
+        sql_warehouse_id="123",
         locations=["1", "2", "3"],
     )
     assert len(results) == 2
     if include_spans:
-        mock_get_traces.assert_called_once_with(["tr-1234567", "tr-8910"])
+        mock_get_traces.assert_called_once_with(["tr-1234567", "tr-8910"], sql_warehouse_id="123")
     else:
         mock_get_traces.assert_not_called()
     mock_artifact_repo.download_trace_data.assert_not_called()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18024?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18024/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18024/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18024/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `mlflow.search_traces` API accept `sql_warehouse_id` parameter and pass it to the `SearchTraces` backend endpoint. This API also calls `GetTraces` API to load spans, but the warehouse id is not propagated to this call.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
