### PR TITLE
Deprecate generate_signature_output in favor of input_example (#13327)

### DIFF
--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -25,6 +25,7 @@ import numpy as np
 import pandas as pd
 import yaml
 from packaging.version import Version
+import warnings
 
 from mlflow import pyfunc
 from mlflow.entities.model_registry.prompt import Prompt
@@ -1683,8 +1684,7 @@ def _try_import_conversational_pipeline():
 
         return ConversationalPipeline
     except ImportError:
-        return
-
+        return    
 
 def generate_signature_output(pipeline, data, model_config=None, params=None, flavor_config=None):
     """
@@ -1703,7 +1703,16 @@ def generate_signature_output(pipeline, data, model_config=None, params=None, fl
 
     Returns:
         The output from the ``pyfunc`` pipeline wrapper's ``predict`` method
-    """
+     """
+    warnings.warn(
+        "The function `mlflow.transformers.generate_signature_output` is deprecated "
+        "and will be removed in a future release. "
+        "Please use the `input_example` argument for model signature inference instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
+
+
     import transformers
 
     from mlflow.transformers import signature

--- a/mlflow/transformers/signature.py
+++ b/mlflow/transformers/signature.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import warnings
 
 import numpy as np
 
@@ -176,6 +177,14 @@ def format_input_example_for_special_cases(input_example, pipeline):
 def generate_signature_output(pipeline, data, model_config=None, flavor_config=None, params=None):
     # Lazy import to avoid circular dependencies. Ideally we should move _TransformersWrapper
     # out from __init__.py to avoid this.
+    import warnings
+    warnings.warn(
+        "The function `mlflow.transformers.generate_signature_output` is deprecated "
+        "and will be removed in a future release. "
+        "Please use the `input_example` argument for model signature inference instead.",
+        DeprecationWarning,
+        stacklevel=2
+    )
     from mlflow.transformers import _TransformersWrapper
 
     return _TransformersWrapper(


### PR DESCRIPTION
### Related Issues/PRs

Resolve #13327

---

### What changes are proposed in this pull request?

- Added `DeprecationWarning` in both `mlflow/transformers/__init__.py` and `mlflow/transformers/signature.py`
- Marked the `generate_signature_output` function as deprecated in favor of using the `input_example` argument
- Retained backward compatibility so existing user code does not immediately break
- Verified correct deprecation behavior using a Hugging Face text-classification pipeline

---

### How is this PR tested?

- [x] Manual test with a `distilbert-base-uncased` text-classification pipeline (using PyTorch backend)
- [x] Confirmed that `DeprecationWarning` appears exactly once and that the function output remains valid

---

### Does this PR require a documentation update?

- [x] No
- [ ] Yes — I would update examples, API references, or usage instructions accordingly

---

### Release Notes

#### Is this a user-facing change?

- [x] Yes — this adds a deprecation notice to users
- [ ] No

---

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/models`: model serialization, deserialization, and flavor APIs

---

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes?

- [x] `rn/bug-fix` — mention under Bug Fixes in Changelog
- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/documentation`

---

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No
