### PR TITLE
UI fix

### DIFF
--- a/mlflow/server/js/src/home/components/DiscoverNews.tsx
+++ b/mlflow/server/js/src/home/components/DiscoverNews.tsx
@@ -26,7 +26,7 @@ const NewsThumbnail = ({ gradient, title, description, icon: IconComponent }: Ne
       }}
     >
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-        <Typography.Text bold color="primary">
+        <Typography.Text bold style={{ color: theme.colors.grey800 }}>
           {title}
         </Typography.Text>
         {description ? <Typography.Text color="secondary">{description}</Typography.Text> : <Spacer size="sm" />}

--- a/mlflow/server/js/src/home/components/DiscoverNews.tsx
+++ b/mlflow/server/js/src/home/components/DiscoverNews.tsx
@@ -4,7 +4,10 @@ import { FormattedMessage } from 'react-intl';
 import { homeNewsItems } from '../news-items';
 
 type NewsThumbnailProps = {
-  gradient: string;
+  gradient: {
+    light: string;
+    dark: string;
+  };
   title: ReactNode;
   description: ReactNode;
   icon?: ComponentType<{ className?: string; css?: any }>;
@@ -18,7 +21,7 @@ const NewsThumbnail = ({ gradient, title, description, icon: IconComponent }: Ne
       css={{
         borderRadius: theme.borders.borderRadiusMd,
         aspectRatio: '16 / 9',
-        background: gradient,
+        background: theme.isDarkMode ? gradient.dark : gradient.light,
         display: 'flex',
         flexDirection: 'column',
         padding: theme.spacing.md,
@@ -26,7 +29,7 @@ const NewsThumbnail = ({ gradient, title, description, icon: IconComponent }: Ne
       }}
     >
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-        <Typography.Text bold style={{ color: theme.colors.grey800 }}>
+        <Typography.Text bold color="primary">
           {title}
         </Typography.Text>
         {description ? <Typography.Text color="secondary">{description}</Typography.Text> : <Spacer size="sm" />}

--- a/mlflow/server/js/src/home/news-items.tsx
+++ b/mlflow/server/js/src/home/news-items.tsx
@@ -11,7 +11,10 @@ export const homeNewsItems: HomeNewsItemDefinition[] = [
     link: 'https://mlflow.org/docs/latest/genai/mcp/index.html',
     componentId: 'mlflow.home.news.auto_tune_llm_judge',
     thumbnail: {
-      gradient: 'linear-gradient(135deg, #E9F2FF 0%, #F4EBFF 100%)',
+      gradient: {
+        light: 'linear-gradient(135deg, #E9F2FF 0%, #F4EBFF 100%)',
+        dark: 'linear-gradient(135deg, #1E2633 0%, #2A2434 100%)',
+      },
       icon: AssistantIcon,
     },
   },
@@ -23,7 +26,10 @@ export const homeNewsItems: HomeNewsItemDefinition[] = [
     link: 'https://mlflow.org/docs/latest/genai/prompt-registry/optimize-prompts',
     componentId: 'mlflow.home.news.optimize_prompts',
     thumbnail: {
-      gradient: 'linear-gradient(135deg, #E8F7F2 0%, #D5E8FF 100%)',
+      gradient: {
+        light: 'linear-gradient(135deg, #E8F7F2 0%, #D5E8FF 100%)',
+        dark: 'linear-gradient(135deg, #1E2B2A 0%, #1C2A3A 100%)',
+      },
       icon: NotebookIcon,
     },
   },
@@ -34,7 +40,10 @@ export const homeNewsItems: HomeNewsItemDefinition[] = [
     link: 'https://mlflow.org/docs/latest/genai/eval-monitor/scorers/llm-judge/agentic-overview/index.html',
     componentId: 'mlflow.home.news.agents_as_a_judge',
     thumbnail: {
-      gradient: 'linear-gradient(135deg, #FFF5E1 0%, #FFE2F2 100%)',
+      gradient: {
+        light: 'linear-gradient(135deg, #FFF5E1 0%, #FFE2F2 100%)',
+        dark: 'linear-gradient(135deg, #3A2A1C 0%, #3A2230 100%)',
+      },
       icon: RobotIcon,
     },
   },
@@ -45,7 +54,10 @@ export const homeNewsItems: HomeNewsItemDefinition[] = [
     link: 'https://mlflow.org/docs/latest/genai/datasets/',
     componentId: 'mlflow.home.news.dataset_tracking',
     thumbnail: {
-      gradient: 'linear-gradient(135deg, #E6F3FF 0%, #E0F1F6 100%)',
+      gradient: {
+        light: 'linear-gradient(135deg, #E6F3FF 0%, #E0F1F6 100%)',
+        dark: 'linear-gradient(135deg, #1F2B38 0%, #1E2A2F 100%)',
+      },
       icon: DatabaseIcon,
     },
   },

--- a/mlflow/server/js/src/home/types.ts
+++ b/mlflow/server/js/src/home/types.ts
@@ -16,7 +16,10 @@ export interface HomeNewsItemDefinition {
   link: string;
   componentId: string;
   thumbnail: {
-    gradient: string;
+    gradient: {
+      light: string;
+      dark: string;
+    };
     label?: ReactNode;
     icon?: ComponentType<{ className?: string; css?: any }>;
   };


### PR DESCRIPTION
### Related Issues/PRs


### What changes are proposed in this pull request?

In the product onboarding page, the heading is not visible when using the dark theme. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Earlier:
<img width="1524" height="301" alt="Screenshot 2025-10-15 at 9 11 16 AM" src="https://github.com/user-attachments/assets/f9fb3a65-d3bf-4d8e-ab04-db1d1cc2432a" />


After:
<img width="1524" height="327" alt="Screenshot 2025-10-15 at 8 49 25 AM" src="https://github.com/user-attachments/assets/6430c5f6-efb9-415f-bd9d-ebf09110b543" />




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
