### PR TITLE
Fix job backend race conditions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -100,7 +100,7 @@ jobs:
         run: |
           source .venv/bin/activate
           source dev/setup-ssh.sh
-          for i in {1..20}; do pytest --quiet --requires-ssh tests/server/jobs; done
+          for i in {1..20}; do pytest tests/server/jobs -s; done
 
       # TODO: Remove this step once support for pydantic v1 is dropped
       # - name: Run gateway tests with pydantic v1

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -100,9 +100,7 @@ jobs:
         run: |
           source .venv/bin/activate
           source dev/setup-ssh.sh
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
-            --ignore-flavors --ignore=tests/examples --ignore=tests/evaluate \
-            --ignore tests/genai tests
+          for i in {1..20}; do pytest --quiet --requires-ssh tests/server/jobs; done
 
       # TODO: Remove this step once support for pydantic v1 is dropped
       # - name: Run gateway tests with pydantic v1

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -3,7 +3,6 @@ Internal job APIs for UI invocation
 """
 
 import json
-import os
 from typing import Any
 
 from fastapi import APIRouter, HTTPException

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -16,14 +16,6 @@ from mlflow.exceptions import MlflowException
 job_api_router = APIRouter(prefix="/ajax-api/3.0/jobs", tags=["Job"])
 
 
-_ALLOWED_JOB_FUNCTION_LIST = [
-    # Putting all allowed job function in the list
-]
-
-if allowed_job_function_list_env := os.environ.get("_MLFLOW_ALLOWED_JOB_FUNCTION_LIST"):
-    _ALLOWED_JOB_FUNCTION_LIST += allowed_job_function_list_env.split(",")
-
-
 class Job(BaseModel):
     """
     Pydantic model for job query response.
@@ -81,10 +73,6 @@ def submit_job(payload: SubmitJobPayload) -> Job:
 
     function_fullname = payload.function_fullname
     try:
-        if function_fullname not in _ALLOWED_JOB_FUNCTION_LIST:
-            raise MlflowException.invalid_parameter_value(
-                f"The function {function_fullname} is not in the allowed job function list"
-            )
         function = _load_function(function_fullname)
         job = submit_job(function, payload.params, payload.timeout)
         return Job.from_job_entity(job)

--- a/mlflow/server/jobs/_job_runner.py
+++ b/mlflow/server/jobs/_job_runner.py
@@ -13,7 +13,6 @@ The job runner will:
 import logging
 import os
 
-from mlflow.exceptions import MlflowException
 from mlflow.server import HUEY_STORAGE_PATH_ENV_VAR
 from mlflow.server.jobs import _ALLOWED_JOB_FUNCTION_LIST
 from mlflow.server.jobs.utils import (
@@ -34,5 +33,5 @@ if __name__ == "__main__":
             _launch_huey_consumer(job_fn_fullname)
         except Exception as e:
             logging.warning(
-                f"Launch Huey consumer for {job_fn_fullname} jobs failed, root cause: {repr(e)}"
+                f"Launch Huey consumer for {job_fn_fullname} jobs failed, root cause: {e!r}"
             )

--- a/mlflow/server/jobs/_job_runner.py
+++ b/mlflow/server/jobs/_job_runner.py
@@ -11,9 +11,9 @@ The job runner will:
 """
 
 import os
-import time
 
 from mlflow.server import HUEY_STORAGE_PATH_ENV_VAR
+from mlflow.server.jobs import _ALLOWED_JOB_FUNCTION_LIST
 from mlflow.server.jobs.utils import (
     _enqueue_unfinished_jobs,
     _launch_huey_consumer,
@@ -26,17 +26,5 @@ if __name__ == "__main__":
 
     huey_store_path = os.environ[HUEY_STORAGE_PATH_ENV_VAR]
 
-    seen_huey_files = set()
-    huey_file_suffix = ".mlflow-huey-store"
-
-    while True:
-        time.sleep(0.5)
-        current_huey_files = set(os.listdir(huey_store_path))
-        new_huey_files = current_huey_files - seen_huey_files
-
-        for huey_file in new_huey_files:
-            if huey_file.endswith(huey_file_suffix):
-                job_fn_fullname = huey_file[: -len(huey_file_suffix)]
-                _launch_huey_consumer(job_fn_fullname)
-
-        seen_huey_files = current_huey_files
+    for job_fn_fullname in _ALLOWED_JOB_FUNCTION_LIST:
+        _launch_huey_consumer(job_fn_fullname)

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -323,7 +323,7 @@ def _launch_huey_consumer(job_fn_fullname: str) -> None:
     threading.Thread(
         target=_huey_consumer_thread,
         name=f"MLflow-huey-consumer-{job_fn_fullname}-watcher",
-        daemon=True,
+        daemon=False,
     ).start()
 
 

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -111,6 +111,21 @@ def _initialize_tables(engine):
     _upgrade_db(engine)
 
 
+def _safe_initialize_tables(engine):
+    import hashlib
+    from mlflow.utils.file_utils import ExclusiveFileLock
+
+    if os.name == "nt":
+        if not _all_tables_exist(engine):
+            _initialize_tables(engine)
+        return
+
+    url_hash = hashlib.md5(str(engine.url).encode("utf-8")).hexdigest()  # noqa: S324
+    with ExclusiveFileLock(f"/tmp/db_init_lock-{url_hash}"):
+        if not _all_tables_exist(engine):
+            _initialize_tables(engine)
+
+
 def _get_latest_schema_revision():
     """Get latest schema revision as a string."""
     # We aren't executing any commands against a DB, so we leave the DB URL unspecified

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -113,6 +113,7 @@ def _initialize_tables(engine):
 
 def _safe_initialize_tables(engine):
     import hashlib
+
     from mlflow.utils.file_utils import ExclusiveFileLock
 
     if os.name == "nt":

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -37,8 +37,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(db_uri)
-        if not mlflow.store.db.utils._all_tables_exist(self.engine):
-            mlflow.store.db.utils._initialize_tables(self.engine)
+        mlflow.store.db.utils._safe_initialize_tables(self.engine)
 
         SessionMaker = sqlalchemy.orm.sessionmaker(bind=self.engine)
         self.ManagedSessionMaker = mlflow.store.db.utils._get_managed_session_maker(

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -979,3 +979,30 @@ def read_yaml(root: str, file_name: str) -> dict[str, Any]:
 
     with open(os.path.join(root, file_name)) as f:
         return yaml.safe_load(f)
+
+
+class ExclusiveFileLock:
+    """
+    Exclusive file lock (only works on Unix system)
+    """
+
+    def __init__(self, path):
+        if os.name == "nt":
+            raise MlflowException("ExclusiveFileLock class does not support Windows system.")
+        self.path = path
+        self.fd = None
+
+    def __enter__(self):
+        import fcntl
+
+        # Open file (create if missing)
+        self.fd = open(self.path, "w")
+        # Acquire exclusive lock (blocking)
+        fcntl.flock(self.fd, fcntl.LOCK_EX)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import fcntl
+
+        # Release lock
+        fcntl.flock(self.fd, fcntl.LOCK_UN)
+        self.fd.close()

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+import mlflow
 import mlflow.server.handlers
 from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
@@ -16,14 +17,13 @@ from mlflow.server import (
     HUEY_STORAGE_PATH_ENV_VAR,
 )
 from mlflow.server.handlers import _get_job_store
-from mlflow.server.jobs import get_job, job, submit_job
+from mlflow.server.jobs import get_job, job, submit_job, TransientError, _ALLOWED_JOB_FUNCTION_LIST
 from mlflow.server.jobs.utils import _launch_job_runner
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
 # TODO: Remove `pytest.mark.xfail` after fixing flakiness
 pytestmark = [
     pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
-    pytest.mark.xfail,
 ]
 
 
@@ -47,7 +47,10 @@ def _launch_job_runner_for_test():
 
 @contextmanager
 def _setup_job_runner(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, backend_store_uri: str | None = None
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    allowed_job_functions: list[str],
+    backend_store_uri: str | None = None,
 ):
     backend_store_uri = backend_store_uri or f"sqlite:///{tmp_path / 'mlflow.db'}"
     # Pre-initialize the database to prevent race conditions when the tracking store and job store
@@ -62,10 +65,21 @@ def _setup_job_runner(
         monkeypatch.setenv(BACKEND_STORE_URI_ENV_VAR, backend_store_uri)
         monkeypatch.setenv(ARTIFACT_ROOT_ENV_VAR, default_artifact_root)
         monkeypatch.setenv(HUEY_STORAGE_PATH_ENV_VAR, str(huey_store_path))
+        monkeypatch.setenv(
+            "_MLFLOW_ALLOWED_JOB_FUNCTION_LIST",
+            ",".join(allowed_job_functions)
+        )
+        _ALLOWED_JOB_FUNCTION_LIST.clear()
+        _ALLOWED_JOB_FUNCTION_LIST.extend(allowed_job_functions)
 
         with _launch_job_runner_for_test() as job_runner_proc:
+            time.sleep(10)
             yield job_runner_proc
     finally:
+        # Clear the huey instance cache AFTER killing the runner to ensure clean state for next test
+        import mlflow.server.jobs.utils
+
+        mlflow.server.jobs.utils._huey_instance_map.clear()
         mlflow.server.handlers._job_store = None
 
 
@@ -77,7 +91,10 @@ def basic_job_fun(x, y, sleep_secs=0):
 
 
 def test_basic_job(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"]
+    ):
         submitted_job = submit_job(basic_job_fun, {"x": 3, "y": 4})
         wait_job_finalize(submitted_job.job_id)
         job = get_job(submitted_job.job_id)
@@ -99,7 +116,10 @@ def json_in_out_fun(data):
 
 
 def test_job_json_input_output(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.json_in_out_fun"],
+    ):
         submitted_job = submit_job(json_in_out_fun, {"data": {"x": 3, "y": 4}})
         wait_job_finalize(submitted_job.job_id)
         job = get_job(submitted_job.job_id)
@@ -118,7 +138,10 @@ def err_fun(data):
 
 
 def test_error_job(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.err_fun"],
+    ):
         submitted_job = submit_job(err_fun, {"data": None})
         wait_job_finalize(submitted_job.job_id)
         job = get_job(submitted_job.job_id)
@@ -139,7 +162,10 @@ def assert_job_result(job_id, expected_status, expected_result):
 
 
 def test_job_resume_on_job_runner_restart(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path) as job_runner_proc:
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+    ) as job_runner_proc:
         job1_id = submit_job(basic_job_fun, {"x": 3, "y": 4, "sleep_secs": 0}).job_id
         job2_id = submit_job(basic_job_fun, {"x": 5, "y": 6, "sleep_secs": 2}).job_id
         job3_id = submit_job(basic_job_fun, {"x": 7, "y": 8, "sleep_secs": 0}).job_id
@@ -172,7 +198,11 @@ def test_job_resume_on_new_job_runner(monkeypatch, tmp_path):
 
     backend_store_uri = f"sqlite:///{db_tmp_path / 'mlflow.db'!s}"
 
-    with _setup_job_runner(monkeypatch, runner1_tmp_path, backend_store_uri) as job_runner_proc:
+    with _setup_job_runner(
+        monkeypatch, runner1_tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        backend_store_uri=backend_store_uri,
+    ) as job_runner_proc:
         job1_id = submit_job(basic_job_fun, {"x": 3, "y": 4, "sleep_secs": 0}).job_id
         job2_id = submit_job(basic_job_fun, {"x": 5, "y": 6, "sleep_secs": 2}).job_id
         job3_id = submit_job(basic_job_fun, {"x": 7, "y": 8, "sleep_secs": 0}).job_id
@@ -186,7 +216,11 @@ def test_job_resume_on_new_job_runner(monkeypatch, tmp_path):
     # ensure the job runner process is killed.
     job_runner_proc.wait()
 
-    with _setup_job_runner(monkeypatch, runner2_tmp_path, backend_store_uri):
+    with _setup_job_runner(
+        monkeypatch, runner2_tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        backend_store_uri=backend_store_uri,
+    ):
         wait_job_finalize(job2_id)
         wait_job_finalize(job3_id)
         # assert all jobs are done.
@@ -210,7 +244,13 @@ def job_fun_parallelism3(x, y, sleep_secs=0):
 
 
 def test_job_queue_parallelism(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=[
+            "tests.server.jobs.test_jobs.job_fun_parallelism2",
+            "tests.server.jobs.test_jobs.job_fun_parallelism3",
+        ],
+    ):
         for x in range(4):
             submit_job(job_fun_parallelism2, {"x": x, "y": 1, "sleep_secs": 5}).job_id
 
@@ -258,33 +298,40 @@ def test_job_queue_parallelism(monkeypatch, tmp_path):
 
 
 @job(max_workers=1)
-def transient_err_fun(tmp_dir: str, succeed_on_nth_run: int):
-    """
-    This function will raise `TransientError` on the first (`succeed_on_nth_run` - 1) runs,
-    then return 100 on the `succeed_on_nth_run` run. The `tmp_dir` records the run state.
-    """
-    from mlflow.server.jobs import TransientError
+def transient_err_fun_always_fail():
+    raise TransientError(RuntimeError("test transient error."))
 
-    # create one file with a unique name for each function call
-    with open(os.path.join(tmp_dir, uuid.uuid4().hex), "w") as f:
-        f.close()
-    time.sleep(0.1)
-    if len(os.listdir(tmp_dir)) == succeed_on_nth_run:
+
+@job(max_workers=1)
+def transient_err_fun_fail_then_succeed(counter_file: str):
+    counter_path = Path(counter_file)
+
+    try:
+        current = int(counter_path.read_text()) if counter_path.exists() else 0
+    except (ValueError, FileNotFoundError):
+        current = 0
+
+    current += 1
+    counter_path.write_text(str(current))
+
+    if current >= 2:
         return 100
     raise TransientError(RuntimeError("test transient error."))
 
 
 @job(max_workers=1, transient_error_classes=[TimeoutError])
-def transient_err_fun2(tmp_dir: str, succeed_on_nth_run: int):
-    """
-    This function will raise `TimeoutError` on the first (`succeed_on_nth_run` - 1) runs,
-    then return 100 on the `succeed_on_nth_run` run. The `tmp_dir` records the run state.
-    """
-    # create one file with a unique name for each function call
-    with open(os.path.join(tmp_dir, uuid.uuid4().hex), "w") as f:
-        f.close()
-    time.sleep(0.1)
-    if len(os.listdir(tmp_dir)) == succeed_on_nth_run:
+def transient_err_fun2_fail_then_succeed(counter_file: str):
+    counter_path = Path(counter_file)
+
+    try:
+        current = int(counter_path.read_text()) if counter_path.exists() else 0
+    except (ValueError, FileNotFoundError):
+        current = 0
+
+    current += 1
+    counter_path.write_text(str(current))
+
+    if current >= 2:
         return 100
     raise TimeoutError("test transient timeout error.")
 
@@ -302,15 +349,18 @@ def wait_job_finalize(job_id, timeout=60):
 def test_job_retry_on_transient_error(monkeypatch, tmp_path):
     monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_BASE_DELAY", "1")
     monkeypatch.setenv("MLFLOW_SERVER_JOB_TRANSIENT_ERROR_MAX_RETRIES", "2")
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=[
+            "tests.server.jobs.test_jobs.transient_err_fun_always_fail",
+            "tests.server.jobs.test_jobs.transient_err_fun_fail_then_succeed",
+            "tests.server.jobs.test_jobs.transient_err_fun2_fail_then_succeed",
+        ],
+    ):
         store = _get_job_store()
 
-        job1_tmp_path = tmp_path / "job1"
-        job1_tmp_path.mkdir()
-
-        job1_id = submit_job(
-            transient_err_fun, {"tmp_dir": str(job1_tmp_path), "succeed_on_nth_run": 3}
-        ).job_id
+        # Test 1: Job that always fails should exhaust retries and fail
+        job1_id = submit_job(transient_err_fun_always_fail, {}).job_id
         wait_job_finalize(job1_id, timeout=120)
         assert_job_result(job1_id, JobStatus.FAILED, "RuntimeError('test transient error.')")
         job1 = store.get_job(job1_id)
@@ -318,11 +368,10 @@ def test_job_retry_on_transient_error(monkeypatch, tmp_path):
         assert job1.result == "RuntimeError('test transient error.')"
         assert job1.retry_count == 2
 
-        job2_tmp_path = tmp_path / "job2"
-        job2_tmp_path.mkdir()
-
+        # Test 2: Job that fails once then succeeds should succeed with retry_count=1
+        job2_counter = tmp_path / "job2_counter.txt"
         job2_id = submit_job(
-            transient_err_fun, {"tmp_dir": str(job2_tmp_path), "succeed_on_nth_run": 2}
+            transient_err_fun_fail_then_succeed, {"counter_file": str(job2_counter)}
         ).job_id
         wait_job_finalize(job2_id)
         assert_job_result(job2_id, JobStatus.SUCCEEDED, 100)
@@ -331,11 +380,10 @@ def test_job_retry_on_transient_error(monkeypatch, tmp_path):
         assert job2.result == "100"
         assert job2.retry_count == 1
 
-        job3_tmp_path = tmp_path / "job3"
-        job3_tmp_path.mkdir()
-
+        # Test 3: Same as test 2 but with custom transient_error_classes
+        job3_counter = tmp_path / "job3_counter.txt"
         job3_id = submit_job(
-            transient_err_fun2, {"tmp_dir": str(job3_tmp_path), "succeed_on_nth_run": 2}
+            transient_err_fun2_fail_then_succeed, {"counter_file": str(job3_counter)}
         ).job_id
         wait_job_finalize(job3_id)
         assert_job_result(job3_id, JobStatus.SUCCEEDED, 100)
@@ -351,7 +399,10 @@ def test_job_retry_on_transient_error(monkeypatch, tmp_path):
 # multi-processes case.
 def test_submit_jobs_from_multi_processes(monkeypatch, tmp_path):
     context = multiprocessing.get_context("spawn")
-    with _setup_job_runner(monkeypatch, tmp_path), context.Pool(2) as pool:
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+    ), context.Pool(2) as pool:
         job_id = submit_job(basic_job_fun, {"x": 1, "y": 1, "sleep_secs": 0}).job_id
         wait_job_finalize(job_id)
 
@@ -379,7 +430,10 @@ def sleep_fun(sleep_secs, tmp_dir):
 def test_job_timeout(monkeypatch, tmp_path):
     from mlflow.server.jobs.utils import is_process_alive
 
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.sleep_fun"],
+    ):
         job_tmp_path = tmp_path / "job"
         job_tmp_path.mkdir()
 
@@ -413,7 +467,10 @@ def test_list_job_pagination(monkeypatch, tmp_path):
     import mlflow.store.jobs.sqlalchemy_store
 
     monkeypatch.setattr(mlflow.store.jobs.sqlalchemy_store, "_LIST_JOB_PAGE_SIZE", 3)
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+    ):
         job_ids = []
         for x in range(10):
             job_id = submit_job(basic_job_fun, {"x": x, "y": 4}).job_id
@@ -428,7 +485,10 @@ def bad_job_function() -> None:
 
 
 def test_job_function_without_decorator(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.bad_job_function"],
+    ):
         with pytest.raises(
             MlflowException,
             match="The job function tests.server.jobs.test_jobs.bad_job_function is not decorated",
@@ -442,7 +502,10 @@ def job_use_process(tmp_dir):
 
 
 def test_job_use_process(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.job_use_process"],
+    ):
         job_tmp_path = tmp_path / "job"
         job_tmp_path.mkdir()
 
@@ -454,7 +517,10 @@ def test_job_use_process(monkeypatch, tmp_path):
 
 
 def test_submit_job_bad_call(monkeypatch, tmp_path):
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+    ):
         with pytest.raises(
             MlflowException,
             match="When calling 'submit_job', the 'params' argument must be a dict.",
@@ -479,7 +545,10 @@ def check_python_env_fn():
 def test_job_with_python_env(monkeypatch, tmp_path):
     monkeypatch.setenv("MLFLOW_HOME", _get_mlflow_repo_home())
 
-    with _setup_job_runner(monkeypatch, tmp_path):
+    with _setup_job_runner(
+        monkeypatch, tmp_path,
+        allowed_job_functions=["tests.server.jobs.test_jobs.check_python_env_fn"],
+    ):
         job_id = submit_job(check_python_env_fn, params={}).job_id
         wait_job_finalize(job_id, timeout=600)
         job = get_job(job_id)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/18215?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18215/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18215/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18215/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Fix job backend race conditions

Since the job backend changes to forcebily use "process" mode, the unit tests captures some race conditions and become flaky.

In this PR, I made 2 major fixes:

* Launch Huey consumer immediately when job runner is started. (previous behavior is to lazily launch Huey consumer when the first job is submitted to Huey queue, **this triggers Huey race condition that causes the job being scheduled twice**) 
* Add system-wide exclusive lock for JobStore sqlalchemy engine initialization. Concurrently initializing sqlalchemy engine might cause sqlalchemy internal race condition errors and make follow-up SQL operations fail. **NOTE: pre-initialize the sqlalchemy engine in a separate process does not help**.  This race condition is captured by `test_job_queue_parallelism`


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
