### PR TITLE
Fix missing description button in experiment header

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewManagementMenu.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewManagementMenu.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from '@testing-library/react';
+import { ExperimentViewManagementMenu } from './ExperimentViewManagementMenu';
+import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { BrowserRouter } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+import type { ExperimentEntity } from '@mlflow/mlflow/src/experiment-tracking/types';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import promiseMiddleware from 'redux-promise-middleware';
+
+describe('ExperimentViewManagementMenu', () => {
+  const defaultExperiment: ExperimentEntity = {
+    experimentId: '123',
+    name: 'test/experiment/name',
+    artifactLocation: 'file:/tmp/mlruns',
+    lifecycleStage: 'active',
+    allowedActions: [],
+    creationTime: 0,
+    lastUpdateTime: 0,
+    tags: [],
+  };
+
+  const renderTestComponent = (props: Partial<React.ComponentProps<typeof ExperimentViewManagementMenu>> = {}) => {
+    const mockStore = configureStore([thunk, promiseMiddleware()]);
+    const queryClient = new QueryClient();
+
+    return render(<ExperimentViewManagementMenu experiment={defaultExperiment} {...props} />, {
+      wrapper: ({ children }) => (
+        <QueryClientProvider client={queryClient}>
+          <BrowserRouter>
+            <Provider
+              store={mockStore({
+                entities: {
+                  experimentsById: {},
+                },
+              })}
+            >
+              <IntlProvider locale="en">
+                <DesignSystemProvider>{children}</DesignSystemProvider>
+              </IntlProvider>
+            </Provider>
+          </BrowserRouter>
+        </QueryClientProvider>
+      ),
+    });
+  };
+
+  test('it should render the management menu with rename and delete buttons', async () => {
+    renderTestComponent();
+
+    // Check that the overflow menu trigger is present
+    const menuTrigger = screen.getByTestId('overflow-menu-trigger');
+    expect(menuTrigger).toBeInTheDocument();
+
+    // Click the menu trigger to open the menu
+    await userEvent.click(menuTrigger);
+
+    // Check that rename and delete buttons are present
+    expect(await screen.findByText('Rename')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+
+  test('it should render the edit description button when setEditing is provided', async () => {
+    const setEditing = jest.fn();
+    renderTestComponent({ setEditing });
+
+    // Click the menu trigger to open the menu
+    const menuTrigger = screen.getByTestId('overflow-menu-trigger');
+    await userEvent.click(menuTrigger);
+
+    // Check that edit description button is present
+    expect(await screen.findByText('Edit description')).toBeInTheDocument();
+    expect(screen.getByText('Rename')).toBeInTheDocument();
+    expect(screen.getByText('Delete')).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewManagementMenu.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewManagementMenu.tsx
@@ -37,6 +37,22 @@ export const ExperimentViewManagementMenu = ({
     <>
       <OverflowMenu
         menu={[
+          ...(setEditing
+            ? [
+                {
+                  id: 'edit-description',
+                  itemName: (
+                    <Typography.Text>
+                      <FormattedMessage
+                        defaultMessage="Edit description"
+                        description="Text for edit description button on experiment view page header"
+                      />
+                    </Typography.Text>
+                  ),
+                  onClick: () => setEditing(true),
+                },
+              ]
+            : []),
           {
             id: 'rename',
             itemName: (

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -746,6 +746,10 @@
     "defaultMessage": "The retrieval groundedness LLM judge returns a binary evaluation and written rationale on whether the generated response is factually consistent with the agent's retrieved context.",
     "description": "Evaluation results > known type of evaluation result assessment > description of retrieval groundedness judge."
   },
+  "6R2ply": {
+    "defaultMessage": "Edit description",
+    "description": "Text for edit description button on experiment view page header"
+  },
   "6UqPlE": {
     "defaultMessage": "No parameters recorded",
     "description": "Run page > Overview > Parameters table > No parameters recorded"
@@ -2561,13 +2565,13 @@
     "defaultMessage": "On",
     "description": "Runs charts > line chart > display points > on setting label"
   },
-  "Qg12xQ": {
-    "defaultMessage": "Register prompts",
-    "description": "Home page quick action title for registering prompts"
-  },
   "QcEYpD": {
     "defaultMessage": "Add to evaluation dataset",
     "description": "Add traces to evaluation dataset action"
+  },
+  "Qg12xQ": {
+    "defaultMessage": "Register prompts",
+    "description": "Home page quick action title for registering prompts"
   },
   "QhEnTA": {
     "defaultMessage": "Name",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/18208?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18208/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18208/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18208/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #18172

### What changes are proposed in this pull request?

Looks like this accidentally got removed in the UI sync. It's supposed to be in the extra actions header button.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/68edb91c-b340-49c6-9732-f2cc4ffc5dbf



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
