### PR TITLE
Job backend: allow explicitly setting job function to run in an individual process

### DIFF
--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -58,6 +58,7 @@ def submit_job(
     function: Callable[..., Any],
     params: dict[str, Any],
     timeout: float | None = None,
+    use_process: bool | None = None,
 ) -> JobEntity:
     """
     Submit a job to the job queue. The job is executed at most once.
@@ -80,6 +81,11 @@ def submit_job(
             The function must be decorated by `mlflow.server.jobs.job_function` decorator.
         params: The params to be passed to the job function.
         timeout: (optional) The job execution timeout, default None (no timeout)
+        use_process: (optional) Specify whether to run the job in an individual process.
+            If the job uses environment variables (e.g. API keys),
+            it should be run in an individual process to isolate the environment variable settings.
+            Default value is None, in the case the job is executed in a thread
+            if timeout is not set.
 
     Returns:
         The job entity. You can call `get_job` API by the job id to get
@@ -124,6 +130,7 @@ def submit_job(
         function,
         params,
         timeout,
+        use_process,
     )
 
     return job

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -32,11 +32,12 @@ class TransientError(RuntimeError):
 class JobFunctionMetadata:
     fn_fullname: str
     max_workers: int
-    use_process: bool | None = None
+    use_process: bool
 
 
 def job(
-    max_workers: int, use_process: bool | None = None
+    max_workers: int,
+    use_process: bool = True,
 ) -> Callable[[Callable[P, R]], Callable[P, R]]:
     """
     The decorator for the custom job function for setting max parallel workers that
@@ -48,8 +49,7 @@ def job(
         use_process: (optional) Specify whether to run the job in an individual process.
             If the job uses environment variables (e.g. API keys),
             it should be run in an individual process to isolate the environment variable settings.
-            Default value is None, in the case the job runs in a thread
-            if timeout is not set, but still runs in a process if timeout is set.
+            Default value is True.
     """
 
     def decorator(fn: Callable[P, R]) -> Callable[P, R]:

--- a/mlflow/server/jobs/util.py
+++ b/mlflow/server/jobs/util.py
@@ -109,11 +109,6 @@ def _execute_function_with_timeout(
     """
     use_process = func._job_fn_metadata.use_process
 
-    if use_process is None:
-        # if `use_process` is not set,
-        # set `use_process` to True if timeout is set, otherwise set to False.
-        use_process = timeout is not None
-
     if timeout and not use_process:
         raise MlflowException.invalid_parameter_value(
             "If setting timeout for a job, 'use_process' param must be 'True'"

--- a/tests/server/jobs/test_job.py
+++ b/tests/server/jobs/test_job.py
@@ -439,7 +439,6 @@ def test_job_use_process(monkeypatch, tmp_path):
         job_tmp_path = tmp_path / "job"
         job_tmp_path.mkdir()
 
-        # warm up
         job_id1 = submit_job(job_use_process, {"tmp_dir": str(job_tmp_path)}).job_id
         job_id2 = submit_job(job_use_process, {"tmp_dir": str(job_tmp_path)}).job_id
         wait_job_finalize(job_id1)

--- a/tests/server/jobs/test_job.py
+++ b/tests/server/jobs/test_job.py
@@ -105,7 +105,7 @@ def test_validate_function_parameters_with_positional_args():
         _validate_function_parameters(test_func_with_args, {})
 
 
-@job(max_workers=1)
+@job(max_workers=1, use_process=False)
 def basic_job_fun(x, y, sleep_secs=0):
     if sleep_secs > 0:
         time.sleep(sleep_secs)
@@ -127,7 +127,7 @@ def test_basic_job(monkeypatch, tmp_path):
         assert job.retry_count == 0
 
 
-@job(max_workers=1)
+@job(max_workers=1, use_process=False)
 def json_in_out_fun(data):
     x = data["x"]
     y = data["y"]
@@ -148,7 +148,7 @@ def test_job_json_input_output(monkeypatch, tmp_path):
         assert job.retry_count == 0
 
 
-@job(max_workers=1)
+@job(max_workers=1, use_process=False)
 def err_fun(data):
     raise RuntimeError()
 
@@ -231,14 +231,14 @@ def test_job_resume_on_new_job_runner(monkeypatch, tmp_path):
         assert_job_result(job3_id, JobStatus.SUCCEEDED, 15)
 
 
-@job(max_workers=2)
+@job(max_workers=2, use_process=False)
 def job_fun_parallelism2(x, y, sleep_secs=0):
     if sleep_secs > 0:
         time.sleep(sleep_secs)
     return x + y
 
 
-@job(max_workers=3)
+@job(max_workers=3, use_process=False)
 def job_fun_parallelism3(x, y, sleep_secs=0):
     if sleep_secs > 0:
         time.sleep(sleep_secs)
@@ -281,7 +281,7 @@ def test_job_queue_parallelism(monkeypatch, tmp_path):
         assert_job_result(job_p3_ids[3], JobStatus.SUCCEEDED, 4)
 
 
-@job(max_workers=1)
+@job(max_workers=1, use_process=False)
 def transient_err_fun(tmp_dir: str, succeed_on_nth_run: int):
     """
     This function will raise `TransientError` on the first (`succeed_on_nth_run` - 1) runs,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/18049?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18049/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18049/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18049/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Job backend: allow explicitly setting job function to run in an individual process

We might need to set environment variables (e.g. API keys) for job function.

To isolate environment variable settings, we need to support running job in an individual process

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?
Job backend: allow explicitly setting job function to run in an individual process

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
