### PR TITLE
[Datasets UI][2/x] Export some utils from ModelTraceExplorer

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -28,7 +28,7 @@
     "@ag-grid-community/react": "^27.2.1",
     "@apollo/client": "^3.6.9",
     "@craco/craco": "7.0.0-alpha.0",
-    "@databricks/design-system": "^1.12.20",
+    "@databricks/design-system": "^1.12.21",
     "@emotion/cache": "^11.11.0",
     "@emotion/react": "^11.11.3",
     "@tanstack/react-query": "^4.29.17",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -10,7 +10,10 @@ export {
   getModelTraceSpanId,
   getModelTraceSpanParentId,
   getModelTraceId,
+  isV3ModelTraceInfo,
+  tryDeserializeAttribute,
 } from './ModelTraceExplorer.utils';
+export { getAssessmentValue } from './assessments-pane/utils';
 export { AssessmentSchemaContextProvider, type AssessmentSchema } from './contexts/AssessmentSchemaContext';
 export * from './ModelTrace.types';
 export * from './oss-notebook-renderer/mlflow-fetch-utils';

--- a/mlflow/server/js/yarn.lock
+++ b/mlflow/server/js/yarn.lock
@@ -2560,9 +2560,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@databricks/design-system@npm:^1.12.20":
-  version: 1.12.21
-  resolution: "@databricks/design-system@npm:1.12.21"
+"@databricks/design-system@npm:^1.12.21":
+  version: 1.12.22
+  resolution: "@databricks/design-system@npm:1.12.22"
   dependencies:
     "@ant-design/icons": "npm:^4.7.0"
     "@babel/runtime": "npm:^7.27.3"
@@ -2591,7 +2591,7 @@ __metadata:
     chroma-js: "npm:^2.4.2"
     classnames: "npm:^2.3.1"
     date-fns: "npm:^3.6.0"
-    dom-accessibility-api: "npm:^0.5.9"
+    dom-accessibility-api: "npm:^0.7.0"
     downshift: "npm:^6.1.9"
     enzyme: "npm:^3.11.0"
     lodash: "npm:^4.17.21"
@@ -2604,7 +2604,7 @@ __metadata:
     moment: ^2.25.3
     react: "*"
     react-dom: "*"
-  checksum: 10c0/9c1ddd49b5eb53f991f16490666c50ca16765242390f61335a781f364ad340cc2c38d92bb475cb9f7b55a0fafd8d5bafe7eceb468c981415b77ef5ef1510e391
+  checksum: 10c0/bad36095618b282d484e5df5c4b33411a87db5aad4082e42f8f4a752c191c6a987aa4f5f3f56d5317ca98dbd67e04b505db6c17728effd16cec059650c433519
   languageName: node
   linkType: hard
 
@@ -4343,7 +4343,7 @@ __metadata:
     "@babel/preset-react": "npm:^7.27.1"
     "@babel/preset-typescript": "npm:^7.27.1"
     "@craco/craco": "npm:7.0.0-alpha.0"
-    "@databricks/design-system": "npm:^1.12.20"
+    "@databricks/design-system": "npm:^1.12.21"
     "@emotion/babel-plugin": "npm:^11.11.0"
     "@emotion/babel-preset-css-prop": "npm:^11.11.0"
     "@emotion/cache": "npm:^11.11.0"
@@ -15053,6 +15053,13 @@ __metadata:
   version: 0.6.3
   resolution: "dom-accessibility-api@npm:0.6.3"
   checksum: 10c0/10bee5aa514b2a9a37c87cd81268db607a2e933a050074abc2f6fa3da9080ebed206a320cbc123567f2c3087d22292853bdfdceaffdd4334ffe2af9510b29360
+  languageName: node
+  linkType: hard
+
+"dom-accessibility-api@npm:^0.7.0":
+  version: 0.7.0
+  resolution: "dom-accessibility-api@npm:0.7.0"
+  checksum: 10c0/51d3fe283b0b4882442ba7cd7c76d27aa96b57e1854f0373be62c0abfaa95e89f4c1a1b883712814dc52b0a0853147f6de681fae20467a29d3a485df9b7329d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18078/files/fb36f25b6a783a5766885640e2ddff11cc96b6a1..ce8ec64bd3ba39da1cda2ee05c01f40ee5ca3d6a) to review incremental changes.
- [stack/update-package](https://github.com/mlflow/mlflow/pull/18077) [[Files changed](https://github.com/mlflow/mlflow/pull/18077/files)]
  - [**stack/export-utils**](https://github.com/mlflow/mlflow/pull/18078) [[Files changed](https://github.com/mlflow/mlflow/pull/18078/files/fb36f25b6a783a5766885640e2ddff11cc96b6a1..ce8ec64bd3ba39da1cda2ee05c01f40ee5ca3d6a)]
    - [stack/query-hooks](https://github.com/mlflow/mlflow/pull/18079) [[Files changed](https://github.com/mlflow/mlflow/pull/18079/files/ce8ec64bd3ba39da1cda2ee05c01f40ee5ca3d6a..25d962fde7f562afa7aa40530eb42420d34c01df)]
      - [stack/mutation-hooks](https://github.com/mlflow/mlflow/pull/18099) [[Files changed](https://github.com/mlflow/mlflow/pull/18099/files/25d962fde7f562afa7aa40530eb42420d34c01df..1dd8d15b81d9456825f3ba2f9c3fa87bdd78647d)]
        - [stack/creation-modal](https://github.com/mlflow/mlflow/pull/18100) [[Files changed](https://github.com/mlflow/mlflow/pull/18100/files/1dd8d15b81d9456825f3ba2f9c3fa87bdd78647d..8d4f15e7fe4cd6be9fd76bcbcadbfda6bb26b558)]
          - [stack/dataset-list-table](https://github.com/mlflow/mlflow/pull/18104) [[Files changed](https://github.com/mlflow/mlflow/pull/18104/files/8d4f15e7fe4cd6be9fd76bcbcadbfda6bb26b558..cf56f52191a9fdba143e2174ea3b89c62bdd6cca)]
            - [stack/records-table](https://github.com/mlflow/mlflow/pull/18105) [[Files changed](https://github.com/mlflow/mlflow/pull/18105/files/cf56f52191a9fdba143e2174ea3b89c62bdd6cca..7b52a567f39c663f5d8726001e2c5defb3e9e557)]
              - [stack/export-to-dataset-modal](https://github.com/mlflow/mlflow/pull/18107) [[Files changed](https://github.com/mlflow/mlflow/pull/18107/files/7b52a567f39c663f5d8726001e2c5defb3e9e557..7470dc44d4964cd49e8a917ad18d3cafd8967594)]
                - [stack/integration](https://github.com/mlflow/mlflow/pull/18108) [[Files changed](https://github.com/mlflow/mlflow/pull/18108/files/7470dc44d4964cd49e8a917ad18d3cafd8967594..54090a7e956cc2ae1bf27fd98733f825644c1225)]
                  - [stack/export-traces](https://github.com/mlflow/mlflow/pull/18109) [[Files changed](https://github.com/mlflow/mlflow/pull/18109/files/54090a7e956cc2ae1bf27fd98733f825644c1225..6911185a5872c956b02ef19bd2d9e50c6fe44896)]
                    - [stack/empty-states](https://github.com/mlflow/mlflow/pull/18110) [[Files changed](https://github.com/mlflow/mlflow/pull/18110/files/6911185a5872c956b02ef19bd2d9e50c6fe44896..36e4d8693dc8eadf85da559a5c050bf14427fe9d)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

#### Stack context

This PR stack introduces a frontend for the new eval datasets feature. Users can:

1. View, create, and delete datasets from a tab in the experiments pane
2. Export traces from the traces tab to their datasets

Features that will not make it into 3.5 due to bandwidth:

1. Editing / viewing dataset tags
2. Global dataset management (i.e. new top-level tab like prompts / models)
  a. This will be useful for associating datasets to multiple experiments

#### PR context

This PR exports a few useful utils from the trace UI, which I will use for the trace export feature down the line.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Should be a no-op but tested at the end of the stack

https://github.com/user-attachments/assets/7928ba35-667a-42c4-8d3b-79587d7cea61

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
