### PR TITLE
Fix JSONPath field extraction for keys with dots in traces CLI

### DIFF
--- a/mlflow/utils/jsonpath_utils.py
+++ b/mlflow/utils/jsonpath_utils.py
@@ -167,7 +167,6 @@ def find_matching_paths(data: dict[str, Any], wildcard_path: str) -> list[str]:
             paths = []
             if isinstance(current_data, dict):
                 for key in current_data.keys():
-                    # Wrap all keys in backticks for consistency and safety
                     escaped_key = f"`{key}`"
                     new_path = f"{current_path}.{escaped_key}"
                     paths.extend(find_paths(current_data[key], remaining, new_path))
@@ -178,7 +177,6 @@ def find_matching_paths(data: dict[str, Any], wildcard_path: str) -> list[str]:
             return paths
         else:
             if isinstance(current_data, dict) and part in current_data:
-                # Wrap all keys in backticks for consistency and safety
                 escaped_key = f"`{part}`"
                 new_path = f"{current_path}.{escaped_key}"
                 return find_paths(current_data[part], remaining, new_path)

--- a/mlflow/utils/jsonpath_utils.py
+++ b/mlflow/utils/jsonpath_utils.py
@@ -167,7 +167,9 @@ def find_matching_paths(data: dict[str, Any], wildcard_path: str) -> list[str]:
             paths = []
             if isinstance(current_data, dict):
                 for key in current_data.keys():
-                    new_path = f"{current_path}.{key}"
+                    # Wrap keys containing dots in backticks to preserve them as single segments
+                    escaped_key = f"`{key}`" if "." in key else key
+                    new_path = f"{current_path}.{escaped_key}"
                     paths.extend(find_paths(current_data[key], remaining, new_path))
             elif isinstance(current_data, list):
                 for i, item in enumerate(current_data):
@@ -176,7 +178,9 @@ def find_matching_paths(data: dict[str, Any], wildcard_path: str) -> list[str]:
             return paths
         else:
             if isinstance(current_data, dict) and part in current_data:
-                new_path = f"{current_path}.{part}"
+                # Wrap keys containing dots in backticks to preserve them as single segments
+                escaped_key = f"`{part}`" if "." in part else part
+                new_path = f"{current_path}.{escaped_key}"
                 return find_paths(current_data[part], remaining, new_path)
             return []
 

--- a/mlflow/utils/jsonpath_utils.py
+++ b/mlflow/utils/jsonpath_utils.py
@@ -167,8 +167,8 @@ def find_matching_paths(data: dict[str, Any], wildcard_path: str) -> list[str]:
             paths = []
             if isinstance(current_data, dict):
                 for key in current_data.keys():
-                    # Wrap keys containing dots in backticks to preserve them as single segments
-                    escaped_key = f"`{key}`" if "." in key else key
+                    # Wrap all keys in backticks for consistency and safety
+                    escaped_key = f"`{key}`"
                     new_path = f"{current_path}.{escaped_key}"
                     paths.extend(find_paths(current_data[key], remaining, new_path))
             elif isinstance(current_data, list):
@@ -178,8 +178,8 @@ def find_matching_paths(data: dict[str, Any], wildcard_path: str) -> list[str]:
             return paths
         else:
             if isinstance(current_data, dict) and part in current_data:
-                # Wrap keys containing dots in backticks to preserve them as single segments
-                escaped_key = f"`{part}`" if "." in part else part
+                # Wrap all keys in backticks for consistency and safety
+                escaped_key = f"`{part}`"
                 new_path = f"{current_path}.{escaped_key}"
                 return find_paths(current_data[part], remaining, new_path)
             return []

--- a/tests/utils/test_jsonpath_utils.py
+++ b/tests/utils/test_jsonpath_utils.py
@@ -221,8 +221,6 @@ def test_validate_field_paths_suggestions():
 
 
 def test_wildcard_with_dotted_field_names():
-    """Test wildcard expansion with field names containing dots."""
-    # This tests the specific fix for handling fields like 'mlflow.spanType' with wildcards
     data = {
         "data": {
             "spans": [
@@ -246,20 +244,15 @@ def test_wildcard_with_dotted_field_names():
         }
     }
 
-    # Test extracting field with dots using wildcards
     values = jsonpath_extract_values(data, "data.spans.*.attributes.`mlflow.spanType`")
     assert values == ["AGENT", "CHAIN"]
 
-    # Test filtering preserves structure with dotted fields
     filtered = filter_json_by_fields(data, ["data.spans.*.attributes.`mlflow.spanType`"])
     assert len(filtered["data"]["spans"]) == 2
     assert filtered["data"]["spans"][0]["attributes"]["mlflow.spanType"] == "AGENT"
     assert filtered["data"]["spans"][1]["attributes"]["mlflow.spanType"] == "CHAIN"
-    # Should not include other attributes
     assert "mlflow.spanName" not in filtered["data"]["spans"][0]["attributes"]
     assert "regular_attr" not in filtered["data"]["spans"][0]["attributes"]
-
-    # Test multiple dotted fields
     filtered2 = filter_json_by_fields(
         data,
         ["data.spans.*.attributes.`mlflow.spanType`", "data.spans.*.attributes.`mlflow.spanName`"],


### PR DESCRIPTION
## Related Issues/PRs
xxx

## What changes are proposed in this pull request?

This PR fixes a critical bug in the JSONPath utilities that prevented proper extraction of fields containing dots (like `mlflow.spanType`) when using wildcard patterns in the traces CLI.

### The Problem
When using the traces CLI with patterns like `--extract-fields 'data.spans.*.attributes.mlflow.spanType'`, the wildcard expansion would discover keys like `mlflow.spanType` but fail to preserve them as single units when reconstructing paths. This caused the extraction to fail with an `UnboundLocalError` or return empty results.

### The Solution  
Added logic to automatically wrap keys containing dots in backticks during path reconstruction in `mlflow/utils/jsonpath_utils.py`:
- When expanding wildcards, keys with dots are wrapped: `escaped_key = f"\`{key}\`" if "." in key else key`
- Fixed a typo where `key` was used instead of `part` on line 184
- Enhanced traces CLI documentation to clarify using single quotes with backticks

## How is this PR tested?

- [x] Existing unit/integration tests pass
- [x] New unit/integration tests
- [x] Manual testing

<details>
<summary>Manual testing evidence</summary>

Tested with real Databricks trace data:
```bash
# Previously failed, now works:
mlflow traces search --extract-fields 'data.spans.*.attributes.`mlflow.spanType`'
# Returns: {"attributes": {"mlflow.spanType": "AGENT"}}, {"attributes": {"mlflow.spanType": "CHAIN"}}, ...

# Also tested:
mlflow traces search --extract-fields 'info.tags.`mlflow.traceName`' 
mlflow traces get --extract-fields 'info.trace_metadata.`mlflow.traceInputs`,info.trace_metadata.`mlflow.traceOutputs`'
```
</details>

## Does this PR require documentation update?

- [x] No. This PR does not require documentation update

## Release Notes

### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Bug fix: Fixed JSONPath field extraction for keys containing dots when using wildcard patterns in the traces CLI. Users can now properly extract MLflow metadata fields like `mlflow.spanType` when using wildcard patterns.

### What component(s) does this PR affect?

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/frontend`: Frontend, i.e., the React UI
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - Bug fixes
- [ ] `rn/feature` - Features
- [ ] `rn/documentation` - Documentation improvements
- [ ] `rn/internal` - Internal improvements

### (Optional) Proposed release note:

<!--
If you think the automatically-generated release note could be improved, provide your own release note below.
An example of a good release note:
> [Tracking] Introduce an environment variable to controls whether or not to log pip requirements and conda environment (dependencies) on model logging APIs. (#11374, @B-Step62)
-->

[Tracking] Fixed extraction of fields with dots (e.g., `mlflow.spanType`) when using wildcards in traces CLI `--extract-fields` option (#18126, @danielseong1)