### PR TITLE
Add support for profile usage in Databricks Agents dataset API operat…

### DIFF
--- a/mlflow/genai/datasets/__init__.py
+++ b/mlflow/genai/datasets/__init__.py
@@ -7,14 +7,16 @@ The API docs can be found here:
 """
 
 import logging
+import os
 import time
+from contextlib import contextmanager
 from typing import Any
 
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 from mlflow.store.tracking import SEARCH_EVALUATION_DATASETS_MAX_RESULTS
 from mlflow.tracking import get_tracking_uri
 from mlflow.utils.annotations import deprecated_parameter, experimental
-from mlflow.utils.uri import is_databricks_uri
+from mlflow.utils.uri import get_db_info_from_uri, is_databricks_uri
 
 _logger = logging.getLogger(__name__)
 
@@ -22,6 +24,41 @@ _ERROR_MSG = (
     "The `databricks-agents` package is required to use `mlflow.genai.datasets`. "
     "Please install it with `pip install databricks-agents`."
 )
+
+_DATABRICKS_CONFIG_PROFILE_ENV_VAR = "DATABRICKS_CONFIG_PROFILE"
+
+
+@contextmanager
+def _databricks_profile_env():
+    """
+    Context manager that temporarily sets DATABRICKS_CONFIG_PROFILE based on the tracking URI.
+
+    This ensures that databricks.agents SDK functions use the correct profile specified
+    in the MLflow tracking URI. The databricks.agents SDK creates WorkspaceClient instances
+    internally without accepting profile parameters, so it relies on the
+    DATABRICKS_CONFIG_PROFILE environment variable to determine which profile to use.
+
+    The tracking URI profile takes precedence over any existing DATABRICKS_CONFIG_PROFILE
+    environment variable for the duration of MLflow operations. The original value is
+    restored after the operation completes.
+    """
+    tracking_uri = get_tracking_uri()
+    profile, _ = get_db_info_from_uri(tracking_uri)
+
+    if not profile:
+        yield
+        return
+
+    original_profile = os.environ.get(_DATABRICKS_CONFIG_PROFILE_ENV_VAR)
+    os.environ[_DATABRICKS_CONFIG_PROFILE_ENV_VAR] = profile
+
+    try:
+        yield
+    finally:
+        if original_profile is not None:
+            os.environ[_DATABRICKS_CONFIG_PROFILE_ENV_VAR] = original_profile
+        else:
+            os.environ.pop(_DATABRICKS_CONFIG_PROFILE_ENV_VAR, None)
 
 
 def _validate_databricks_params(
@@ -140,7 +177,8 @@ def create_dataset(
         try:
             from databricks.agents.datasets import create_dataset as db_create
 
-            return EvaluationDataset(db_create(name, experiment_ids))
+            with _databricks_profile_env():
+                return EvaluationDataset(db_create(name, experiment_ids))
         except ImportError as e:
             raise ImportError(_ERROR_MSG) from e
     else:
@@ -213,7 +251,8 @@ def delete_dataset(
         try:
             from databricks.agents.datasets import delete_dataset as db_delete
 
-            return db_delete(name)
+            with _databricks_profile_env():
+                return db_delete(name)
         except ImportError as e:
             raise ImportError(_ERROR_MSG) from e
     else:
@@ -277,7 +316,8 @@ def get_dataset(
         try:
             from databricks.agents.datasets import get_dataset as db_get
 
-            return EvaluationDataset(db_get(name))
+            with _databricks_profile_env():
+                return EvaluationDataset(db_get(name))
         except ImportError as e:
             raise ImportError(_ERROR_MSG) from e
     else:

--- a/mlflow/genai/datasets/evaluation_dataset.py
+++ b/mlflow/genai/datasets/evaluation_dataset.py
@@ -183,15 +183,23 @@ class EvaluationDataset(Dataset, PyFuncConvertibleDatasetMixin):
         if self._mlflow_dataset:
             self._mlflow_dataset.merge_records(records)
             return self
-        dataset = self._databricks_dataset.merge_records(records)
+
+        from mlflow.genai.datasets import _databricks_profile_env
+
+        with _databricks_profile_env():
+            dataset = self._databricks_dataset.merge_records(records)
         return EvaluationDataset(dataset)
 
     def to_df(self) -> "pd.DataFrame":
         """Convert the dataset to a pandas DataFrame."""
         if self._mlflow_dataset:
             return self._mlflow_dataset.to_df()
+
         if self._df is None:
-            self._df = self._databricks_dataset.to_df()
+            from mlflow.genai.datasets import _databricks_profile_env
+
+            with _databricks_profile_env():
+                self._df = self._databricks_dataset.to_df()
         return self._df
 
     def has_records(self) -> bool:

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -513,7 +513,7 @@ def test_databricks_dataset_merge_records_uses_profile(monkeypatch):
     monkeypatch.setitem(sys.modules, "databricks.agents.datasets", mock_agents_module)
     monkeypatch.setattr("mlflow.genai.datasets.get_tracking_uri", lambda: "databricks://myprofile")
 
-    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
 
     dataset = get_dataset(name="catalog.schema.table")
 

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -446,13 +446,14 @@ def test_databricks_profile_env_var_set_from_uri(monkeypatch):
     monkeypatch.setitem(sys.modules, "databricks.agents.datasets", mock_agents_module)
     monkeypatch.setattr("mlflow.genai.datasets.get_tracking_uri", lambda: "databricks://myprofile")
 
-    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
 
     get_dataset(name="catalog.schema.table")
     create_dataset(name="catalog.schema.table", experiment_id="exp1")
     delete_dataset(name="catalog.schema.table")
 
-    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
+
     assert profile_values_during_calls == [
         ("get_dataset", "myprofile"),
         ("create_dataset", "myprofile"),
@@ -517,15 +518,15 @@ def test_databricks_dataset_merge_records_uses_profile(monkeypatch):
 
     dataset = get_dataset(name="catalog.schema.table")
 
-    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
 
     dataset.merge_records([{"inputs": {"q": "test"}}])
     assert profile_during_merge == "myprofile"
-    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
 
     dataset.to_df()
     assert profile_during_to_df == "myprofile"
-    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+    assert "DATABRICKS_CONFIG_PROFILE" not in os.environ
 
 
 def test_create_dataset_with_user_tag(tracking_uri, experiments):

--- a/tests/genai/datasets/test_fluent.py
+++ b/tests/genai/datasets/test_fluent.py
@@ -417,6 +417,117 @@ def test_databricks_profile_uri_support():
         )
 
 
+def test_databricks_profile_env_var_set_from_uri(monkeypatch):
+    mock_dataset = mock.Mock()
+    profile_values_during_calls = []
+
+    def mock_get_dataset(name):
+        profile_values_during_calls.append(
+            ("get_dataset", os.environ.get("DATABRICKS_CONFIG_PROFILE"))
+        )
+        return mock_dataset
+
+    def mock_create_dataset(name, experiment_ids):
+        profile_values_during_calls.append(
+            ("create_dataset", os.environ.get("DATABRICKS_CONFIG_PROFILE"))
+        )
+        return mock_dataset
+
+    def mock_delete_dataset(name):
+        profile_values_during_calls.append(
+            ("delete_dataset", os.environ.get("DATABRICKS_CONFIG_PROFILE"))
+        )
+
+    mock_agents_module = mock.Mock(
+        get_dataset=mock_get_dataset,
+        create_dataset=mock_create_dataset,
+        delete_dataset=mock_delete_dataset,
+    )
+    monkeypatch.setitem(sys.modules, "databricks.agents.datasets", mock_agents_module)
+    monkeypatch.setattr("mlflow.genai.datasets.get_tracking_uri", lambda: "databricks://myprofile")
+
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+
+    get_dataset(name="catalog.schema.table")
+    create_dataset(name="catalog.schema.table", experiment_id="exp1")
+    delete_dataset(name="catalog.schema.table")
+
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+    assert profile_values_during_calls == [
+        ("get_dataset", "myprofile"),
+        ("create_dataset", "myprofile"),
+        ("delete_dataset", "myprofile"),
+    ]
+
+
+def test_databricks_profile_env_var_overridden_and_restored(monkeypatch):
+    mock_dataset = mock.Mock()
+    profile_during_call = None
+
+    def mock_get_dataset(name):
+        nonlocal profile_during_call
+        profile_during_call = os.environ.get("DATABRICKS_CONFIG_PROFILE")
+        return mock_dataset
+
+    mock_agents_module = mock.Mock(get_dataset=mock_get_dataset)
+    monkeypatch.setitem(sys.modules, "databricks.agents.datasets", mock_agents_module)
+    monkeypatch.setattr("mlflow.genai.datasets.get_tracking_uri", lambda: "databricks://myprofile")
+    monkeypatch.setenv("DATABRICKS_CONFIG_PROFILE", "original_profile")
+
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") == "original_profile"
+
+    get_dataset(name="catalog.schema.table")
+
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") == "original_profile"
+    assert profile_during_call == "myprofile"
+
+
+def test_databricks_dataset_merge_records_uses_profile(monkeypatch):
+    profile_during_merge = None
+    profile_during_to_df = None
+
+    mock_inner_dataset = mock.Mock()
+    mock_inner_dataset.digest = "test_digest"
+    mock_inner_dataset.name = "catalog.schema.table"
+    mock_inner_dataset.dataset_id = "dataset-123"
+
+    def mock_merge_records(records):
+        nonlocal profile_during_merge
+        profile_during_merge = os.environ.get("DATABRICKS_CONFIG_PROFILE")
+        return mock_inner_dataset
+
+    def mock_to_df():
+        nonlocal profile_during_to_df
+        profile_during_to_df = os.environ.get("DATABRICKS_CONFIG_PROFILE")
+        import pandas as pd
+
+        return pd.DataFrame({"test": [1, 2, 3]})
+
+    mock_inner_dataset.merge_records = mock_merge_records
+    mock_inner_dataset.to_df = mock_to_df
+
+    def mock_get_dataset(name):
+        return mock_inner_dataset
+
+    mock_agents_module = mock.Mock(get_dataset=mock_get_dataset)
+    monkeypatch.setitem(sys.modules, "databricks.agents.datasets", mock_agents_module)
+    monkeypatch.setattr("mlflow.genai.datasets.get_tracking_uri", lambda: "databricks://myprofile")
+
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+
+    dataset = get_dataset(name="catalog.schema.table")
+
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+
+    dataset.merge_records([{"inputs": {"q": "test"}}])
+    assert profile_during_merge == "myprofile"
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+
+    dataset.to_df()
+    assert profile_during_to_df == "myprofile"
+    assert os.environ.get("DATABRICKS_CONFIG_PROFILE") is None
+
+
 def test_create_dataset_with_user_tag(tracking_uri, experiments):
     dataset = create_dataset(
         name="test_user_attribution",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18431?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18431/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18431/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18431/merge
```

</p>
</details>

…ions

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add support for setting the databricks-sdk ENV VAR for profile usage based on the MLflow tracking URI used during dataset operations. Since the databricks-agents package does not support creating WorkspaceClient instances that utilize a profile, locally setting this variable is a viable approach to have consistent resolution in a natively supported Client manner. 

Tested fully e2e with profiles to use all CRUD APIs (create, merge_records, to_df, and delete) on a non-default workspace to ensure that this works as expected. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
