### PR TITLE
Call `get_experiment` within `set_experiment_trace_location` API to trigger init side effect.

### DIFF
--- a/mlflow/tracing/enablement.py
+++ b/mlflow/tracing/enablement.py
@@ -9,6 +9,7 @@ from mlflow.entities.trace_location import UCSchemaLocation
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
 from mlflow.utils.uri import is_databricks_uri
+from mlflow.version import IS_TRACING_SDK_ONLY
 
 _logger = logging.getLogger(__name__)
 
@@ -87,7 +88,7 @@ def set_experiment_trace_location(
     # Check if the experiment exists. In Databricks notebook, this `get_experiment` call triggers
     # a side effect to create the experiment for the notebook if it doesn't exist. This side effect
     # is convenient for users.
-    if experiment_id:
+    if experiment_id and not IS_TRACING_SDK_ONLY:
         try:
             mlflow.get_experiment(str(experiment_id))
         except Exception as e:

--- a/mlflow/tracing/enablement.py
+++ b/mlflow/tracing/enablement.py
@@ -4,6 +4,7 @@ Trace enablement functionality for MLflow to enable tracing to Databricks Storag
 
 import logging
 
+import mlflow
 from mlflow.entities.trace_location import UCSchemaLocation
 from mlflow.exceptions import MlflowException
 from mlflow.utils.annotations import experimental
@@ -82,6 +83,18 @@ def set_experiment_trace_location(
             "Experiment ID is required to set storage location, either pass it as an argument or "
             "use `mlflow.set_experiment` to set the current experiment."
         )
+
+    # Check if the experiment exists. In Databricks notebook, this `get_experiment` call triggers
+    # a side effect to create the experiment for the notebook if it doesn't exist. This side effect
+    # is convenient for users.
+    if experiment_id:
+        try:
+            mlflow.get_experiment(str(experiment_id))
+        except Exception as e:
+            raise MlflowException.invalid_parameter_value(
+                f"Could not find experiment with ID {experiment_id}. Please make sure the "
+                "experiment exists before setting the storage location."
+            ) from e
 
     uc_schema_location = TracingClient()._set_experiment_trace_location(
         location=location,

--- a/tests/tracing/test_enablement.py
+++ b/tests/tracing/test_enablement.py
@@ -14,6 +14,8 @@ from mlflow.tracing.enablement import (
     unset_experiment_trace_location,
 )
 
+from tests.tracing.helper import skip_when_testing_trace_sdk
+
 
 @pytest.fixture
 def mock_databricks_tracking_uri():
@@ -21,6 +23,7 @@ def mock_databricks_tracking_uri():
         yield
 
 
+@skip_when_testing_trace_sdk
 def test_set_experiment_trace_location(mock_databricks_tracking_uri):
     experiment_id = mlflow.create_experiment("test_experiment")
     location = UCSchemaLocation(catalog_name="test_catalog", schema_name="test_schema")
@@ -83,6 +86,7 @@ def test_set_experiment_trace_location_no_experiment(mock_databricks_tracking_ur
             set_experiment_trace_location(location=location)
 
 
+@skip_when_testing_trace_sdk
 def test_set_experiment_trace_location_non_existent_experiment(mock_databricks_tracking_uri):
     location = UCSchemaLocation(catalog_name="test_catalog", schema_name="test_schema")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18114?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18114/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18114/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18114/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Call `get_experiment` API inside the `set_experiment_trace_location` API before linking the experiment to UC table. One reason is for failing fast, but another main reason is convenience in Databricks notebook. When user creates a notebook in Databricks, it does not have an experiment associated first. Then when user calls the `GetExperiment` API with the notebook ID first time, MLflow backend creates an experiment with the same ID and associate it with the notebook. By calling `get_experiment` inside the location API, we can trigger this side effect.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
