### PR TITLE
Add telemetry for adapt_prompts

### DIFF
--- a/mlflow/genai/optimize/adapt.py
+++ b/mlflow/genai/optimize/adapt.py
@@ -12,6 +12,8 @@ from mlflow.genai.optimize.adapters import BasePromptAdapter, get_default_adapte
 from mlflow.genai.optimize.types import EvaluationResultRecord, LLMParams, PromptAdaptationResult
 from mlflow.genai.prompts import load_prompt, register_prompt
 from mlflow.genai.utils.trace_utils import convert_predict_fn
+from mlflow.telemetry.events import PromptAdaptationEvent
+from mlflow.telemetry.track import record_usage_event
 from mlflow.utils import gorilla
 from mlflow.utils.annotations import experimental
 from mlflow.utils.autologging_utils.safety import _wrap_patch
@@ -21,6 +23,7 @@ if TYPE_CHECKING:
 
 
 @experimental(version="3.5.0")
+@record_usage_event(PromptAdaptationEvent)
 def adapt_prompts(
     predict_fn: Callable[..., Any],
     train_data: "EvaluationDatasetTypes",

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -187,7 +187,7 @@ class PromptAdaptationEvent(Event):
         if optimizer := arguments.get("optimizer"):
             result["optimizer_type"] = type(optimizer).__name__
         else:
-            result["optimizer_type"] = "default"
+            result["optimizer_type"] = None
 
         # Track the number of prompts being adapted
         target_prompt_uris = arguments.get("target_prompt_uris") or []

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -177,7 +177,7 @@ class PromptOptimizationEvent(Event):
 
 
 class PromptAdaptationEvent(Event):
-    name: str = "prompt_adaptation"
+    name: str = "adapt_prompt"
 
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -176,6 +176,32 @@ class PromptOptimizationEvent(Event):
     name: str = "prompt_optimization"
 
 
+class PromptAdaptationEvent(Event):
+    name: str = "prompt_adaptation"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        result = {}
+
+        # Track the optimizer type used
+        if optimizer := arguments.get("optimizer"):
+            result["optimizer_type"] = type(optimizer).__name__
+        else:
+            result["optimizer_type"] = "default"
+
+        # Track the number of prompts being adapted
+        target_prompt_uris = arguments.get("target_prompt_uris") or []
+        try:
+            result["prompt_count"] = len(target_prompt_uris)
+        except TypeError:
+            result["prompt_count"] = None
+
+        # Track if custom eval_metric is provided
+        result["custom_eval_metric"] = arguments.get("eval_metric") is not None
+
+        return result
+
+
 class LogDatasetEvent(Event):
     name: str = "log_dataset"
 

--- a/tests/telemetry/test_events.py
+++ b/tests/telemetry/test_events.py
@@ -88,7 +88,7 @@ def test_event_name():
     assert MergeRecordsEvent.name == "merge_records"
     assert MakeJudgeEvent.name == "make_judge"
     assert AlignJudgeEvent.name == "align_judge"
-    assert PromptAdaptationEvent.name == "prompt_adaptation"
+    assert PromptAdaptationEvent.name == "adapt_prompt"
 
 
 @pytest.mark.parametrize(
@@ -159,7 +159,7 @@ def test_align_judge_parse_params(arguments, expected_params):
             },
             {"optimizer_type": "CustomAdapter", "prompt_count": 2, "custom_eval_metric": True},
         ),
-        # No optimizer provided - should return None
+        # No optimizer provided - optimizer_type should be None
         (
             {"optimizer": None, "target_prompt_uris": ["prompts:/test/1"], "eval_metric": None},
             {"optimizer_type": None, "prompt_count": 1, "custom_eval_metric": False},


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18182?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18182/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18182/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18182/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add telemetry for adapt_prompts

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
