### PR TITLE
Add `/resolve` command to automatically address PR review comments

### DIFF
--- a/.claude/commands/resolve.md
+++ b/.claude/commands/resolve.md
@@ -31,7 +31,7 @@ Automatically fetch and address PR review comments. This command examines review
 
 1. **Auto-detect PR context**:
 
-   - Use `gh pr view --json url,number -q '.url, .number'` to get PR info for the current branch
+   - Use `gh pr view --json url -q '.url'` to get PR info for the current branch
    - Parse to extract owner, repo, and PR number
    - If auto-detection fails, inform the user that no PR was found for the current branch
 

--- a/.claude/commands/resolve.md
+++ b/.claude/commands/resolve.md
@@ -1,0 +1,64 @@
+---
+allowed-tools: Skill, Read, Edit, Write, Glob, Grep, Bash
+argument-hint: [extra_context]
+description: Resolve PR review comments by fetching unresolved feedback and making necessary code changes
+---
+
+# Resolve PR Review Comments
+
+Automatically fetch and address PR review comments. This command examines review feedback and makes necessary code changes to resolve the issues.
+
+## Usage
+
+```
+/resolve [extra_context]
+```
+
+## Arguments
+
+- `extra_context` (optional): Additional instructions or filtering context (e.g., focus on specific files or issue types)
+
+## Examples
+
+```
+/resolve                                           # Address all unresolved PR comments
+/resolve Focus on type hint issues only            # Filter specific comment types
+/resolve Skip comments from automated bots         # Apply custom filtering
+/resolve Only resolve comments in mlflow/tracking/ # Focus on specific directories
+```
+
+## Instructions
+
+1. **Auto-detect PR context**:
+
+   - Use `gh pr view --json url,number -q '.url, .number'` to get PR info for the current branch
+   - Parse to extract owner, repo, and PR number
+   - If auto-detection fails, inform the user that no PR was found for the current branch
+
+2. **Fetch unresolved review comments**:
+
+   - Invoke the `fetch-unresolved-comments` skill to get only unresolved review threads
+
+3. **Apply additional filtering** from user instructions if provided (e.g., focus on specific files or issue types)
+
+4. For each unresolved review comment:
+
+   - Read the file and surrounding code for context
+   - Make minimal, precise changes to address the feedback
+   - Follow project style guides (Python: see `dev/guides/python.md`)
+
+5. After making all changes, commit them:
+
+   - Stage changes: `git add .`
+   - Create DCO-signed commit with this exact format:
+
+     ```bash
+     git commit -s -m "Address PR review comments
+
+     🤖 Generated with Claude Code
+
+     Co-Authored-By: Claude <noreply@anthropic.com>"
+     ```
+
+   - Handle any pre-commit hook failures (they may auto-fix formatting)
+   - **DO NOT PUSH** the changes; just commit them locally

--- a/.claude/commands/resolve.md
+++ b/.claude/commands/resolve.md
@@ -38,6 +38,7 @@ Automatically fetch and address PR review comments. This command examines review
 2. **Fetch unresolved review comments**:
 
    - Invoke the `fetch-unresolved-comments` skill to get only unresolved review threads
+   - If no unresolved comments are found, inform the user and exit
 
 3. **Apply additional filtering** from user instructions if provided (e.g., focus on specific files or issue types)
 

--- a/.claude/skills/fetch-unresolved-comments/SKILL.md
+++ b/.claude/skills/fetch-unresolved-comments/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: fetch-unresolved-comments
+description: Fetch unresolved PR review comments using GitHub GraphQL API, filtering out resolved and outdated feedback.
+---
+
+# Fetch Unresolved PR Review Comments
+
+Uses GitHub's GraphQL API to fetch only unresolved review thread comments from a pull request.
+
+## When to Use
+
+- You need to get only unresolved review comments from a PR
+- You want to filter out already-resolved and outdated feedback
+
+## Instructions
+
+1. **Parse PR information**:
+
+   - Extract owner, repo, and PR number from the provided PR URL or arguments
+   - Or use `gh pr view --json number -q .number` to get the current branch's PR number
+
+2. **Run the Python script**:
+
+   ```bash
+   GITHUB_TOKEN=$(gh auth token) \
+       uv run python .claude/skills/fetch-unresolved-comments/fetch_unresolved_comments.py <owner> <repo> <pr_number>
+   ```
+
+3. **Script options**:
+
+   - `--token <token>`: Provide token explicitly (default: GITHUB_TOKEN or GH_TOKEN env var)
+
+4. **Parse the JSON output**:
+   The script always outputs JSON with:
+   - `total`: Total number of unresolved comments across all threads
+   - `by_file`: Review threads grouped by file path (each thread contains multiple comments in a conversation)
+
+## Example JSON Output
+
+```json
+{
+  "total": 3,
+  "by_file": {
+    ".github/workflows/resolve.yml": [
+      {
+        "thread_id": "PRRT_kwDOAL...",
+        "isOutdated": false,
+        "line": 40,
+        "startLine": null,
+        "diffHunk": "@@ -0,0 +1,245 @@\n+name: resolve...",
+        "comments": [
+          {
+            "id": 2437935275,
+            "body": "We can remove this once we get the key.",
+            "author": "harupy",
+            "createdAt": "2025-10-17T00:53:20Z"
+          },
+          {
+            "id": 2437935276,
+            "body": "Good catch, I'll update it.",
+            "author": "contributor",
+            "createdAt": "2025-10-17T01:10:15Z"
+          }
+        ]
+      }
+    ],
+    ".gitignore": [
+      {
+        "thread_id": "PRRT_kwDOAL...",
+        "isOutdated": false,
+        "line": 133,
+        "startLine": null,
+        "diffHunk": "@@ -130,0 +133,2 @@\n+.claude/*",
+        "comments": [
+          {
+            "id": 2437935280,
+            "body": "Should we add this to .gitignore?",
+            "author": "reviewer",
+            "createdAt": "2025-10-17T01:15:42Z"
+          }
+        ]
+      }
+    ]
+  }
+}
+```

--- a/.claude/skills/fetch-unresolved-comments/fetch_unresolved_comments.py
+++ b/.claude/skills/fetch-unresolved-comments/fetch_unresolved_comments.py
@@ -9,10 +9,11 @@ import argparse
 import json
 import os
 import sys
+from typing import Any
 from urllib.request import Request, urlopen
 
 
-def fetch_unresolved_comments(owner: str, repo: str, pr_number: int, token: str) -> dict[str, str]:
+def fetch_unresolved_comments(owner: str, repo: str, pr_number: int, token: str) -> dict[str, Any]:
     """Fetch unresolved review threads from a PR using GraphQL."""
 
     query = """
@@ -69,7 +70,7 @@ def fetch_unresolved_comments(owner: str, repo: str, pr_number: int, token: str)
         sys.exit(1)
 
 
-def format_comments(data: dict[str, str]) -> dict[str, str]:
+def format_comments(data: dict[str, Any]) -> dict[str, Any]:
     """Format unresolved comments for easier consumption."""
 
     try:

--- a/.claude/skills/fetch-unresolved-comments/fetch_unresolved_comments.py
+++ b/.claude/skills/fetch-unresolved-comments/fetch_unresolved_comments.py
@@ -1,0 +1,168 @@
+"""Fetch unresolved PR review comments using GitHub GraphQL API.
+
+Example usage:
+    GITHUB_TOKEN=$(gh auth token) uv run --no-project .claude/skills/fetch-unresolved-comments/fetch_unresolved_comments.py mlflow mlflow 18327
+"""  # noqa: E501
+# ruff: noqa: T201
+
+import argparse
+import json
+import os
+import sys
+from urllib.request import Request, urlopen
+
+
+def fetch_unresolved_comments(owner: str, repo: str, pr_number: int, token: str) -> dict[str, str]:
+    """Fetch unresolved review threads from a PR using GraphQL."""
+
+    query = """
+    query($owner: String!, $repo: String!, $prNumber: Int!) {
+      repository(owner: $owner, name: $repo) {
+        pullRequest(number: $prNumber) {
+          reviewThreads(first: 100) {
+            nodes {
+              id
+              isResolved
+              isOutdated
+              comments(first: 100) {
+                nodes {
+                  id
+                  databaseId
+                  body
+                  path
+                  line
+                  startLine
+                  diffHunk
+                  author {
+                    login
+                  }
+                  createdAt
+                  updatedAt
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+
+    variables = {
+        "owner": owner,
+        "repo": repo,
+        "prNumber": pr_number,
+    }
+
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Content-Type": "application/json",
+    }
+
+    data = json.dumps({"query": query, "variables": variables}).encode("utf-8")
+    request = Request("https://api.github.com/graphql", data=data, headers=headers)
+
+    try:
+        with urlopen(request) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except Exception as e:
+        print(f"Error fetching data: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def format_comments(data: dict[str, str]) -> dict[str, str]:
+    """Format unresolved comments for easier consumption."""
+
+    try:
+        threads = data["data"]["repository"]["pullRequest"]["reviewThreads"]["nodes"]
+    except (KeyError, TypeError):
+        print("Error: Invalid response structure", file=sys.stderr)
+        print(json.dumps(data, indent=2), file=sys.stderr)
+        sys.exit(1)
+
+    by_file = {}
+    total_comments = 0
+
+    for thread in threads:
+        if not thread["isResolved"]:
+            comments = []
+            path = None
+            line = None
+            start_line = None
+            diff_hunk = None
+
+            for comment in thread["comments"]["nodes"]:
+                if path is None:
+                    path = comment["path"]
+                    line = comment["line"]
+                    start_line = comment.get("startLine")
+                    diff_hunk = comment.get("diffHunk")
+
+                comments.append(
+                    {
+                        "id": comment["databaseId"],
+                        "body": comment["body"],
+                        "author": comment["author"]["login"] if comment["author"] else "unknown",
+                        "createdAt": comment["createdAt"],
+                    }
+                )
+                total_comments += 1
+
+            if path:
+                if path not in by_file:
+                    by_file[path] = []
+
+                by_file[path].append(
+                    {
+                        "thread_id": thread["id"],
+                        "isOutdated": thread["isOutdated"],
+                        "line": line,
+                        "startLine": start_line,
+                        "diffHunk": diff_hunk,
+                        "comments": comments,
+                    }
+                )
+
+    return {
+        "total": total_comments,
+        "by_file": by_file,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Fetch unresolved PR review comments using GitHub GraphQL API"
+    )
+    parser.add_argument("owner", help="Repository owner")
+    parser.add_argument("repo", help="Repository name")
+    parser.add_argument("pr_number", type=int, help="Pull request number")
+    parser.add_argument(
+        "--token",
+        default=os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN"),
+        help="GitHub token (default: GITHUB_TOKEN or GH_TOKEN env var)",
+    )
+
+    args = parser.parse_args()
+
+    if not args.token:
+        print(
+            "Error: GitHub token required (use --token or set GITHUB_TOKEN/GH_TOKEN)",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    data = fetch_unresolved_comments(args.owner, args.repo, args.pr_number, args.token)
+    formatted = format_comments(data)
+    formatted["by_file"] = {
+        path: [thread for thread in threads if not thread["isOutdated"]]
+        for path, threads in formatted["by_file"].items()
+    }
+    formatted["by_file"] = {k: v for k, v in formatted["by_file"].items() if v}
+    formatted["total"] = sum(
+        len(thread["comments"]) for threads in formatted["by_file"].values() for thread in threads
+    )
+
+    print(json.dumps(formatted, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -137,16 +137,8 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ needs.verify.outputs.prompt }}
         run: |
-          PR_URL="https://github.com/${REPOSITORY}/pull/${PR_NUMBER}"
-
-          RESOLVE_CMD="/resolve $PR_URL"
-          if [ -n "$PROMPT" ]; then
-            RESOLVE_CMD="$RESOLVE_CMD $PROMPT"
-          fi
-
-          # Capture output to a file (with verbose logging to stderr)
           OUTPUT_FILE="/tmp/output.json"
-          timeout 10m claude --print --verbose --output-format json "$RESOLVE_CMD" > "$OUTPUT_FILE" || true
+          timeout 10m claude --print --verbose --output-format json "/resolve $PROMPT" > "$OUTPUT_FILE" || true
 
           # Display output in workflow logs (pretty print if valid JSON)
           echo "=== Claude Output ==="

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -133,12 +133,14 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPOSITORY: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
           PROMPT: ${{ needs.verify.outputs.prompt }}
         run: |
           OUTPUT_FILE="/tmp/output.json"
-          timeout 10m claude --print --verbose --output-format json "/resolve $PROMPT" > "$OUTPUT_FILE" || true
+
+          # Safe construction using arrays - PROMPT is passed as separate argument to prevent shell injection
+          ARGS=("/resolve")
+          [ -n "$PROMPT" ] && ARGS+=("$PROMPT")
+          timeout 10m claude --print --verbose --output-format json "${ARGS[@]}" > "$OUTPUT_FILE" || true
 
           # Display output in workflow logs (pretty print if valid JSON)
           echo "=== Claude Output ==="

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -22,7 +22,8 @@ jobs:
     timeout-minutes: 5
     if: >
       (github.event_name == 'pull_request' &&
-       github.event.pull_request.head.repo.full_name == github.repository)
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  verify:
+  precheck:
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -91,7 +91,7 @@ jobs:
           echo "prompt=$PROMPT" >> $GITHUB_OUTPUT
 
   resolve:
-    needs: verify
+    needs: precheck
     runs-on: ubuntu-latest
     permissions:
       issues: read
@@ -108,8 +108,8 @@ jobs:
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          repository: ${{ needs.verify.outputs.head_repository }}
-          ref: ${{ needs.verify.outputs.head_ref }}
+          repository: ${{ needs.precheck.outputs.head_repository }}
+          ref: ${{ needs.precheck.outputs.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Configure git
@@ -133,7 +133,7 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PROMPT: ${{ needs.verify.outputs.prompt }}
+          PROMPT: ${{ needs.precheck.outputs.prompt }}
         run: |
           OUTPUT_FILE="/tmp/output.json"
 
@@ -169,8 +169,8 @@ jobs:
             git push
           fi
 
-  notify:
-    needs: [verify, resolve]
+  report:
+    needs: [precheck, resolve]
     if: always()
     runs-on: ubuntu-latest
     permissions:
@@ -180,13 +180,12 @@ jobs:
       - name: Update original comment with result
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
-          COMMENT_ID: ${{ needs.verify.outputs.comment_id }}
+          COMMENT_ID: ${{ needs.precheck.outputs.comment_id }}
           RESOLVE_JOB_STATUS: ${{ needs.resolve.result }}
           CLAUDE_OUTPUT: ${{ needs.resolve.outputs.claude_output }}
         with:
           script: |
             const resolveJobStatus = process.env.RESOLVE_JOB_STATUS;
-
             const statusMessage = resolveJobStatus !== 'success'
               ? `⚠️ Workflow encountered an error.`
               : `✅ Workflow completed successfully.`;

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -177,7 +177,7 @@ jobs:
 
   notify:
     needs: [verify, resolve]
-    if: always() && github.event_name == 'issue_comment'
+    if: always()
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -191,9 +191,7 @@ jobs:
           CLAUDE_OUTPUT: ${{ needs.resolve.outputs.claude_output }}
         with:
           script: |
-            const commentId = parseInt(process.env.COMMENT_ID, 10);
             const resolveJobStatus = process.env.RESOLVE_JOB_STATUS;
-            const claudeOutput = process.env.CLAUDE_OUTPUT || '';
 
             const statusMessage = resolveJobStatus !== 'success'
               ? `⚠️ Workflow encountered an error.`
@@ -202,38 +200,35 @@ jobs:
             let resultMessage = statusMessage;
 
             // Extract and display Claude's result and raw output
+            const claudeOutput = process.env.CLAUDE_OUTPUT || '';
             if (claudeOutput) {
-              let detailsContent = '';
-              let prettyJson = claudeOutput;
-
               try {
-                const parsed = JSON.parse(claudeOutput);
-                if (parsed.result) {
-                  detailsContent += `${parsed.result}\n\n`;
+                const events = JSON.parse(claudeOutput);
+                const resultEvent = events.find(({ type }) => type === 'result');
+                if (resultEvent) {
+                  resultMessage += `\n\n<details>\n<summary>Claude Output</summary>\n\n${resultEvent.result}\n\n</details>`;
                 }
-                // Pretty print the JSON with 2-space indentation
-                prettyJson = JSON.stringify(parsed, null, 2);
               } catch (e) {
                 console.log('Failed to parse Claude output as JSON:', e);
               }
-
-              // Add raw JSON (pretty printed)
-              detailsContent += `**Raw Output:**\n\n\`\`\`json\n${prettyJson}\n\`\`\``;
-
-              resultMessage += `\n\n<details>\n<summary>Claude Output</summary>\n\n${detailsContent}\n\n</details>`;
             }
 
-            const { data: currentComment } = await github.rest.issues.getComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: commentId,
-            });
+            console.log('Result message to post:', resultMessage);
 
-            const updatedBody = `${currentComment.body}\n\n---\n${resultMessage}`;
+            if (process.env.COMMENT_ID) {
+              const commentId = parseInt(process.env.COMMENT_ID, 10);
+              const { data: currentComment } = await github.rest.issues.getComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+              });
 
-            await github.rest.issues.updateComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              comment_id: commentId,
-              body: updatedBody,
-            });
+              const updatedBody = `${currentComment.body}\n\n---\n${resultMessage}`;
+
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: commentId,
+                body: updatedBody,
+              });
+            }

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -27,6 +27,7 @@ jobs:
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.issue.author_association) &&
        contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        startsWith(github.event.comment.body, '/resolve'))
     outputs:

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -26,6 +26,7 @@ jobs:
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&
+       contains(fromJson('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association) &&
        startsWith(github.event.comment.body, '/resolve'))
     outputs:
       head_ref: ${{ steps.pr-info.outputs.head_ref }}

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -121,7 +121,7 @@ jobs:
 
       - name: Set up pre-commit
         run: |
-          uv run --only-group lint pre-commit install --install-hooks
+          uv run --only-group lint pre-commit install
           uv run --only-group lint pre-commit run install-bin -a -v
 
       - name: Install Claude CLI

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -21,7 +21,8 @@ jobs:
       pull-requests: read
     timeout-minutes: 5
     if: >
-      github.event_name == 'pull_request'
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository)
       ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request &&

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -1,0 +1,239 @@
+name: resolve
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request:
+    paths:
+      - .github/workflows/resolve.yml
+      - .claude/commands/resolve.md
+      - .claude/skills/fetch-unresolved-comments/**
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: read
+    timeout-minutes: 5
+    if: >
+      github.event_name == 'pull_request'
+      ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       startsWith(github.event.comment.body, '/resolve'))
+    outputs:
+      head_ref: ${{ steps.pr-info.outputs.head_ref }}
+      head_repository: ${{ steps.pr-info.outputs.head_repository }}
+      prompt: ${{ steps.prompt.outputs.prompt }}
+      comment_id: ${{ github.event.comment.id }}
+    steps:
+      - name: Check authorization
+        if: ${{ github.event_name == 'issue_comment' }}
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { comment } = context.payload;
+
+            // Check user association - only allow OWNER, MEMBER, or COLLABORATOR
+            const authorAssociation = comment.author_association;
+            const isAllowed = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(authorAssociation);
+
+            let message;
+            if (isAllowed) {
+              const workflowUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+              message = `🚀 [Resolve workflow started](${workflowUrl})`;
+            } else {
+              message = `⚠️ Only repository maintainers and collaborators are allowed to trigger this workflow. Your association: ${authorAssociation}`;
+            }
+
+            const updatedBody = `${comment.body}\n\n---\n${message}`;
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: comment.id,
+              body: updatedBody,
+            });
+
+            if (!isAllowed) {
+              throw new Error(`User not allowed to trigger workflow: ${comment.user.login} (association: ${authorAssociation})`);
+            }
+
+      - name: Get PR information
+        id: pr-info
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+        with:
+          script: |
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_repository', pr.head.repo.full_name);
+
+      - name: Extract optional prompt from comment
+        if: github.event_name == 'issue_comment'
+        id: prompt
+        env:
+          COMMENT_BODY: ${{ github.event.comment.body }}
+        run: |
+          PROMPT=$(echo "$COMMENT_BODY" | sed 's|^/resolve\s*||' | xargs)
+          echo "prompt=$PROMPT" >> $GITHUB_OUTPUT
+
+  resolve:
+    needs: verify
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+      pull-requests: read
+    timeout-minutes: 30
+    outputs:
+      claude_output: ${{ steps.claude-fix.outputs.output }}
+    steps:
+      - uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          repository: ${{ needs.verify.outputs.head_repository }}
+          ref: ${{ needs.verify.outputs.head_ref }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Configure git
+        run: |
+          git config user.name 'mlflow-app[bot]'
+          git config user.email 'mlflow-app[bot]@users.noreply.github.com'
+
+      - uses: ./.github/actions/setup-python
+
+      - name: Set up pre-commit
+        run: |
+          uv run --only-group lint pre-commit install --install-hooks
+          uv run --only-group lint pre-commit run install-bin -a -v
+
+      - name: Install Claude CLI
+        run: |
+          npm install -g @anthropic-ai/claude-code@2.0.24
+
+      - name: Run Claude resolve command
+        id: claude-fix
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          PROMPT: ${{ needs.verify.outputs.prompt }}
+        run: |
+          PR_URL="https://github.com/${REPOSITORY}/pull/${PR_NUMBER}"
+
+          RESOLVE_CMD="/resolve $PR_URL"
+          if [ -n "$PROMPT" ]; then
+            RESOLVE_CMD="$RESOLVE_CMD $PROMPT"
+          fi
+
+          # Capture output to a file (with verbose logging to stderr)
+          OUTPUT_FILE="/tmp/output.json"
+          timeout 10m claude --print --verbose --output-format json "$RESOLVE_CMD" > "$OUTPUT_FILE" || true
+
+          # Display output in workflow logs (pretty print if valid JSON)
+          echo "=== Claude Output ==="
+          if jq empty "$OUTPUT_FILE" 2>/dev/null; then
+            jq . "$OUTPUT_FILE"
+          else
+            cat "$OUTPUT_FILE"
+          fi
+          echo "===================="
+
+          # Save output for later use
+          OUTPUT=$(cat "$OUTPUT_FILE")
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Push changes
+        env:
+          IS_PULL_REQUEST: ${{ github.event_name == 'pull_request' }}
+        run: |
+          if [ "$IS_PULL_REQUEST" = "true" ]; then
+            echo "Running git push in dry-run mode (pull_request event)"
+            git push --dry-run
+          else
+            echo "Pushing changes to remote"
+            git push
+          fi
+
+  notify:
+    needs: [verify, resolve]
+    if: always() && github.event_name == 'issue_comment'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    timeout-minutes: 5
+    steps:
+      - name: Update original comment with result
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        env:
+          COMMENT_ID: ${{ needs.verify.outputs.comment_id }}
+          RESOLVE_JOB_STATUS: ${{ needs.resolve.result }}
+          CLAUDE_OUTPUT: ${{ needs.resolve.outputs.claude_output }}
+        with:
+          script: |
+            const commentId = parseInt(process.env.COMMENT_ID, 10);
+            const resolveJobStatus = process.env.RESOLVE_JOB_STATUS;
+            const claudeOutput = process.env.CLAUDE_OUTPUT || '';
+
+            const statusMessage = resolveJobStatus !== 'success'
+              ? `⚠️ Workflow encountered an error.`
+              : `✅ Workflow completed successfully.`;
+
+            let resultMessage = statusMessage;
+
+            // Extract and display Claude's result and raw output
+            if (claudeOutput) {
+              let detailsContent = '';
+              let prettyJson = claudeOutput;
+
+              try {
+                const parsed = JSON.parse(claudeOutput);
+                if (parsed.result) {
+                  detailsContent += `${parsed.result}\n\n`;
+                }
+                // Pretty print the JSON with 2-space indentation
+                prettyJson = JSON.stringify(parsed, null, 2);
+              } catch (e) {
+                console.log('Failed to parse Claude output as JSON:', e);
+              }
+
+              // Add raw JSON (pretty printed)
+              detailsContent += `**Raw Output:**\n\n\`\`\`json\n${prettyJson}\n\`\`\``;
+
+              resultMessage += `\n\n<details>\n<summary>Claude Output</summary>\n\n${detailsContent}\n\n</details>`;
+            }
+
+            const { data: currentComment } = await github.rest.issues.getComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: commentId,
+            });
+
+            const updatedBody = `${currentComment.body}\n\n---\n${resultMessage}`;
+
+            await github.rest.issues.updateComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: commentId,
+              body: updatedBody,
+            });

--- a/.gitignore
+++ b/.gitignore
@@ -129,5 +129,8 @@ a.md
 # Ignore a gunicorn config file
 gunicorn.conf.py
 
-# Ignore claude files (but not CLAUDE.md which we're tracking)
-.claude/
+# ignore everything in .claude
+.claude/*
+# except commands and skills
+!.claude/commands/
+!.claude/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,7 @@ gunicorn.conf.py
 # except commands and skills
 !.claude/commands/
 !.claude/skills/
+
+# Ignore act test files
+.github/workflows/test-*.json
+.github/workflows/test-*.env

--- a/.gitignore
+++ b/.gitignore
@@ -134,7 +134,3 @@ gunicorn.conf.py
 # except commands and skills
 !.claude/commands/
 !.claude/skills/
-
-# Ignore act test files
-.github/workflows/test-*.json
-.github/workflows/test-*.env


### PR DESCRIPTION
### What changes are proposed in this pull request?

Adds `/resolve` slash command to automatically address PR review comments using Claude Code in GitHub Actions.

**Key features:**
- Uses GitHub GraphQL API to fetch only unresolved review comments (REST API doesn't provide `isResolved` status)
- Filters out resolved and outdated comments automatically
- Prioritizes reviewer suggestion blocks
- Creates DCO-signed commits

**Implementation:**
- Agent Skill with Python script using GraphQL API
- No MCP dependencies (uses `gh` CLI directly)
- Verbose logging for debugging

**Files added:**
- `.claude/commands/resolve.md` - Slash command definition
- `.claude/skills/fetch-unresolved-comments/` - Agent Skill with Python script
- `.github/workflows/resolve.yml` - GitHub Actions workflow
- Updated `.gitignore` - Track `.claude/commands/` and `.claude/skills/`

**Usage:**
```bash
/resolve                              # Auto-detects PR from current branch
/resolve Focus on type hints only     # With filtering context
```

### How is this PR tested?

- [x] Manual tests on this PR (#18327: correctly returns 3 unresolved comments vs 9 total from REST API)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with Claude Code