### PR TITLE
Delete parent child run together

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.enzyme.test.tsx
@@ -45,6 +45,7 @@ describe('MyComponent', () => {
       openErrorModal: jest.fn(),
       deleteRunApi: getMockDeleteRunApiFn(false, []),
       intl: { formatMessage: jest.fn() },
+      childRunIdsBySelectedParent: {},
     };
     wrapper = shallow(<DeleteRunModalImpl {...minimalProps} />);
   });
@@ -60,7 +61,7 @@ describe('MyComponent', () => {
     const deleteRunApi = getMockDeleteRunApiFn(false, deletedRunIds);
     wrapper = shallow(<DeleteRunModalImpl {...{ ...minimalProps, deleteRunApi }} />);
     instance = wrapper.instance();
-    instance.handleSubmit().then(() => {
+    instance.handleDeleteSelected().then(() => {
       expect(deletedRunIds).toEqual(minimalProps.selectedRunIds);
       done();
     });
@@ -72,9 +73,33 @@ describe('MyComponent', () => {
     const deleteRunApi = getMockDeleteRunApiFn(true, deletedRunIds);
     wrapper = shallow(<DeleteRunModalImpl {...{ ...minimalProps, deleteRunApi }} />);
     instance = wrapper.instance();
-    instance.handleSubmit().then(() => {
+    instance.handleDeleteSelected().then(() => {
       expect(deletedRunIds).toEqual([]);
       expect(minimalProps.openErrorModal).toHaveBeenCalled();
+      done();
+    });
+  });
+
+  test('should delete child runs when selected', (done) => {
+    const deletedRunIds: any = [];
+    const deleteRunApi = getMockDeleteRunApiFn(false, deletedRunIds);
+    const childRunIdsBySelectedParent = { runId0: ['childRun1', 'childRun2'] };
+    wrapper = shallow(<DeleteRunModalImpl {...{ ...minimalProps, deleteRunApi, childRunIdsBySelectedParent }} />);
+    instance = wrapper.instance();
+    instance.handleDeleteWithChildren().then(() => {
+      expect(deletedRunIds).toEqual(['runId0', 'runId1', 'childRun1', 'childRun2']);
+      done();
+    });
+  });
+
+  test('should not duplicate already selected child runs', (done) => {
+    const deletedRunIds: any = [];
+    const deleteRunApi = getMockDeleteRunApiFn(false, deletedRunIds);
+    const childRunIdsBySelectedParent = { runId0: ['runId1'] };
+    wrapper = shallow(<DeleteRunModalImpl {...{ ...minimalProps, deleteRunApi, childRunIdsBySelectedParent }} />);
+    instance = wrapper.instance();
+    instance.handleDeleteWithChildren().then(() => {
+      expect(deletedRunIds).toEqual(['runId0', 'runId1']);
       done();
     });
   });

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
@@ -172,8 +172,8 @@ export class DeleteRunModalImpl extends Component<Props, State> {
           </p>
           {hasChildRuns ? (
             <p>
-              {childRunCount} child {Utils.pluralize('run', childRunCount)} will also be removed when deleting selected
-              runs and children ({totalRunsWithChildren} total).
+              The selected run has {childRunCount} child {Utils.pluralize('run', childRunCount)}. Delete this run alone
+              or all {totalRunsWithChildren}?
             </p>
           ) : null}
           {/* @ts-expect-error TS(4111): Property 'MLFLOW_SHOW_GDPR_PURGING_MESSAGES' comes from a... Remove this comment to see the full error message */}

--- a/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/DeleteRunModal.tsx
@@ -6,12 +6,17 @@
  */
 
 import React, { Component } from 'react';
-import { ConfirmModal } from './ConfirmModal';
 import { deleteRunApi, openErrorModal } from '../../actions';
 import { connect } from 'react-redux';
 import Utils from '../../../common/utils/Utils';
 import type { IntlShape } from 'react-intl';
 import { injectIntl } from 'react-intl';
+import { Button, Modal } from '@databricks/design-system';
+import { EXPERIMENT_PARENT_ID_TAG } from '../experiment-page/utils/experimentPage.common-utils';
+
+interface State {
+  deletingMode: null | 'selected' | 'withChildren';
+}
 
 type Props = {
   isOpen: boolean;
@@ -21,17 +26,66 @@ type Props = {
   deleteRunApi: (...args: any[]) => any;
   onSuccess?: () => void;
   intl: IntlShape;
+  childRunIdsBySelectedParent: Record<string, string[]>;
 };
 
-export class DeleteRunModalImpl extends Component<Props> {
+export class DeleteRunModalImpl extends Component<Props, State> {
   constructor(props: Props) {
     super(props);
-    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleDelete = this.handleDelete.bind(this);
+    this.handleDeleteSelected = this.handleDeleteSelected.bind(this);
+    this.handleDeleteWithChildren = this.handleDeleteWithChildren.bind(this);
+    this.onRequestClose = this.onRequestClose.bind(this);
   }
 
-  handleSubmit() {
+  state: State = {
+    deletingMode: null,
+  };
+
+  getChildRunIdsToDelete() {
+    const { childRunIdsBySelectedParent, selectedRunIds } = this.props;
+    const selectedRunIdsSet = new Set(selectedRunIds);
+    const childRunIdsSet = new Set<string>();
+
+    Object.values(childRunIdsBySelectedParent).forEach((childIds = []) => {
+      childIds.forEach((childId) => {
+        if (!selectedRunIdsSet.has(childId)) {
+          childRunIdsSet.add(childId);
+        }
+      });
+    });
+
+    return Array.from(childRunIdsSet);
+  }
+
+  getRunIdsToDelete(includeDescendants: boolean) {
+    if (!includeDescendants) {
+      return this.props.selectedRunIds;
+    }
+    const childRunIds = this.getChildRunIdsToDelete();
+    return [...this.props.selectedRunIds, ...childRunIds];
+  }
+
+  handleDelete(includeDescendants: boolean) {
+    if (this.state.deletingMode) {
+      return Promise.resolve();
+    }
+    this.setState({ deletingMode: includeDescendants ? 'withChildren' : 'selected' });
+    return this.deleteRuns(includeDescendants);
+  }
+
+  handleDeleteSelected() {
+    return this.handleDelete(false);
+  }
+
+  handleDeleteWithChildren() {
+    return this.handleDelete(true);
+  }
+
+  deleteRuns(includeDescendants: boolean) {
     const deletePromises: any = [];
-    this.props.selectedRunIds.forEach((runId) => {
+    const runIdsToDelete = this.getRunIdsToDelete(includeDescendants);
+    runIdsToDelete.forEach((runId) => {
       deletePromises.push(this.props.deleteRunApi(runId));
     });
     return Promise.all(deletePromises)
@@ -44,44 +98,148 @@ export class DeleteRunModalImpl extends Component<Props> {
       })
       .then(() => {
         this.props.onSuccess?.();
+      })
+      .finally(() => {
+        this.setState({ deletingMode: null });
+        this.props.onClose();
       });
+  }
+
+  onRequestClose() {
+    if (!this.state.deletingMode) {
+      this.props.onClose();
+    }
   }
 
   render() {
     const number = this.props.selectedRunIds.length;
+    const childRunIds = this.getChildRunIdsToDelete();
+    const childRunCount = childRunIds.length;
+    const hasChildRuns = childRunCount > 0;
+    const totalRunsWithChildren = number + childRunCount;
+    const { deletingMode } = this.state;
+    const isDeletingSelected = deletingMode === 'selected';
+    const isDeletingWithChildren = deletingMode === 'withChildren';
+
+    const deleteSelectedButton = (
+      <Button
+        componentId="delete-selected"
+        key="delete-selected"
+        onClick={this.handleDeleteSelected}
+        disabled={isDeletingWithChildren}
+        loading={isDeletingSelected}
+        type="primary"
+      >
+        Delete selected
+      </Button>
+    );
+
+    const deleteSelectedAndChildrenButton = hasChildRuns ? (
+      <Button
+        componentId="delete-selected-children"
+        key="delete-selected-children"
+        type="primary"
+        onClick={this.handleDeleteWithChildren}
+        disabled={isDeletingSelected}
+        loading={isDeletingWithChildren}
+      >
+        Delete selected and children
+      </Button>
+    ) : null;
+
+    const footerButtons = [
+      <Button componentId="cancel" key="cancel" onClick={this.onRequestClose} disabled={!!deletingMode}>
+        Cancel
+      </Button>,
+      deleteSelectedButton,
+      ...(deleteSelectedAndChildrenButton ? [deleteSelectedAndChildrenButton] : []),
+    ];
+
     return (
-      <ConfirmModal
-        isOpen={this.props.isOpen}
-        onClose={this.props.onClose}
-        handleSubmit={this.handleSubmit}
+      <Modal
+        componentId="delete-run-modal"
+        data-testid="delete-run-modal"
         title={`Delete Experiment ${Utils.pluralize('Run', number)}`}
-        helpText={
-          <div>
+        visible={this.props.isOpen}
+        onCancel={this.onRequestClose}
+        footer={footerButtons}
+      >
+        <div className="modal-explanatory-text">
+          <p>
+            <b>
+              Selected {number} experiment {Utils.pluralize('run', number)}.
+            </b>
+          </p>
+          {hasChildRuns ? (
             <p>
-              <b>
-                {number} experiment {Utils.pluralize('run', number)} will be deleted.
-              </b>
+              {childRunCount} child {Utils.pluralize('run', childRunCount)} will also be removed when deleting selected
+              runs and children ({totalRunsWithChildren} total).
             </p>
-            {/* @ts-expect-error TS(4111): Property 'MLFLOW_SHOW_GDPR_PURGING_MESSAGES' comes from a... Remove this comment to see the full error message */}
-            {process.env.MLFLOW_SHOW_GDPR_PURGING_MESSAGES === 'true' ? (
-              <p>
-                Deleted runs are restorable for 30 days, after which they are purged along with associated metrics,
-                params, tags, and artifacts.
-              </p>
-            ) : (
-              ''
-            )}
-          </div>
-        }
-        confirmButtonText="Delete"
-      />
+          ) : null}
+          {/* @ts-expect-error TS(4111): Property 'MLFLOW_SHOW_GDPR_PURGING_MESSAGES' comes from a... Remove this comment to see the full error message */}
+          {process.env.MLFLOW_SHOW_GDPR_PURGING_MESSAGES === 'true' ? (
+            <p>
+              Deleted runs are restorable for 30 days, after which they are purged along with associated metrics,
+              params, tags, and artifacts.
+            </p>
+          ) : (
+            ''
+          )}
+        </div>
+      </Modal>
     );
   }
 }
+
+const mapStateToProps = (state: any, ownProps: { selectedRunIds: string[] }) => {
+  const tagsByRunUuid = state.entities?.tagsByRunUuid || {};
+  const parentToChildrenMap: Record<string, string[]> = {};
+
+  Object.entries(tagsByRunUuid).forEach(([runId, tags]) => {
+    const parentTag = (tags as any)?.[EXPERIMENT_PARENT_ID_TAG];
+    const parentRunId = parentTag?.value;
+    if (parentRunId) {
+      if (!parentToChildrenMap[parentRunId]) {
+        parentToChildrenMap[parentRunId] = [];
+      }
+      parentToChildrenMap[parentRunId].push(runId);
+    }
+  });
+
+  const resolveDescendants = (runId: string) => {
+    const result: string[] = [];
+    const stack = [...(parentToChildrenMap[runId] || [])];
+    const visited = new Set<string>();
+
+    while (stack.length) {
+      const current = stack.pop();
+      if (current && !visited.has(current)) {
+        visited.add(current);
+        result.push(current);
+        const children = parentToChildrenMap[current];
+        if (children) {
+          stack.push(...children);
+        }
+      }
+    }
+
+    return result;
+  };
+
+  const childRunIdsBySelectedParent: Record<string, string[]> = {};
+  ownProps.selectedRunIds.forEach((runId) => {
+    const descendants = resolveDescendants(runId);
+    if (descendants.length) {
+      childRunIdsBySelectedParent[runId] = descendants;
+    }
+  });
+
+  return { childRunIdsBySelectedParent };
+};
 
 const mapDispatchToProps = {
   deleteRunApi,
   openErrorModal,
 };
 
-export default connect(null, mapDispatchToProps)(injectIntl(DeleteRunModalImpl));
+export default connect(mapStateToProps, mapDispatchToProps)(injectIntl(DeleteRunModalImpl));


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/18052?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18052/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18052/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18052/merge
```

</p>
</details>

### Related Issues/PRs

Fix #2347 

### What changes are proposed in this pull request?

This PR add support for deleting Parent run and child run together along with deleting only Parent run.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1703" height="901" alt="Screenshot 2025-10-01 at 1 08 37 PM" src="https://github.com/user-attachments/assets/666c7be4-ec58-4c92-a035-db799d8f2245" />
<img width="1698" height="944" alt="Screenshot 2025-10-01 at 1 08 50 PM" src="https://github.com/user-attachments/assets/64ee703f-953e-4ce5-841f-9e505a9d4610" />
<img width="1728" height="950" alt="Screenshot 2025-10-01 at 1 09 01 PM" src="https://github.com/user-attachments/assets/7dd9dec3-a68e-4bd1-bad1-c69861b40f1d" />
<img width="1704" height="962" alt="Screenshot 2025-10-01 at 1 09 10 PM" src="https://github.com/user-attachments/assets/9de1555b-8dad-42e6-bcbf-1729641e1eff" />
<img width="1728" height="934" alt="Screenshot 2025-10-01 at 1 09 18 PM" src="https://github.com/user-attachments/assets/7a688ec0-a80c-4c34-a793-7ac738871845" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Users can now choose between deleting the all the child run present with parent run and also option for deleting only parent run as well.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
