### PR TITLE
Temporarily disable macOS CI due to GitHub service issue

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -32,7 +32,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [
+            ubuntu-latest,
+            # TODO: Uncomment once https://www.githubstatus.com/incidents/071h21gptcp0 is resolved
+            # macos-latest,
+          ]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     permissions:


### PR DESCRIPTION
### Related Issues/PRs

N/A - Addressing GitHub service incident

### What changes are proposed in this pull request?

Comments out `macos-latest` from the CI matrix with a TODO to re-enable once the GitHub incident is resolved.

**GitHub Incident Details:**
- **Title**: Degraded Performance for GitHub Actions MacOS Runners
- **Status**: Investigating (as of Oct 01, 2025 07:59 UTC)
- **Link**: https://www.githubstatus.com/incidents/071h21gptcp0

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with Claude Code