### PR TITLE
Fix logged models not showing up in run details page

### DIFF
--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -45,7 +45,7 @@ export const isRunPageLoggedModelsTableEnabled = () => true;
 /**
  * Flags enabling fetching data via GraphQL for particular views:
  */
-export const shouldEnableGraphQLRunDetailsPage = () => false;
+export const shouldEnableGraphQLRunDetailsPage = () => true;
 export const shouldEnableGraphQLSampledMetrics = () => false;
 export const shouldEnableGraphQLModelVersionsForRunDetails = () => false;
 export const shouldRerunExperimentUISeeding = () => false;

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
@@ -97,6 +97,10 @@ const testEntitiesState: Partial<ReduxState['entities']> = {
 };
 
 describe('RunViewOverview integration', () => {
+  beforeEach(() => {
+    jest.mocked(useGetRunQuery).mockReset();
+  });
+
   const onRunDataUpdated = jest.fn();
   const renderComponent = ({
     tags = {},

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewOverview.intg.test.tsx
@@ -6,7 +6,8 @@ import type { ReduxState } from '../../../redux-types';
 import { MemoryRouter } from '../../../common/utils/RoutingUtils';
 import { cloneDeep, merge } from 'lodash';
 import userEvent from '@testing-library/user-event';
-import { getRunApi, setTagApi } from '../../actions';
+import { setTagApi } from '../../actions';
+import { useGetRunQuery } from './hooks/useGetRunQuery';
 import { usePromptVersionsForRunQuery } from '../../pages/prompts/hooks/usePromptVersionsForRunQuery';
 import { NOTE_CONTENT_TAG } from '../../utils/NoteUtils';
 import { DesignSystemProvider } from '@databricks/design-system';
@@ -25,7 +26,10 @@ jest.mock('../../../common/components/Prompt', () => ({
 
 jest.mock('../../actions', () => ({
   setTagApi: jest.fn(() => ({ type: 'setTagApi', payload: Promise.resolve() })),
-  getRunApi: jest.fn(() => ({ type: 'getRunApi', payload: Promise.resolve() })),
+}));
+
+jest.mock('./hooks/useGetRunQuery', () => ({
+  useGetRunQuery: jest.fn(),
 }));
 
 const testPromptName = 'test-prompt';
@@ -296,6 +300,14 @@ describe('RunViewOverview integration', () => {
     const testParentRunUuid = 'test-parent-run-uuid';
     const testParentRunName = 'Test parent run name';
 
+    (useGetRunQuery as jest.Mock).mockReturnValue({
+      data: { info: { runName: testParentRunName, runUuid: testParentRunUuid, experimentId: testExperimentId } },
+      loading: false,
+      apolloError: undefined,
+      apiError: undefined,
+      refetchRun: jest.fn(),
+    });
+
     const { container } = renderComponent({
       tags: {
         [EXPERIMENT_PARENT_ID_TAG]: {
@@ -333,7 +345,7 @@ describe('RunViewOverview integration', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Parent run name loading')).toBeInTheDocument();
-      expect(getRunApi).toHaveBeenCalledWith(testParentRunUuid);
+      expect(useGetRunQuery).toHaveBeenCalledWith({ runUuid: testParentRunUuid, disabled: false });
     });
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
@@ -25,8 +25,6 @@ export const RunViewParentRunBox = ({ parentRunUuid }: { parentRunUuid: string }
     return shouldEnableGraphQLRunDetailsPage() ? parentRunInfoGraphql?.data?.info : parentRunInfoRedux;
   }, [parentRunInfoGraphql, parentRunInfoRedux]);
 
-  console.log('@@@@ parentRunInfo', parentRunInfo);
-
   useEffect(() => {
     // Don't call REST API if GraphQL is enabled
     if (shouldEnableGraphQLRunDetailsPage()) {

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewParentRunBox.tsx
@@ -25,6 +25,8 @@ export const RunViewParentRunBox = ({ parentRunUuid }: { parentRunUuid: string }
     return shouldEnableGraphQLRunDetailsPage() ? parentRunInfoGraphql?.data?.info : parentRunInfoRedux;
   }, [parentRunInfoGraphql, parentRunInfoRedux]);
 
+  console.log('@@@@ parentRunInfo', parentRunInfo);
+
   useEffect(() => {
     // Don't call REST API if GraphQL is enabled
     if (shouldEnableGraphQLRunDetailsPage()) {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/18082?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18082/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18082/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18082/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #18066

### What changes are proposed in this pull request?

In the recent UI sync we forgot to flip a flag that should be GA'd. This enables fetching run details via graphQL, which is what our new code paths rely on.

In the new rendering mode, we show logged models as a table rather than in the sidebar (see screenshot below)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="1728" height="960" alt="Screenshot 2025-10-02 at 4 52 41 PM" src="https://github.com/user-attachments/assets/6a1a5ac6-318f-4986-afc9-aff24d96d0c5" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
