### PR TITLE
Move fastmcp to optional mcp extra

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -380,7 +380,7 @@ jobs:
       - uses: ./.github/actions/setup-java
       - name: Install python dependencies
         run: |
-          uv sync --extra extras --extra genai
+          uv sync --extra extras --extra genai --extra mcp
           uv pip install \
             -r requirements/test-requirements.txt \
             'pyspark<3.5.6' datasets tensorflow torch transformers tf-keras openai \

--- a/dev/install-common-deps.sh
+++ b/dev/install-common-deps.sh
@@ -50,7 +50,7 @@ pip --version
 if [[ "$SKINNY" == "true" ]]; then
   pip install ./libs/skinny
 else
-  pip install .[extras,gateway,jobs] --upgrade
+  pip install .[extras,gateway,jobs,mcp] --upgrade
 fi
 
 req_files=""

--- a/dev/pyproject.py
+++ b/dev/pyproject.py
@@ -351,6 +351,7 @@ def build(package_type: PackageType) -> None:
                 ],
                 "gateway": gateways_requirements,
                 "genai": gateways_requirements,
+                "mcp": ["fastmcp<3,>=2.0.0"],
                 "sqlserver": ["mlflow-dbstore"],
                 "aliyun-oss": ["aliyunstoreplugin"],
                 "jfrog": ["mlflow-jfrog-plugin"],

--- a/docs/docs/genai/mcp/index.mdx
+++ b/docs/docs/genai/mcp/index.mdx
@@ -32,10 +32,8 @@ This integration makes it easy to incorporate MLflow tracing capabilities into A
 To use the MLflow MCP server, install MLflow with the `mcp` extra:
 
 ```bash
-pip install mlflow[mcp]>=3.5.1
+pip install 'mlflow[mcp]>=3.5.1'
 ```
-
-This installs MLflow along with the required MCP dependencies (`fastmcp`).
 
 ## Set up
 

--- a/docs/docs/genai/mcp/index.mdx
+++ b/docs/docs/genai/mcp/index.mdx
@@ -6,7 +6,7 @@ import TabItem from "@theme/TabItem";
 :::info
 
 - This feature is experimental and may change in future releases.
-- MLflow 3.4 or newer is required.
+- MLflow 3.5.1 or newer is required.
 
 :::
 
@@ -24,8 +24,18 @@ This integration makes it easy to incorporate MLflow tracing capabilities into A
 
 ## Prerequisites
 
-- MLflow version 3.4 or newer
+- MLflow version 3.5.1 or newer
 - An MCP-compatible client (VS Code, Cursor, Claude, etc.)
+
+## Installation
+
+To use the MLflow MCP server, install MLflow with the `mcp` extra:
+
+```bash
+pip install mlflow[mcp]>=3.5.1
+```
+
+This installs MLflow along with the required MCP dependencies (`fastmcp`).
 
 ## Set up
 
@@ -41,7 +51,7 @@ Add to your VS Code configuration file (`.vscode/mcp.json`):
   "servers": {
     "mlflow-mcp": {
       "command": "uv",
-      "args": ["run", "--with", "mlflow>=3.4", "mlflow", "mcp", "run"],
+      "args": ["run", "--with", "mlflow>=3.5.1", "--extra", "mcp", "mlflow", "mcp", "run"],
       "env": {
         "MLFLOW_TRACKING_URI": "<MLFLOW_TRACKING_URI>"
       }
@@ -60,7 +70,7 @@ Add to your Cursor configuration file (`.cursor/mcp.json`):
   "mcpServers": {
     "mlflow-mcp": {
       "command": "uv",
-      "args": ["run", "--with", "mlflow>=3.4", "mlflow", "mcp", "run"],
+      "args": ["run", "--with", "mlflow>=3.5.1", "--extra", "mcp", "mlflow", "mcp", "run"],
       "env": {
         "MLFLOW_TRACKING_URI": "<MLFLOW_TRACKING_URI>"
       }
@@ -79,7 +89,7 @@ Add to your Claude `.claude/settings.json`:
   "mcpServers": {
     "mlflow-mcp": {
       "command": "uv",
-      "args": ["run", "--with", "mlflow>=3.4", "mlflow", "mcp", "run"],
+      "args": ["run", "--with", "mlflow>=3.5.1", "--extra", "mcp", "mlflow", "mcp", "run"],
       "env": {
         "MLFLOW_TRACKING_URI": "<MLFLOW_TRACKING_URI>"
       }

--- a/libs/skinny/pyproject.toml
+++ b/libs/skinny/pyproject.toml
@@ -94,6 +94,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
+mcp = ["fastmcp<3,>=2.0.0"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]

--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -1,15 +1,17 @@
 import contextlib
 import io
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import click
 from click.types import BOOL, FLOAT, INT, STRING, UUID
-from fastmcp import FastMCP
-from fastmcp.tools import FunctionTool
 
 from mlflow.ai_commands.ai_command_utils import get_command_body, list_commands
 from mlflow.cli.scorers import commands as scorers_cli
 from mlflow.cli.traces import commands as traces_cli
+
+if TYPE_CHECKING:
+    from fastmcp import FastMCP
+    from fastmcp.tools import FunctionTool
 
 
 def param_type_to_json_schema_type(pt: click.ParamType) -> str:
@@ -70,10 +72,12 @@ def fn_wrapper(command: click.Command) -> Callable[..., str]:
     return wrapper
 
 
-def cmd_to_function_tool(cmd: click.Command) -> FunctionTool:
+def cmd_to_function_tool(cmd: click.Command) -> "FunctionTool":
     """
     Converts a Click command to a FunctionTool.
     """
+    from fastmcp.tools import FunctionTool
+
     return FunctionTool(
         fn=fn_wrapper(cmd),
         name=cmd.callback.__name__,
@@ -82,7 +86,7 @@ def cmd_to_function_tool(cmd: click.Command) -> FunctionTool:
     )
 
 
-def register_prompts(mcp: FastMCP) -> None:
+def register_prompts(mcp: "FastMCP") -> None:
     """Register AI commands as MCP prompts."""
     for command in list_commands():
         # Convert slash-separated keys to underscores for MCP names
@@ -101,7 +105,9 @@ def register_prompts(mcp: FastMCP) -> None:
         make_prompt(command["key"])
 
 
-def create_mcp() -> FastMCP:
+def create_mcp() -> "FastMCP":
+    from fastmcp import FastMCP
+
     tools = [
         *[cmd_to_function_tool(cmd) for cmd in traces_cli.commands.values()],
         *[cmd_to_function_tool(cmd) for cmd in scorers_cli.commands.values()],

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -34,7 +34,6 @@ dependencies = [
   "alembic<2,!=1.10.0",
   "cryptography<47,>=43.0.0",
   "docker<8,>=4.0.0",
-  "fastmcp<3,>=2.0.0",
   "graphene<4",
   "gunicorn<24; platform_system != 'Windows'",
   "matplotlib<4",
@@ -95,6 +94,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
+mcp = ["fastmcp<3,>=2.0.0"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ dependencies = [
   "databricks-sdk<1,>=0.20.0",
   "docker<8,>=4.0.0",
   "fastapi<1",
-  "fastmcp<3,>=2.0.0",
   "gitpython<4,>=3.1.9",
   "graphene<4",
   "gunicorn<24; platform_system != 'Windows'",
@@ -112,6 +111,7 @@ genai = [
   "uvicorn[standard]<1",
   "watchfiles<2",
 ]
+mcp = ["fastmcp<3,>=2.0.0"]
 sqlserver = ["mlflow-dbstore"]
 aliyun-oss = ["aliyunstoreplugin"]
 jfrog = ["mlflow-jfrog-plugin"]

--- a/requirements/core-requirements.yaml
+++ b/requirements/core-requirements.yaml
@@ -71,8 +71,3 @@ matplotlib:
 graphene:
   pip_release: graphene
   max_major_version: 3
-
-fastmcp:
-  pip_release: fastmcp
-  minimum: "2.0.0"
-  max_major_version: 2

--- a/uv.lock
+++ b/uv.lock
@@ -1440,18 +1440,19 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "3.24.0"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
-    { name = "docstring-parser", marker = "python_full_version < '4'" },
+    { name = "docstring-parser" },
     { name = "rich" },
     { name = "rich-rst" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/30/ca/7782da3b03242d5f0a16c20371dff99d4bd1fedafe26bc48ff82e42be8c9/cyclopts-3.24.0.tar.gz", hash = "sha256:de6964a041dfb3c57bf043b41e68c43548227a17de1bad246e3a0bfc5c4b7417", size = 76131, upload-time = "2025-09-08T15:40:57.75Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/d1/2f2b99ec5ea54ac18baadfc4a011e2a1743c1eaae1e39838ca520dcf4811/cyclopts-4.0.0.tar.gz", hash = "sha256:0dae712085e91d32cc099ea3d78f305b0100a3998b1dec693be9feb0b1be101f", size = 143546, upload-time = "2025-10-20T18:33:01.456Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/8b/2c95f0645c6f40211896375e6fa51f504b8ccb29c21f6ae661fe87ab044e/cyclopts-3.24.0-py3-none-any.whl", hash = "sha256:809d04cde9108617106091140c3964ee6fceb33cecdd537f7ffa360bde13ed71", size = 86154, upload-time = "2025-09-08T15:40:56.41Z" },
+    { url = "https://files.pythonhosted.org/packages/44/0e/0a22e076944600aeb06f40b7e03bbd762a42d56d43a2f5f4ab954aed9005/cyclopts-4.0.0-py3-none-any.whl", hash = "sha256:e64801a2c86b681f08323fd50110444ee961236a0bae402a66d2cc3feda33da7", size = 178837, upload-time = "2025-10-20T18:33:00.191Z" },
 ]
 
 [[package]]
@@ -1686,7 +1687,7 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "2.12.4"
+version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "authlib" },
@@ -1701,9 +1702,9 @@ dependencies = [
     { name = "python-dotenv" },
     { name = "rich" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/b2/57845353a9bc63002995a982e66f3d0be4ec761e7bcb89e7d0638518d42a/fastmcp-2.12.4.tar.gz", hash = "sha256:b55fe89537038f19d0f4476544f9ca5ac171033f61811cc8f12bdeadcbea5016", size = 7167745, upload-time = "2025-09-26T16:43:27.71Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/a6/e3b46cd3e228635e0064c2648788b6f66a53bf0d0ddbf5fb44cca951f908/fastmcp-2.12.5.tar.gz", hash = "sha256:2dfd02e255705a4afe43d26caddbc864563036e233dbc6870f389ee523b39a6a", size = 7190263, upload-time = "2025-10-17T13:24:58.896Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/c7/562ff39f25de27caec01e4c1e88cbb5fcae5160802ba3d90be33165df24f/fastmcp-2.12.4-py3-none-any.whl", hash = "sha256:56188fbbc1a9df58c537063f25958c57b5c4d715f73e395c41b51550b247d140", size = 329090, upload-time = "2025-09-26T16:43:25.314Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/c1/9fb98c9649e15ea8cc691b4b09558b61dafb3dc0345f7322f8c4a8991ade/fastmcp-2.12.5-py3-none-any.whl", hash = "sha256:b1e542f9b83dbae7cecfdc9c73b062f77074785abda9f2306799116121344133", size = 329099, upload-time = "2025-10-17T13:24:57.518Z" },
 ]
 
 [[package]]
@@ -3320,7 +3321,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.17.0"
+version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -3335,9 +3336,9 @@ dependencies = [
     { name = "starlette" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/79/5724a540df19e192e8606c543cdcf162de8eb435077520cca150f7365ec0/mcp-1.17.0.tar.gz", hash = "sha256:1b57fabf3203240ccc48e39859faf3ae1ccb0b571ff798bbedae800c73c6df90", size = 477951, upload-time = "2025-10-10T12:16:44.519Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/a1/b1f328da3b153683d2ec34f849b4b6eac2790fb240e3aef06ff2fab3df9d/mcp-1.16.0.tar.gz", hash = "sha256:39b8ca25460c578ee2cdad33feeea122694cfdf73eef58bee76c42f6ef0589df", size = 472918, upload-time = "2025-10-02T16:58:20.631Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/72/3751feae343a5ad07959df713907b5c3fbaed269d697a14b0c449080cf2e/mcp-1.17.0-py3-none-any.whl", hash = "sha256:0660ef275cada7a545af154db3082f176cf1d2681d5e35ae63e014faf0a35d40", size = 167737, upload-time = "2025-10-10T12:16:42.863Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/0e/7cebc88e17daf94ebe28c95633af595ccb2864dc2ee7abd75542d98495cc/mcp-1.16.0-py3-none-any.whl", hash = "sha256:ec917be9a5d31b09ba331e1768aa576e0af45470d657a0319996a20a57d7d633", size = 167266, upload-time = "2025-10-02T16:58:19.039Z" },
 ]
 
 [[package]]
@@ -3362,7 +3363,6 @@ dependencies = [
     { name = "databricks-sdk" },
     { name = "docker" },
     { name = "fastapi" },
-    { name = "fastmcp" },
     { name = "flask" },
     { name = "flask-cors" },
     { name = "gitpython" },
@@ -3445,6 +3445,9 @@ jobs = [
 ]
 langchain = [
     { name = "langchain" },
+]
+mcp = [
+    { name = "fastmcp" },
 ]
 mlserver = [
     { name = "mlserver" },
@@ -3529,7 +3532,7 @@ requires-dist = [
     { name = "fastapi", specifier = "<1" },
     { name = "fastapi", marker = "extra == 'gateway'", specifier = "<1" },
     { name = "fastapi", marker = "extra == 'genai'", specifier = "<1" },
-    { name = "fastmcp", specifier = ">=2.0.0,<3" },
+    { name = "fastmcp", marker = "extra == 'mcp'", specifier = ">=2.0.0,<3" },
     { name = "flask", specifier = "<4" },
     { name = "flask-cors", specifier = "<7" },
     { name = "flask-wtf", marker = "extra == 'auth'", specifier = "<2" },
@@ -3580,7 +3583,7 @@ requires-dist = [
     { name = "watchfiles", marker = "extra == 'gateway'", specifier = "<2" },
     { name = "watchfiles", marker = "extra == 'genai'", specifier = "<2" },
 ]
-provides-extras = ["extras", "databricks", "mlserver", "gateway", "genai", "sqlserver", "aliyun-oss", "jfrog", "langchain", "auth", "jobs"]
+provides-extras = ["extras", "databricks", "mlserver", "gateway", "genai", "mcp", "sqlserver", "aliyun-oss", "jfrog", "langchain", "auth", "jobs"]
 
 [package.metadata.requires-dev]
 build = [


### PR DESCRIPTION
### Related Issues/PRs

Fix https://github.com/mlflow/mlflow/issues/18407

### What changes are proposed in this pull request?

This PR moves `fastmcp` from core dependencies to a new optional `mcp` extra. Users who need MCP server functionality must now explicitly install it:

```bash
pip install mlflow[mcp]>=3.5.1
```

This change reduces the default dependency footprint for users who don't use the MCP server feature.

### How is this PR tested?

- [x] Existing unit/integration tests (MCP tests in CI updated to install mcp extra)
- [x] Manual tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions (installation commands in MCP docs)

### Release Notes

#### Is this a user-facing change?

- [x] Yes. `fastmcp` is now an optional dependency. To use the MLflow MCP server, install with: `pip install mlflow[mcp]>=3.5.1`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [x] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)