### PR TITLE
Job backend: add last_update_time column for job table, for counting job pending / execution time

### DIFF
--- a/mlflow/entities/_job.py
+++ b/mlflow/entities/_job.py
@@ -20,6 +20,7 @@ class Job(_MlflowObject):
         status: JobStatus,
         result: str | None,
         retry_count: int = 0,
+        last_update_time: int = None,
     ):
         super().__init__()
         self._job_id = job_id
@@ -30,6 +31,7 @@ class Job(_MlflowObject):
         self._status = status
         self._result = result
         self._retry_count = retry_count
+        self._last_update_time = last_update_time
 
     @property
     def job_id(self) -> str:
@@ -95,6 +97,11 @@ class Job(_MlflowObject):
     def retry_count(self) -> int:
         """Integer containing the job retry count"""
         return self._retry_count
+
+    @property
+    def last_update_time(self) -> int:
+        """Last update timestamp of the job, in number of milliseconds since the UNIX epoch."""
+        return self._last_update_time
 
     def __repr__(self) -> str:
         return f"<Job(job_id={self.job_id}, function_fullname={self.function_fullname})>"

--- a/mlflow/entities/_job.py
+++ b/mlflow/entities/_job.py
@@ -19,8 +19,8 @@ class Job(_MlflowObject):
         timeout: float | None,
         status: JobStatus,
         result: str | None,
-        retry_count: int = 0,
-        last_update_time: int = None,
+        retry_count: int,
+        last_update_time: int,
     ):
         super().__init__()
         self._job_id = job_id

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -36,6 +36,7 @@ class Job(BaseModel):
     status: str
     result: Any
     retry_count: int
+    last_update_time: int
 
     @classmethod
     def from_job_entity(cls, job: JobEntity) -> "Job":
@@ -48,6 +49,7 @@ class Job(BaseModel):
             status=str(job.status),
             result=job.parsed_result,
             retry_count=job.retry_count,
+            last_update_time=job.last_update_time,
         )
 
 

--- a/mlflow/store/db_migrations/versions/bf29a5ff90ea_add_jobs_table.py
+++ b/mlflow/store/db_migrations/versions/bf29a5ff90ea_add_jobs_table.py
@@ -27,6 +27,7 @@ def upgrade():
         sa.Column("status", sa.Integer(), nullable=False),
         sa.Column("result", sa.Text(), nullable=True),
         sa.Column("retry_count", sa.Integer(), default=0),
+        sa.Column("last_update_time", sa.BigInteger(), default=lambda: int(time.time() * 1000)),
         sa.PrimaryKeyConstraint("id", name="jobs_pk"),
     )
     with op.batch_alter_table("jobs", schema=None) as batch_op:

--- a/mlflow/store/db_migrations/versions/bf29a5ff90ea_add_jobs_table.py
+++ b/mlflow/store/db_migrations/versions/bf29a5ff90ea_add_jobs_table.py
@@ -31,7 +31,7 @@ def upgrade():
         sa.Column("timeout", sa.Float(precision=53), nullable=True),
         sa.Column("status", sa.Integer(), nullable=False),
         sa.Column("result", sa.Text(), nullable=True),
-        sa.Column("retry_count", sa.Integer(), default=0),
+        sa.Column("retry_count", sa.Integer(), default=0, nullable=False),
         sa.Column(
             "last_update_time",
             sa.BigInteger(),

--- a/mlflow/store/db_migrations/versions/bf29a5ff90ea_add_jobs_table.py
+++ b/mlflow/store/db_migrations/versions/bf29a5ff90ea_add_jobs_table.py
@@ -20,14 +20,24 @@ def upgrade():
     op.create_table(
         "jobs",
         sa.Column("id", sa.String(length=36), nullable=False),
-        sa.Column("creation_time", sa.BigInteger(), default=lambda: int(time.time() * 1000)),
+        sa.Column(
+            "creation_time",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
         sa.Column("function_fullname", sa.String(length=500), nullable=False),
         sa.Column("params", sa.Text(), nullable=False),
         sa.Column("timeout", sa.Float(precision=53), nullable=True),
         sa.Column("status", sa.Integer(), nullable=False),
         sa.Column("result", sa.Text(), nullable=True),
         sa.Column("retry_count", sa.Integer(), default=0),
-        sa.Column("last_update_time", sa.BigInteger(), default=lambda: int(time.time() * 1000)),
+        sa.Column(
+            "last_update_time",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
         sa.PrimaryKeyConstraint("id", name="jobs_pk"),
     )
     with op.batch_alter_table("jobs", schema=None) as batch_op:

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -68,6 +68,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
                 timeout=timeout,
                 status=JobStatus.PENDING.to_int(),
                 result=None,
+                last_update_time=creation_time,
             )
 
             session.add(job)
@@ -85,6 +86,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job = self._get_sql_job(session, job_id)
 
             job.status = JobStatus.RUNNING.to_int()
+            job.last_update_time = get_current_time_millis()
 
     def reset_job(self, job_id: str) -> None:
         """
@@ -97,6 +99,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job = self._get_sql_job(session, job_id)
 
             job.status = JobStatus.PENDING.to_int()
+            job.last_update_time = get_current_time_millis()
 
     def finish_job(self, job_id: str, result: str) -> None:
         """
@@ -111,6 +114,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
 
             job.status = JobStatus.SUCCEEDED.to_int()
             job.result = result
+            job.last_update_time = get_current_time_millis()
 
     def fail_job(self, job_id: str, error: str) -> None:
         """
@@ -125,6 +129,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
 
             job.status = JobStatus.FAILED.to_int()
             job.result = error
+            job.last_update_time = get_current_time_millis()
 
     def mark_job_timed_out(self, job_id: str) -> None:
         """
@@ -137,6 +142,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job = self._get_sql_job(session, job_id)
 
             job.status = JobStatus.TIMEOUT.to_int()
+            job.last_update_time = get_current_time_millis()
 
     def retry_or_fail_job(self, job_id: str, error: str) -> int | None:
         """
@@ -165,6 +171,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
                 return None
             job.retry_count += 1
             job.status = JobStatus.PENDING.to_int()
+            job.last_update_time = get_current_time_millis()
             return job.retry_count
 
     def list_jobs(

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1976,7 +1976,7 @@ class SqlJob(Base):
     Job result: `Text`.
     """
 
-    retry_count = Column(Integer, default=0)
+    retry_count = Column(Integer, default=0, nullable=False)
     """
     Job retry count: `Integer`
     """

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1946,7 +1946,7 @@ class SqlJob(Base):
     Job ID: `String` (limit 36 characters). *Primary Key* for ``jobs`` table.
     """
 
-    creation_time = Column(BigInteger, default=get_current_time_millis)
+    creation_time = Column(BigInteger, default=get_current_time_millis, nullable=False)
     """
     Creation timestamp: `BigInteger`.
     """
@@ -1981,7 +1981,7 @@ class SqlJob(Base):
     Job retry count: `Integer`
     """
 
-    last_update_time = Column(BigInteger(), default=get_current_time_millis)
+    last_update_time = Column(BigInteger(), default=get_current_time_millis, nullable=False)
     """
     Last Update time of experiment: `BigInteger`.
     """

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2018,4 +2018,5 @@ class SqlJob(Base):
             status=JobStatus.from_int(self.status),
             result=self.result,
             retry_count=self.retry_count,
+            last_update_time=self.last_update_time,
         )

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -1981,6 +1981,11 @@ class SqlJob(Base):
     Job retry count: `Integer`
     """
 
+    last_update_time = Column(BigInteger(), default=get_current_time_millis)
+    """
+    Last Update time of experiment: `BigInteger`.
+    """
+
     __table_args__ = (
         PrimaryKeyConstraint("id", name="jobs_pk"),
         Index(

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -68,7 +68,7 @@ CREATE TABLE jobs (
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
-	retry_count INTEGER,
+	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -62,14 +62,14 @@ CREATE TABLE inputs (
 
 CREATE TABLE jobs (
 	id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
-	creation_time BIGINT,
+	creation_time BIGINT NOT NULL,
 	function_fullname VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	params VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	retry_count INTEGER,
-	last_update_time BIGINT,
+	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -69,6 +69,7 @@ CREATE TABLE jobs (
 	status INTEGER NOT NULL,
 	result VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	retry_count INTEGER,
+	last_update_time BIGINT,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -70,6 +70,7 @@ CREATE TABLE jobs (
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
+	last_update_time BIGINT,
 	PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -63,14 +63,14 @@ CREATE TABLE inputs (
 
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
-	creation_time BIGINT,
+	creation_time BIGINT NOT NULL,
 	function_fullname VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
 	timeout DOUBLE,
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
-	last_update_time BIGINT,
+	last_update_time BIGINT NOT NULL,
 	PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -69,7 +69,7 @@ CREATE TABLE jobs (
 	timeout DOUBLE,
 	status INTEGER NOT NULL,
 	result TEXT,
-	retry_count INTEGER,
+	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
 	PRIMARY KEY (id)
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -64,14 +64,14 @@ CREATE TABLE inputs (
 
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
-	creation_time BIGINT,
+	creation_time BIGINT NOT NULL,
 	function_fullname VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
 	timeout DOUBLE PRECISION,
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
-	last_update_time BIGINT,
+	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -70,7 +70,7 @@ CREATE TABLE jobs (
 	timeout DOUBLE PRECISION,
 	status INTEGER NOT NULL,
 	result TEXT,
-	retry_count INTEGER,
+	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -71,6 +71,7 @@ CREATE TABLE jobs (
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
+	last_update_time BIGINT,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -64,14 +64,14 @@ CREATE TABLE inputs (
 
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
-	creation_time BIGINT,
+	creation_time BIGINT NOT NULL,
 	function_fullname VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
-	last_update_time BIGINT,
+	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -70,7 +70,7 @@ CREATE TABLE jobs (
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result TEXT,
-	retry_count INTEGER,
+	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -71,6 +71,7 @@ CREATE TABLE jobs (
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
+	last_update_time BIGINT,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -64,14 +64,14 @@ CREATE TABLE inputs (
 
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
-	creation_time BIGINT,
+	creation_time BIGINT NOT NULL,
 	function_fullname VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
-	last_update_time BIGINT,
+	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -70,7 +70,7 @@ CREATE TABLE jobs (
 	timeout FLOAT,
 	status INTEGER NOT NULL,
 	result TEXT,
-	retry_count INTEGER,
+	retry_count INTEGER NOT NULL,
 	last_update_time BIGINT NOT NULL,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -71,6 +71,7 @@ CREATE TABLE jobs (
 	status INTEGER NOT NULL,
 	result TEXT,
 	retry_count INTEGER,
+	last_update_time BIGINT,
 	CONSTRAINT jobs_pk PRIMARY KEY (id)
 )
 

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -101,6 +101,7 @@ def test_job_endpoint(server_url: str):
     response2.raise_for_status()
     job_json = response2.json()
     job_json.pop("creation_time")
+    job_json.pop("last_update_time")
     assert job_json == {
         "job_id": job_id,
         "function_fullname": "test_endpoint.simple_job_fun",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/18071?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18071/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18071/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18071/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Job backend: add last_update_time for job table,  for counting job pending / execution time

When job is created, last_update_time is set to job creation time.
When job status is changed, last_update_time is updated.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Job backend: add last_update_time for job table

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
