### PR TITLE
[Datasets UI][6/x] Add table component to list available datasets

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetButton.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetButton.tsx
@@ -1,0 +1,25 @@
+import { Button, DatabaseIcon } from '@databricks/design-system';
+import { useState } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { CreateEvaluationDatasetModal } from './CreateEvaluationDatasetModal';
+
+export const CreateEvaluationDatasetButton = ({ experimentId }: { experimentId: string }) => {
+  const [showCreateDatasetModal, setShowCreateDatasetModal] = useState(false);
+  return (
+    <>
+      <Button
+        componentId="mlflow.eval-datasets.create-dataset-button"
+        css={{ width: 'min-content' }}
+        icon={<DatabaseIcon />}
+        onClick={() => setShowCreateDatasetModal(true)}
+      >
+        <FormattedMessage defaultMessage="Create dataset" description="Create evaluation dataset button" />
+      </Button>
+      <CreateEvaluationDatasetModal
+        experimentId={experimentId}
+        visible={showCreateDatasetModal}
+        onCancel={() => setShowCreateDatasetModal(false)}
+      />
+    </>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
@@ -1,0 +1,78 @@
+import { FormUI, Input, Modal } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { useCreateEvaluationDatasetMutation } from '../hooks/useCreateEvaluationDatasetMutation';
+import { useCallback, useState } from 'react';
+
+export const CreateEvaluationDatasetModal = ({
+  visible,
+  experimentId,
+  onCancel,
+}: {
+  visible: boolean;
+  experimentId: string;
+  onCancel: () => void;
+}) => {
+  const intl = useIntl();
+  const [datasetName, setDatasetName] = useState('');
+  const [datasetNameError, setDatasetNameError] = useState('');
+  const { createEvaluationDatasetMutation, isLoading } = useCreateEvaluationDatasetMutation({
+    onSuccess: () => {
+      // close modal when dataset is created
+      onCancel();
+    },
+  });
+
+  const handleCreateEvaluationDataset = useCallback(() => {
+    if (!datasetName) {
+      setDatasetNameError(
+        intl.formatMessage({
+          defaultMessage: 'Dataset name is required',
+          description: 'Input field error when dataset name is empty',
+        }),
+      );
+      return;
+    }
+    createEvaluationDatasetMutation({ datasetName, experimentIds: [experimentId] });
+  }, [createEvaluationDatasetMutation, experimentId, datasetName, intl]);
+
+  return (
+    <Modal
+      componentId="mlflow.create-evaluation-dataset-modal"
+      visible={visible}
+      onCancel={onCancel}
+      okText={intl.formatMessage({ defaultMessage: 'Create', description: 'Create evaluation dataset button text' })}
+      cancelText={intl.formatMessage({
+        defaultMessage: 'Cancel',
+        description: 'Cancel create evaluation dataset button text',
+      })}
+      onOk={handleCreateEvaluationDataset}
+      okButtonProps={{ loading: isLoading }}
+      title={
+        <FormattedMessage
+          defaultMessage="Create evaluation dataset"
+          description="Create evaluation dataset modal title"
+        />
+      }
+    >
+      <FormUI.Label htmlFor="dataset-name-input">
+        <FormattedMessage defaultMessage="Dataset name" description="Dataset name label" />
+      </FormUI.Label>
+      <Input
+        componentId="mlflow.create-evaluation-dataset-modal.dataset-name"
+        id="dataset-name-input"
+        name="name"
+        type="text"
+        placeholder={intl.formatMessage({
+          defaultMessage: 'Enter dataset name',
+          description: 'Dataset name placeholder',
+        })}
+        value={datasetName}
+        onChange={(e) => {
+          setDatasetName(e.target.value);
+          setDatasetNameError('');
+        }}
+      />
+      {datasetNameError && <FormUI.Message type="error" message={datasetNameError} />}
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/CreateEvaluationDatasetModal.tsx
@@ -46,7 +46,7 @@ export const CreateEvaluationDatasetModal = ({
         description: 'Cancel create evaluation dataset button text',
       })}
       onOk={handleCreateEvaluationDataset}
-      okButtonProps={{ loading: isLoading }}
+      okButtonProps={{ loading: isLoading, disabled: !datasetName }}
       title={
         <FormattedMessage
           defaultMessage="Create evaluation dataset"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsActionsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsActionsCell.tsx
@@ -38,6 +38,7 @@ export const ActionsCell = ({ row }: { row: Row<EvaluationDataset> }) => {
         <DropdownMenu.Content align="end">
           <DropdownMenu.Item
             componentId="mlflow.eval-datasets.delete-dataset-menu-option"
+            disabled={isDeletingDataset}
             onClick={(e) => {
               e.stopPropagation();
               e.preventDefault();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsActionsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsActionsCell.tsx
@@ -1,0 +1,61 @@
+import { DropdownMenu, OverflowIcon, PencilIcon, Spinner, TableRowAction, TrashIcon } from '@databricks/design-system';
+import { Button } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { Row } from '@tanstack/react-table';
+import { EvaluationDataset } from '../types';
+import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
+import { useDeleteEvaluationDatasetMutation } from '../hooks/useDeleteEvaluationDatasetMutation';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback } from 'react';
+
+// Component for rendering dataset actions
+export const ActionsCell = ({ row }: { row: Row<EvaluationDataset> }) => {
+  const queryClient = useQueryClient();
+
+  const { deleteEvaluationDatasetMutation, isLoading: isDeletingDataset } = useDeleteEvaluationDatasetMutation({
+    onSuccess: () => {
+      // invalidate the datasets query
+      queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });
+    },
+  });
+
+  const handleDelete = useCallback(() => {
+    deleteEvaluationDatasetMutation({ datasetId: row.original.dataset_id });
+  }, [deleteEvaluationDatasetMutation, row]);
+
+  return (
+    <TableRowAction css={{ padding: 0 }}>
+      <DropdownMenu.Root>
+        <DropdownMenu.Trigger asChild>
+          <Button
+            componentId="mlflow.eval-datasets.dataset-actions-menu"
+            size="small"
+            icon={<OverflowIcon />}
+            aria-label="Dataset actions"
+            css={{ padding: '4px' }}
+          />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Content align="end">
+          <DropdownMenu.Item
+            componentId="mlflow.eval-datasets.delete-dataset-menu-option"
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              handleDelete();
+            }}
+          >
+            <DropdownMenu.IconWrapper>
+              <TrashIcon />
+            </DropdownMenu.IconWrapper>
+            <FormattedMessage defaultMessage="Delete dataset" description="Delete evaluation dataset menu item" />
+            {isDeletingDataset && (
+              <DropdownMenu.HintColumn>
+                <Spinner />
+              </DropdownMenu.HintColumn>
+            )}
+          </DropdownMenu.Item>
+        </DropdownMenu.Content>
+      </DropdownMenu.Root>
+    </TableRowAction>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsActionsCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsActionsCell.tsx
@@ -1,4 +1,4 @@
-import { DropdownMenu, OverflowIcon, PencilIcon, Spinner, TableRowAction, TrashIcon } from '@databricks/design-system';
+import { DropdownMenu, OverflowIcon, Spinner, TableRowAction, TrashIcon } from '@databricks/design-system';
 import { Button } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { Row } from '@tanstack/react-table';

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsLastUpdatedCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsLastUpdatedCell.tsx
@@ -1,0 +1,17 @@
+import { Tooltip } from '@databricks/design-system';
+import { timeSinceStr } from '@mlflow/mlflow/src/shared/web-shared/genai-traces-table/utils/DisplayUtils';
+import { Row } from '@tanstack/react-table';
+import { EvaluationDataset } from '../types';
+
+export const LastUpdatedCell = ({ row }: { row: Row<EvaluationDataset> }) => {
+  return row.original.last_update_time ? (
+    <Tooltip
+      content={new Date(row.original.last_update_time).toLocaleString()}
+      componentId="mlflow.eval-datasets.last-updated-cell-tooltip"
+    >
+      <span>{timeSinceStr(row.original.last_update_time)}</span>
+    </Tooltip>
+  ) : (
+    <span>-</span>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -19,7 +19,7 @@ import { useIntl } from '@databricks/i18n';
 import type { ColumnDef, Row, SortDirection, SortingState } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table';
 import { EvaluationDataset } from '../types';
-import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatsets';
+import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatasets';
 import { NameCell } from './ExperimentEvaluationDatasetsNameCell';
 import { LastUpdatedCell } from './ExperimentEvaluationDatasetsLastUpdatedCell';
 import { ActionsCell } from './ExperimentEvaluationDatasetsActionsCell';

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -14,9 +14,8 @@ import {
   ColumnsIcon,
   DropdownMenu,
   Typography,
-  DatabaseIcon,
 } from '@databricks/design-system';
-import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { useIntl } from '@databricks/i18n';
 import type { ColumnDef, Row, SortDirection, SortingState } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table';
 import { EvaluationDataset } from '../types';
@@ -27,6 +26,7 @@ import { ActionsCell } from './ExperimentEvaluationDatasetsActionsCell';
 import { isEqual } from 'lodash';
 import { CreateEvaluationDatasetModal } from './CreateEvaluationDatasetModal';
 import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
+import { CreateEvaluationDatasetButton } from './CreateEvaluationDatasetButton';
 
 const COLUMN_IDS = {
   NAME: 'name',
@@ -271,14 +271,7 @@ export const ExperimentEvaluationDatasetsListTable = ({
           </DropdownMenu.Root>
         </div>
       </div>
-      <Button
-        componentId="mlflow.eval-datasets.create-dataset-button"
-        css={{ width: 'min-content' }}
-        icon={<DatabaseIcon />}
-        onClick={() => setShowCreateDatasetModal(true)}
-      >
-        <FormattedMessage defaultMessage="Create dataset" description="Create evaluation dataset button" />
-      </Button>
+      <CreateEvaluationDatasetButton experimentId={experimentId} />
       <div css={{ flex: 1, minHeight: 0, position: 'relative' }}>
         <Table
           css={{ height: '100%' }}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -1,0 +1,337 @@
+import React, { useState, useEffect, useCallback, useRef } from 'react';
+import {
+  Empty,
+  Table,
+  TableHeader,
+  TableRow,
+  TableSkeletonRows,
+  Input,
+  Button,
+  RefreshIcon,
+  useDesignSystemTheme,
+  SearchIcon,
+  TableCell,
+  ColumnsIcon,
+  DropdownMenu,
+  Typography,
+  DatabaseIcon,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import type { ColumnDef, Row, SortDirection, SortingState } from '@tanstack/react-table';
+import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table';
+import { EvaluationDataset } from '../types';
+import { useSearchEvaluationDatasets } from '../hooks/useSearchEvaluationDatsets';
+import { NameCell } from './ExperimentEvaluationDatasetsNameCell';
+import { LastUpdatedCell } from './ExperimentEvaluationDatasetsLastUpdatedCell';
+import { ActionsCell } from './ExperimentEvaluationDatasetsActionsCell';
+import { isEqual } from 'lodash';
+import { CreateEvaluationDatasetModal } from './CreateEvaluationDatasetModal';
+import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
+
+const COLUMN_IDS = {
+  NAME: 'name',
+  LAST_UPDATE_TIME: 'last_update_time',
+  CREATED_TIME: 'created_time',
+  CREATED_BY: 'created_by',
+  SOURCE_TYPE: 'source_type',
+  ACTIONS: 'actions',
+};
+
+const DEFAULT_ENABLED_COLUMN_IDS = [COLUMN_IDS.NAME, COLUMN_IDS.LAST_UPDATE_TIME, COLUMN_IDS.ACTIONS];
+const UNSELECTABLE_COLUMN_IDS = [COLUMN_IDS.ACTIONS];
+
+const columns: ColumnDef<EvaluationDataset, any>[] = [
+  {
+    id: COLUMN_IDS.NAME,
+    accessorKey: 'name',
+    header: 'Name',
+    enableSorting: true,
+    cell: NameCell,
+  },
+  {
+    id: COLUMN_IDS.LAST_UPDATE_TIME,
+    accessorKey: 'last_update_time',
+    accessorFn: (row: EvaluationDataset) => (row.last_update_time ? new Date(row.last_update_time).getTime() : 0),
+    header: 'Updated At',
+    enableSorting: true,
+    size: 100,
+    maxSize: 100,
+    cell: LastUpdatedCell,
+  },
+  {
+    id: COLUMN_IDS.CREATED_TIME,
+    accessorKey: 'created_time',
+    accessorFn: (row: EvaluationDataset) => (row.created_time ? new Date(row.created_time).getTime() : 0),
+    header: 'Created At',
+    enableSorting: true,
+    cell: ({ row }: { row: Row<EvaluationDataset> }) => new Date(row.original.created_time).toLocaleString(),
+  },
+  {
+    id: COLUMN_IDS.CREATED_BY,
+    accessorKey: 'created_by',
+    header: 'Created By',
+    enableSorting: true,
+  },
+  {
+    id: COLUMN_IDS.SOURCE_TYPE,
+    accessorKey: 'source_type',
+    header: 'Source Type',
+    enableSorting: true,
+  },
+  {
+    id: 'actions',
+    header: '',
+    enableSorting: false,
+    size: 36,
+    maxSize: 36,
+    cell: ActionsCell,
+  },
+];
+
+interface ExperimentEvaluationDatasetsTableRowProps {
+  row: Row<EvaluationDataset>;
+  columnVisibility: { [key: string]: boolean };
+  isActive: boolean;
+  setSelectedDataset: (dataset: EvaluationDataset | undefined) => void;
+}
+
+const ExperimentEvaluationDatasetsTableRow: React.FC<
+  React.PropsWithChildren<ExperimentEvaluationDatasetsTableRowProps>
+> = React.memo(
+  ({ row, isActive, setSelectedDataset }) => {
+    const { theme } = useDesignSystemTheme();
+
+    return (
+      <TableRow
+        key={row.id}
+        className="eval-datasets-table-row"
+        onClick={() => {
+          setSelectedDataset(row.original);
+        }}
+      >
+        {row.getVisibleCells().map((cell) => (
+          <TableCell
+            key={cell.id}
+            css={{
+              backgroundColor: isActive ? theme.colors.actionDefaultBackgroundHover : 'transparent',
+              width: cell.column.columnDef.size ? `${cell.column.columnDef.size}px` : 'auto',
+              maxWidth: cell.column.columnDef.maxSize ? `${cell.column.columnDef.maxSize}px` : 'auto',
+              minWidth: cell.column.columnDef.minSize ? `${cell.column.columnDef.minSize}px` : 'auto',
+              ...(cell.column.id === 'actions' && { paddingLeft: 0, paddingRight: 0 }),
+            }}
+          >
+            {flexRender(cell.column.columnDef.cell, cell.getContext())}
+          </TableCell>
+        ))}
+      </TableRow>
+    );
+  },
+  (prev, next) => {
+    return prev.isActive === next.isActive && isEqual(prev.columnVisibility, next.columnVisibility);
+  },
+);
+
+export const ExperimentEvaluationDatasetsListTable = ({
+  experimentId,
+  selectedDataset,
+  setSelectedDataset,
+}: {
+  experimentId: string;
+  selectedDataset?: EvaluationDataset;
+  setSelectedDataset: (dataset: EvaluationDataset | undefined) => void;
+}) => {
+  const intl = useIntl();
+  const { theme } = useDesignSystemTheme();
+
+  const [sorting, setSorting] = useState<SortingState>([
+    {
+      id: 'created_time',
+      desc: true, // Most recent first
+    },
+  ]);
+  const [columnVisibility, setColumnVisibility] = useState<{ [key: string]: boolean }>(
+    columns.reduce((acc, column) => {
+      acc[column.id ?? ''] = DEFAULT_ENABLED_COLUMN_IDS.includes(column.id ?? '');
+      return acc;
+    }, {} as { [key: string]: boolean }),
+  );
+  const [showCreateDatasetModal, setShowCreateDatasetModal] = useState(false);
+  // searchFilter only gets updated after the user presses enter
+  const [searchFilter, setSearchFilter] = useState('');
+  // control field that gets updated immediately
+  const [internalSearchFilter, setInternalSearchFilter] = useState(searchFilter);
+
+  const {
+    data: datasets,
+    isLoading,
+    isFetching,
+    error,
+    refetch,
+    fetchNextPage,
+    hasNextPage,
+  } = useSearchEvaluationDatasets({ experimentId, nameFilter: searchFilter });
+
+  const table = useReactTable({
+    columns,
+    data: datasets ?? [],
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.dataset_id,
+    enableSorting: true,
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    enableColumnResizing: false,
+    state: {
+      sorting,
+      columnVisibility,
+    },
+  });
+
+  const fetchMoreOnBottomReached = useInfiniteScrollFetch({
+    isFetching,
+    hasNextPage: hasNextPage ?? false,
+    fetchNextPage,
+  });
+
+  // Set the selected dataset to the first one (respecting sort order) if we don't already have one
+  // or if the selected dataset went out of scope (e.g. was deleted)
+  useEffect(() => {
+    if (datasets?.length && (!selectedDataset || !datasets.some((d) => d.dataset_id === selectedDataset.dataset_id))) {
+      // Use the sorted data from the table to respect the current sort order
+      const sortedRows = table.getRowModel().rows;
+      if (sortedRows.length > 0) {
+        setSelectedDataset(sortedRows[0].original);
+      }
+    }
+  }, [datasets, selectedDataset, setSelectedDataset, table]);
+
+  if (error) {
+    return <div>Error loading datasets</div>;
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%' }}>
+      <div css={{ display: 'flex', gap: theme.spacing.sm, alignItems: 'center', marginBottom: theme.spacing.sm }}>
+        <Input
+          allowClear
+          placeholder="Search by dataset name"
+          value={internalSearchFilter}
+          onChange={(e) => {
+            setInternalSearchFilter(e.target.value);
+            if (!e.target.value) {
+              setSearchFilter(e.target.value);
+            }
+          }}
+          onClear={() => {
+            setInternalSearchFilter('');
+            setSearchFilter('');
+          }}
+          onPressEnter={() => setSearchFilter(internalSearchFilter)}
+          componentId="mlflow.eval-datasets.search-input"
+          css={{ flex: 1 }}
+          prefix={<SearchIcon />}
+        />
+        <div css={{ display: 'flex', alignItems: 'center', marginRight: theme.spacing.sm }}>
+          <Button
+            icon={<RefreshIcon />}
+            disabled={isFetching}
+            onClick={() => refetch()}
+            componentId="mlflow.eval-datasets.table-refresh-button"
+          />
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <Button icon={<ColumnsIcon />} componentId="mlflow.eval-datasets.table-column-selector-button" />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              {columns.map(
+                (column) =>
+                  !UNSELECTABLE_COLUMN_IDS.includes(column.id ?? '') && (
+                    <DropdownMenu.CheckboxItem
+                      componentId="mlflow.eval-datasets.table-column-selector-checkbox"
+                      key={column.id ?? ''}
+                      checked={columnVisibility[column.id ?? ''] ?? false}
+                      onCheckedChange={(checked) =>
+                        setColumnVisibility({
+                          ...columnVisibility,
+                          [column.id ?? '']: checked,
+                        })
+                      }
+                    >
+                      <DropdownMenu.ItemIndicator />
+                      <Typography.Text>{column.header}</Typography.Text>
+                    </DropdownMenu.CheckboxItem>
+                  ),
+              )}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </div>
+      </div>
+      <Button
+        componentId="mlflow.eval-datasets.create-dataset-button"
+        css={{ width: 'min-content' }}
+        icon={<DatabaseIcon />}
+        onClick={() => setShowCreateDatasetModal(true)}
+      >
+        <FormattedMessage defaultMessage="Create dataset" description="Create evaluation dataset button" />
+      </Button>
+      <div css={{ flex: 1, minHeight: 0, position: 'relative' }}>
+        <Table
+          css={{ height: '100%' }}
+          empty={
+            !isLoading && table.getRowModel().rows.length === 0 ? (
+              <Empty
+                description={intl.formatMessage({
+                  defaultMessage: 'No evaluation datasets found',
+                  description: 'Empty state for the evaluation datasets page',
+                })}
+              />
+            ) : undefined
+          }
+          onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget as HTMLDivElement)}
+          scrollable
+        >
+          <TableRow isHeader>
+            {table.getLeafHeaders().map((header) => (
+              <TableHeader
+                key={header.id}
+                sortable={header.column.getCanSort()}
+                sortDirection={header.column.getIsSorted() as SortDirection}
+                onToggleSort={header.column.getToggleSortingHandler()}
+                componentId={`mlflow.eval-datasets.${header.column.id}-header`}
+                header={header}
+                column={header.column}
+                css={{
+                  width: header.column.columnDef.size ? `${header.column.columnDef.size}px` : 'auto',
+                  maxWidth: header.column.columnDef.maxSize ? `${header.column.columnDef.maxSize}px` : 'auto',
+                  minWidth: header.column.columnDef.minSize ? `${header.column.columnDef.minSize}px` : 'auto',
+                  cursor: header.column.getCanSort() ? 'pointer' : 'default',
+                }}
+              >
+                {flexRender(header.column.columnDef.header, header.getContext())}
+              </TableHeader>
+            ))}
+          </TableRow>
+
+          {!isLoading &&
+            table
+              .getRowModel()
+              .rows.map((row) => (
+                <ExperimentEvaluationDatasetsTableRow
+                  key={row.id}
+                  row={row}
+                  columnVisibility={columnVisibility}
+                  isActive={row.original.dataset_id === selectedDataset?.dataset_id}
+                  setSelectedDataset={setSelectedDataset}
+                />
+              ))}
+
+          {(isLoading || isFetching) && <TableSkeletonRows table={table} />}
+        </Table>
+        <CreateEvaluationDatasetModal
+          experimentId={experimentId}
+          visible={showCreateDatasetModal}
+          onCancel={() => setShowCreateDatasetModal(false)}
+        />
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback, useRef } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   Empty,
   Table,
@@ -24,7 +24,6 @@ import { NameCell } from './ExperimentEvaluationDatasetsNameCell';
 import { LastUpdatedCell } from './ExperimentEvaluationDatasetsLastUpdatedCell';
 import { ActionsCell } from './ExperimentEvaluationDatasetsActionsCell';
 import { isEqual } from 'lodash';
-import { CreateEvaluationDatasetModal } from './CreateEvaluationDatasetModal';
 import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
 import { CreateEvaluationDatasetButton } from './CreateEvaluationDatasetButton';
 
@@ -155,7 +154,6 @@ export const ExperimentEvaluationDatasetsListTable = ({
       return acc;
     }, {} as { [key: string]: boolean }),
   );
-  const [showCreateDatasetModal, setShowCreateDatasetModal] = useState(false);
   // searchFilter only gets updated after the user presses enter
   const [searchFilter, setSearchFilter] = useState('');
   // control field that gets updated immediately
@@ -325,11 +323,6 @@ export const ExperimentEvaluationDatasetsListTable = ({
 
           {(isLoading || isFetching) && <TableSkeletonRows table={table} />}
         </Table>
-        <CreateEvaluationDatasetModal
-          experimentId={experimentId}
-          visible={showCreateDatasetModal}
-          onCancel={() => setShowCreateDatasetModal(false)}
-        />
       </div>
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -192,7 +192,6 @@ export const ExperimentEvaluationDatasetsListTable = ({
 
   if (!datasets?.length) {
     setSelectedDataset(undefined);
-    return;
   }
 
   // set the selected dataset to the first one if the is no selected dataset,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -190,23 +190,20 @@ export const ExperimentEvaluationDatasetsListTable = ({
     fetchNextPage,
   });
 
-  useEffect(() => {
-    // if all datasets were deleted, set the selected dataset to undefined
-    if (!datasets?.length) {
-      setSelectedDataset(undefined);
-      return;
-    }
+  if (!datasets?.length) {
+    setSelectedDataset(undefined);
+    return;
+  }
 
-    // set the selected dataset to the first one if the is no selected dataset,
-    // or if the selected dataset went out of scope (e.g. was deleted / not in search)
-    if (!selectedDataset || !datasets.some((d) => d.dataset_id === selectedDataset.dataset_id)) {
-      // Use the sorted data from the table to respect the current sort order
-      const sortedRows = table.getRowModel().rows;
-      if (sortedRows.length > 0) {
-        setSelectedDataset(sortedRows[0].original);
-      }
+  // set the selected dataset to the first one if the is no selected dataset,
+  // or if the selected dataset went out of scope (e.g. was deleted / not in search)
+  if (!selectedDataset || !datasets.some((d) => d.dataset_id === selectedDataset.dataset_id)) {
+    // Use the sorted data from the table to respect the current sort order
+    const sortedRows = table.getRowModel().rows;
+    if (sortedRows.length > 0) {
+      setSelectedDataset(sortedRows[0].original);
     }
-  }, [datasets, selectedDataset, setSelectedDataset, table]);
+  }
 
   if (error) {
     return <div>Error loading datasets</div>;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -192,10 +192,16 @@ export const ExperimentEvaluationDatasetsListTable = ({
     fetchNextPage,
   });
 
-  // Set the selected dataset to the first one (respecting sort order) if we don't already have one
-  // or if the selected dataset went out of scope (e.g. was deleted)
   useEffect(() => {
-    if (datasets?.length && (!selectedDataset || !datasets.some((d) => d.dataset_id === selectedDataset.dataset_id))) {
+    // if all datasets were deleted, set the selected dataset to undefined
+    if (!datasets?.length) {
+      setSelectedDataset(undefined);
+      return;
+    }
+
+    // set the selected dataset to the first one if the is no selected dataset,
+    // or if the selected dataset went out of scope (e.g. was deleted / not in search)
+    if (!selectedDataset || !datasets.some((d) => d.dataset_id === selectedDataset.dataset_id)) {
       // Use the sorted data from the table to respect the current sort order
       const sortedRows = table.getRowModel().rows;
       if (sortedRows.length > 0) {
@@ -277,7 +283,7 @@ export const ExperimentEvaluationDatasetsListTable = ({
         <Table
           css={{ height: '100%' }}
           empty={
-            !isLoading && table.getRowModel().rows.length === 0 ? (
+            !isLoading && !isFetching && datasets.length === 0 ? (
               <Empty
                 description={intl.formatMessage({
                   defaultMessage: 'No evaluation datasets found',

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsNameCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsNameCell.tsx
@@ -1,0 +1,18 @@
+import { Typography } from '@databricks/design-system';
+import { useDesignSystemTheme } from '@databricks/design-system';
+import { Row } from '@tanstack/react-table';
+import { EvaluationDataset } from '../types';
+
+export const NameCell = ({ row }: { row: Row<EvaluationDataset> }) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div css={{ overflow: 'hidden', display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+      <Typography.Link
+        css={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden', flexShrink: 1 }}
+        componentId="mlflow.eval-datasets.dataset-name-cell"
+      >
+        {row.original.name}
+      </Typography.Link>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/ExperimentEvaluationDatasetsNameCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/ExperimentEvaluationDatasetsNameCell.tsx
@@ -1,0 +1,18 @@
+import { Typography } from '@databricks/design-system';
+import { useDesignSystemTheme } from '@databricks/design-system';
+import { Row } from '@tanstack/react-table';
+import { EvaluationDataset } from '../types';
+
+export const NameCell = ({ row }: { row: Row<EvaluationDataset> }) => {
+  const { theme } = useDesignSystemTheme();
+  return (
+    <div css={{ overflow: 'hidden', display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+      <Typography.Link
+        css={{ textOverflow: 'ellipsis', whiteSpace: 'nowrap', overflow: 'hidden', flexShrink: 1 }}
+        componentId="mlflow.eval-datasets.dataset-name-cell"
+      >
+        {row.original.name}
+      </Typography.Link>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
@@ -1,0 +1,49 @@
+import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { EvaluationDataset } from '../types';
+import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
+
+type CreateDatasetResponse = {
+  dataset: EvaluationDataset;
+};
+
+type CreateDatasetPayload = {
+  datasetName: string;
+  experimentIds?: string[];
+};
+
+export const useCreateEvaluationDatasetMutation = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+}) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: createEvaluationDatasetMutation, isLoading } = useMutation({
+    mutationFn: async ({ datasetName, experimentIds }: CreateDatasetPayload) => {
+      const response = (await postJson({
+        relativeUrl: 'ajax-api/3.0/mlflow/datasets/create',
+        data: {
+          name: datasetName,
+          experiment_ids: experimentIds,
+        },
+      })) as CreateDatasetResponse;
+
+      return response.dataset;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+
+  return {
+    createEvaluationDatasetMutation,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
@@ -1,4 +1,4 @@
-import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { EvaluationDataset } from '../types';
 import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
@@ -23,13 +23,16 @@ export const useCreateEvaluationDatasetMutation = ({
 
   const { mutate: createEvaluationDatasetMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetName, experimentIds }: CreateDatasetPayload) => {
-      const response = (await postJson({
-        relativeUrl: 'ajax-api/3.0/mlflow/datasets/create',
-        data: {
-          name: datasetName,
-          experiment_ids: experimentIds,
-        },
-      })) as CreateDatasetResponse;
+      const requestBody = {
+        datasetName,
+        experimentIds,
+      };
+
+      const response = (await fetchAPI(
+        getAjaxUrl('ajax-api/3.0/mlflow/datasets/create'),
+        'POST',
+        requestBody,
+      )) as CreateDatasetResponse;
 
       return response.dataset;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
@@ -24,8 +24,8 @@ export const useCreateEvaluationDatasetMutation = ({
   const { mutate: createEvaluationDatasetMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetName, experimentIds }: CreateDatasetPayload) => {
       const requestBody = {
-        datasetName,
-        experimentIds,
+        name: datasetName,
+        experiment_ids: experimentIds,
       };
 
       const response = (await fetchAPI(

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
@@ -1,0 +1,34 @@
+import { deleteJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
+
+export const useDeleteEvaluationDatasetMutation = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+}) => {
+  const queryClient = useQueryClient();
+
+  const { mutate: deleteEvaluationDatasetMutation, isLoading } = useMutation({
+    mutationFn: async ({ datasetId }: { datasetId: string }) => {
+      await deleteJson({
+        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}`,
+        data: {},
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+
+  return {
+    deleteEvaluationDatasetMutation,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
@@ -1,4 +1,4 @@
-import { deleteJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { SEARCH_EVALUATION_DATASETS_QUERY_KEY } from '../constants';
 
@@ -13,10 +13,7 @@ export const useDeleteEvaluationDatasetMutation = ({
 
   const { mutate: deleteEvaluationDatasetMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetId }: { datasetId: string }) => {
-      await deleteJson({
-        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}`,
-        data: {},
-      });
+      await fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}`), 'DELETE');
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useInfiniteScrollFetch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useInfiniteScrollFetch.tsx
@@ -1,0 +1,26 @@
+import { useCallback } from 'react';
+
+const INFINITE_SCROLL_BOTTOM_OFFSET = 200;
+
+// util function to fetch next page when user scrolls to the of a scrollable container
+export const useInfiniteScrollFetch = ({
+  isFetching,
+  hasNextPage,
+  fetchNextPage,
+}: {
+  isFetching: boolean;
+  hasNextPage: boolean;
+  fetchNextPage: () => void;
+}) => {
+  return useCallback(
+    (containerRefElement?: HTMLDivElement | null) => {
+      if (containerRefElement) {
+        const { scrollHeight, scrollTop, clientHeight } = containerRefElement;
+        if (scrollHeight - scrollTop - clientHeight < INFINITE_SCROLL_BOTTOM_OFFSET && !isFetching && hasNextPage) {
+          fetchNextPage();
+        }
+      }
+    },
+    [fetchNextPage, isFetching, hasNextPage],
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useInfiniteScrollFetch.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useInfiniteScrollFetch.tsx
@@ -2,7 +2,9 @@ import { useCallback } from 'react';
 
 const INFINITE_SCROLL_BOTTOM_OFFSET = 200;
 
-// util function to fetch next page when user scrolls to the of a scrollable container
+/**
+ * Util function to fetch next page when user scrolls to the end of a scrollable container
+ */
 export const useInfiniteScrollFetch = ({
   isFetching,
   hasNextPage,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
@@ -1,4 +1,4 @@
-import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 import { useMutation } from '@tanstack/react-query';
 
 type UpsertDatasetRecordsPayload = {
@@ -21,13 +21,16 @@ export const useUpsertDatasetRecordsMutation = ({
 }) => {
   const { mutate: upsertDatasetRecordsMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetId, records }: UpsertDatasetRecordsPayload) => {
-      const response = (await postJson({
-        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}/records`,
-        data: {
-          dataset_id: datasetId,
-          records: records,
-        },
-      })) as UpsertDatasetRecordsResponse;
+      const requestBody = {
+        dataset_id: datasetId,
+        records: records,
+      };
+
+      const response = (await fetchAPI(
+        getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}/records`),
+        'POST',
+        requestBody,
+      )) as UpsertDatasetRecordsResponse;
 
       return response;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
@@ -1,0 +1,46 @@
+import { postJson } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { useMutation } from '@tanstack/react-query';
+
+type UpsertDatasetRecordsPayload = {
+  datasetId: string;
+  // JSON serialized list of dataset records
+  records: string;
+};
+
+type UpsertDatasetRecordsResponse = {
+  insertedCount: number;
+  updatedCount: number;
+};
+
+export const useUpsertDatasetRecordsMutation = ({
+  onSuccess,
+  onError,
+}: {
+  onSuccess?: () => void;
+  onError?: (error: any) => void;
+}) => {
+  const { mutate: upsertDatasetRecordsMutation, isLoading } = useMutation({
+    mutationFn: async ({ datasetId, records }: UpsertDatasetRecordsPayload) => {
+      const response = (await postJson({
+        relativeUrl: `ajax-api/3.0/mlflow/datasets/${datasetId}/records`,
+        data: {
+          dataset_id: datasetId,
+          records: records,
+        },
+      })) as UpsertDatasetRecordsResponse;
+
+      return response;
+    },
+    onSuccess: () => {
+      onSuccess?.();
+    },
+    onError: (error) => {
+      onError?.(error);
+    },
+  });
+
+  return {
+    upsertDatasetRecordsMutation,
+    isLoading,
+  };
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2226,6 +2226,10 @@
     "defaultMessage": "{count, plural, =1 {1 month} other {# months}} ago",
     "description": "Time duration in months"
   },
+  "N7BCue": {
+    "defaultMessage": "Create dataset",
+    "description": "Create evaluation dataset button"
+  },
   "N8YuIr": {
     "defaultMessage": "Error while loading metric page",
     "description": "Title of the error state on the metric page"

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -363,6 +363,10 @@
     "defaultMessage": "Model schema",
     "description": "Heading text for the model schema of the registered model from the experiment run"
   },
+  "287Ack": {
+    "defaultMessage": "Create evaluation dataset",
+    "description": "Create evaluation dataset modal title"
+  },
   "28Dnzz": {
     "defaultMessage": "Parameters",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > parameters heading"
@@ -3231,6 +3235,10 @@
     "defaultMessage": "just now",
     "description": "Indicates a time duration that just passed"
   },
+  "ZQpc2w": {
+    "defaultMessage": "Enter dataset name",
+    "description": "Dataset name placeholder"
+  },
   "ZRUzaz": {
     "defaultMessage": "Install MLflow 3:",
     "description": "Instruction for installing MLflow from mlflow-3 branch in log MLflow 3 models"
@@ -3578,6 +3586,10 @@
   "crTWax": {
     "defaultMessage": "Key",
     "description": "Key-value tag editor modal > Key input label"
+  },
+  "creoEe": {
+    "defaultMessage": "Create",
+    "description": "Create evaluation dataset button text"
   },
   "csNr/8": {
     "defaultMessage": "Disable grouped runs to compare parameters, tag, or attributes",
@@ -4599,6 +4611,10 @@
     "defaultMessage": "Pass",
     "description": "The label for a passing asseessment above a bar-chart in the summary stats."
   },
+  "nEnDEu": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel create evaluation dataset button text"
+  },
   "nEoTsR": {
     "defaultMessage": "Completed Runs",
     "description": "Label for the progress bar to show the number of completed runs"
@@ -5103,6 +5119,10 @@
     "defaultMessage": "Ignore column ordering",
     "description": "Toggle text that determines whether to ignore column order in the\n                      model comparison page"
   },
+  "sbHChH": {
+    "defaultMessage": "Dataset name is required",
+    "description": "Input field error when dataset name is empty"
+  },
   "sblqXA": {
     "defaultMessage": "Use the runs difference view to compare model and system metrics, parameters, attributes, and tags across runs.",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > chart not configured warning > description"
@@ -5486,6 +5506,10 @@
   "xZ/PkV": {
     "defaultMessage": "Search prompts",
     "description": "Placeholder text for the search input in the prompts table on the logged model details page"
+  },
+  "xdFMIN": {
+    "defaultMessage": "Dataset name",
+    "description": "Dataset name label"
   },
   "xgypqc": {
     "defaultMessage": "Copied to clipboard",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1558,6 +1558,10 @@
     "defaultMessage": "Version {versionNum}",
     "description": "Title text for model version page"
   },
+  "F4K195": {
+    "defaultMessage": "No evaluation datasets found",
+    "description": "Empty state for the evaluation datasets page"
+  },
   "F8MqzZ": {
     "defaultMessage": "Path",
     "description": "Label for displaying the current experiment path"
@@ -3566,6 +3570,10 @@
   "cK6riy": {
     "defaultMessage": "Schema",
     "description": "Table title text for schema table in the model comparison page"
+  },
+  "cMRvTA": {
+    "defaultMessage": "Delete dataset",
+    "description": "Delete evaluation dataset menu item"
   },
   "cMa3hp": {
     "defaultMessage": "Run evaluation",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18104/files/c73364baf4ece74c301767c5bda6ab3cf5eb3a5b..655403a204a85596753b9bca0a652a1085f2fe1b) to review incremental changes.
- [stack/mutation-hooks](https://github.com/mlflow/mlflow/pull/18099) [[Files changed](https://github.com/mlflow/mlflow/pull/18099/files)]
  - [stack/creation-modal](https://github.com/mlflow/mlflow/pull/18100) [[Files changed](https://github.com/mlflow/mlflow/pull/18100/files/dbad26ad42782e74039fe716ccbec977dc05853e..c73364baf4ece74c301767c5bda6ab3cf5eb3a5b)]
    - [**stack/dataset-list-table**](https://github.com/mlflow/mlflow/pull/18104) [[Files changed](https://github.com/mlflow/mlflow/pull/18104/files/c73364baf4ece74c301767c5bda6ab3cf5eb3a5b..655403a204a85596753b9bca0a652a1085f2fe1b)]
      - [stack/records-table](https://github.com/mlflow/mlflow/pull/18105) [[Files changed](https://github.com/mlflow/mlflow/pull/18105/files/655403a204a85596753b9bca0a652a1085f2fe1b..ed92e33e7e0b89152e1f5e6c2f7615a063c2959f)]
        - [stack/export-to-dataset-modal](https://github.com/mlflow/mlflow/pull/18107) [[Files changed](https://github.com/mlflow/mlflow/pull/18107/files/ed92e33e7e0b89152e1f5e6c2f7615a063c2959f..6cfe1c950f26be17af589f6e8f3ca44e6d37a081)]
          - [stack/integration](https://github.com/mlflow/mlflow/pull/18108) [[Files changed](https://github.com/mlflow/mlflow/pull/18108/files/6cfe1c950f26be17af589f6e8f3ca44e6d37a081..4d4f6766097677a015d73f2f14df98af22277857)]
            - [stack/export-traces](https://github.com/mlflow/mlflow/pull/18109) [[Files changed](https://github.com/mlflow/mlflow/pull/18109/files/4d4f6766097677a015d73f2f14df98af22277857..f6760f8fa96559da4e1a7228ede38af8657e217f)]
              - [stack/empty-states](https://github.com/mlflow/mlflow/pull/18110) [[Files changed](https://github.com/mlflow/mlflow/pull/18110/files/f6760f8fa96559da4e1a7228ede38af8657e217f..34b33f13cf4569eb93a16d36af821a593cd407d2)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds the table component for the left pane of the datasets tab. It's a table that lists all traces associated with the active experiment.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Demo:



https://github.com/user-attachments/assets/097eca14-3562-4c9d-bd1f-e53a125612bd




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
