### PR TITLE
Handle external GPT models for conversion logic

### DIFF
--- a/mlflow/types/responses.py
+++ b/mlflow/types/responses.py
@@ -410,6 +410,8 @@ def _cc_stream_to_responses_stream(
     tool_calls = []
     msg_id = None
     for chunk in chunks:
+        if chunk.get("choices") is None or len(chunk["choices"]) == 0:
+            continue
         delta = chunk["choices"][0]["delta"]
         msg_id = chunk.get("id", None)
         content = delta.get("content", None)

--- a/tests/pyfunc/test_responses_agent.py
+++ b/tests/pyfunc/test_responses_agent.py
@@ -1258,9 +1258,6 @@ def test_prep_msgs_for_cc_llm_empty_arguments(responses_input, cc_msgs):
 
 
 def test_cc_stream_to_responses_stream_handles_multiple_invalid_chunks():
-    """Test that _cc_stream_to_responses_stream correctly handles chunks with empty or
-    None choices.
-    """
     chunks_with_mixed_validity = [
         {"choices": None, "id": "msg-1"},
         {"choices": [], "id": "msg-2"},

--- a/tests/pyfunc/test_responses_agent.py
+++ b/tests/pyfunc/test_responses_agent.py
@@ -31,6 +31,7 @@ from mlflow.types.responses import (
     ResponsesAgentRequest,
     ResponsesAgentResponse,
     ResponsesAgentStreamEvent,
+    output_to_responses_items_stream,
 )
 
 if _HAS_LANGCHAIN_BASE_MESSAGE:
@@ -1254,3 +1255,27 @@ def test_prep_msgs_for_cc_llm(responses_input, cc_msgs):
 def test_prep_msgs_for_cc_llm_empty_arguments(responses_input, cc_msgs):
     result = ResponsesAgent.prep_msgs_for_cc_llm(responses_input)
     assert result == cc_msgs
+
+
+def test_cc_stream_to_responses_stream_handles_multiple_invalid_chunks():
+    """Test that _cc_stream_to_responses_stream correctly handles chunks with empty or
+    None choices.
+    """
+    chunks_with_mixed_validity = [
+        {"choices": None, "id": "msg-1"},
+        {"choices": [], "id": "msg-2"},
+        {"choices": [{"delta": {"content": "valid"}}], "id": "msg-3"},
+        {"choices": None, "id": "msg-4"},
+        {"choices": [{"delta": {"content": " content"}}], "id": "msg-5"},
+    ]
+
+    events = list(output_to_responses_items_stream(iter(chunks_with_mixed_validity)))
+
+    # Should only process chunks with valid choices
+    # Expected: 2 delta events + 1 done event (content gets aggregated)
+    assert len(events) == 3
+    assert events[0].type == "response.output_text.delta"
+    assert events[0].delta == "valid"
+    assert events[1].type == "response.output_text.delta"
+    assert events[1].delta == " content"
+    assert events[2].type == "response.output_item.done"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/bbqiu/mlflow/pull/18290?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18290/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18290/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18290/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Updating parser to accommodate for empty choices array. Equivalent change: https://github.com/databricks-eng/universe/pull/1275261/files

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
