### PR TITLE
Allow disable eval sample check

### DIFF
--- a/docs/docs/genai/eval-monitor/faq.mdx
+++ b/docs/docs/genai/eval-monitor/faq.mdx
@@ -1,0 +1,64 @@
+import { APILink } from "@site/src/components/APILink";
+import ImageBox from '@site/src/components/ImageBox';
+
+# Evaluate & Monitor FAQ
+
+This page addresses frequently asked questions about MLflow's GenAI evaluation.
+
+## Where can I find the evaluation results in MLflow UI?
+
+After an evaluation completes, you can find the resulting runs on the experiment page. Click the run name to view aggregated metrics and metadata in the overview pane.
+
+To inspect per-row evaluation results, open the **Traces** tab on the run overview page.
+
+<ImageBox src="/images/mlflow-3/eval-monitor/quickstart-eval-result.png" alt="Detailed Evaluation Results" width="90%" />
+
+## How to change the concurrency of the evaluation?
+
+MLflow uses a thread pool to run the predict function and scorers in parallel. Configure the number of workers by setting the `MLFLOW_GENAI_EVAL_MAX_WORKERS` environment variable (default: `10`).
+
+```bash
+export MLFLOW_GENAI_EVAL_MAX_WORKERS=5
+```
+
+## Why does MLflow make N+1 predictions during evaluation?
+
+MLflow requires the predict function passed through the `predict_fn` parameter to emit a single trace per call. To ensure the function produces a trace, MLflow first runs one additional prediction on a single input.
+
+If you are confident the predict function already generates traces, skip this validation by setting the `MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION` environment variable to `true`.
+
+```bash
+export MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION=true
+```
+
+## How do I change the name of the evaluation run?
+
+By default, `mlflow.genai.evaluate` generates a random run name. Set a custom name by wrapping the call with `mlflow.start_run`.
+
+```python
+with mlflow.start_run(run_name="My Evaluation Run") as run:
+    mlflow.genai.evaluate(...)
+```
+
+## How do I use Databricks Model Serving endpoints as the predict function?
+
+MLflow provides <APILink fn="mlflow.genai.to_predict_fn" />, which wraps a Databricks Model Serving endpoint so it behaves like a predict function compatible with GenAI evaluation.
+
+The wrapper:
+
+- Translates each input sample into the request payload expected by the endpoint.
+- Injects `{"databricks_options": {"return_trace": True}}` so the endpoint returns a model-generated trace.
+- Copies the trace into the current experiment so it appears in the MLflow UI.
+
+```python
+import mlflow
+from mlflow.genai.scorers import Correctness
+
+mlflow.genai.evaluate(
+    # The {"messages": ...} part must be compatible with the request schema of the endpoint
+    data=[{"inputs": {"messages": [{"role": "user", "content": "What is MLflow?"}]}}],
+    # Your Databricks Model Serving endpoint URI
+    predict_fn=mlflow.genai.to_predict_fn("endpoints:/chat"),
+    scorers=[Correctness()],
+)
+```

--- a/docs/sidebarsGenAI.ts
+++ b/docs/sidebarsGenAI.ts
@@ -341,6 +341,11 @@ const sidebarsGenAI: SidebarsConfig = {
           id: 'eval-monitor/legacy-llm-evaluation',
           label: 'LLM Evaluation (Legacy)',
         },
+        {
+          type: 'doc',
+          id: 'eval-monitor/faq',
+          label: 'FAQ',
+        },
       ],
       link: {
         type: 'doc',

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -632,9 +632,19 @@ _MLFLOW_EVALUATE_SUPPRESS_CLASSIFICATION_ERRORS = _BooleanEnvironmentVariable(
 )
 
 #: Maximum number of workers to use for running model prediction and scoring during
-# for each row in the dataset passed to the `mlflow.genai.evaluate` function.
+#: for each row in the dataset passed to the `mlflow.genai.evaluate` function.
 #: (default: ``10``)
 MLFLOW_GENAI_EVAL_MAX_WORKERS = _EnvironmentVariable("MLFLOW_GENAI_EVAL_MAX_WORKERS", int, 10)
+
+
+#: Skip trace validation during GenAI evaluation. By default (False), MLflow will validate if
+#: the given predict function generates a valid trace, and otherwise wraps it with @mlflow.trace
+#: decorator to make sure a trace is generated. This validation requires running a single
+#: prediction. When you are sure that the predict function generates a trace, set this to True
+#: to skip the validation and save the time of running a single prediction.
+MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION = _BooleanEnvironmentVariable(
+    "MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION", False
+)
 
 #: Whether to warn (default) or raise (opt-in) for unresolvable requirements inference for
 #: a model's dependency inference. If set to True, an exception will be raised if requirements

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -149,12 +149,13 @@ def test_convert_predict_fn_skip_validation(monkeypatch):
         call_count += 1
         return question + context
 
-    converted_fn = convert_predict_fn(dummy_predict_fn)
+    sample_input = {"question": "test", "context": "test"}
+    converted_fn = convert_predict_fn(dummy_predict_fn, sample_input)
     # Predict function should not be validated when the env var is set to True
     assert call_count == 0
 
     # converted function takes a single 'request' argument
-    result = converted_fn(request={"question": "test", "context": "test"})
+    result = converted_fn(request=sample_input)
     assert result == "testtest"
 
 

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -139,6 +139,25 @@ def test_convert_predict_fn(predict_fn_generator, with_tracing, should_be_wrappe
     assert len(get_traces()) == 1
 
 
+def test_convert_predict_fn_skip_validation(monkeypatch):
+    monkeypatch.setenv("MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION", "true")
+
+    call_count = 0
+
+    def dummy_predict_fn(question: str, context: str):
+        nonlocal call_count
+        call_count += 1
+        return question + context
+
+    converted_fn = convert_predict_fn(dummy_predict_fn)
+    # Predict function should not be validated when the env var is set to True
+    assert call_count == 0
+
+    # converted function takes a single 'request' argument
+    result = converted_fn(request={"question": "test", "context": "test"})
+    assert result == "testtest"
+
+
 def create_span(
     span_id: int,
     parent_id: int,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18032?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18032/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18032/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18032/merge
```

</p>
</details>

### What changes are proposed in this pull request?

When users call `mlflow.genai.evaluate` with `predict_fn`, MLflow will validate if the given function generates a valid trace. If it doesn't generate a trace, MLflow wraps it with the `@mlflow.trace` decorator to make sure a trace is generated. This validation requires running a single prediction, because otherwise we don't know if the function is traced or not.

We got a feedback that this validation is not desired when the user is certain about that the function is traced. For such case, the prediction cost is waste. To address this, this PR introduces an env var to skip validation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduce `MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION` env var to skip function validation during GenAI evaluation.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
