### PR TITLE
Adjust util for remote tracking server declaration

### DIFF
--- a/mlflow/genai/datasets/__init__.py
+++ b/mlflow/genai/datasets/__init__.py
@@ -14,7 +14,7 @@ from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 from mlflow.store.tracking import SEARCH_EVALUATION_DATASETS_MAX_RESULTS
 from mlflow.tracking import get_tracking_uri
 from mlflow.utils.annotations import deprecated_parameter, experimental
-from mlflow.utils.databricks_utils import is_databricks_default_tracking_uri
+from mlflow.utils.uri import is_databricks_uri
 
 _logger = logging.getLogger(__name__)
 
@@ -131,7 +131,7 @@ def create_dataset(
 
     experiment_ids = [experiment_id] if isinstance(experiment_id, str) else experiment_id
 
-    if is_databricks_default_tracking_uri(get_tracking_uri()):
+    if is_databricks_uri(get_tracking_uri()):
         if tags is not None:
             raise NotImplementedError(
                 "Tags are not supported in Databricks environments. "
@@ -208,7 +208,7 @@ def delete_dataset(
         records, tags, and metadata will be permanently removed.
     """
 
-    if is_databricks_default_tracking_uri(get_tracking_uri()):
+    if is_databricks_uri(get_tracking_uri()):
         _validate_databricks_params(name, dataset_id)
         try:
             from databricks.agents.datasets import delete_dataset as db_delete
@@ -272,7 +272,7 @@ def get_dataset(
             dataset.merge_records(new_test_cases)
     """
 
-    if is_databricks_default_tracking_uri(get_tracking_uri()):
+    if is_databricks_uri(get_tracking_uri()):
         _validate_databricks_params(name, dataset_id)
         try:
             from databricks.agents.datasets import get_dataset as db_get
@@ -429,7 +429,7 @@ def search_datasets(
         This API is not available in Databricks environments. Use Unity Catalog
         search capabilities in Databricks instead.
     """
-    if is_databricks_default_tracking_uri(get_tracking_uri()):
+    if is_databricks_uri(get_tracking_uri()):
         raise NotImplementedError(
             "Dataset search is not available in Databricks. "
             "Use Unity Catalog search capabilities instead."
@@ -528,7 +528,7 @@ def set_dataset_tags(
         This API is not available in Databricks environments yet.
         Tags in Databricks are managed through Unity Catalog.
     """
-    if is_databricks_default_tracking_uri(get_tracking_uri()):
+    if is_databricks_uri(get_tracking_uri()):
         raise NotImplementedError(
             "Dataset tag operations are not available in Databricks yet. "
             "Tags are managed through Unity Catalog."
@@ -578,7 +578,7 @@ def delete_dataset_tag(
         This API is not available in Databricks environments yet.
         Tags in Databricks are managed through Unity Catalog.
     """
-    if is_databricks_default_tracking_uri(get_tracking_uri()):
+    if is_databricks_uri(get_tracking_uri()):
         raise NotImplementedError(
             "Dataset tag operations are not available in Databricks yet. "
             "Tags are managed through Unity Catalog."
@@ -594,7 +594,7 @@ def _validate_association_operation():
     from mlflow.store.tracking.file_store import FileStore
     from mlflow.tracking._tracking_service.utils import _get_store
 
-    if is_databricks_default_tracking_uri(get_tracking_uri()):
+    if is_databricks_uri(get_tracking_uri()):
         raise NotImplementedError(
             "Dataset association operations are not available in Databricks yet. "
             "Associations are managed through Unity Catalog."

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -399,15 +399,17 @@ def test_databricks_profile_uri_support():
             },
         ),
     ):
-        get_dataset(name="catalog.schema.table")
+        result = get_dataset(name="catalog.schema.table")
         sys.modules["databricks.agents.datasets"].get_dataset.assert_called_once_with(
             "catalog.schema.table"
         )
+        assert isinstance(result, EvaluationDataset)
 
-        create_dataset(name="catalog.schema.table2", experiment_id=["exp1"])
+        result2 = create_dataset(name="catalog.schema.table2", experiment_id=["exp1"])
         sys.modules["databricks.agents.datasets"].create_dataset.assert_called_once_with(
             "catalog.schema.table2", ["exp1"]
         )
+        assert isinstance(result2, EvaluationDataset)
 
         delete_dataset(name="catalog.schema.table3")
         sys.modules["databricks.agents.datasets"].delete_dataset.assert_called_once_with(

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -40,7 +40,7 @@ def mock_client():
 
 @pytest.fixture
 def mock_databricks_environment():
-    with mock.patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True):
+    with mock.patch("mlflow.genai.datasets.is_databricks_uri", return_value=True):
         yield
 
 
@@ -374,12 +374,45 @@ def test_search_datasets_databricks(mock_databricks_environment):
 
 def test_databricks_import_error():
     with (
-        mock.patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True),
+        mock.patch("mlflow.genai.datasets.is_databricks_uri", return_value=True),
         mock.patch.dict("sys.modules", {"databricks.agents.datasets": None}),
         mock.patch("builtins.__import__", side_effect=ImportError("No module")),
     ):
         with pytest.raises(ImportError, match="databricks-agents"):
             create_dataset(name="test", experiment_id="exp1")
+
+
+def test_databricks_profile_uri_support():
+    mock_dataset = mock.Mock()
+    with (
+        mock.patch(
+            "mlflow.genai.datasets.get_tracking_uri", return_value="databricks://profilename"
+        ),
+        mock.patch.dict(
+            "sys.modules",
+            {
+                "databricks.agents.datasets": mock.Mock(
+                    get_dataset=mock.Mock(return_value=mock_dataset),
+                    create_dataset=mock.Mock(return_value=mock_dataset),
+                    delete_dataset=mock.Mock(),
+                )
+            },
+        ),
+    ):
+        get_dataset(name="catalog.schema.table")
+        sys.modules["databricks.agents.datasets"].get_dataset.assert_called_once_with(
+            "catalog.schema.table"
+        )
+
+        create_dataset(name="catalog.schema.table2", experiment_id=["exp1"])
+        sys.modules["databricks.agents.datasets"].create_dataset.assert_called_once_with(
+            "catalog.schema.table2", ["exp1"]
+        )
+
+        delete_dataset(name="catalog.schema.table3")
+        sys.modules["databricks.agents.datasets"].delete_dataset.assert_called_once_with(
+            "catalog.schema.table3"
+        )
 
 
 def test_create_dataset_with_user_tag(tracking_uri, experiments):

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -372,9 +372,7 @@ def test_evaluate_with_managed_dataset(is_in_databricks):
             mock.patch(
                 "databricks.rag_eval.datasets.entities._get_client", return_value=mock_client
             ),
-            mock.patch(
-                "mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True
-            ),
+            mock.patch("mlflow.genai.datasets.is_databricks_uri", return_value=True),
         ):
             dataset = create_dataset(
                 uc_table_name="mlflow.managed.dataset", experiment_id="exp-123"

--- a/tests/genai/test_genai_import_without_agent_sdk.py
+++ b/tests/genai/test_genai_import_without_agent_sdk.py
@@ -22,7 +22,7 @@ def test_namespaced_import_raises_when_agents_not_installed():
     import mlflow.genai
 
     # Mock to simulate Databricks environment without databricks-agents installed
-    with patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True):
+    with patch("mlflow.genai.datasets.is_databricks_uri", return_value=True):
         with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
             mlflow.genai.create_dataset("test_schema")
 
@@ -40,21 +40,21 @@ def test_mlflow_genai_datasets_star_import_succeeds():
 
 def test_create_dataset_raises_when_agents_not_installed():
     # Mock to simulate Databricks environment without databricks-agents installed
-    with patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True):
+    with patch("mlflow.genai.datasets.is_databricks_uri", return_value=True):
         with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
             create_dataset("test_dataset")
 
 
 def test_get_dataset_raises_when_agents_not_installed():
     # Mock to simulate Databricks environment without databricks-agents installed
-    with patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True):
+    with patch("mlflow.genai.datasets.is_databricks_uri", return_value=True):
         with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
             get_dataset("test_dataset")
 
 
 def test_delete_dataset_raises_when_agents_not_installed():
     # Mock to simulate Databricks environment without databricks-agents installed
-    with patch("mlflow.genai.datasets.is_databricks_default_tracking_uri", return_value=True):
+    with patch("mlflow.genai.datasets.is_databricks_uri", return_value=True):
         with pytest.raises(ImportError, match="The `databricks-agents` package is required"):
             delete_dataset("test_dataset")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18411?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18411/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18411/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18411/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
#18396 

### What changes are proposed in this pull request?

Fixes an issue where profile information was not being recognized when connecting to aliased remote tracking servers on Databricks for evaluation datasets APIs.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
