### PR TITLE
Option to disable none parameters in mlflow.xgboost.autolog

### DIFF
--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -509,6 +509,7 @@ def autolog(
             The registered model is created if it does not already exist.
         model_format: File format in which the model is to be saved.
         extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+        exclude_none_params: If ``True``, parameters with value ``None`` are excluded from
     """
     import numpy as np
     import xgboost

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -459,6 +459,7 @@ def autolog(
     registered_model_name=None,
     model_format="xgb",
     extra_tags=None,
+    exclude_none_params=False,
 ):
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
@@ -660,7 +661,12 @@ def autolog(
         autologging_client = MlflowAutologgingQueueingClient()
         # logging booster params separately to extract key/value pairs and make it easier to
         # compare them across runs.
-        booster_params = args[0] if len(args) > 0 else kwargs["params"]
+        booster_params_raw = args[0] if args else kwargs["params"]
+        booster_params = (
+            {k: v for k, v in booster_params_raw.items() if v is not None}
+            if exclude_none_params
+            else booster_params_raw
+        )
         autologging_client.log_params(run_id=mlflow.active_run().info.run_id, params=booster_params)
 
         unlogged_params = [
@@ -674,8 +680,13 @@ def autolog(
             "callbacks",
             "learning_rates",
         ]
-        params_to_log_for_fn = get_mlflow_run_params_for_fn_args(
+        params_to_log_for_fn_raw = get_mlflow_run_params_for_fn_args(
             original, args, kwargs, unlogged_params
+        )
+        params_to_log_for_fn = (
+            {k: v for k, v in params_to_log_for_fn_raw.items() if v is not None}
+            if exclude_none_params
+            else params_to_log_for_fn_raw
         )
         autologging_client.log_params(
             run_id=mlflow.active_run().info.run_id, params=params_to_log_for_fn


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Shubham1193/mlflow/pull/18149?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18149/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18149/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18149/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #18060 
### What changes are proposed in this pull request?


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [✓] Manual tests


<img width="817" height="505" alt="image" src="https://github.com/user-attachments/assets/92a2c59a-65b8-4c29-9727-1fee4b35fcd4" />

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [✓] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.


#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [✓] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [✓] Yes (this PR will be cherry-picked and included in the next patch release)
- [] No (this PR will be included in the next minor release)
