### PR TITLE
Fix resolve workflow permissions to allow PR comment updates

### DIFF
--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     timeout-minutes: 5
     if: >
       (github.event_name == 'pull_request' &&
@@ -99,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: read
-      pull-requests: write
+      pull-requests: read
     timeout-minutes: 30
     outputs:
       claude_output: ${{ steps.claude-fix.outputs.output }}


### PR DESCRIPTION
### Related Issues/PRs

Follow-up for https://github.com/mlflow/mlflow/pull/18327

### What changes are proposed in this pull request?

This PR fixes the permissions in the resolve workflow to enable PR comment updates. The `precheck` job needs `pull-requests: write` permission to update comments on PRs, while the `resolve` job only needs `pull-requests: read` permission.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)