### PR TITLE
Fix flaky job test by pre-initializing database to avoid race conditions

### DIFF
--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -78,16 +78,14 @@ jobs:
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          for i in {1..10}; do
-            pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
-              --ignore-flavors \
-              --ignore=tests/projects \
-              --ignore=tests/examples \
-              --ignore=tests/evaluate \
-              --ignore=tests/optuna \
-              --ignore=tests/pyspark/optuna \
-              --ignore=tests/genai \
-              --ignore=tests/telemetry \
-              --ignore=tests/gateway \
-              tests
-          done
+          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+            --ignore-flavors \
+            --ignore=tests/projects \
+            --ignore=tests/examples \
+            --ignore=tests/evaluate \
+            --ignore=tests/optuna \
+            --ignore=tests/pyspark/optuna \
+            --ignore=tests/genai \
+            --ignore=tests/telemetry \
+            --ignore=tests/gateway \
+            tests

--- a/.github/workflows/protobuf-cross-test.yml
+++ b/.github/workflows/protobuf-cross-test.yml
@@ -78,14 +78,16 @@ jobs:
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
-            --ignore-flavors \
-            --ignore=tests/projects \
-            --ignore=tests/examples \
-            --ignore=tests/evaluate \
-            --ignore=tests/optuna \
-            --ignore=tests/pyspark/optuna \
-            --ignore=tests/genai \
-            --ignore=tests/telemetry \
-            --ignore=tests/gateway \
-            tests
+          for i in {1..10}; do
+            pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+              --ignore-flavors \
+              --ignore=tests/projects \
+              --ignore=tests/examples \
+              --ignore=tests/evaluate \
+              --ignore=tests/optuna \
+              --ignore=tests/pyspark/optuna \
+              --ignore=tests/genai \
+              --ignore=tests/telemetry \
+              --ignore=tests/gateway \
+              tests
+          done

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -46,7 +46,7 @@ def _setup_job_runner(
     backend_store_uri = backend_store_uri or f"sqlite:///{tmp_path / 'mlflow.db'}"
     # Pre-initialize the database to prevent race conditions when the tracking store and job store
     # attempt to initialize the database simultaneously.
-    store = SqlAlchemyStore(backend_store_uri)
+    store = SqlAlchemyStore(backend_store_uri, (tmp_path / "artifacts").as_uri())
     store.engine.dispose()
     huey_store_path = tmp_path / "huey_store"
     huey_store_path.mkdir()


### PR DESCRIPTION
### Related Issues/PRs

Similar to #18101

### What changes are proposed in this pull request?

Pre-initialize the database in the `_setup_job_runner` test fixture to prevent race conditions when the tracking store and job store attempt to initialize the database simultaneously.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with Claude Code