### PR TITLE
Improve error message for search_traces

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -36,6 +36,7 @@ from mlflow.tracking._tracking_service.utils import _get_store, _resolve_trackin
 from mlflow.utils import is_uuid
 from mlflow.utils.mlflow_tags import IMMUTABLE_TAGS
 from mlflow.utils.uri import add_databricks_profile_info_to_artifact_uri, is_databricks_uri
+from mlflow.utils.validation import _validate_list_param
 
 _logger = logging.getLogger(__name__)
 
@@ -223,6 +224,8 @@ class TracingClient:
             some store implementations may not support pagination and thus the returned token would
             not be meaningful in such cases.
         """
+        _validate_list_param("experiment_ids", experiment_ids, allow_none=False)
+
         if model_id is not None:
             if filter_string:
                 raise MlflowException(

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -42,6 +42,7 @@ from mlflow.tracing.utils import (
 from mlflow.tracing.utils.search import extract_span_inputs_outputs, traces_to_df
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import deprecated_parameter
+from mlflow.utils.validation import _validate_list_param
 
 _logger = logging.getLogger(__name__)
 
@@ -810,6 +811,8 @@ def search_traces(
                     " the `return_type='pandas'` option, or set `return_type='list'`."
                 ),
             )
+
+    _validate_list_param("experiment_ids", experiment_ids, allow_none=True)
 
     if not experiment_ids:
         if experiment_id := _get_experiment_id():

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -8,6 +8,7 @@ import numbers
 import posixpath
 import re
 import urllib.parse
+from typing import Any
 
 from mlflow.entities import Dataset, DatasetInput, InputTag, Param, RunTag
 from mlflow.entities.model_registry.prompt_version import PROMPT_TEXT_TAG_KEY
@@ -477,7 +478,7 @@ def _validate_experiment_id_type(experiment_id):
         )
 
 
-def _validate_list_param(param_name, param_value, allow_none=False):
+def _validate_list_param(param_name: str, param_value: Any, allow_none: bool = False) -> None:
     """
     Validate that a parameter is a list and raise a helpful error if it isn't.
 

--- a/mlflow/utils/validation.py
+++ b/mlflow/utils/validation.py
@@ -477,6 +477,28 @@ def _validate_experiment_id_type(experiment_id):
         )
 
 
+def _validate_list_param(param_name, param_value, allow_none=False):
+    """
+    Validate that a parameter is a list and raise a helpful error if it isn't.
+
+    Args:
+        param_name: Name of the parameter being validated (e.g., "experiment_ids")
+        param_value: The value to validate
+        allow_none: If True, None is allowed. If False, None is treated as invalid.
+
+    Raises:
+        MlflowException: If the parameter is not a list (and not None when allow_none=True)
+    """
+    if allow_none and param_value is None:
+        return
+
+    if not isinstance(param_value, list):
+        raise MlflowException.invalid_parameter_value(
+            f"{param_name} must be a list, got {type(param_value).__name__}. "
+            f"Did you mean to use {param_name}=[{param_value!r}]?"
+        )
+
+
 def _validate_model_name(model_name):
     if model_name is None or model_name == "":
         raise MlflowException(missing_value("name"), error_code=INVALID_PARAMETER_VALUE)

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -936,6 +936,14 @@ def test_search_traces_invalid_return_types(mock_client):
         mlflow.search_traces(extract_fields=["foo.inputs.bar"], return_type="list")
 
 
+def test_search_traces_validates_experiment_ids_type():
+    with pytest.raises(MlflowException, match=r"experiment_ids must be a list"):
+        mlflow.search_traces(experiment_ids=4)
+
+    with pytest.raises(MlflowException, match=r"experiment_ids must be a list"):
+        mlflow.search_traces(experiment_ids="4")
+
+
 def test_search_traces_with_pagination(mock_client):
     traces = [
         Trace(

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -373,6 +373,14 @@ def test_client_search_traces_trace_data_download_error(mock_store, include_span
             mock_get_artifact_repository.assert_not_called()
 
 
+def test_client_search_traces_validates_experiment_ids_type():
+    with pytest.raises(MlflowException, match=r"experiment_ids must be a list"):
+        MlflowClient().search_traces(experiment_ids=4)
+
+    with pytest.raises(MlflowException, match=r"experiment_ids must be a list"):
+        MlflowClient().search_traces(experiment_ids="4")
+
+
 def test_client_delete_traces(mock_store):
     MlflowClient().delete_traces(
         experiment_id="0",

--- a/tests/utils/test_validation.py
+++ b/tests/utils/test_validation.py
@@ -379,10 +379,16 @@ def test_setting_experiment_artifact_location_env_var_works(monkeypatch):
     _validate_experiment_artifact_location_length(artifact_location)
 
 
-def test_validate_list_param_with_valid_list():
-    _validate_list_param("experiment_ids", ["1", "2", "3"])
-    _validate_list_param("test_param", [])
-    _validate_list_param("test_param", [1, 2, 3])
+@pytest.mark.parametrize(
+    "param_value",
+    [
+        ["1", "2", "3"],
+        [],
+        [1, 2, 3],
+    ],
+)
+def test_validate_list_param_with_valid_list(param_value):
+    _validate_list_param("experiment_ids", param_value)
 
 
 def test_validate_list_param_with_none_not_allowed():
@@ -394,23 +400,18 @@ def test_validate_list_param_with_none_allowed():
     _validate_list_param("experiment_ids", None, allow_none=True)
 
 
-def test_validate_list_param_with_int():
+@pytest.mark.parametrize(
+    ("param_name", "param_value", "expected_type"),
+    [
+        ("experiment_ids", 4, "int"),
+        ("param_name", "value", "str"),
+        ("my_param", {"key": "value"}, "dict"),
+    ],
+)
+def test_validate_list_param_with_invalid_type(param_name, param_value, expected_type):
     with pytest.raises(
-        MlflowException, match=r"experiment_ids must be a list, got int"
+        MlflowException, match=rf"{param_name} must be a list, got {expected_type}"
     ) as exc_info:
-        _validate_list_param("experiment_ids", 4)
-    assert "Did you mean to use experiment_ids=[4]?" in str(exc_info.value)
+        _validate_list_param(param_name, param_value)
+    assert f"Did you mean to use {param_name}=[{param_value!r}]?" in str(exc_info.value)
     assert exc_info.value.error_code == "INVALID_PARAMETER_VALUE"
-
-
-def test_validate_list_param_with_string():
-    with pytest.raises(MlflowException, match=r"param_name must be a list, got str") as exc_info:
-        _validate_list_param("param_name", "value")
-    assert "Did you mean to use param_name=['value']?" in str(exc_info.value)
-    assert exc_info.value.error_code == "INVALID_PARAMETER_VALUE"
-
-
-def test_validate_list_param_with_dict():
-    with pytest.raises(MlflowException, match=r"my_param must be a list, got dict") as exc_info:
-        _validate_list_param("my_param", {"key": "value"})
-    assert "Did you mean to use my_param=[{'key': 'value'}]?" in str(exc_info.value)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18153?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18153/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18153/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18153/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Make the error message much more clear to users who use search_traces and pass in the wrong data structure for experiment_ids

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
