### PR TITLE
Update otel endpoint

### DIFF
--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -422,8 +422,6 @@ class DatabricksTracingRestStore(RestStore):
                 "`tracking_uri` must be provided to log spans to with Databricks tracking server."
             )
 
-        # TODO: check server version
-
         endpoint = f"/api/2.0/otel{OTLP_TRACES_PATH}"
         try:
             config = get_databricks_workspace_client_config(tracking_uri)

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -424,7 +424,7 @@ class DatabricksTracingRestStore(RestStore):
 
         # TODO: check server version
 
-        endpoint = f"/api/2.0/tracing/otel{OTLP_TRACES_PATH}"
+        endpoint = f"/api/2.0/otel{OTLP_TRACES_PATH}"
         try:
             config = get_databricks_workspace_client_config(tracking_uri)
         except Exception as e:

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -984,7 +984,7 @@ def test_log_spans_to_uc_table_success(mock_http_request, mock_get_config, diff_
     # Verify HTTP request details
     call_kwargs = mock_http_request.call_args
     assert call_kwargs[1]["method"] == "POST"
-    assert call_kwargs[1]["endpoint"] == "/api/2.0/tracing/otel/v1/traces"
+    assert call_kwargs[1]["endpoint"] == "/api/2.0/otel/v1/traces"
     assert "Content-Type" in call_kwargs[1]["extra_headers"]
     assert call_kwargs[1]["extra_headers"]["Content-Type"] == "application/x-protobuf"
     assert "X-Databricks-UC-Table-Name" in call_kwargs[1]["extra_headers"]
@@ -1213,7 +1213,7 @@ def test_verify_trace_response_success_empty_response():
     response.status_code = 200
     response.text = ""
 
-    result = store._verify_trace_response(response, "/api/2.0/tracing/otel/v1/traces")
+    result = store._verify_trace_response(response, "/api/2.0/otel/v1/traces")
 
     assert result.status_code == 200
     assert result._content == b"{}"
@@ -1232,4 +1232,4 @@ def test_verify_trace_response_error_with_protobuf():
     response.content = error_status.SerializeToString()
 
     with pytest.raises(RestException, match="Invalid request"):
-        store._verify_trace_response(response, "/api/2.0/tracing/otel/v1/traces")
+        store._verify_trace_response(response, "/api/2.0/otel/v1/traces")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18310?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18310/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18310/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18310/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The DBX backend endpoints for span ingestion is changed from `/api/2.0/tracing/otel/v1` to `/api/2.0/otel/v1`.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Tested span ingestion and fetch.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
