### PR TITLE
Pin uvloop<0.22 to fix mlserver compatibility

### DIFF
--- a/mlflow/models/container/__init__.py
+++ b/mlflow/models/container/__init__.py
@@ -93,6 +93,8 @@ def _install_pyfunc_deps(
         server_deps = [
             "'mlserver>=1.2.0,!=1.3.1,<2.0.0'",
             "'mlserver-mlflow>=1.2.0,!=1.3.1,<2.0.0'",
+            # uvloop >= 0.22 is not compatible with mlserver
+            "'uvloop<0.22'",
         ]
 
     install_server_deps = [f"pip install {' '.join(server_deps)}"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18370?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18370/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18370/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18370/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR pins `uvloop<0.22` to maintain compatibility with mlserver. uvloop 0.22 introduced breaking changes that cause mlserver worker processes to fail during initialization.

**Error details:**
The breaking change in uvloop 0.22.0 ([release notes](https://github.com/MagicStack/uvloop/releases/tag/v0.22.0)) causes the following error when mlserver workers attempt to get the event loop:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
  File "/root/.mlflow/envs/mlflow-145bb9709c734de6787db68f6d1f625e1aece93a/lib/python3.10/site-packages/mlserver/parallel/worker.py", line 81, in _ignore_signals
    loop = asyncio.get_event_loop()
  File "/root/.mlflow/envs/mlflow-145bb9709c734de6787db68f6d1f625e1aece93a/lib/python3.10/site-packages/uvloop/__init__.py", line 206, in get_event_loop
    raise RuntimeError(
```

**Evidence:**
- CI failure log: https://github.com/mlflow/mlflow/actions/runs/18577201648/job/52964859606
- uvloop 0.22.1 was downloaded during the build (see job logs)

### How is this PR tested?

- [x] Existing unit/integration tests

This fix prevents the mlserver worker initialization failures seen in CI.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed mlserver deployment failures caused by uvloop 0.22 incompatibility by pinning uvloop to versions below 0.22.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)