### PR TITLE
Handle Databricks FMAPI style in openai autolog

### DIFF
--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -399,7 +399,20 @@ def _reconstruct_completion_from_stream(chunks: list[Any]) -> Any:
     def _extract_content(chunk: Any) -> str:
         if not chunk.choices:
             return ""
-        return chunk.choices[0].delta.content or ""
+        content = chunk.choices[0].delta.content
+        if content is None:
+            return ""
+        # Handle Databricks streaming format where content can be a list of content items
+        # See https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#content-item
+        if isinstance(content, list):
+            text_parts = []
+            for item in content:
+                if isinstance(item, dict):
+                    # Extract text from text items only.
+                    if item.get("type") == "text" and "text" in item:
+                        text_parts.append(item["text"])
+            return "".join(text_parts)
+        return content
 
     message = ChatCompletionMessage(
         role="assistant", content="".join(map(_extract_content, chunks))

--- a/mlflow/openai/autolog.py
+++ b/mlflow/openai/autolog.py
@@ -407,10 +407,9 @@ def _reconstruct_completion_from_stream(chunks: list[Any]) -> Any:
         if isinstance(content, list):
             text_parts = []
             for item in content:
-                if isinstance(item, dict):
-                    # Extract text from text items only.
-                    if item.get("type") == "text" and "text" in item:
-                        text_parts.append(item["text"])
+                # Extract text from text items only.
+                if isinstance(item, dict) and item.get("type") == "text" and "text" in item:
+                    text_parts.append(item["text"])
             return "".join(text_parts)
         return content
 

--- a/tests/openai/mock_openai.py
+++ b/tests/openai/mock_openai.py
@@ -10,6 +10,7 @@ from mlflow.types.chat import ChatCompletionRequest
 from mlflow.utils import IS_PYDANTIC_V2_OR_NEWER
 
 EMPTY_CHOICES = "EMPTY_CHOICES"
+LIST_CONTENT = "LIST_CONTENT"
 
 app = fastapi.FastAPI()
 
@@ -91,6 +92,37 @@ def _make_chat_stream_chunk_empty_choices():
     }
 
 
+def _make_chat_stream_chunk_with_list_content(content_list, include_usage: bool = False):
+    # Create a streaming chunk with list content (Databricks format).
+    return {
+        "id": "chatcmpl-123",
+        "object": "chat.completion.chunk",
+        "created": 1677652288,
+        "model": "gpt-4o-mini",
+        "system_fingerprint": "fp_44709d6fcb",
+        "choices": [
+            {
+                "delta": {
+                    "content": content_list,
+                    "function_call": None,
+                    "role": None,
+                    "tool_calls": None,
+                },
+                "finish_reason": None,
+                "index": 0,
+                "logprobs": None,
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 9,
+            "completion_tokens": 12,
+            "total_tokens": 21,
+        }
+        if include_usage
+        else None,
+    }
+
+
 async def chat_response_stream(include_usage: bool = False):
     # OpenAI Chat Completion stream only includes usage in the last chunk
     # if {"stream_options": {"include_usage": True}} is specified in the request.
@@ -103,6 +135,16 @@ async def chat_response_stream_empty_choices():
     yield _make_chat_stream_chunk("Hello")
 
 
+async def chat_response_stream_with_list_content(include_usage: bool = False):
+    # Simulate Databricks streaming format with list content.
+    yield _make_chat_stream_chunk_with_list_content(
+        [{"type": "text", "text": "Hello"}], include_usage=False
+    )
+    yield _make_chat_stream_chunk_with_list_content(
+        [{"type": "text", "text": " world"}], include_usage=include_usage
+    )
+
+
 @app.post("/chat/completions", response_model_exclude_unset=True)
 async def chat(payload: ChatCompletionRequest):
     if payload.stream:
@@ -110,6 +152,13 @@ async def chat(payload: ChatCompletionRequest):
         if EMPTY_CHOICES == payload.messages[0].content:
             content = (
                 f"data: {json.dumps(d)}\n\n" async for d in chat_response_stream_empty_choices()
+            )
+        elif LIST_CONTENT == payload.messages[0].content:
+            content = (
+                f"data: {json.dumps(d)}\n\n"
+                async for d in chat_response_stream_with_list_content(
+                    include_usage=(payload.stream_options or {}).get("include_usage", False)
+                )
             )
         else:
             content = (

--- a/tests/openai/test_openai_autolog.py
+++ b/tests/openai/test_openai_autolog.py
@@ -18,7 +18,7 @@ from mlflow.tracing.constant import (
     TraceMetadataKey,
 )
 
-from tests.openai.mock_openai import EMPTY_CHOICES
+from tests.openai.mock_openai import EMPTY_CHOICES, LIST_CONTENT
 from tests.tracing.helper import get_traces, skip_when_testing_trace_sdk
 
 MOCK_TOOLS = [
@@ -351,6 +351,39 @@ async def test_chat_completions_streaming_empty_choices(client):
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     assert trace.info.status == "OK"
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_streaming_with_list_content(client):
+    # Test streaming with Databricks-style list content in chunks.
+    mlflow.openai.autolog()
+    stream = client.chat.completions.create(
+        messages=[{"role": "user", "content": LIST_CONTENT}],
+        model="gpt-4o-mini",
+        stream=True,
+    )
+
+    if client._is_async:
+        chunks = []
+        async for chunk in await stream:
+            chunks.append(chunk)
+    else:
+        chunks = list(stream)
+
+    assert len(chunks) == 2
+    assert chunks[0].choices[0].delta.content == [{"type": "text", "text": "Hello"}]
+    assert chunks[1].choices[0].delta.content == [{"type": "text", "text": " world"}]
+
+    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
+    assert trace is not None
+    assert trace.info.status == "OK"
+    assert len(trace.data.spans) == 1
+    span = trace.data.spans[0]
+    assert span.span_type == SpanType.CHAT_MODEL
+
+    # Verify the reconstructed message content is correct (text extracted from list)
+    assert isinstance(span.outputs, dict)
+    assert span.outputs["choices"][0]["message"]["content"] == "Hello world"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18354?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18354/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18354/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18354/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The foundation model api schema of Databricks is not fully compatible to OpenAI chat completion. Concretely, the "content" field of a chat message can be a list of content items (https://docs.databricks.com/aws/en/machine-learning/foundation-model-apis/api-reference#content-item).
When a list is returned as the response content, the openai autologging gets broken, causing an empty output field.

<img width="854" height="148" alt="Screenshot 2025-10-16 at 19 28 19" src="https://github.com/user-attachments/assets/b05f3ec5-39ce-4f0c-891b-40192586c49a" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
