### PR TITLE
Add configuration option for long-running deployments client requests

### DIFF
--- a/docs/docs/genai/governance/ai-gateway/guides/step2-query-deployments/index.mdx
+++ b/docs/docs/genai/governance/ai-gateway/guides/step2-query-deployments/index.mdx
@@ -105,21 +105,3 @@ print(response)
 ```
 
 And there you have it! You've successfully set up your first gateway server and served three OpenAI models.
-
-## Troubleshooting
-
-### Timeout errors for long-running predictions
-
-If you encounter timeout errors when querying endpoints with long-running operations (e.g., agent predictions that take several minutes), increase the retry timeout:
-
-```python
-import os
-
-# Set retry timeout to 15 minutes for long-running agent predictions
-os.environ["MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT"] = "900"
-
-from mlflow.deployments import get_deploy_client
-
-client = get_deploy_client("databricks")
-response = client.predict(endpoint="my-agent-endpoint", inputs=data)
-```

--- a/docs/docs/genai/governance/ai-gateway/guides/step2-query-deployments/index.mdx
+++ b/docs/docs/genai/governance/ai-gateway/guides/step2-query-deployments/index.mdx
@@ -105,3 +105,21 @@ print(response)
 ```
 
 And there you have it! You've successfully set up your first gateway server and served three OpenAI models.
+
+## Troubleshooting
+
+### Timeout errors for long-running predictions
+
+If you encounter timeout errors when querying endpoints with long-running operations (e.g., agent predictions that take several minutes), increase the retry timeout:
+
+```python
+import os
+
+# Set retry timeout to 15 minutes for long-running agent predictions
+os.environ["MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT"] = "900"
+
+from mlflow.deployments import get_deploy_client
+
+client = get_deploy_client("databricks")
+response = client.predict(endpoint="my-agent-endpoint", inputs=data)
+```

--- a/docs/docs/genai/serving/responses-agent.mdx
+++ b/docs/docs/genai/serving/responses-agent.mdx
@@ -682,6 +682,10 @@ ResponsesAgent works with structured schemas for requests and responses, check <
    - `MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT`: Maximum time for a SINGLE HTTP request (default: 120s)
    - `MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT`: Maximum time for ALL retry attempts combined (default: 600s)
 
+   :::warning
+   `MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT` does not cancel hanging HTTP requests. It only checks elapsed time after each request completes. A hanging request will continue until `MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT` is reached, potentially causing token wastage and duplicate trace entries.
+   :::
+
    For a long-running agent that takes 10 minutes per query:
 
    ```python

--- a/docs/docs/genai/serving/responses-agent.mdx
+++ b/docs/docs/genai/serving/responses-agent.mdx
@@ -678,6 +678,18 @@ ResponsesAgent works with structured schemas for requests and responses, check <
 2. **Schema Validation**: Verify input/output formats match expected schemas
 3. **Model Logging Issues**: User `models from code` feature to log the model
 4. **Missing traces**: Enable tracing by `mlflow.<flavor>.autolog` or manual tracing with `mlflow.start_span`
+5. **Timeout errors on long-running agent predictions**: If predictions take several minutes (e.g., agents with complex tool calling), increase `MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT` (default: 600s) to prevent premature timeouts:
+
+   ```python
+   import os
+
+   os.environ["MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT"] = "1200"  # 20 minutes
+
+   from mlflow.deployments import get_deploy_client
+
+   client = get_deploy_client("databricks")
+   response = client.predict(endpoint="my-agent", inputs=data)
+   ```
 
 ### Debugging
 

--- a/docs/docs/genai/serving/responses-agent.mdx
+++ b/docs/docs/genai/serving/responses-agent.mdx
@@ -678,18 +678,31 @@ ResponsesAgent works with structured schemas for requests and responses, check <
 2. **Schema Validation**: Verify input/output formats match expected schemas
 3. **Model Logging Issues**: User `models from code` feature to log the model
 4. **Missing traces**: Enable tracing by `mlflow.<flavor>.autolog` or manual tracing with `mlflow.start_span`
-5. **Timeout errors on long-running agent predictions**: If predictions take several minutes (e.g., agents with complex tool calling), increase `MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT` (default: 600s) to prevent premature timeouts:
+5. **Timeout errors on long-running agent predictions**: If predictions take several minutes (e.g., agents with complex tool calling), you need to configure TWO separate timeouts:
+   - `MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT`: Maximum time for a SINGLE HTTP request (default: 120s)
+   - `MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT`: Maximum time for ALL retry attempts combined (default: 600s)
+
+   For a long-running agent that takes 10 minutes per query:
 
    ```python
    import os
 
-   os.environ["MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT"] = "1200"  # 20 minutes
+   # Allow individual requests up to 15 minutes
+   os.environ["MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT"] = "900"
+
+   # Allow total retry time up to 20 minutes
+   os.environ["MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT"] = "1200"
 
    from mlflow.deployments import get_deploy_client
 
    client = get_deploy_client("databricks")
    response = client.predict(endpoint="my-agent", inputs=data)
    ```
+
+   :::tip
+   - If your longest query takes N seconds, set `MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT` to at least N seconds
+   - Set `MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT` >= `MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT`
+     :::
 
 ### Debugging
 

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -134,6 +134,11 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         timeout: int | None = None,
         retry_timeout_seconds: int | None = None,
     ):
+        """
+        Args:
+            timeout: Maximum time (in seconds) for a single HTTP request.
+            retry_timeout_seconds: Maximum time (in seconds) for all retry attempts combined.
+        """
         validate_deployment_timeout_config(timeout, retry_timeout_seconds)
 
         call_kwargs = {}

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -8,6 +8,7 @@ from mlflow.deployments.constants import (
     MLFLOW_DEPLOYMENT_CLIENT_REQUEST_RETRY_CODES,
 )
 from mlflow.environment_variables import (
+    MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT,
     MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT,
     MLFLOW_HTTP_REQUEST_TIMEOUT,
 )
@@ -127,6 +128,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         route: str | None = None,
         json_body: dict[str, Any] | None = None,
         timeout: int | None = None,
+        retry_timeout_seconds: int | None = None,
     ):
         call_kwargs = {}
         if method.lower() == "get":
@@ -139,6 +141,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             endpoint=posixpath.join(prefix, "serving-endpoints", route or ""),
             method=method,
             timeout=MLFLOW_HTTP_REQUEST_TIMEOUT.get() if timeout is None else timeout,
+            retry_timeout_seconds=retry_timeout_seconds,
             raise_on_status=False,
             retry_codes=MLFLOW_DEPLOYMENT_CLIENT_REQUEST_RETRY_CODES,
             extra_headers={"X-Databricks-Endpoints-API-Client": "Databricks Deployment Client"},
@@ -155,6 +158,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
         route: str | None = None,
         json_body: dict[str, Any] | None = None,
         timeout: int | None = None,
+        retry_timeout_seconds: int | None = None,
     ) -> Iterator[str]:
         call_kwargs = {}
         if method.lower() == "get":
@@ -167,6 +171,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             endpoint=posixpath.join(prefix, "serving-endpoints", route or ""),
             method=method,
             timeout=MLFLOW_HTTP_REQUEST_TIMEOUT.get() if timeout is None else timeout,
+            retry_timeout_seconds=retry_timeout_seconds,
             raise_on_status=False,
             retry_codes=MLFLOW_DEPLOYMENT_CLIENT_REQUEST_RETRY_CODES,
             extra_headers={"X-Databricks-Endpoints-API-Client": "Databricks Deployment Client"},
@@ -243,6 +248,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             route=posixpath.join(endpoint, "invocations"),
             json_body=inputs,
             timeout=MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT.get(),
+            retry_timeout_seconds=MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT.get(),
         )
 
     def predict_stream(
@@ -302,6 +308,7 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
             route=posixpath.join(endpoint, "invocations"),
             json_body={**inputs, "stream": True},
             timeout=MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT.get(),
+            retry_timeout_seconds=MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT.get(),
         )
 
         for line in chunk_line_iter:

--- a/mlflow/deployments/databricks/__init__.py
+++ b/mlflow/deployments/databricks/__init__.py
@@ -136,6 +136,10 @@ class DatabricksDeploymentClient(BaseDeploymentClient):
     ):
         """
         Args:
+            method: HTTP method (GET, POST, etc.).
+            prefix: API prefix path.
+            route: Endpoint route.
+            json_body: Request payload.
             timeout: Maximum time (in seconds) for a single HTTP request.
             retry_timeout_seconds: Maximum time (in seconds) for all retry attempts combined.
         """

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -555,19 +555,27 @@ MLFLOW_MULTIPART_DOWNLOAD_CHUNK_SIZE = _EnvironmentVariable(
 #: (default: ``True``)
 MLFLOW_ALLOW_HTTP_REDIRECTS = _BooleanEnvironmentVariable("MLFLOW_ALLOW_HTTP_REDIRECTS", True)
 
-#: Specifies the client-based timeout (in seconds) when making an HTTP request to a deployment
-#: target. Used within the `predict` and `predict_stream` APIs.
+#: Timeout for a SINGLE HTTP request to a deployment endpoint (in seconds).
+#: This controls how long ONE individual predict/predict_stream request can take before timing out.
+#: If your model inference takes longer than this (e.g., long-running agent queries that take
+#: several minutes), you MUST increase this value to allow the single request to complete.
+#: For example, if your longest query takes 5 minutes, set this to at least 300 seconds.
+#: Used within the `predict` and `predict_stream` APIs.
 #: (default: ``120``)
 MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT", int, 120
 )
 
-#: Specifies the overall retry timeout (in seconds) for deployment predict operations. This controls
-#: how long the client will retry before giving up entirely. For long-running agent predictions
-#: that may take several minutes, increase this value to prevent premature timeout and retries.
+#: TOTAL time limit for ALL retry attempts combined (in seconds).
+#: This controls how long the client will keep retrying failed requests across ALL attempts
+#: before giving up entirely. This is SEPARATE from MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT, which
+#: controls how long a SINGLE request can run, while this variable controls the TOTAL time
+#: for ALL retries. For long-running operations that may also experience transient failures,
+#: ensure BOTH timeouts are set appropriately. This value should be greater than or equal to
+#: MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT.
 #: (default: ``600``)
-MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT = _EnvironmentVariable(
-    "MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT", int, 600
+MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT", int, 600
 )
 
 MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI = _EnvironmentVariable(

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -562,6 +562,14 @@ MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT", int, 120
 )
 
+#: Specifies the overall retry timeout (in seconds) for deployment predict operations. This controls
+#: how long the client will retry before giving up entirely. For long-running agent predictions
+#: that may take several minutes, increase this value to prevent premature timeout and retries.
+#: (default: ``600``)
+MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT = _EnvironmentVariable(
+    "MLFLOW_DEPLOYMENT_PREDICT_RETRY_TIMEOUT", int, 600
+)
+
 MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI = _EnvironmentVariable(
     "MLFLOW_GATEWAY_RATE_LIMITS_STORAGE_URI", str, None
 )

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -384,7 +384,7 @@ def _validate_backoff_factor(backoff_factor):
         )
 
 
-def validate_deployment_timeout_config(timeout, retry_timeout_seconds):
+def validate_deployment_timeout_config(timeout: int | None, retry_timeout_seconds: int | None):
     """
     Validate that total retry timeout is not less than single request timeout.
 
@@ -394,13 +394,14 @@ def validate_deployment_timeout_config(timeout, retry_timeout_seconds):
     """
     if timeout is not None and retry_timeout_seconds is not None:
         if retry_timeout_seconds < timeout:
-            _logger.warning(
+            warnings.warn(
                 f"MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT ({retry_timeout_seconds}s) is set "
                 f"lower than MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT ({timeout}s). This means the "
                 "total retry timeout could expire before a single request completes, causing "
                 "premature failures. For long-running predictions, ensure "
                 "MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT >= MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT. "
-                f"Recommended: Set MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT to at least {timeout}s."
+                f"Recommended: Set MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT to at least {timeout}s.",
+                stacklevel=2,
             )
 
 

--- a/mlflow/utils/rest_utils.py
+++ b/mlflow/utils/rest_utils.py
@@ -384,6 +384,26 @@ def _validate_backoff_factor(backoff_factor):
         )
 
 
+def validate_deployment_timeout_config(timeout, retry_timeout_seconds):
+    """
+    Validate that total retry timeout is not less than single request timeout.
+
+    Args:
+        timeout: Maximum time for a single HTTP request (in seconds)
+        retry_timeout_seconds: Maximum time for all retry attempts combined (in seconds)
+    """
+    if timeout is not None and retry_timeout_seconds is not None:
+        if retry_timeout_seconds < timeout:
+            _logger.warning(
+                f"MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT ({retry_timeout_seconds}s) is set "
+                f"lower than MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT ({timeout}s). This means the "
+                "total retry timeout could expire before a single request completes, causing "
+                "premature failures. For long-running predictions, ensure "
+                "MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT >= MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT. "
+                f"Recommended: Set MLFLOW_DEPLOYMENT_PREDICT_TOTAL_TIMEOUT to at least {timeout}s."
+            )
+
+
 def _time_sleep(seconds: float) -> None:
     """
     This function is specifically mocked in `test_rest_utils.py` to test the backoff logic in

--- a/tests/deployments/databricks/test_databricks.py
+++ b/tests/deployments/databricks/test_databricks.py
@@ -497,7 +497,9 @@ def test_predict_with_retry_timeout_env_var(monkeypatch):
     mock_resp.url = os.environ["DATABRICKS_HOST"]
     mock_resp.status_code = 200
 
-    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=mock_resp) as mock_http:
+    with mock.patch(
+        "mlflow.deployments.databricks.http_request", return_value=mock_resp
+    ) as mock_http:
         resp = client.predict(endpoint="test", inputs={})
         mock_http.assert_called_once()
         call_kwargs = mock_http.call_args[1]
@@ -517,7 +519,9 @@ def test_predict_stream_with_retry_timeout_env_var(monkeypatch):
     mock_resp.status_code = 200
     mock_resp.encoding = "utf-8"
 
-    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=mock_resp) as mock_http:
+    with mock.patch(
+        "mlflow.deployments.databricks.http_request", return_value=mock_resp
+    ) as mock_http:
         chunks = list(client.predict_stream(endpoint="test", inputs={}))
         mock_http.assert_called_once()
         call_kwargs = mock_http.call_args[1]

--- a/tests/utils/test_rest_utils.py
+++ b/tests/utils/test_rest_utils.py
@@ -905,7 +905,7 @@ def test_deployment_client_timeout_propagation(monkeypatch):
             "http://my-host",  # host
             None,  # token
             None,  # databricks_auth_profile
-            retry_timeout_seconds=None,
+            retry_timeout_seconds=600,
             timeout=300,  # MLFLOW_DEPLOYMENT_PREDICT_TIMEOUT value
         )
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18363?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18363/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18363/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18363/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

For requests going through the get_deploy_client() API that exceed the default retry timeout, retry logic is triggered, creating multiple concurrent requests due to the retry logic. 

This PR exposes a new env var config that can be set to override the default retry timeout value that would trigger additional submissions to an endpoint, allowing for users to handle configurations for agent-based calls whose durations are measured in minutes. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [X] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
