### PR TITLE
Fix Otel dual export

### DIFF
--- a/tests/tracing/utils/test_otlp.py
+++ b/tests/tracing/utils/test_otlp.py
@@ -152,7 +152,11 @@ def test_export_to_otel_collector(otel_collector, monkeypatch):
         # Check if spans are in the logs - the debug exporter outputs span details
         # The BatchSpanProcessor may send spans in multiple batches, so we check for any evidence
         # that the collector is receiving spans from our test
-        if "predict" in collector_logs:
+        if (
+            "predict" in collector_logs
+            and "add_one_with_custom_name" in collector_logs
+            and "square" in collector_logs
+        ):
             # We found evidence that spans are being exported to the collector
             # The child spans may come in separate batches, but OTLP export works
             spans_found = True


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18163?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18163/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18163/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18163/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Fix regression on Otel export introduced in https://github.com/mlflow/mlflow/pull/17187

The above PR accidentally moved the following line into inside if-branch that is only applied to a root span
```
span.set_attribute(SpanAttributeKey.REQUEST_ID, json.dumps(trace_info.trace_id))
```

This results in a key error when processing non-root spans

```
2025/10/01 22:40:43 DEBUG mlflow.tracing.utils: Failed to get attribute mlflow.traceRequestId with from span _Span(name="child", context=SpanContext(trace_id=0xa9970d329f54b1fc14946f418c0b0dbb, span_id=0xe169a3eb826aef50, trace_flags=0x01, trace_state=[], is_remote=False)).
Traceback (most recent call last):
  File "/local_disk0/.ephemeral_nfs/envs/pythonEnv-0e9c05ec-4f92-4cb0-a748-15a8e06adcb0/lib/python3.12/site-packages/mlflow/tracing/utils/__init__.py", line 265, in get_otel_attribute
    return json.loads(span.attributes.get(key))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/json/__init__.py", line 339, in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
TypeError: the JSON object must be str, bytes or bytearray, not NoneType
2025/10/01 22:40:43 DEBUG mlflow.tracing.fluent: Failed to start span child.
Traceback (most recent call last):
  File "/databricks/python/lib/python3.12/site-packages/cachetools/__init__.py", line 68, in __getitem__
    return self.__data[key]
           ~~~~~~~~~~~^^^^^
KeyError: None
```

The CI unfortunately did not capture this because the test case only validates if a root span is exported or not. 

This PR fixes the issue and adding test coverage.


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Tested with Databricks OTLP endpoint:

```python
import mlflow
from databricks.sdk import WorkspaceClient
import os
import logging

os.environ["OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"] = TRACES_ENDPOINT
os.environ["OTEL_EXPORTER_OTLP_TRACES_PROTOCOL"] = "http/protobuf"

# Set auth and table name headers
w = WorkspaceClient()
HEADERS = {"X-Databricks-UC-Table-Name": TRACES_TABLE_NAME, **w.config.authenticate()}
os.environ["OTEL_EXPORTER_OTLP_TRACES_HEADERS"] = ','.join([f'{k}={v}' for k, v in HEADERS.items()])
os.environ["OTEL_SERVICE_NAME"] = "databricks-otel-collector"

import mlflow

with mlflow.start_span(name="parent") as span:
    span.set_inputs({"a": 1})
    span.set_outputs({"b": 2})

    with mlflow.start_span(name="child") as child_span:
        span.set_inputs({"child_a": 1})
        span.set_outputs({"child_b": 2})

with mlflow.start_span(name="parent2") as span:
    span.set_inputs({"a2": 1})
    span.set_outputs({"b2": 2})
```

<img width="1035" height="288" alt="Screenshot 2025-10-07 at 17 22 17" src="https://github.com/user-attachments/assets/088d6bbd-9e7a-4d06-9bc9-bf3bee61ba82" />

Dual write also works as expected:

```
os.environ["MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT"] = "true"

mlflow.set_tracking_uri("databricks")
mlflow.set_experiment(experiment_id="...")
```

<img width="1051" height="120" alt="Screenshot 2025-10-07 at 17 25 47" src="https://github.com/user-attachments/assets/c9858e2c-70d4-4d49-9edf-759f7dbc62dc" />

<img width="1328" height="282" alt="Screenshot 2025-10-07 at 17 27 14" src="https://github.com/user-attachments/assets/dece302f-4e81-4e5e-9b65-5189c423790c" />



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix a regression introduced by 3.4.0 for OTLP export.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
