### PR TITLE
AI-gateway revamp: Make anthropic provider supporting function calling

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -1349,6 +1349,7 @@ mlflow.types.chat.ParamProperty
 mlflow.types.chat.ParamType
 mlflow.types.chat.TextContentPart
 mlflow.types.chat.ToolCall
+mlflow.types.chat.ToolCallDelta
 mlflow.types.llm.ChatChoice
 mlflow.types.llm.ChatChoiceDelta
 mlflow.types.llm.ChatChoiceLogProbs

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -171,6 +171,9 @@ class AnthropicAdapter(ProviderAdapter):
         content = resp.get("delta") or resp.get("content_block") or {}
         if (stop_reason := content.get("stop_reason")) is not None:
             stop_reason = "length" if stop_reason == "max_tokens" else "stop"
+
+        # example of function calling delta message format:
+        # https://platform.openai.com/docs/guides/function-calling#streaming
         if content.get("type") == "tool_use":
             delta = chat.StreamDelta(
                 tool_calls=[ToolCallDelta(

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -11,6 +11,7 @@ from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions
+from mlflow.types.chat import ToolCallDelta, Function
 
 
 class AnthropicAdapter(ProviderAdapter):
@@ -170,6 +171,28 @@ class AnthropicAdapter(ProviderAdapter):
         content = resp.get("delta") or resp.get("content_block") or {}
         if (stop_reason := content.get("stop_reason")) is not None:
             stop_reason = "length" if stop_reason == "max_tokens" else "stop"
+        if content.get("type") == "tool_use":
+            delta = chat.StreamDelta(
+                tool_calls=[ToolCallDelta(
+                    index=0,
+                    id=content.get("id"),
+                    type="function",
+                    function=Function(name=content.get("name")),
+                )]
+            )
+        elif content.get("type") == "input_json_delta":
+            delta = chat.StreamDelta(
+                tool_calls=[ToolCallDelta(
+                    index=0,
+                    function=Function(arguments=content.get("partial_json"))
+                )]
+            )
+        else:
+            delta = chat.StreamDelta(
+                role=None,
+                content=content.get("text"),
+            )
+
         return chat.StreamResponsePayload(
             id=resp["id"],
             created=int(time.time()),
@@ -178,10 +201,7 @@ class AnthropicAdapter(ProviderAdapter):
                 chat.StreamChoice(
                     index=resp["index"],
                     finish_reason=stop_reason,
-                    delta=chat.StreamDelta(
-                        role=None,
-                        content=content.get("text"),
-                    ),
+                    delta=delta,
                 )
             ],
         )
@@ -357,7 +377,9 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
                         self.config,
                     )
             else:
-                yield AnthropicAdapter.model_to_chat_streaming(resp, self.config)
+                yield AnthropicAdapter.model_to_chat_streaming(
+                    resp, self.config
+                )
 
     async def chat(self, payload: chat.RequestPayload) -> chat.ResponsePayload:
         from fastapi.encoders import jsonable_encoder

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -71,8 +71,8 @@ ContentType = Annotated[str | ContentPartsList, Field(union_mode="left_to_right"
 
 
 class Function(BaseModel):
-    name: str
-    arguments: str
+    name: str | None
+    arguments: str | None
 
     def to_tool_call(self, id=None) -> ToolCall:
         if id is None:
@@ -195,9 +195,17 @@ class ChatUsage(BaseModel):
     total_tokens: int | None = None
 
 
+class ToolCallDelta(BaseModel):
+    index: int
+    id: str | None = None
+    type: str | None = None
+    function: Function
+
+
 class ChatChoiceDelta(BaseModel):
     role: str | None = None
     content: str | None = None
+    tool_calls: list[ToolCallDelta] | None = None
 
 
 class ChatChunkChoice(BaseModel):

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -71,8 +71,8 @@ ContentType = Annotated[str | ContentPartsList, Field(union_mode="left_to_right"
 
 
 class Function(BaseModel):
-    name: str | None
-    arguments: str | None
+    name: str | None = None
+    arguments: str | None = None
 
     def to_tool_call(self, id=None) -> ToolCall:
         if id is None:

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -505,6 +505,190 @@ async def test_chat_stream():
         )
 
 
+def chat_function_calling_stream_response():
+    return [
+        b"event: message_start\n",
+        b'data: {"type": "message_start", "message": {"id": "test-id", "type": "message", '
+        b'"role": "assistant", "content": [], "model": "claude-2.1", "stop_reason": null, '
+        b'"stop_sequence": null, "usage": {"input_tokens": 25, "output_tokens": 1}}}\n',
+        b"\n",
+        b"event: content_block_start\n",
+        b'data: {"type": "content_block_start", "index":0, "content_block":{"type":"tool_use",'
+        b'"id":"toolu_001","name":"get_weather","input":{}}}\n',
+        b"\n",
+        b"event: ping\n",
+        b'data: {"type": "ping"}\n',
+        b"\n",
+        b"event: content_block_delta\n",
+        b'data: {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", '
+        b'"partial_json": "{\\"location\\":"}}\n',
+        b"\n",
+        b'data: {"type": "content_block_delta", "index": 0, "delta": {"type": "input_json_delta", '
+        b'"partial_json": "\\"Singapore\\"}"}}\n',
+        b"\n",
+        b"event: content_block_stop\n",
+        b'data: {"type": "content_block_stop", "index": 0}\n',
+        b"\n",
+        b"event: message_delta\n",
+        b'data: {"type": "message_delta", "delta": {"stop_reason": "tool_use", '
+        b'"stop_sequence":null, "usage":{"output_tokens": 15}}}\n',
+        b"\n",
+        b"event: message_stop\n",
+        b'data: {"type": "message_stop"}\n',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_chat_function_calling_stream():
+    resp = chat_function_calling_stream_response()
+    config = chat_config()
+
+    with (
+        mock.patch("time.time", return_value=1677858242),
+        mock.patch(
+            "aiohttp.ClientSession.post", return_value=MockAsyncStreamingResponse(resp)
+        ) as mock_post,
+    ):
+        provider = AnthropicProvider(EndpointConfig(**config))
+        payload = chat_function_calling_payload(stream=True)
+        response = provider.chat_stream(chat.RequestPayload(**payload))
+        chunks = [jsonable_encoder(chunk) async for chunk in response]
+        assert chunks == [
+          {
+            "id": "test-id",
+            "object": "chat.completion.chunk",
+            "created": 1677858242,
+            "model": "claude-2.1",
+            "choices": [
+              {
+                "index": 0,
+                "finish_reason": None,
+                "delta": {
+                  "role": None,
+                  "content": None,
+                  "tool_calls": [
+                    {
+                      "index": 0,
+                      "id": "toolu_001",
+                      "type": "function",
+                      "function": {
+                        "name": "get_weather",
+                        "arguments": None
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "test-id",
+            "object": "chat.completion.chunk",
+            "created": 1677858242,
+            "model": "claude-2.1",
+            "choices": [
+              {
+                "index": 0,
+                "finish_reason": None,
+                "delta": {
+                  "role": None,
+                  "content": None,
+                  "tool_calls": [
+                    {
+                      "index": 0,
+                      "id": None,
+                      "type": None,
+                      "function": {
+                        "name": None,
+                        "arguments": "{\"location\":"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "test-id",
+            "object": "chat.completion.chunk",
+            "created": 1677858242,
+            "model": "claude-2.1",
+            "choices": [
+              {
+                "index": 0,
+                "finish_reason": None,
+                "delta": {
+                  "role": None,
+                  "content": None,
+                  "tool_calls": [
+                    {
+                      "index": 0,
+                      "id": None,
+                      "type": None,
+                      "function": {
+                        "name": None,
+                        "arguments": "\"Singapore\"}"
+                      }
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          {
+            "id": "test-id",
+            "object": "chat.completion.chunk",
+            "created": 1677858242,
+            "model": "claude-2.1",
+            "choices": [
+              {
+                "index": 0,
+                "finish_reason": "stop",
+                "delta": {
+                  "role": None,
+                  "content": None,
+                  "tool_calls": None
+                }
+              }
+            ]
+          }
+        ]
+        mock_post.assert_called_once_with(
+            "https://api.anthropic.com/v1/messages",
+            json={
+                "model": "claude-2.1",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": "What's the weather like in Singapore today?"
+                    }
+                ],
+                "max_tokens": MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
+                "temperature": 0.25,
+                "tools": [
+                    {
+                        "name": "get_weather",
+                        "description": "Get current temperature for a given location.",
+                        "input_schema": {
+                            "properties": {
+                                "location": {
+                                    "type": "string",
+                                    "description": "The name of a city"
+                                }
+                            },
+                            "type": "object",
+                            "required": [
+                                "location"
+                            ]
+                        }
+                    }
+                ],
+                "stream": True,
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
+
+
 def embedding_config():
     return {
         "name": "embeddings",

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -323,7 +323,7 @@ async def test_chat_stream():
                 "created": 1677858242,
                 "model": "claude-2.1",
                 "choices": [
-                    {"index": 0, "finish_reason": None, "delta": {"role": None, "content": ""}}
+                    {"index": 0, "finish_reason": None, "delta": {"role": None, "content": "", 'tool_calls': None,}}
                 ],
             },
             {
@@ -335,7 +335,7 @@ async def test_chat_stream():
                     {
                         "index": 0,
                         "finish_reason": None,
-                        "delta": {"role": None, "content": "Hello"},
+                        "delta": {"role": None, "content": "Hello", 'tool_calls': None,},
                     }
                 ],
             },
@@ -345,7 +345,7 @@ async def test_chat_stream():
                 "created": 1677858242,
                 "model": "claude-2.1",
                 "choices": [
-                    {"index": 0, "finish_reason": None, "delta": {"role": None, "content": "!"}}
+                    {"index": 0, "finish_reason": None, "delta": {"role": None, "content": "!", 'tool_calls': None,}}
                 ],
             },
             {
@@ -354,7 +354,7 @@ async def test_chat_stream():
                 "created": 1677858242,
                 "model": "claude-2.1",
                 "choices": [
-                    {"index": 0, "finish_reason": "stop", "delta": {"role": None, "content": None}}
+                    {"index": 0, "finish_reason": "stop", "delta": {"role": None, "content": None, 'tool_calls': None,}}
                 ],
             },
         ]

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -307,23 +307,22 @@ def chat_function_calling_payload(stream: bool = False):
             {"role": "user", "content": "What's the weather like in Singapore today?"},
         ],
         "temperature": 0.5,
-        "tools": [{
-            "type": "function",
-            "function": {
-                "name": "get_weather",
-                "description": "Get current temperature for a given location.",
-                "parameters": {
-                    "type": "object",
-                    "properties": {
-                        "location": {
-                            "type": "string",
-                            "description": "The name of a city"
-                        }
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get current temperature for a given location.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "location": {"type": "string", "description": "The name of a city"}
+                        },
+                        "required": ["location"],
                     },
-                    "required": ["location"],
                 },
             }
-        }],
+        ],
     }
     if stream:
         payload["stream"] = True
@@ -333,20 +332,20 @@ def chat_function_calling_payload(stream: bool = False):
 def chat_function_calling_response():
     # see https://docs.anthropic.com/claude/reference/messages_post
     return {
-      "id": "test-id",
-      "model": "claude-2.1",
-      "type": "message",
-      "role": "assistant",
-      "stop_reason": "tool_use",
-      "content": [
-        {
-          "type": "tool_use",
-          "id": "toolu_001",
-          "name": "get_weather",
-          "input": { "location": "Singapore" }
-        }
-      ],
-      "usage": {"input_tokens": 10, "output_tokens": 25},
+        "id": "test-id",
+        "model": "claude-2.1",
+        "type": "message",
+        "role": "assistant",
+        "stop_reason": "tool_use",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": "toolu_001",
+                "name": "get_weather",
+                "input": {"location": "Singapore"},
+            }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 25},
     }
 
 
@@ -363,36 +362,32 @@ async def test_chat_function_calling():
         response = await provider.chat(chat.RequestPayload(**payload))
 
         assert jsonable_encoder(response) == {
-          "id": "test-id",
-          "object": "chat.completion",
-          "created": 1677858242,
-          "model": "claude-2.1",
-          "choices": [
-            {
-              "index": 0,
-              "message": {
-                "role": "assistant",
-                "content": [],
-                "tool_calls": [
-                  {
-                    "id": "toolu_001",
-                    "type": "function",
-                    "function": {
-                      "name": "get_weather",
-                      "arguments": "{\"location\": \"Singapore\"}"
-                    }
-                  }
-                ],
-                "refusal": None,
-              },
-              "finish_reason": "stop"
-            }
-          ],
-          "usage": {
-            "prompt_tokens": 10,
-            "completion_tokens": 25,
-            "total_tokens": 35
-          }
+            "id": "test-id",
+            "object": "chat.completion",
+            "created": 1677858242,
+            "model": "claude-2.1",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {
+                        "role": "assistant",
+                        "content": [],
+                        "tool_calls": [
+                            {
+                                "id": "toolu_001",
+                                "type": "function",
+                                "function": {
+                                    "name": "get_weather",
+                                    "arguments": '{"location": "Singapore"}',
+                                },
+                            }
+                        ],
+                        "refusal": None,
+                    },
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 25, "total_tokens": 35},
         }
 
         mock_post.assert_called_once_with(
@@ -400,10 +395,7 @@ async def test_chat_function_calling():
             json={
                 "model": "claude-2.1",
                 "messages": [
-                    {
-                        "role": "user",
-                        "content": "What's the weather like in Singapore today?"
-                    }
+                    {"role": "user", "content": "What's the weather like in Singapore today?"}
                 ],
                 "max_tokens": MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
                 "temperature": 0.25,
@@ -413,18 +405,13 @@ async def test_chat_function_calling():
                         "description": "Get current temperature for a given location.",
                         "input_schema": {
                             "properties": {
-                                "location": {
-                                    "type": "string",
-                                    "description": "The name of a city"
-                                }
+                                "location": {"type": "string", "description": "The name of a city"}
                             },
                             "type": "object",
-                            "required": [
-                                "location"
-                            ]
-                        }
+                            "required": ["location"],
+                        },
                     }
-                ]
+                ],
             },
             timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
         )
@@ -452,7 +439,15 @@ async def test_chat_stream():
                 "created": 1677858242,
                 "model": "claude-2.1",
                 "choices": [
-                    {"index": 0, "finish_reason": None, "delta": {"role": None, "content": "", 'tool_calls': None,}}
+                    {
+                        "index": 0,
+                        "finish_reason": None,
+                        "delta": {
+                            "role": None,
+                            "content": "",
+                            "tool_calls": None,
+                        },
+                    }
                 ],
             },
             {
@@ -464,7 +459,11 @@ async def test_chat_stream():
                     {
                         "index": 0,
                         "finish_reason": None,
-                        "delta": {"role": None, "content": "Hello", 'tool_calls': None,},
+                        "delta": {
+                            "role": None,
+                            "content": "Hello",
+                            "tool_calls": None,
+                        },
                     }
                 ],
             },
@@ -474,7 +473,15 @@ async def test_chat_stream():
                 "created": 1677858242,
                 "model": "claude-2.1",
                 "choices": [
-                    {"index": 0, "finish_reason": None, "delta": {"role": None, "content": "!", 'tool_calls': None,}}
+                    {
+                        "index": 0,
+                        "finish_reason": None,
+                        "delta": {
+                            "role": None,
+                            "content": "!",
+                            "tool_calls": None,
+                        },
+                    }
                 ],
             },
             {
@@ -483,7 +490,15 @@ async def test_chat_stream():
                 "created": 1677858242,
                 "model": "claude-2.1",
                 "choices": [
-                    {"index": 0, "finish_reason": "stop", "delta": {"role": None, "content": None, 'tool_calls': None,}}
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "delta": {
+                            "role": None,
+                            "content": None,
+                            "tool_calls": None,
+                        },
+                    }
                 ],
             },
         ]
@@ -554,114 +569,98 @@ async def test_chat_function_calling_stream():
         response = provider.chat_stream(chat.RequestPayload(**payload))
         chunks = [jsonable_encoder(chunk) async for chunk in response]
         assert chunks == [
-          {
-            "id": "test-id",
-            "object": "chat.completion.chunk",
-            "created": 1677858242,
-            "model": "claude-2.1",
-            "choices": [
-              {
-                "index": 0,
-                "finish_reason": None,
-                "delta": {
-                  "role": None,
-                  "content": None,
-                  "tool_calls": [
+            {
+                "id": "test-id",
+                "object": "chat.completion.chunk",
+                "created": 1677858242,
+                "model": "claude-2.1",
+                "choices": [
                     {
-                      "index": 0,
-                      "id": "toolu_001",
-                      "type": "function",
-                      "function": {
-                        "name": "get_weather",
-                        "arguments": None
-                      }
+                        "index": 0,
+                        "finish_reason": None,
+                        "delta": {
+                            "role": None,
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": "toolu_001",
+                                    "type": "function",
+                                    "function": {"name": "get_weather", "arguments": None},
+                                }
+                            ],
+                        },
                     }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "id": "test-id",
-            "object": "chat.completion.chunk",
-            "created": 1677858242,
-            "model": "claude-2.1",
-            "choices": [
-              {
-                "index": 0,
-                "finish_reason": None,
-                "delta": {
-                  "role": None,
-                  "content": None,
-                  "tool_calls": [
+                ],
+            },
+            {
+                "id": "test-id",
+                "object": "chat.completion.chunk",
+                "created": 1677858242,
+                "model": "claude-2.1",
+                "choices": [
                     {
-                      "index": 0,
-                      "id": None,
-                      "type": None,
-                      "function": {
-                        "name": None,
-                        "arguments": "{\"location\":"
-                      }
+                        "index": 0,
+                        "finish_reason": None,
+                        "delta": {
+                            "role": None,
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": None,
+                                    "type": None,
+                                    "function": {"name": None, "arguments": '{"location":'},
+                                }
+                            ],
+                        },
                     }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "id": "test-id",
-            "object": "chat.completion.chunk",
-            "created": 1677858242,
-            "model": "claude-2.1",
-            "choices": [
-              {
-                "index": 0,
-                "finish_reason": None,
-                "delta": {
-                  "role": None,
-                  "content": None,
-                  "tool_calls": [
+                ],
+            },
+            {
+                "id": "test-id",
+                "object": "chat.completion.chunk",
+                "created": 1677858242,
+                "model": "claude-2.1",
+                "choices": [
                     {
-                      "index": 0,
-                      "id": None,
-                      "type": None,
-                      "function": {
-                        "name": None,
-                        "arguments": "\"Singapore\"}"
-                      }
+                        "index": 0,
+                        "finish_reason": None,
+                        "delta": {
+                            "role": None,
+                            "content": None,
+                            "tool_calls": [
+                                {
+                                    "index": 0,
+                                    "id": None,
+                                    "type": None,
+                                    "function": {"name": None, "arguments": '"Singapore"}'},
+                                }
+                            ],
+                        },
                     }
-                  ]
-                }
-              }
-            ]
-          },
-          {
-            "id": "test-id",
-            "object": "chat.completion.chunk",
-            "created": 1677858242,
-            "model": "claude-2.1",
-            "choices": [
-              {
-                "index": 0,
-                "finish_reason": "stop",
-                "delta": {
-                  "role": None,
-                  "content": None,
-                  "tool_calls": None
-                }
-              }
-            ]
-          }
+                ],
+            },
+            {
+                "id": "test-id",
+                "object": "chat.completion.chunk",
+                "created": 1677858242,
+                "model": "claude-2.1",
+                "choices": [
+                    {
+                        "index": 0,
+                        "finish_reason": "stop",
+                        "delta": {"role": None, "content": None, "tool_calls": None},
+                    }
+                ],
+            },
         ]
         mock_post.assert_called_once_with(
             "https://api.anthropic.com/v1/messages",
             json={
                 "model": "claude-2.1",
                 "messages": [
-                    {
-                        "role": "user",
-                        "content": "What's the weather like in Singapore today?"
-                    }
+                    {"role": "user", "content": "What's the weather like in Singapore today?"}
                 ],
                 "max_tokens": MLFLOW_AI_GATEWAY_ANTHROPIC_DEFAULT_MAX_TOKENS,
                 "temperature": 0.25,
@@ -671,16 +670,11 @@ async def test_chat_function_calling_stream():
                         "description": "Get current temperature for a given location.",
                         "input_schema": {
                             "properties": {
-                                "location": {
-                                    "type": "string",
-                                    "description": "The name of a city"
-                                }
+                                "location": {"type": "string", "description": "The name of a city"}
                             },
                             "type": "object",
-                            "required": [
-                                "location"
-                            ]
-                        }
+                            "required": ["location"],
+                        },
                     }
                 ],
                 "stream": True,

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -195,7 +195,11 @@ async def test_chat_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": " Hi", 'tool_calls': None,},
+                        "delta": {
+                            "role": None,
+                            "content": " Hi",
+                            "tool_calls": None,
+                        },
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -208,7 +212,11 @@ async def test_chat_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": " there", 'tool_calls': None,},
+                        "delta": {
+                            "role": None,
+                            "content": " there",
+                            "tool_calls": None,
+                        },
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -221,7 +229,11 @@ async def test_chat_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": None, 'tool_calls': None,},
+                        "delta": {
+                            "role": None,
+                            "content": None,
+                            "tool_calls": None,
+                        },
                         "finish_reason": "COMPLETE",
                         "index": 0,
                     }

--- a/tests/gateway/providers/test_cohere.py
+++ b/tests/gateway/providers/test_cohere.py
@@ -195,7 +195,7 @@ async def test_chat_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": " Hi"},
+                        "delta": {"role": None, "content": " Hi", 'tool_calls': None,},
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -208,7 +208,7 @@ async def test_chat_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": " there"},
+                        "delta": {"role": None, "content": " there", 'tool_calls': None,},
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -221,7 +221,7 @@ async def test_chat_stream():
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": None},
+                        "delta": {"role": None, "content": None, 'tool_calls': None,},
                         "finish_reason": "COMPLETE",
                         "index": 0,
                     }

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -435,7 +435,15 @@ async def test_gemini_chat_stream(resp):
             "created": 1,
             "model": "gemini-2.0-flash",
             "choices": [
-                {"index": 0, "finish_reason": None, "delta": {"role": "assistant", "content": "a", 'tool_calls': None,}}
+                {
+                    "index": 0,
+                    "finish_reason": None,
+                    "delta": {
+                        "role": "assistant",
+                        "content": "a",
+                        "tool_calls": None,
+                    },
+                }
             ],
         },
         {
@@ -447,7 +455,11 @@ async def test_gemini_chat_stream(resp):
                 {
                     "index": 0,
                     "finish_reason": "stop",
-                    "delta": {"role": "assistant", "content": "b", 'tool_calls': None,},
+                    "delta": {
+                        "role": "assistant",
+                        "content": "b",
+                        "tool_calls": None,
+                    },
                 }
             ],
         },

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -435,7 +435,7 @@ async def test_gemini_chat_stream(resp):
             "created": 1,
             "model": "gemini-2.0-flash",
             "choices": [
-                {"index": 0, "finish_reason": None, "delta": {"role": "assistant", "content": "a"}}
+                {"index": 0, "finish_reason": None, "delta": {"role": "assistant", "content": "a", 'tool_calls': None,}}
             ],
         },
         {
@@ -447,7 +447,7 @@ async def test_gemini_chat_stream(resp):
                 {
                     "index": 0,
                     "finish_reason": "stop",
-                    "delta": {"role": "assistant", "content": "b"},
+                    "delta": {"role": "assistant", "content": "b", 'tool_calls': None,},
                 }
             ],
         },

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -179,7 +179,7 @@ async def _run_test_chat_stream(resp, provider):
             {
                 "choices": [
                     {
-                        "delta": {"content": None, "role": "assistant"},
+                        "delta": {"content": None, "role": "assistant", 'tool_calls': None,},
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -191,7 +191,7 @@ async def _run_test_chat_stream(resp, provider):
             },
             {
                 "choices": [
-                    {"delta": {"content": "test", "role": None}, "finish_reason": None, "index": 0}
+                    {"delta": {"content": "test", "role": None, 'tool_calls': None,}, "finish_reason": None, "index": 0}
                 ],
                 "created": 1,
                 "id": "test-id",
@@ -200,7 +200,7 @@ async def _run_test_chat_stream(resp, provider):
             },
             {
                 "choices": [
-                    {"delta": {"content": None, "role": None}, "finish_reason": "stop", "index": 0}
+                    {"delta": {"content": None, "role": None, 'tool_calls': None,}, "finish_reason": "stop", "index": 0}
                 ],
                 "created": 1,
                 "id": "test-id",

--- a/tests/gateway/providers/test_openai.py
+++ b/tests/gateway/providers/test_openai.py
@@ -179,7 +179,11 @@ async def _run_test_chat_stream(resp, provider):
             {
                 "choices": [
                     {
-                        "delta": {"content": None, "role": "assistant", 'tool_calls': None,},
+                        "delta": {
+                            "content": None,
+                            "role": "assistant",
+                            "tool_calls": None,
+                        },
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -191,7 +195,15 @@ async def _run_test_chat_stream(resp, provider):
             },
             {
                 "choices": [
-                    {"delta": {"content": "test", "role": None, 'tool_calls': None,}, "finish_reason": None, "index": 0}
+                    {
+                        "delta": {
+                            "content": "test",
+                            "role": None,
+                            "tool_calls": None,
+                        },
+                        "finish_reason": None,
+                        "index": 0,
+                    }
                 ],
                 "created": 1,
                 "id": "test-id",
@@ -200,7 +212,15 @@ async def _run_test_chat_stream(resp, provider):
             },
             {
                 "choices": [
-                    {"delta": {"content": None, "role": None, 'tool_calls': None,}, "finish_reason": "stop", "index": 0}
+                    {
+                        "delta": {
+                            "content": None,
+                            "role": None,
+                            "tool_calls": None,
+                        },
+                        "finish_reason": "stop",
+                        "index": 0,
+                    }
                 ],
                 "created": 1,
                 "id": "test-id",

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -510,7 +510,7 @@ async def test_chat_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": "test"},
+                        "delta": {"role": None, "content": "test", 'tool_calls': None,},
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -522,7 +522,7 @@ async def test_chat_stream(resp):
             },
             {
                 "choices": [
-                    {"delta": {"role": None, "content": "test"}, "finish_reason": None, "index": 0}
+                    {"delta": {"role": None, "content": "test", 'tool_calls': None,}, "finish_reason": None, "index": 0}
                 ],
                 "created": 1,
                 "id": "test-id",
@@ -532,7 +532,7 @@ async def test_chat_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": "test"},
+                        "delta": {"role": None, "content": "test", 'tool_calls': None,},
                         "finish_reason": "length",
                         "index": 0,
                     }

--- a/tests/gateway/providers/test_togetherai.py
+++ b/tests/gateway/providers/test_togetherai.py
@@ -510,7 +510,11 @@ async def test_chat_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": "test", 'tool_calls': None,},
+                        "delta": {
+                            "role": None,
+                            "content": "test",
+                            "tool_calls": None,
+                        },
                         "finish_reason": None,
                         "index": 0,
                     }
@@ -522,7 +526,15 @@ async def test_chat_stream(resp):
             },
             {
                 "choices": [
-                    {"delta": {"role": None, "content": "test", 'tool_calls': None,}, "finish_reason": None, "index": 0}
+                    {
+                        "delta": {
+                            "role": None,
+                            "content": "test",
+                            "tool_calls": None,
+                        },
+                        "finish_reason": None,
+                        "index": 0,
+                    }
                 ],
                 "created": 1,
                 "id": "test-id",
@@ -532,7 +544,11 @@ async def test_chat_stream(resp):
             {
                 "choices": [
                     {
-                        "delta": {"role": None, "content": "test", 'tool_calls': None,},
+                        "delta": {
+                            "role": None,
+                            "content": "test",
+                            "tool_calls": None,
+                        },
                         "finish_reason": "length",
                         "index": 0,
                     }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/18294?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18294/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18294/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18294/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Make anthropic provider supporting function calling


#### **Manual test**

**Step 1**
prepare an ai-gateway configure file `gateway.yml` like:

```
endpoints:
  - name: claude-chat
    endpoint_type: llm/v1/chat
    model:
      provider: anthropic
      name: claude-sonnet-4-20250514
      config:
        anthropic_api_key: $ANTHROPIC_API_KEY
```
then launch the ai-gateway server:

```
export ANTHROPIC_API_KEY=<your key>
mlflow gateway start --config-path gateway.yml
```

**Step 2**  (non-stream response test)

Run python REPL, type the following code to test:
```
from openai import OpenAI

client = OpenAI(
    base_url="http://127.0.0.1:5000/v1",
    api_key="test",
)

tools = [{
    "type": "function",
    "function": {
        "name": "get_weather",
        "description": "Get current temperature for a given location.",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {
                    "type": "string",
                    "description": "City and country e.g. Bogotá, Colombia"
                }
            },
            "required": ["location"],
            "additionalProperties": False
        },
        "strict": True
    }
}]


messages = [{"role": "user", "content": "What's the weather like in Paris today?"}]

response = client.chat.completions.create(
    model="claude-chat",
    messages=messages,
    tools=tools,
)



tool_use_resp_msg = response.choices[0].message
messages.append(tool_use_resp_msg.dict())

# append function calling result
messages.append({
    "role": "tool",
    "tool_call_id": tool_use_resp_msg.tool_calls[0].id,
    "content": "{\"temperature\": 31.2, \"condition\": \"sunny\"}"
})

response = client.chat.completions.create(
    model="claude-chat",
    messages=messages,
    tools=tools,
)


# you'll get the final LLM generated result here
print("Result:\n" + str(response.choices[0].message.content))
```

**Step 3**  (stream response test)
Type the following code to python REPL:

```
from openai import OpenAI

client = OpenAI(
    base_url="http://127.0.0.1:5000/v1",
    api_key="test",
)

tools = [{
    "type": "function",
    "function": {
        "name": "get_weather",
        "description": "Get current temperature for a given location.",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {
                    "type": "string",
                    "description": "City and country e.g. Bogotá, Colombia"
                }
            },
            "required": ["location"],
        },
    }
}]


messages = [{"role": "user", "content": "What's the weather like in Paris today?"}]

response = client.chat.completions.create(
    model="claude-chat",
    messages=messages,
    tools=tools,
    stream=True,
)

# you'll get chunked response that splits the function calling input argument JSON string into chunks
for chunk in response:
    print(chunk)
    print("--------------")

```



### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Make anthropic provider supporting function calling

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
