### PR TITLE
Make spans/logs table name fields in the trace location private

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -496,6 +496,7 @@ mlflow.entities.TraceInfo.from_proto
 mlflow.entities.TraceInfo.to_dict
 mlflow.entities.TraceInfo.to_proto
 mlflow.entities.TraceLocation
+mlflow.entities.TraceLocation.from_databricks_uc_schema
 mlflow.entities.TraceLocation.from_dict
 mlflow.entities.TraceLocation.from_experiment_id
 mlflow.entities.TraceLocation.from_proto

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -37,7 +37,6 @@ from mlflow.utils.databricks_tracing_utils import (
     assessment_to_proto,
     trace_from_proto,
     trace_info_to_proto,
-    trace_location_from_databricks_uc_schema,
     trace_location_to_proto,
     uc_schema_location_from_proto,
     uc_schema_location_to_proto,
@@ -245,7 +244,7 @@ class DatabricksTracingRestStore(RestStore):
                         case [catalog, schema]:
                             trace_locations.append(
                                 trace_location_to_proto(
-                                    trace_location_from_databricks_uc_schema(catalog, schema)
+                                    TraceLocation.from_databricks_uc_schema(catalog, schema)
                                 )
                             )
                             contain_uc_schemas = True
@@ -507,7 +506,7 @@ class DatabricksTracingRestStore(RestStore):
             assessment.assessment_id = assessment_id
             catalog, schema = location.split(".")
             assessment.trace_location.CopyFrom(
-                trace_location_to_proto(trace_location_from_databricks_uc_schema(catalog, schema)),
+                trace_location_to_proto(TraceLocation.from_databricks_uc_schema(catalog, schema)),
             )
             assessment.trace_id = parsed_trace_id
             # Field mask specifies which fields to update.

--- a/mlflow/tracing/processor/uc_table.py
+++ b/mlflow/tracing/processor/uc_table.py
@@ -36,6 +36,7 @@ class DatabricksUCTableSpanProcessor(BaseMlflowSpanProcessor):
         if uc_spans_table_name := get_active_spans_table_name():
             catalog_name, schema_name, spans_table_name = uc_spans_table_name.split(".")
             trace_location = TraceLocation.from_databricks_uc_schema(catalog_name, schema_name)
+            trace_location.uc_schema._otel_spans_table_name = spans_table_name
             trace_id = generate_trace_id_v4(root_span, trace_location.uc_schema.schema_location)
         else:
             raise MlflowException(

--- a/mlflow/tracing/processor/uc_table.py
+++ b/mlflow/tracing/processor/uc_table.py
@@ -4,6 +4,7 @@ from opentelemetry.sdk.trace import Span as OTelSpan
 from opentelemetry.sdk.trace.export import SpanExporter
 
 from mlflow.entities.trace_info import TraceInfo
+from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.exceptions import MlflowException
 from mlflow.tracing.processor.base_mlflow import BaseMlflowSpanProcessor
@@ -11,7 +12,6 @@ from mlflow.tracing.utils import (
     generate_trace_id_v4,
     get_active_spans_table_name,
 )
-from mlflow.utils.databricks_tracing_utils import trace_location_from_databricks_uc_schema
 
 _logger = logging.getLogger(__name__)
 
@@ -35,9 +35,7 @@ class DatabricksUCTableSpanProcessor(BaseMlflowSpanProcessor):
         """
         if uc_spans_table_name := get_active_spans_table_name():
             catalog_name, schema_name, spans_table_name = uc_spans_table_name.split(".")
-            trace_location = trace_location_from_databricks_uc_schema(
-                catalog_name, schema_name, spans_table_name
-            )
+            trace_location = TraceLocation.from_databricks_uc_schema(catalog_name, schema_name)
             trace_id = generate_trace_id_v4(root_span, trace_location.uc_schema.schema_location)
         else:
             raise MlflowException(

--- a/mlflow/utils/databricks_tracing_utils.py
+++ b/mlflow/utils/databricks_tracing_utils.py
@@ -30,22 +30,19 @@ def uc_schema_location_to_proto(uc_schema_location: UCSchemaLocation) -> pb.UCSc
     return pb.UCSchemaLocation(
         catalog_name=uc_schema_location.catalog_name,
         schema_name=uc_schema_location.schema_name,
-        otel_spans_table_name=uc_schema_location.otel_spans_table_name,
-        otel_logs_table_name=uc_schema_location.otel_logs_table_name,
+        otel_spans_table_name=uc_schema_location._otel_spans_table_name,
+        otel_logs_table_name=uc_schema_location._otel_logs_table_name,
     )
 
 
 def uc_schema_location_from_proto(proto: pb.UCSchemaLocation) -> UCSchemaLocation:
-    return UCSchemaLocation(
-        catalog_name=proto.catalog_name,
-        schema_name=proto.schema_name,
-        otel_spans_table_name=proto.otel_spans_table_name
-        if proto.HasField("otel_spans_table_name")
-        else None,
-        otel_logs_table_name=proto.otel_logs_table_name
-        if proto.HasField("otel_logs_table_name")
-        else None,
-    )
+    location = UCSchemaLocation(catalog_name=proto.catalog_name, schema_name=proto.schema_name)
+
+    if proto.HasField("otel_spans_table_name"):
+        location._otel_spans_table_name = proto.otel_spans_table_name
+    if proto.HasField("otel_logs_table_name"):
+        location._otel_logs_table_name = proto.otel_logs_table_name
+    return location
 
 
 def inference_table_location_to_proto(
@@ -78,23 +75,6 @@ def trace_location_to_proto(trace_location: TraceLocation) -> pb.TraceLocation:
         )
     else:
         raise ValueError(f"Unsupported trace location type: {trace_location.type}")
-
-
-def trace_location_from_databricks_uc_schema(
-    catalog_name: str,
-    schema_name: str,
-    otel_spans_table_name: str | None = None,
-    otel_logs_table_name: str | None = None,
-) -> TraceLocation:
-    return TraceLocation(
-        type=TraceLocationType.UC_SCHEMA,
-        uc_schema=UCSchemaLocation(
-            catalog_name=catalog_name,
-            schema_name=schema_name,
-            otel_spans_table_name=otel_spans_table_name,
-            otel_logs_table_name=otel_logs_table_name,
-        ),
-    )
 
 
 def trace_location_type_from_proto(proto: pb.TraceLocation.TraceLocationType) -> TraceLocationType:

--- a/tests/entities/test_trace_location.py
+++ b/tests/entities/test_trace_location.py
@@ -67,7 +67,7 @@ def test_trace_location_mismatch():
         )
 
 
-def test_trace_location_from_proto_mlflow_experiment():
+def test_trace_location_from_v4_proto_mlflow_experiment():
     proto = pb.TraceLocation(
         type=pb.TraceLocation.TraceLocationType.MLFLOW_EXPERIMENT,
         mlflow_experiment=pb.TraceLocation.MlflowExperimentLocation(experiment_id="1234"),
@@ -77,7 +77,7 @@ def test_trace_location_from_proto_mlflow_experiment():
     assert trace_location.mlflow_experiment.experiment_id == "1234"
 
 
-def test_trace_location_from_proto_inference_table():
+def test_trace_location_from_v4_proto_inference_table():
     proto = pb.TraceLocation(
         type=pb.TraceLocation.TraceLocationType.INFERENCE_TABLE,
         inference_table=pb.TraceLocation.InferenceTableLocation(
@@ -93,8 +93,8 @@ def test_uc_schema_location_full_otel_spans_table_name():
     uc_schema = UCSchemaLocation(
         catalog_name="test_catalog",
         schema_name="test_schema",
-        otel_spans_table_name="otel_spans",
     )
+    uc_schema._otel_spans_table_name = "otel_spans"
     assert uc_schema.full_otel_spans_table_name == "test_catalog.test_schema.otel_spans"
 
 

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -50,7 +50,6 @@ from mlflow.tracing.constant import TRACE_ID_V4_PREFIX
 from mlflow.utils.databricks_tracing_utils import (
     assessment_to_proto,
     trace_info_to_proto,
-    trace_location_from_databricks_uc_schema,
     trace_location_to_proto,
     trace_to_proto,
 )
@@ -133,7 +132,7 @@ def test_create_trace_v4_uc_location(monkeypatch):
 
     trace_info = TraceInfo(
         trace_id="trace:/catalog.schema/123",
-        trace_location=trace_location_from_databricks_uc_schema("catalog", "schema"),
+        trace_location=TraceLocation.from_databricks_uc_schema("catalog", "schema"),
         request_time=123,
         execution_duration=10,
         state=TraceState.OK,
@@ -547,7 +546,7 @@ def test_search_traces_with_mixed_locations():
         else:
             catalog, schema = location.split(".")
             trace_locations.append(
-                trace_location_to_proto(trace_location_from_databricks_uc_schema(catalog, schema))
+                trace_location_to_proto(TraceLocation.from_databricks_uc_schema(catalog, schema))
             )
 
     expected_request = SearchTraces(
@@ -829,8 +828,8 @@ def test_set_experiment_trace_location():
         assert isinstance(result, UCSchemaLocation)
         assert result.catalog_name == "test_catalog"
         assert result.schema_name == "test_schema"
-        assert result.otel_spans_table_name == "test_spans"
-        assert result.otel_logs_table_name == "test_logs"
+        assert result.full_otel_spans_table_name == "test_catalog.test_schema.test_spans"
+        assert result.full_otel_logs_table_name == "test_catalog.test_schema.test_logs"
 
 
 def test_set_experiment_trace_location_with_existing_location():

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -23,7 +23,6 @@ from mlflow.tracing.provider import _get_tracer
 from mlflow.tracking.fluent import _get_experiment_id
 from mlflow.utils.autologging_utils import AUTOLOGGING_INTEGRATIONS, get_autolog_function
 from mlflow.utils.autologging_utils.safety import revert_patches
-from mlflow.utils.databricks_tracing_utils import trace_location_from_databricks_uc_schema
 from mlflow.version import IS_TRACING_SDK_ONLY
 
 
@@ -140,9 +139,7 @@ def create_test_trace_info_with_uc_table(
 ) -> TraceInfo:
     return TraceInfo(
         trace_id=trace_id,
-        trace_location=trace_location_from_databricks_uc_schema(
-            catalog_name, schema_name, spans_table_name
-        ),
+        trace_location=TraceLocation.from_databricks_uc_schema(catalog_name, schema_name),
         request_time=0,
         execution_duration=1,
         state=TraceState.OK,

--- a/tests/tracing/processor/test_uc_table_processor.py
+++ b/tests/tracing/processor/test_uc_table_processor.py
@@ -44,9 +44,9 @@ def test_on_start_with_uc_table_name(monkeypatch):
 
     # Verify trace location is UC_SCHEMA type
     assert trace_info.trace_location.type == TraceLocationType.UC_SCHEMA
-    assert trace_info.trace_location.uc_schema.catalog_name == "catalog1"
-    assert trace_info.trace_location.uc_schema.schema_name == "schema1"
-    assert trace_info.trace_location.uc_schema.otel_spans_table_name == "spans_table"
+    uc_schema = trace_info.trace_location.uc_schema
+    assert uc_schema.catalog_name == "catalog1"
+    assert uc_schema.schema_name == "schema1"
 
     # Verify trace state and timing
     assert trace_info.state == TraceState.IN_PROGRESS

--- a/tests/tracing/test_enablement.py
+++ b/tests/tracing/test_enablement.py
@@ -34,9 +34,9 @@ def test_set_experiment_trace_location(mock_databricks_tracking_uri):
         expected_location = UCSchemaLocation(
             catalog_name="test_catalog",
             schema_name="test_schema",
-            otel_spans_table_name="spans_table",
-            otel_logs_table_name="logs_table",
         )
+        expected_location._otel_logs_table_name = "logs_table"
+        expected_location._otel_spans_table_name = "spans_table"
         mock_client._set_experiment_trace_location.return_value = expected_location
 
         # Test with explicit experiment ID and sql_warehouse_id

--- a/tests/utils/test_databricks_tracing_utils.py
+++ b/tests/utils/test_databricks_tracing_utils.py
@@ -33,7 +33,6 @@ from mlflow.utils.databricks_tracing_utils import (
     trace_from_proto,
     trace_info_to_dict,
     trace_info_to_proto,
-    trace_location_from_databricks_uc_schema,
     trace_location_from_proto,
     trace_location_to_proto,
     trace_to_proto,
@@ -43,7 +42,7 @@ from mlflow.utils.databricks_tracing_utils import (
 
 
 def test_trace_location_to_proto_uc_schema():
-    trace_location = trace_location_from_databricks_uc_schema(
+    trace_location = TraceLocation.from_databricks_uc_schema(
         catalog_name="test_catalog", schema_name="test_schema"
     )
     proto = trace_location_to_proto(trace_location)
@@ -166,7 +165,7 @@ def test_trace_info_to_proto():
     trace_id = f"trace:/catalog.schema/{otel_trace_id}"
     trace_info = TraceInfo(
         trace_id=trace_id,
-        trace_location=trace_location_from_databricks_uc_schema(
+        trace_location=TraceLocation.from_databricks_uc_schema(
             catalog_name="catalog", schema_name="schema"
         ),
         request_time=0,
@@ -203,7 +202,7 @@ def test_trace_to_proto_and_from_proto():
     trace = Trace(
         info=TraceInfo(
             trace_id=trace_id,
-            trace_location=trace_location_from_databricks_uc_schema(
+            trace_location=TraceLocation.from_databricks_uc_schema(
                 catalog_name="catalog", schema_name="schema"
             ),
             request_time=0,
@@ -247,7 +246,7 @@ def test_trace_info_from_proto_handles_uc_schema_location():
     proto = pb.TraceInfo(
         trace_id="test_trace_id",
         trace_location=trace_location_to_proto(
-            trace_location_from_databricks_uc_schema(catalog_name="catalog", schema_name="schema")
+            TraceLocation.from_databricks_uc_schema(catalog_name="catalog", schema_name="schema")
         ),
         request_preview="test request",
         response_preview="test response",
@@ -270,7 +269,7 @@ def test_trace_info_from_proto_handles_uc_schema_location():
 def test_trace_info_to_dict():
     trace_info = TraceInfo(
         trace_id="test_trace_id",
-        trace_location=trace_location_from_databricks_uc_schema(
+        trace_location=TraceLocation.from_databricks_uc_schema(
             catalog_name="catalog", schema_name="schema"
         ),
         request_time=0,
@@ -312,7 +311,7 @@ def test_add_size_stats_to_trace_metadata_for_v4_trace():
     trace = Trace(
         info=TraceInfo(
             trace_id="test_trace_id",
-            trace_location=trace_location_from_databricks_uc_schema(
+            trace_location=TraceLocation.from_databricks_uc_schema(
                 catalog_name="catalog", schema_name="schema"
             ),
             request_time=0,
@@ -407,7 +406,7 @@ def test_get_trace_id_from_assessment_proto():
     proto = pb.Assessment(
         trace_id="1234",
         trace_location=trace_location_to_proto(
-            trace_location_from_databricks_uc_schema(catalog_name="catalog", schema_name="schema")
+            TraceLocation.from_databricks_uc_schema(catalog_name="catalog", schema_name="schema")
         ),
     )
     assert get_trace_id_from_assessment_proto(proto) == "trace:/catalog.schema/1234"

--- a/tests/utils/test_databricks_tracing_utils.py
+++ b/tests/utils/test_databricks_tracing_utils.py
@@ -81,14 +81,14 @@ def test_uc_schema_location_from_proto():
     proto = pb.UCSchemaLocation(
         catalog_name="test_catalog",
         schema_name="test_schema",
-        otel_spans_table_name="test_catalog.test_schema.test_spans",
-        otel_logs_table_name="test_catalog.test_schema.test_logs",
+        otel_spans_table_name="test_spans",
+        otel_logs_table_name="test_logs",
     )
     schema_location = uc_schema_location_from_proto(proto)
     assert schema_location.catalog_name == "test_catalog"
     assert schema_location.schema_name == "test_schema"
-    assert schema_location.otel_spans_table_name == "test_catalog.test_schema.test_spans"
-    assert schema_location.otel_logs_table_name == "test_catalog.test_schema.test_logs"
+    assert schema_location.full_otel_spans_table_name == "test_catalog.test_schema.test_spans"
+    assert schema_location.full_otel_logs_table_name == "test_catalog.test_schema.test_logs"
 
 
 def test_inference_table_location_to_proto():
@@ -107,33 +107,31 @@ def test_schema_location_to_proto():
     schema_location = UCSchemaLocation(
         catalog_name="test_catalog",
         schema_name="test_schema",
-        otel_spans_table_name="test_catalog.test_schema.test_spans",
-        otel_logs_table_name="test_catalog.test_schema.test_logs",
     )
+    schema_location._otel_spans_table_name = "test_spans"
+    schema_location._otel_logs_table_name = "test_logs"
     proto = uc_schema_location_to_proto(schema_location)
     assert proto.catalog_name == "test_catalog"
     assert proto.schema_name == "test_schema"
-    assert proto.otel_spans_table_name == "test_catalog.test_schema.test_spans"
-    assert proto.otel_logs_table_name == "test_catalog.test_schema.test_logs"
+    assert proto.otel_spans_table_name == "test_spans"
+    assert proto.otel_logs_table_name == "test_logs"
 
 
 def test_trace_location_from_proto_uc_schema():
     proto = pb.TraceLocation(
         type=pb.TraceLocation.TraceLocationType.UC_SCHEMA,
-        uc_schema=uc_schema_location_to_proto(
-            UCSchemaLocation(
-                catalog_name="catalog",
-                schema_name="schema",
-                otel_spans_table_name="catalog.schema.spans",
-                otel_logs_table_name="catalog.schema.logs",
-            )
+        uc_schema=pb.UCSchemaLocation(
+            catalog_name="catalog",
+            schema_name="schema",
+            otel_spans_table_name="spans",
+            otel_logs_table_name="logs",
         ),
     )
     trace_location = trace_location_from_proto(proto)
     assert trace_location.uc_schema.catalog_name == "catalog"
     assert trace_location.uc_schema.schema_name == "schema"
-    assert trace_location.uc_schema.otel_spans_table_name == "catalog.schema.spans"
-    assert trace_location.uc_schema.otel_logs_table_name == "catalog.schema.logs"
+    assert trace_location.uc_schema.full_otel_spans_table_name == "catalog.schema.spans"
+    assert trace_location.uc_schema.full_otel_logs_table_name == "catalog.schema.logs"
 
 
 def test_trace_location_from_proto_mlflow_experiment():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18106?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18106/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18106/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18106/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Currently, the `UCSchemaLocation` object takes `otel_spans_table_name` and `otel_logs_table_name` parameters. However, indeed those table names are fixed to `mlflow_experiment_trace_otel_spans` by the backend, resulting in a confusing situation like this:

```
# Set destination
mlflow.tracing.set_desitnation(
    location=UCSchemaLocation(
        catelog_name="catalog",
        schema_name="schema",
        otel_spans_table_name="my_table_name"  # <- a custom table name
    )
)

# Log a span
with mlflow.start_span(name="..."):
    pass

# Trace is logged to the table "mlflow_experiment_trace_otel_spans", not "my_table_name"!
```

To avoid confusion, this PR removes table name parameters from the constructor.

They are still in the dataclass as a private field, to store the full table name in case the object is returned from the backend.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
