### PR TITLE
Fix span ID parsing in the UI

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.test.tsx
@@ -654,3 +654,37 @@ describe('getDefaultActiveTab', () => {
     expect(getDefaultActiveTab(otelSpan)).toBe('attributes');
   });
 });
+
+describe('decodeSpanId', () => {
+  it('should decode v3 base64 span id when length < 16', () => {
+    const base64Id = 'FFJ0+hVpnGg=';
+    const result = decodeSpanId(base64Id, true);
+    expect(result).toBe('145274fa15699c68');
+  });
+
+  it('should return v3 hex span id as-is when length >= 16', () => {
+    // 16 character hex string (8 bytes)
+    const hexId = '145274fa15699c68';
+    const result = decodeSpanId(hexId, true);
+    expect(result).toBe('145274fa15699c68');
+  });
+
+  it('should decode v2 span id with 0x prefix', () => {
+    const spanId = '0x145274fa15699c68';
+    const result = decodeSpanId(spanId, false);
+    expect(result).toBe('145274fa15699c68');
+  });
+
+  it('should return v2 hex span id as-is without prefix', () => {
+    const spanId = '145274fa15699c68';
+    const result = decodeSpanId(spanId, false);
+    expect(result).toBe('145274fa15699c68');
+  });
+
+  it('should return empty string for null or undefined span id', () => {
+    expect(decodeSpanId(null, true)).toBe('');
+    expect(decodeSpanId(undefined, true)).toBe('');
+    expect(decodeSpanId(null, false)).toBe('');
+    expect(decodeSpanId(undefined, false)).toBe('');
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -453,7 +453,8 @@ export const decodeSpanId = (spanId: string | null | undefined, isV3Span: boolea
     return '';
   }
 
-  if (isV3Span) {
+  // only attempt decoding if the id length is less than 16 chars
+  if (isV3Span && spanId.length < 16) {
     // v3 span ids are base64 encoded
     try {
       return base64ToHex(spanId);


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/18419?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18419/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18419/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18419/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

In 3.5.0, we removed base64 encoding for span IDs. However, the UI still tries to parse it as base64, which causes a mismatch with associated assessments. This PR fixes by only parsing the ID if it's less than 16 chars.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Run the following script, and validate assessments can be viewed in UI

```python
import mlflow


@mlflow.trace
def bar():
    return mlflow.get_current_active_span().span_id


@mlflow.trace
def foo():
    return bar()


span_id = foo()
mlflow.log_feedback(
    trace_id=mlflow.get_last_active_trace_id(),
    span_id=span_id,
    value=1.0,
    name="test",
)
```

<img width="1727" height="958" alt="Screenshot 2025-10-21 at 9 41 57 AM" src="https://github.com/user-attachments/assets/40e6dc7b-59c2-4945-aaf5-5238604a2c21" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
