### PR TITLE
Fix spark udf on multi driver

### DIFF
--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -121,7 +121,11 @@ class DBConnectArtifactCache:
             return single_candidate
 
         multi_driver_root = "/local_disk0/.ephemeral_nfs_multi_driver"
-        if os.path.isdir(multi_driver_root):
+        if (
+            os.environ.get("AETHER_MULTI_DRIVER_ENABLED", "false") == "true"
+            and os.environ.get("AETHER_MULTI_DRIVER_NOTEBOOK_LIBRARY_ENABLED", "false") == "true"
+            and os.path.isdir(multi_driver_root)
+        ):
             try:
                 children = sorted(os.listdir(multi_driver_root))
             except OSError:

--- a/mlflow/pyfunc/dbconnect_artifact_cache.py
+++ b/mlflow/pyfunc/dbconnect_artifact_cache.py
@@ -108,14 +108,32 @@ class DBConnectArtifactCache:
             raise RuntimeError(f"The artifact '{cache_key}' does not exist.")
         archive_file_name = self._cache[cache_key]
 
-        if session_id := os.environ.get("DB_SESSION_UUID"):
-            return (
-                f"/local_disk0/.ephemeral_nfs/artifacts/{session_id}/archives/{archive_file_name}"
-            )
+        session_id = os.environ.get("DB_SESSION_UUID")
+        if not session_id:
+            # If 'DB_SESSION_UUID' environment variable does not exist, it means it is running
+            # in a dedicated mode Spark cluster.
+            return os.path.join(os.getcwd(), archive_file_name)
 
-        # If 'DB_SESSION_UUID' environment variable does not exist, it means it is running
-        # in a dedicated mode Spark cluster.
-        return os.path.join(os.getcwd(), archive_file_name)
+        relative_path = os.path.join("artifacts", session_id, "archives", archive_file_name)
+        single_driver_root = "/local_disk0/.ephemeral_nfs"
+        single_candidate = os.path.join(single_driver_root, relative_path)
+        if os.path.exists(single_candidate):
+            return single_candidate
+
+        multi_driver_root = "/local_disk0/.ephemeral_nfs_multi_driver"
+        if os.path.isdir(multi_driver_root):
+            try:
+                children = sorted(os.listdir(multi_driver_root))
+            except OSError:
+                children = []
+
+            for child in children:
+                child_candidate = os.path.join(multi_driver_root, child, relative_path)
+                if os.path.exists(child_candidate):
+                    return child_candidate
+
+        # Fall back to the original single-driver location to preserve previous behaviour.
+        return single_candidate
 
 
 def archive_directory(input_dir, archive_file_path):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18410?quickstart=1)

#### Install mlflow from this PR

```
# Use `%sh` to run this command on Databricks
OPTIONS=$(if pip freeze | grep -q 'mlflow @ git+https://github.com/mlflow/mlflow.git'; then echo '--force-reinstall --no-deps'; fi)
pip install $OPTIONS git+https://github.com/mlflow/mlflow.git@refs/pull/18410/merge
```

#### Checkout with GitHub CLI

```
gh pr checkout 18410
```

</p>
</details>

### What changes are proposed in this pull request?

MLflow Spark UDF distribute model artifacts to the executors via NFS. Currently, the UDF looks for a hard-coded location `/local_disk0/.ephemeral_nfs", however, a user reported that the location is no longer accessible on Serverless compute. We've identified the recent rollout of multi-driver architecture is related, but we also found the directory still exists in the executor so need further investigation on why it is not visible from the UDF. Most likely related to spark UDF sandbox.

A short-term workaround to this problem is to look for a new `/local_disk0/.ephemeral_nfs_multi_driver` location that was added by the new architecture. The directory contains subdirectories, each of which corresponds to a single driver, and one of them contains the model artifacts. Therefore, this PR adds a fallback logic to iterates on these subdirectories to fetch the model artifacts. 

This does not scale when the number of drivers becomes tens or hundreds of order, but which is not likely happen very soon. In the meantime, we will investigate on the access issue and seek for a longer-term solution.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified the fix works on serverless.

```
import mlflow
from pyspark.sql.functions import struct, col

# Load simple sklearn model as a Spark UDF.
loaded_model = mlflow.pyfunc.spark_udf(spark, model_uri=logged_model)

spark_df = spark_df.withColumn('predictions', loaded_model(struct(*map(col, spark_df.columns))))
display(spark_df)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.


Fix Spark UDF execution issue in Databricks Serverless Compute.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
