### PR TITLE
Fix type checking in truncation message extraction (#18249)

### DIFF
--- a/mlflow/tracing/utils/truncation.py
+++ b/mlflow/tracing/utils/truncation.py
@@ -80,10 +80,10 @@ def _try_extract_messages(obj: dict[str, Any]) -> list[dict[str, Any]] | None:
         and isinstance(choices, list)
         and len(choices) > 0
         and isinstance(choices[0], dict)
-        and "message" in choices[0]
-        and _is_message(choices[0]["message"])
+        and (msg := choices[0].get("message"))
+        and _is_message(msg)
     ):
-        return [choices[0].get("message")]
+        return [msg]
 
     # Check if the object contains a message in OpenAI Responses API request format
     if (input := obj.get("input")) and isinstance(input, list):

--- a/tests/tracing/utils/test_truncation.py
+++ b/tests/tracing/utils/test_truncation.py
@@ -169,27 +169,22 @@ def test_truncate_non_openai_choices_format():
 
 def test_truncate_invalid_message_types():
     result = _get_truncated_preview(json.dumps({"messages": 123, "data": "a" * 50}), role="user")
-    assert len(result) == 50
     assert result.startswith('{"messages":')
 
     result = _get_truncated_preview(json.dumps({"input": "string", "data": "a" * 50}), role="user")
-    assert len(result) == 50
     assert result.startswith('{"input":')
 
     result = _get_truncated_preview(json.dumps({"output": 123, "data": "a" * 50}), role="user")
-    assert len(result) == 50
     assert result.startswith('{"output":')
 
     result = _get_truncated_preview(
         json.dumps({"choices": {"0": "value"}, "data": "a" * 50}), role="user"
     )
-    assert len(result) == 50
     assert result.startswith('{"choices":')
 
     result = _get_truncated_preview(
         json.dumps({"request": "string", "data": "a" * 50}), role="user"
     )
-    assert len(result) == 50
     assert result.startswith('{"request":')
 
 
@@ -197,18 +192,15 @@ def test_truncate_choices_with_invalid_message():
     result = _get_truncated_preview(
         json.dumps({"choices": [{"message": "not a dict"}], "data": "a" * 50}), role="user"
     )
-    assert len(result) == 50
     assert result.startswith('{"choices":')
 
     result = _get_truncated_preview(
         json.dumps({"choices": [{"message": {"role": "user"}}], "data": "a" * 50}), role="user"
     )
-    assert len(result) == 50
     assert result.startswith('{"choices":')
 
     result = _get_truncated_preview(
         json.dumps({"choices": [{"message": {"content": "hello"}}], "data": "a" * 50}),
         role="user",
     )
-    assert len(result) == 50
     assert result.startswith('{"choices":')

--- a/tests/tracing/utils/test_truncation.py
+++ b/tests/tracing/utils/test_truncation.py
@@ -155,19 +155,11 @@ def test_truncate_responses_api_output():
     assert _get_truncated_preview(input_str, role="assistant") == "a" * 47 + "..."
 
 
-def test_truncate_non_openai_choices_format():
-    input_str = json.dumps(
-        {
-            "question": "What is 1+1?" + "a" * 50,
-            "choices": ["1", "2", "3", "4"],
-        }
-    )
-    result = _get_truncated_preview(input_str, role="user")
-    assert result.startswith('{"question":')
-
-
-def test_truncate_invalid_message_types():
+def test_truncate_invalid_messages():
     result = _get_truncated_preview(json.dumps({"messages": 123, "data": "a" * 50}), role="user")
+    assert result.startswith('{"messages":')
+
+    result = _get_truncated_preview(json.dumps({"messages": [], "data": "a" * 50}), role="user")
     assert result.startswith('{"messages":')
 
     result = _get_truncated_preview(json.dumps({"input": "string", "data": "a" * 50}), role="user")
@@ -186,8 +178,6 @@ def test_truncate_invalid_message_types():
     )
     assert result.startswith('{"request":')
 
-
-def test_truncate_choices_with_invalid_message():
     result = _get_truncated_preview(
         json.dumps({"choices": [{"message": "not a dict"}], "data": "a" * 50}), role="user"
     )
@@ -195,11 +185,5 @@ def test_truncate_choices_with_invalid_message():
 
     result = _get_truncated_preview(
         json.dumps({"choices": [{"message": {"role": "user"}}], "data": "a" * 50}), role="user"
-    )
-    assert result.startswith('{"choices":')
-
-    result = _get_truncated_preview(
-        json.dumps({"choices": [{"message": {"content": "hello"}}], "data": "a" * 50}),
-        role="user",
     )
     assert result.startswith('{"choices":')

--- a/tests/tracing/utils/test_truncation.py
+++ b/tests/tracing/utils/test_truncation.py
@@ -163,7 +163,6 @@ def test_truncate_non_openai_choices_format():
         }
     )
     result = _get_truncated_preview(input_str, role="user")
-    assert len(result) == 50
     assert result.startswith('{"question":')
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Ninja3047/mlflow/pull/18274?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18274/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18274/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18274/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #18249

### What changes are proposed in this pull request?

Add stricter type checking when trying to extract messages. This should fix issues when the content contain keys that overlap with OpenAI key formats.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
