### PR TITLE
Fix ids in span to_dict and simplify search_traces

### DIFF
--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -230,10 +230,6 @@ class Span:
             "name": self.name,
             "start_time_unix_nano": self.start_time_ns,
             "end_time_unix_nano": self.end_time_ns,
-            "status": {
-                "code": self.status.status_code.value,
-                "message": self.status.description,
-            },
             "events": [
                 {
                     "name": event.name,
@@ -242,6 +238,10 @@ class Span:
                 }
                 for event in self.events
             ],
+            "status": {
+                "code": self.status.status_code.value,
+                "message": self.status.description,
+            },
             # save the dumped attributes so they can be loaded correctly when deserializing
             "attributes": {k: self._span.attributes.get(k) for k in self.attributes.keys()},
             # use this to distinguish the span dict version when deserializing

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -113,6 +113,3 @@ ASSESSMENT_ID_PREFIX = "a-"
 # To make sure get_trace API does not fail due to this delay, we retry up to a reasonable timeout.
 # Setting 15 seconds because the initial version of the backend is known to have 1~5 seconds delay.
 GET_TRACE_V4_RETRY_TIMEOUT_SECONDS = 15
-
-# Span dict version for checking when deserializing
-SPAN_DICT_VERSION_KEY = "mlflow.span_dict.version"

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -113,3 +113,6 @@ ASSESSMENT_ID_PREFIX = "a-"
 # To make sure get_trace API does not fail due to this delay, we retry up to a reasonable timeout.
 # Setting 15 seconds because the initial version of the backend is known to have 1~5 seconds delay.
 GET_TRACE_V4_RETRY_TIMEOUT_SECONDS = 15
+
+# Span dict version for checking when deserializing
+SPAN_DICT_VERSION_KEY = "mlflow.span_dict.version"

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -34,14 +34,13 @@ from mlflow.tracing.constant import (
 from mlflow.tracing.provider import is_tracing_enabled, safe_set_span_in_context
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import (
-    SPANS_COLUMN_NAME,
     TraceJSONEncoder,
     capture_function_input_args,
     encode_span_id,
     exclude_immutable_tags,
     get_otel_attribute,
 )
-from mlflow.tracing.utils.search import extract_span_inputs_outputs, traces_to_df
+from mlflow.tracing.utils.search import traces_to_df
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import deprecated_parameter
 from mlflow.utils.validation import _validate_list_param
@@ -862,13 +861,7 @@ def search_traces(
     )
 
     if return_type == "pandas":
-        results = traces_to_df(results)
-        if extract_fields:
-            results = extract_span_inputs_outputs(
-                traces=results,
-                fields=extract_fields,
-                col_name=SPANS_COLUMN_NAME,
-            )
+        results = traces_to_df(results, extract_fields=extract_fields)
 
     return results
 

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -17,7 +17,7 @@ from mlflow.entities.span import (
     create_mlflow_span,
 )
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.constant import SPAN_DICT_VERSION_KEY, TRACE_ID_V4_PREFIX
+from mlflow.tracing.constant import TRACE_ID_V4_PREFIX
 from mlflow.tracing.provider import _get_tracer, trace_disabled
 from mlflow.tracing.utils import build_otel_context, encode_span_id, encode_trace_id
 from mlflow.tracing.utils.otlp import _set_otel_proto_anyvalue
@@ -602,16 +602,10 @@ def test_span_to_dict_v4_format():
 
     span_dict = span.to_dict()
 
-    # Verify v4 format
-    assert span_dict[SPAN_DICT_VERSION_KEY] == 4
-
     # Verify human-readable IDs (not base64 encoded)
     assert span_dict["trace_id"].startswith("tr-")
     assert not span_dict["span_id"].startswith("tr-")
     assert not span_dict["parent_span_id"].startswith("tr-")
-
-    # Verify otel_trace_id exists
-    assert "otel_trace_id" in span_dict
 
     # Verify structure
     assert span_dict["name"] == "child"
@@ -678,7 +672,6 @@ def test_span_dict_v4_with_no_parent():
 
     # Root span should have None for parent_span_id
     assert span_dict["parent_span_id"] is None
-    assert span_dict[SPAN_DICT_VERSION_KEY] == 4
 
     # Deserialize and verify
     recovered = Span.from_dict(span_dict)

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -12,9 +12,12 @@ from opentelemetry.trace import StatusCode as OTelStatusCode
 
 import mlflow
 from mlflow.entities import LiveSpan, Span, SpanEvent, SpanStatus, SpanStatusCode, SpanType
-from mlflow.entities.span import NoOpSpan, create_mlflow_span
+from mlflow.entities.span import (
+    NoOpSpan,
+    create_mlflow_span,
+)
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.constant import TRACE_ID_V4_PREFIX
+from mlflow.tracing.constant import SPAN_DICT_VERSION_KEY, TRACE_ID_V4_PREFIX
 from mlflow.tracing.provider import _get_tracer, trace_disabled
 from mlflow.tracing.utils import build_otel_context, encode_span_id, encode_trace_id
 from mlflow.tracing.utils.otlp import _set_otel_proto_anyvalue
@@ -586,3 +589,120 @@ def test_otel_roundtrip_conversion(sample_otel_span_for_conversion):
         assert rt_event.name == orig_event.name
         assert rt_event.timestamp == orig_event.timestamp
         assert rt_event.attributes == orig_event.attributes
+
+
+def test_span_to_dict_v4_format():
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
+            span.set_inputs({"input": 1})
+            span.set_outputs(2)
+            span.set_attribute("key", 3)
+            span.set_status("OK")
+            span.add_event(SpanEvent("test_event", timestamp=99999, attributes={"foo": "bar"}))
+
+    span_dict = span.to_dict()
+
+    # Verify v4 format
+    assert span_dict[SPAN_DICT_VERSION_KEY] == 4
+
+    # Verify human-readable IDs (not base64 encoded)
+    assert span_dict["trace_id"].startswith("tr-")
+    assert not span_dict["span_id"].startswith("tr-")
+    assert not span_dict["parent_span_id"].startswith("tr-")
+
+    # Verify otel_trace_id exists
+    assert "otel_trace_id" in span_dict
+
+    # Verify structure
+    assert span_dict["name"] == "child"
+    assert isinstance(span_dict["start_time_unix_nano"], int)
+    assert isinstance(span_dict["end_time_unix_nano"], int)
+
+    # Verify status structure
+    assert "status" in span_dict
+    assert span_dict["status"]["code"] == SpanStatusCode.OK.value
+    assert "message" in span_dict["status"]
+
+    # Verify events structure
+    assert len(span_dict["events"]) == 1
+    assert span_dict["events"][0]["name"] == "test_event"
+    assert span_dict["events"][0]["time_unix_nano"] == 99999
+    assert span_dict["events"][0]["attributes"] == {"foo": "bar"}
+
+    # Verify attributes are preserved
+    assert "attributes" in span_dict
+    assert "mlflow.spanInputs" in span_dict["attributes"]
+    assert "mlflow.spanOutputs" in span_dict["attributes"]
+
+
+def test_span_from_dict_old_format():
+    span_dict = {
+        "trace_id": "6ST7JNq8BC4JRp0HA/vD6Q==",
+        "span_id": "Sd/l0Zs4M3g=",
+        "parent_span_id": None,
+        "name": "test_span",
+        "start_time_unix_nano": 1000000000,
+        "end_time_unix_nano": 2000000000,
+        "status": {"code": "STATUS_CODE_ERROR", "message": "Error occurred"},
+        "attributes": {
+            "mlflow.spanInputs": '{"query": "test"}',
+            "mlflow.spanOutputs": '{"result": "success"}',
+            "custom": "value",
+            "mlflow.traceRequestId": '"tr-e924fb24dabc042e09469d0703fbc3e9"',
+        },
+        "events": [],
+    }
+
+    # Deserialize it
+    recovered_span = Span.from_dict(span_dict)
+
+    # Verify all fields are recovered correctly
+    assert recovered_span.trace_id == "tr-e924fb24dabc042e09469d0703fbc3e9"
+    assert recovered_span.span_id == "49dfe5d19b383378"
+    assert recovered_span.parent_id is None
+    assert recovered_span.name == span_dict["name"]
+    assert recovered_span.start_time_ns == span_dict["start_time_unix_nano"]
+    assert recovered_span.end_time_ns == span_dict["end_time_unix_nano"]
+    assert recovered_span.status.status_code.value == "ERROR"
+    assert recovered_span.inputs == {"query": "test"}
+    assert recovered_span.outputs == {"result": "success"}
+    assert recovered_span.get_attribute("custom") == "value"
+
+
+def test_span_dict_v4_with_no_parent():
+    with mlflow.start_span("root_span") as span:
+        span.set_inputs({"x": 1})
+        span.set_outputs({"y": 2})
+
+    span_dict = span.to_dict()
+
+    # Root span should have None for parent_span_id
+    assert span_dict["parent_span_id"] is None
+    assert span_dict[SPAN_DICT_VERSION_KEY] == 4
+
+    # Deserialize and verify
+    recovered = Span.from_dict(span_dict)
+    assert recovered.parent_id is None
+    assert recovered.name == "root_span"
+    assert recovered.inputs == {"x": 1}
+    assert recovered.outputs == {"y": 2}
+
+
+def test_span_dict_v4_preserves_ids_across_serialization():
+    with mlflow.start_span("parent"):
+        with mlflow.start_span("child") as child:
+            pass
+
+    # Get the dict representation
+    child_dict = child.to_dict()
+
+    # Verify IDs are in human-readable format
+    assert child_dict["trace_id"] == child.trace_id
+    assert child_dict["span_id"] == child.span_id
+    assert child_dict["parent_span_id"] == child.parent_id
+
+    # Deserialize and verify IDs match
+    recovered = Span.from_dict(child_dict)
+    assert recovered.trace_id == child.trace_id
+    assert recovered.span_id == child.span_id
+    assert recovered.parent_id == child.parent_id

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -23,7 +23,7 @@ from mlflow.entities.assessment import Expectation
 from mlflow.entities.trace_state import TraceState
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.constant import TRACE_SCHEMA_VERSION_KEY
+from mlflow.tracing.constant import SPAN_DICT_VERSION_KEY, TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 from mlflow.utils.proto_json_utils import (
@@ -111,14 +111,14 @@ def test_json_deserialization(monkeypatch):
                     "name": "predict",
                     "trace_id": mock.ANY,
                     "span_id": mock.ANY,
-                    "parent_span_id": "",
+                    "parent_span_id": None,
                     "start_time_unix_nano": trace.data.spans[0].start_time_ns,
                     "end_time_unix_nano": trace.data.spans[0].end_time_ns,
+                    "events": [],
                     "status": {
-                        "code": "STATUS_CODE_OK",
+                        "code": "OK",
                         "message": "",
                     },
-                    "trace_state": "",
                     "attributes": {
                         "mlflow.traceRequestId": json.dumps(trace.info.request_id),
                         "mlflow.spanType": '"UNKNOWN"',
@@ -126,6 +126,8 @@ def test_json_deserialization(monkeypatch):
                         "mlflow.spanInputs": '{"x": 2, "y": 5}',
                         "mlflow.spanOutputs": "8",
                     },
+                    SPAN_DICT_VERSION_KEY: 4,
+                    "otel_trace_id": mock.ANY,
                 },
                 {
                     "name": "add_one_with_custom_name",
@@ -134,11 +136,11 @@ def test_json_deserialization(monkeypatch):
                     "parent_span_id": mock.ANY,
                     "start_time_unix_nano": trace.data.spans[1].start_time_ns,
                     "end_time_unix_nano": trace.data.spans[1].end_time_ns,
+                    "events": [],
                     "status": {
-                        "code": "STATUS_CODE_OK",
+                        "code": "OK",
                         "message": "",
                     },
-                    "trace_state": "",
                     "attributes": {
                         "mlflow.traceRequestId": json.dumps(trace.info.request_id),
                         "mlflow.spanType": '"LLM"',
@@ -149,6 +151,8 @@ def test_json_deserialization(monkeypatch):
                         "datetime": json.dumps(str(datetime_now)),
                         "metadata": '{"foo": "bar"}',
                     },
+                    SPAN_DICT_VERSION_KEY: 4,
+                    "otel_trace_id": mock.ANY,
                 },
             ],
         },

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -23,7 +23,7 @@ from mlflow.entities.assessment import Expectation
 from mlflow.entities.trace_state import TraceState
 from mlflow.environment_variables import MLFLOW_TRACKING_USERNAME
 from mlflow.exceptions import MlflowException
-from mlflow.tracing.constant import SPAN_DICT_VERSION_KEY, TRACE_SCHEMA_VERSION_KEY
+from mlflow.tracing.constant import TRACE_SCHEMA_VERSION_KEY
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 from mlflow.utils.proto_json_utils import (
@@ -126,8 +126,6 @@ def test_json_deserialization(monkeypatch):
                         "mlflow.spanInputs": '{"x": 2, "y": 5}',
                         "mlflow.spanOutputs": "8",
                     },
-                    SPAN_DICT_VERSION_KEY: 4,
-                    "otel_trace_id": mock.ANY,
                 },
                 {
                     "name": "add_one_with_custom_name",
@@ -151,8 +149,6 @@ def test_json_deserialization(monkeypatch):
                         "datetime": json.dumps(str(datetime_now)),
                         "metadata": '{"foo": "bar"}',
                     },
-                    SPAN_DICT_VERSION_KEY: 4,
-                    "otel_trace_id": mock.ANY,
                 },
             ],
         },

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -6,7 +6,6 @@ import pytest
 import mlflow
 from mlflow.entities import SpanType, TraceData
 from mlflow.entities.span_event import SpanEvent
-from mlflow.tracing.constant import SPAN_DICT_VERSION_KEY
 
 
 def test_json_deserialization():
@@ -69,8 +68,6 @@ def test_json_deserialization():
                         },
                     }
                 ],
-                SPAN_DICT_VERSION_KEY: 4,
-                "otel_trace_id": mock.ANY,
             },
             {
                 "name": "with_ok_event",
@@ -94,8 +91,6 @@ def test_json_deserialization():
                         "attributes": {"foo": "bar"},
                     }
                 ],
-                SPAN_DICT_VERSION_KEY: 4,
-                "otel_trace_id": mock.ANY,
             },
             {
                 "name": "always_fail_name",
@@ -127,8 +122,6 @@ def test_json_deserialization():
                         },
                     }
                 ],
-                SPAN_DICT_VERSION_KEY: 4,
-                "otel_trace_id": mock.ANY,
             },
         ],
     }

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -6,6 +6,7 @@ import pytest
 import mlflow
 from mlflow.entities import SpanType, TraceData
 from mlflow.entities.span_event import SpanEvent
+from mlflow.tracing.constant import SPAN_DICT_VERSION_KEY
 
 
 def test_json_deserialization():
@@ -43,14 +44,13 @@ def test_json_deserialization():
                 "name": "predict",
                 "trace_id": mock.ANY,
                 "span_id": mock.ANY,
-                "parent_span_id": "",
+                "parent_span_id": None,
                 "start_time_unix_nano": trace.data.spans[0].start_time_ns,
                 "end_time_unix_nano": trace.data.spans[0].end_time_ns,
                 "status": {
-                    "code": "STATUS_CODE_ERROR",
+                    "code": "ERROR",
                     "message": "Exception: Error!",
                 },
-                "trace_state": "",
                 "attributes": {
                     "mlflow.traceRequestId": json.dumps(trace.info.trace_id),
                     "mlflow.spanType": '"UNKNOWN"',
@@ -69,6 +69,8 @@ def test_json_deserialization():
                         },
                     }
                 ],
+                SPAN_DICT_VERSION_KEY: 4,
+                "otel_trace_id": mock.ANY,
             },
             {
                 "name": "with_ok_event",
@@ -78,10 +80,9 @@ def test_json_deserialization():
                 "start_time_unix_nano": trace.data.spans[1].start_time_ns,
                 "end_time_unix_nano": trace.data.spans[1].end_time_ns,
                 "status": {
-                    "code": "STATUS_CODE_OK",
+                    "code": "OK",
                     "message": "",
                 },
-                "trace_state": "",
                 "attributes": {
                     "mlflow.traceRequestId": json.dumps(trace.info.trace_id),
                     "mlflow.spanType": '"UNKNOWN"',
@@ -93,6 +94,8 @@ def test_json_deserialization():
                         "attributes": {"foo": "bar"},
                     }
                 ],
+                SPAN_DICT_VERSION_KEY: 4,
+                "otel_trace_id": mock.ANY,
             },
             {
                 "name": "always_fail_name",
@@ -102,10 +105,9 @@ def test_json_deserialization():
                 "start_time_unix_nano": trace.data.spans[2].start_time_ns,
                 "end_time_unix_nano": trace.data.spans[2].end_time_ns,
                 "status": {
-                    "code": "STATUS_CODE_ERROR",
+                    "code": "ERROR",
                     "message": "Exception: Error!",
                 },
-                "trace_state": "",
                 "attributes": {
                     "delta": "1",
                     "mlflow.traceRequestId": json.dumps(trace.info.trace_id),
@@ -125,6 +127,8 @@ def test_json_deserialization():
                         },
                     }
                 ],
+                SPAN_DICT_VERSION_KEY: 4,
+                "otel_trace_id": mock.ANY,
             },
         ],
     }

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -29,7 +29,6 @@ from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing.client import TracingClient
 from mlflow.tracing.constant import (
-    SPAN_DICT_VERSION_KEY,
     TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
     TraceMetadataKey,
@@ -1070,7 +1069,6 @@ def test_search_traces_dataframe_contains_human_readable_ids():
         assert df_span["trace_id"] == trace_span.trace_id
         assert df_span["span_id"] == trace_span.span_id
         assert df_span["parent_span_id"] == trace_span.parent_id
-        assert df_span[SPAN_DICT_VERSION_KEY] == 4
 
 
 @skip_when_testing_trace_sdk

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -29,6 +29,7 @@ from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.tracing.client import TracingClient
 from mlflow.tracing.constant import (
+    SPAN_DICT_VERSION_KEY,
     TRACE_SCHEMA_VERSION_KEY,
     SpanAttributeKey,
     TraceMetadataKey,
@@ -1046,6 +1047,33 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
 
 
 @skip_when_testing_trace_sdk
+def test_search_traces_dataframe_contains_human_readable_ids():
+    model = DefaultTestModel()
+    model.predict(2, 5)
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    df = mlflow.search_traces(max_results=1)
+
+    # Verify trace_id in DataFrame is human-readable (not encoded)
+    assert df.iloc[0].trace_id == trace.info.trace_id
+    # The trace_id should be in tr-XXXXX format, not base64 encoded
+    assert df.iloc[0].trace_id.startswith("tr-")
+
+    # Verify spans in DataFrame contain human-readable IDs (not base64 encoded)
+    df_spans = df.iloc[0].spans
+    expected_spans = [span.to_dict() for span in trace.data.spans]
+    assert df_spans == expected_spans
+
+    # Verify that each span has non-encoded IDs
+    for df_span, trace_span in zip(df_spans, trace.data.spans):
+        # IDs should match the human-readable format
+        assert df_span["trace_id"] == trace_span.trace_id
+        assert df_span["span_id"] == trace_span.span_id
+        assert df_span["parent_span_id"] == trace_span.parent_id
+        assert df_span[SPAN_DICT_VERSION_KEY] == 4
+
+
+@skip_when_testing_trace_sdk
 def test_search_traces_handles_missing_response_tags_and_metadata(mock_client):
     mock_client.search_traces.return_value = PagedList(
         [
@@ -1108,6 +1136,26 @@ def test_search_traces_with_non_dict_span_inputs_outputs():
     assert df["non_dict_span.inputs"].tolist() == [["a", "b"]]
     assert df["non_dict_span.outputs"].tolist() == [[1, 2, 3]]
     assert df["non_dict_span.inputs.x"].isnull().all()
+
+
+@skip_when_testing_trace_sdk
+def test_search_traces_extract_fields_preserves_standard_columns():
+    with mlflow.start_span(name="test_span") as span:
+        span.set_inputs({"x": 1})
+        span.set_outputs({"y": 2})
+
+    df = mlflow.search_traces(extract_fields=["test_span.inputs.x"])
+
+    # Verify standard columns still exist
+    assert "trace_id" in df.columns
+    assert "spans" in df.columns
+    assert "tags" in df.columns
+    assert "request" in df.columns
+    assert "response" in df.columns
+
+    # Verify extract field was added
+    assert "test_span.inputs.x" in df.columns
+    assert df["test_span.inputs.x"].tolist() == [1]
 
 
 @skip_when_testing_trace_sdk


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/18239?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18239/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18239/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18239/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
This is not an issue introduced by trace v4, the span.to_dict method saves encoded trace id in v3 format as well.

1. Old span.to_dict saves encoded trace_id as bytes, and this is confusing when users use search_traces and see the result dataframe. 
This PR updates the `to_dict` function to preserve the same string representation of original span object, and updates `from_dict` to reconstruct the Span object from it. To keep backwards compatibility, I'm adding `SPAN_DICT_VERSION_KEY` field in the dictionary, and preserve `otel_trace_id` so that when we construct the Span from dictionary we can reconstruct the span context.
2. Simplifies search_traces logic: the old logic converts trace to pandas Dataframe, and then load it back if extract_fields is not None. This is redundant, so I simplify it to directly extract fields from the span object.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
