### PR TITLE
Log assessments to DSPy eval traces

### DIFF
--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -1,4 +1,5 @@
 import importlib
+import logging
 
 from packaging.version import Version
 
@@ -11,6 +12,9 @@ from mlflow.utils.autologging_utils import (
     get_autologging_config,
     safe_patch,
 )
+from mlflow.utils.autologging_utils.safety import exception_safe_function_for_class
+
+_logger = logging.getLogger(__name__)
 
 
 def autolog(
@@ -64,7 +68,6 @@ def autolog(
     import dspy
 
     from mlflow.dspy.callback import MlflowCallback
-    from mlflow.dspy.util import log_dspy_dataset, log_dspy_lm_state, save_dspy_module_state
 
     # Enable tracing by setting the MlflowCallback
     if not disable:
@@ -79,76 +82,6 @@ def autolog(
             callbacks=[c for c in dspy.settings.callbacks if not isinstance(c, MlflowCallback)]
         )
 
-    # Patch teleprompter/evaluator not to generate traces by default
-    def patch_fn(original, self, *args, **kwargs):
-        # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
-        # check this flag at runtime to determine if we should generate traces.
-        # method to disable tracing for compile and evaluate by default
-        @trace_disabled
-        def _trace_disabled_fn(self, *args, **kwargs):
-            return original(self, *args, **kwargs)
-
-        def _compile_fn(self, *args, **kwargs):
-            if callback := _active_callback():
-                callback.optimizer_stack_level += 1
-            try:
-                if get_autologging_config(FLAVOR_NAME, "log_traces_from_compile"):
-                    result = original(self, *args, **kwargs)
-                else:
-                    result = _trace_disabled_fn(self, *args, **kwargs)
-                return result
-            finally:
-                if callback:
-                    callback.optimizer_stack_level -= 1
-                    if callback.optimizer_stack_level == 0:
-                        # Reset the callback state after the completion of root compile
-                        callback.reset()
-
-        if isinstance(self, Teleprompter):
-            if not get_autologging_config(FLAVOR_NAME, "log_compiles"):
-                return _compile_fn(self, *args, **kwargs)
-
-            program = _compile_fn(self, *args, **kwargs)
-            # Save the state of the best model in json format
-            # so that users can see the demonstrations and instructions.
-            save_dspy_module_state(program, "best_model.json")
-
-            # Teleprompter.get_params is introduced in dspy 2.6.15
-            params = (
-                self.get_params()
-                if Version(importlib.metadata.version("dspy")) >= Version("2.6.15")
-                else {}
-            )
-            # Construct the dict of arguments passed to the compile call
-            inputs = construct_full_inputs(original, self, *args, **kwargs)
-            # Update params with the arguments passed to the compile call
-            params.update(inputs)
-            mlflow.log_params(
-                {k: v for k, v in inputs.items() if isinstance(v, (int, float, str, bool))}
-            )
-
-            # Log the current DSPy LM state
-            log_dspy_lm_state()
-
-            if trainset := inputs.get("trainset"):
-                log_dspy_dataset(trainset, "trainset.json")
-            if valset := inputs.get("valset"):
-                log_dspy_dataset(valset, "valset.json")
-            return program
-
-        if isinstance(self, Teleprompter) and get_autologging_config(
-            FLAVOR_NAME, "log_traces_from_compile"
-        ):
-            return original(self, *args, **kwargs)
-
-        if isinstance(self, Evaluate) and get_autologging_config(
-            FLAVOR_NAME, "log_traces_from_eval"
-        ):
-            return original(self, *args, **kwargs)
-
-        return _trace_disabled_fn(self, *args, **kwargs)
-
-    from dspy.evaluate import Evaluate
     from dspy.teleprompt import Teleprompter
 
     compile_patch = "compile"
@@ -161,9 +94,11 @@ def autolog(
                 FLAVOR_NAME,
                 cls,
                 compile_patch,
-                patch_fn,
+                _patched_compile,
                 manage_run=get_autologging_config(FLAVOR_NAME, "log_compiles"),
             )
+
+    from dspy.evaluate import Evaluate
 
     call_patch = "__call__"
     if hasattr(Evaluate, call_patch):
@@ -171,7 +106,7 @@ def autolog(
             FLAVOR_NAME,
             Evaluate,
             call_patch,
-            patch_fn,
+            _patched_evaluate,
         )
 
 
@@ -200,3 +135,132 @@ def _active_callback():
     for callback in dspy.settings.callbacks:
         if isinstance(callback, MlflowCallback):
             return callback
+
+
+def _patched_compile(original, self, *args, **kwargs):
+    from mlflow.dspy.util import log_dspy_dataset, log_dspy_lm_state, save_dspy_module_state
+
+    # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
+    # check this flag at runtime to determine if we should generate traces.
+    # method to disable tracing for compile and evaluate by default
+    @trace_disabled
+    def _trace_disabled_fn(self, *args, **kwargs):
+        return original(self, *args, **kwargs)
+
+    def _compile_fn(self, *args, **kwargs):
+        if callback := _active_callback():
+            callback.optimizer_stack_level += 1
+        try:
+            if get_autologging_config(FLAVOR_NAME, "log_traces_from_compile"):
+                result = original(self, *args, **kwargs)
+            else:
+                result = _trace_disabled_fn(self, *args, **kwargs)
+            return result
+        finally:
+            if callback:
+                callback.optimizer_stack_level -= 1
+                if callback.optimizer_stack_level == 0:
+                    # Reset the callback state after the completion of root compile
+                    callback.reset()
+
+    if not get_autologging_config(FLAVOR_NAME, "log_compiles"):
+        return _compile_fn(self, *args, **kwargs)
+
+    program = _compile_fn(self, *args, **kwargs)
+    # Save the state of the best model in json format
+    # so that users can see the demonstrations and instructions.
+    save_dspy_module_state(program, "best_model.json")
+
+    # Teleprompter.get_params is introduced in dspy 2.6.15
+    params = (
+        self.get_params()
+        if Version(importlib.metadata.version("dspy")) >= Version("2.6.15")
+        else {}
+    )
+    # Construct the dict of arguments passed to the compile call
+    inputs = construct_full_inputs(original, self, *args, **kwargs)
+    # Update params with the arguments passed to the compile call
+    params.update(inputs)
+    mlflow.log_params({k: v for k, v in inputs.items() if isinstance(v, (int, float, str, bool))})
+
+    # Log the current DSPy LM state
+    log_dspy_lm_state()
+
+    if trainset := inputs.get("trainset"):
+        log_dspy_dataset(trainset, "trainset.json")
+    if valset := inputs.get("valset"):
+        log_dspy_dataset(valset, "valset.json")
+    return program
+
+    if get_autologging_config(FLAVOR_NAME, "log_traces_from_compile"):
+        return original(self, *args, **kwargs)
+    else:
+        return _trace_disabled_fn(self, *args, **kwargs)
+
+
+def _patched_evaluate(original, self, *args, **kwargs):
+    # NB: Since calling mlflow.dspy.autolog() again does not unpatch a function, we need to
+    # check this flag at runtime to determine if we should generate traces.
+    # method to disable tracing for compile and evaluate by default
+    @trace_disabled
+    def _trace_disabled_fn(self, *args, **kwargs):
+        return original(self, *args, **kwargs)
+
+    if not get_autologging_config(FLAVOR_NAME, "log_traces_from_eval"):
+        return _trace_disabled_fn(self, *args, **kwargs)
+
+    # Patch metric call to log assessment results on the prediction traces
+    new_kwargs = construct_full_inputs(original, self, *args, **kwargs)
+    metric = new_kwargs.get("metric") or self.metric
+    new_kwargs["metric"] = _patch_metric(metric)
+
+    args_passed_positional = list(new_kwargs.keys())[: len(args)]
+    new_args = []
+    for arg in args_passed_positional:
+        new_args.append(new_kwargs.pop(arg))
+
+    return original(self, *new_args, **new_kwargs)
+
+
+def _patch_metric(metric):
+    """Patch the metric call to log assessment results on the prediction traces."""
+    import dspy
+
+    # NB: This patch MUST not raise an exception, otherwise may interrupt the evaluation call.
+    @exception_safe_function_for_class
+    def _patched(*args, **kwargs):
+        # NB: DSPy runs prediction and the metric call in the same thread, so we can retrieve
+        # the prediction trace ID using the last active trace ID.
+        # https://github.com/stanfordnlp/dspy/blob/8224a99ca6402863540aae5aa3bc5eddbd2947c4/dspy/evaluate/evaluate.py#L170-L173
+        pred_trace_id = mlflow.get_last_active_trace_id(thread_local=True)
+        if not pred_trace_id:
+            _logger.debug("Tracing during evaluation is enabled, but no prediction trace found.")
+            return metric(*args, **kwargs)
+
+        try:
+            score = metric(*args, **kwargs)
+        except Exception as e:
+            _logger.debug("Metric call failed, logging an assessment with error")
+            mlflow.log_feedback(trace_id=pred_trace_id, name=metric.__name__, error=e)
+            raise
+
+        try:
+            if isinstance(score, dspy.Prediction):
+                value = getattr(score, "score", None)
+                rationale = getattr(score, "feedback", None)
+            else:
+                value = score
+                rationale = None
+
+            mlflow.log_feedback(
+                trace_id=pred_trace_id,
+                name=metric.__name__,
+                value=value,
+                rationale=rationale,
+            )
+        except Exception as e:
+            _logger.debug(f"Failed to log feedback for metric on prediction trace: {e}")
+
+        return score
+
+    return _patched

--- a/mlflow/dspy/autolog.py
+++ b/mlflow/dspy/autolog.py
@@ -246,6 +246,8 @@ def _patch_metric(metric):
 
         try:
             if isinstance(score, dspy.Prediction):
+                # GEPA metric returns a Prediction object with score and feedback attributes.
+                # https://dspy.ai/tutorials/gepa_aime/
                 value = getattr(score, "score", None)
                 rationale = getattr(score, "feedback", None)
             else:

--- a/mlflow/utils/autologging_utils/safety.py
+++ b/mlflow/utils/autologging_utils/safety.py
@@ -915,6 +915,7 @@ _VALIDATION_EXEMPT_ARGUMENTS = [
     #    the first element.
     ValidationExemptArgument("tensorflow", "fit", is_iterator, 1, "x"),
     ValidationExemptArgument("keras", "fit", is_iterator, 1, "x"),
+    ValidationExemptArgument("dspy", "__call__", lambda x: isinstance(x, Callable), 2, "metric"),
 ]
 
 

--- a/tests/dspy/test_dspy_autolog.py
+++ b/tests/dspy/test_dspy_autolog.py
@@ -7,7 +7,6 @@ import dspy
 import dspy.teleprompt
 import pytest
 from dspy.evaluate import Evaluate
-from dspy.evaluate.evaluate import EvaluationResult
 from dspy.evaluate.metrics import answer_exact_match
 from dspy.predict import Predict
 from dspy.primitives.example import Example
@@ -896,7 +895,12 @@ def test_autolog_log_traces_from_evals(call_args):
     else:
         result = evaluator(program, answer_exact_match, devset=examples)
 
-    assert isinstance(result, EvaluationResult)
+    if _DSPY_VERSION >= Version("3.0.0"):
+        from dspy.evaluate.evaluate import EvaluationResult
+
+        assert isinstance(result, EvaluationResult)
+    else:
+        assert result is not None
 
     traces = get_traces()
     assert len(traces) == 2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18136?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18136/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18136/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18136/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Log metric score and feedback during DSPy evaluation as MLflow Assessment on the prediction traces. This allow users to inspect the score and natural language feedback for each prediction using MLflow's Trace tab.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="1647" height="559" alt="Screenshot 2025-10-06 at 13 46 15" src="https://github.com/user-attachments/assets/d9a77d24-22ce-4dd1-ad83-8a5cc2f597cc" />

<img width="1689" height="654" alt="Screenshot 2025-10-06 at 13 46 29" src="https://github.com/user-attachments/assets/631db1c9-8f1b-430e-a5dc-488f37bee429" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Record DSPy metric outputs as trace assessments to provide better visualization on the evaluation results.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
