### PR TITLE
Fix response handling in log_spans

### DIFF
--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -2,7 +2,6 @@ import logging
 from copy import deepcopy
 from urllib.parse import quote
 
-from google.rpc import status_pb2
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
 from mlflow.entities import Assessment, Span, Trace, TraceInfo, TraceLocation
@@ -466,9 +465,11 @@ class DatabricksTracingRestStore(RestStore):
 
         # Handle non-200 status codes
         if response.status_code != 200:
-            # OTLP traces endpoint returns a protobuf status message
-            error_status = status_pb2.Status()
             try:
+                from google.rpc import status_pb2
+
+                # OTLP traces endpoint returns a protobuf status message
+                error_status = status_pb2.Status()
                 error_status.ParseFromString(response.content)
             except Exception:
                 base_msg = (

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -1,5 +1,4 @@
 import logging
-from copy import deepcopy
 from urllib.parse import quote
 
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
@@ -439,7 +438,7 @@ class DatabricksTracingRestStore(RestStore):
         scope_spans = resource_spans.scope_spans.add()
         scope_spans.spans.extend(span.to_otel_proto() for span in spans)
 
-        host_creds = deepcopy(self.get_host_creds())
+        host_creds = self.get_host_creds()
         # avoid using databricks sdk for this request since we need special handling
         # for the protobuf response
         host_creds.use_databricks_sdk = False
@@ -472,12 +471,10 @@ class DatabricksTracingRestStore(RestStore):
                 error_status = status_pb2.Status()
                 error_status.ParseFromString(response.content)
             except Exception:
-                base_msg = (
-                    f"API request to endpoint {endpoint} "
-                    f"failed with error code {response.status_code} != 200"
-                )
                 raise MlflowException(
-                    f"{base_msg}. Response body: '{response.text}'",
+                    f"API request to endpoint {endpoint} "
+                    f"failed with error code {response.status_code}. "
+                    f"Response body: '{response.text}'",
                     error_code=get_error_code(response.status_code),
                 )
             else:

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -1,6 +1,8 @@
 import logging
+from copy import deepcopy
 from urllib.parse import quote
 
+from google.rpc import status_pb2
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 
 from mlflow.entities import Assessment, Span, Trace, TraceInfo, TraceLocation
@@ -10,7 +12,7 @@ from mlflow.environment_variables import (
     MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT,
     MLFLOW_TRACING_SQL_WAREHOUSE_ID,
 )
-from mlflow.exceptions import MlflowException
+from mlflow.exceptions import MlflowException, RestException, get_error_code
 from mlflow.protos.databricks_pb2 import (
     ALREADY_EXISTS,
     ENDPOINT_NOT_FOUND,
@@ -57,7 +59,6 @@ from mlflow.utils.rest_utils import (
     get_single_assessment_endpoint_v4,
     get_single_trace_endpoint_v4,
     http_request,
-    verify_rest_response,
 )
 
 DATABRICKS_UC_TABLE_HEADER = "X-Databricks-UC-Table-Name"
@@ -439,8 +440,12 @@ class DatabricksTracingRestStore(RestStore):
         scope_spans = resource_spans.scope_spans.add()
         scope_spans.spans.extend(span.to_otel_proto() for span in spans)
 
+        host_creds = deepcopy(self.get_host_creds())
+        # avoid using databricks sdk for this request since we need special handling
+        # for the protobuf response
+        host_creds.use_databricks_sdk = False
         response = http_request(
-            host_creds=self.get_host_creds(),
+            host_creds=host_creds,
             endpoint=endpoint,
             method="POST",
             data=request.SerializeToString(),
@@ -450,8 +455,36 @@ class DatabricksTracingRestStore(RestStore):
                 **config.authenticate(),
             },
         )
-        verify_rest_response(response, endpoint)
+        self._verify_trace_response(response, endpoint)
         return spans
+
+    def _verify_trace_response(self, response, endpoint):
+        # v1/traces endpoint returns empty response for successful requests
+        if response.status_code == 200 and response.text.strip() == "":
+            response._content = b"{}"
+            return response
+
+        # Handle non-200 status codes
+        if response.status_code != 200:
+            # OTLP traces endpoint returns a protobuf status message
+            error_status = status_pb2.Status()
+            try:
+                error_status.ParseFromString(response.content)
+            except Exception:
+                base_msg = (
+                    f"API request to endpoint {endpoint} "
+                    f"failed with error code {response.status_code} != 200"
+                )
+                raise MlflowException(
+                    f"{base_msg}. Response body: '{response.text}'",
+                    error_code=get_error_code(response.status_code),
+                )
+            else:
+                raise RestException(
+                    {"error_code": response.status_code, "message": error_status.message}
+                )
+
+        return response
 
     def create_assessment(self, assessment: Assessment) -> Assessment:
         """

--- a/requirements/test-requirements.txt
+++ b/requirements/test-requirements.txt
@@ -38,3 +38,5 @@ polars>=1
 dspy
 # required for testing mlflow.server.jobs
 huey<3,>=2.5.0
+# required for testing mlflow.store.tracking.databricks_rest_store
+grpcio-status

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -50,6 +50,13 @@ from mlflow.utils.rest_utils import (
     MlflowHostCreds,
 )
 
+try:
+    from google.rpc import status_pb2
+
+    grpc_status_exists = True
+except ImportError:
+    grpc_status_exists = False
+
 
 @pytest.fixture
 def sql_warehouse_id(monkeypatch):
@@ -1214,9 +1221,8 @@ def test_verify_trace_response_success_empty_response():
     assert result._content == b"{}"
 
 
+@pytest.mark.skipif(grpc_status_exists is False, reason="grpcio-status is not installed")
 def test_verify_trace_response_error_with_protobuf():
-    from google.rpc import status_pb2
-
     store = DatabricksTracingRestStore(lambda: MlflowHostCreds("http://localhost"))
     response = mock.MagicMock()
     response.status_code = 400

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -946,11 +946,8 @@ def test_log_spans_to_uc_table_empty_spans():
 
 @mock.patch("mlflow.store.tracking.databricks_rest_store.get_databricks_workspace_client_config")
 @mock.patch("mlflow.store.tracking.databricks_rest_store.http_request")
-@mock.patch("mlflow.store.tracking.databricks_rest_store.verify_rest_response")
 @pytest.mark.parametrize("diff_trace_id", [True, False])
-def test_log_spans_to_uc_table_success(
-    mock_verify, mock_http_request, mock_get_config, diff_trace_id
-):
+def test_log_spans_to_uc_table_success(mock_http_request, mock_get_config, diff_trace_id):
     # Mock configuration
     mock_config = mock.MagicMock()
     mock_config.authenticate.return_value = {"Authorization": "Bearer token"}
@@ -958,19 +955,24 @@ def test_log_spans_to_uc_table_success(
 
     spans = create_mock_spans(diff_trace_id)
 
-    # Mock HTTP response
+    # Mock HTTP response with empty content (successful response)
     mock_response = mock.MagicMock()
+    mock_response.status_code = 200
+    mock_response.text = ""
     mock_http_request.return_value = mock_response
 
-    store = DatabricksTracingRestStore(lambda: MlflowHostCreds("http://localhost"))
+    # Create store with mock host creds that have use_databricks_sdk set to True
+    mock_host_creds = MlflowHostCreds("http://localhost")
+    mock_host_creds.use_databricks_sdk = True
+
+    store = DatabricksTracingRestStore(lambda: mock_host_creds)
 
     # Execute
-    store.log_spans("catalog.schema.spans", spans, tracking_uri="databricks")
+    result = store.log_spans("catalog.schema.spans", spans, tracking_uri="databricks")
 
     # Verify calls
     mock_get_config.assert_called_once_with("databricks")
     mock_http_request.assert_called_once()
-    mock_verify.assert_called_once_with(mock_response, "/api/2.0/tracing/otel/v1/traces")
 
     # Verify HTTP request details
     call_kwargs = mock_http_request.call_args
@@ -980,6 +982,14 @@ def test_log_spans_to_uc_table_success(
     assert call_kwargs[1]["extra_headers"]["Content-Type"] == "application/x-protobuf"
     assert "X-Databricks-UC-Table-Name" in call_kwargs[1]["extra_headers"]
     assert call_kwargs[1]["extra_headers"]["X-Databricks-UC-Table-Name"] == "catalog.schema.spans"
+
+    # Verify that use_databricks_sdk is set to False in the request
+    host_creds_used = call_kwargs[1]["host_creds"]
+    assert host_creds_used.use_databricks_sdk is False
+    # Verify original host_creds is not modified
+    assert mock_host_creds.use_databricks_sdk is True
+
+    assert result == spans
 
 
 @mock.patch("mlflow.store.tracking.databricks_rest_store.get_databricks_workspace_client_config")
@@ -1190,3 +1200,32 @@ def test_delete_assessment(sql_warehouse_id):
             json_body=None,
             version="4.0",
         )
+
+
+def test_verify_trace_response_success_empty_response():
+    store = DatabricksTracingRestStore(lambda: MlflowHostCreds("http://localhost"))
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.text = ""
+
+    result = store._verify_trace_response(response, "/api/2.0/tracing/otel/v1/traces")
+
+    assert result.status_code == 200
+    assert result._content == b"{}"
+
+
+def test_verify_trace_response_error_with_protobuf():
+    from google.rpc import status_pb2
+
+    store = DatabricksTracingRestStore(lambda: MlflowHostCreds("http://localhost"))
+    response = mock.MagicMock()
+    response.status_code = 400
+
+    # Create a protobuf error status
+    error_status = status_pb2.Status()
+    error_status.code = 400
+    error_status.message = "Invalid request: missing required field"
+    response.content = error_status.SerializeToString()
+
+    with pytest.raises(RestException, match="Invalid request"):
+        store._verify_trace_response(response, "/api/2.0/tracing/otel/v1/traces")

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -993,8 +993,6 @@ def test_log_spans_to_uc_table_success(mock_http_request, mock_get_config, diff_
     # Verify that use_databricks_sdk is set to False in the request
     host_creds_used = call_kwargs[1]["host_creds"]
     assert host_creds_used.use_databricks_sdk is False
-    # Verify original host_creds is not modified
-    assert mock_host_creds.use_databricks_sdk is True
 
     assert result == spans
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/18280?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18280/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18280/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18280/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
v1/traces endpoint follows [OTLP convention](https://opentelemetry.io/docs/specs/otlp/#failures-1) to return protobuf response, but databricks sdk is not able to parse the response correctly. As a result I enforce to not use databricks_sdk for log_spans operation.

Before the PR:
"/Users/serena.ruan/miniconda3/envs/mlflow/lib/python3.10/site-packages/databricks/sdk/errors/parser.py", line 87, in get_api_error
    {"message": "unable to parse response. " + _unknown_error(response)},
  File "/Users/serena.ruan/miniconda3/envs/mlflow/lib/python3.10/site-packages/databricks/sdk/errors/parser.py", line 39, in _unknown_error
    request_log = RoundTrip(response, debug_headers=True, debug_truncate_bytes=10 * 1024).generate()
  File "/Users/serena.ruan/miniconda3/envs/mlflow/lib/python3.10/site-packages/databricks/sdk/logger/round_trip_logger.py", line 47, in generate
    sb.append("> [raw stream]" if self._raw else self._redacted_dump("> ", request.body))
  File "/Users/serena.ruan/miniconda3/envs/mlflow/lib/python3.10/site-packages/databricks/sdk/logger/round_trip_logger.py", line 113, in _redacted_dump
    if len(body) == 0:
TypeError: object of type '_io.BytesIO' has no len()

After the PR:
2025/10/13 16:54:22 WARNING mlflow.tracing.client: Failed to log span to location serena.otel_bug_bash_new.mlflow_experiment_trace_otel_spans: 403: Failed to get signed principal context token for user ......

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
