### PR TITLE
Test autologging with skinny

### DIFF
--- a/.github/workflows/cross-version-tests.yml
+++ b/.github/workflows/cross-version-tests.yml
@@ -165,6 +165,11 @@ jobs:
           if [[ "${{ matrix.category }}" == "tracing-sdk" ]]; then
             pip install libs/tracing
             pip install pytest pytest-asyncio pytest-cov
+          # Similarly for skinny package tests
+          if [[ "${{ matrix.category }}" == "skinny" ]]; then
+            pip install libs/skinny
+            pip install pytest pytest-asyncio pytest-cov
+          fi
           # Other two categories of tests (model/autologging)
           else
             pip install .[extras]

--- a/dev/set_matrix.py
+++ b/dev/set_matrix.py
@@ -647,25 +647,26 @@ def expand_config(config: dict[str, Any], *, is_ref: bool = False) -> set[Matrix
             # Add tracing SDK test with the latest stable version
             if len(versions) > 0 and category == "autologging" and cfg.test_tracing_sdk:
                 version = sorted(versions)[-1]  # Test against the latest stable version
-                matrix.add(
-                    MatrixItem(
-                        name=f"{name}-tracing",
-                        flavor=flavor,
-                        category="tracing-sdk",
-                        job_name=f"{name} / tracing-sdk / {version}",
-                        install=install,
-                        # --import-mode=importlib is required for testing tracing SDK
-                        # (mlflow-tracing) works properly, without being affected by environment.
-                        run=run.replace("pytest", "pytest --import-mode=importlib"),
-                        package=package_info.pip_release,
-                        version=version,
-                        java=java,
-                        supported=version <= cfg.maximum,
-                        free_disk_space=free_disk_space,
-                        python=python,
-                        runs_on=runs_on,
+                for category in ["tracing-sdk", "skinny"]:
+                    matrix.add(
+                        MatrixItem(
+                            name=f"{name}-tracing",
+                            flavor=flavor,
+                            category=category,
+                            job_name=f"{name} / {category} / {version}",
+                            install=install,
+                            # --import-mode=importlib is required for testing tracing SDK
+                            # works properly, without being affected by environment.
+                            run=run.replace("pytest", "pytest --import-mode=importlib"),
+                            package=package_info.pip_release,
+                            version=version,
+                            java=java,
+                            supported=version <= cfg.maximum,
+                            free_disk_space=free_disk_space,
+                            python=python,
+                            runs_on=runs_on,
+                        )
                     )
-                )
 
             if package_info.install_dev:
                 install_dev = remove_comments(package_info.install_dev)

--- a/mlflow/types/__init__.py
+++ b/mlflow/types/__init__.py
@@ -3,12 +3,13 @@ The :py:mod:`mlflow.types` module defines data types and utilities to be used by
 components to describe interface independent of other frameworks or languages.
 """
 
-from mlflow.version import IS_TRACING_SDK_ONLY
+from mlflow.version import IS_MLFLOW_SKINNY, IS_TRACING_SDK_ONLY
 
-if not IS_TRACING_SDK_ONLY:
+if not (IS_TRACING_SDK_ONLY or IS_MLFLOW_SKINNY):
     import mlflow.types.llm  # noqa: F401
 
-    # Our typing system depends on numpy, which is not included in mlflow-tracing package
+    # Our typing system depends on numpy, which is not included in mlflow-tracing
+    # and mlflow-skinny package
     from mlflow.types.schema import ColSpec, DataType, ParamSchema, ParamSpec, Schema, TensorSpec
 
     __all__ = [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18093?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18093/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18093/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18093/merge
```

</p>
</details>

### What changes are proposed in this pull request?

`mlflow.xyz.autolog` for tracing should work with `mllfow-skinny`. We test this with `mlflow-tracing`, but not for skinny.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
