### PR TITLE
Dump `sql_warehouse_id` into trace UI mimebundle

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -11,6 +11,7 @@ from mlflow.entities.span import Span, SpanType
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.entities.trace_info_v2 import TraceInfoV2
+from mlflow.environment_variables import MLFLOW_TRACING_SQL_WAREHOUSE_ID
 from mlflow.exceptions import MlflowException
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
 from mlflow.protos.service_pb2 import Trace as ProtoTrace
@@ -76,10 +77,17 @@ class Trace(_MlflowObject):
         return cls.from_dict(trace_dict)
 
     def _serialize_for_mimebundle(self):
-        # databricks notebooks will use the request ID to
+        # databricks notebooks will use the trace ID to
         # fetch the trace from the backend. including the
         # full JSON can cause notebooks to exceed size limits
-        return json.dumps(self.info.request_id)
+        return json.dumps(
+            {
+                "trace_id": self.info.request_id,
+                # TODO: remove this once sql_warehouse_id
+                # is optional in the v4 tracing APIs
+                "sql_warehouse_id": MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),
+            }
+        )
 
     def _repr_mimebundle_(self, include=None, exclude=None):
         """

--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -82,7 +82,7 @@ class Trace(_MlflowObject):
         # full JSON can cause notebooks to exceed size limits
         return json.dumps(
             {
-                "trace_id": self.info.request_id,
+                "trace_id": self.info.trace_id,
                 # TODO: remove this once sql_warehouse_id
                 # is optional in the v4 tracing APIs
                 "sql_warehouse_id": MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/18165?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18165/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18165/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18165/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The Trace v4 APIs require `sql_warehouse_id` for fetching the trace data, so we need to include this in the serialized data. We investigated a few alternative options:

1. Doing nothing and just waiting until `sql_warehouse_id` is optional (rejected as notebook display is still important for users)
2. Rendering a selector in the UI (rejected due to bad UX)
3. This option (dumping `sql_warehouse_id` into the mimebundle)
4. Dumping full trace data into the notebook as we used to to (rejected because notebooks still have a default limit of 10mb)

Long term we'll still go with #1, but as a stopgap solution until `sql_warehouse_id` is resolvable in the backend, we felt like this is the least bad option.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
