### PR TITLE
Implement lazy logger initialization in `claude_code.tracing`

### DIFF
--- a/mlflow/claude_code/tracing.py
+++ b/mlflow/claude_code/tracing.py
@@ -80,11 +80,15 @@ def setup_logging() -> logging.Logger:
     return logger
 
 
-_MODULE_LOGGER = setup_logging()
+_MODULE_LOGGER: logging.Logger | None = None
 
 
 def get_logger() -> logging.Logger:
     """Get the configured module logger."""
+    global _MODULE_LOGGER
+
+    if _MODULE_LOGGER is None:
+        _MODULE_LOGGER = setup_logging()
     return _MODULE_LOGGER
 
 

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -70,6 +70,8 @@ def test_setup_logging_creates_logger(monkeypatch, tmp_path):
 
 
 def test_custom_logging_level():
+    setup_logging()
+
     assert CLAUDE_TRACING_LEVEL > logging.INFO
     assert CLAUDE_TRACING_LEVEL < logging.WARNING
     assert logging.getLevelName(CLAUDE_TRACING_LEVEL) == "CLAUDE_TRACING"

--- a/tests/claude_code/test_tracing.py
+++ b/tests/claude_code/test_tracing.py
@@ -1,9 +1,12 @@
+import importlib
 import json
 import logging
+from pathlib import Path
 
 import pytest
 
 import mlflow
+import mlflow.claude_code.tracing as tracing_module
 from mlflow.claude_code.tracing import (
     CLAUDE_TRACING_LEVEL,
     get_hook_response,
@@ -70,6 +73,33 @@ def test_custom_logging_level():
     assert CLAUDE_TRACING_LEVEL > logging.INFO
     assert CLAUDE_TRACING_LEVEL < logging.WARNING
     assert logging.getLevelName(CLAUDE_TRACING_LEVEL) == "CLAUDE_TRACING"
+
+
+def test_get_logger_lazy_initialization(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    # Force reload to reset the module state
+    importlib.reload(tracing_module)
+
+    log_dir = tmp_path / ".claude" / "mlflow"
+
+    # Before calling get_logger(), the log directory should NOT exist
+    assert not log_dir.exists()
+
+    # Call get_logger() for the first time - this should trigger initialization
+    logger1 = tracing_module.get_logger()
+
+    # After calling get_logger(), the log directory SHOULD exist
+    assert log_dir.exists()
+    assert log_dir.is_dir()
+
+    # Verify logger was created properly
+    assert logger1 is not None
+    assert logger1.name == "mlflow.claude_code.tracing"
+
+    # Call get_logger() again - should return the same logger instance
+    logger2 = tracing_module.get_logger()
+    assert logger2 is logger1
 
 
 # ============================================================================


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR implements lazy initialization for the module-level logger in `mlflow/claude_code/tracing.py` to avoid filesystem side effects at import time.

**Changes:**
- Changed `_MODULE_LOGGER` from eager initialization to lazy initialization pattern
- Logger is now created only on first call to `get_logger()`
- Avoids creating `.claude/mlflow/` directory and log files at module import time

**Why this change is needed:**
The previous implementation called `setup_logging()` at module import time, which created directories and files in the current working directory regardless of whether the functionality was used. Lazy initialization ensures resources are only consumed when the feature is actively used.

### How is this PR tested?

- [x] New unit/integration tests
- [x] Existing unit/integration tests

Added new test `test_get_logger_lazy_initialization` that verifies:
- No filesystem I/O happens at module import
- Logger is created on first `get_logger()` call
- Subsequent calls return the same logger instance

All 13 tests in `tests/claude_code/test_tracing.py` pass.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)