### PR TITLE
Add expandable arrow UI for Expectations in trace view

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentItemHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentItemHeader.tsx
@@ -8,7 +8,7 @@ import { AssessmentSourceName } from './AssessmentSourceName';
 import { timeSinceStr } from './AssessmentsPane.utils';
 import type { Assessment } from '../ModelTrace.types';
 
-const getSourceIcon = (source: Assessment['source']) => {
+export const getSourceIcon = (source: Assessment['source']) => {
   switch (source.source_type) {
     case 'HUMAN':
       return UserIcon;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentItemHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentItemHeader.tsx
@@ -7,17 +7,7 @@ import { AssessmentDeleteModal } from './AssessmentDeleteModal';
 import { AssessmentSourceName } from './AssessmentSourceName';
 import { timeSinceStr } from './AssessmentsPane.utils';
 import type { Assessment } from '../ModelTrace.types';
-
-export const getSourceIcon = (source: Assessment['source']) => {
-  switch (source.source_type) {
-    case 'HUMAN':
-      return UserIcon;
-    case 'LLM_JUDGE':
-      return SparkleIcon;
-    default:
-      return CodeIcon;
-  }
-};
+import { getSourceIcon } from './utils';
 
 export const AssessmentItemHeader = ({
   // connector is not displayed in history items

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
@@ -21,13 +21,13 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
   // the summary view displays all assessments regardless of span, so
   // we need some way to indicate which span an assessment is associated with.
   const showAssociatedSpan = activeView === 'summary' && associatedSpan;
-  
+
   const parsedValue = getParsedExpectationValue(expectation.expectation);
 
-  const sourceDisplay = expectation.source 
-    ? (typeof expectation.source === 'string' 
-        ? expectation.source 
-        : `${expectation.source.source_type || 'Unknown'} (${expectation.source.source_id || 'N/A'})`)
+  const sourceDisplay = expectation.source
+    ? typeof expectation.source === 'string'
+      ? expectation.source
+      : `${expectation.source.source_type || 'Unknown'} (${expectation.source.source_id || 'N/A'})`
     : null;
 
   return (
@@ -71,18 +71,14 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
             gap: theme.spacing.xs,
           }}
         >
-          <div 
+          <div
             css={{ paddingTop: 2, flexShrink: 0, cursor: 'pointer' }}
             onClick={(e) => {
               e.stopPropagation();
               setIsExpanded(!isExpanded);
             }}
           >
-            {isExpanded ? (
-              <ChevronDownIcon css={{ fontSize: 16 }} />
-            ) : (
-              <ChevronRightIcon css={{ fontSize: 16 }} />
-            )}
+            {isExpanded ? <ChevronDownIcon css={{ fontSize: 16 }} /> : <ChevronRightIcon css={{ fontSize: 16 }} />}
           </div>
           <div css={{ flex: 1, minWidth: 0 }}>
             {isExpanded ? (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
@@ -1,4 +1,4 @@
-import { createElement, useState } from 'react';
+import { useState } from 'react';
 import { Typography, useDesignSystemTheme, ChevronRightIcon, ChevronDownIcon } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { AssessmentActionsOverflowMenu } from './AssessmentActionsOverflowMenu';
@@ -9,7 +9,7 @@ import { ExpectationValuePreview } from './ExpectationValuePreview';
 import { SpanNameDetailViewLink } from './SpanNameDetailViewLink';
 import type { ExpectationAssessment } from '../ModelTrace.types';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
-import { getSourceIcon } from './AssessmentItemHeader';
+import { getSourceIcon } from './utils';
 
 export const ExpectationItem = ({ expectation }: { expectation: ExpectationAssessment }) => {
   const { theme } = useDesignSystemTheme();
@@ -24,6 +24,7 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
   const showAssociatedSpan = activeView === 'summary' && associatedSpan;
 
   const parsedValue = getParsedExpectationValue(expectation.expectation);
+  const SourceIcon = getSourceIcon(expectation.source);
 
   return (
     <div
@@ -60,14 +61,12 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
         />
       ) : (
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-          {expectation.source && (
-            <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-              {createElement(getSourceIcon(expectation.source))}
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+            <SourceIcon/> 
               <Typography.Text size="sm" color="secondary">
                 {expectation.source.source_id}
               </Typography.Text>
             </div>
-          )}
           <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.xs }}>
             <div
               css={{ paddingTop: 2, flexShrink: 0, cursor: 'pointer' }}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { createElement, useState } from 'react';
 import { Typography, useDesignSystemTheme, ChevronRightIcon, ChevronDownIcon } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { AssessmentActionsOverflowMenu } from './AssessmentActionsOverflowMenu';
@@ -9,6 +9,7 @@ import { ExpectationValuePreview } from './ExpectationValuePreview';
 import { SpanNameDetailViewLink } from './SpanNameDetailViewLink';
 import type { ExpectationAssessment } from '../ModelTrace.types';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
+import { getSourceIcon } from './AssessmentItemHeader';
 
 export const ExpectationItem = ({ expectation }: { expectation: ExpectationAssessment }) => {
   const { theme } = useDesignSystemTheme();
@@ -23,12 +24,6 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
   const showAssociatedSpan = activeView === 'summary' && associatedSpan;
 
   const parsedValue = getParsedExpectationValue(expectation.expectation);
-
-  const sourceDisplay = expectation.source
-    ? typeof expectation.source === 'string'
-      ? expectation.source
-      : `${expectation.source.source_type || 'Unknown'} (${expectation.source.source_id || 'N/A'})`
-    : null;
 
   return (
     <div
@@ -64,38 +59,48 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
           onCancel={() => setIsEditing(false)}
         />
       ) : (
-        <div
-          css={{
-            display: 'flex',
-            alignItems: 'flex-start',
-            gap: theme.spacing.xs,
-          }}
-        >
-          <div
-            css={{ paddingTop: 2, flexShrink: 0, cursor: 'pointer' }}
-            onClick={(e) => {
-              e.stopPropagation();
-              setIsExpanded(!isExpanded);
-            }}
-          >
-            {isExpanded ? <ChevronDownIcon css={{ fontSize: 16 }} /> : <ChevronRightIcon css={{ fontSize: 16 }} />}
-          </div>
-          <div css={{ flex: 1, minWidth: 0 }}>
-            {isExpanded ? (
-              <div>
-                <Typography.Text css={{ display: 'block', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-                  {typeof parsedValue === 'string' ? parsedValue : JSON.stringify(parsedValue, null, 2)}
-                </Typography.Text>
-                {/* FIX: Use sourceDisplay instead of expectation.source directly */}
-                {sourceDisplay && (
-                  <Typography.Text color="secondary" size="sm" css={{ display: 'block', marginTop: theme.spacing.sm }}>
-                    Source: {sourceDisplay}
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          {expectation.source && (
+            <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+              {createElement(getSourceIcon(expectation.source))}
+              <Typography.Text size="sm" color="secondary">
+                {expectation.source.source_id}
+              </Typography.Text>
+            </div>
+          )}
+          <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.xs }}>
+            <div
+              css={{ paddingTop: 2, flexShrink: 0, cursor: 'pointer' }}
+              onClick={(e) => {
+                e.stopPropagation();
+                setIsExpanded(!isExpanded);
+              }}
+            >
+              {isExpanded ? (
+                <ChevronDownIcon css={{ fontSize: 16 }} />
+              ) : (
+                <ChevronRightIcon css={{ fontSize: 16 }} />
+              )}
+            </div>
+            <div css={{ flex: 1, minWidth: 0 }}>
+              {isExpanded ? (
+                <div
+                  css={{
+                    backgroundColor: theme.colors.backgroundSecondary,
+                    padding: theme.spacing.sm,
+                    borderRadius: theme.borders.borderRadiusMd,
+                    whiteSpace: 'pre-wrap',
+                    wordBreak: 'break-word',
+                  }}
+                >
+                  <Typography.Text>
+                    {typeof parsedValue === 'string' ? parsedValue : JSON.stringify(parsedValue, null, 2)}
                   </Typography.Text>
-                )}
-              </div>
-            ) : (
-              <ExpectationValuePreview parsedValue={parsedValue} />
-            )}
+                </div>
+              ) : (
+                <ExpectationValuePreview parsedValue={parsedValue} singleLine />
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
@@ -1,8 +1,6 @@
 import { useState } from 'react';
-
-import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Typography, useDesignSystemTheme, ChevronRightIcon, ChevronDownIcon } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
-
 import { AssessmentActionsOverflowMenu } from './AssessmentActionsOverflowMenu';
 import { AssessmentDeleteModal } from './AssessmentDeleteModal';
 import { AssessmentEditForm } from './AssessmentEditForm';
@@ -16,14 +14,21 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
   const { theme } = useDesignSystemTheme();
   const [isEditing, setIsEditing] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [isExpanded, setIsExpanded] = useState(false);
   const { nodeMap, activeView } = useModelTraceExplorerViewState();
 
   const associatedSpan = expectation.span_id ? nodeMap[expectation.span_id] : null;
   // the summary view displays all assessments regardless of span, so
   // we need some way to indicate which span an assessment is associated with.
   const showAssociatedSpan = activeView === 'summary' && associatedSpan;
-
+  
   const parsedValue = getParsedExpectationValue(expectation.expectation);
+
+  const sourceDisplay = expectation.source 
+    ? (typeof expectation.source === 'string' 
+        ? expectation.source 
+        : `${expectation.source.source_type || 'Unknown'} (${expectation.source.source_id || 'N/A'})`)
+    : null;
 
   return (
     <div
@@ -59,7 +64,44 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
           onCancel={() => setIsEditing(false)}
         />
       ) : (
-        <ExpectationValuePreview parsedValue={parsedValue} />
+        <div
+          css={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            gap: theme.spacing.xs,
+          }}
+        >
+          <div 
+            css={{ paddingTop: 2, flexShrink: 0, cursor: 'pointer' }}
+            onClick={(e) => {
+              e.stopPropagation();
+              setIsExpanded(!isExpanded);
+            }}
+          >
+            {isExpanded ? (
+              <ChevronDownIcon css={{ fontSize: 16 }} />
+            ) : (
+              <ChevronRightIcon css={{ fontSize: 16 }} />
+            )}
+          </div>
+          <div css={{ flex: 1, minWidth: 0 }}>
+            {isExpanded ? (
+              <div>
+                <Typography.Text css={{ display: 'block', whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
+                  {typeof parsedValue === 'string' ? parsedValue : JSON.stringify(parsedValue, null, 2)}
+                </Typography.Text>
+                {/* FIX: Use sourceDisplay instead of expectation.source directly */}
+                {sourceDisplay && (
+                  <Typography.Text color="secondary" size="sm" css={{ display: 'block', marginTop: theme.spacing.sm }}>
+                    Source: {sourceDisplay}
+                  </Typography.Text>
+                )}
+              </div>
+            ) : (
+              <ExpectationValuePreview parsedValue={parsedValue} />
+            )}
+          </div>
+        </div>
       )}
       {showAssociatedSpan && (
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/ExpectationItem.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { Typography, useDesignSystemTheme, ChevronRightIcon, ChevronDownIcon } from '@databricks/design-system';
+import { Typography, useDesignSystemTheme, ChevronRightIcon, ChevronDownIcon, Button } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { AssessmentActionsOverflowMenu } from './AssessmentActionsOverflowMenu';
 import { AssessmentDeleteModal } from './AssessmentDeleteModal';
@@ -10,6 +10,7 @@ import { SpanNameDetailViewLink } from './SpanNameDetailViewLink';
 import type { ExpectationAssessment } from '../ModelTrace.types';
 import { useModelTraceExplorerViewState } from '../ModelTraceExplorerViewStateContext';
 import { getSourceIcon } from './utils';
+import { AssessmentSourceName } from './AssessmentSourceName';
 
 export const ExpectationItem = ({ expectation }: { expectation: ExpectationAssessment }) => {
   const { theme } = useDesignSystemTheme();
@@ -60,33 +61,31 @@ export const ExpectationItem = ({ expectation }: { expectation: ExpectationAsses
           onCancel={() => setIsEditing(false)}
         />
       ) : (
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
-          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
-            <SourceIcon/> 
-              <Typography.Text size="sm" color="secondary">
-                {expectation.source.source_id}
-              </Typography.Text>
-            </div>
-          <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.xs }}>
-            <div
-              css={{ paddingTop: 2, flexShrink: 0, cursor: 'pointer' }}
-              onClick={(e) => {
-                e.stopPropagation();
-                setIsExpanded(!isExpanded);
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+          <div css={{ display: 'flex', alignItems: 'center' }}>
+            <SourceIcon
+              size={theme.typography.fontSizeSm}
+              css={{
+                padding: 2,
+                backgroundColor: theme.colors.actionIconBackgroundHover,
+                borderRadius: theme.borders.borderRadiusFull,
               }}
-            >
-              {isExpanded ? (
-                <ChevronDownIcon css={{ fontSize: 16 }} />
-              ) : (
-                <ChevronRightIcon css={{ fontSize: 16 }} />
-              )}
-            </div>
+            />
+            <AssessmentSourceName source={expectation.source} />
+          </div>
+          <div css={{ display: 'flex', alignItems: isExpanded ? 'flex-start' : 'center', gap: theme.spacing.xs }}>
+            <Button
+              componentId="shared.model-trace-explorer.toggle-expectation-expanded"
+              size="small"
+              icon={isExpanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
+              onClick={() => setIsExpanded(!isExpanded)}
+            />
             <div css={{ flex: 1, minWidth: 0 }}>
               {isExpanded ? (
                 <div
                   css={{
                     backgroundColor: theme.colors.backgroundSecondary,
-                    padding: theme.spacing.sm,
+                    padding: `${theme.spacing.xs}px ${theme.spacing.sm}px`,
                     borderRadius: theme.borders.borderRadiusMd,
                     whiteSpace: 'pre-wrap',
                     wordBreak: 'break-word',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/utils.tsx
@@ -1,4 +1,5 @@
 import type { Assessment } from '../ModelTrace.types';
+import { useDesignSystemTheme, Typography, SparkleIcon, UserIcon, CodeIcon } from '@databricks/design-system';
 
 export const getAssessmentValue = (assessment: Assessment) => {
   if ('feedback' in assessment) {
@@ -10,4 +11,15 @@ export const getAssessmentValue = (assessment: Assessment) => {
   }
 
   return assessment.expectation.serialized_value.value;
+};
+
+export const getSourceIcon = (source: Assessment['source']) => {
+  switch (source.source_type) {
+    case 'HUMAN':
+      return UserIcon;
+    case 'LLM_JUDGE':
+      return SparkleIcon;
+    default:
+      return CodeIcon;
+  }
 };


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/NJAHNAVI2907/mlflow/pull/18334?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18334/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18334/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18334/merge
```

</p>
</details>

- Add ChevronRight/ChevronDown icons to ExpectationItem component and Display full expectation text when expanded with proper text wrapping

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
 Resolve #18321
 Resolve #18323

### What changes are proposed in this pull request?

This PR adds expandable arrow UI functionality to Expectations in the MLflow trace detail view, matching the existing behavior of Feedbacks/Assessments. And this PR adds expandable arrow UI that provides

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests


https://github.com/user-attachments/assets/d746d736-d929-4120-8b10-7faf35a7a688

<img width="1617" height="922" alt="image" src="https://github.com/user-attachments/assets/66c391d8-e592-47da-bd6a-b43288e88b90" />

<img width="1627" height="1000" alt="image" src="https://github.com/user-attachments/assets/c5a00abb-e5ed-4ea0-aca4-de99c1a7812b" />



<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
