### PR TITLE
Suppress false alert from span logging

### DIFF
--- a/mlflow/tracing/export/mlflow_v3.py
+++ b/mlflow/tracing/export/mlflow_v3.py
@@ -42,6 +42,11 @@ class MlflowV3SpanExporter(SpanExporter):
         # Display handler is no-op when running outside of notebooks.
         self._display_handler = get_display_handler()
 
+        # A flag to cache the failure of exporting spans so that the client will not try to export
+        # spans again and trigger excessive server side errors. Default to True (optimistically
+        # assume the store supports span-level logging).
+        self._should_export_spans_incrementally = True
+
     def export(self, spans: Sequence[ReadableSpan]) -> None:
         """
         Export the spans to the destination.
@@ -52,7 +57,9 @@ class MlflowV3SpanExporter(SpanExporter):
         """
         manager = InMemoryTraceManager.get_instance()
 
-        self._export_spans_incrementally(spans, manager)
+        if self._should_export_spans_incrementally:
+            self._export_spans_incrementally(spans, manager)
+
         self._export_traces(spans, manager)
 
     def _export_spans_incrementally(
@@ -160,18 +167,18 @@ class MlflowV3SpanExporter(SpanExporter):
         except NotImplementedError:
             # Silently skip if the store doesn't support log_spans. This is expected for stores that
             # don't implement span-level logging, and we don't want to spam warnings for every span.
-            pass
+            self._should_export_spans_incrementally = False
         except RestException as e:
             # When the FileStore is behind the tracking server, it returns 501 exception.
             # However, the OTLP endpoint returns general HTTP error, not MlflowException, which does
             # not include error_code in the body and handled as a general server side error. Hence,
             # we need to check the message to handle this case.
             if "REST OTLP span logging is not supported" in e.message:
-                pass
+                self._should_export_spans_incrementally = False
             else:
-                _logger.warning(f"Failed to log span to MLflow backend: {e}")
+                _logger.debug(f"Failed to log span to MLflow backend: {e}")
         except Exception as e:
-            _logger.warning(f"Failed to log span to MLflow backend: {e}")
+            _logger.debug(f"Failed to log span to MLflow backend: {e}")
 
     def _log_trace(self, trace: Trace, prompts: Sequence[PromptVersion]) -> None:
         """

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2573,7 +2573,7 @@ def test_start_trace(mlflow_client):
     def _exclude_system_keys(d: dict[str, str]):
         return {k: v for k, v in d.items() if not k.startswith("mlflow.")}
 
-    with mock.patch("mlflow.tracing.export.mlflow_v3._logger") as mock_logger:
+    with mock.patch("mlflow.tracing.export.mlflow_v3._logger.warning") as mock_warning:
         with mlflow.start_span(name="test") as span:
             mlflow.update_current_trace(
                 tags={
@@ -2603,7 +2603,7 @@ def test_start_trace(mlflow_client):
     }
 
     # No "Failed to log span to MLflow backend" warning should be issued
-    for call in mock_logger.warning.call_args_list:
+    for call in mock_warning.call_args_list:
         assert "Failed to log span to MLflow backend" not in str(call)
 
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -2565,49 +2565,45 @@ def test_legacy_start_and_end_trace_v2(mlflow_client):
     }
 
 
-def test_start_trace(mlflow_client):
-    experiment_id = mlflow_client.create_experiment("start end trace")
-
-    # Trace CRUD APIs are not directly exposed as public API of MlflowClient,
-    # so we use the underlying tracking client to test them.
-    client = mlflow_client._tracing_client
+@mock.patch("mlflow.tracing.export.mlflow_v3._logger")
+def test_start_trace(mock_exporter_logger, mlflow_client):
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
+    experiment_id = mlflow.set_experiment("start end trace").experiment_id
 
     # Helper function to remove auto-added system tags (mlflow.xxx) from testing
-    def _exclude_system_tags(tags: dict[str, str]):
-        return {k: v for k, v in tags.items() if not k.startswith("mlflow.")}
+    def _exclude_system_keys(d: dict[str, str]):
+        return {k: v for k, v in d.items() if not k.startswith("mlflow.")}
 
-    trace_info = TraceInfo(
-        trace_id="tr-1234",
-        trace_location=TraceLocation.from_experiment_id(experiment_id),
-        request_time=1000,
-        execution_duration=2000,
-        state=TraceState.OK,
-        trace_metadata={
-            "meta1": "apple",
-            "meta2": "grape",
-            TRACE_SCHEMA_VERSION_KEY: "3",
-        },
-        tags={
-            "tag1": "football",
-            "tag2": "basketball",
-        },
-    )
-    trace_info = client.start_trace(trace_info)
-    assert trace_info.trace_id == "tr-1234"
-    assert trace_info.experiment_id == experiment_id
-    assert trace_info.request_time == 1000
-    assert trace_info.execution_duration == 2000
-    assert trace_info.state == TraceState.OK
-    assert trace_info.trace_metadata == {
+    with mlflow.start_span(name="test") as span:
+        mlflow.update_current_trace(
+            tags={
+                "tag1": "football",
+                "tag2": "basketball",
+            },
+            metadata={
+                "meta1": "apple",
+                "meta2": "grape",
+            },
+        )
+
+    trace = mlflow_client.get_trace(span.trace_id)
+    assert trace.info.trace_id == span.trace_id
+    assert trace.info.experiment_id == experiment_id
+    assert trace.info.request_time > 0
+    assert trace.info.execution_duration is not None
+    assert trace.info.state == TraceState.OK
+    assert _exclude_system_keys(trace.info.trace_metadata) == {
         "meta1": "apple",
         "meta2": "grape",
-        TRACE_SCHEMA_VERSION_KEY: "3",
     }
-    assert _exclude_system_tags(trace_info.tags) == {
+    assert trace.info.trace_metadata[TRACE_SCHEMA_VERSION_KEY] == "3"
+    assert _exclude_system_keys(trace.info.tags) == {
         "tag1": "football",
         "tag2": "basketball",
     }
-    assert trace_info == client.get_trace_info(trace_info.trace_id)
+
+    # No logging failure warning should be issued
+    mock_exporter_logger.warning.assert_not_called()
 
 
 def test_search_traces(mlflow_client):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18092?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18092/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18092/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18092/merge
```

</p>
</details>

### What changes are proposed in this pull request?

When users log spans to an MLflow tracking server with file store backend, the following warning is shown at client side.

> Failed to log span to MLflow backend: REST OTLP span logging is not supported by FileStore

This not-supported error supposed to be suppressed because we optimistically call `log_spans` [here](https://github.com/mlflow/mlflow/blob/8506bd263c258360d3875c62ca55eb7461112c53/mlflow/tracing/export/mlflow_v3.py#L162-L163).

```
        try:
            self._client.log_spans(experiment_id, spans)
        except NotImplementedError:
            # Silently skip if the store doesn't support log_spans. This is expected for stores that
            # don't implement span-level logging, and we don't want to spam warnings for every span.
            pass
```

However, this block only catches `NotImplementedError`, therefore does not cover the case where users have a tracking server running.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
