### PR TITLE
Fix false warning from span logging

### DIFF
--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -99,17 +99,11 @@ class TracingClient:
         Returns:
             List of logged Span objects from the backend.
         """
-        try:
-            return self.store.log_spans(
-                location=location,
-                spans=spans,
-                tracking_uri=self.tracking_uri if is_databricks_uri(self.tracking_uri) else None,
-            )
-        except Exception as e:
-            _logger.warning(
-                f"Failed to log span to location {location}: {e}",
-                exc_info=_logger.isEnabledFor(logging.DEBUG),
-            )
+        return self.store.log_spans(
+            location=location,
+            spans=spans,
+            tracking_uri=self.tracking_uri if is_databricks_uri(self.tracking_uri) else None,
+        )
 
     def delete_traces(
         self,

--- a/mlflow/tracing/export/uc_table.py
+++ b/mlflow/tracing/export/uc_table.py
@@ -56,7 +56,9 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
             try:
                 self._client.log_spans(location, spans)
             except Exception as e:
-                if not self._has_raised_span_export_error:
+                if self._has_raised_span_export_error:
+                    _logger.debug(f"Failed to log spans to the trace server: {e}", exc_info=True)
+                else:
                     _logger.warning(f"Failed to log spans to the trace server: {e}")
                     self._has_raised_span_export_error = True
 

--- a/mlflow/tracing/export/uc_table.py
+++ b/mlflow/tracing/export/uc_table.py
@@ -22,6 +22,9 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
         # Override this to False since spans are logged to UC table instead of artifacts.
         self._should_log_spans_to_artifacts = False
 
+        # Track if we've raised an error for span export to avoid raising it multiple times.
+        self._has_raised_span_export_error = False
+
     def _export_spans_incrementally(self, spans: Sequence[ReadableSpan]) -> None:
         """
         Export spans incrementally as they complete.
@@ -53,7 +56,9 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
             try:
                 self._client.log_spans(location, spans)
             except Exception as e:
-                _logger.debug(f"Failed to log spans to the trace server: {e}")
+                if not self._has_raised_span_export_error:
+                    _logger.warning(f"Failed to log spans to the trace server: {e}")
+                    self._has_raised_span_export_error = True
 
     def _should_enable_async_logging(self) -> bool:
         return MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()

--- a/mlflow/tracing/export/uc_table.py
+++ b/mlflow/tracing/export/uc_table.py
@@ -50,7 +50,10 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
                 )
             )
         else:
-            self._client.log_spans(location, spans)
+            try:
+                self._client.log_spans(location, spans)
+            except Exception as e:
+                _logger.debug(f"Failed to log spans to the trace server: {e}")
 
     def _should_enable_async_logging(self) -> bool:
         return MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18276?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18276/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18276/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18276/merge
```

</p>
</details>

### What changes are proposed in this pull request?

When using a backend store that does't support span-level logging, tracing emits excessive warnings about logging error:

```
Failed to log span to location ....
```

The client should not swallow exception [here](https://github.com/mlflow/mlflow/blob/45db46c18d21882830ab64d7151508c66b47649b/mlflow/tracing/client.py#L110C19-L110C66) and issue warning. Instead, the upstream exporter should decide what to do.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
