### PR TITLE
Fetch config after adding first record

### DIFF
--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -47,7 +47,6 @@ class TelemetryClient:
         self._consumer_threads = []
         self._is_config_fetched = False
         self.config = None
-        self._fetch_config()
 
     def __enter__(self):
         return self
@@ -241,6 +240,10 @@ class TelemetryClient:
                 return
 
             self._set_up_threads()
+
+            # only fetch config when activating to avoid fetching when
+            # no records are added
+            self._fetch_config()
 
             # Callback to ensure remaining tasks are processed before program exit
             if not self._atexit_callback_registered:

--- a/tests/telemetry/conftest.py
+++ b/tests/telemetry/conftest.py
@@ -76,12 +76,11 @@ def mock_requests_get(request):
 
 @pytest.fixture
 def mock_telemetry_client(mock_requests_get, mock_requests):
-    client = TelemetryClient()
-    # ensure config is fetched before the test
-    client._config_thread.join(timeout=1)
-    yield client
-    # TODO: add a context manager to always clean up the threads for tests
-    client._clean_up()
+    with TelemetryClient() as client:
+        client.activate()
+        # ensure config is fetched before the test
+        client._config_thread.join(timeout=1)
+        yield client
 
 
 @pytest.fixture(autouse=True)

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -28,7 +28,6 @@ if not IS_TRACING_SDK_ONLY:
 
 
 def test_telemetry_client_initialization(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test that TelemetryClient initializes correctly."""
     assert mock_telemetry_client.info is not None
     assert mock_telemetry_client._queue.maxsize == MAX_QUEUE_SIZE
     assert mock_telemetry_client._max_workers == MAX_WORKERS
@@ -48,7 +47,6 @@ def test_telemetry_client_session_id(
 
 
 def test_add_record_and_send(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test adding a record and sending it to the mock server."""
     # Create a test record
     record = Record(
         event_name="test_event",
@@ -70,7 +68,6 @@ def test_add_record_and_send(mock_telemetry_client: TelemetryClient, mock_reques
 
 
 def test_batch_processing(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test that multiple records are batched correctly."""
     mock_telemetry_client._batch_size = 3  # Set small batch size for testing
 
     # Add multiple records
@@ -88,7 +85,6 @@ def test_batch_processing(mock_telemetry_client: TelemetryClient, mock_requests)
 
 
 def test_flush_functionality(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test that flush properly sends pending records."""
     record = Record(
         event_name="test_event",
         timestamp_ns=time.time_ns(),
@@ -253,7 +249,6 @@ def test_telemetry_retry_on_request_error(error_type, terminate):
 
 
 def test_stop_event(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test that records are not added when telemetry client is stopped."""
     mock_telemetry_client._is_stopped = True
 
     record = Record(
@@ -272,8 +267,6 @@ def test_stop_event(mock_telemetry_client: TelemetryClient, mock_requests):
 
 
 def test_concurrent_record_addition(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test adding records from multiple threads."""
-
     def add_records(thread_id):
         for i in range(5):
             record = Record(
@@ -308,7 +301,6 @@ def test_concurrent_record_addition(mock_telemetry_client: TelemetryClient, mock
 
 
 def test_telemetry_info_inclusion(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test that telemetry info is included in records."""
     record = Record(
         event_name="test_event",
         timestamp_ns=time.time_ns(),
@@ -330,7 +322,6 @@ def test_telemetry_info_inclusion(mock_telemetry_client: TelemetryClient, mock_r
 
 
 def test_partition_key(mock_telemetry_client: TelemetryClient, mock_requests):
-    """Test that partition key is set correctly."""
     record = Record(
         event_name="test_event",
         timestamp_ns=time.time_ns(),
@@ -360,7 +351,6 @@ def test_max_workers_setup(monkeypatch):
 
 
 def test_log_suppression_in_consumer_thread(mock_requests, capsys, mock_telemetry_client):
-    """Test that logs are suppressed in the consumer thread but not in main thread."""
     # Clear any existing captured output
     capsys.readouterr()
 
@@ -395,7 +385,6 @@ def test_log_suppression_in_consumer_thread(mock_requests, capsys, mock_telemetr
 
 
 def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_client):
-    """Test that consumer thread produces no stderr output at all."""
     # Clear any existing captured output
     capsys.readouterr()
 
@@ -433,7 +422,6 @@ def test_consumer_thread_no_stderr_output(mock_requests, capsys, mock_telemetry_
 
 
 def test_batch_time_interval(mock_requests, monkeypatch):
-    """Test that batching respects time interval configuration."""
     monkeypatch.setattr("mlflow.telemetry.client.BATCH_TIME_INTERVAL_SECONDS", 1)
     telemetry_client = TelemetryClient()
 
@@ -724,6 +712,7 @@ def test_client_set_to_none_if_config_none():
         )
         with TelemetryClient() as telemetry_client:
             assert telemetry_client is not None
+            telemetry_client.activate()
             telemetry_client._config_thread.join(timeout=3)
             assert not telemetry_client._config_thread.is_alive()
             assert telemetry_client.config is None
@@ -752,6 +741,7 @@ def test_records_not_dropped_when_fetching_config(mock_requests):
             ),
         )
         with TelemetryClient() as telemetry_client:
+            telemetry_client.activate()
             # wait for config to be fetched
             telemetry_client._config_thread.join(timeout=3)
             telemetry_client.add_record(record)
@@ -835,6 +825,8 @@ def test_disable_events(mock_requests):
                 "mlflow.telemetry.track.get_telemetry_client", return_value=telemetry_client
             ),
         ):
+            telemetry_client.activate()
+            telemetry_client._config_thread.join(timeout=1)
             mlflow.initialize_logged_model(name="model", tags={"key": "value"})
             telemetry_client.flush()
             assert len(mock_requests) == 0
@@ -843,4 +835,34 @@ def test_disable_events(mock_requests):
                 pass
             validate_telemetry_record(
                 telemetry_client, mock_requests, CreateRunEvent.name, check_params=False
+            )
+
+
+def test_fetch_config_after_first_record(mock_requests):
+    record = Record(
+        event_name="test_event",
+        timestamp_ns=time.time_ns(),
+        status=Status.SUCCESS,
+        duration_ms=0,
+    )
+
+    with mock.patch("mlflow.telemetry.client.requests.get") as mock_requests_get:
+        mock_requests_get.return_value = mock.Mock(
+            status_code=200,
+            json=mock.Mock(
+                return_value={
+                    "mlflow_version": VERSION,
+                    "disable_telemetry": False,
+                    "ingestion_url": "http://localhost:9999",
+                    "rollout_percentage": 70,
+                }
+            ),
+        )
+        with TelemetryClient() as telemetry_client:
+            telemetry_client.add_record(record)
+            telemetry_client._config_thread.join(timeout=1)
+            assert telemetry_client._is_config_fetched is True
+            telemetry_client.flush()
+            validate_telemetry_record(
+                telemetry_client, mock_requests, record.event_name, check_params=False
             )

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -838,7 +838,8 @@ def test_disable_events(mock_requests):
             )
 
 
-def test_fetch_config_after_first_record(mock_requests):
+@pytest.mark.no_mock_requests_get
+def test_fetch_config_after_first_record():
     record = Record(
         event_name="test_event",
         timestamp_ns=time.time_ns(),
@@ -859,10 +860,7 @@ def test_fetch_config_after_first_record(mock_requests):
             ),
         )
         with TelemetryClient() as telemetry_client:
+            assert telemetry_client._is_config_fetched is False
             telemetry_client.add_record(record)
             telemetry_client._config_thread.join(timeout=1)
             assert telemetry_client._is_config_fetched is True
-            telemetry_client.flush()
-            validate_telemetry_record(
-                telemetry_client, mock_requests, record.event_name, check_params=False
-            )

--- a/tests/telemetry/test_track.py
+++ b/tests/telemetry/test_track.py
@@ -145,6 +145,7 @@ def test_is_telemetry_disabled_for_event():
     with mock.patch("mlflow.telemetry.client.requests.get", side_effect=mock_requests_get):
         client = TelemetryClient()
         assert client is not None
+        client.activate()
         assert client.config is None
         with mock.patch("mlflow.telemetry.track.get_telemetry_client", return_value=client):
             # do not skip when config is not fetched yet
@@ -168,6 +169,7 @@ def test_is_telemetry_disabled_for_event():
     with mock.patch("mlflow.telemetry.client.requests.get", side_effect=mock_requests_get):
         client = TelemetryClient()
         assert client is not None
+        client.activate()
         assert client.config is None
         with (
             mock.patch("mlflow.telemetry.track.get_telemetry_client", return_value=client),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/18338?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18338/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18338/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18338/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Update telemetry client to only fetch config after first record is added, this avoids huge amount of requests from 'import mlflow only' sessions hitting the config url

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
