### PR TITLE
Fix assessment APIs

### DIFF
--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -534,8 +534,9 @@ class DatabricksTracingRestStore(RestStore):
 
             endpoint = get_single_assessment_endpoint_v4(location, parsed_trace_id, assessment_id)
             endpoint = self._append_sql_warehouse_id_param(endpoint)
-            mask_param = ",".join(mask.paths)
-            if mask_param:
+
+            if mask.paths:
+                mask_param = ",".join(mask.paths)
                 endpoint = f"{endpoint}&update_mask={mask_param}"
 
             req_body = message_to_json(assessment)
@@ -586,4 +587,6 @@ class DatabricksTracingRestStore(RestStore):
             return super().delete_assessment(trace_id, assessment_id)
 
     def _append_sql_warehouse_id_param(self, endpoint: str) -> str:
-        return f"{endpoint}?sql_warehouse_id={MLFLOW_TRACING_SQL_WAREHOUSE_ID.get()}"
+        if sql_warehouse_id := MLFLOW_TRACING_SQL_WAREHOUSE_ID.get():
+            return f"{endpoint}?sql_warehouse_id={sql_warehouse_id}"
+        return endpoint

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -16,6 +16,7 @@ from mlflow.protos.databricks_pb2 import (
     INVALID_PARAMETER_VALUE,
     ErrorCode,
 )
+from mlflow.protos.databricks_tracing_pb2 import Assessment as ProtoAssessment
 from mlflow.protos.databricks_tracing_pb2 import (
     BatchGetTraces,
     CreateAssessment,
@@ -463,19 +464,17 @@ class DatabricksTracingRestStore(RestStore):
         """
         location, trace_id = parse_trace_id_v4(assessment.trace_id)
         if location is not None:
-            req_body = message_to_json(
-                CreateAssessment(
-                    assessment=assessment_to_proto(assessment),
-                    sql_warehouse_id=MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),
-                )
+            req_body = message_to_json(assessment_to_proto(assessment))
+            endpoint = self._append_sql_warehouse_id_param(
+                f"{get_single_trace_endpoint_v4(location, trace_id)}/assessments",
             )
-            endpoint = f"{get_single_trace_endpoint_v4(location, trace_id)}/assessments"
             response_proto = self._call_endpoint(
                 CreateAssessment,
                 req_body,
                 endpoint=endpoint,
+                response_proto=ProtoAssessment(),
             )
-            return Assessment.from_proto(response_proto.assessment)
+            return Assessment.from_proto(response_proto)
 
         return super().create_assessment(assessment)
 
@@ -508,11 +507,7 @@ class DatabricksTracingRestStore(RestStore):
 
         location, parsed_trace_id = parse_trace_id_v4(trace_id)
         if location is not None:
-            update = UpdateAssessment(
-                sql_warehouse_id=MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),
-            )
-            endpoint = get_single_assessment_endpoint_v4(location, parsed_trace_id, assessment_id)
-            assessment = update.assessment
+            assessment = UpdateAssessment().assessment
             assessment.assessment_id = assessment_id
             catalog, schema = location.split(".")
             assessment.trace_location.CopyFrom(
@@ -520,8 +515,7 @@ class DatabricksTracingRestStore(RestStore):
             )
             assessment.trace_id = parsed_trace_id
             # Field mask specifies which fields to update.
-            mask = update.update_mask
-
+            mask = UpdateAssessment().update_mask
             if name is not None:
                 assessment.assessment_name = name
                 mask.paths.append("assessment_name")
@@ -538,13 +532,20 @@ class DatabricksTracingRestStore(RestStore):
                 assessment.metadata.update(metadata)
                 mask.paths.append("metadata")
 
-            req_body = message_to_json(update)
+            endpoint = get_single_assessment_endpoint_v4(location, parsed_trace_id, assessment_id)
+            endpoint = self._append_sql_warehouse_id_param(endpoint)
+            mask_param = ",".join(mask.paths)
+            if mask_param:
+                endpoint = f"{endpoint}&update_mask={mask_param}"
+
+            req_body = message_to_json(assessment)
             response_proto = self._call_endpoint(
                 UpdateAssessment,
                 req_body,
                 endpoint=endpoint,
+                response_proto=ProtoAssessment(),
             )
-            return Assessment.from_proto(response_proto.assessment)
+            return Assessment.from_proto(response_proto)
         else:
             return super().update_assessment(
                 trace_id, assessment_id, name, expectation, feedback, rationale, metadata
@@ -557,18 +558,13 @@ class DatabricksTracingRestStore(RestStore):
 
         location, trace_id = parse_trace_id_v4(trace_id)
         if location is not None:
-            req_body = message_to_json(
-                GetAssessment(
-                    sql_warehouse_id=MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),
-                )
+            endpoint = self._append_sql_warehouse_id_param(
+                get_single_assessment_endpoint_v4(location, trace_id, assessment_id)
             )
-            endpoint = get_single_assessment_endpoint_v4(location, trace_id, assessment_id)
             response_proto = self._call_endpoint(
-                GetAssessment,
-                req_body,
-                endpoint=endpoint,
+                GetAssessment, endpoint=endpoint, response_proto=ProtoAssessment()
             )
-            return Assessment.from_proto(response_proto.assessment)
+            return Assessment.from_proto(response_proto)
 
         return super().get_assessment(trace_id, assessment_id)
 
@@ -582,16 +578,12 @@ class DatabricksTracingRestStore(RestStore):
         """
         location, trace_id = parse_trace_id_v4(trace_id)
         if location is not None:
-            req_body = message_to_json(
-                DeleteAssessment(
-                    sql_warehouse_id=MLFLOW_TRACING_SQL_WAREHOUSE_ID.get(),
-                )
+            endpoint = self._append_sql_warehouse_id_param(
+                get_single_assessment_endpoint_v4(location, trace_id, assessment_id)
             )
-            endpoint = get_single_assessment_endpoint_v4(location, trace_id, assessment_id)
-            self._call_endpoint(
-                DeleteAssessment,
-                req_body,
-                endpoint=endpoint,
-            )
+            self._call_endpoint(DeleteAssessment, endpoint=endpoint)
         else:
             return super().delete_assessment(trace_id, assessment_id)
+
+    def _append_sql_warehouse_id_param(self, endpoint: str) -> str:
+        return f"{endpoint}?sql_warehouse_id={MLFLOW_TRACING_SQL_WAREHOUSE_ID.get()}"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18209?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18209/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18209/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18209/merge
```

</p>
</details>

### What changes are proposed in this pull request?

1. `CreateAssessment`, `UpdateAssessment` APIs should take assessment as unwrapped request payload, not wrapped by `{"assessment": ...}`. Other params e.g. location, sql_warehouse_id should be either in path or query param.
2. Similarly, response should just be assessment json, not wrapped.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

```
import mlflow
from mlflow.entities import AssessmentSource, AssessmentSourceType

mlflow.set_tracking_uri("databricks")

# Create
assessment = mlflow.log_feedback(
    trace_id=trace_id,
    name="test",
    value=True,
    source=AssessmentSource(
        source_id="yuki",
        source_type=AssessmentSourceType.HUMAN,
    ),
)

# Get
mlflow.get_assessment(trace_id=trace_id, assessment_id=assessment.assessment_id)

# Update
assessment.value = False
mlflow.update_assessment(
    assessment_id=assessment.assessment_id,
    trace_id=assessment.trace_id,
    assessment=assessment,
)

# Delete
mlflow.delete_assessment(
    assessment_id=assessment.assessment_id,
    trace_id=assessment.trace_id,
)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
