### PR TITLE
Fix missing metadata in ts sdk trace

### DIFF
--- a/.github/workflows/typescript.yml
+++ b/.github/workflows/typescript.yml
@@ -7,9 +7,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-    paths:
-      - libs/typescript/**
-      - .github/workflows/typescript.yml
   push:
     branches:
       - master

--- a/libs/typescript/core/src/core/constants.ts
+++ b/libs/typescript/core/src/core/constants.ts
@@ -40,7 +40,7 @@ export const TraceMetadataKey = {
   SOURCE_RUN: 'mlflow.sourceRun',
   MODEL_ID: 'mlflow.modelId',
   SIZE_BYTES: 'mlflow.trace.sizeBytes',
-  SCHEMA_VERSION: 'mlflow.traceSchemaVersion',
+  SCHEMA_VERSION: 'mlflow.trace_schema.version',
   TOKEN_USAGE: 'mlflow.trace.tokenUsage',
   // Deprecated, do not use. These fields are used for storing trace request and response
   // in MLflow 2.x. In MLflow 3.x, these are replaced in favor of the request_preview and

--- a/libs/typescript/core/src/exporters/mlflow.ts
+++ b/libs/typescript/core/src/exporters/mlflow.ts
@@ -11,7 +11,12 @@ import { InMemoryTraceManager } from '../core/trace_manager';
 import { TraceInfo } from '../core/entities/trace_info';
 import { createTraceLocationFromExperimentId } from '../core/entities/trace_location';
 import { fromOtelStatus, TraceState } from '../core/entities/trace_state';
-import { SpanAttributeKey, TRACE_ID_PREFIX, TraceMetadataKey } from '../core/constants';
+import {
+  SpanAttributeKey,
+  TRACE_ID_PREFIX,
+  TRACE_SCHEMA_VERSION,
+  TraceMetadataKey
+} from '../core/constants';
 import {
   convertHrTimeToMs,
   deduplicateSpanNamesInPlace,
@@ -56,7 +61,9 @@ export class MlflowSpanProcessor implements SpanProcessor {
         requestTime: convertHrTimeToMs(span.startTime),
         executionDuration: 0,
         state: TraceState.IN_PROGRESS,
-        traceMetadata: {},
+        traceMetadata: {
+          [TraceMetadataKey.SCHEMA_VERSION]: TRACE_SCHEMA_VERSION
+        },
         tags: {},
         assessments: []
       });

--- a/libs/typescript/core/tests/clients/client.test.ts
+++ b/libs/typescript/core/tests/clients/client.test.ts
@@ -59,10 +59,7 @@ describe('MlflowClient', () => {
       expect(createdTraceInfo.requestPreview).toBe('{"input":"test"}');
       expect(createdTraceInfo.responsePreview).toBe('{"output":"result"}');
       expect(createdTraceInfo.clientRequestId).toBe('client-request-id');
-      expect(createdTraceInfo.traceMetadata).toEqual({
-        'meta-key': 'meta-value',
-        'mlflow.trace_schema.version': '3'
-      });
+      expect(createdTraceInfo.traceMetadata).toEqual({'meta-key': 'meta-value'});
       expect(createdTraceInfo.tags).toEqual({
         'tag-key': 'tag-value',
         'mlflow.artifactLocation': expect.any(String)

--- a/libs/typescript/core/tests/clients/client.test.ts
+++ b/libs/typescript/core/tests/clients/client.test.ts
@@ -59,7 +59,7 @@ describe('MlflowClient', () => {
       expect(createdTraceInfo.requestPreview).toBe('{"input":"test"}');
       expect(createdTraceInfo.responsePreview).toBe('{"output":"result"}');
       expect(createdTraceInfo.clientRequestId).toBe('client-request-id');
-      expect(createdTraceInfo.traceMetadata).toEqual({'meta-key': 'meta-value'});
+      expect(createdTraceInfo.traceMetadata).toEqual({ 'meta-key': 'meta-value' });
       expect(createdTraceInfo.tags).toEqual({
         'tag-key': 'tag-value',
         'mlflow.artifactLocation': expect.any(String)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18178?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18178/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18178/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18178/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Recent updates in `TraceInfo` Python data model removes `__post_init__` that adds trace version metadata tag during read path. This field should be set by the exporter side. Adding the missing logic to TS SDK exporter.

Also the issue was not caught during PR because we only run TS SDK tests when any code changes in `libs/typescript`. However, it is possible that we change Python backend and introduces regression in TS SDK. This PR updates the TS SDK tests to run on every PR.


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
