### PR TITLE
Add log_none_params to xgboost autologging

### DIFF
--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -684,9 +684,7 @@ def autolog(
             original, args, kwargs, unlogged_params
         )
         if not log_none_parameters:
-            params_to_log_for_fn = {
-                k: v for k, v in params_to_log_for_fn.items() if v is not None
-            }
+            params_to_log_for_fn = {k: v for k, v in params_to_log_for_fn.items() if v is not None}
         autologging_client.log_params(
             run_id=mlflow.active_run().info.run_id, params=params_to_log_for_fn
         )

--- a/mlflow/xgboost/__init__.py
+++ b/mlflow/xgboost/__init__.py
@@ -459,6 +459,7 @@ def autolog(
     registered_model_name=None,
     model_format="xgb",
     extra_tags=None,
+    log_none_parameters=True,
 ):
     """
     Enables (or disables) and configures autologging from XGBoost to MLflow. Logs the following:
@@ -508,6 +509,7 @@ def autolog(
             The registered model is created if it does not already exist.
         model_format: File format in which the model is to be saved.
         extra_tags: A dictionary of extra tags to set on each managed run created by autologging.
+        log_none_parameters: If ``False``, parameters with value ``None`` are not logged.
     """
     import numpy as np
     import xgboost
@@ -661,6 +663,10 @@ def autolog(
         # logging booster params separately to extract key/value pairs and make it easier to
         # compare them across runs.
         booster_params = args[0] if len(args) > 0 else kwargs["params"]
+        # Filter out None parameters if log_none_parameters is False
+        if not log_none_parameters:
+            booster_params = {k: v for k, v in booster_params.items() if v is not None}
+
         autologging_client.log_params(run_id=mlflow.active_run().info.run_id, params=booster_params)
 
         unlogged_params = [
@@ -677,6 +683,10 @@ def autolog(
         params_to_log_for_fn = get_mlflow_run_params_for_fn_args(
             original, args, kwargs, unlogged_params
         )
+        if not log_none_parameters:
+            params_to_log_for_fn = {
+                k: v for k, v in params_to_log_for_fn.items() if v is not None
+            }
         autologging_client.log_params(
             run_id=mlflow.active_run().info.run_id, params=params_to_log_for_fn
         )

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -792,6 +792,7 @@ def test_xgb_log_datasets_with_evals(bst_params, dtrain):
         }
     )
 
+
 def test_xgb_autolog_filter_none_parameters(bst_params, dtrain):
     mlflow.xgboost.autolog(log_none_parameters=True)
     xgb.train(bst_params, dtrain)

--- a/tests/xgboost/test_xgboost_autolog.py
+++ b/tests/xgboost/test_xgboost_autolog.py
@@ -19,7 +19,10 @@ from mlflow import MlflowClient
 from mlflow.models import Model
 from mlflow.models.utils import _read_example
 from mlflow.types.utils import _infer_schema
-from mlflow.utils.autologging_utils import BatchMetricsLogger, picklable_exception_safe_function
+from mlflow.utils.autologging_utils import (
+    BatchMetricsLogger,
+    picklable_exception_safe_function,
+)
 from mlflow.xgboost._autolog import IS_TRAINING_CALLBACK_SUPPORTED, autolog_callback
 
 mpl.use("Agg")
@@ -788,3 +791,32 @@ def test_xgb_log_datasets_with_evals(bst_params, dtrain):
             }
         }
     )
+
+def test_xgb_autolog_filter_none_parameters(bst_params, dtrain):
+    mlflow.xgboost.autolog(log_none_parameters=True)
+    xgb.train(bst_params, dtrain)
+    run1 = get_latest_run()
+    params1 = run1.data.params
+    none_count1 = sum(1 for v in params1.values() if v == "None")
+    mlflow.xgboost.autolog(log_none_parameters=False)
+    xgb.train(bst_params, dtrain)
+    run2 = get_latest_run()
+    params2 = run2.data.params
+    none_count2 = sum(1 for v in params2.values() if v == "None")
+    assert none_count1 > 0, "Default should log None parameters"
+    assert none_count2 == 0, f"Filtered run has {none_count2} None parameters"
+    assert len(params2) < len(params1), "Filtered run should have fewer parameters"
+
+
+def test_xgb_autolog_default_logs_none_params(bst_params, dtrain):
+    """Test backward compatibility: default behavior logs None parameters"""
+
+    mlflow.xgboost.autolog()
+    xgb.train(bst_params, dtrain)
+
+    run = get_latest_run()
+    params = run.data.params
+    none_count = sum(1 for v in params.values() if v == "None")
+
+    assert none_count > 0, "Default behavior should log None parameters"
+    assert len(params) > 5, "Default should log many parameters"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/NJAHNAVI2907/mlflow/pull/18152?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18152/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18152/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18152/merge
```

</p>
</details>

#18060

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
#18060

### What changes are proposed in this pull request?

This PR adds a `log_none_parameters` parameter to `mlflow.xgboost.autolog()` that allows users to filter out parameters with `None` values from being logged. When set to `False`, only parameters with actual values are logged, reducing clutter in the MLflow UI and making it easier to identify meaningful hyperparameters. The parameter defaults to `True` to maintain full backward compatibility with existing code.


### How is this PR tested?

- [X] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<img width="1518" height="988" alt="Screenshot 2025-10-07 at 12 54 45 AM" src="https://github.com/user-attachments/assets/982f9568-4f29-4a0f-8945-5cfb38236360" />

<img width="1176" height="380" alt="image" src="https://github.com/user-attachments/assets/b2dceac3-0e53-4973-9e95-779204ace6f3" />



### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [X] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
