### PR TITLE
Job backend: Fix job store sql engine race condition

### DIFF
--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -37,8 +37,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)
         self.engine = mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(db_uri)
-        if not mlflow.store.db.utils._all_tables_exist(self.engine):
-            mlflow.store.db.utils._initialize_tables(self.engine)
+        mlflow.store.db.utils._safe_initialize_tables(self.engine)
 
         SessionMaker = sqlalchemy.orm.sessionmaker(bind=self.engine)
         self.ManagedSessionMaker = mlflow.store.db.utils._get_managed_session_maker(

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -24,6 +24,7 @@ from concurrent.futures import as_completed
 from contextlib import contextmanager
 from dataclasses import dataclass
 from subprocess import CalledProcessError, TimeoutExpired
+from types import TracebackType
 from typing import Any
 from urllib.parse import unquote
 from urllib.request import pathname2url
@@ -992,7 +993,8 @@ class ExclusiveFileLock:
         self.path = path
         self.fd = None
 
-    def __enter__(self):
+    def __enter__(self) -> None:
+        # Python on Windows does not have `fcntl` module, so importing it lazily.
         import fcntl  # clint: disable=lazy-builtin-import
 
         # Open file (create if missing)
@@ -1000,7 +1002,13 @@ class ExclusiveFileLock:
         # Acquire exclusive lock (blocking)
         fcntl.flock(self.fd, fcntl.LOCK_EX)
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ):
+        # Python on Windows does not have `fcntl` module, so importing it lazily.
         import fcntl  # clint: disable=lazy-builtin-import
 
         # Release lock

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -979,3 +979,30 @@ def read_yaml(root: str, file_name: str) -> dict[str, Any]:
 
     with open(os.path.join(root, file_name)) as f:
         return yaml.safe_load(f)
+
+
+class ExclusiveFileLock:
+    """
+    Exclusive file lock (only works on Unix system)
+    """
+
+    def __init__(self, path):
+        if os.name == "nt":
+            raise MlflowException("ExclusiveFileLock class does not support Windows system.")
+        self.path = path
+        self.fd = None
+
+    def __enter__(self):
+        import fcntl
+
+        # Open file (create if missing)
+        self.fd = open(self.path, "w")
+        # Acquire exclusive lock (blocking)
+        fcntl.flock(self.fd, fcntl.LOCK_EX)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        import fcntl
+
+        # Release lock
+        fcntl.flock(self.fd, fcntl.LOCK_UN)
+        self.fd.close()

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -993,7 +993,7 @@ class ExclusiveFileLock:
         self.fd = None
 
     def __enter__(self):
-        import fcntl
+        import fcntl  # clint: disable=lazy-builtin-import
 
         # Open file (create if missing)
         self.fd = open(self.path, "w")
@@ -1001,7 +1001,7 @@ class ExclusiveFileLock:
         fcntl.flock(self.fd, fcntl.LOCK_EX)
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        import fcntl
+        import fcntl  # clint: disable=lazy-builtin-import
 
         # Release lock
         fcntl.flock(self.fd, fcntl.LOCK_UN)

--- a/mlflow/utils/file_utils.py
+++ b/mlflow/utils/file_utils.py
@@ -987,7 +987,7 @@ class ExclusiveFileLock:
     Exclusive file lock (only works on Unix system)
     """
 
-    def __init__(self, path):
+    def __init__(self, path: str):
         if os.name == "nt":
             raise MlflowException("ExclusiveFileLock class does not support Windows system.")
         self.path = path

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -20,7 +20,7 @@ from mlflow.server.jobs.utils import _launch_job_runner
 # TODO: Remove `pytest.mark.xfail` after fixing flakiness
 pytestmark = [
     pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
-    pytest.mark.xfail,
+    pytest.mark.repeat(30),
 ]
 
 

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -50,12 +50,6 @@ def _setup_job_runner(
     backend_store_uri: str | None = None,
 ):
     backend_store_uri = backend_store_uri or f"sqlite:///{tmp_path / 'mlflow.db'}"
-    """
-    # Pre-initialize the database to prevent race conditions when the tracking store and job store
-    # attempt to initialize the database simultaneously.
-    store = SqlAlchemyStore(backend_store_uri, (tmp_path / "artifacts").as_uri())
-    store.engine.dispose()
-    """
     huey_store_path = tmp_path / "huey_store"
     huey_store_path.mkdir()
     default_artifact_root = str(tmp_path / "artifacts")

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -20,7 +20,6 @@ from mlflow.server.jobs.utils import _launch_job_runner
 # TODO: Remove `pytest.mark.xfail` after fixing flakiness
 pytestmark = [
     pytest.mark.skipif(os.name == "nt", reason="MLflow job execution is not supported on Windows"),
-    pytest.mark.repeat(30),
 ]
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/18233?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18233/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18233/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18233/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Add system-wide exclusive lock for JobStore sqlalchemy engine initialization. **Concurrently initializing sqlalchemy engine from multiple processes** might cause sqlalchemy internal race condition errors and make follow-up SQL operations fail. 

NOTE: pre-initializing the sqlalchemy engine in a separate process does not help. This race condition is captured by `test_job_queue_parallelism`, it causes sqlalchemy exceptions like:
```
Traceback (most recent call last):
  File "/Users/weichen.xu/opt/miniconda3/envs/py310/lib/python3.10/site-packages/huey/api.py", line 394, in _execute
    task_value = task.execute()
  File "/Users/weichen.xu/opt/miniconda3/envs/py310/lib/python3.10/site-packages/huey/api.py", line 834, in execute
    return func(*args, **kwargs)
  File "/Users/weichen.xu/work/mlflow/mlflow/server/jobs/utils.py", line 222, in _exec_job
    job_store = _get_job_store()
  File "/Users/weichen.xu/work/mlflow/mlflow/server/handlers.py", line 502, in _get_job_store
    _job_store = SqlAlchemyJobStore(store_uri)
  File "/Users/weichen.xu/work/mlflow/mlflow/store/jobs/sqlalchemy_store.py", line 41, in __init__
    mlflow.store.db.utils._initialize_tables(self.engine)
  File "/Users/weichen.xu/work/mlflow/mlflow/store/db/utils.py", line 111, in _initialize_tables
    _upgrade_db(engine)
  File "/Users/weichen.xu/work/mlflow/mlflow/store/db/utils.py", line 236, in _upgrade_db
    command.upgrade(config, "heads")
  File "/Users/weichen.xu/opt/miniconda3/envs/py310/lib/python3.10/site-packages/alembic/command.py", line 397, in upgrade
    with EnvironmentContext(
  File "/Users/weichen.xu/opt/miniconda3/envs/py310/lib/python3.10/site-packages/alembic/runtime/environment.py", line 217, in __exit__
    self._remove_proxy()
  File "/Users/weichen.xu/opt/miniconda3/envs/py310/lib/python3.10/site-packages/alembic/util/langhelpers.py", line 87, in _remove_proxy
    del globals_[attr_name]
KeyError: 'script'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
