### PR TITLE
Fix trace_info to dict conversion for v4

### DIFF
--- a/mlflow/entities/trace.py
+++ b/mlflow/entities/trace.py
@@ -117,11 +117,9 @@ class Trace(_MlflowObject):
         return bundle
 
     def to_pandas_dataframe_row(self) -> dict[str, Any]:
-        from mlflow.utils.databricks_tracing_utils import trace_to_json
-
         return {
             "trace_id": self.info.trace_id,
-            "trace": trace_to_json(self),  # json string to be compatible with Spark DataFrame
+            "trace": self.to_json(),  # json string to be compatible with Spark DataFrame
             "client_request_id": self.info.client_request_id,
             "state": self.info.state,
             "request_time": self.info.request_time,

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -11,6 +11,7 @@ from mlflow.entities.assessment import Assessment
 from mlflow.entities.trace_location import TraceLocation
 from mlflow.entities.trace_state import TraceState
 from mlflow.entities.trace_status import TraceStatus
+from mlflow.protos.databricks_tracing_pb2 import TraceInfo as ProtoTraceInfoV4
 from mlflow.protos.service_pb2 import TraceInfoV3 as ProtoTraceInfoV3
 from mlflow.tracing.constant import TraceMetadataKey
 
@@ -80,8 +81,13 @@ class TraceInfo(_MlflowObject):
 
             # V4 trace info has URI-format trace id and uc schema location
             if trace_location.type == "UC_SCHEMA":
+                from mlflow.tracing.utils import construct_trace_id_v4
+
                 schema = trace_location.uc_schema
-                d["trace_id"] = f"trace:/{schema.catalog_name}.{schema.schema_name}/{d['trace_id']}"
+                d["trace_id"] = construct_trace_id_v4(
+                    location=f"{schema.catalog_name}.{schema.schema_name}",
+                    trace_id=d["trace_id"],
+                )
 
         if state := d.get("state"):
             d["state"] = TraceState(state)
@@ -96,10 +102,10 @@ class TraceInfo(_MlflowObject):
 
         return cls(**d)
 
-    def to_proto(self) -> ProtoTraceInfoV3:
+    def to_proto(self) -> ProtoTraceInfoV3 | ProtoTraceInfoV4:
         from mlflow.entities.trace_info_v2 import _truncate_request_metadata, _truncate_tags
 
-        if self.is_v4():
+        if self._is_v4():
             from mlflow.utils.databricks_tracing_utils import trace_info_to_v4_proto
 
             return trace_info_to_v4_proto(self)
@@ -237,5 +243,5 @@ class TraceInfo(_MlflowObject):
             return json.loads(usage_json)
         return None
 
-    def is_v4(self) -> bool:
+    def _is_v4(self) -> bool:
         return self.trace_location.uc_schema is not None

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -96,7 +96,7 @@ class DatabricksTracingRestStore(RestStore):
             The returned TraceInfo object from the backend.
         """
         try:
-            if trace_info.is_v4():
+            if trace_info._is_v4():
                 return self._start_trace_v4(trace_info)
 
         # Temporarily we capture all exceptions and fallback to v3 if the trace location is not uc

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -42,7 +42,6 @@ from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH
 from mlflow.utils.databricks_tracing_utils import (
     assessment_to_proto,
     trace_from_proto,
-    trace_info_to_proto,
     trace_location_to_proto,
     uc_schema_location_from_proto,
     uc_schema_location_to_proto,
@@ -97,7 +96,7 @@ class DatabricksTracingRestStore(RestStore):
             The returned TraceInfo object from the backend.
         """
         try:
-            if trace_info.trace_location.uc_schema is not None:
+            if trace_info.is_v4():
                 return self._start_trace_v4(trace_info)
 
         # Temporarily we capture all exceptions and fallback to v3 if the trace location is not uc
@@ -114,7 +113,7 @@ class DatabricksTracingRestStore(RestStore):
         if location is None:
             raise MlflowException("Invalid trace ID format for v4 API.")
 
-        req_body = message_to_json(trace_info_to_proto(trace_info))
+        req_body = message_to_json(trace_info.to_proto())
         response_proto = self._call_endpoint(
             CreateTraceInfo,
             req_body,

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -512,7 +512,6 @@ def add_size_stats_to_trace_metadata(trace: Trace):
     This function must not throw an exception.
     """
     from mlflow.entities import Trace, TraceData
-    from mlflow.utils.databricks_tracing_utils import trace_to_json
 
     try:
         span_sizes = []
@@ -525,9 +524,7 @@ def add_size_stats_to_trace_metadata(trace: Trace):
         # again (which can be expensive), we compute the size of the trace without spans
         # and combine it with the total size of the spans.
         empty_trace = Trace(info=trace.info, data=TraceData(spans=[]))
-        # use trace_to_json instead of empty_trace.to_json() to be compatible with trace v4
-        # proto, which is a superset of the trace v3 proto.
-        metadata_size = len(trace_to_json(empty_trace).encode("utf-8"))
+        metadata_size = len((empty_trace.to_json()).encode("utf-8"))
 
         # NB: the third term is the size of comma separators between spans (", ").
         trace_size_bytes = sum(span_sizes) + metadata_size + (len(span_sizes) - 1) * 2

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -270,7 +270,7 @@ def test_trace_pandas_dataframe_columns():
     assert Trace.pandas_dataframe_columns() == list(t.to_pandas_dataframe_row())
 
     t = Trace(
-        info=create_test_trace_info_with_uc_table("a", "catalog", "schema", "spans_table"),
+        info=create_test_trace_info_with_uc_table("a", "catalog", "schema"),
         data=TraceData(),
     )
     assert Trace.pandas_dataframe_columns() == list(t.to_pandas_dataframe_row())

--- a/tests/entities/test_trace_info.py
+++ b/tests/entities/test_trace_info.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import pytest
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -121,6 +123,53 @@ def test_backwards_compatibility_with_v2():
     assert trace_info.request_metadata == {"foo": "bar"}
     assert trace_info.timestamp_ms == 1234567890
     assert trace_info.execution_time_ms is None
+
+
+def test_trace_info_v4():
+    trace_info_v4 = TraceInfo(
+        # v4 trace info has URI-format trace id and uc schema location
+        trace_id="trace:/catalog.schema/test_trace_id",
+        trace_location=TraceLocation.from_databricks_uc_schema(
+            catalog_name="catalog", schema_name="schema"
+        ),
+        request_time=0,
+        state=TraceState.OK,
+        request_preview="request",
+        response_preview="response",
+        client_request_id="client_request_id",
+        tags={"key": "value"},
+    )
+    dict_trace_info_v4 = trace_info_v4.to_dict()
+    assert dict_trace_info_v4 == {
+        "trace_id": "test_trace_id",
+        "trace_location": {
+            "type": "UC_SCHEMA",
+            "uc_schema": {
+                "catalog_name": "catalog",
+                "schema_name": "schema",
+            },
+        },
+        "request_time": mock.ANY,
+        "state": "OK",
+        "request_preview": "request",
+        "response_preview": "response",
+        "client_request_id": "client_request_id",
+        "tags": {"key": "value"},
+    }
+    assert TraceInfo.from_dict(dict_trace_info_v4) == trace_info_v4
+
+    proto_trace_info_v4 = trace_info_v4.to_proto()
+    assert proto_trace_info_v4.trace_id == "test_trace_id"
+    assert proto_trace_info_v4.trace_location.uc_schema.catalog_name == "catalog"
+    assert proto_trace_info_v4.trace_location.uc_schema.schema_name == "schema"
+    assert proto_trace_info_v4.state == 1
+    assert proto_trace_info_v4.request_preview == "request"
+    assert proto_trace_info_v4.response_preview == "response"
+    assert proto_trace_info_v4.client_request_id == "client_request_id"
+    assert proto_trace_info_v4.tags == {"key": "value"}
+    assert len(proto_trace_info_v4.assessments) == 0
+
+    assert TraceInfo.from_proto(proto_trace_info_v4) == trace_info_v4
 
 
 @pytest.mark.parametrize("client_request_id", [None, "client_request_id"])

--- a/tests/entities/test_trace_info.py
+++ b/tests/entities/test_trace_info.py
@@ -147,6 +147,8 @@ def test_trace_info_v4():
             "uc_schema": {
                 "catalog_name": "catalog",
                 "schema_name": "schema",
+                "otel_spans_table_name": "mlflow_experiment_trace_otel_spans",
+                "otel_logs_table_name": "mlflow_experiment_trace_otel_logs",
             },
         },
         "request_time": mock.ANY,

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -27,7 +27,6 @@ from mlflow.protos import service_pb2 as pb
 from mlflow.tracing.constant import TraceMetadataKey, TraceSizeStatsKey
 from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
 from mlflow.tracing.provider import _get_trace_exporter
-from mlflow.utils.databricks_tracing_utils import trace_to_json
 
 _EXPERIMENT_ID = "dummy-experiment-id"
 
@@ -100,9 +99,7 @@ def test_export(is_async, monkeypatch):
     size_bytes = int(trace_info.trace_metadata.pop(TraceMetadataKey.SIZE_BYTES))
 
     # The total size of the trace should much with the size of the trace object
-    expected_size_bytes = len(
-        trace_to_json(Trace(info=trace_info, data=trace_data)).encode("utf-8")
-    )
+    expected_size_bytes = len(Trace(info=trace_info, data=trace_data).to_json()).encode("utf-8")
 
     assert size_bytes == expected_size_bytes
     assert size_stats[TraceSizeStatsKey.TOTAL_SIZE_BYTES] == expected_size_bytes

--- a/tests/tracing/export/test_mlflow_v3_exporter.py
+++ b/tests/tracing/export/test_mlflow_v3_exporter.py
@@ -99,7 +99,7 @@ def test_export(is_async, monkeypatch):
     size_bytes = int(trace_info.trace_metadata.pop(TraceMetadataKey.SIZE_BYTES))
 
     # The total size of the trace should much with the size of the trace object
-    expected_size_bytes = len(Trace(info=trace_info, data=trace_data).to_json()).encode("utf-8")
+    expected_size_bytes = len(Trace(info=trace_info, data=trace_data).to_json().encode("utf-8"))
 
     assert size_bytes == expected_size_bytes
     assert size_stats[TraceSizeStatsKey.TOTAL_SIZE_BYTES] == expected_size_bytes

--- a/tests/tracing/export/test_uc_table_exporter.py
+++ b/tests/tracing/export/test_uc_table_exporter.py
@@ -27,7 +27,7 @@ def test_export_spans_to_uc_table(is_async, monkeypatch):
     span = Span(otel_span)
 
     # Create trace info with UC table
-    trace_info = create_test_trace_info_with_uc_table(trace_id, "catalog", "schema", "spans")
+    trace_info = create_test_trace_info_with_uc_table(trace_id, "catalog", "schema")
     trace_manager.register_trace(otel_span.context.trace_id, trace_info)
     trace_manager.register_span(span)
 

--- a/tests/tracing/helper.py
+++ b/tests/tracing/helper.py
@@ -135,7 +135,7 @@ def create_test_trace_info(
 
 
 def create_test_trace_info_with_uc_table(
-    trace_id: str, catalog_name: str, schema_name: str, spans_table_name: str
+    trace_id: str, catalog_name: str, schema_name: str
 ) -> TraceInfo:
     return TraceInfo(
         trace_id=trace_id,

--- a/tests/utils/test_databricks_tracing_utils.py
+++ b/tests/utils/test_databricks_tracing_utils.py
@@ -32,7 +32,6 @@ from mlflow.utils.databricks_tracing_utils import (
     mlflow_experiment_location_to_proto,
     trace_from_proto,
     trace_info_to_dict,
-    trace_info_to_proto,
     trace_location_from_proto,
     trace_location_to_proto,
     trace_to_proto,
@@ -158,7 +157,7 @@ def test_trace_location_from_proto_inference_table():
     assert trace_location.inference_table.full_table_name == "test_catalog.test_schema.test_table"
 
 
-def test_trace_info_to_proto():
+def test_trace_info_to_v4_proto():
     otel_trace_id = "2efb31387ff19263f92b2c0a61b0a8bc"
     trace_id = f"trace:/catalog.schema/{otel_trace_id}"
     trace_info = TraceInfo(
@@ -173,7 +172,7 @@ def test_trace_info_to_proto():
         client_request_id="client_request_id",
         tags={"key": "value"},
     )
-    proto_trace_info = trace_info_to_proto(trace_info)
+    proto_trace_info = trace_info.to_proto()
     assert proto_trace_info.trace_id == otel_trace_id
     assert proto_trace_info.trace_location.uc_schema.catalog_name == "catalog"
     assert proto_trace_info.trace_location.uc_schema.schema_name == "schema"

--- a/tests/utils/test_databricks_tracing_utils.py
+++ b/tests/utils/test_databricks_tracing_utils.py
@@ -1,5 +1,4 @@
 import json
-from unittest import mock
 
 from google.protobuf.timestamp_pb2 import Timestamp
 
@@ -31,7 +30,6 @@ from mlflow.utils.databricks_tracing_utils import (
     inference_table_location_to_proto,
     mlflow_experiment_location_to_proto,
     trace_from_proto,
-    trace_info_to_dict,
     trace_location_from_proto,
     trace_location_to_proto,
     trace_to_proto,
@@ -261,40 +259,6 @@ def test_trace_info_from_proto_handles_uc_schema_location():
     assert trace_info.trace_metadata[TRACE_SCHEMA_VERSION_KEY] == str(TRACE_SCHEMA_VERSION)
     assert trace_info.trace_metadata["other_key"] == "other_value"
     assert trace_info.tags == {"test_tag": "test_value"}
-
-
-def test_trace_info_to_dict():
-    trace_info = TraceInfo(
-        trace_id="test_trace_id",
-        trace_location=TraceLocation.from_databricks_uc_schema(
-            catalog_name="catalog", schema_name="schema"
-        ),
-        request_time=0,
-        state=TraceState.OK,
-        request_preview="request",
-        response_preview="response",
-        client_request_id="client_request_id",
-        tags={"key": "value"},
-    )
-    assert trace_info_to_dict(trace_info) == {
-        "trace_id": "test_trace_id",
-        "trace_location": {
-            "type": "UC_SCHEMA",
-            "uc_schema": {
-                "catalog_name": "catalog",
-                "schema_name": "schema",
-                # Default table names
-                "otel_spans_table_name": "mlflow_experiment_trace_otel_spans",
-                "otel_logs_table_name": "mlflow_experiment_trace_otel_logs",
-            },
-        },
-        "request_time": mock.ANY,
-        "state": "OK",
-        "request_preview": "request",
-        "response_preview": "response",
-        "client_request_id": "client_request_id",
-        "tags": {"key": "value"},
-    }
 
 
 def test_add_size_stats_to_trace_metadata_for_v4_trace():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18129?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18129/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18129/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18129/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Fix `to_dict()` / `from_dict()` for v4 trace.
```
trace_info_v4.to_dict()
```

> ValueError: Enum TraceLocationType has no value defined for name <TraceLocationType.UC_SCHEMA: 'UC_SCHEMA'>

The error is because v4 trace info has a separate utility under `databricks_tracing_utils.py`. The intention was to split out v4 proto logic outside the main entity. However, public interface should still work.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
