### PR TITLE
Fix Dataset issue

### DIFF
--- a/mlflow/data/dataset.py
+++ b/mlflow/data/dataset.py
@@ -62,6 +62,11 @@ class Dataset:
 
         return json.dumps(self.to_dict())
 
+    def _get_source_type(self) -> str:
+        """Returns the type of the dataset's underlying source."""
+
+        return self.source._get_source_type()
+
     @property
     def name(self) -> str:
         """

--- a/tests/data/test_meta_dataset.py
+++ b/tests/data/test_meta_dataset.py
@@ -3,10 +3,13 @@ from unittest.mock import patch
 
 import pytest
 
+pd = pytest.importorskip("pandas")
+
 from mlflow.data.delta_dataset_source import DeltaDatasetSource
 from mlflow.data.http_dataset_source import HTTPDatasetSource
 from mlflow.data.huggingface_dataset_source import HuggingFaceDatasetSource
 from mlflow.data.meta_dataset import MetaDataset
+from mlflow.data.pandas_dataset import from_pandas
 from mlflow.data.uc_volume_dataset_source import UCVolumeDatasetSource
 from mlflow.exceptions import MlflowException
 from mlflow.types import DataType
@@ -103,3 +106,18 @@ def test_meta_dataset_with_uc_source():
         assert parsed_json["digest"] is not None
         assert path in parsed_json["source"]
         assert parsed_json["source_type"] == "uc_volume"
+
+
+def test_create_meta_dataset_from_dataset():
+    pandas_dataset = from_pandas(
+        df=pd.DataFrame({"a": [1, 2, 3]}),
+        source="/tmp/test.csv",
+    )
+
+    meta_dataset = MetaDataset(source=pandas_dataset)
+
+    parsed_json = json.loads(meta_dataset.to_json())
+
+    assert parsed_json["source_type"] == pandas_dataset._get_source_type()
+    dataset_json = json.loads(parsed_json["source"])
+    assert dataset_json["source_type"] == pandas_dataset.source._get_source_type()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/18081?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18081/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18081/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18081/merge
```

</p>
</details>

### Related Issues/PRs

Fix #18065 

### What changes are proposed in this pull request?

Fix AttributeError: 'PandasDataset' object has no attribute '_get_source_type' when creating a MetaDataset from a PandasDataset.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
