### PR TITLE
Add clint rule to enforce `mock.patch` as context manager

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -569,6 +569,16 @@ class Linter(ast.NodeVisitor):
         if deco := rules.PytestMarkRepeat.check(node.decorator_list, self.resolver):
             self._check(Location.from_node(deco), rules.PytestMarkRepeat())
 
+    def _mock_patch_as_decorator(self, node: ast.FunctionDef | ast.AsyncFunctionDef) -> None:
+        # Only check in test files
+        if not self.path.name.startswith("test_"):
+            return
+
+        # Check all decorators, not just the first one
+        for deco in node.decorator_list:
+            if rules.MockPatchAsDecorator.check([deco], self.resolver, self.path):
+                self._check(Location.from_node(deco), rules.MockPatchAsDecorator())
+
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
         self._test_name_typo(node)
         self._syntax_error_example(node)
@@ -576,6 +586,7 @@ class Linter(ast.NodeVisitor):
         self._markdown_link(node)
         self._invalid_abstract_method(node)
         self._pytest_mark_repeat(node)
+        self._mock_patch_as_decorator(node)
         self._redundant_test_docstring(node)
 
         for arg in node.args.args + node.args.kwonlyargs + node.args.posonlyargs:
@@ -599,6 +610,7 @@ class Linter(ast.NodeVisitor):
         self._markdown_link(node)
         self._invalid_abstract_method(node)
         self._pytest_mark_repeat(node)
+        self._mock_patch_as_decorator(node)
         self._redundant_test_docstring(node)
         self.stack.append(node)
         self._no_rst(node)

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -21,6 +21,7 @@ from clint.rules.markdown_link import MarkdownLink
 from clint.rules.missing_docstring_param import MissingDocstringParam
 from clint.rules.missing_notebook_h1_header import MissingNotebookH1Header
 from clint.rules.mlflow_class_name import MlflowClassName
+from clint.rules.mock_patch_as_decorator import MockPatchAsDecorator
 from clint.rules.multi_assign import MultiAssign
 from clint.rules.no_class_based_tests import NoClassBasedTests
 from clint.rules.no_rst import NoRst
@@ -70,6 +71,7 @@ __all__ = [
     "MissingDocstringParam",
     "MissingNotebookH1Header",
     "MlflowClassName",
+    "MockPatchAsDecorator",
     "NoClassBasedTests",
     "NoRst",
     "NoShebang",

--- a/dev/clint/src/clint/rules/mock_patch_as_decorator.py
+++ b/dev/clint/src/clint/rules/mock_patch_as_decorator.py
@@ -7,25 +7,32 @@ from clint.rules.base import Rule
 
 class MockPatchAsDecorator(Rule):
     # TODO: Gradually migrate these files to use mock.patch as context manager
-    # Remove files from this list once they've been migrated (total: 71 violations)
+    # Remove files from this list once they've been migrated (total: 117 violations)
     # Files are sorted by violation count (descending) to prioritize migration
     IGNORED_FILES = {
+        "tests/genai/scorers/test_registered_scorers_scheduling.py",  # 25
         "tests/utils/test_rest_utils.py",  # 15
         "tests/store/artifact/test_hdfs_artifact_repo.py",  # 10
         "tests/utils/test_databricks_utils.py",  # 10
+        "tests/genai/scorers/test_builtin_scorers.py",  # 6
         "tests/evaluate/test_evaluation.py",  # 5
+        "tests/genai/scorers/test_scorer_CRUD.py",  # 5
         "tests/langchain/test_langchain_model_export.py",  # 5
         "tests/projects/test_docker_projects.py",  # 4
         "tests/store/tracking/test_databricks_rest_store.py",  # 4
         "tests/store/tracking/test_rest_store.py",  # 4
         "tests/store/tracking/test_sqlalchemy_store.py",  # 4
+        "tests/genai/test_genai_import_without_agent_sdk.py",  # 3
+        "tests/mistral/test_mistral_autolog.py",  # 3
         "tests/models/test_model_config.py",  # 3
         "tests/transformers/test_transformers_model_export.py",  # 3
         "tests/genai/judges/test_judge_utils.py",  # 2
         "tests/projects/test_databricks.py",  # 2
         "tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py",  # 2
+        "tests/tracing/utils/test_processor.py",  # 2
         "tests/autologging/test_autologging_safety_unit.py",  # 1
         "tests/db/test_tracking_operations.py",  # 1
+        "tests/evaluate/logging/test_evaluation.py",  # 1
         "tests/genai/evaluate/test_context.py",  # 1
         "tests/genai/evaluate/test_evaluation.py",  # 1
         "tests/pyfunc/test_pyfunc_model_with_type_hints.py",  # 1
@@ -33,6 +40,7 @@ class MockPatchAsDecorator(Rule):
         "tests/store/artifact/test_azure_blob_artifact_repo.py",  # 1
         "tests/store/artifact/test_dbfs_artifact_repo_delegation.py",  # 1
         "tests/store/model_registry/test_rest_store.py",  # 1
+        "tests/store/tracking/test_abstract_store.py",  # 1
         "tests/tracing/export/test_async_export_queue.py",  # 1
         "tests/tracing/export/test_mlflow_v3_exporter.py",  # 1
         "tests/tracing/test_fluent.py",  # 1

--- a/dev/clint/src/clint/rules/mock_patch_as_decorator.py
+++ b/dev/clint/src/clint/rules/mock_patch_as_decorator.py
@@ -1,0 +1,68 @@
+import ast
+from pathlib import Path
+
+from clint.resolver import Resolver
+from clint.rules.base import Rule
+
+
+class MockPatchAsDecorator(Rule):
+    # TODO: Gradually migrate these files to use mock.patch as context manager
+    # Remove files from this list once they've been migrated (total: 71 violations)
+    # Files are sorted by violation count (descending) to prioritize migration
+    IGNORED_FILES = {
+        "tests/utils/test_rest_utils.py",  # 15
+        "tests/store/artifact/test_hdfs_artifact_repo.py",  # 10
+        "tests/utils/test_databricks_utils.py",  # 10
+        "tests/evaluate/test_evaluation.py",  # 5
+        "tests/langchain/test_langchain_model_export.py",  # 5
+        "tests/projects/test_docker_projects.py",  # 4
+        "tests/store/tracking/test_databricks_rest_store.py",  # 4
+        "tests/store/tracking/test_rest_store.py",  # 4
+        "tests/store/tracking/test_sqlalchemy_store.py",  # 4
+        "tests/models/test_model_config.py",  # 3
+        "tests/transformers/test_transformers_model_export.py",  # 3
+        "tests/genai/judges/test_judge_utils.py",  # 2
+        "tests/projects/test_databricks.py",  # 2
+        "tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py",  # 2
+        "tests/autologging/test_autologging_safety_unit.py",  # 1
+        "tests/db/test_tracking_operations.py",  # 1
+        "tests/genai/evaluate/test_context.py",  # 1
+        "tests/genai/evaluate/test_evaluation.py",  # 1
+        "tests/pyfunc/test_pyfunc_model_with_type_hints.py",  # 1
+        "tests/server/test_security_integration.py",  # 1
+        "tests/store/artifact/test_azure_blob_artifact_repo.py",  # 1
+        "tests/store/artifact/test_dbfs_artifact_repo_delegation.py",  # 1
+        "tests/store/model_registry/test_rest_store.py",  # 1
+        "tests/tracing/export/test_async_export_queue.py",  # 1
+        "tests/tracing/export/test_mlflow_v3_exporter.py",  # 1
+        "tests/tracing/test_fluent.py",  # 1
+        "tests/tracking/test_client.py",  # 1
+        "tests/transformers/test_transformers_llm_inference_utils.py",  # 1
+    }
+
+    def _message(self) -> str:
+        return (
+            "Do not use `unittest.mock.patch` as a decorator. "
+            "Use it as a context manager to avoid patches being active longer than needed "
+            "and to make it clear which code depends on them."
+        )
+
+    @staticmethod
+    def check(
+        decorator_list: list[ast.expr], resolver: Resolver, file_path: Path | None = None
+    ) -> ast.expr | None:
+        """
+        Returns the decorator node if it is a `@mock.patch` or `@patch` decorator.
+        """
+        # Skip files in the ignore list
+        if file_path and str(file_path) in MockPatchAsDecorator.IGNORED_FILES:
+            return None
+
+        for deco in decorator_list:
+            if res := resolver.resolve(deco):
+                match res:
+                    # Resolver returns ["unittest", "mock", "patch", ...]
+                    # The *_ captures variants like "object", "dict", etc.
+                    case ["unittest", "mock", "patch", *_]:
+                        return deco
+        return None

--- a/dev/clint/tests/rules/test_mock_patch_as_decorator.py
+++ b/dev/clint/tests/rules/test_mock_patch_as_decorator.py
@@ -1,0 +1,108 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.linter import Location, lint_file
+from clint.rules.mock_patch_as_decorator import MockPatchAsDecorator
+
+
+def test_mock_patch_as_decorator_unittest_mock(index_path: Path) -> None:
+    code = """
+import unittest.mock
+
+@unittest.mock.patch("foo.bar")
+def test_foo(mock_bar):
+    ...
+"""
+    config = Config(select={MockPatchAsDecorator.name})
+    violations = lint_file(Path("test_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, MockPatchAsDecorator) for v in violations)
+    assert violations[0].loc == Location(3, 1)
+
+
+def test_mock_patch_as_decorator_from_unittest_import_mock(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+@mock.patch("foo.bar")
+def test_foo(mock_bar):
+    ...
+"""
+    config = Config(select={MockPatchAsDecorator.name})
+    violations = lint_file(Path("test_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, MockPatchAsDecorator) for v in violations)
+    assert violations[0].loc == Location(3, 1)
+
+
+def test_mock_patch_object_as_decorator(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+@mock.patch.object(SomeClass, "method")
+def test_foo(mock_method):
+    ...
+"""
+    config = Config(select={MockPatchAsDecorator.name})
+    violations = lint_file(Path("test_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, MockPatchAsDecorator) for v in violations)
+    assert violations[0].loc == Location(3, 1)
+
+
+def test_mock_patch_dict_as_decorator(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+@mock.patch.dict("os.environ", {"FOO": "bar"})
+def test_foo():
+    ...
+"""
+    config = Config(select={MockPatchAsDecorator.name})
+    violations = lint_file(Path("test_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, MockPatchAsDecorator) for v in violations)
+    assert violations[0].loc == Location(3, 1)
+
+
+def test_mock_patch_as_context_manager_is_ok(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar") as mock_bar:
+        ...
+"""
+    config = Config(select={MockPatchAsDecorator.name})
+    violations = lint_file(Path("test_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_non_test_file_not_checked(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+@mock.patch("foo.bar")
+def foo(mock_bar):
+    ...
+"""
+    config = Config(select={MockPatchAsDecorator.name})
+    violations = lint_file(Path("mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_multiple_patch_decorators(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+@mock.patch("foo.bar")
+@mock.patch("foo.baz")
+def test_foo(mock_baz, mock_bar):
+    ...
+"""
+    config = Config(select={MockPatchAsDecorator.name})
+    violations = lint_file(Path("test_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 2
+    assert all(isinstance(v.rule, MockPatchAsDecorator) for v in violations)
+    assert violations[0].loc == Location(3, 1)
+    assert violations[1].loc == Location(4, 1)

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -100,8 +100,6 @@ class DatabricksTracingRestStore(RestStore):
             if trace_info.trace_location.uc_schema is not None:
                 return self._start_trace_v4(trace_info)
 
-        # Temporarily we capture all exceptions and fallback to v3 if the trace location is not uc
-        # TODO: remove this once the endpoint is fully rolled out
         except Exception as e:
             if trace_info.trace_location.mlflow_experiment is None:
                 _logger.debug("MLflow experiment is not set for trace, cannot fallback to V3 API.")
@@ -223,7 +221,6 @@ class DatabricksTracingRestStore(RestStore):
         model_id: str | None = None,
         locations: list[str] | None = None,
     ) -> tuple[list[TraceInfo], str | None]:
-        # This API is not client-facing, so we should always use `locations`.
         if experiment_ids is not None:
             raise MlflowException("`experiment_ids` is deprecated, use `locations` instead.")
         if not locations:
@@ -231,7 +228,6 @@ class DatabricksTracingRestStore(RestStore):
                 "At least one location must be specified for searching traces."
             )
 
-        # model_id is only supported by V3 API
         if model_id is not None:
             return self._search_unified_traces(
                 model_id=model_id,
@@ -279,10 +275,6 @@ class DatabricksTracingRestStore(RestStore):
                 endpoint=f"{_V4_TRACE_REST_API_PATH_PREFIX}/search",
             )
         except MlflowException as e:
-            # There are 2 expected failure cases:
-            # 1. Server does not support SearchTracesV4 API yet.
-            # 2. Server supports V4 API but the experiment location is not supported yet.
-            # For these known cases, MLflow fallback to V3 API.
             if e.error_code == ErrorCode.Name(ENDPOINT_NOT_FOUND):
                 if contain_uc_schemas:
                     raise MlflowException.invalid_parameter_value(
@@ -335,7 +327,6 @@ class DatabricksTracingRestStore(RestStore):
         )
         req_body = message_to_json(request)
         response_proto = self._call_endpoint(SearchUnifiedTraces, req_body)
-        # Convert TraceInfo (v2) objects to TraceInfoV3 objects for consistency
         trace_infos = [TraceInfo.from_proto(t) for t in response_proto.traces]
         return trace_infos, response_proto.next_page_token or None
 
@@ -381,7 +372,6 @@ class DatabricksTracingRestStore(RestStore):
                 raise
         _logger.debug(f"Created trace UC storage location: {location}")
 
-        # link experiment to uc trace location
         req_body = message_to_json(
             LinkExperimentToUCTraceLocation(
                 experiment_id=experiment_id,
@@ -421,8 +411,6 @@ class DatabricksTracingRestStore(RestStore):
             raise MlflowException(
                 "`tracking_uri` must be provided to log spans to with Databricks tracking server."
             )
-
-        # TODO: check server version
 
         endpoint = f"/api/2.0/tracing/otel{OTLP_TRACES_PATH}"
         try:
@@ -514,7 +502,6 @@ class DatabricksTracingRestStore(RestStore):
                 trace_location_to_proto(TraceLocation.from_databricks_uc_schema(catalog, schema)),
             )
             assessment.trace_id = parsed_trace_id
-            # Field mask specifies which fields to update.
             mask = UpdateAssessment().update_mask
             if name is not None:
                 assessment.assessment_name = name

--- a/tests/utils/test_model_utils.py
+++ b/tests/utils/test_model_utils.py
@@ -88,14 +88,14 @@ def test_add_code_to_system_path(sklearn_knn_model, model_path):
     assert "site-packages" in sys.modules["pandas"].__file__
 
 
-@mock.patch("builtins.open", side_effect=OSError("[Errno 95] Operation not supported"))
 def test_add_code_to_system_path_not_copyable_file(sklearn_knn_model, model_path):
-    with pytest.raises(MlflowException, match=r"Failed to copy the specified code path"):
-        mlflow.sklearn.save_model(
-            sk_model=sklearn_knn_model,
-            path=model_path,
-            code_paths=["tests/utils/test_resources/dummy_module.py"],
-        )
+    with mock.patch("builtins.open", side_effect=OSError("[Errno 95] Operation not supported")):
+        with pytest.raises(MlflowException, match=r"Failed to copy the specified code path"):
+            mlflow.sklearn.save_model(
+                sk_model=sklearn_knn_model,
+                path=model_path,
+                code_paths=["tests/utils/test_resources/dummy_module.py"],
+            )
 
 
 def test_env_var_tracker(monkeypatch):


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR adds a new clint rule (`MockPatchAsDecorator`) that enforces using `unittest.mock.patch` as a context manager instead of a decorator. Using context managers makes it clear which code depends on the mock and avoids patches being active longer than needed.

**Bad:**
```python
@mock.patch("builtins.open", side_effect=OSError("Operation not supported"))
def test_example(mock_open):
    # The mock is active for the entire test function
    assert some_function() == expected_value
```

**Good:**
```python
def test_example():
    # The mock is only active within the context manager scope
    with mock.patch("builtins.open", side_effect=OSError("Operation not supported")):
        assert some_function() == expected_value
```

The rule includes an ignore list with 117 existing violations across 36 test files to allow gradual migration. Files are sorted by violation count to help prioritize migration efforts.

Also migrated one test file (`tests/utils/test_model_utils.py`) to demonstrate the conversion pattern.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)