### PR TITLE
Add support for using the same DB for tracking and auth

### DIFF
--- a/docs/docs/self-hosting/security/basic-http-auth.mdx
+++ b/docs/docs/self-hosting/security/basic-http-auth.mdx
@@ -1078,3 +1078,8 @@ MLFLOW_AUTH_CONFIG_PATH=/path/to/my_auth_config.ini mlflow server --app-name bas
 
 The database must be created before starting the MLflow server. The database schema will be created automatically
 when the server starts.
+
+:::note
+Auth migrations use a separate version table (`alembic_version_auth`) from tracking migrations (`alembic_version`).
+This allows you to safely use the same database for both tracking data and auth data without migration conflicts.
+:::

--- a/docs/docs/self-hosting/security/basic-http-auth.mdx
+++ b/docs/docs/self-hosting/security/basic-http-auth.mdx
@@ -1082,4 +1082,7 @@ when the server starts.
 :::note
 Auth migrations use a separate version table (`alembic_version_auth`) from tracking migrations (`alembic_version`).
 This allows you to safely use the same database for both tracking data and auth data without migration conflicts.
+
+To use separate databases instead, configure `database_uri` to point to a different database than `--backend-store-uri`.
+By default, auth uses `basic_auth.db` (SQLite) while tracking uses the database specified by `--backend-store-uri`.
 :::

--- a/mlflow/server/auth/db/migrations/env.py
+++ b/mlflow/server/auth/db/migrations/env.py
@@ -44,6 +44,7 @@ def run_migrations_offline() -> None:
         target_metadata=target_metadata,
         literal_binds=True,
         dialect_opts={"paramstyle": "named"},
+        version_table="alembic_version_auth",
     )
 
     with context.begin_transaction():
@@ -64,7 +65,11 @@ def run_migrations_online() -> None:
     )
 
     with connectable.connect() as connection:
-        context.configure(connection=connection, target_metadata=target_metadata)
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            version_table="alembic_version_auth",
+        )
 
         with context.begin_transaction():
             context.run_migrations()

--- a/mlflow/server/auth/db/utils.py
+++ b/mlflow/server/auth/db/utils.py
@@ -32,6 +32,6 @@ def migrate_if_needed(engine: Engine, revision: str) -> None:
     alembic_cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
     script_dir = ScriptDirectory.from_config(alembic_cfg)
     with engine.begin() as conn:
-        context = MigrationContext.configure(conn)
+        context = MigrationContext.configure(conn, opts={"version_table": "alembic_version_auth"})
         if context.get_current_revision() != script_dir.get_current_head():
             upgrade(alembic_cfg, revision)

--- a/tests/server/auth/db/test_cli.py
+++ b/tests/server/auth/db/test_cli.py
@@ -16,12 +16,13 @@ def test_upgrade(tmp_path: Path) -> None:
         cursor = conn.cursor()
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
         tables = cursor.fetchall()
-        assert tables == [
-            ("alembic_version_auth",),
-            ("users",),
-            ("experiment_permissions",),
-            ("registered_model_permissions",),
-        ]
+
+    assert tables == [
+        ("alembic_version_auth",),
+        ("users",),
+        ("experiment_permissions",),
+        ("registered_model_permissions",),
+    ]
 
 
 def test_auth_and_tracking_store_coexist(tmp_path: Path) -> None:
@@ -42,10 +43,10 @@ def test_auth_and_tracking_store_coexist(tmp_path: Path) -> None:
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
         tables = {t[0] for t in cursor.fetchall()}
 
-        assert "alembic_version" in tables
-        assert "alembic_version_auth" in tables
-        assert "users" in tables
-        assert "experiment_permissions" in tables
-        assert "registered_model_permissions" in tables
-        assert "experiments" in tables
-        assert "runs" in tables
+    assert "alembic_version" in tables
+    assert "alembic_version_auth" in tables
+    assert "users" in tables
+    assert "experiment_permissions" in tables
+    assert "registered_model_permissions" in tables
+    assert "experiments" in tables
+    assert "runs" in tables

--- a/tests/server/auth/db/test_cli.py
+++ b/tests/server/auth/db/test_cli.py
@@ -17,8 +17,35 @@ def test_upgrade(tmp_path: Path) -> None:
         cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
         tables = cursor.fetchall()
         assert tables == [
-            ("alembic_version",),
+            ("alembic_version_auth",),
             ("users",),
             ("experiment_permissions",),
             ("registered_model_permissions",),
         ]
+
+
+def test_auth_and_tracking_store_coexist(tmp_path: Path) -> None:
+    from mlflow.store.db.utils import _safe_initialize_tables, create_sqlalchemy_engine_with_retry
+
+    runner = CliRunner()
+    db = tmp_path / "test.db"
+    db_url = f"sqlite:///{db}"
+
+    tracking_engine = create_sqlalchemy_engine_with_retry(db_url)
+    _safe_initialize_tables(tracking_engine)
+
+    res = runner.invoke(cli.upgrade, ["--url", db_url], catch_exceptions=False)
+    assert res.exit_code == 0, res.output
+
+    with sqlite3.connect(db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = {t[0] for t in cursor.fetchall()}
+
+        assert "alembic_version" in tables
+        assert "alembic_version_auth" in tables
+        assert "users" in tables
+        assert "experiment_permissions" in tables
+        assert "registered_model_permissions" in tables
+        assert "experiments" in tables
+        assert "runs" in tables


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18384?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18384/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18384/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18384/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
#18373 

### What changes are proposed in this pull request?

Adds the ability to have two separate alembic tracking tables in the same DB for users who wish to have their auth and tracking services co-located in the same database. 
Currently this is not possible due the shared table state where the migration script setup will encounter missing lineage processing due to the different upgrades that need to be applied to the DB architecture (auth is different from tracking). 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
