### PR TITLE
Add label-based force-run capability to examples workflow

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -62,14 +62,20 @@ jobs:
       - name: Check diff
         id: check-diff
         if: github.event_name == 'pull_request'
+        env:
+          FORCE_RUN_EXAMPLES: ${{ contains(github.event.pull_request.labels.*.name, 'examples.yml') }}
         run: |
           REPO="${{ github.repository }}"
           PR_NUMBER="${{ github.event.pull_request.number }}"
           BASE_REF="${{ github.base_ref }}"
           CHANGED_FILES=$(python dev/list_changed_files.py --repository $REPO --pr-num $PR_NUMBER | grep "tests/examples\|examples" || true);
-          EXAMPLES_CHANGED=$([[ ! -z "$CHANGED_FILES" ]] && echo "true" || echo "false")
+          if [ "$FORCE_RUN_EXAMPLES" = "true" ]; then
+            EXAMPLES_CHANGED="true"
+          else
+            EXAMPLES_CHANGED=$([ ! -z "$CHANGED_FILES" ] && echo "true" || echo "false")
+          fi
 
-          echo -e "CHANGED_FILES:\nCHANGED_FILES"
+          echo -e "CHANGED_FILES:\n$CHANGED_FILES"
           echo "EXAMPLES_CHANGED: $EXAMPLES_CHANGED"
           echo "examples_changed=$EXAMPLES_CHANGED" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18450?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18450/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18450/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18450/merge
```

</p>
</details>

### Related Issues/PRs

Related: #18425

### What changes are proposed in this pull request?

Add the ability to force-run example tests via the `examples.yml` label. This allows testing dependency changes that affect examples (like library version pins) without requiring modifications to example code itself.

Also fixes a variable interpolation bug where `CHANGED_FILES` wasn't being expanded in the log output.

### How is this PR tested?

- [x] Existing unit/integration tests

The workflow logic will be validated when a PR with the `examples.yml` label is created.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)