### PR TITLE
Fix /resolve command PR detection in GitHub Actions

### DIFF
--- a/.claude/commands/resolve.md
+++ b/.claude/commands/resolve.md
@@ -31,9 +31,11 @@ Automatically fetch and address PR review comments. This command examines review
 
 1. **Auto-detect PR context**:
 
-   - Use `gh pr view --json url -q '.url'` to get PR info for the current branch
-   - Parse to extract owner, repo, and PR number
-   - If auto-detection fails, inform the user that no PR was found for the current branch
+   - First check for environment variables:
+     - If `PR_NUMBER` and `GITHUB_REPOSITORY` are set, read them and parse `GITHUB_REPOSITORY` as `owner/repo` and use `PR_NUMBER` directly
+   - Otherwise:
+     - Use `gh pr view --json url -q '.url'` to get PR info for the current branch and parse to extract owner, repo, and PR number
+   - If neither method works, inform the user that no PR was found and exit
 
 2. **Fetch unresolved review comments**:
 

--- a/.github/workflows/resolve.yml
+++ b/.github/workflows/resolve.yml
@@ -138,6 +138,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PROMPT: ${{ needs.precheck.outputs.prompt }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
         run: |
           OUTPUT_FILE="/tmp/output.json"
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

The `/resolve` command failed to detect PR context when triggered by `issue_comment` events because `gh pr view` doesn't work reliably in that context. This PR fixes the issue by:

1. Passing `PR_NUMBER` as an environment variable in the GitHub Actions workflow
2. Updating the resolve command to check for environment variables first before falling back to `gh pr view`

This ensures the command works both in GitHub Actions (via environment variables) and locally (via `gh pr view`).

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)