### PR TITLE
Fix Span to_dict format to be loadable with from_dict in old versions

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -476,8 +476,8 @@ mlflow.entities.SpanEvent.to_otel_proto
 mlflow.entities.SpanEvent.to_proto
 mlflow.entities.SpanStatus
 mlflow.entities.SpanStatusCode
-mlflow.entities.SpanStatusCode.from_proto_status_code
-mlflow.entities.SpanStatusCode.to_proto_status_code
+mlflow.entities.SpanStatusCode.from_otel_proto_status_code_name
+mlflow.entities.SpanStatusCode.to_otel_proto_status_code_name
 mlflow.entities.SpanType
 mlflow.entities.Trace
 mlflow.entities.Trace.from_dict

--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -477,6 +477,7 @@ mlflow.entities.SpanEvent.to_proto
 mlflow.entities.SpanStatus
 mlflow.entities.SpanStatusCode
 mlflow.entities.SpanStatusCode.from_proto_status_code
+mlflow.entities.SpanStatusCode.to_proto_status_code
 mlflow.entities.SpanType
 mlflow.entities.Trace
 mlflow.entities.Trace.from_dict

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -279,8 +279,13 @@ class Span:
                 )
                 span_id = decode_id(data["span_id"])
                 parent_id = decode_id(data["parent_span_id"]) if data["parent_span_id"] else None
-                # Try to parse as protobuf enum name first (for backward compatibility),
-                # then fall back to value format (for forward compatibility)
+                # NB: This handles an inadvertent breaking change introduced in MLflow 3.5.0
+                # that broke forward compatibility with versions <3.5.0. Prior to 3.5.0, spans
+                # were serialized with protobuf enum names (e.g., "STATUS_CODE_OK"). In 3.5.0,
+                # this was changed to enum values (e.g., "OK"), making spans logged by 3.5.0
+                # unreadable by earlier versions. We now serialize using protobuf enum names
+                # again (for backward compatibility) while also supporting enum values when
+                # deserializing (to handle spans logged by 3.5.0).
                 status_code_str = data["status"]["code"]
                 try:
                     status_code = SpanStatusCode.from_proto_status_code(status_code_str)

--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -18,16 +18,11 @@ class SpanStatusCode(str, Enum):
     OK = "OK"
     ERROR = "ERROR"
 
-    def to_proto_status_code_name(self) -> str:
+    def to_otel_proto_status_code_name(self) -> str:
         """
-        Convert the SpanStatusCode to the corresponding protobuf enum name.
-
-        Returns:
-            The protobuf enum name (e.g., "STATUS_CODE_OK")
+        Convert the SpanStatusCode to the corresponding OpenTelemetry protobuf enum name.
         """
-        from mlflow.protos.databricks_trace_server_pb2 import Span as ProtoSpan
-
-        proto_code = ProtoSpan.Status.StatusCode
+        proto_code = OtelStatus.StatusCode
         mapping = {
             SpanStatusCode.UNSET: proto_code.Name(proto_code.STATUS_CODE_UNSET),
             SpanStatusCode.OK: proto_code.Name(proto_code.STATUS_CODE_OK),
@@ -36,24 +31,22 @@ class SpanStatusCode(str, Enum):
         return mapping[self]
 
     @staticmethod
-    def from_proto_status_code(status_code: str) -> SpanStatusCode:
+    def from_otel_proto_status_code_name(status_code_name: str) -> SpanStatusCode:
         """
-        Convert a string status code to the corresponding SpanStatusCode enum value.
+        Convert an OpenTelemetry protobuf enum name to the corresponding SpanStatusCode enum value.
         """
-        from mlflow.protos.databricks_trace_server_pb2 import Span as ProtoSpan
-
-        proto_code = ProtoSpan.Status.StatusCode
-        status_code_mapping = {
+        proto_code = OtelStatus.StatusCode
+        mapping = {
             proto_code.Name(proto_code.STATUS_CODE_UNSET): SpanStatusCode.UNSET,
             proto_code.Name(proto_code.STATUS_CODE_OK): SpanStatusCode.OK,
             proto_code.Name(proto_code.STATUS_CODE_ERROR): SpanStatusCode.ERROR,
         }
         try:
-            return status_code_mapping[status_code]
+            return mapping[status_code_name]
         except KeyError:
             raise MlflowException(
-                f"Invalid status code: {status_code}. "
-                f"Valid values are: {', '.join(status_code_mapping.keys())}",
+                f"Invalid status code name: {status_code_name}. "
+                f"Valid values are: {', '.join(mapping.keys())}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 

--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -25,10 +25,13 @@ class SpanStatusCode(str, Enum):
         Returns:
             The protobuf enum name (e.g., "STATUS_CODE_OK")
         """
+        from mlflow.protos.databricks_trace_server_pb2 import Span as ProtoSpan
+
+        proto_code = ProtoSpan.Status.StatusCode
         mapping = {
-            SpanStatusCode.UNSET: "STATUS_CODE_UNSET",
-            SpanStatusCode.OK: "STATUS_CODE_OK",
-            SpanStatusCode.ERROR: "STATUS_CODE_ERROR",
+            SpanStatusCode.UNSET: proto_code.Name(proto_code.STATUS_CODE_UNSET),
+            SpanStatusCode.OK: proto_code.Name(proto_code.STATUS_CODE_OK),
+            SpanStatusCode.ERROR: proto_code.Name(proto_code.STATUS_CODE_ERROR),
         }
         return mapping[self]
 

--- a/mlflow/entities/span_status.py
+++ b/mlflow/entities/span_status.py
@@ -18,6 +18,20 @@ class SpanStatusCode(str, Enum):
     OK = "OK"
     ERROR = "ERROR"
 
+    def to_proto_status_code_name(self) -> str:
+        """
+        Convert the SpanStatusCode to the corresponding protobuf enum name.
+
+        Returns:
+            The protobuf enum name (e.g., "STATUS_CODE_OK")
+        """
+        mapping = {
+            SpanStatusCode.UNSET: "STATUS_CODE_UNSET",
+            SpanStatusCode.OK: "STATUS_CODE_OK",
+            SpanStatusCode.ERROR: "STATUS_CODE_ERROR",
+        }
+        return mapping[self]
+
     @staticmethod
     def from_proto_status_code(status_code: str) -> SpanStatusCode:
         """

--- a/mlflow/entities/trace_info.py
+++ b/mlflow/entities/trace_info.py
@@ -62,7 +62,7 @@ class TraceInfo(_MlflowObject):
             res.pop("execution_duration", None)
             res["execution_duration_ms"] = self.execution_duration
         # override trace_id to be the same as trace_info.trace_id since it's parsed
-        # when converting to proto
+        # when converting to proto if it's v4
         res["trace_id"] = self.trace_id
         return res
 

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -702,7 +702,6 @@ def test_span_dict_v4_preserves_ids_across_serialization():
 
 
 def test_span_from_dict_supports_both_status_code_formats():
-    """Test that from_dict handles both protobuf enum names and enum values."""
     with mlflow.start_span("test") as span:
         span.set_status("OK")
 

--- a/tests/entities/test_span.py
+++ b/tests/entities/test_span.py
@@ -591,44 +591,6 @@ def test_otel_roundtrip_conversion(sample_otel_span_for_conversion):
         assert rt_event.attributes == orig_event.attributes
 
 
-def test_span_to_dict_v4_format():
-    with mlflow.start_span("parent"):
-        with mlflow.start_span("child", span_type=SpanType.LLM) as span:
-            span.set_inputs({"input": 1})
-            span.set_outputs(2)
-            span.set_attribute("key", 3)
-            span.set_status("OK")
-            span.add_event(SpanEvent("test_event", timestamp=99999, attributes={"foo": "bar"}))
-
-    span_dict = span.to_dict()
-
-    # Verify human-readable IDs (not base64 encoded)
-    assert span_dict["trace_id"].startswith("tr-")
-    assert not span_dict["span_id"].startswith("tr-")
-    assert not span_dict["parent_span_id"].startswith("tr-")
-
-    # Verify structure
-    assert span_dict["name"] == "child"
-    assert isinstance(span_dict["start_time_unix_nano"], int)
-    assert isinstance(span_dict["end_time_unix_nano"], int)
-
-    # Verify status structure
-    assert "status" in span_dict
-    assert span_dict["status"]["code"] == "STATUS_CODE_OK"
-    assert "message" in span_dict["status"]
-
-    # Verify events structure
-    assert len(span_dict["events"]) == 1
-    assert span_dict["events"][0]["name"] == "test_event"
-    assert span_dict["events"][0]["time_unix_nano"] == 99999
-    assert span_dict["events"][0]["attributes"] == {"foo": "bar"}
-
-    # Verify attributes are preserved
-    assert "attributes" in span_dict
-    assert "mlflow.spanInputs" in span_dict["attributes"]
-    assert "mlflow.spanOutputs" in span_dict["attributes"]
-
-
 def test_span_from_dict_old_format():
     span_dict = {
         "trace_id": "6ST7JNq8BC4JRp0HA/vD6Q==",
@@ -681,26 +643,6 @@ def test_span_dict_v4_with_no_parent():
     assert recovered.outputs == {"y": 2}
 
 
-def test_span_dict_v4_preserves_ids_across_serialization():
-    with mlflow.start_span("parent"):
-        with mlflow.start_span("child") as child:
-            pass
-
-    # Get the dict representation
-    child_dict = child.to_dict()
-
-    # Verify IDs are in human-readable format
-    assert child_dict["trace_id"] == child.trace_id
-    assert child_dict["span_id"] == child.span_id
-    assert child_dict["parent_span_id"] == child.parent_id
-
-    # Deserialize and verify IDs match
-    recovered = Span.from_dict(child_dict)
-    assert recovered.trace_id == child.trace_id
-    assert recovered.span_id == child.span_id
-    assert recovered.parent_id == child.parent_id
-
-
 def test_span_from_dict_supports_both_status_code_formats():
     with mlflow.start_span("test") as span:
         span.set_status("OK")
@@ -728,3 +670,103 @@ def test_span_from_dict_supports_both_status_code_formats():
     span_dict["status"]["code"] = "ERROR"
     recovered = Span.from_dict(span_dict)
     assert recovered.status.status_code == SpanStatusCode.ERROR
+
+
+def test_load_from_old_span_dict():
+    span_dict = {
+        "trace_id": "ZqqBulxlq2cwRCfKHxmDVA==",
+        "span_id": "/mCYZRxbTqw=",
+        "trace_state": "",
+        "parent_span_id": "f6qlKYqTw2E=",
+        "name": "custom",
+        "start_time_unix_nano": 1761103703884225000,
+        "end_time_unix_nano": 1761103703884454000,
+        "attributes": {
+            "mlflow.spanOutputs": "4",
+            "mlflow.spanType": '"LLM"',
+            "mlflow.spanInputs": '{"z": 3}',
+            "mlflow.traceRequestId": '"tr-66aa81ba5c65ab67304427ca1f198354"',
+            "delta": "1",
+            "mlflow.spanFunctionName": '"add_one"',
+        },
+        "status": {"message": "", "code": "STATUS_CODE_OK"},
+        "events": [
+            {
+                "time_unix_nano": 1761105506649041,
+                "name": "agent_action",
+                "attributes": {
+                    "tool": "search_web",
+                    "tool_input": '"What is MLflow?"',
+                    "log": "test",
+                },
+            }
+        ],
+    }
+    span = Span.from_dict(span_dict)
+    assert span.trace_id == "tr-66aa81ba5c65ab67304427ca1f198354"
+    assert span.span_id == "fe6098651c5b4eac"
+    assert span.parent_id == "7faaa5298a93c361"
+    assert span.name == "custom"
+    assert span.start_time_ns == 1761103703884225000
+    assert span.end_time_ns == 1761103703884454000
+    assert span.status == SpanStatus(SpanStatusCode.OK, description="")
+    assert span.inputs == {"z": 3}
+    assert span.outputs == 4
+    assert len(span.events) == 1
+    assert span.events[0].name == "agent_action"
+    assert span.events[0].timestamp == 1761105506649041
+    assert span.events[0].attributes == {
+        "tool": "search_web",
+        "tool_input": '"What is MLflow?"',
+        "log": "test",
+    }
+
+
+def test_load_from_3_5_0_span_dict():
+    span_dict = {
+        "trace_id": "tr-66aa81ba5c65ab67304427ca1f198354",
+        "span_id": "fe6098651c5b4eac",
+        "trace_state": "",
+        "parent_span_id": "7faaa5298a93c361",
+        "name": "custom",
+        "start_time_unix_nano": 1761103703884225000,
+        "end_time_unix_nano": 1761103703884454000,
+        "attributes": {
+            "mlflow.spanOutputs": "4",
+            "mlflow.spanType": '"LLM"',
+            "mlflow.spanInputs": '{"z": 3}',
+            "mlflow.traceRequestId": '"tr-66aa81ba5c65ab67304427ca1f198354"',
+            "delta": "1",
+            "mlflow.spanFunctionName": '"add_one"',
+        },
+        "status": {"message": "", "code": "OK"},
+        "events": [
+            {
+                "time_unix_nano": 1761105506649041,
+                "name": "agent_action",
+                "attributes": {
+                    "tool": "search_web",
+                    "tool_input": '"What is MLflow?"',
+                    "log": "test",
+                },
+            }
+        ],
+    }
+    span = Span.from_dict(span_dict)
+    assert span.trace_id == "tr-66aa81ba5c65ab67304427ca1f198354"
+    assert span.span_id == "fe6098651c5b4eac"
+    assert span.parent_id == "7faaa5298a93c361"
+    assert span.name == "custom"
+    assert span.start_time_ns == 1761103703884225000
+    assert span.end_time_ns == 1761103703884454000
+    assert span.status == SpanStatus(SpanStatusCode.OK, description="")
+    assert span.inputs == {"z": 3}
+    assert span.outputs == 4
+    assert len(span.events) == 1
+    assert span.events[0].name == "agent_action"
+    assert span.events[0].timestamp == 1761105506649041
+    assert span.events[0].attributes == {
+        "tool": "search_web",
+        "tool_input": '"What is MLflow?"',
+        "log": "test",
+    }

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -116,7 +116,7 @@ def test_json_deserialization(monkeypatch):
                     "end_time_unix_nano": trace.data.spans[0].end_time_ns,
                     "events": [],
                     "status": {
-                        "code": "OK",
+                        "code": "STATUS_CODE_OK",
                         "message": "",
                     },
                     "attributes": {
@@ -136,7 +136,7 @@ def test_json_deserialization(monkeypatch):
                     "end_time_unix_nano": trace.data.spans[1].end_time_ns,
                     "events": [],
                     "status": {
-                        "code": "OK",
+                        "code": "STATUS_CODE_OK",
                         "message": "",
                     },
                     "attributes": {
@@ -464,3 +464,68 @@ def test_search_assessments():
     assert trace.search_assessments(span_id="123") == [assessments[2], assessments[3]]
     assert trace.search_assessments(span_id="123", name="relevance") == [assessments[2]]
     assert trace.search_assessments(type="expectation") == [assessments[3]]
+
+
+def test_trace_from_dict_load_old_trace():
+    trace_dict = {
+        "info": {
+            "trace_id": "tr-ee17184669c265ffdcf9299b36f6dccc",
+            "trace_location": {
+                "type": "MLFLOW_EXPERIMENT",
+                "mlflow_experiment": {"experiment_id": "0"},
+            },
+            "request_time": "2025-10-22T04:14:54.524Z",
+            "state": "OK",
+            "trace_metadata": {
+                "mlflow.trace_schema.version": "3",
+                "mlflow.traceInputs": '"abc"',
+                "mlflow.source.type": "LOCAL",
+                "mlflow.source.git.branch": "branch-3.4",
+                "mlflow.source.name": "a.py",
+                "mlflow.source.git.commit": "78d075062b120597050bf2b3839a426feea5ea4c",
+                "mlflow.user": "serena.ruan",
+                "mlflow.traceOutputs": '"def"',
+                "mlflow.source.git.repoURL": "git@github.com:mlflow/mlflow.git",
+                "mlflow.trace.sizeBytes": "1226",
+            },
+            "tags": {
+                "mlflow.artifactLocation": "mlflow-artifacts:/0/traces",
+                "mlflow.traceName": "test",
+            },
+            "request_preview": '"abc"',
+            "response_preview": '"def"',
+            "execution_duration_ms": 60,
+        },
+        "data": {
+            "spans": [
+                {
+                    "trace_id": "7hcYRmnCZf/c+SmbNvbczA==",
+                    "span_id": "3ElmHER9IVU=",
+                    "trace_state": "",
+                    "parent_span_id": "",
+                    "name": "test",
+                    "start_time_unix_nano": 1761106494524157000,
+                    "end_time_unix_nano": 1761106494584860000,
+                    "attributes": {
+                        "mlflow.spanOutputs": '"def"',
+                        "mlflow.spanType": '"UNKNOWN"',
+                        "mlflow.spanInputs": '"abc"',
+                        "mlflow.traceRequestId": '"tr-ee17184669c265ffdcf9299b36f6dccc"',
+                        "test": '"test"',
+                    },
+                    "status": {"message": "", "code": "STATUS_CODE_OK"},
+                }
+            ]
+        },
+    }
+    trace = Trace.from_dict(trace_dict)
+    assert trace.info.trace_id == "tr-ee17184669c265ffdcf9299b36f6dccc"
+    assert trace.info.request_time == 1761106494524
+    assert trace.info.execution_duration == 60
+    assert trace.info.trace_location == TraceLocation.from_experiment_id("0")
+    assert len(trace.data.spans) == 1
+    assert trace.data.spans[0].name == "test"
+    assert trace.data.spans[0].inputs == "abc"
+    assert trace.data.spans[0].outputs == "def"
+    assert trace.data.spans[0].start_time_ns == 1761106494524157000
+    assert trace.data.spans[0].end_time_ns == 1761106494584860000

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -47,7 +47,7 @@ def test_json_deserialization():
                 "start_time_unix_nano": trace.data.spans[0].start_time_ns,
                 "end_time_unix_nano": trace.data.spans[0].end_time_ns,
                 "status": {
-                    "code": "ERROR",
+                    "code": "STATUS_CODE_ERROR",
                     "message": "Exception: Error!",
                 },
                 "attributes": {
@@ -77,7 +77,7 @@ def test_json_deserialization():
                 "start_time_unix_nano": trace.data.spans[1].start_time_ns,
                 "end_time_unix_nano": trace.data.spans[1].end_time_ns,
                 "status": {
-                    "code": "OK",
+                    "code": "STATUS_CODE_OK",
                     "message": "",
                 },
                 "attributes": {
@@ -100,7 +100,7 @@ def test_json_deserialization():
                 "start_time_unix_nano": trace.data.spans[2].start_time_ns,
                 "end_time_unix_nano": trace.data.spans[2].end_time_ns,
                 "status": {
-                    "code": "ERROR",
+                    "code": "STATUS_CODE_ERROR",
                     "message": "Exception: Error!",
                 },
                 "attributes": {

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1046,32 +1046,6 @@ def test_search_traces_yields_expected_dataframe_contents(monkeypatch):
 
 
 @skip_when_testing_trace_sdk
-def test_search_traces_dataframe_contains_human_readable_ids():
-    model = DefaultTestModel()
-    model.predict(2, 5)
-
-    trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
-    df = mlflow.search_traces(max_results=1)
-
-    # Verify trace_id in DataFrame is human-readable (not encoded)
-    assert df.iloc[0].trace_id == trace.info.trace_id
-    # The trace_id should be in tr-XXXXX format, not base64 encoded
-    assert df.iloc[0].trace_id.startswith("tr-")
-
-    # Verify spans in DataFrame contain human-readable IDs (not base64 encoded)
-    df_spans = df.iloc[0].spans
-    expected_spans = [span.to_dict() for span in trace.data.spans]
-    assert df_spans == expected_spans
-
-    # Verify that each span has non-encoded IDs
-    for df_span, trace_span in zip(df_spans, trace.data.spans):
-        # IDs should match the human-readable format
-        assert df_span["trace_id"] == trace_span.trace_id
-        assert df_span["span_id"] == trace_span.span_id
-        assert df_span["parent_span_id"] == trace_span.parent_id
-
-
-@skip_when_testing_trace_sdk
 def test_search_traces_handles_missing_response_tags_and_metadata(mock_client):
     mock_client.search_traces.return_value = PagedList(
         [


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbrx-euirim/mlflow/pull/18439?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18439/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18439/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18439/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR fixes a span status code serialization and deserialization issue that prevented MLflow 3.5 traces from being read by earlier versions of MLflow.

MLflow 3.5.0 serialized the status code into the enum value, while previous versions of MLflow serialized it into the protobuf value (effectively the Python enum name). Previous versions of MLflow expected the enum name when reading traces, leading to errors when attempting to read MLflow 3.5 traces.

This PR restores the status code encoding mechanism while preserving compatibility, on read, with both the 3.5 and <3.5 traces.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
