### PR TITLE
Handle LLM judge and custom scorers in adapt_prompts

### DIFF
--- a/mlflow/genai/optimize/adapt.py
+++ b/mlflow/genai/optimize/adapt.py
@@ -155,6 +155,8 @@ def adapt_prompts(
             for prompt_name, prompt in optimizer_output.optimized_prompts.items()
         ],
         optimizer_name=optimizer.__class__.__name__,
+        initial_eval_score=optimizer_output.initial_eval_score,
+        final_eval_score=optimizer_output.final_eval_score,
     )
 
 

--- a/mlflow/genai/optimize/adapt.py
+++ b/mlflow/genai/optimize/adapt.py
@@ -73,9 +73,8 @@ def adapt_prompts(
         target_prompt_uris: a list of prompt uris to be optimized.
             The prompt templates should be used by the predict_fn.
         optimizer_lm_params: model parameters used in the optimization algorithm.
-            The model name can be specified in either format:
-            - `<provider>:/<model>` (e.g., "openai:/gpt-4o")
-            - `<provider>/<model>` (e.g., "openai/gpt-4o")
+            The model name can be specified in the format
+            `<provider>:/<model>` (e.g., "openai:/gpt-4o")
         scorers: List of scorers that evaluate the inputs, outputs and expectations.
             If None, uses a default scorer that applies exact match for numeric types
             and LLM judge for text.
@@ -250,7 +249,7 @@ def _build_eval_fn(
         try:
             with ThreadPoolExecutor(
                 max_workers=MLFLOW_GENAI_EVAL_MAX_WORKERS.get(),
-                thread_name_prefix="MlflowGenAIEvalHarness",
+                thread_name_prefix="MLflowPromptAdaptation",
             ) as executor:
                 futures = [executor.submit(_run_single, record) for record in dataset]
                 return [future.result() for future in futures]

--- a/mlflow/genai/optimize/adapt.py
+++ b/mlflow/genai/optimize/adapt.py
@@ -35,6 +35,7 @@ _logger = logging.getLogger(__name__)
 @experimental(version="3.5.0")
 @record_usage_event(PromptAdaptationEvent)
 def adapt_prompts(
+    *,
     predict_fn: Callable[..., Any],
     train_data: "EvaluationDatasetTypes",
     target_prompt_uris: list[str],

--- a/mlflow/genai/optimize/adapt.py
+++ b/mlflow/genai/optimize/adapt.py
@@ -173,7 +173,6 @@ def adapt_prompts(
         predict_fn=predict_fn, sample_input=converted_train_data[0]["inputs"]
     )
 
-    # Create metric from scorers
     metric_fn = create_metric_from_scorers(scorers, objective)
     eval_fn = _build_eval_fn(predict_fn, metric_fn)
 
@@ -225,7 +224,8 @@ def _build_eval_fn(
 
         def _run_single(record: dict[str, Any]):
             inputs = record["inputs"]
-            outputs = record["outputs"]
+            # use expectations if provided, otherwise use outputs
+            outputs = record.get("expectations") or record.get("outputs")
             eval_request_id = str(uuid.uuid4())
             # set prediction context to retrieve the trace by the request id,
             # and set is_evaluate to True to disable async trace logging

--- a/mlflow/genai/optimize/adapters/gepa_adapter.py
+++ b/mlflow/genai/optimize/adapters/gepa_adapter.py
@@ -1,8 +1,11 @@
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from mlflow.genai.optimize.adapters.base import BasePromptAdapter, _EvalFunc
 from mlflow.genai.optimize.types import EvaluationResultRecord, LLMParams, PromptAdapterOutput
 from mlflow.utils.annotations import experimental
+
+if TYPE_CHECKING:
+    import gepa
 
 
 @experimental(version="3.5.0")
@@ -200,5 +203,32 @@ class GepaPromptAdapter(BasePromptAdapter):
         )
 
         optimized_prompts = gepa_result.best_candidate
+        initial_score, final_score = self._extract_eval_scores(gepa_result)
 
-        return PromptAdapterOutput(optimized_prompts=optimized_prompts)
+        return PromptAdapterOutput(
+            optimized_prompts=optimized_prompts,
+            initial_eval_score=initial_score,
+            final_eval_score=final_score,
+        )
+
+    def _extract_eval_scores(self, result: "gepa.GEPAResult") -> tuple[float | None, float | None]:
+        """
+        Extract initial and final evaluation scores from GEPA result.
+
+        Args:
+            result: GEPA optimization result
+
+        Returns:
+            Tuple of (initial_score, final_score), both can be None if unavailable
+        """
+        final_score = None
+        initial_score = None
+
+        scores = result.val_aggregate_scores
+        if scores and len(scores) > 0:
+            # The first score is the initial baseline score
+            initial_score = scores[0]
+            # The highest score is the final optimized score
+            final_score = max(scores)
+
+        return initial_score, final_score

--- a/mlflow/genai/optimize/adapters/gepa_adapter.py
+++ b/mlflow/genai/optimize/adapters/gepa_adapter.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 from mlflow.genai.optimize.adapters.base import BasePromptAdapter, _EvalFunc
-from mlflow.genai.optimize.types import LLMParams, PromptAdapterOutput
+from mlflow.genai.optimize.types import EvaluationResultRecord, LLMParams, PromptAdapterOutput
 from mlflow.utils.annotations import experimental
 
 
@@ -148,7 +148,7 @@ class GepaPromptAdapter(BasePromptAdapter):
             def make_reflective_dataset(
                 self,
                 candidate: dict[str, str],
-                eval_batch: "gepa.EvaluationBatch",
+                eval_batch: "gepa.EvaluationBatch[EvaluationResultRecord, Any]",
                 components_to_update: list[str],
             ) -> dict[str, list[dict[str, Any]]]:
                 """

--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING, Any
 
 from mlflow.entities.model_registry import PromptVersion
 from mlflow.environment_variables import MLFLOW_GENAI_EVAL_MAX_WORKERS
-from mlflow.exceptions import MlflowException
 from mlflow.genai.optimize.optimizers.base_optimizer import BasePromptOptimizer
 from mlflow.genai.optimize.types import LLMParams, ObjectiveFn, OptimizerOutput
+from mlflow.genai.optimize.util import create_metric_from_scorers
 from mlflow.genai.scorers import Scorer
 from mlflow.utils.annotations import experimental
 
@@ -125,6 +125,7 @@ class _GEPAOptimizer(BasePromptOptimizer):
                 self.llm_params = llm_params
                 self.scorers = scorers_list
                 self.objective = objective_fn
+                self.metric = create_metric_from_scorers(scorers_list, objective_fn)
 
             def evaluate(
                 self,
@@ -172,7 +173,7 @@ class _GEPAOptimizer(BasePromptOptimizer):
                 filled_prompt = format_prompt(prompt_template, **inputs)
                 expectations = record.get("expectations")
                 outputs = self._call_llm(filled_prompt)
-                score = self._metric(inputs, outputs, expectations, self.scorers, self.objective)
+                score = self.metric(inputs, outputs, expectations)
 
                 return {
                     "inputs": inputs,
@@ -180,35 +181,6 @@ class _GEPAOptimizer(BasePromptOptimizer):
                     "expectations": expectations,
                     "score": score,
                 }
-
-            def _metric(
-                self,
-                inputs: dict[str, Any],
-                outputs: dict[str, Any],
-                expectations: dict[str, Any],
-                scorers: list[Scorer],
-                objective: ObjectiveFn | None,
-            ) -> float:
-                scores = {}
-
-                for scorer in scorers:
-                    scores[scorer.name] = scorer.run(
-                        inputs=inputs, outputs=outputs, expectations=expectations
-                    )
-                if objective is not None:
-                    return objective(scores)
-                elif all(isinstance(score, (int, float, bool)) for score in scores.values()):
-                    # Use total score by default if no objective is provided
-                    return sum(scores.values())
-                else:
-                    non_numerical_scorers = [
-                        k for k, v in scores.items() if not isinstance(v, (int, float, bool))
-                    ]
-                    raise MlflowException(
-                        f"Scorer [{','.join(non_numerical_scorers)}] return a string, Assessment or"
-                        " a list of Assessment. Please provide `objective` function to aggregate "
-                        "non-numerical values into a single value for optimization."
-                    )
 
             def _call_llm(self, prompt: str) -> str:
                 try:

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -152,9 +152,13 @@ class PromptAdapterOutput:
         optimized_prompts: The optimized prompts as
             a dict (prompt template name -> prompt template).
             e.g., {"question": "What is the capital of {{country}}?"}
+        initial_eval_score: The evaluation score before optimization (optional).
+        final_eval_score: The evaluation score after optimization (optional).
     """
 
     optimized_prompts: dict[str, str]
+    initial_eval_score: float | None = None
+    final_eval_score: float | None = None
 
 
 @experimental(version="3.5.0")
@@ -166,7 +170,11 @@ class PromptAdaptationResult:
     Args:
         optimized_prompts: The optimized prompts.
         optimizer_name: The name of the optimizer.
+        initial_eval_score: The evaluation score before optimization (optional).
+        final_eval_score: The evaluation score after optimization (optional).
     """
 
     optimized_prompts: list[PromptVersion]
     optimizer_name: str
+    initial_eval_score: float | None = None
+    final_eval_score: float | None = None

--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -1,7 +1,10 @@
 import functools
-from typing import Any
+from typing import Any, Callable
 
 from pydantic import BaseModel, create_model
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.scorers import Scorer
 
 
 def infer_type_from_value(value: Any, model_name: str = "Output") -> type:
@@ -26,3 +29,53 @@ def infer_type_from_value(value: Any, model_name: str = "Output") -> type:
     elif isinstance(value, BaseModel):
         return type(value)
     return Any
+
+
+def create_metric_from_scorers(
+    scorers: list[Scorer],
+    objective: Callable[[dict[str, Any]], float] | None = None,
+) -> Callable[[dict[str, Any], dict[str, Any], dict[str, Any]], float]:
+    """
+    Create a metric function from scorers and an optional objective function.
+
+    Args:
+        scorers: List of scorers to evaluate inputs, outputs, and expectations.
+        objective: Optional function that aggregates scorer outputs into a single score.
+                  Takes a dict mapping scorer names to scores and returns a float.
+                  If None and all scorers return numerical values, sums them by default.
+
+    Returns:
+        A callable that takes (inputs, outputs, expectations) and returns a float score.
+
+    Raises:
+        MlflowException: If scorers return non-numerical values and no objective is provided.
+    """
+
+    def metric(
+        inputs: dict[str, Any],
+        outputs: dict[str, Any],
+        expectations: dict[str, Any],
+    ) -> float:
+        scores = {}
+
+        for scorer in scorers:
+            scores[scorer.name] = scorer.run(
+                inputs=inputs, outputs=outputs, expectations=expectations
+            )
+
+        if objective is not None:
+            return objective(scores)
+        elif all(isinstance(score, (int, float, bool)) for score in scores.values()):
+            # Use total score by default if no objective is provided
+            return sum(scores.values())
+        else:
+            non_numerical_scorers = [
+                k for k, v in scores.items() if not isinstance(v, (int, float, bool))
+            ]
+            raise MlflowException(
+                f"Scorer [{','.join(non_numerical_scorers)}] return a string, Assessment or "
+                "a list of Assessment. Please provide `objective` function to aggregate "
+                "non-numerical values into a single value for optimization."
+            )
+
+    return metric

--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -73,7 +73,7 @@ def create_metric_from_scorers(
                 k for k, v in scores.items() if not isinstance(v, (int, float, bool))
             ]
             raise MlflowException(
-                f"Scorer [{','.join(non_numerical_scorers)}] return a string, Assessment or "
+                f"Scorers [{','.join(non_numerical_scorers)}] return a string, Assessment or "
                 "a list of Assessment. Please provide `objective` function to aggregate "
                 "non-numerical values into a single value for optimization."
             )

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -196,8 +196,12 @@ class PromptAdaptationEvent(Event):
         except TypeError:
             result["prompt_count"] = None
 
-        # Track if custom scorers are provided
-        result["custom_scorers"] = arguments.get("scorers") is not None
+        # Track if custom scorers are provided and how many
+        scorers = arguments.get("scorers")
+        try:
+            result["scorer_count"] = len(scorers)
+        except TypeError:
+            result["scorer_count"] = None
 
         # Track if custom objective is provided
         result["custom_objective"] = arguments.get("objective") is not None

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -196,8 +196,11 @@ class PromptAdaptationEvent(Event):
         except TypeError:
             result["prompt_count"] = None
 
-        # Track if custom eval_metric is provided
-        result["custom_eval_metric"] = arguments.get("eval_metric") is not None
+        # Track if custom scorers are provided
+        result["custom_scorers"] = arguments.get("scorers") is not None
+
+        # Track if custom objective is provided
+        result["custom_objective"] = arguments.get("objective") is not None
 
         return result
 

--- a/tests/genai/optimize/adapters/test_gepa_adapter.py
+++ b/tests/genai/optimize/adapters/test_gepa_adapter.py
@@ -84,6 +84,7 @@ def test_gepa_adapter_optimize(sample_train_data, sample_target_prompts, mock_ev
         "system_prompt": "You are a highly skilled assistant.",
         "instruction": "Please answer this question carefully: {{question}}",
     }
+    mock_result.val_aggregate_scores = [0.5, 0.6, 0.8, 0.9]  # Mock scores for testing
     mock_gepa_module.optimize.return_value = mock_result
     mock_gepa_module.EvaluationBatch = MagicMock()
     adapter = GepaPromptAdapter(max_metric_calls=50, display_progress_bar=True)
@@ -101,6 +102,9 @@ def test_gepa_adapter_optimize(sample_train_data, sample_target_prompts, mock_ev
     assert result.optimized_prompts == mock_result.best_candidate
     assert "system_prompt" in result.optimized_prompts
     assert "instruction" in result.optimized_prompts
+    # Verify scores are extracted
+    assert result.initial_eval_score == 0.5  # First score
+    assert result.final_eval_score == 0.9  # Max score
 
     # Verify GEPA was called with correct parameters
     mock_gepa_module.optimize.assert_called_once()
@@ -125,6 +129,7 @@ def test_gepa_adapter_optimize_with_reflection_lm(
     }
     mock_result = Mock()
     mock_result.best_candidate = sample_target_prompts
+    mock_result.val_aggregate_scores = []
     mock_gepa_module.optimize.return_value = mock_result
     mock_gepa_module.EvaluationBatch = MagicMock()
 
@@ -153,6 +158,7 @@ def test_gepa_adapter_optimize_model_name_parsing(
     }
     mock_result = Mock()
     mock_result.best_candidate = sample_target_prompts
+    mock_result.val_aggregate_scores = []
     mock_gepa_module.optimize.return_value = mock_result
     mock_gepa_module.EvaluationBatch = MagicMock()
 
@@ -200,6 +206,7 @@ def test_gepa_adapter_single_record_dataset(sample_target_prompts, mock_eval_fn)
     }
     mock_result = Mock()
     mock_result.best_candidate = sample_target_prompts
+    mock_result.val_aggregate_scores = []
     mock_gepa_module.optimize.return_value = mock_result
     mock_gepa_module.EvaluationBatch = MagicMock()
 
@@ -228,6 +235,7 @@ def test_gepa_adapter_custom_adapter_evaluate(
     }
     mock_result = Mock()
     mock_result.best_candidate = sample_target_prompts
+    mock_result.val_aggregate_scores = []
     mock_gepa_module.optimize.return_value = mock_result
     mock_gepa_module.EvaluationBatch = MagicMock()
 

--- a/tests/genai/optimize/optimizers/test_dspy_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_dspy_optimizer.py
@@ -169,7 +169,7 @@ def test_convert_to_dspy_metric_raises_on_non_numeric_score():
 
     with pytest.raises(
         MlflowException,
-        match=r"Scorer \[non_numeric_scorer\] return a string, Assessment or a list of Assessment.",
+        match=r"Scorers \[non_numeric_scorer \(type: str\)\] return non-numerical values",
     ):
         metric(
             dspy.Example(input_text="Hello", language="Spanish"),

--- a/tests/genai/optimize/test_adapt.py
+++ b/tests/genai/optimize/test_adapt.py
@@ -101,7 +101,7 @@ def test_adapt_prompts_single_prompt(sample_translation_prompt, sample_dataset):
         target_prompt_uris=[
             f"prompts:/{sample_translation_prompt.name}/{sample_translation_prompt.version}"
         ],
-        optimizer_lm_params=LLMParams(model_name="test/model"),
+        optimizer_lm_params=LLMParams(model_name="openai:/gpt-4o-mini"),
         optimizer=mock_adapter,
     )
 
@@ -126,7 +126,7 @@ def test_adapt_prompts_multiple_prompts(
             f"prompts:/{sample_translation_prompt.name}/{sample_translation_prompt.version}",
             f"prompts:/{sample_summarization_prompt.name}/{sample_summarization_prompt.version}",
         ],
-        optimizer_lm_params=LLMParams(model_name="test/model"),
+        optimizer_lm_params=LLMParams(model_name="openai:/gpt-4o-mini"),
         optimizer=mock_adapter,
     )
 
@@ -188,7 +188,7 @@ def test_adapt_prompts_eval_function_behavior(sample_translation_prompt, sample_
         target_prompt_uris=[
             f"prompts:/{sample_translation_prompt.name}/{sample_translation_prompt.version}"
         ],
-        optimizer_lm_params=LLMParams(model_name="test/model"),
+        optimizer_lm_params=LLMParams(model_name="openai:/gpt-4o-mini"),
         optimizer=testing_adapter,
     )
 
@@ -210,7 +210,7 @@ def test_adapt_prompts_with_list_dataset(sample_translation_prompt, sample_summa
         target_prompt_uris=[
             f"prompts:/{sample_translation_prompt.name}/{sample_translation_prompt.version}"
         ],
-        optimizer_lm_params=LLMParams(model_name="test/model"),
+        optimizer_lm_params=LLMParams(model_name="openai:/gpt-4o-mini"),
         optimizer=mock_adapter,
     )
 
@@ -267,7 +267,9 @@ def test_adapt_prompts_llm_params_passed(sample_translation_prompt, sample_datas
     ],
 )
 def test_compute_score_exact_match(program_outputs, expected_outputs, expected_score):
-    assert _compute_score(program_outputs, expected_outputs, "test/model") == expected_score
+    assert (
+        _compute_score(program_outputs, expected_outputs, "openai:/gpt-4o-mini") == expected_score
+    )
 
 
 def test_compute_score_llm_judge_semantic_matching():
@@ -287,7 +289,8 @@ def test_compute_score_llm_judge_semantic_matching():
 
         # Verify judge called with string representations
         mock_judge.assert_called_once_with(
-            outputs="The capital of France is Paris", expectations={"expected_output": "Paris"}
+            outputs={"outputs": "The capital of France is Paris"},
+            expectations={"outputs": "Paris"},
         )
         assert score == 1.0
 
@@ -296,13 +299,14 @@ def test_compute_score_llm_judge_semantic_matching():
     with patch("mlflow.genai.judges.make_judge") as mock_make_judge:
         mock_judge = Mock(return_value=mock_result)
         mock_make_judge.return_value = mock_judge
-        assert _compute_score("output", "different", "test/model") == 0.0
+        assert _compute_score("output", "different", "openai:/gpt-4o-mini") == 0.0
 
 
 def test_compute_score_error_handling():
     with patch("mlflow.genai.judges.make_judge") as mock_make_judge:
-        mock_make_judge.side_effect = Exception("API Error")
-        assert _compute_score("output", "expected", "test/model") == 0.0
+        mock_judge = Mock(side_effect=Exception("API Error"))
+        mock_make_judge.return_value = mock_judge
+        assert _compute_score("output", "expected", "openai:/gpt-4o-mini") == 0.0
 
 
 def test_adapt_prompts_with_custom_eval_metric(sample_translation_prompt, sample_dataset):
@@ -343,7 +347,7 @@ def test_adapt_prompts_with_custom_eval_metric(sample_translation_prompt, sample
         target_prompt_uris=[
             f"prompts:/{sample_translation_prompt.name}/{sample_translation_prompt.version}"
         ],
-        optimizer_lm_params=LLMParams(model_name="test/model"),
+        optimizer_lm_params=LLMParams(model_name="openai:/gpt-4o-mini"),
         optimizer=testing_adapter,
         eval_metric=custom_metric,
     )

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -3,7 +3,10 @@ from typing import Any, Union
 import pytest
 from pydantic import BaseModel
 
-from mlflow.genai.optimize.util import infer_type_from_value
+from mlflow.entities.assessment import Feedback
+from mlflow.genai.judges import CategoricalRating
+from mlflow.genai.optimize.util import create_metric_from_scorers, infer_type_from_value
+from mlflow.genai.scorers import scorer
 
 
 @pytest.mark.parametrize(
@@ -121,3 +124,37 @@ def test_infer_unsupported_type(type_to_infer):
 def test_model_name_parameter(input_dict, model_name):
     result = infer_type_from_value(input_dict, model_name=model_name)
     assert result.__name__ == model_name
+
+
+@pytest.mark.parametrize(
+    ("categorical_value", "expected_score"),
+    [
+        (CategoricalRating.YES, 1.0),
+        (CategoricalRating.NO, 0.0),
+    ],
+)
+def test_create_metric_from_scorers_with_categorical_rating(categorical_value, expected_score):
+    @scorer(name="test_scorer")
+    def test_scorer(inputs, outputs):
+        return Feedback(name="test_scorer", value=categorical_value)
+
+    metric = create_metric_from_scorers([test_scorer])
+
+    result = metric({"input": "test"}, {"output": "result"}, {})
+    assert result == expected_score
+
+
+def test_create_metric_from_scorers_with_multiple_categorical_ratings():
+    @scorer(name="scorer1")
+    def scorer1(inputs, outputs):
+        return Feedback(name="scorer1", value=CategoricalRating.YES)
+
+    @scorer(name="scorer2")
+    def scorer2(inputs, outputs):
+        return Feedback(name="scorer2", value=CategoricalRating.YES)
+
+    metric = create_metric_from_scorers([scorer1, scorer2])
+
+    # Should sum: 1.0 + 1.0 = 2.0
+    result = metric({"input": "test"}, {"output": "result"}, {})
+    assert result == 2.0

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from mlflow.prompt.constants import IS_PROMPT_TAG_KEY
@@ -146,23 +148,60 @@ def test_align_judge_parse_params(arguments, expected_params):
             {
                 "optimizer": type("MockOptimizer", (), {})(),
                 "target_prompt_uris": ["prompts:/test/1"],
-                "eval_metric": None,
+                "scorers": None,
+                "objective": None,
             },
-            {"optimizer_type": "MockOptimizer", "prompt_count": 1, "custom_eval_metric": False},
+            {
+                "optimizer_type": "MockOptimizer",
+                "prompt_count": 1,
+                "custom_scorers": False,
+                "custom_objective": False,
+            },
         ),
-        # Multiple prompt URIs
+        # Multiple prompt URIs with custom scorers
         (
             {
                 "optimizer": type("CustomAdapter", (), {})(),
                 "target_prompt_uris": ["prompts:/test/1", "prompts:/test/2"],
-                "eval_metric": lambda x, y: 1.0,
+                "scorers": [Mock()],
+                "objective": None,
             },
-            {"optimizer_type": "CustomAdapter", "prompt_count": 2, "custom_eval_metric": True},
+            {
+                "optimizer_type": "CustomAdapter",
+                "prompt_count": 2,
+                "custom_scorers": True,
+                "custom_objective": False,
+            },
+        ),
+        # Custom objective
+        (
+            {
+                "optimizer": type("TestAdapter", (), {})(),
+                "target_prompt_uris": ["prompts:/test/1"],
+                "scorers": [Mock()],
+                "objective": lambda scores: sum(scores.values()),
+            },
+            {
+                "optimizer_type": "TestAdapter",
+                "prompt_count": 1,
+                "custom_scorers": True,
+                "custom_objective": True,
+            },
         ),
         # No optimizer provided - optimizer_type should be None
         (
-            {"optimizer": None, "target_prompt_uris": ["prompts:/test/1"], "eval_metric": None},
-            {"optimizer_type": None, "prompt_count": 1, "custom_eval_metric": False},
+            {
+                "optimizer": None,
+                "target_prompt_uris": ["prompts:/test/1"],
+                "scorers": None,
+                "objective": None,
+            },
+            {
+                "optimizer_type": None,
+                "prompt_count": 1,
+                "custom_scorers": False,
+                "custom_objective": False,
+            },
         ),
     ],
 )

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -154,7 +154,7 @@ def test_align_judge_parse_params(arguments, expected_params):
             {
                 "optimizer_type": "MockOptimizer",
                 "prompt_count": 1,
-                "custom_scorers": False,
+                "scorer_count": None,
                 "custom_objective": False,
             },
         ),
@@ -169,22 +169,22 @@ def test_align_judge_parse_params(arguments, expected_params):
             {
                 "optimizer_type": "CustomAdapter",
                 "prompt_count": 2,
-                "custom_scorers": True,
+                "scorer_count": 1,
                 "custom_objective": False,
             },
         ),
-        # Custom objective
+        # Custom objective with multiple scorers
         (
             {
                 "optimizer": type("TestAdapter", (), {})(),
                 "target_prompt_uris": ["prompts:/test/1"],
-                "scorers": [Mock()],
+                "scorers": [Mock(), Mock(), Mock()],
                 "objective": lambda scores: sum(scores.values()),
             },
             {
                 "optimizer_type": "TestAdapter",
                 "prompt_count": 1,
-                "custom_scorers": True,
+                "scorer_count": 3,
                 "custom_objective": True,
             },
         ),
@@ -199,7 +199,7 @@ def test_align_judge_parse_params(arguments, expected_params):
             {
                 "optimizer_type": None,
                 "prompt_count": 1,
-                "custom_scorers": False,
+                "scorer_count": None,
                 "custom_objective": False,
             },
         ),

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -411,7 +411,12 @@ def test_prompt_adaptation(mock_requests, mock_telemetry_client: TelemetryClient
         mock_telemetry_client,
         mock_requests,
         PromptAdaptationEvent.name,
-        {"optimizer_type": "MockAdapter", "prompt_count": 1, "custom_eval_metric": False},
+        {
+            "optimizer_type": "MockAdapter",
+            "prompt_count": 1,
+            "custom_scorers": False,
+            "custom_objective": False,
+        },
     )
 
 

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -415,6 +415,7 @@ def test_prompt_adaptation(mock_requests, mock_telemetry_client: TelemetryClient
             "optimizer_type": "MockAdapter",
             "prompt_count": 1,
             "custom_scorers": False,
+            "scorer_count": None,
             "custom_objective": False,
         },
     )

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -414,7 +414,6 @@ def test_prompt_adaptation(mock_requests, mock_telemetry_client: TelemetryClient
         {
             "optimizer_type": "MockAdapter",
             "prompt_count": 1,
-            "custom_scorers": False,
             "scorer_count": None,
             "custom_objective": False,
         },


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18140?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18140/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18140/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18140/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Handle LLM judge in the default metric. Also support custom scorers in adapt_prompts

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
