### PR TITLE
[Datasets UI][5/x] Add button + modal to create a dataset

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetButton.tsx
@@ -1,0 +1,25 @@
+import { Button, DatabaseIcon } from '@databricks/design-system';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { CreateEvaluationDatasetModal } from './CreateEvaluationDatasetModal';
+
+export const CreateEvaluationDatasetButton = ({ experimentId }: { experimentId: string }) => {
+  const [showCreateDatasetModal, setShowCreateDatasetModal] = useState(false);
+  return (
+    <>
+      <Button
+        componentId="mlflow.eval-datasets.create-dataset-button"
+        css={{ width: 'min-content' }}
+        icon={<DatabaseIcon />}
+        onClick={() => setShowCreateDatasetModal(true)}
+      >
+        <FormattedMessage defaultMessage="Create dataset" description="Create evaluation dataset button" />
+      </Button>
+      <CreateEvaluationDatasetModal
+        experimentId={experimentId}
+        visible={showCreateDatasetModal}
+        onCancel={() => setShowCreateDatasetModal(false)}
+      />
+    </>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
@@ -1,0 +1,78 @@
+import { FormUI, Input, Modal } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { useCreateEvaluationDatasetMutation } from '../hooks/useCreateEvaluationDatasetMutation';
+import { useCallback, useState } from 'react';
+
+export const CreateEvaluationDatasetModal = ({
+  visible,
+  experimentId,
+  onCancel,
+}: {
+  visible: boolean;
+  experimentId: string;
+  onCancel: () => void;
+}) => {
+  const intl = useIntl();
+  const [datasetName, setDatasetName] = useState('');
+  const [datasetNameError, setDatasetNameError] = useState('');
+  const { createEvaluationDatasetMutation, isLoading } = useCreateEvaluationDatasetMutation({
+    onSuccess: () => {
+      // close modal when dataset is created
+      onCancel();
+    },
+  });
+
+  const handleCreateEvaluationDataset = useCallback(() => {
+    if (!datasetName) {
+      setDatasetNameError(
+        intl.formatMessage({
+          defaultMessage: 'Dataset name is required',
+          description: 'Input field error when dataset name is empty',
+        }),
+      );
+      return;
+    }
+    createEvaluationDatasetMutation({ datasetName, experimentIds: [experimentId] });
+  }, [createEvaluationDatasetMutation, experimentId, datasetName, intl]);
+
+  return (
+    <Modal
+      componentId="mlflow.create-evaluation-dataset-modal"
+      visible={visible}
+      onCancel={onCancel}
+      okText={intl.formatMessage({ defaultMessage: 'Create', description: 'Create evaluation dataset button text' })}
+      cancelText={intl.formatMessage({
+        defaultMessage: 'Cancel',
+        description: 'Cancel create evaluation dataset button text',
+      })}
+      onOk={handleCreateEvaluationDataset}
+      okButtonProps={{ loading: isLoading }}
+      title={
+        <FormattedMessage
+          defaultMessage="Create evaluation dataset"
+          description="Create evaluation dataset modal title"
+        />
+      }
+    >
+      <FormUI.Label htmlFor="dataset-name-input">
+        <FormattedMessage defaultMessage="Dataset name" description="Dataset name label" />
+      </FormUI.Label>
+      <Input
+        componentId="mlflow.create-evaluation-dataset-modal.dataset-name"
+        id="dataset-name-input"
+        name="name"
+        type="text"
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Enter dataset name',
+          description: 'Dataset name placeholder',
+        })}
+        value={datasetName}
+        onChange={(e) => {
+          setDatasetName(e.target.value);
+          setDatasetNameError('');
+        }}
+      />
+      {datasetNameError && <FormUI.Message type="error" message={datasetNameError} />}
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
@@ -46,7 +46,7 @@ export const CreateEvaluationDatasetModal = ({
         description: 'Cancel create evaluation dataset button text',
       })}
       onOk={handleCreateEvaluationDataset}
-      okButtonProps={{ loading: isLoading }}
+      okButtonProps={{ loading: isLoading, disabled: !datasetName }}
       title={
         <FormattedMessage
           defaultMessage="Create evaluation dataset"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
@@ -1,0 +1,49 @@
+import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { EvaluationDataset } from '../types';
+import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
+
+type CreateDatasetResponse = {
+  dataset: EvaluationDataset;
+};
+
+type CreateDatasetPayload = {
+  datasetName: string;
+  experimentIds?: string[];
+};
+
+export const useCreateEvaluationDatasetMutation = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+}) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: createEvaluationDatasetMutation, isLoading } = useMutation({
+    mutationFn: async ({ datasetName, experimentIds }: CreateDatasetPayload) => {
+      const response = (await postJson({
+        relativeUrl: 'ajax-api/3.0/mlflow/datasets/create',
+        data: {
+          name: datasetName,
+          experiment_ids: experimentIds,
+        },
+      })) as CreateDatasetResponse;
+
+      return response.dataset;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+
+  return {
+    createEvaluationDatasetMutation,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
@@ -1,4 +1,4 @@
-import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { EvaluationDataset } from '../types';
 import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
@@ -23,13 +23,16 @@ export const useCreateEvaluationDatasetMutation = ({
 
   const { mutate: createEvaluationDatasetMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetName, experimentIds }: CreateDatasetPayload) => {
-      const response = (await postJson({
-        relativeUrl: 'ajax-api/3.0/mlflow/datasets/create',
-        data: {
-          name: datasetName,
-          experiment_ids: experimentIds,
-        },
-      })) as CreateDatasetResponse;
+      const requestBody = {
+        datasetName,
+        experimentIds,
+      };
+
+      const response = (await fetchAPI(
+        getAjaxUrl('ajax-api/3.0/mlflow/datasets/create'),
+        'POST',
+        requestBody,
+      )) as CreateDatasetResponse;
 
       return response.dataset;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
@@ -24,8 +24,8 @@ export const useCreateEvaluationDatasetMutation = ({
   const { mutate: createEvaluationDatasetMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetName, experimentIds }: CreateDatasetPayload) => {
       const requestBody = {
-        datasetName,
-        experimentIds,
+        name: datasetName,
+        experiment_ids: experimentIds,
       };
 
       const response = (await fetchAPI(

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
@@ -1,0 +1,34 @@
+import { deleteJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
+
+export const useDeleteEvaluationDatasetMutation = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+}) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: deleteEvaluationDatasetMutation, isLoading } = useMutation({
+    mutationFn: async ({ datasetId }: { datasetId: string }) => {
+      await deleteJson({
+        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}`,
+        data: {},
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+
+  return {
+    deleteEvaluationDatasetMutation,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
@@ -1,4 +1,4 @@
-import { deleteJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
 
@@ -13,10 +13,7 @@ export const useDeleteEvaluationDatasetMutation = ({
 
   const { mutate: deleteEvaluationDatasetMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetId }: { datasetId: string }) => {
-      await deleteJson({
-        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}`,
-        data: {},
-      });
+      await fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}`), 'DELETE');
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
@@ -1,4 +1,4 @@
-import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { useMutation } from '@tanstack/react-query';
 
 type UpsertDatasetRecordsPayload = {
@@ -21,13 +21,16 @@ export const useUpsertDatasetRecordsMutation = ({
 }) => {
   const { mutate: upsertDatasetRecordsMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetId, records }: UpsertDatasetRecordsPayload) => {
-      const response = (await postJson({
-        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}/records`,
-        data: {
-          dataset_id: datasetId,
-          records: records,
-        },
-      })) as UpsertDatasetRecordsResponse;
+      const requestBody = {
+        dataset_id: datasetId,
+        records: records,
+      };
+
+      const response = (await fetchAPI(
+        getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}/records`),
+        'POST',
+        requestBody,
+      )) as UpsertDatasetRecordsResponse;
 
       return response;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
@@ -1,0 +1,46 @@
+import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { useMutation } from '@tanstack/react-query';
+
+type UpsertDatasetRecordsPayload = {
+  datasetId: string;
+  // JSON serialized list of dataset records
+  records: string;
+};
+
+type UpsertDatasetRecordsResponse = {
+  insertedCount: number;
+  updatedCount: number;
+};
+
+export const useUpsertDatasetRecordsMutation = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+}) => {
+  const { mutate: upsertDatasetRecordsMutation, isLoading } = useMutation({
+    mutationFn: async ({ datasetId, records }: UpsertDatasetRecordsPayload) => {
+      const response = (await postJson({
+        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}/records`,
+        data: {
+          dataset_id: datasetId,
+          records: records,
+        },
+      })) as UpsertDatasetRecordsResponse;
+
+      return response;
+    },
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+
+  return {
+    upsertDatasetRecordsMutation,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2226,6 +2226,10 @@
     "defaultMessage": "{count, plural, =1 {1 month} other {# months}} ago",
     "description": "Time duration in months"
   },
+  "N7BCue": {
+    "defaultMessage": "Create dataset",
+    "description": "Create evaluation dataset button"
+  },
   "N8YuIr": {
     "defaultMessage": "Error while loading metric page",
     "description": "Title of the error state on the metric page"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -363,6 +363,10 @@
     "defaultMessage": "Model schema",
     "description": "Heading text for the model schema of the registered model from the experiment run"
   },
+  "287Ack": {
+    "defaultMessage": "Create evaluation dataset",
+    "description": "Create evaluation dataset modal title"
+  },
   "28Dnzz": {
     "defaultMessage": "Parameters",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > parameters heading"
@@ -3231,6 +3235,10 @@
     "defaultMessage": "just now",
     "description": "Indicates a time duration that just passed"
   },
+  "ZQpc2w": {
+    "defaultMessage": "Enter dataset name",
+    "description": "Dataset name placeholder"
+  },
   "ZRUzaz": {
     "defaultMessage": "Install MLflow 3:",
     "description": "Instruction for installing MLflow from mlflow-3 branch in log MLflow 3 models"
@@ -3578,6 +3586,10 @@
   "crTWax": {
     "defaultMessage": "Key",
     "description": "Key-value tag editor modal > Key input label"
+  },
+  "creoEe": {
+    "defaultMessage": "Create",
+    "description": "Create evaluation dataset button text"
   },
   "csNr/8": {
     "defaultMessage": "Disable grouped runs to compare parameters, tag, or attributes",
@@ -4599,6 +4611,10 @@
     "defaultMessage": "Pass",
     "description": "The label for a passing asseessment above a bar-chart in the summary stats."
   },
+  "nEnDEu": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel create evaluation dataset button text"
+  },
   "nEoTsR": {
     "defaultMessage": "Completed Runs",
     "description": "Label for the progress bar to show the number of completed runs"
@@ -5103,6 +5119,10 @@
     "defaultMessage": "Ignore column ordering",
     "description": "Toggle text that determines whether to ignore column order in the\n                      model comparison page"
   },
+  "sbHChH": {
+    "defaultMessage": "Dataset name is required",
+    "description": "Input field error when dataset name is empty"
+  },
   "sblqXA": {
     "defaultMessage": "Use the runs difference view to compare model and system metrics, parameters, attributes, and tags across runs.",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > chart not configured warning > description"
@@ -5486,6 +5506,10 @@
   "xZ/PkV": {
     "defaultMessage": "Search prompts",
     "description": "Placeholder text for the search input in the prompts table on the logged model details page"
+  },
+  "xdFMIN": {
+    "defaultMessage": "Dataset name",
+    "description": "Dataset name label"
   },
   "xgypqc": {
     "defaultMessage": "Copied to clipboard",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18100/files/dbad26ad42782e74039fe716ccbec977dc05853e..c73364baf4ece74c301767c5bda6ab3cf5eb3a5b) to review incremental changes.
- [stack/mutation-hooks](https://github.com/mlflow/mlflow/pull/18099) [[Files changed](https://github.com/mlflow/mlflow/pull/18099/files)]
  - [**stack/creation-modal**](https://github.com/mlflow/mlflow/pull/18100) [[Files changed](https://github.com/mlflow/mlflow/pull/18100/files/dbad26ad42782e74039fe716ccbec977dc05853e..c73364baf4ece74c301767c5bda6ab3cf5eb3a5b)]
    - [stack/dataset-list-table](https://github.com/mlflow/mlflow/pull/18104) [[Files changed](https://github.com/mlflow/mlflow/pull/18104/files/c73364baf4ece74c301767c5bda6ab3cf5eb3a5b..655403a204a85596753b9bca0a652a1085f2fe1b)]
      - [stack/records-table](https://github.com/mlflow/mlflow/pull/18105) [[Files changed](https://github.com/mlflow/mlflow/pull/18105/files/655403a204a85596753b9bca0a652a1085f2fe1b..ed92e33e7e0b89152e1f5e6c2f7615a063c2959f)]
        - [stack/export-to-dataset-modal](https://github.com/mlflow/mlflow/pull/18107) [[Files changed](https://github.com/mlflow/mlflow/pull/18107/files/ed92e33e7e0b89152e1f5e6c2f7615a063c2959f..6cfe1c950f26be17af589f6e8f3ca44e6d37a081)]
          - [stack/integration](https://github.com/mlflow/mlflow/pull/18108) [[Files changed](https://github.com/mlflow/mlflow/pull/18108/files/6cfe1c950f26be17af589f6e8f3ca44e6d37a081..4d4f6766097677a015d73f2f14df98af22277857)]
            - [stack/export-traces](https://github.com/mlflow/mlflow/pull/18109) [[Files changed](https://github.com/mlflow/mlflow/pull/18109/files/4d4f6766097677a015d73f2f14df98af22277857..f6760f8fa96559da4e1a7228ede38af8657e217f)]
              - [stack/empty-states](https://github.com/mlflow/mlflow/pull/18110) [[Files changed](https://github.com/mlflow/mlflow/pull/18110/files/f6760f8fa96559da4e1a7228ede38af8657e217f..34b33f13cf4569eb93a16d36af821a593cd407d2)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR creates a button which displays a modal to create a dataset. It shows up in 3 places:

1. Dataset tab empty state
2. Dataset tab left pane toolbar
3. Export to traces modal toolbar (not a huge fan of the modal-in-modal, but i don't have any better ideas right now)

For now the form is simple—we only require users to specify a dataset name, and we automatically attach it to the experiment for them. In the future, we may implement some extended features like:

1. global dataset management (e.g. create a dataset and link it to multiple experiments)
2. dataset tag management

But for initial launch we don't have capacity to implement these

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

All 3:


https://github.com/user-attachments/assets/d8f9eef8-8d9d-4cfd-9bcc-d4ba308861e6



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
