### PR TITLE
Add `unlink_traces_from_run` batch operation

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -141,6 +141,7 @@ mlflow.client.MlflowClient.start_span
 mlflow.client.MlflowClient.start_trace
 mlflow.client.MlflowClient.test_webhook
 mlflow.client.MlflowClient.transition_model_version_stage
+mlflow.client.MlflowClient.unlink_traces_from_run
 mlflow.client.MlflowClient.update_model_version
 mlflow.client.MlflowClient.update_registered_model
 mlflow.client.MlflowClient.update_run

--- a/mlflow/store/tracking/abstract_store.py
+++ b/mlflow/store/tracking/abstract_store.py
@@ -1233,6 +1233,21 @@ class AbstractStore:
             MlflowException: If more than 100 traces are provided.
         """
 
+    def unlink_traces_from_run(self, trace_ids: list[str], run_id: str) -> None:
+        """
+        Unlink multiple traces from a run by removing entity associations.
+
+        Args:
+            trace_ids: List of trace IDs to unlink from the run.
+            run_id: ID of the run to unlink traces from.
+
+        Raises:
+            MlflowException: If the operation is not supported or fails.
+        """
+        raise NotImplementedError(
+            f"Unlinking traces from runs is not implemented for {self.__class__.__name__}."
+        )
+
     def calculate_trace_filter_correlation(
         self,
         experiment_ids: list[str],

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -703,11 +703,11 @@ class DatabricksTracingRestStore(RestStore):
 
         traces_by_location = self._group_traces_by_location(trace_ids)
 
-        for location_id, trace_ids_for_location in traces_by_location.items():
+        for location_id, batch_trace_ids in traces_by_location.items():
             if location_id is None:
-                super().link_traces_to_run(trace_ids_for_location, run_id)
+                super().link_traces_to_run(batch_trace_ids, run_id)
             else:
-                self._batch_link_traces_to_run(location_id, trace_ids_for_location, run_id)
+                self._batch_link_traces_to_run(location_id, batch_trace_ids, run_id)
 
     def unlink_traces_from_run(self, trace_ids: list[str], run_id: str) -> None:
         """
@@ -722,15 +722,15 @@ class DatabricksTracingRestStore(RestStore):
 
         traces_by_location = self._group_traces_by_location(trace_ids)
 
-        for location_id, trace_ids_for_location in traces_by_location.items():
+        for location_id, batch_trace_ids in traces_by_location.items():
             if location_id is None:
                 raise MlflowException(
                     "Unlinking V3 traces from runs is not supported. Only V4 traces (with UC "
                     "schema locations) can be unlinked. Unsupported trace IDs: "
-                    f"{trace_ids_for_location}"
+                    f"{batch_trace_ids}"
                 )
             else:
-                self._batch_unlink_traces_from_run(location_id, trace_ids_for_location, run_id)
+                self._batch_unlink_traces_from_run(location_id, batch_trace_ids, run_id)
 
     def _append_sql_warehouse_id_param(self, endpoint: str) -> str:
         if sql_warehouse_id := MLFLOW_TRACING_SQL_WAREHOUSE_ID.get():

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -722,8 +722,7 @@ class DatabricksTracingRestStore(RestStore):
 
         traces_by_location = self._group_traces_by_location(trace_ids)
 
-        v3_trace_ids = traces_by_location.pop(None, [])
-        if v3_trace_ids:
+        if v3_trace_ids := traces_by_location.pop(None, []):
             raise MlflowException(
                 "Unlinking V3 traces from runs is not supported. Only V4 traces (with UC "
                 "schema locations) can be unlinked. Unsupported trace IDs: "

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -634,11 +634,8 @@ class DatabricksTracingRestStore(RestStore):
         traces_by_location: dict[str | None, list[str]] = defaultdict(list)
 
         for trace_id in trace_ids:
-            location_id, otel_trace_id = parse_trace_id_v4(trace_id)
-            if location_id is None:
-                traces_by_location[None].append(trace_id)
-            else:
-                traces_by_location[location_id].append(otel_trace_id)
+            location_id, trace_id = parse_trace_id_v4(trace_id)
+            traces_by_location[location_id].append(trace_id)
 
         return traces_by_location
 
@@ -724,9 +721,8 @@ class DatabricksTracingRestStore(RestStore):
 
         if v3_trace_ids := traces_by_location.pop(None, []):
             raise MlflowException(
-                "Unlinking V3 traces from runs is not supported. Only V4 traces (with UC "
-                "schema locations) can be unlinked. Unsupported trace IDs: "
-                f"{v3_trace_ids}"
+                "Unlinking traces from runs is only supported for traces with UC schema "
+                f"locations. Unsupported trace IDs: {v3_trace_ids}"
             )
 
         for location_id, batch_trace_ids in traces_by_location.items():

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -722,15 +722,16 @@ class DatabricksTracingRestStore(RestStore):
 
         traces_by_location = self._group_traces_by_location(trace_ids)
 
+        v3_trace_ids = traces_by_location.pop(None, [])
+        if v3_trace_ids:
+            raise MlflowException(
+                "Unlinking V3 traces from runs is not supported. Only V4 traces (with UC "
+                "schema locations) can be unlinked. Unsupported trace IDs: "
+                f"{v3_trace_ids}"
+            )
+
         for location_id, batch_trace_ids in traces_by_location.items():
-            if location_id is None:
-                raise MlflowException(
-                    "Unlinking V3 traces from runs is not supported. Only V4 traces (with UC "
-                    "schema locations) can be unlinked. Unsupported trace IDs: "
-                    f"{batch_trace_ids}"
-                )
-            else:
-                self._batch_unlink_traces_from_run(location_id, batch_trace_ids, run_id)
+            self._batch_unlink_traces_from_run(location_id, batch_trace_ids, run_id)
 
     def _append_sql_warehouse_id_param(self, endpoint: str) -> str:
         if sql_warehouse_id := MLFLOW_TRACING_SQL_WAREHOUSE_ID.get():

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -1098,3 +1098,22 @@ class TrackingServiceClient:
             )
 
         return self.store.link_traces_to_run(trace_ids, run_id)
+
+    def unlink_traces_from_run(self, trace_ids: list[str], run_id: str) -> None:
+        """
+        Unlink multiple traces from a run by removing entity associations.
+
+        Args:
+            trace_ids: List of trace IDs to unlink from the run.
+            run_id: ID of the run to unlink traces from.
+
+        Raises:
+            MlflowException: If run_id is empty.
+        """
+        if not trace_ids:
+            return
+
+        if not run_id:
+            raise MlflowException.invalid_parameter_value("run_id cannot be empty")
+
+        return self.store.unlink_traces_from_run(trace_ids, run_id)

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -59,6 +59,7 @@ from mlflow.tracking._tracking_service import utils
 from mlflow.tracking.context import registry as context_registry
 from mlflow.tracking.metric_value_conversion_utils import convert_metric_value_to_float_if_possible
 from mlflow.utils import chunk_list
+from mlflow.utils.annotations import experimental
 from mlflow.utils.async_logging.run_operations import RunOperations, get_combined_run_operations
 from mlflow.utils.databricks_utils import get_workspace_url, is_in_databricks_notebook
 from mlflow.utils.mlflow_tags import MLFLOW_RUN_IS_EVALUATION, MLFLOW_USER
@@ -1099,6 +1100,7 @@ class TrackingServiceClient:
 
         return self.store.link_traces_to_run(trace_ids, run_id)
 
+    @experimental(version="3.5.0")
     def unlink_traces_from_run(self, trace_ids: list[str], run_id: str) -> None:
         """
         Unlink multiple traces from a run by removing entity associations.

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -892,9 +892,12 @@ class MlflowClient:
 
                 client = MlflowClient()
 
-                # Unlink multiple traces from a run
+                # Unlink multiple V4 traces from a run
                 client.unlink_traces_from_run(
-                    trace_ids=["trace_123", "trace_456", "trace_789"],
+                    trace_ids=[
+                        "trace://catalog.schema/abc123",
+                        "trace://catalog.schema/def456",
+                    ],
                     run_id="run_abc",
                 )
         """

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -875,6 +875,30 @@ class MlflowClient:
         """
         return self._tracking_client.link_traces_to_run(trace_ids, run_id)
 
+    def unlink_traces_from_run(self, trace_ids: list[str], run_id: str) -> None:
+        """
+        Unlink multiple traces from a run by removing entity associations.
+
+        Args:
+            trace_ids: List of trace IDs to unlink from the run.
+            run_id: ID of the run to unlink traces from.
+
+        Example:
+            .. code-block:: python
+
+                import mlflow
+                from mlflow import MlflowClient
+
+                client = MlflowClient()
+
+                # Unlink multiple traces from a run
+                client.unlink_traces_from_run(
+                    trace_ids=["trace_123", "trace_456", "trace_789"],
+                    run_id="run_abc",
+                )
+        """
+        return self._tracking_client.unlink_traces_from_run(trace_ids, run_id)
+
     # TODO: Use model_id in MLflow 3.0
     @experimental(version="3.0.0")
     @require_prompt_registry

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -875,6 +875,7 @@ class MlflowClient:
         """
         return self._tracking_client.link_traces_to_run(trace_ids, run_id)
 
+    @experimental(version="3.5.0")
     def unlink_traces_from_run(self, trace_ids: list[str], run_id: str) -> None:
         """
         Unlink multiple traces from a run by removing entity associations.

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -1348,6 +1348,114 @@ def test_link_traces_to_run_with_empty_list_does_nothing():
         mock_http.assert_not_called()
 
 
+def test_unlink_traces_from_run_with_v4_trace_ids_uses_batch_v4_endpoint():
+    creds = MlflowHostCreds("https://hello")
+    store = DatabricksTracingRestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.text = json.dumps({})
+
+    location = "catalog.schema"
+    trace_ids = [
+        f"{TRACE_ID_V4_PREFIX}{location}/trace123",
+        f"{TRACE_ID_V4_PREFIX}{location}/trace456",
+    ]
+    run_id = "run_abc"
+
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        store.unlink_traces_from_run(trace_ids=trace_ids, run_id=run_id)
+
+        expected_json = {
+            "location_id": location,
+            "trace_ids": ["trace123", "trace456"],
+            "run_id": run_id,
+        }
+
+        mock_http.assert_called_once_with(
+            host_creds=creds,
+            endpoint=f"/api/4.0/mlflow/traces/{location}/unlink-from-run/batchDelete",
+            method="DELETE",
+            json=expected_json,
+        )
+
+
+def test_unlink_traces_from_run_with_v3_trace_ids_raises_error():
+    creds = MlflowHostCreds("https://hello")
+    store = DatabricksTracingRestStore(lambda: creds)
+
+    trace_ids = ["tr-123", "tr-456"]
+    run_id = "run_abc"
+
+    with pytest.raises(MlflowException, match="Unlinking V3 traces from runs is not supported"):
+        store.unlink_traces_from_run(trace_ids=trace_ids, run_id=run_id)
+
+
+def test_unlink_traces_from_run_with_mixed_v3_v4_trace_ids_raises_error():
+    creds = MlflowHostCreds("https://hello")
+    store = DatabricksTracingRestStore(lambda: creds)
+
+    location = "catalog.schema"
+    v3_trace_id = "tr-123"
+    v4_trace_id = f"{TRACE_ID_V4_PREFIX}{location}/trace456"
+    trace_ids = [v3_trace_id, v4_trace_id]
+    run_id = "run_abc"
+
+    # Should raise error because V3 traces are not supported for unlinking
+    with pytest.raises(MlflowException, match="Unlinking V3 traces from runs is not supported"):
+        store.unlink_traces_from_run(trace_ids=trace_ids, run_id=run_id)
+
+
+def test_unlink_traces_from_run_with_different_locations_groups_by_location():
+    creds = MlflowHostCreds("https://hello")
+    store = DatabricksTracingRestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+    response.text = json.dumps({})
+
+    location1 = "catalog1.schema1"
+    location2 = "catalog2.schema2"
+    trace_ids = [
+        f"{TRACE_ID_V4_PREFIX}{location1}/trace123",
+        f"{TRACE_ID_V4_PREFIX}{location2}/trace456",
+        f"{TRACE_ID_V4_PREFIX}{location1}/trace789",
+    ]
+    run_id = "run_abc"
+
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        store.unlink_traces_from_run(trace_ids=trace_ids, run_id=run_id)
+
+        # Should make 2 separate batch calls, one for each location
+        assert mock_http.call_count == 2
+
+        # Verify calls were made for both locations
+        calls = mock_http.call_args_list
+        call_endpoints = {call.kwargs["endpoint"] for call in calls}
+        expected_endpoints = {
+            f"/api/4.0/mlflow/traces/{location1}/unlink-from-run/batchDelete",
+            f"/api/4.0/mlflow/traces/{location2}/unlink-from-run/batchDelete",
+        }
+        assert call_endpoints == expected_endpoints
+
+        # Verify the trace IDs were grouped correctly
+        for call in calls:
+            endpoint = call.kwargs["endpoint"]
+            json_body = call.kwargs["json"]
+            if location1 in endpoint:
+                assert set(json_body["trace_ids"]) == {"trace123", "trace789"}
+            elif location2 in endpoint:
+                assert json_body["trace_ids"] == ["trace456"]
+            assert json_body["run_id"] == run_id
+
+
+def test_unlink_traces_from_run_with_empty_list_does_nothing():
+    creds = MlflowHostCreds("https://hello")
+    store = DatabricksTracingRestStore(lambda: creds)
+
+    with mock.patch("mlflow.utils.rest_utils.http_request") as mock_http:
+        store.unlink_traces_from_run(trace_ids=[], run_id="run_abc")
+        mock_http.assert_not_called()
+
+
 def test_verify_trace_response_success_empty_response():
     store = DatabricksTracingRestStore(lambda: MlflowHostCreds("http://localhost"))
     response = mock.MagicMock()

--- a/tests/store/tracking/test_databricks_rest_store.py
+++ b/tests/store/tracking/test_databricks_rest_store.py
@@ -1386,7 +1386,10 @@ def test_unlink_traces_from_run_with_v3_trace_ids_raises_error():
     trace_ids = ["tr-123", "tr-456"]
     run_id = "run_abc"
 
-    with pytest.raises(MlflowException, match="Unlinking V3 traces from runs is not supported"):
+    with pytest.raises(
+        MlflowException,
+        match="Unlinking traces from runs is only supported for traces with UC schema",
+    ):
         store.unlink_traces_from_run(trace_ids=trace_ids, run_id=run_id)
 
 
@@ -1401,7 +1404,10 @@ def test_unlink_traces_from_run_with_mixed_v3_v4_trace_ids_raises_error():
     run_id = "run_abc"
 
     # Should raise error because V3 traces are not supported for unlinking
-    with pytest.raises(MlflowException, match="Unlinking V3 traces from runs is not supported"):
+    with pytest.raises(
+        MlflowException,
+        match="Unlinking traces from runs is only supported for traces with UC schema",
+    ):
         store.unlink_traces_from_run(trace_ids=trace_ids, run_id=run_id)
 
 


### PR DESCRIPTION
### Related Issues/PRs

Follows up on #18295 which added `link_traces_to_run`.

### What changes are proposed in this pull request?

Adds `unlink_traces_from_run()` batch operation to `MlflowClient` and `DatabricksRestStore` for unlinking traces from runs (V4 traces only).

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added `unlink_traces_from_run()` method to `MlflowClient` for batch unlinking traces from runs.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)