### PR TITLE
[Datasets UI][7/x] Add table component for dataset rows (right pane)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetJsonCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetJsonCell.tsx
@@ -1,0 +1,48 @@
+import { useDesignSystemTheme } from '@databricks/design-system';
+import { Cell, Table } from '@tanstack/react-table';
+import { EvaluationDatasetRecord } from '../types';
+import { CodeSnippet } from '@databricks/web-shared/snippet';
+
+export const JsonCell = ({
+  cell,
+  table: { options },
+}: {
+  cell: Cell<EvaluationDatasetRecord, any>;
+  table: Table<EvaluationDatasetRecord>;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const value = JSON.stringify(cell.getValue(), null, 2);
+  const rowSize = (options?.meta as any)?.rowSize;
+  // only applies for 'md' and 'lg' row sizes
+  const rowHeight = rowSize === 'md' ? theme.typography.fontSizeLg * 5 : theme.typography.fontSizeLg * 10;
+
+  return (
+    <div css={{ overflow: 'hidden', display: 'flex', alignItems: 'center', gap: theme.spacing.xs, flex: 1 }}>
+      {rowSize === 'sm' ? (
+        <code
+          css={{
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+            fontSize: `${theme.typography.fontSizeSm}px !important`,
+            margin: '0 !important',
+          }}
+        >
+          {value}
+        </code>
+      ) : (
+        <CodeSnippet
+          language="json"
+          style={{
+            padding: theme.spacing.xs,
+            border: `1px solid ${theme.colors.border}`,
+            height: rowHeight,
+            width: '100%',
+          }}
+        >
+          {value}
+        </CodeSnippet>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsTable.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react';
+import { useGetDatasetRecords } from '../hooks/useGetDatasetRecords';
+import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from '@tanstack/react-table';
+import { Empty, TableCell, TableHeader, TableRow, TableSkeletonRows } from '@databricks/design-system';
+import { Table } from '@databricks/design-system';
+import { useIntl } from 'react-intl';
+import { JsonCell } from './ExperimentEvaluationDatasetJsonCell';
+import { ExperimentEvaluationDatasetRecordsToolbar } from './ExperimentEvaluationDatasetRecordsToolbar';
+import { EvaluationDataset, EvaluationDatasetRecord } from '../types';
+import { useInfiniteScrollFetch } from '../hooks/useInfiniteScrollFetch';
+
+const INPUTS_COLUMN_ID = 'inputs';
+const OUTPUTS_COLUMN_ID = 'outputs';
+const EXPECTATIONS_COLUMN_ID = 'expectations';
+
+const columns: ColumnDef<EvaluationDatasetRecord, string>[] = [
+  {
+    id: INPUTS_COLUMN_ID,
+    accessorKey: 'inputs',
+    header: 'Inputs',
+    enableResizing: false,
+    cell: JsonCell,
+  },
+  {
+    id: OUTPUTS_COLUMN_ID,
+    accessorKey: 'outputs',
+    header: 'Outputs',
+    enableResizing: false,
+    cell: JsonCell,
+  },
+  {
+    id: EXPECTATIONS_COLUMN_ID,
+    accessorKey: 'expectations',
+    header: 'Expectations',
+    enableResizing: false,
+    cell: JsonCell,
+  },
+];
+
+export const ExperimentEvaluationDatasetRecordsTable = ({ dataset }: { dataset: EvaluationDataset | undefined }) => {
+  const intl = useIntl();
+  const datasetId = dataset?.dataset_id;
+
+  const [rowSize, setRowSize] = useState<'sm' | 'md' | 'lg'>('sm');
+  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({
+    [INPUTS_COLUMN_ID]: true,
+    [OUTPUTS_COLUMN_ID]: false,
+    [EXPECTATIONS_COLUMN_ID]: true,
+  });
+
+  const {
+    data: datasetRecords,
+    isLoading,
+    isFetching,
+    error,
+    fetchNextPage,
+    hasNextPage,
+  } = useGetDatasetRecords({
+    datasetId: datasetId ?? '',
+    enabled: !!datasetId,
+  });
+
+  const fetchMoreOnBottomReached = useInfiniteScrollFetch({
+    isFetching,
+    hasNextPage: hasNextPage ?? false,
+    fetchNextPage,
+  });
+
+  const table = useReactTable({
+    columns,
+    data: datasetRecords ?? [],
+    getCoreRowModel: getCoreRowModel(),
+    getRowId: (row) => row.dataset_record_id,
+    enableColumnResizing: false,
+    meta: { rowSize },
+    state: {
+      columnVisibility,
+    },
+  });
+
+  return (
+    <div
+      css={{
+        flex: 1,
+        minHeight: 0,
+        position: 'relative',
+        overflow: 'hidden',
+        display: 'flex',
+        flexDirection: 'column',
+      }}
+    >
+      <ExperimentEvaluationDatasetRecordsToolbar
+        dataset={dataset}
+        datasetRecords={datasetRecords ?? []}
+        columns={columns}
+        columnVisibility={columnVisibility}
+        setColumnVisibility={setColumnVisibility}
+        rowSize={rowSize}
+        setRowSize={setRowSize}
+      />
+      <Table
+        css={{ flex: 1 }}
+        empty={
+          !isLoading && table.getRowModel().rows.length === 0 ? (
+            <Empty
+              description={intl.formatMessage({
+                defaultMessage: 'No records found',
+                description: 'Empty state for the evaluation dataset records table',
+              })}
+            />
+          ) : undefined
+        }
+        scrollable
+        onScroll={(e) => fetchMoreOnBottomReached(e.currentTarget as HTMLDivElement)}
+      >
+        <TableRow isHeader>
+          {table.getLeafHeaders().map(
+            (header) =>
+              header.column.getIsVisible() && (
+                <TableHeader
+                  key={header.id}
+                  componentId={`mlflow.eval-dataset-records.${header.column.id}-header`}
+                  header={header}
+                  column={header.column}
+                  css={{ position: 'sticky', top: 0, zIndex: 1 }}
+                >
+                  {flexRender(header.column.columnDef.header, header.getContext())}
+                </TableHeader>
+              ),
+          )}
+        </TableRow>
+        {isLoading ? (
+          <TableSkeletonRows table={table} />
+        ) : (
+          table.getRowModel().rows.map((row) => (
+            <TableRow key={row.id}>
+              {row.getVisibleCells().map((cell) => (
+                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+              ))}
+            </TableRow>
+          ))
+        )}
+      </Table>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsTable.tsx
@@ -37,9 +37,9 @@ const columns: ColumnDef<EvaluationDatasetRecord, string>[] = [
   },
 ];
 
-export const ExperimentEvaluationDatasetRecordsTable = ({ dataset }: { dataset: EvaluationDataset | undefined }) => {
+export const ExperimentEvaluationDatasetRecordsTable = ({ dataset }: { dataset: EvaluationDataset }) => {
   const intl = useIntl();
-  const datasetId = dataset?.dataset_id;
+  const datasetId = dataset.dataset_id;
 
   const [rowSize, setRowSize] = useState<'sm' | 'md' | 'lg'>('sm');
   const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>({
@@ -129,17 +129,14 @@ export const ExperimentEvaluationDatasetRecordsTable = ({ dataset }: { dataset: 
               ),
           )}
         </TableRow>
-        {isLoading ? (
-          <TableSkeletonRows table={table} />
-        ) : (
-          table.getRowModel().rows.map((row) => (
-            <TableRow key={row.id}>
-              {row.getVisibleCells().map((cell) => (
-                <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
-              ))}
-            </TableRow>
-          ))
-        )}
+        {table.getRowModel().rows.map((row) => (
+          <TableRow key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <TableCell key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</TableCell>
+            ))}
+          </TableRow>
+        ))}
+        {(isLoading || isFetching) && <TableSkeletonRows table={table} />}
       </Table>
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsToolbar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsToolbar.tsx
@@ -1,0 +1,137 @@
+import {
+  Button,
+  ColumnsIcon,
+  DropdownMenu,
+  RowsIcon,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { ColumnDef } from '@tanstack/react-table';
+import { FormattedMessage } from 'react-intl';
+import { EvaluationDataset, EvaluationDatasetRecord } from '../types';
+import { parseJSONSafe } from '@mlflow/mlflow/src/common/utils/TagUtils';
+
+const getTotalRecordsCount = (profile: string | undefined): number | undefined => {
+  if (!profile) {
+    return undefined;
+  }
+
+  const profileJson = parseJSONSafe(profile);
+  return profileJson?.num_records ?? undefined;
+};
+
+export const ExperimentEvaluationDatasetRecordsToolbar = ({
+  dataset,
+  datasetRecords,
+  columns,
+  columnVisibility,
+  setColumnVisibility,
+  rowSize,
+  setRowSize,
+}: {
+  dataset: EvaluationDataset;
+  datasetRecords: EvaluationDatasetRecord[];
+  columns: ColumnDef<EvaluationDatasetRecord, any>[];
+  columnVisibility: Record<string, boolean>;
+  setColumnVisibility: (columnVisibility: Record<string, boolean>) => void;
+  rowSize: 'sm' | 'md' | 'lg';
+  setRowSize: (rowSize: 'sm' | 'md' | 'lg') => void;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const datasetName = dataset?.name;
+  const profile = dataset?.profile;
+  const totalRecordsCount = getTotalRecordsCount(profile);
+  const loadedRecordsCount = datasetRecords.length;
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        alignItems: 'flex-start',
+        justifyContent: 'space-between',
+        marginBottom: theme.spacing.sm,
+      }}
+    >
+      <div
+        css={{
+          display: 'flex',
+          flexDirection: 'column',
+          paddingLeft: theme.spacing.sm,
+          paddingRight: theme.spacing.sm,
+        }}
+      >
+        <Typography.Title level={3} withoutMargins>
+          {datasetName}
+        </Typography.Title>
+        <Typography.Text color="secondary" size="sm">
+          <FormattedMessage
+            defaultMessage="Displaying {loadedRecordsCount} of {totalRecordsCount, plural, =1 {1 record} other {# records}}"
+            description="Label for the number of records displayed"
+            values={{ loadedRecordsCount: loadedRecordsCount ?? 0, totalRecordsCount: totalRecordsCount ?? 0 }}
+          />
+        </Typography.Text>
+      </div>
+      <div css={{ display: 'flex', alignItems: 'flex-start' }}>
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <Button componentId="mlflow.eval-datasets.records-toolbar.row-size-toggle" icon={<RowsIcon />} />
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content align="end">
+            <DropdownMenu.RadioGroup
+              componentId="mlflow.eval-datasets.records-toolbar.row-size-radio"
+              value={rowSize}
+              onValueChange={(value) => setRowSize(value as 'sm' | 'md' | 'lg')}
+            >
+              <DropdownMenu.Label>
+                <Typography.Text color="secondary">
+                  <FormattedMessage defaultMessage="Row height" description="Label for the row height radio group" />
+                </Typography.Text>
+              </DropdownMenu.Label>
+              <DropdownMenu.RadioItem key="sm" value="sm">
+                <DropdownMenu.ItemIndicator />
+                <Typography.Text>
+                  <FormattedMessage defaultMessage="Small" description="Small row size" />
+                </Typography.Text>
+              </DropdownMenu.RadioItem>
+              <DropdownMenu.RadioItem key="md" value="md">
+                <DropdownMenu.ItemIndicator />
+                <Typography.Text>
+                  <FormattedMessage defaultMessage="Medium" description="Medium row size" />
+                </Typography.Text>
+              </DropdownMenu.RadioItem>
+              <DropdownMenu.RadioItem key="lg" value="lg">
+                <DropdownMenu.ItemIndicator />
+                <Typography.Text>
+                  <FormattedMessage defaultMessage="Large" description="Large row size" />
+                </Typography.Text>
+              </DropdownMenu.RadioItem>
+            </DropdownMenu.RadioGroup>
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+        <DropdownMenu.Root>
+          <DropdownMenu.Trigger asChild>
+            <Button componentId="mlflow.eval-datasets.records-toolbar.columns-toggle" icon={<ColumnsIcon />} />
+          </DropdownMenu.Trigger>
+          <DropdownMenu.Content>
+            {columns.map((column) => (
+              <DropdownMenu.CheckboxItem
+                componentId="YOUR_TRACKING_ID"
+                key={column.id}
+                checked={columnVisibility[column.id ?? ''] ?? false}
+                onCheckedChange={(checked) =>
+                  setColumnVisibility({
+                    ...columnVisibility,
+                    [column.id ?? '']: checked,
+                  })
+                }
+              >
+                <DropdownMenu.ItemIndicator />
+                <Typography.Text>{column.header}</Typography.Text>
+              </DropdownMenu.CheckboxItem>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Root>
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1450,6 +1450,10 @@
     "defaultMessage": "Y axis",
     "description": "Label for Y axis in scatter chart configurator in compare runs chart config modal"
   },
+  "DcGPfO": {
+    "defaultMessage": "Row height",
+    "description": "Label for the row height radio group"
+  },
   "Dhn7Mb": {
     "defaultMessage": "Displaying Runs from {numExperiments} Experiments",
     "description": "Message shown when displaying runs from multiple experiments"
@@ -2748,6 +2752,10 @@
     "defaultMessage": "Cancel",
     "description": "Cancel button label within a modal for adding/editing a new runs comparison chart"
   },
+  "TnD/vL": {
+    "defaultMessage": "No records found",
+    "description": "Empty state for the evaluation dataset records table"
+  },
   "Tpj2su": {
     "defaultMessage": "Attributes",
     "description": "Label for the attributes column group in the logged model column selector"
@@ -3235,6 +3243,10 @@
     "defaultMessage": "Adheres to guidelines",
     "description": "Evaluation results > guideline adherence assessment > positive value label. Displayed if evaluation result adheres to the guidelines."
   },
+  "ZNyTjg": {
+    "defaultMessage": "Small",
+    "description": "Small row size"
+  },
   "ZO8PZt": {
     "defaultMessage": "{count, plural, =1 {1 minute} other {# minutes}} ago",
     "description": "Time duration in minutes"
@@ -3603,6 +3615,10 @@
     "defaultMessage": "Create",
     "description": "Create evaluation dataset button text"
   },
+  "crmbMK": {
+    "defaultMessage": "Displaying {loadedRecordsCount} of {totalRecordsCount, plural, =1 {1 record} other {# records}}",
+    "description": "Label for the number of records displayed"
+  },
   "csNr/8": {
     "defaultMessage": "Disable grouped runs to compare parameters, tag, or attributes",
     "description": "Experiment tracking > runs charts > cards > RunsChartsDifferenceChartCard > disable group runs tooltip message"
@@ -3862,6 +3878,10 @@
   "faLIN+": {
     "defaultMessage": "Timestamp",
     "description": "Run page > Charts tab > Chart tooltip > Timestamp label"
+  },
+  "fcIHyN": {
+    "defaultMessage": "Medium",
+    "description": "Medium row size"
   },
   "ffIouW": {
     "defaultMessage": "Retrieval sufficiency assessment is missing. This is likely because your agent is not returning retrieved_context.",
@@ -5522,6 +5542,10 @@
   "xdFMIN": {
     "defaultMessage": "Dataset name",
     "description": "Dataset name label"
+  },
+  "xgbeVS": {
+    "defaultMessage": "Large",
+    "description": "Large row size"
   },
   "xgypqc": {
     "defaultMessage": "Copied to clipboard",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18105/files) to review incremental changes.
- [**stack/records-table**](https://github.com/mlflow/mlflow/pull/18105) [[Files changed](https://github.com/mlflow/mlflow/pull/18105/files)]
  - [stack/export-to-dataset-modal](https://github.com/mlflow/mlflow/pull/18107) [[Files changed](https://github.com/mlflow/mlflow/pull/18107/files/c6ea30f0262e03a9aa9cda757913e3ce572fe8ce..a15d9b2dc1f134a8c88e392b6a1997667689e10f)]
    - [stack/integration](https://github.com/mlflow/mlflow/pull/18108) [[Files changed](https://github.com/mlflow/mlflow/pull/18108/files/a15d9b2dc1f134a8c88e392b6a1997667689e10f..d69d990d18fd9a93f2760b8be0ac99ff2cf5443e)]
      - [stack/export-traces](https://github.com/mlflow/mlflow/pull/18109) [[Files changed](https://github.com/mlflow/mlflow/pull/18109/files/d69d990d18fd9a93f2760b8be0ac99ff2cf5443e..97139fda4a57ebde9a9ebdf30faeb25c72ffda90)]
        - [stack/empty-states](https://github.com/mlflow/mlflow/pull/18110) [[Files changed](https://github.com/mlflow/mlflow/pull/18110/files/97139fda4a57ebde9a9ebdf30faeb25c72ffda90..061871d754b83cb8b3e18938bea0f0fe43a81b45)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR implements the dataset records view in the right pane. Mostly it's just a simple view to display the rows. There is also an option to change the row size to better display larger data.

Eventually we should add the following features, but no bandwidth for initial release:

1. Dataset tag management (display list of tags and allow user to edit)
2. Delete records (there is no backend API for this yet)
3. Editing rows from the UI (we'll see if we get feedback that this is useful or not)


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/89e1fdb3-6e66-40a7-8379-a12bbecfbd78



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
