### PR TITLE
Address a race condition in Jobs

### DIFF
--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -220,7 +220,17 @@ def _exec_job(
     from mlflow.server.handlers import _get_job_store
 
     job_store = _get_job_store()
-    job_store.start_job(job_id)
+
+    # Try to start the job. If it's not in PENDING state, skip execution.
+    # This handles the case where a stale huey task tries to execute a job
+    # that was already reset and re-enqueued after a runner restart.
+    try:
+        _logger.debug(f"Starting job execution for {job_id}")
+        job_store.start_job(job_id)
+    except Exception as e:
+        _logger.debug(f"Skipping execution of job {job_id}: {e}")
+        # Don't re-raise - just return silently to avoid huey internal retries
+        return
 
     fn_metadata = function._job_fn_metadata
 
@@ -235,20 +245,24 @@ def _exec_job(
         )
 
     if job_result is None:
+        _logger.debug(f"Job {job_id} timed out")
         job_store.mark_job_timed_out(job_id)
         return
 
     if job_result.succeeded:
+        _logger.debug(f"Job {job_id} succeeded with result: {job_result.result}")
         job_store.finish_job(job_id, job_result.result)
         return
 
     if job_result.is_transient_error:
         # For transient errors, if the retry count is less than max allowed count,
         # trigger task retry by raising `RetryTask` exception.
+        _logger.debug(f"Job {job_id} failed with transient error: {job_result.error}")
         retry_count = job_store.retry_or_fail_job(job_id, job_result.error)
         if retry_count is not None:
             _exponential_backoff_retry(retry_count)
     else:
+        _logger.debug(f"Job {job_id} failed with error: {job_result.error}")
         job_store.fail_job(job_id, job_result.error)
 
 
@@ -383,15 +397,19 @@ def _enqueue_unfinished_jobs() -> None:
 
     for job in unfinished_jobs:
         if job.status == JobStatus.RUNNING:
-            job_store.reset_job(job.job_id)  # reset the job status to PENDING
+            _logger.debug(
+                f"Resetting job {job.job_id} from RUNNING to PENDING after runner restart"
+            )
+            job_store.reset_job(job.job_id)
 
+        # Re-enqueue the job. If there's a stale task in the huey queue, it will be skipped
+        # because _exec_job checks if the job is in PENDING state before executing.
         params = json.loads(job.params)
         function = _load_function(job.function_fullname)
         timeout = job.timeout
-        # enqueue job
-        _get_or_init_huey_instance(job.function_fullname).submit_task(
-            job.job_id, function, params, timeout
-        )
+        huey_instance = _get_or_init_huey_instance(job.function_fullname)
+        _logger.debug(f"Enqueueing unfinished job {job.job_id} to huey queue")
+        huey_instance.submit_task(job.job_id, function, params, timeout)
 
 
 def _validate_function_parameters(function: Callable[..., Any], params: dict[str, Any]) -> None:

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -88,11 +88,37 @@ class SqlAlchemyJobStore(AbstractJobStore):
     def start_job(self, job_id: str) -> None:
         """
         Start a job by setting its status to RUNNING.
+        Only succeeds if the job is currently in PENDING state.
 
         Args:
             job_id: The ID of the job to start
+
+        Raises:
+            MlflowException: If job is not in PENDING state or doesn't exist
         """
-        self._update_job(job_id, JobStatus.RUNNING)
+        with self.ManagedSessionMaker() as session:
+            # Atomic update: only transition from PENDING to RUNNING
+            rows_updated = (
+                session.query(SqlJob)
+                .filter(SqlJob.id == job_id, SqlJob.status == JobStatus.PENDING.to_int())
+                .update(
+                    {
+                        SqlJob.status: JobStatus.RUNNING.to_int(),
+                        SqlJob.last_update_time: get_current_time_millis(),
+                    }
+                )
+            )
+
+            if rows_updated == 0:
+                job = session.query(SqlJob).filter(SqlJob.id == job_id).one_or_none()
+                if job is None:
+                    raise MlflowException(
+                        f"Job with ID {job_id} not found", error_code=RESOURCE_DOES_NOT_EXIST
+                    )
+                raise MlflowException(
+                    f"Job {job_id} is in {JobStatus.from_int(job.status)} state, "
+                    "cannot start (must be PENDING)"
+                )
 
     def reset_job(self, job_id: str) -> None:
         """

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -1,13 +1,11 @@
 import multiprocessing
 import os
 import time
-import uuid
 from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
 
-import mlflow.server.handlers
 from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
 from mlflow.server import (
@@ -16,7 +14,7 @@ from mlflow.server import (
     HUEY_STORAGE_PATH_ENV_VAR,
 )
 from mlflow.server.handlers import _get_job_store
-from mlflow.server.jobs import get_job, job, submit_job
+from mlflow.server.jobs import TransientError, get_job, job, submit_job
 from mlflow.server.jobs.utils import _launch_job_runner
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
@@ -64,6 +62,10 @@ def _setup_job_runner(
         with _launch_job_runner_for_test() as job_runner_proc:
             yield job_runner_proc
     finally:
+        # Clear the huey instance cache AFTER killing the runner to ensure clean state for next test
+        import mlflow.server.jobs.utils
+
+        mlflow.server.jobs.utils._huey_instance_map.clear()
         mlflow.server.handlers._job_store = None
 
 
@@ -256,33 +258,40 @@ def test_job_queue_parallelism(monkeypatch, tmp_path):
 
 
 @job(max_workers=1)
-def transient_err_fun(tmp_dir: str, succeed_on_nth_run: int):
-    """
-    This function will raise `TransientError` on the first (`succeed_on_nth_run` - 1) runs,
-    then return 100 on the `succeed_on_nth_run` run. The `tmp_dir` records the run state.
-    """
-    from mlflow.server.jobs import TransientError
+def transient_err_fun_always_fail():
+    raise TransientError(RuntimeError("test transient error."))
 
-    # create one file with a unique name for each function call
-    with open(os.path.join(tmp_dir, uuid.uuid4().hex), "w") as f:
-        f.close()
-    time.sleep(0.1)
-    if len(os.listdir(tmp_dir)) == succeed_on_nth_run:
+
+@job(max_workers=1)
+def transient_err_fun_fail_then_succeed(counter_file: str):
+    counter_path = Path(counter_file)
+
+    try:
+        current = int(counter_path.read_text()) if counter_path.exists() else 0
+    except (ValueError, FileNotFoundError):
+        current = 0
+
+    current += 1
+    counter_path.write_text(str(current))
+
+    if current >= 2:
         return 100
     raise TransientError(RuntimeError("test transient error."))
 
 
 @job(max_workers=1, transient_error_classes=[TimeoutError])
-def transient_err_fun2(tmp_dir: str, succeed_on_nth_run: int):
-    """
-    This function will raise `TimeoutError` on the first (`succeed_on_nth_run` - 1) runs,
-    then return 100 on the `succeed_on_nth_run` run. The `tmp_dir` records the run state.
-    """
-    # create one file with a unique name for each function call
-    with open(os.path.join(tmp_dir, uuid.uuid4().hex), "w") as f:
-        f.close()
-    time.sleep(0.1)
-    if len(os.listdir(tmp_dir)) == succeed_on_nth_run:
+def transient_err_fun2_fail_then_succeed(counter_file: str):
+    counter_path = Path(counter_file)
+
+    try:
+        current = int(counter_path.read_text()) if counter_path.exists() else 0
+    except (ValueError, FileNotFoundError):
+        current = 0
+
+    current += 1
+    counter_path.write_text(str(current))
+
+    if current >= 2:
         return 100
     raise TimeoutError("test transient timeout error.")
 
@@ -303,12 +312,8 @@ def test_job_retry_on_transient_error(monkeypatch, tmp_path):
     with _setup_job_runner(monkeypatch, tmp_path):
         store = _get_job_store()
 
-        job1_tmp_path = tmp_path / "job1"
-        job1_tmp_path.mkdir()
-
-        job1_id = submit_job(
-            transient_err_fun, {"tmp_dir": str(job1_tmp_path), "succeed_on_nth_run": 3}
-        ).job_id
+        # Test 1: Job that always fails should exhaust retries and fail
+        job1_id = submit_job(transient_err_fun_always_fail, {}).job_id
         wait_job_finalize(job1_id, timeout=120)
         assert_job_result(job1_id, JobStatus.FAILED, "RuntimeError('test transient error.')")
         job1 = store.get_job(job1_id)
@@ -316,11 +321,10 @@ def test_job_retry_on_transient_error(monkeypatch, tmp_path):
         assert job1.result == "RuntimeError('test transient error.')"
         assert job1.retry_count == 2
 
-        job2_tmp_path = tmp_path / "job2"
-        job2_tmp_path.mkdir()
-
+        # Test 2: Job that fails once then succeeds should succeed with retry_count=1
+        job2_counter = tmp_path / "job2_counter.txt"
         job2_id = submit_job(
-            transient_err_fun, {"tmp_dir": str(job2_tmp_path), "succeed_on_nth_run": 2}
+            transient_err_fun_fail_then_succeed, {"counter_file": str(job2_counter)}
         ).job_id
         wait_job_finalize(job2_id)
         assert_job_result(job2_id, JobStatus.SUCCEEDED, 100)
@@ -329,11 +333,10 @@ def test_job_retry_on_transient_error(monkeypatch, tmp_path):
         assert job2.result == "100"
         assert job2.retry_count == 1
 
-        job3_tmp_path = tmp_path / "job3"
-        job3_tmp_path.mkdir()
-
+        # Test 3: Same as test 2 but with custom transient_error_classes
+        job3_counter = tmp_path / "job3_counter.txt"
         job3_id = submit_job(
-            transient_err_fun2, {"tmp_dir": str(job3_tmp_path), "succeed_on_nth_run": 2}
+            transient_err_fun2_fail_then_succeed, {"counter_file": str(job3_counter)}
         ).job_id
         wait_job_finalize(job3_id)
         assert_job_result(job3_id, JobStatus.SUCCEEDED, 100)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18195?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18195/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18195/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18195/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

During development of scheduled scorers, it was discovered that a critical race condition can occur during process failure (while in processing mode) where an invalid huey state can create duplicate job submissions when restarting. 
The change here converts start_job() to be an atomic state change operation, ensuring that invalid states will not trigger huey's automatic retry policy. 
Modified some tests to verify the behavior change (existing tests don't precisely trigger the race condition consistently due to timing, while a 'real' job run (retrieving a scorer definition from the registry and running it) would trigger this condition). 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
