### PR TITLE
Fix attribute error in StrandsAgent tracing

### DIFF
--- a/mlflow/strands/autolog.py
+++ b/mlflow/strands/autolog.py
@@ -13,6 +13,7 @@ from opentelemetry.sdk.trace import (
 )
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
 from opentelemetry.trace import (
+    NoOpTracer,
     NoOpTracerProvider,
     ProxyTracerProvider,
     get_tracer_provider,
@@ -39,6 +40,9 @@ class StrandsSpanProcessor(SimpleSpanProcessor):
 
     def on_start(self, span: OTelSpan, parent_context: Context | None = None):
         tracer = _get_tracer(__name__)
+        if isinstance(tracer, NoOpTracer):
+            return
+
         tracer.span_processor.on_start(span, parent_context)
         trace_id = get_otel_attribute(span, SpanAttributeKey.REQUEST_ID)
         mlflow_span = create_mlflow_span(span, trace_id)

--- a/tests/strands/test_strands_tracing.py
+++ b/tests/strands/test_strands_tracing.py
@@ -9,6 +9,7 @@ from strands.tools.tools import PythonAgentTool
 import mlflow
 from mlflow.entities import SpanType
 from mlflow.tracing.constant import SpanAttributeKey
+from mlflow.tracing.provider import trace_disabled
 
 from tests.tracing.helper import get_traces
 
@@ -277,3 +278,16 @@ def test_autolog_disable_prevents_new_traces():
     mlflow.strands.autolog(disable=True)
     agent2("bye")
     assert len(get_traces()) == 1
+
+
+def test_autolog_does_not_raise_npe_when_tracing_disabled():
+    mlflow.strands.autolog()
+
+    agent = Agent(model=DummyModel("hi"), name="agent")
+
+    @trace_disabled
+    def run():
+        agent("hello")
+
+    run()
+    assert len(get_traces()) == 0


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18409?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18409/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18409/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18409/merge
```

</p>
</details>

### What changes are proposed in this pull request?

When using Strands Agents for the GenAI evaluation, it raises an error `AttributeError: 'NoOpTracer' object has no attribute 'span_processor'`.

```
import mlflow
from strands import Agent
from strands.models.openai import OpenAIModel

mlflow.strands.autolog()

model = OpenAIModel(model_id="gpt-4o-mini")
agent = Agent(model=model)

def predict_fn(question):
    return agent(question))

data = [{"inputs": {"question": "What is 3*18"}, "expectations": {"result": 54}}]
mlflow.genai.evaluate(data=data, predict_fn=predict_fn, scorers=[...])
```

This is raised when MLflow executes the predict function once for trace validation. At that moment, we disable tracing via the `@trace_disabled` decorator, such that it doesn't log an extra trace to the eval run. This makes OTel tracer object to `NoOpTracer` and results in the attribute error [here](https://github.com/mlflow/mlflow/blob/master/mlflow/strands/autolog.py#L42):

```
        tracer = _get_tracer(__name__)
        tracer.span_processor.on_start(span, parent_context)
```

This PR adds a simple check to avoid this error.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
