### PR TITLE
Fix flaky `test_otel_logging` by caching database initialization

### DIFF
--- a/tests/tracing/test_otel_logging.py
+++ b/tests/tracing/test_otel_logging.py
@@ -5,7 +5,10 @@ This test suite verifies that the experiment ID header functionality works corre
 when using OpenTelemetry clients to send spans to MLflow's OTel endpoint.
 """
 
+import shutil
 import time
+from pathlib import Path
+from typing import Iterator
 
 import pytest
 import requests
@@ -22,24 +25,48 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.util._once import Once
 
 import mlflow
+from mlflow.server import handlers
+from mlflow.server.fastapi_app import app as mlflow_app
+from mlflow.server.handlers import initialize_backend_stores
+from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.tracing.utils import encode_trace_id
 from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER
 from mlflow.version import IS_TRACING_SDK_ONLY
 
-from tests.tracking.integration_test_utils import _init_server
+from tests.helper_functions import get_safe_port
+from tests.store.tracking.test_sqlalchemy_store import ARTIFACT_URI
+from tests.tracking.integration_test_utils import ServerThread
 
 if IS_TRACING_SDK_ONLY:
     pytest.skip("OTel endpoint tests require full MLflow server", allow_module_level=True)
 
 
+@pytest.fixture(scope="module")
+def cached_db(tmp_path_factory) -> Path:
+    """Creates and caches a SQLite database to avoid repeated migrations for each test run."""
+    tmp_path = tmp_path_factory.mktemp("sqlite_db")
+    db_path = tmp_path / "mlflow.db"
+    db_uri = f"sqlite:///{db_path}"
+    store = SqlAlchemyStore(db_uri, ARTIFACT_URI)
+    store.engine.dispose()
+    return db_path
+
+
 @pytest.fixture
-def mlflow_server(tmp_path):
-    """Fixture to provide a running MLflow server with FastAPI that includes OTel routes."""
-    backend_store_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+def mlflow_server(tmp_path: Path, cached_db: Path) -> Iterator[str]:
+    # Copy the pre-initialized cached DB into this test's tmp path
+    db_path = tmp_path / "mlflow.db"
+    shutil.copy(cached_db, db_path)
+
+    backend_store_uri = f"sqlite:///{db_path}"
     artifact_root = tmp_path.as_uri()
 
-    # Use _init_server with FastAPI (which is now the default)
-    with _init_server(backend_store_uri, artifact_root) as url:
+    handlers._tracking_store = None
+    handlers._model_registry_store = None
+    initialize_backend_stores(backend_store_uri, default_artifact_root=artifact_root)
+
+    # Start the FastAPI app in a background thread and yield its URL.
+    with ServerThread(mlflow_app, get_safe_port()) as url:
         yield url
 
 


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Fixes a flaky test in `test_otel_logging.py` that was timing out due to database migrations taking ~10 seconds **_on windows_**. The test was failing with:

```
FAILED tests/tracing/test_otel_logging.py::test_missing_required_span_fields_returns_422 - requests.exceptions.ReadTimeout: HTTPConnectionPool(host='127.0.0.1', port=52142): Read timed out. (read timeout=10)
```

Failed job: https://github.com/mlflow/mlflow/actions/runs/18207631749/job/51841591829

The logs show database migrations taking ~10 seconds during server startup:

```
2025/10/02 23:19:45 INFO mlflow.store.db.utils: Creating initial MLflow database tables...
2025/10/02 23:19:45 INFO mlflow.store.db.utils: Updating database tables
2025-10-02 23:19:45 INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
2025-10-02 23:19:45 INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
2025-10-02 23:19:45 INFO  [alembic.runtime.migration] Running upgrade  -> 451aebb31d03, add metric step
...
2025-10-02 23:19:55 INFO  [alembic.runtime.migration] Running upgrade bda7b8c39065 -> cbc13b556ace, add V3 trace schema columns
2025/10/02 23:19:56 INFO mlflow.tracking.fluent: Active model is cleared
```

The fix introduces a module-scoped `cached_db` fixture that pre-initializes the database once and copies it for each test, eliminating migration overhead.

Also updates the test to use `ServerThread` directly instead of `_init_server` for better control over the test server lifecycle.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)