### PR TITLE
Allow passing empty scorer list for manual result comparison

### DIFF
--- a/mlflow/genai/scorers/validation.py
+++ b/mlflow/genai/scorers/validation.py
@@ -33,13 +33,15 @@ def validate_scorers(scorers: list[Any]) -> list[Scorer]:
     Returns:
         A list of valid scorers.
     """
-    if not isinstance(scorers, list) or len(scorers) == 0:
+    if not isinstance(scorers, list):
         raise MlflowException.invalid_parameter_value(
-            "The `scorers` argument must be a list of scorers with at least one scorer. "
-            "If you are unsure about which scorer to use, you can specify "
-            "`scorers=mlflow.genai.scorers.get_all_scorers()` to jump start with all "
-            "available built-in scorers."
+            "The `scorers` argument must be a list of scorers. If you are unsure about which "
+            "scorer to use, you can specify `scorers=mlflow.genai.scorers.get_all_scorers()` "
+            "to jump start with all available built-in scorers."
         )
+
+    if len(scorers) == 0:
+        return []
 
     valid_scorers = []
     legacy_metrics = []

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -2,7 +2,7 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 from unittest import mock
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import ANY, MagicMock
 
 import pandas as pd
 import pytest
@@ -14,13 +14,35 @@ from mlflow.entities.span import SpanType
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets import EvaluationDataset, create_dataset
+from mlflow.genai.evaluation.entities import EvaluationResult
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.scorers.builtin_scorers import RelevanceToQuery
 from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_IS_EVALUATION
 
-from tests.evaluate.test_evaluation import _DUMMY_CHAT_RESPONSE
 from tests.tracing.helper import get_traces
+
+_DUMMY_CHAT_RESPONSE = {
+    "id": "1",
+    "object": "text_completion",
+    "created": "2021-10-01T00:00:00.000000Z",
+    "model": "gpt-4o-mini",
+    "choices": [
+        {
+            "index": 0,
+            "message": {
+                "content": "This is a response",
+                "role": "assistant",
+            },
+            "finish_reason": "length",
+        }
+    ],
+    "usage": {
+        "prompt_tokens": 1,
+        "completion_tokens": 1,
+        "total_tokens": 2,
+    },
+}
 
 
 class TestModel:
@@ -527,13 +549,26 @@ def test_model_from_deployment_endpoint(is_in_databricks):
         assert spans[0].outputs == _DUMMY_CHAT_RESPONSE
 
 
-def test_no_scorers():
-    with patch("mlflow.get_tracking_uri", return_value="databricks"):
-        with pytest.raises(TypeError, match=r"evaluate\(\) missing 1 required positional"):
-            mlflow.genai.evaluate(data=[{"inputs": "Hello", "outputs": "Hi"}])
+def test_missing_scorers_argument():
+    with pytest.raises(TypeError, match=r"evaluate\(\) missing 1 required positional"):
+        mlflow.genai.evaluate(data=[{"inputs": "Hello", "outputs": "Hi"}])
 
-        with pytest.raises(MlflowException, match=r"The `scorers` argument must be a list of"):
-            mlflow.genai.evaluate(data=[{"inputs": "Hello", "outputs": "Hi"}], scorers=[])
+
+def test_empty_scorers_allowed():
+    mock_result = EvaluationResult(run_id="test-run", metrics={}, result_df=pd.DataFrame())
+
+    data = [{"inputs": {"question": "What is MLflow?"}, "outputs": "MLflow is an ML platform"}]
+
+    with (
+        mock.patch("mlflow.genai.evaluation.base._evaluate_oss") as mock_evaluate_oss,
+        mock.patch("mlflow.genai.evaluation.base.clean_up_extra_traces") as mock_clean_up,
+    ):
+        mock_evaluate_oss.return_value = mock_result
+        result = mlflow.genai.evaluate(data=data, scorers=[])
+
+    assert result is mock_result
+    mock_evaluate_oss.assert_called_once()
+    mock_clean_up.assert_called_once_with(mock_result.run_id, ANY)
 
 
 @pytest.mark.parametrize("pass_full_dataframe", [True, False])

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -45,6 +45,10 @@ def test_validate_scorers_valid():
     assert all(isinstance(scorer, Scorer) for scorer in scorers)
 
 
+def test_validate_scorers_empty_list():
+    assert validate_scorers([]) == []
+
+
 @databricks_only
 def test_validate_scorers_legacy_metric():
     from databricks.agents.evals import metric


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18265?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18265/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18265/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18265/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Support https://github.com/mlflow/mlflow/issues/18251. `mlflow.genai.evaluate` can be also used for running batch evaluation and compare results manually.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support passing an empty scorer list to the. `mlflow.genai.evaluate` API.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
