### PR TITLE
Fix serialization bug in file store

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -614,12 +614,11 @@ class FileStore(AbstractStore):
     ):
         model_version_dict = dict(model_version)
         # Remove fields that are stored separately or derived from other sources
-        del model_version_dict["tags"]
-        # metrics and params are fetched from the logged model, not stored in meta.yaml
-        model_version_dict.pop("metrics", None)
-        model_version_dict.pop("params", None)
-        # aliases are stored separately at the registered model level
-        model_version_dict.pop("aliases", None)
+        # - tags are stored in a separate folder
+        # - metrics and params are fetched from the logged model, not stored in meta.yaml
+        # - aliases are stored separately at the registered model level
+        for field in ["tags", "metrics", "params", "aliases"]:
+            model_version_dict.pop(field, None)
         meta_dir = meta_dir or self._get_model_version_dir(
             model_version.name, model_version.version
         )

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -613,7 +613,13 @@ class FileStore(AbstractStore):
         self, model_version: FileModelVersion, meta_dir=None, overwrite=True
     ):
         model_version_dict = dict(model_version)
+        # Remove fields that are stored separately or derived from other sources
         del model_version_dict["tags"]
+        # metrics and params are fetched from the logged model, not stored in meta.yaml
+        model_version_dict.pop("metrics", None)
+        model_version_dict.pop("params", None)
+        # aliases are stored separately at the registered model level
+        model_version_dict.pop("aliases", None)
         meta_dir = meta_dir or self._get_model_version_dir(
             model_version.name, model_version.version
         )

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+import mlflow
 from mlflow.entities.model_registry import (
     ModelVersion,
     ModelVersionTag,
@@ -17,6 +18,7 @@ from mlflow.protos.databricks_pb2 import (
     RESOURCE_DOES_NOT_EXIST,
     ErrorCode,
 )
+from mlflow.pyfunc import PythonModel
 from mlflow.store.model_registry.file_store import FileStore
 from mlflow.utils.file_utils import path_to_local_file_uri
 from mlflow.utils.time import get_current_time_millis
@@ -1816,85 +1818,80 @@ def test_create_registered_model_handle_prompt_properly(store):
         store.create_registered_model("prompt")
 
 
-def test_create_model_version_with_model_id_and_no_run_id(store):
+def test_create_model_version_with_model_id_and_no_run_id(store: FileStore):
+    class SimpleModel(PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
+
     name = "test_model_with_model_id"
     store.create_registered_model(name)
 
-    mock_run_id = "mock-run-id-123"
-    mock_logged_model = mock.MagicMock()
-    mock_logged_model.source_run_id = mock_run_id
-
-    with mock.patch("mlflow.tracking.client.MlflowClient") as mock_client_class:
-        mock_client = mock.MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.get_logged_model.return_value = mock_logged_model
-
-        mv = store.create_model_version(
-            name=name,
-            source="/absolute/path/to/source",
-            run_id=None,
-            model_id="test-model-id-456",
+    with mlflow.start_run() as run:
+        model_info = mlflow.pyfunc.log_model(
+            name="model",
+            python_model=SimpleModel(),
         )
+        run_id = run.info.run_id
+        model_id = model_info.model_id
 
-        mock_client.get_logged_model.assert_any_call("test-model-id-456")
+    mv = store.create_model_version(
+        name=name,
+        source="/absolute/path/to/source",
+        run_id=None,
+        model_id=model_id,
+    )
 
-        assert mv.run_id == mock_run_id
+    assert mv.run_id == run_id
 
-        mvd = store.get_model_version(name=mv.name, version=mv.version)
-        assert mvd.run_id == mock_run_id
+    mvd = store.get_model_version(name=mv.name, version=mv.version)
+    assert mvd.run_id == run_id
 
 
-def test_update_model_version_with_model_id_and_metrics(store):
-    from mlflow.entities.logged_model_parameter import LoggedModelParameter
-    from mlflow.entities.metric import Metric
+def test_update_model_version_with_model_id_and_metrics(store: FileStore):
+    class SimpleModel(PythonModel):
+        def predict(self, context, model_input, params=None):
+            return model_input
 
     name = "test_model_with_model_id_and_metrics"
     store.create_registered_model(name)
 
-    mock_run_id = "mock-run-id-789"
-    mock_logged_model = mock.MagicMock()
-    mock_logged_model.source_run_id = mock_run_id
-    mock_logged_model.metrics = [
-        Metric(
-            key="execution_time",
-            value=33.74682,
-            timestamp=1760606180996,
-            step=0,
-            run_id=mock_run_id,
-            model_id="test-model-id-789",
-            dataset_name=None,
-            dataset_digest=None,
+    with mlflow.start_run() as run:
+        mlflow.log_param("learning_rate", "0.001")
+        model_info = mlflow.pyfunc.log_model(
+            name="model",
+            python_model=SimpleModel(),
         )
-    ]
-    mock_logged_model.params = [LoggedModelParameter(key="learning_rate", value="0.001")]
+        mlflow.log_metric("execution_time", 33.74682, step=0, model_id=model_info.model_id)
+        run_id = run.info.run_id
+        model_id = model_info.model_id
 
-    with mock.patch("mlflow.tracking.client.MlflowClient") as mock_client_class:
-        mock_client = mock.MagicMock()
-        mock_client_class.return_value = mock_client
-        mock_client.get_logged_model.return_value = mock_logged_model
+    mv = store.create_model_version(
+        name=name,
+        source="/absolute/path/to/source",
+        run_id=None,
+        model_id=model_id,
+    )
 
-        mv = store.create_model_version(
-            name=name,
-            source="/absolute/path/to/source",
-            run_id=None,
-            model_id="test-model-id-789",
-        )
+    assert mv.run_id == run_id
 
-        assert mv.run_id == mock_run_id
+    mvd = store.get_model_version(name=mv.name, version=mv.version)
+    assert mvd.run_id == run_id
+    assert mvd.metrics is not None
+    assert len(mvd.metrics) == 1
+    assert mvd.metrics[0].key == "execution_time"
+    assert mvd.metrics[0].value == 33.74682
+    assert mvd.params == {"learning_rate": "0.001"}
 
-        mvd = store.get_model_version(name=mv.name, version=mv.version)
-        assert mvd.run_id == mock_run_id
-        assert mvd.metrics == mock_logged_model.metrics
-        assert mvd.params == mock_logged_model.params
+    updated_mvd = store.update_model_version(
+        name=mv.name,
+        version=mv.version,
+        description="Test description with metrics",
+    )
+    assert updated_mvd.description == "Test description with metrics"
 
-        updated_mvd = store.update_model_version(
-            name=mv.name,
-            version=mv.version,
-            description="Test description with metrics",
-        )
-        assert updated_mvd.description == "Test description with metrics"
-
-        retrieved_mvd = store.get_model_version(name=mv.name, version=mv.version)
-        assert retrieved_mvd.description == "Test description with metrics"
-        assert retrieved_mvd.metrics == mock_logged_model.metrics
-        assert retrieved_mvd.params == mock_logged_model.params
+    retrieved_mvd = store.get_model_version(name=mv.name, version=mv.version)
+    assert retrieved_mvd.description == "Test description with metrics"
+    assert retrieved_mvd.metrics is not None
+    assert len(retrieved_mvd.metrics) == 1
+    assert retrieved_mvd.metrics[0].key == "execution_time"
+    assert retrieved_mvd.params == {"learning_rate": "0.001"}


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18365?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18365/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18365/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18365/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
#18352 

### What changes are proposed in this pull request?

Fixes a FileStore serialization bug where params and metrics were incorrectly left in to LoggedModel instances when storing model metadata via YAML serialization. This bug was introduced in #15698. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
