### PR TITLE
Adjust truncation logic in trace previews

### DIFF
--- a/mlflow/tracing/utils/truncation.py
+++ b/mlflow/tracing/utils/truncation.py
@@ -33,20 +33,18 @@ def _get_truncated_preview(request_or_response: str | None, role: str) -> str:
 
     max_length = _get_max_length()
 
-    if len(request_or_response) <= max_length:
-        return request_or_response
-
     content = None
+    obj = None
 
-    # Parse JSON serialized request/response
     try:
         obj = json.loads(request_or_response)
     except json.JSONDecodeError:
-        obj = None
+        pass
 
-    if messages := _try_extract_messages(obj):
-        msg = _get_last_message(messages, role=role)
-        content = _get_text_content_from_message(msg)
+    if obj is not None:
+        if messages := _try_extract_messages(obj):
+            msg = _get_last_message(messages, role=role)
+            content = _get_text_content_from_message(msg)
 
     content = content or request_or_response
 

--- a/tests/genai/evaluate/test_to_predict_fn.py
+++ b/tests/genai/evaluate/test_to_predict_fn.py
@@ -1,4 +1,3 @@
-import json
 from unittest import mock
 
 import pytest
@@ -110,7 +109,7 @@ def test_to_predict_fn_does_not_return_trace(
     # Bare-minimum trace should be created when the endpoint does not return a trace
     mock_tracing_client.start_trace.assert_called_once()
     trace_info = mock_tracing_client.start_trace.call_args[0][0]
-    assert trace_info.request_preview == json.dumps({"messages": messages})
+    assert trace_info.request_preview == "What is Spark?"
     trace_data = mock_tracing_client._upload_trace_data.call_args[0][1]
     assert len(trace_data.spans) == 1
     assert trace_data.spans[0].name == "predict"
@@ -217,7 +216,7 @@ def test_to_predict_fn_should_not_pass_databricks_options_to_fmapi(
     # Bare-minimum trace should be created when the endpoint does not return a trace
     mock_tracing_client.start_trace.assert_called_once()
     trace_info = mock_tracing_client.start_trace.call_args[0][0]
-    assert trace_info.request_preview == json.dumps({"messages": messages})
+    assert trace_info.request_preview == "What is Spark?"
     trace_data = mock_tracing_client._upload_trace_data.call_args[0][1]
     assert len(trace_data.spans) == 1
     assert trace_data.spans[0].name == "predict"

--- a/tests/tracing/utils/test_truncation.py
+++ b/tests/tracing/utils/test_truncation.py
@@ -176,3 +176,47 @@ def test_truncate_invalid_messages(input_data):
         assert result.startswith(input_str[:20])
     else:
         assert result == input_str
+
+
+@pytest.mark.parametrize(
+    ("request_data", "expected_content", "should_not_contain"),
+    [
+        (
+            {"request": {"input": [{"role": "user", "content": "Hello"}]}},
+            "Hello",
+            "request",
+        ),
+        (
+            {"request": {"tool_choice": None, "input": [{"role": "user", "content": "Weather?"}]}},
+            "Weather?",
+            '"tool_choice"',
+        ),
+        (
+            {"request": {"input": [{"role": "user", "content": "Hi"}]}},
+            "Hi",
+            '"request"',
+        ),
+    ],
+    ids=["short_structured_json", "agent_format_with_null_fields", "responses_agent_short"],
+)
+def test_truncate_structured_json_extracts_content(request_data, expected_content, should_not_contain):
+    input_str = json.dumps(request_data)
+    result = _get_truncated_preview(input_str, role="user")
+    assert result == expected_content
+    assert should_not_contain not in result
+
+
+@pytest.mark.parametrize(
+    ("content_value", "expected_in_result"),
+    [
+        (None, '"content": null'),
+        ("", '"content": ""'),
+        (123, '"content": 123'),
+    ],
+    ids=["null_content", "empty_string_content", "numeric_content"],
+)
+def test_truncate_invalid_content_falls_back_to_json(content_value, expected_in_result):
+    request_data = {"input": [{"role": "user", "content": content_value}]}
+    input_str = json.dumps(request_data)
+    result = _get_truncated_preview(input_str, role="user")
+    assert expected_in_result in result or result.endswith("...")

--- a/tests/tracing/utils/test_truncation.py
+++ b/tests/tracing/utils/test_truncation.py
@@ -199,7 +199,9 @@ def test_truncate_invalid_messages(input_data):
     ],
     ids=["short_structured_json", "agent_format_with_null_fields", "responses_agent_short"],
 )
-def test_truncate_structured_json_extracts_content(request_data, expected_content, should_not_contain):
+def test_truncate_structured_json_extracts_content(
+    request_data, expected_content, should_not_contain
+):
     input_str = json.dumps(request_data)
     result = _get_truncated_preview(input_str, role="user")
     assert result == expected_content


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18412?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18412/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18412/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18412/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Adjusts the logic within trace truncation and parsing for previews to be more consistent with content (namely for agent workflows) parsing by removing the short-circuit based on content length and extracting after serializing for every message.

This change is in response to user confusion with agent demos and the application of traced DSPy operations that create preview elements of the trace structure for short-length traces that are inconsistent based on the nature of the agent (some inputs create extracted components that have an ideal UI experience, shorter ones contain raw JSON that is filled with null values for fields that are not used), adding to confusion and an assumption that something is broken with the MLflow UI. 

The impact of this change is slight ( a negligible ~<100us / trace) in order to get the massive UX benefits of smart extraction and consistency of experience. 

For performance impact, I did a test of deserializing traces that are near the threshold of the cutoff mark to estimate what the effect would be. 

For 1000 traces (Requests format):

Average processing time overhead: 103.7us
Min overhead: 99.7us
Max overhead: 111.3us

Without the smart parsing (existing logic) averaged 0.13us of processing time to run through the truncation util (up to the short-circuit portion). 

This represents ~800x performance impact. 

However, when running these demo traces through the entire processing pipeline, it represents a net increase in total processing of ~0.5% of the total end to end execution time and added ~5% additional CPU load for running through a simulated load of 500 traces / s. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
