### PR TITLE
Fix typo in gepa version

### DIFF
--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -215,7 +215,7 @@ class GepaPromptOptimizer(BasePromptOptimizer):
             "use_mlflow": enable_tracking,
         }
 
-        if Version(importlib.metadata.version("gepa")) < Version("0.10.0"):
+        if Version(importlib.metadata.version("gepa")) < Version("0.0.10"):
             kwargs.pop("use_mlflow")
         gepa_result = gepa.optimize(**kwargs)
 

--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -215,7 +215,7 @@ class GepaPromptOptimizer(BasePromptOptimizer):
             "use_mlflow": enable_tracking,
         }
 
-        if Version(importlib.metadata.version("gepa")) < Version("0.0.10"):
+        if Version(importlib.metadata.version("gepa")) < Version("0.0.18"):
             kwargs.pop("use_mlflow")
         gepa_result = gepa.optimize(**kwargs)
 

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -375,17 +375,8 @@ def test_make_reflective_dataset_with_traces(
     assert system_data[1]["expectations"] == {"expected_response": "Paris"}
 
 
-@pytest.mark.parametrize(
-    ("gepa_version", "enable_tracking"),
-    [
-        ("0.0.9", True),
-        ("0.0.5", False),
-        ("0.0.10", True),
-        ("0.0.10", False),
-        ("0.1.0", True),
-        ("0.1.0", False),
-    ],
-)
+@pytest.mark.parametrize("gepa_version", ["0.0.9", "0.0.18", "0.1.0"])
+@pytest.mark.parametrize("enable_tracking", [True, False])
 def test_gepa_optimizer_version_check(
     sample_train_data: list[dict[str, Any]],
     sample_target_prompts: dict[str, str],

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -3,6 +3,7 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
+from packaging.version import Version
 
 from mlflow.genai.optimize.optimizers.gepa_optimizer import GepaPromptOptimizer
 from mlflow.genai.optimize.types import EvaluationResultRecord, PromptOptimizerOutput
@@ -372,3 +373,55 @@ def test_make_reflective_dataset_with_traces(
     assert system_data[1]["inputs"] == {"question": "What is the capital of France?"}
     assert system_data[1]["outputs"] == "Paris"
     assert system_data[1]["expectations"] == {"expected_response": "Paris"}
+
+
+@pytest.mark.parametrize(
+    ("gepa_version", "enable_tracking"),
+    [
+        ("0.0.9", True),
+        ("0.0.5", False),
+        ("0.0.10", True),
+        ("0.0.10", False),
+        ("0.1.0", True),
+        ("0.1.0", False),
+    ],
+)
+def test_gepa_optimizer_version_check(
+    sample_train_data: list[dict[str, Any]],
+    sample_target_prompts: dict[str, str],
+    mock_eval_fn: Any,
+    gepa_version: str,
+    enable_tracking: bool,
+):
+    mock_gepa_module = MagicMock()
+    mock_modules = {
+        "gepa": mock_gepa_module,
+        "gepa.core": MagicMock(),
+        "gepa.core.adapter": MagicMock(),
+    }
+    mock_result = Mock()
+    mock_result.best_candidate = sample_target_prompts
+    mock_result.val_aggregate_scores = []
+    mock_gepa_module.optimize.return_value = mock_result
+    mock_gepa_module.EvaluationBatch = MagicMock()
+
+    optimizer = GepaPromptOptimizer(reflection_model="openai:/gpt-4o")
+
+    with (
+        patch.dict(sys.modules, mock_modules),
+        patch("importlib.metadata.version", return_value=gepa_version),
+    ):
+        optimizer.optimize(
+            eval_fn=mock_eval_fn,
+            train_data=sample_train_data,
+            target_prompts=sample_target_prompts,
+            enable_tracking=enable_tracking,
+        )
+
+    call_kwargs = mock_gepa_module.optimize.call_args.kwargs
+
+    if Version(gepa_version) < Version("0.0.10"):
+        assert "use_mlflow" not in call_kwargs
+    else:
+        assert "use_mlflow" in call_kwargs
+        assert call_kwargs["use_mlflow"] == enable_tracking


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18423?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18423/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18423/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18423/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Fix typo in gepa version, which should be 0.0.18 instead of 0.10.0.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
