### PR TITLE
Add clint rule to prevent nested mock.patch context managers

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -779,6 +779,12 @@ class Linter(ast.NodeVisitor):
         self.generic_visit(node)
         self.in_TYPE_CHECKING = False
 
+    def visit_With(self, node: ast.With) -> None:
+        # Only check in test files
+        if self.path.name.startswith("test_") and rules.NestedMockPatch.check(node, self.resolver):
+            self._check(Location.from_node(node), rules.NestedMockPatch())
+        self.generic_visit(node)
+
     def post_visit(self) -> None:
         if self.is_mlflow_init_py and (diff := self.lazy_modules.keys() - self.imported_modules):
             for mod in diff:

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -24,6 +24,7 @@ from clint.rules.mlflow_class_name import MlflowClassName
 from clint.rules.mock_patch_as_decorator import MockPatchAsDecorator
 from clint.rules.mock_patch_dict_environ import MockPatchDictEnviron
 from clint.rules.multi_assign import MultiAssign
+from clint.rules.nested_mock_patch import NestedMockPatch
 from clint.rules.no_class_based_tests import NoClassBasedTests
 from clint.rules.no_rst import NoRst
 from clint.rules.no_shebang import NoShebang
@@ -74,6 +75,7 @@ __all__ = [
     "MlflowClassName",
     "MockPatchDictEnviron",
     "MockPatchAsDecorator",
+    "NestedMockPatch",
     "NoClassBasedTests",
     "NoRst",
     "NoShebang",

--- a/dev/clint/src/clint/rules/nested_mock_patch.py
+++ b/dev/clint/src/clint/rules/nested_mock_patch.py
@@ -1,0 +1,54 @@
+import ast
+
+from clint.resolver import Resolver
+from clint.rules.base import Rule
+
+
+class NestedMockPatch(Rule):
+    def _message(self) -> str:
+        return (
+            "Do not nest `unittest.mock.patch` context managers. "
+            "Use multiple context managers in a single `with` statement instead: "
+            "`with mock.patch(...), mock.patch(...): ...`"
+        )
+
+    @staticmethod
+    def check(node: ast.With, resolver: Resolver) -> bool:
+        """
+        Returns True if the with statement uses mock.patch and contains only a single
+        nested with statement that also uses mock.patch.
+        """
+        # Check if the outer with statement uses mock.patch
+        outer_has_mock_patch = any(
+            NestedMockPatch._is_mock_patch(item.context_expr, resolver) for item in node.items
+        )
+
+        if not outer_has_mock_patch:
+            return False
+
+        # Check if the body has exactly one statement and it's a with statement
+        if len(node.body) == 1 and isinstance(node.body[0], ast.With):
+            # Check if the nested with statement also uses mock.patch
+            inner_has_mock_patch = any(
+                NestedMockPatch._is_mock_patch(item.context_expr, resolver)
+                for item in node.body[0].items
+            )
+
+            if inner_has_mock_patch:
+                return True
+
+        return False
+
+    @staticmethod
+    def _is_mock_patch(node: ast.expr, resolver: Resolver) -> bool:
+        """
+        Returns True if the node is a call to mock.patch or any of its variants.
+        """
+        # Handle direct calls: mock.patch(...), mock.patch.object(...), etc.
+        if isinstance(node, ast.Call):
+            if res := resolver.resolve(node.func):
+                match res:
+                    # Matches unittest.mock.patch, unittest.mock.patch.object, etc.
+                    case ["unittest", "mock", "patch", *_]:
+                        return True
+        return False

--- a/dev/clint/tests/rules/test_nested_mock_patch.py
+++ b/dev/clint/tests/rules/test_nested_mock_patch.py
@@ -1,0 +1,201 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.linter import Location, lint_file
+from clint.rules.nested_mock_patch import NestedMockPatch
+
+
+def test_nested_mock_patch_unittest_mock(index_path: Path) -> None:
+    code = """
+import unittest.mock
+
+def test_foo():
+    with unittest.mock.patch("foo.bar"):
+        with unittest.mock.patch("foo.baz"):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, NestedMockPatch) for v in violations)
+    assert violations[0].loc == Location(4, 4)
+
+
+def test_nested_mock_patch_from_unittest_import_mock(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"):
+        with mock.patch("foo.baz"):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, NestedMockPatch) for v in violations)
+    assert violations[0].loc == Location(4, 4)
+
+
+def test_nested_mock_patch_object(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch.object(SomeClass, "method"):
+        with mock.patch.object(AnotherClass, "method"):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, NestedMockPatch) for v in violations)
+    assert violations[0].loc == Location(4, 4)
+
+
+def test_nested_mock_patch_dict(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch.dict("os.environ", {"FOO": "bar"}):
+        with mock.patch.dict("os.environ", {"BAZ": "qux"}):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, NestedMockPatch) for v in violations)
+    assert violations[0].loc == Location(4, 4)
+
+
+def test_nested_mock_patch_mixed(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"):
+        with mock.patch.object(SomeClass, "method"):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 1
+    assert all(isinstance(v.rule, NestedMockPatch) for v in violations)
+    assert violations[0].loc == Location(4, 4)
+
+
+def test_multiple_context_managers_is_ok(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"), mock.patch("foo.baz"):
+        ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_multiple_context_managers_with_object_is_ok(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"), mock.patch.object(SomeClass, "method"):
+        ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_nested_with_but_not_mock_patch_is_ok(index_path: Path) -> None:
+    code = """
+def test_foo():
+    with open("file.txt"):
+        with open("file2.txt"):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_nested_with_only_one_mock_patch_is_ok(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"):
+        with open("file.txt"):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_non_nested_mock_patches_are_ok(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"):
+        pass
+    with mock.patch("foo.baz"):
+        pass
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_non_test_file_not_checked(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def foo():
+    with mock.patch("foo.bar"):
+        with mock.patch("foo.baz"):
+            ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_nested_with_code_after_is_ok(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"):
+        with mock.patch("foo.baz"):
+            ...
+
+        assert True
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    assert len(violations) == 0
+
+
+def test_deeply_nested_mock_patch(index_path: Path) -> None:
+    code = """
+from unittest import mock
+
+def test_foo():
+    with mock.patch("foo.bar"):
+        with mock.patch("foo.baz"):
+            with mock.patch("foo.qux"):
+                ...
+"""
+    config = Config(select={NestedMockPatch.name})
+    violations = lint_file(Path("test_nested_mock_patch.py"), code, config, index_path)
+    # Should detect both levels of nesting
+    assert len(violations) == 2
+    assert all(isinstance(v.rule, NestedMockPatch) for v in violations)
+    assert violations[0].loc == Location(4, 4)
+    assert violations[1].loc == Location(5, 8)

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -635,11 +635,13 @@ def test_memory(simple_agent_1, task_1, monkeypatch, autolog):
         tasks=[task_1],
         memory=True,
     )
-    with patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION):
-        with patch("openai.OpenAI") as client:
-            client().embeddings.create.return_value = _EMBEDDING
-            autolog()
-            crew.kickoff()
+    with (
+        patch("litellm.completion", return_value=_SIMPLE_CHAT_COMPLETION),
+        patch("openai.OpenAI") as client,
+    ):
+        client().embeddings.create.return_value = _EMBEDDING
+        autolog()
+        crew.kickoff()
 
     traces = get_traces()
     assert len(traces) == 1

--- a/tests/evaluate/test_evaluation.py
+++ b/tests/evaluate/test_evaluation.py
@@ -1049,41 +1049,37 @@ def test_custom_evaluators_no_model_or_preds(multiclass_logistic_regressor_model
     """
     Tests that custom evaluators are called correctly when no model or predictions are provided
     """
-    with mock.patch.object(
-        _model_evaluation_registry, "_registry", {"test_evaluator1": FakeEvaluator1}
+    with (
+        mock.patch.object(
+            _model_evaluation_registry, "_registry", {"test_evaluator1": FakeEvaluator1}
+        ),
+        mock.patch.object(FakeEvaluator1, "can_evaluate", return_value=True) as mock_can_evaluate,
+        mock.patch.object(FakeEvaluator1, "evaluate") as mock_evaluate,
     ):
-        with (
-            mock.patch.object(
-                FakeEvaluator1, "can_evaluate", return_value=True
-            ) as mock_can_evaluate,
-            mock.patch.object(FakeEvaluator1, "evaluate") as mock_evaluate,
-        ):
-            with mlflow.start_run() as run:
-                evaluate(
-                    model=None,
-                    data=iris_dataset._constructor_args["data"],
-                    predictions=None,
-                    model_type="classifier",
-                    targets=iris_dataset._constructor_args["targets"],
-                    evaluators="test_evaluator1",
-                    evaluator_config=None,
-                    extra_metrics=None,
-                )
+        with mlflow.start_run() as run:
+            evaluate(
+                model=None,
+                data=iris_dataset._constructor_args["data"],
+                predictions=None,
+                model_type="classifier",
+                targets=iris_dataset._constructor_args["targets"],
+                evaluators="test_evaluator1",
+                evaluator_config=None,
+                extra_metrics=None,
+            )
 
-                mock_can_evaluate.assert_called_once_with(
-                    model_type="classifier", evaluator_config={}
-                )
-                mock_evaluate.assert_called_once_with(
-                    model=None,
-                    dataset=iris_dataset,
-                    predictions=None,
-                    model_type="classifier",
-                    model_id=None,
-                    run_id=run.info.run_id,
-                    evaluator_config={},
-                    extra_metrics=None,
-                    custom_artifacts=None,
-                )
+            mock_can_evaluate.assert_called_once_with(model_type="classifier", evaluator_config={})
+            mock_evaluate.assert_called_once_with(
+                model=None,
+                dataset=iris_dataset,
+                predictions=None,
+                model_type="classifier",
+                model_id=None,
+                run_id=run.info.run_id,
+                evaluator_config={},
+                extra_metrics=None,
+                custom_artifacts=None,
+            )
 
 
 def test_start_run_or_reuse_active_run():

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -213,12 +213,14 @@ async def test_gemini_completions():
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
     )
 
-    with mock.patch("time.time", return_value=1234567890):
-        with mock.patch(
+    with (
+        mock.patch("time.time", return_value=1234567890),
+        mock.patch(
             "aiohttp.ClientSession.post",
             return_value=MockAsyncResponse(fake_completion_response()),
-        ) as mock_post:
-            response = await provider.completions(completions.RequestPayload(**payload))
+        ) as mock_post,
+    ):
+        response = await provider.completions(completions.RequestPayload(**payload))
 
     expected_choices = [
         completions.Choice(
@@ -315,12 +317,14 @@ async def test_gemini_chat():
         "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent"
     )
 
-    with mock.patch("time.time", return_value=1234567890):
-        with mock.patch(
+    with (
+        mock.patch("time.time", return_value=1234567890),
+        mock.patch(
             "aiohttp.ClientSession.post",
             return_value=MockAsyncResponse(fake_chat_response()),
-        ) as mock_post:
-            response = await provider.chat(chat.RequestPayload(**payload))
+        ) as mock_post,
+    ):
+        response = await provider.chat(chat.RequestPayload(**payload))
 
     expected_choices = [
         chat.Choice(

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -373,11 +373,13 @@ def test_search_datasets_databricks(mock_databricks_environment):
 
 
 def test_databricks_import_error():
-    with mock.patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True):
-        with mock.patch.dict("sys.modules", {"databricks.agents.datasets": None}):
-            with mock.patch("builtins.__import__", side_effect=ImportError("No module")):
-                with pytest.raises(ImportError, match="databricks-agents"):
-                    create_dataset(name="test", experiment_id="exp1")
+    with (
+        mock.patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True),
+        mock.patch.dict("sys.modules", {"databricks.agents.datasets": None}),
+        mock.patch("builtins.__import__", side_effect=ImportError("No module")),
+    ):
+        with pytest.raises(ImportError, match="databricks-agents"):
+            create_dataset(name="test", experiment_id="exp1")
 
 
 def test_create_dataset_with_user_tag(tracking_uri, experiments):

--- a/tests/metrics/test_metric_definitions.py
+++ b/tests/metrics/test_metric_definitions.py
@@ -182,15 +182,17 @@ def test_fails_to_load_metric():
 
     predictions = pd.Series(["random text", "This is a sentence"])
     e = ImportError("mocked error")
-    with mock.patch(
-        "mlflow.metrics.metric_definitions._cached_evaluate_load", side_effect=e
-    ) as mock_load:
-        with mock.patch("mlflow.metrics.metric_definitions._logger.warning") as mock_warning:
-            toxicity().eval_fn(predictions, None, {})
-            mock_load.assert_called_once_with("toxicity", module_type="measurement")
-            mock_warning.assert_called_once_with(
-                f"Failed to load 'toxicity' metric (error: {e!r}), skipping metric logging.",
-            )
+    with (
+        mock.patch(
+            "mlflow.metrics.metric_definitions._cached_evaluate_load", side_effect=e
+        ) as mock_load,
+        mock.patch("mlflow.metrics.metric_definitions._logger.warning") as mock_warning,
+    ):
+        toxicity().eval_fn(predictions, None, {})
+        mock_load.assert_called_once_with("toxicity", module_type="measurement")
+        mock_warning.assert_called_once_with(
+            f"Failed to load 'toxicity' metric (error: {e!r}), skipping metric logging.",
+        )
 
 
 def test_mae():

--- a/tests/models/test_display_utils.py
+++ b/tests/models/test_display_utils.py
@@ -77,17 +77,21 @@ def test_should_not_render_eval_template_generic_signature(enable_databricks_env
 
 
 def test_should_not_render_eval_template_outside_databricks_env():
-    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=False):
-        with mock.patch("IPython.get_ipython", return_value=True):
-            signature = infer_signature(_CHAT_REQUEST, _STRING_RESPONSE)
-            assert not _should_render_agent_eval_template(signature)
+    with (
+        mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=False),
+        mock.patch("IPython.get_ipython", return_value=True),
+    ):
+        signature = infer_signature(_CHAT_REQUEST, _STRING_RESPONSE)
+        assert not _should_render_agent_eval_template(signature)
 
 
 def test_should_not_render_eval_template_outside_notebook_env():
-    with mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True):
-        with mock.patch("IPython.get_ipython", return_value=None):
-            signature = infer_signature(_CHAT_REQUEST, _STRING_RESPONSE)
-            assert not _should_render_agent_eval_template(signature)
+    with (
+        mock.patch("mlflow.utils.databricks_utils.is_in_databricks_runtime", return_value=True),
+        mock.patch("IPython.get_ipython", return_value=None),
+    ):
+        signature = infer_signature(_CHAT_REQUEST, _STRING_RESPONSE)
+        assert not _should_render_agent_eval_template(signature)
 
 
 def test_generate_agent_eval_recipe():

--- a/tests/projects/test_kubernetes.py
+++ b/tests/projects/test_kubernetes.py
@@ -101,25 +101,27 @@ def test_run_kubernetes_job():
         "        command: ['perl',  '-Mbignum=bpi', '-wle']\n"
         "      restartPolicy: Never\n"
     )
-    with mock.patch("kubernetes.config.load_kube_config") as kube_config_mock:
-        with mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock:
-            submitted_run_obj = kb.run_kubernetes_job(
-                project_name=project_name,
-                active_run=active_run,
-                image_tag=image_tag,
-                image_digest=image_digest,
-                command=command,
-                env_vars=env_vars,
-                job_template=job_template,
-                kube_context=kube_context,
-            )
+    with (
+        mock.patch("kubernetes.config.load_kube_config") as kube_config_mock,
+        mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock,
+    ):
+        submitted_run_obj = kb.run_kubernetes_job(
+            project_name=project_name,
+            active_run=active_run,
+            image_tag=image_tag,
+            image_digest=image_digest,
+            command=command,
+            env_vars=env_vars,
+            job_template=job_template,
+            kube_context=kube_context,
+        )
 
-            assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
-            assert submitted_run_obj._job_name.startswith(project_name)
-            assert submitted_run_obj._job_namespace == "mlflow"
-            assert kube_api_mock.call_count == 1
-            args = kube_config_mock.call_args_list
-            assert args[0][1]["context"] == kube_context
+        assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
+        assert submitted_run_obj._job_name.startswith(project_name)
+        assert submitted_run_obj._job_namespace == "mlflow"
+        assert kube_api_mock.call_count == 1
+        args = kube_config_mock.call_args_list
+        assert args[0][1]["context"] == kube_context
 
 
 def test_run_kubernetes_job_current_kubecontext():
@@ -147,26 +149,28 @@ def test_run_kubernetes_job_current_kubecontext():
         "        command: ['perl',  '-Mbignum=bpi', '-wle']\n"
         "      restartPolicy: Never\n"
     )
-    with mock.patch("kubernetes.config.load_kube_config") as kube_config_mock:
-        with mock.patch("kubernetes.config.load_incluster_config") as incluster_kube_config_mock:
-            with mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock:
-                submitted_run_obj = kb.run_kubernetes_job(
-                    project_name=project_name,
-                    active_run=active_run,
-                    image_tag=image_tag,
-                    image_digest=image_digest,
-                    command=command,
-                    env_vars=env_vars,
-                    job_template=job_template,
-                    kube_context=kube_context,
-                )
+    with (
+        mock.patch("kubernetes.config.load_kube_config") as kube_config_mock,
+        mock.patch("kubernetes.config.load_incluster_config") as incluster_kube_config_mock,
+        mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock,
+    ):
+        submitted_run_obj = kb.run_kubernetes_job(
+            project_name=project_name,
+            active_run=active_run,
+            image_tag=image_tag,
+            image_digest=image_digest,
+            command=command,
+            env_vars=env_vars,
+            job_template=job_template,
+            kube_context=kube_context,
+        )
 
-                assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
-                assert submitted_run_obj._job_name.startswith(project_name)
-                assert submitted_run_obj._job_namespace == "mlflow"
-                assert kube_api_mock.call_count == 1
-                assert kube_config_mock.call_count == 1
-                assert incluster_kube_config_mock.call_count == 0
+        assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
+        assert submitted_run_obj._job_name.startswith(project_name)
+        assert submitted_run_obj._job_namespace == "mlflow"
+        assert kube_api_mock.call_count == 1
+        assert kube_config_mock.call_count == 1
+        assert incluster_kube_config_mock.call_count == 0
 
 
 def test_run_kubernetes_job_in_cluster():
@@ -195,25 +199,27 @@ def test_run_kubernetes_job_in_cluster():
     )
     with mock.patch("kubernetes.config.load_kube_config") as kube_config_mock:
         kube_config_mock.side_effect = ConfigException()
-        with mock.patch("kubernetes.config.load_incluster_config") as incluster_kube_config_mock:
-            with mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock:
-                submitted_run_obj = kb.run_kubernetes_job(
-                    project_name=project_name,
-                    active_run=active_run,
-                    image_tag=image_tag,
-                    image_digest=image_digest,
-                    command=command,
-                    env_vars=env_vars,
-                    job_template=job_template,
-                    kube_context=kube_context,
-                )
+        with (
+            mock.patch("kubernetes.config.load_incluster_config") as incluster_kube_config_mock,
+            mock.patch("kubernetes.client.BatchV1Api.create_namespaced_job") as kube_api_mock,
+        ):
+            submitted_run_obj = kb.run_kubernetes_job(
+                project_name=project_name,
+                active_run=active_run,
+                image_tag=image_tag,
+                image_digest=image_digest,
+                command=command,
+                env_vars=env_vars,
+                job_template=job_template,
+                kube_context=kube_context,
+            )
 
-                assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
-                assert submitted_run_obj._job_name.startswith(project_name)
-                assert submitted_run_obj._job_namespace == "mlflow"
-                assert kube_api_mock.call_count == 1
-                assert kube_config_mock.call_count == 1
-                assert incluster_kube_config_mock.call_count == 1
+            assert submitted_run_obj._mlflow_run_id == active_run.info.run_id
+            assert submitted_run_obj._job_name.startswith(project_name)
+            assert submitted_run_obj._job_namespace == "mlflow"
+            assert kube_api_mock.call_count == 1
+            assert kube_config_mock.call_count == 1
+            assert incluster_kube_config_mock.call_count == 1
 
 
 def test_push_image_to_registry():

--- a/tests/projects/test_utils.py
+++ b/tests/projects/test_utils.py
@@ -235,29 +235,29 @@ def test_fetch_create_and_log(tmp_path):
     expected_dir = str(tmp_path)
     project_uri = "http://someuri/myproject.git"
     user_param = {"method_name": "newton"}
-    with mock.patch("mlflow.projects.utils._fetch_project", return_value=expected_dir):
-        with mock.patch(
-            "mlflow.projects._project_spec.load_project", return_value=mock_fetched_project
-        ):
-            work_dir = fetch_and_validate_project("", "", entry_point_name, user_param)
-            project = load_project(work_dir)
-            assert mock_fetched_project == project
-            assert expected_dir == work_dir
-            # Create a run
-            active_run = get_or_create_run(
-                run_id=None,
-                uri=project_uri,
-                experiment_id=experiment_id,
-                work_dir=work_dir,
-                version=None,
-                entry_point=entry_point_name,
-                parameters=user_param,
-            )
+    with (
+        mock.patch("mlflow.projects.utils._fetch_project", return_value=expected_dir),
+        mock.patch("mlflow.projects._project_spec.load_project", return_value=mock_fetched_project),
+    ):
+        work_dir = fetch_and_validate_project("", "", entry_point_name, user_param)
+        project = load_project(work_dir)
+        assert mock_fetched_project == project
+        assert expected_dir == work_dir
+        # Create a run
+        active_run = get_or_create_run(
+            run_id=None,
+            uri=project_uri,
+            experiment_id=experiment_id,
+            work_dir=work_dir,
+            version=None,
+            entry_point=entry_point_name,
+            parameters=user_param,
+        )
 
-            # check tags
-            run = mlflow.get_run(active_run.info.run_id)
-            assert MLFLOW_PROJECT_ENTRY_POINT in run.data.tags
-            assert MLFLOW_SOURCE_NAME in run.data.tags
-            assert entry_point_name == run.data.tags[MLFLOW_PROJECT_ENTRY_POINT]
-            assert project_uri == run.data.tags[MLFLOW_SOURCE_NAME]
-            assert user_param == run.data.params
+        # check tags
+        run = mlflow.get_run(active_run.info.run_id)
+        assert MLFLOW_PROJECT_ENTRY_POINT in run.data.tags
+        assert MLFLOW_SOURCE_NAME in run.data.tags
+        assert entry_point_name == run.data.tags[MLFLOW_PROJECT_ENTRY_POINT]
+        assert project_uri == run.data.tags[MLFLOW_SOURCE_NAME]
+        assert user_param == run.data.params

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_oss_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_oss_rest_store.py
@@ -136,22 +136,24 @@ def test_create_model_version(mock_http, store, creds):
     mock_local_model_dir.__enter__ = mock.Mock(return_value="/mock/local/model/dir")
     mock_local_model_dir.__exit__ = mock.Mock(return_value=None)
 
-    with mock.patch.object(store, "_local_model_dir", return_value=mock_local_model_dir):
-        with mock.patch.object(
+    with (
+        mock.patch.object(store, "_local_model_dir", return_value=mock_local_model_dir),
+        mock.patch.object(
             store, "_get_artifact_repo", return_value=mock.Mock()
-        ) as mock_artifact_repo:
-            mock_artifact_repo.log_artifacts.return_value = None
+        ) as mock_artifact_repo,
+    ):
+        mock_artifact_repo.log_artifacts.return_value = None
 
-            model_name = "catalog_1.schema_1.model_1"
-            store.create_model_version(
-                name=model_name, source="source", run_id="run_id", description="description"
-            )
-            _verify_requests(
-                mock_http,
-                "models/catalog_1.schema_1.model_1/versions/0/finalize",
-                "PATCH",
-                FinalizeModelVersion(full_name=model_name, version=0),
-            )
+        model_name = "catalog_1.schema_1.model_1"
+        store.create_model_version(
+            name=model_name, source="source", run_id="run_id", description="description"
+        )
+        _verify_requests(
+            mock_http,
+            "models/catalog_1.schema_1.model_1/versions/0/finalize",
+            "PATCH",
+            FinalizeModelVersion(full_name=model_name, version=0),
+        )
 
 
 @pytest.mark.parametrize("version", [0, "0"])

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -2683,12 +2683,14 @@ def test_link_prompt_version_to_model_sets_tag(store):
         mock_tracking_store.get_logged_model.return_value = logged_model
 
         # Mock the UC-specific API call to avoid real API calls
-        with mock.patch.object(store, "_edit_endpoint_and_call"):
-            with mock.patch.object(
+        with (
+            mock.patch.object(store, "_edit_endpoint_and_call"),
+            mock.patch.object(
                 store, "_get_endpoint_from_method", return_value=("/api/test", "POST")
-            ):
-                # Execute
-                store.link_prompt_version_to_model("test_prompt", "1", model_id)
+            ),
+        ):
+            # Execute
+            store.link_prompt_version_to_model("test_prompt", "1", model_id)
 
         # Verify the tag was set
         mock_tracking_store.set_logged_model_tags.assert_called_once()
@@ -2816,12 +2818,14 @@ def test_link_prompt_version_to_run_sets_tag(store):
         mock_tracking_store.get_run.return_value = run
 
         # Mock the UC-specific API call to avoid real API calls
-        with mock.patch.object(store, "_edit_endpoint_and_call"):
-            with mock.patch.object(
+        with (
+            mock.patch.object(store, "_edit_endpoint_and_call"),
+            mock.patch.object(
                 store, "_get_endpoint_from_method", return_value=("/api/test", "POST")
-            ):
-                # Execute
-                store.link_prompt_version_to_run("test_prompt", "1", run_id)
+            ),
+        ):
+            # Execute
+            store.link_prompt_version_to_run("test_prompt", "1", run_id)
 
         # Verify the tag was set
         mock_tracking_store.set_tag.assert_called_once()

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -666,21 +666,25 @@ def test_invoke_custom_judge_model(
         ),
     ):
         if use_native_provider:
-            with mock.patch.object(
-                __import__("mlflow.metrics.genai.model_utils", fromlist=["score_model_on_payload"]),
-                "score_model_on_payload",
-                return_value=mock_response,
-            ):
-                with mock.patch.object(
+            with (
+                mock.patch.object(
+                    __import__(
+                        "mlflow.metrics.genai.model_utils", fromlist=["score_model_on_payload"]
+                    ),
+                    "score_model_on_payload",
+                    return_value=mock_response,
+                ),
+                mock.patch.object(
                     __import__("mlflow.metrics.genai.model_utils", fromlist=["get_endpoint_type"]),
                     "get_endpoint_type",
                     return_value="llm/v1/chat",
-                ):
-                    invoke_judge_model(
-                        model_uri=model_uri,
-                        prompt="Test prompt",
-                        assessment_name="test_assessment",
-                    )
+                ),
+            ):
+                invoke_judge_model(
+                    model_uri=model_uri,
+                    prompt="Test prompt",
+                    assessment_name="test_assessment",
+                )
         else:
             with (
                 mock.patch(

--- a/tests/tracing/processor/test_uc_table_processor.py
+++ b/tests/tracing/processor/test_uc_table_processor.py
@@ -88,19 +88,21 @@ def test_trace_id_generation_with_uc_schema():
     trace_id = 12345
     span = create_mock_otel_span(trace_id=trace_id, span_id=1, parent_id=None, start_time=5_000_000)
 
-    with mock.patch(
-        "mlflow.tracing.processor.uc_table.get_active_spans_table_name",
-        return_value="catalog1.schema1.spans_table",
-    ):
-        with mock.patch(
+    with (
+        mock.patch(
+            "mlflow.tracing.processor.uc_table.get_active_spans_table_name",
+            return_value="catalog1.schema1.spans_table",
+        ),
+        mock.patch(
             "mlflow.tracing.processor.uc_table.generate_trace_id_v4",
             return_value="trace:/catalog1.schema1/12345",
-        ) as mock_generate_trace_id:
-            processor = DatabricksUCTableSpanProcessor(span_exporter=mock.MagicMock())
-            processor.on_start(span)
+        ) as mock_generate_trace_id,
+    ):
+        processor = DatabricksUCTableSpanProcessor(span_exporter=mock.MagicMock())
+        processor.on_start(span)
 
-            # Verify generate_trace_id_v4 was called with correct arguments
-            mock_generate_trace_id.assert_called_once_with(span, "catalog1.schema1")
+        # Verify generate_trace_id_v4 was called with correct arguments
+        mock_generate_trace_id.assert_called_once_with(span, "catalog1.schema1")
 
 
 def test_on_end():

--- a/tests/tracing/test_archival.py
+++ b/tests/tracing/test_archival.py
@@ -42,15 +42,17 @@ def test_enable_databricks_trace_archival_with_explicit_experiment_id():
 
 def test_enable_databricks_trace_archival_with_default_experiment_id():
     mock_enable = mock.MagicMock()
-    with mock.patch.dict(
-        "sys.modules",
-        {"databricks.agents.archive": mock.MagicMock(enable_trace_archival=mock_enable)},
+    with (
+        mock.patch.dict(
+            "sys.modules",
+            {"databricks.agents.archive": mock.MagicMock(enable_trace_archival=mock_enable)},
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="default_exp"),
     ):
-        with mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="default_exp"):
-            enable_databricks_trace_archival(delta_table_fullname="catalog.schema.table")
-            mock_enable.assert_called_once_with(
-                experiment_id="default_exp", table_fullname="catalog.schema.table"
-            )
+        enable_databricks_trace_archival(delta_table_fullname="catalog.schema.table")
+        mock_enable.assert_called_once_with(
+            experiment_id="default_exp", table_fullname="catalog.schema.table"
+        )
 
 
 def test_disable_databricks_trace_archival_with_explicit_experiment_id():
@@ -65,10 +67,12 @@ def test_disable_databricks_trace_archival_with_explicit_experiment_id():
 
 def test_disable_databricks_trace_archival_with_default_experiment_id():
     mock_disable = mock.MagicMock()
-    with mock.patch.dict(
-        "sys.modules",
-        {"databricks.agents.archive": mock.MagicMock(disable_trace_archival=mock_disable)},
+    with (
+        mock.patch.dict(
+            "sys.modules",
+            {"databricks.agents.archive": mock.MagicMock(disable_trace_archival=mock_disable)},
+        ),
+        mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="default_exp"),
     ):
-        with mock.patch("mlflow.tracking.fluent._get_experiment_id", return_value="default_exp"):
-            disable_databricks_trace_archival()
-            mock_disable.assert_called_once_with(experiment_id="default_exp")
+        disable_databricks_trace_archival()
+        mock_disable.assert_called_once_with(experiment_id="default_exp")

--- a/tests/tracing/test_provider.py
+++ b/tests/tracing/test_provider.py
@@ -411,40 +411,44 @@ def test_otlp_exclusive_vs_dual_export(monkeypatch):
 
     # Test 1: OTLP exclusive mode (dual export = false, default)
     monkeypatch.setenv(MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT.name, "false")
-    with mock.patch("mlflow.tracing.provider.should_use_otlp_exporter", return_value=True):
-        with mock.patch("mlflow.tracing.provider.get_otlp_exporter") as mock_get_exporter:
-            mock_get_exporter.return_value = mock.MagicMock()
+    with (
+        mock.patch("mlflow.tracing.provider.should_use_otlp_exporter", return_value=True),
+        mock.patch("mlflow.tracing.provider.get_otlp_exporter") as mock_get_exporter,
+    ):
+        mock_get_exporter.return_value = mock.MagicMock()
 
-            mlflow.tracing.reset()
-            tracer = _get_tracer("test")
+        mlflow.tracing.reset()
+        tracer = _get_tracer("test")
 
-            from mlflow.tracing.provider import _MLFLOW_TRACER_PROVIDER
+        from mlflow.tracing.provider import _MLFLOW_TRACER_PROVIDER
 
-            assert _MLFLOW_TRACER_PROVIDER is not None
-            processors = tracer.span_processor._span_processors
+        assert _MLFLOW_TRACER_PROVIDER is not None
+        processors = tracer.span_processor._span_processors
 
-            # Should have only OTLP processor as primary
-            assert len(processors) == 1
-            assert isinstance(processors[0], OtelSpanProcessor)
+        # Should have only OTLP processor as primary
+        assert len(processors) == 1
+        assert isinstance(processors[0], OtelSpanProcessor)
 
     # Test 2: Dual export mode (both MLflow and OTLP)
     monkeypatch.setenv(MLFLOW_TRACE_ENABLE_OTLP_DUAL_EXPORT.name, "true")
-    with mock.patch("mlflow.tracing.provider.should_use_otlp_exporter", return_value=True):
-        with mock.patch("mlflow.tracing.provider.get_otlp_exporter") as mock_get_exporter:
-            mock_get_exporter.return_value = mock.MagicMock()
+    with (
+        mock.patch("mlflow.tracing.provider.should_use_otlp_exporter", return_value=True),
+        mock.patch("mlflow.tracing.provider.get_otlp_exporter") as mock_get_exporter,
+    ):
+        mock_get_exporter.return_value = mock.MagicMock()
 
-            mlflow.tracing.reset()
-            tracer = _get_tracer("test")
+        mlflow.tracing.reset()
+        tracer = _get_tracer("test")
 
-            from mlflow.tracing.provider import _MLFLOW_TRACER_PROVIDER
+        from mlflow.tracing.provider import _MLFLOW_TRACER_PROVIDER
 
-            assert _MLFLOW_TRACER_PROVIDER is not None
-            processors = tracer.span_processor._span_processors
+        assert _MLFLOW_TRACER_PROVIDER is not None
+        processors = tracer.span_processor._span_processors
 
-            # Should have both processors
-            assert len(processors) == 2
-            assert isinstance(processors[0], OtelSpanProcessor)
-            assert isinstance(processors[1], MlflowV3SpanProcessor)
+        # Should have both processors
+        assert len(processors) == 2
+        assert isinstance(processors[0], OtelSpanProcessor)
+        assert isinstance(processors[1], MlflowV3SpanProcessor)
 
 
 @skip_when_testing_trace_sdk

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -2451,12 +2451,14 @@ def test_delete_prompt_with_versions_unity_catalog_error(registry_uri):
     mock_response = Mock()
     mock_response.prompt_versions = [Mock(version="1")]
 
-    with patch.object(client, "search_prompt_versions", return_value=mock_response):
-        with patch.object(client, "_registry_uri", registry_uri):
-            with pytest.raises(
-                MlflowException, match=r"Cannot delete prompt .* because it still has undeleted"
-            ):
-                client.delete_prompt("test_prompt")
+    with (
+        patch.object(client, "search_prompt_versions", return_value=mock_response),
+        patch.object(client, "_registry_uri", registry_uri),
+    ):
+        with pytest.raises(
+            MlflowException, match=r"Cannot delete prompt .* because it still has undeleted"
+        ):
+            client.delete_prompt("test_prompt")
 
 
 def test_link_prompt_version_to_model_smoke_test(tracking_uri):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18278?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18278/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18278/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18278/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This PR adds a new clint linter rule `NestedMockPatch` that detects nested `mock.patch` context managers in test files and migrates 15 test files to use combined context managers instead:

```python
# Before
with mock.patch(...):
    with mock.patch(...):
        # test code

# After
with mock.patch(...), mock.patch(...):
    # test code
```

The rule only triggers when both the outer and inner `with` statements use `mock.patch`, and preserves intentional nesting patterns like `mock.patch` with `pytest.raises`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests (13 test cases in `dev/clint/tests/rules/test_nested_mock_patch.py`)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)