### PR TITLE
Mark flaky job tests with `xfail`

### DIFF
--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -139,7 +139,6 @@ def assert_job_result(job_id, expected_status, expected_result):
 
 
 def test_job_resume_on_job_runner_restart(monkeypatch, tmp_path):
-    assert False
     with _setup_job_runner(monkeypatch, tmp_path) as job_runner_proc:
         job1_id = submit_job(basic_job_fun, {"x": 3, "y": 4, "sleep_secs": 0}).job_id
         job2_id = submit_job(basic_job_fun, {"x": 5, "y": 6, "sleep_secs": 2}).job_id

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -20,9 +20,11 @@ from mlflow.server.jobs import get_job, job, submit_job
 from mlflow.server.jobs.utils import _launch_job_runner
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
-pytestmark = pytest.mark.skipif(
-    os.name == "nt", reason="MLflow job execution is not supported on Windows"
-)
+# TODO: Remove `pytest.mark.xfail` after fixing flakiness
+pytestmark = [
+    pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
+    pytest.mark.xfail,
+]
 
 
 def _get_mlflow_repo_home():
@@ -137,6 +139,7 @@ def assert_job_result(job_id, expected_status, expected_result):
 
 
 def test_job_resume_on_job_runner_restart(monkeypatch, tmp_path):
+    assert False
     with _setup_job_runner(monkeypatch, tmp_path) as job_runner_proc:
         job1_id = submit_job(basic_job_fun, {"x": 3, "y": 4, "sleep_secs": 0}).job_id
         job2_id = submit_job(basic_job_fun, {"x": 5, "y": 6, "sleep_secs": 2}).job_id


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18210?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18210/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18210/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18210/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Temporarily mark tests in `tests/server/jobs/test_jobs.py` as expected failures using `pytest.mark.xfail` to prevent CI flakiness while a proper fix is being developed.

🤖 Generated with Claude Code

### How is this PR tested?

- [x] Existing unit/integration tests

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)