### PR TITLE
Remove train-val-split option

### DIFF
--- a/mlflow/genai/optimize/adapters/gepa_adapter.py
+++ b/mlflow/genai/optimize/adapters/gepa_adapter.py
@@ -27,8 +27,6 @@ class GepaPromptAdapter(BasePromptAdapter):
             Default: None
         display_progress_bar: Whether to show a progress bar during optimization.
             Default: False
-        train_val_split_ratio: The ratio of the training set to the validation set.
-            Default: 0.8
 
     Example:
 
@@ -74,12 +72,10 @@ class GepaPromptAdapter(BasePromptAdapter):
         max_metric_calls: int = 100,
         reflection_lm: str | None = None,
         display_progress_bar: bool = False,
-        train_val_split_ratio: float = 0.8,
     ):
         self.max_metric_calls = max_metric_calls
         self.reflection_lm = reflection_lm
         self.display_progress_bar = display_progress_bar
-        self.train_val_split_ratio = train_val_split_ratio
 
     def optimize(
         self,
@@ -113,10 +109,6 @@ class GepaPromptAdapter(BasePromptAdapter):
             raise ImportError(
                 "GEPA is not installed. Please install it with: pip install gepa"
             ) from e
-
-        split_idx = int(len(train_data) * self.train_val_split_ratio)
-        gepa_trainset = train_data[:split_idx] if split_idx > 0 else train_data
-        gepa_valset = train_data[split_idx:] if split_idx < len(train_data) else train_data[:1]
 
         model_name = parse_model_name(optimizer_lm_params.model_name)
 
@@ -200,8 +192,7 @@ class GepaPromptAdapter(BasePromptAdapter):
 
         gepa_result = gepa.optimize(
             seed_candidate=target_prompts,
-            trainset=gepa_trainset,
-            valset=gepa_valset,
+            trainset=train_data,
             adapter=adapter,
             reflection_lm=reflection_lm,
             max_metric_calls=self.max_metric_calls,

--- a/tests/genai/optimize/adapters/test_gepa_adapter.py
+++ b/tests/genai/optimize/adapters/test_gepa_adapter.py
@@ -61,7 +61,6 @@ def test_gepa_adapter_initialization():
     assert adapter.max_metric_calls == 100
     assert adapter.reflection_lm is None
     assert adapter.display_progress_bar is False
-    assert adapter.train_val_split_ratio == 0.8
 
 
 def test_gepa_adapter_initialization_with_custom_params():

--- a/tests/genai/optimize/adapters/test_gepa_adapter.py
+++ b/tests/genai/optimize/adapters/test_gepa_adapter.py
@@ -111,8 +111,7 @@ def test_gepa_adapter_optimize(sample_train_data, sample_target_prompts, mock_ev
     assert call_kwargs["max_metric_calls"] == 50
     assert call_kwargs["reflection_lm"] == "openai/gpt-4o-mini"
     assert call_kwargs["display_progress_bar"] is True
-    assert len(call_kwargs["trainset"]) == 3  # 80% of 4 records
-    assert len(call_kwargs["valset"]) == 1  # 20% of 4 records
+    assert len(call_kwargs["trainset"]) == 4
 
 
 def test_gepa_adapter_optimize_with_reflection_lm(
@@ -216,7 +215,6 @@ def test_gepa_adapter_single_record_dataset(sample_target_prompts, mock_eval_fn)
 
     call_kwargs = mock_gepa_module.optimize.call_args.kwargs
     assert len(call_kwargs["trainset"]) == 1
-    assert len(call_kwargs["valset"]) == 1
 
 
 def test_gepa_adapter_custom_adapter_evaluate(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18202?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18202/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18202/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18202/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Remove train-val-split option as it should be handled by gepa rather than mlflow

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
