### PR TITLE
[Eval #1] Fix uniquness handling of trace linking

### DIFF
--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -8221,6 +8221,26 @@ def test_link_traces_to_run_100_limit(store: SqlAlchemyStore):
         store.link_traces_to_run(trace_ids, run.info.run_id)
 
 
+def test_link_traces_to_run_duplicate_trace_ids(store: SqlAlchemyStore):
+    exp_id = store.create_experiment(f"exp-{uuid.uuid4()}")
+    trace_ids = ["trace-1", "trace-2", "trace-3", "trace-4"]
+    for trace_id in trace_ids:
+        trace_info = _create_trace_info(trace_id, exp_id)
+        store.start_trace(trace_info)
+    run = store.create_run(exp_id, user_id="user", start_time=0, tags=[], run_name="test_run")
+    search_args = {"experiment_ids": [exp_id], "filter_string": f"run_id = '{run.info.run_id}'"}
+
+    store.link_traces_to_run(["trace-1", "trace-2", "trace-3"], run.info.run_id)
+
+    assert len(store.search_traces(**search_args)[0]) == 3
+
+    store.link_traces_to_run(["trace-3", "trace-4"], run.info.run_id)
+    assert len(store.search_traces(**search_args)[0]) == 4
+
+    store.link_traces_to_run(["trace-1", "trace-2"], run.info.run_id)
+    assert len(store.search_traces(**search_args)[0]) == 4
+
+
 def test_scorer_operations(store: SqlAlchemyStore):
     """
     Test the scorer operations: register_scorer, list_scorers, get_scorer, and delete_scorer.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18414/files) to review incremental changes.
- [**stack/migrate-eval-1**](https://github.com/mlflow/mlflow/pull/18414) [[Files changed](https://github.com/mlflow/mlflow/pull/18414/files)]
  - [stack/migrate-eval-2](https://github.com/mlflow/mlflow/pull/18415) [[Files changed](https://github.com/mlflow/mlflow/pull/18415/files/e60f3996ca6be6cecca31871a99ed5d2a9fe7ae9..9728a4790245928bc69dfdc3bb031406337e1960)]
    - [stack/migrate-eval-3](https://github.com/mlflow/mlflow/pull/18416) [[Files changed](https://github.com/mlflow/mlflow/pull/18416/files/9728a4790245928bc69dfdc3bb031406337e1960..65aed1755656325463d01f6afec7effb64fd538f)]
      - [stack/migrate-eval-4](https://github.com/mlflow/mlflow/pull/18429) [[Files changed](https://github.com/mlflow/mlflow/pull/18429/files/65aed1755656325463d01f6afec7effb64fd538f..e164f5162bf0e01ca1db5508fa127eae77e54319)]

---------
### What changes are proposed in this pull request?

A small prep work for migrating (unifying) DBX eval harness into OSS one. The `LinkTracesToRun` implementation in SQL store has an issue that it doesn't check the existing rows, therefore when we call the API with a pair of trace and run that are already linked, the API raises an SQL uniqueness constraint error. It is not desirable that we need to check the uniqueness at client side so this should be idempotent.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
