### PR TITLE
Remove X-Frame-Options for notebook trace renderer

### DIFF
--- a/mlflow/server/fastapi_security.py
+++ b/mlflow/server/fastapi_security.py
@@ -74,7 +74,7 @@ class SecurityHeadersMiddleware:
                 headers = dict(message.get("headers", []))
                 headers[b"x-content-type-options"] = b"nosniff"
 
-                # Skip X-Frame-Options for notebook-trace-renderer to allow iframe embedding in Jupyter
+                # Skip X-Frame-Options for notebook renderer to allow iframe embedding in notebooks
                 path = scope.get("path", "")
                 is_notebook_renderer = path.startswith(TRACE_RENDERER_ASSET_PATH)
 

--- a/mlflow/server/security.py
+++ b/mlflow/server/security.py
@@ -20,6 +20,7 @@ from mlflow.server.security_utils import (
     is_api_endpoint,
     should_block_cors_request,
 )
+from mlflow.tracing.constant import TRACE_RENDERER_ASSET_PATH
 
 _logger = logging.getLogger(__name__)
 
@@ -97,7 +98,10 @@ def init_security_middleware(app: Flask) -> None:
     def add_security_headers(response: Response) -> Response:
         response.headers["X-Content-Type-Options"] = "nosniff"
 
-        if x_frame_options and x_frame_options.upper() != "NONE":
+        # Skip X-Frame-Options for notebook-trace-renderer to allow iframe embedding in Jupyter
+        is_notebook_renderer = request.path.startswith(TRACE_RENDERER_ASSET_PATH)
+
+        if x_frame_options and x_frame_options.upper() != "NONE" and not is_notebook_renderer:
             response.headers["X-Frame-Options"] = x_frame_options.upper()
 
         if (

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -113,3 +113,6 @@ ASSESSMENT_ID_PREFIX = "a-"
 # To make sure get_trace API does not fail due to this delay, we retry up to a reasonable timeout.
 # Setting 15 seconds because the initial version of the backend is known to have 1~5 seconds delay.
 GET_TRACE_V4_RETRY_TIMEOUT_SECONDS = 15
+
+# Path to the notebook trace renderer directory
+TRACE_RENDERER_ASSET_PATH = "/static-files/lib/notebook-trace-renderer"

--- a/mlflow/tracing/display/display_handler.py
+++ b/mlflow/tracing/display/display_handler.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode, urljoin
 
 import mlflow
 from mlflow.environment_variables import MLFLOW_MAX_TRACES_TO_DISPLAY_IN_NOTEBOOK
+from mlflow.tracing.constant import TRACE_RENDERER_ASSET_PATH
 from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.uri import is_http_uri
 
@@ -13,9 +14,6 @@ _logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from mlflow.entities import Trace
-
-
-TRACE_RENDERER_ASSET_PATH = "/static-files/lib/notebook-trace-renderer/index.html"
 
 IFRAME_HTML = """
 <div>
@@ -57,7 +55,7 @@ IFRAME_HTML = """
 
 def get_notebook_iframe_html(traces: list["Trace"]):
     # fetch assets from tracking server
-    uri = urljoin(mlflow.get_tracking_uri(), TRACE_RENDERER_ASSET_PATH)
+    uri = urljoin(mlflow.get_tracking_uri(), f"{TRACE_RENDERER_ASSET_PATH}/index.html")
     query_string = _get_query_string_for_traces(traces)
 
     # include mlflow version to invalidate browser cache when mlflow updates

--- a/tests/server/test_security.py
+++ b/tests/server/test_security.py
@@ -159,6 +159,41 @@ def test_x_frame_options_configuration(monkeypatch: pytest.MonkeyPatch):
     assert "X-Frame-Options" not in response.headers
 
 
+def test_notebook_trace_renderer_skips_x_frame_options(monkeypatch: pytest.MonkeyPatch):
+    from mlflow.tracing.constant import TRACE_RENDERER_ASSET_PATH
+
+    app = Flask(__name__)
+
+    @app.route(f"{TRACE_RENDERER_ASSET_PATH}/index.html")
+    def notebook_renderer():
+        return "<html>trace renderer</html>"
+
+    @app.route(f"{TRACE_RENDERER_ASSET_PATH}/js/main.js")
+    def notebook_renderer_js():
+        return "console.log('trace renderer');"
+
+    @app.route("/static-files/other-page.html")
+    def other_page():
+        return "<html>other page</html>"
+
+    # Set X-Frame-Options to DENY to test that it's skipped for notebook renderer
+    monkeypatch.setenv("MLFLOW_SERVER_X_FRAME_OPTIONS", "DENY")
+    security.init_security_middleware(app)
+    client = Client(app)
+
+    response = client.get(f"{TRACE_RENDERER_ASSET_PATH}/index.html")
+    assert response.status_code == 200
+    assert "X-Frame-Options" not in response.headers
+
+    response = client.get(f"{TRACE_RENDERER_ASSET_PATH}/js/main.js")
+    assert response.status_code == 200
+    assert "X-Frame-Options" not in response.headers
+
+    response = client.get("/static-files/other-page.html")
+    assert response.status_code == 200
+    assert response.headers.get("X-Frame-Options") == "DENY"
+
+
 def test_wildcard_hosts(test_app, monkeypatch: pytest.MonkeyPatch):
     """Test that wildcard hosts allow all."""
     monkeypatch.setenv("MLFLOW_SERVER_ALLOWED_HOSTS", "*")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18446?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18446/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18446/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18446/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Currently, `X-Frame-Options=SAMEORIGIN` is added by default for all responses from the tracking server. This option prevents the Jupyter notebook renderer since we use iframe, and typically the Jupyter server and the tracking server are not on the same origin. This PR make an adjustment to the security logic and treat notebook renderer an exception.

<img width="720" height="502" alt="image" src="https://github.com/user-attachments/assets/8ba938bf-586a-4902-a2c6-755e35d64f21" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
