### PR TITLE
Fix typo in assessment endpoints

### DIFF
--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -469,7 +469,7 @@ class DatabricksTracingRestStore(RestStore):
                     sql_warehouse_id=MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),
                 )
             )
-            endpoint = f"{get_single_trace_endpoint_v4(location, trace_id)}/assessment"
+            endpoint = f"{get_single_trace_endpoint_v4(location, trace_id)}/assessments"
             response_proto = self._call_endpoint(
                 CreateAssessment,
                 req_body,

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -517,7 +517,7 @@ def get_single_assessment_endpoint_v4(location: str, trace_id: str, assessment_i
     """
     Get the endpoint for a single assessment using the V4 API.
     """
-    return f"{_V4_TRACE_REST_API_PATH_PREFIX}/{location}/{trace_id}/assessment/{assessment_id}"
+    return f"{_V4_TRACE_REST_API_PATH_PREFIX}/{location}/{trace_id}/assessments/{assessment_id}"
 
 
 def get_logged_model_endpoint(model_id: str) -> str:

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -1011,7 +1011,7 @@ def test_create_assessment():
         _verify_requests(
             mock_http,
             creds,
-            "traces/catalog.schema/1234/assessment",
+            "traces/catalog.schema/1234/assessments",
             "POST",
             message_to_json(request),
             version="4.0",
@@ -1057,7 +1057,7 @@ def test_get_assessment():
         _verify_requests(
             mock_http,
             creds,
-            "traces/catalog.schema/1234/assessment/1234",
+            "traces/catalog.schema/1234/assessments/1234",
             "GET",
             message_to_json(request),
             version="4.0",
@@ -1132,7 +1132,7 @@ def test_update_assessment():
         _verify_requests(
             mock_http,
             creds,
-            "traces/catalog.schema/1234/assessment/1234",
+            "traces/catalog.schema/1234/assessments/1234",
             "PATCH",
             json.dumps(request),
             version="4.0",
@@ -1160,7 +1160,7 @@ def test_delete_assessment():
         _verify_requests(
             mock_http,
             creds,
-            "traces/catalog.schema/1234/assessment/1234",
+            "traces/catalog.schema/1234/assessments/1234",
             "DELETE",
             message_to_json(request),
             version="4.0",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18200?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18200/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18200/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18200/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Title, fixing incorrect endpoint path.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
