### PR TITLE
Add pytest repeat marker to detect flaky tests in `tests/server/jobs/test_jobs.py`

### DIFF
--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -20,9 +20,10 @@ from mlflow.server.jobs import get_job, job, submit_job
 from mlflow.server.jobs.utils import _launch_job_runner
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
-pytestmark = pytest.mark.skipif(
-    os.name == "nt", reason="MLflow job execution is not supported on Windows"
-)
+pytestmark = [
+    pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
+    pytest.mark.repeat(30),
+]
 
 
 def _get_mlflow_repo_home():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18211?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18211/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18211/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18211/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This PR adds `pytest.mark.repeat(30)` to `tests/server/jobs/test_jobs.py` to run all tests in the file 30 times, helping detect potential flaky tests.

### How is this PR tested?

- [x] Existing unit/integration tests (run 30 times via repeat marker)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)