### PR TITLE
Improve pytest hint message for missing dependencies

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -394,7 +394,7 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
     if (
         # `uv run` was used to run tests
         "UV" in os.environ
-        # Some tests failed because of missing dependencies
+        # Tests failed because of missing dependencies
         and (errors := terminalreporter.stats.get("error"))
         and any(re.search(r"ModuleNotFoundError|ImportError", str(e.longrepr)) for e in errors)
     ):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -392,21 +392,17 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         terminalreporter.write("\n")
 
     if (
+        # `uv run` was used to run tests
         "UV" in os.environ
+        # Some tests failed because of missing dependencies
         and (errors := terminalreporter.stats.get("error"))
-        and any(
-            "ModuleNotFoundError" in str(e.longrepr) or "ImportError" in str(e.longrepr)
-            for e in errors
-        )
+        and any(re.search(r"ModuleNotFoundError|ImportError", str(e.longrepr)) for e in errors)
     ):
         terminalreporter.write("\n")
         terminalreporter.section("HINTS", yellow=True)
         terminalreporter.write(
-            "Some tests failed due to missing dependencies (ModuleNotFoundError/ImportError).\n"
             "To run tests with additional packages, use:\n"
             "  uv run --with <package> pytest ...\n\n"
-            "Example:\n"
-            "  uv run --with pyspark pytest tests/pyfunc/test_pyspark.py\n\n"
             "For multiple packages:\n"
             "  uv run --with <package1> --with <package2> pytest ...\n\n",
             yellow=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -391,6 +391,27 @@ def pytest_terminal_summary(terminalreporter, exitstatus, config):
         terminalreporter.write("\n\n::endgroup::\n")
         terminalreporter.write("\n")
 
+    if (
+        "UV" in os.environ
+        and (errors := terminalreporter.stats.get("error"))
+        and any(
+            "ModuleNotFoundError" in str(e.longrepr) or "ImportError" in str(e.longrepr)
+            for e in errors
+        )
+    ):
+        terminalreporter.write("\n")
+        terminalreporter.section("HINTS", yellow=True)
+        terminalreporter.write(
+            "Some tests failed due to missing dependencies (ModuleNotFoundError/ImportError).\n"
+            "To run tests with additional packages, use:\n"
+            "  uv run --with <package> pytest ...\n\n"
+            "Example:\n"
+            "  uv run --with pyspark pytest tests/pyfunc/test_pyspark.py\n\n"
+            "For multiple packages:\n"
+            "  uv run --with <package1> --with <package2> pytest ...\n\n",
+            yellow=True,
+        )
+
     # If there are failed tests, display a command to run them
     failed_test_reports = terminalreporter.stats.get("failed", [])
     if failed_test_reports:


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add a helpful hint message in `tests/conftest.py` when tests fail due to `ModuleNotFoundError` or `ImportError`. The hint guides users to use `uv run --with <package>` to install missing dependencies.

The hint includes:
- Basic usage syntax
- Multi-package installation example

### How is this PR tested?

- [x] Manual tests

Manually verified the hint message appears correctly when running tests with missing dependencies.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)


---

🤖 Generated with [Claude Code](https://claude.com/claude-code)