### PR TITLE
Migrate evaluate workflow to use `uv` for dependency and test management

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -277,7 +277,7 @@ jobs:
           uv sync --extra extras --extra jobs --extra genai
           uv pip install \
             -r requirements/test-requirements.txt \
-            pyspark torch transformers langchain langchain-experimental '.[genai]' 'shap<0.47.0' lightgbm xgboost
+            torch transformers langchain langchain-experimental 'shap<0.47.0' lightgbm xgboost
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -277,7 +277,7 @@ jobs:
           uv sync --extra extras --extra jobs --extra genai
           uv pip install \
             -r requirements/test-requirements.txt \
-            torch transformers 'pyspark<4' langchain langchain-experimental 'shap<0.47.0' lightgbm xgboost
+            torch transformers 'pyspark<3.5.6' langchain langchain-experimental 'shap<0.47.0' lightgbm xgboost
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -274,16 +274,18 @@ jobs:
       - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
-          source ./dev/install-common-deps.sh
-          pip install pyspark torch transformers langchain langchain-experimental '.[genai]' 'shap<0.47.0' lightgbm xgboost
+          uv sync --extra extras --extra jobs --extra genai
+          uv pip install \
+            -r requirements/test-requirements.txt \
+            pyspark torch transformers langchain langchain-experimental '.[genai]' 'shap<0.47.0' lightgbm xgboost
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests
         run: |
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/evaluate --ignore=tests/evaluate/test_default_evaluator_delta.py
+          uv run pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} tests/evaluate --ignore=tests/evaluate/test_default_evaluator_delta.py
       - name: Run tests with delta
         run: |
-          pytest tests/evaluate/test_default_evaluator_delta.py
+          uv run pytest tests/evaluate/test_default_evaluator_delta.py
 
   genai:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -277,7 +277,7 @@ jobs:
           uv sync --extra extras --extra jobs --extra genai
           uv pip install \
             -r requirements/test-requirements.txt \
-            torch transformers langchain langchain-experimental 'shap<0.47.0' lightgbm xgboost
+            torch transformers 'pyspark<4' langchain langchain-experimental 'shap<0.47.0' lightgbm xgboost
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,6 +195,9 @@ build = ["pip", "setuptools", "wheel", "build"]
 [tool.uv]
 required-version = "==0.8.18"
 
+[tool.uv.pip]
+torch-backend = "cpu"
+
 [tool.uv.workspace]
 members = ["dev/clint", "tests/resources/mlflow-test-plugin"]
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18175?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18175/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18175/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18175/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Migrated the `evaluate` workflow in `.github/workflows/master.yml` to use `uv` for faster and more reliable dependency management and test execution.

**Changes:**
- Replaced `source ./dev/install-common-deps.sh` + `pip install` with `uv sync` and `uv pip install`
- Replaced `pytest` commands with `uv run pytest`

🤖 Generated with Claude Code

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)