### PR TITLE
[Datasets UI][11/x] Polish dataset empty states

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/ExperimentEvaluationDatasetsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/ExperimentEvaluationDatasetsPage.tsx
@@ -1,5 +1,5 @@
 import { Global } from '@emotion/react';
-import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useDesignSystemTheme } from '@databricks/design-system';
 import { ResizableBox } from 'react-resizable';
 import { ExperimentViewRunsTableResizerHandle } from '../../components/experiment-page/components/runs/ExperimentViewRunsTableResizer';
 import { useState } from 'react';
@@ -9,7 +9,6 @@ import { ExperimentEvaluationDatasetsListTable } from './components/ExperimentEv
 import { ExperimentEvaluationDatasetRecordsTable } from './components/ExperimentEvaluationDatasetRecordsTable';
 import { EvaluationDataset } from './types';
 import { ExperimentEvaluationDatasetsPageWrapper } from './ExperimentEvaluationDatasetsPageWrapper';
-import { FormattedMessage } from 'react-intl';
 import { ExperimentEvaluationDatasetsEmptyState } from './components/ExperimentEvaluationDatasetsEmptyState';
 
 const ExperimentEvaluationDatasetsPageImpl = () => {

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/ExperimentEvaluationDatasetsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/ExperimentEvaluationDatasetsPage.tsx
@@ -1,5 +1,5 @@
 import { Global } from '@emotion/react';
-import { useDesignSystemTheme } from '@databricks/design-system';
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { ResizableBox } from 'react-resizable';
 import { ExperimentViewRunsTableResizerHandle } from '../../components/experiment-page/components/runs/ExperimentViewRunsTableResizer';
 import { useState } from 'react';
@@ -9,6 +9,8 @@ import { ExperimentEvaluationDatasetsListTable } from './components/ExperimentEv
 import { ExperimentEvaluationDatasetRecordsTable } from './components/ExperimentEvaluationDatasetRecordsTable';
 import { EvaluationDataset } from './types';
 import { ExperimentEvaluationDatasetsPageWrapper } from './ExperimentEvaluationDatasetsPageWrapper';
+import { FormattedMessage } from 'react-intl';
+import { ExperimentEvaluationDatasetsEmptyState } from './components/ExperimentEvaluationDatasetsEmptyState';
 
 const ExperimentEvaluationDatasetsPageImpl = () => {
   const { experimentId } = useParams();
@@ -17,6 +19,7 @@ const ExperimentEvaluationDatasetsPageImpl = () => {
   const [dragging, setDragging] = useState(false);
   const [datasetListHidden, setDatasetListHidden] = useState(false);
   const [selectedDataset, setSelectedDataset] = useState<EvaluationDataset | undefined>(undefined);
+  const [isDatasetsLoading, setIsDatasetsLoading] = useState(false);
 
   invariant(experimentId, 'Experiment ID must be defined');
 
@@ -48,6 +51,7 @@ const ExperimentEvaluationDatasetsPageImpl = () => {
       >
         <div css={{ display: datasetListHidden ? 'none' : 'flex', flex: 1, minWidth: 0 }}>
           <ExperimentEvaluationDatasetsListTable
+            setIsLoading={setIsDatasetsLoading}
             experimentId={experimentId}
             selectedDataset={selectedDataset}
             setSelectedDataset={setSelectedDataset}
@@ -63,6 +67,9 @@ const ExperimentEvaluationDatasetsPageImpl = () => {
           overflow: 'hidden',
         }}
       >
+        {!isDatasetsLoading && !selectedDataset && (
+          <ExperimentEvaluationDatasetsEmptyState experimentId={experimentId} />
+        )}
         {selectedDataset && <ExperimentEvaluationDatasetRecordsTable dataset={selectedDataset} />}
       </div>
       {dragging && (

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsEmptyState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsEmptyState.tsx
@@ -14,6 +14,7 @@ export const ExperimentEvaluationDatasetsEmptyState = ({ experimentId }: { exper
         flexDirection: 'column',
         justifyContent: 'center',
         alignItems: 'center',
+        padding: theme.spacing.md,
       }}
     >
       <Typography.Title level={3} color="secondary">
@@ -33,14 +34,17 @@ export const ExperimentEvaluationDatasetsEmptyState = ({ experimentId }: { exper
                 href="https://mlflow.org/docs/latest/genai/datasets/"
                 openInNewTab
               >
-                {/* eslint-disable-next-line formatjs/enforce-description */}
-                <FormattedMessage defaultMessage="Learn more" />
+                <FormattedMessage defaultMessage="Learn more" description="Learn more link text" />
               </Typography.Link>
             ),
           }}
         />
       </Typography.Paragraph>
-      <img css={{ marginBottom: theme.spacing.md }} src={datasetsEmptyImg} alt="No datasets found" />
+      <img
+        css={{ marginBottom: theme.spacing.md, maxWidth: 'min(100%, 600px)' }}
+        src={datasetsEmptyImg}
+        alt="No datasets found"
+      />
       <CreateEvaluationDatasetButton experimentId={experimentId} />
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsEmptyState.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsEmptyState.tsx
@@ -1,0 +1,47 @@
+import { Empty, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import datasetsEmptyImg from '@mlflow/mlflow/src/common/static/eval-datasets-empty.svg';
+import { FormattedMessage } from 'react-intl';
+import { CreateEvaluationDatasetButton } from './CreateEvaluationDatasetButton';
+
+export const ExperimentEvaluationDatasetsEmptyState = ({ experimentId }: { experimentId: string }) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flex: 1,
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+      }}
+    >
+      <Typography.Title level={3} color="secondary">
+        <FormattedMessage
+          defaultMessage="Create an evaluation dataset"
+          description="Evaluation datasets empty state title"
+        />
+      </Typography.Title>
+      <Typography.Paragraph color="secondary" css={{ maxWidth: 600 }}>
+        <FormattedMessage
+          defaultMessage="Create evaluation datasets in order to iteratively evaluate and improve your app. For example, build a dataset from production traces with negative feedback. {learnMoreLink}"
+          description="Description for a quickstart guide on MLflow evaluation datasets"
+          values={{
+            learnMoreLink: (
+              <Typography.Link
+                componentId="mlflow.eval-datasets.learn-more-link"
+                href="https://mlflow.org/docs/latest/genai/datasets/"
+                openInNewTab
+              >
+                {/* eslint-disable-next-line formatjs/enforce-description */}
+                <FormattedMessage defaultMessage="Learn more" />
+              </Typography.Link>
+            ),
+          }}
+        />
+      </Typography.Paragraph>
+      <img css={{ marginBottom: theme.spacing.md }} src={datasetsEmptyImg} alt="No datasets found" />
+      <CreateEvaluationDatasetButton experimentId={experimentId} />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -134,10 +134,12 @@ export const ExperimentEvaluationDatasetsListTable = ({
   experimentId,
   selectedDataset,
   setSelectedDataset,
+  setIsLoading,
 }: {
   experimentId: string;
   selectedDataset?: EvaluationDataset;
   setSelectedDataset: (dataset: EvaluationDataset | undefined) => void;
+  setIsLoading: (isLoading: boolean) => void;
 }) => {
   const intl = useIntl();
   const { theme } = useDesignSystemTheme();
@@ -203,6 +205,11 @@ export const ExperimentEvaluationDatasetsListTable = ({
       setSelectedDataset(sortedRows[0].original);
     }
   }
+
+  // update loading state in parent
+  useEffect(() => {
+    setIsLoading(isLoading);
+  }, [isLoading, setIsLoading]);
 
   if (error) {
     return <div>Error loading datasets</div>;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetsListTable.tsx
@@ -192,6 +192,11 @@ export const ExperimentEvaluationDatasetsListTable = ({
     fetchNextPage,
   });
 
+  // update loading state in parent
+  useEffect(() => {
+    setIsLoading(isLoading);
+  }, [isLoading, setIsLoading]);
+
   if (!datasets?.length) {
     setSelectedDataset(undefined);
   }
@@ -205,11 +210,6 @@ export const ExperimentEvaluationDatasetsListTable = ({
       setSelectedDataset(sortedRows[0].original);
     }
   }
-
-  // update loading state in parent
-  useEffect(() => {
-    setIsLoading(isLoading);
-  }, [isLoading, setIsLoading]);
 
   if (error) {
     return <div>Error loading datasets</div>;

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1254,6 +1254,10 @@
     "defaultMessage": "Time Range",
     "description": "Label for the start range select dropdown for experiment runs view"
   },
+  "BMUd0e": {
+    "defaultMessage": "Create evaluation datasets in order to iteratively evaluate and improve your app. For example, build a dataset from production traces with negative feedback. {learnMoreLink}",
+    "description": "Description for a quickstart guide on MLflow evaluation datasets"
+  },
   "BOz0T2": {
     "defaultMessage": "Select metric",
     "description": "Placeholder text for a metric selector when configuring a line chart"
@@ -3546,6 +3550,10 @@
   "c0slEY": {
     "defaultMessage": "Click into an individual run to see all models associated with it",
     "description": "MLflow experiment detail page > runs table > tooltip on ML \"Models\" column header"
+  },
+  "c1jD8u": {
+    "defaultMessage": "Create an evaluation dataset",
+    "description": "Evaluation datasets empty state title"
   },
   "c4KA32": {
     "defaultMessage": "An error occurred while attempting to fetch the trace data. Please wait a moment and try again.",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18110/files) to review incremental changes.
- [**stack/empty-states**](https://github.com/mlflow/mlflow/pull/18110) [[Files changed](https://github.com/mlflow/mlflow/pull/18110/files)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This could have been rolled into an earlier PR but I wanted to keep things short (plus I only realized at the end that it was missing)

This PR adds a simple empty state to the datasets tab, with a CTA to create a dataset if there are none.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/8ad2f757-fc42-4e1e-961f-29f147c78a01



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
