### PR TITLE
Add client-side retry for get_trace

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext
@@ -34,7 +35,7 @@ from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.telemetry.events import LogAssessmentEvent, StartTraceEvent
 from mlflow.telemetry.track import record_usage_event
-from mlflow.tracing.constant import TraceMetadataKey
+from mlflow.tracing.constant import GET_TRACE_V4_RETRY_TIMEOUT, TraceMetadataKey
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import TraceJSONEncoder, exclude_immutable_tags, parse_trace_id_v4
 from mlflow.tracing.utils.artifact_utils import get_artifact_uri_for_trace
@@ -151,14 +152,27 @@ class TracingClient:
         """
         location, _ = parse_trace_id_v4(trace_id)
         if location is not None:
-            # V4 trace, load spans from v4 BatchGetTraces endpoint.
-            traces = self.store.batch_get_traces([trace_id], location)
-            if not traces:
-                raise MlflowException(
-                    message=f"Trace with ID {trace_id} is not found.",
-                    error_code=NOT_FOUND,
+            # Retry up to 10 seconds because...
+            start_time = time.time()
+            attempt = 0
+            while time.time() - start_time < GET_TRACE_V4_RETRY_TIMEOUT:
+                # V4 trace, load spans from v4 BatchGetTraces endpoint.
+                # BatchGetTraces returns an empty list if the trace is not found, which will be
+                # retried up to GET_TRACE_V4_RETRY_TIMEOUT seconds.
+                if traces := self.store.batch_get_traces([trace_id], location):
+                    return traces[0]
+
+                attempt += 1
+                interval = 2**attempt
+                _logger.debug(
+                    f"Trace not found, retrying in {interval} seconds (attempt {attempt})"
                 )
-            return traces[0]
+                time.sleep(interval)
+
+            raise MlflowException(
+                message=f"Trace with ID {trace_id} is not found.",
+                error_code=NOT_FOUND,
+            )
         else:
             # V3 trace, load spans from artifact repository.
             try:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -35,7 +35,7 @@ from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.telemetry.events import LogAssessmentEvent, StartTraceEvent
 from mlflow.telemetry.track import record_usage_event
-from mlflow.tracing.constant import GET_TRACE_V4_RETRY_TIMEOUT, TraceMetadataKey
+from mlflow.tracing.constant import GET_TRACE_V4_RETRY_TIMEOUT_SECONDS, TraceMetadataKey
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import TraceJSONEncoder, exclude_immutable_tags, parse_trace_id_v4
 from mlflow.tracing.utils.artifact_utils import get_artifact_uri_for_trace
@@ -154,10 +154,10 @@ class TracingClient:
         if location is not None:
             start_time = time.time()
             attempt = 0
-            while time.time() - start_time < GET_TRACE_V4_RETRY_TIMEOUT:
+            while time.time() - start_time < GET_TRACE_V4_RETRY_TIMEOUT_SECONDS:
                 # For a V4 trace, load spans from the v4 BatchGetTraces endpoint.
                 # BatchGetTraces returns an empty list if the trace is not found, which will be
-                # retried up to GET_TRACE_V4_RETRY_TIMEOUT seconds.
+                # retried up to GET_TRACE_V4_RETRY_TIMEOUT_SECONDS seconds.
                 if traces := self.store.batch_get_traces([trace_id], location):
                     return traces[0]
 

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -152,11 +152,10 @@ class TracingClient:
         """
         location, _ = parse_trace_id_v4(trace_id)
         if location is not None:
-            # Retry up to 10 seconds because...
             start_time = time.time()
             attempt = 0
             while time.time() - start_time < GET_TRACE_V4_RETRY_TIMEOUT:
-                # V4 trace, load spans from v4 BatchGetTraces endpoint.
+                # For a V4 trace, load spans from the v4 BatchGetTraces endpoint.
                 # BatchGetTraces returns an empty list if the trace is not found, which will be
                 # retried up to GET_TRACE_V4_RETRY_TIMEOUT seconds.
                 if traces := self.store.batch_get_traces([trace_id], location):

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -106,3 +106,9 @@ DATABRICKS_OUTPUT_KEY = "databricks_output"
 
 # Assessment constants
 ASSESSMENT_ID_PREFIX = "a-"
+
+
+# Maximum number of seconds to retry getting a trace from the v4 endpoint.
+# V4 traces have some delay in propagation (after the log_spans call returns success response).
+# To make sure get_trace API does not fail due to this delay, we retry up to 30 seconds.
+GET_TRACE_V4_RETRY_TIMEOUT = 30

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -109,6 +109,7 @@ ASSESSMENT_ID_PREFIX = "a-"
 
 
 # Maximum number of seconds to retry getting a trace from the v4 endpoint.
-# V4 traces have some delay in propagation (after the log_spans call returns success response).
-# To make sure get_trace API does not fail due to this delay, we retry up to 30 seconds.
-GET_TRACE_V4_RETRY_TIMEOUT = 30
+# V4 traces have some delay in propagation after the log_spans call returns success response.
+# To make sure get_trace API does not fail due to this delay, we retry up to a reasonable timeout.
+# Setting 15 seconds because the initial version of the backend is known to have 1~5 seconds delay.
+GET_TRACE_V4_RETRY_TIMEOUT_SECONDS = 15

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -8,6 +8,32 @@ from mlflow.tracing.client import TracingClient
 from tests.tracing.helper import skip_when_testing_trace_sdk
 
 
+def test_get_trace_v4():
+    mock_store = Mock()
+    mock_store.batch_get_traces.return_value = ["dummy_trace"]
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient()
+        trace = client.get_trace("trace:/catalog.schema/1234567890")
+
+    assert trace == "dummy_trace"
+    mock_store.batch_get_traces.assert_called_once_with(
+        ["trace:/catalog.schema/1234567890"], "catalog.schema"
+    )
+
+
+def test_get_trace_v4_retry():
+    mock_store = Mock()
+    mock_store.batch_get_traces.side_effect = [[], ["dummy_trace"]]
+
+    with patch("mlflow.tracing.client._get_store", return_value=mock_store):
+        client = TracingClient()
+        trace = client.get_trace("trace:/catalog.schema/1234567890")
+
+    assert trace == "dummy_trace"
+    assert mock_store.batch_get_traces.call_count == 3
+
+
 @skip_when_testing_trace_sdk
 def test_tracing_client_link_prompt_versions_to_trace():
     with mlflow.start_run():

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -31,7 +31,7 @@ def test_get_trace_v4_retry():
         trace = client.get_trace("trace:/catalog.schema/1234567890")
 
     assert trace == "dummy_trace"
-    assert mock_store.batch_get_traces.call_count == 3
+    assert mock_store.batch_get_traces.call_count == 2
 
 
 @skip_when_testing_trace_sdk


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18224?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18224/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18224/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18224/merge
```

</p>
</details>

### What changes are proposed in this pull request?

V4 traces have some delay in propagation (after the log_spans call returns success response).
To make sure get_trace API does not fail due to this delay, we retry up to 30 seconds. We do have log-then-get pattern in a few places (e.g., setting tags, genai evaluation), so it is important to make sure get call doesn't fail when it is called immediately after trace creation.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
