### PR TITLE
Fix chat message parsing in summary view

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTrace.types.ts
@@ -244,6 +244,7 @@ export interface ModelTraceSpanNode extends TimelineTreeNode, Pick<ModelTraceSpa
   inputs?: any;
   outputs?: any;
   children?: ModelTraceSpanNode[];
+  chatMessageFormat?: string;
   chatMessages?: ModelTraceChatMessage[];
   chatTools?: ModelTraceChatTool[];
   parentId?: string | null;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -428,6 +428,7 @@ export const normalizeNewSpanData = (
     outputs,
     attributes,
     events,
+    chatMessageFormat: messageFormat,
     chatMessages,
     chatTools,
     parentId,

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -138,7 +138,9 @@ const normalizeOpenAIResponsesInputMessage = (obj: OpenAIResponsesInputMessage):
 };
 
 export const normalizeOpenAIResponsesInput = (obj: unknown): ModelTraceChatMessage[] | null => {
-  const input: unknown = get(obj, 'input');
+  // if the object does not have the 'input' key, then try using the object directly
+  // (user may have passed in the response input directly to the span)
+  const input: unknown = get(obj, 'input') ?? obj;
 
   if (isString(input)) {
     const message = prettyPrintChatMessage({ type: 'message', content: input, role: 'user' });
@@ -201,7 +203,9 @@ export const normalizeOpenAIResponsesOutput = (obj: unknown): ModelTraceChatMess
     return null;
   }
 
-  const output: unknown = get(obj, 'output');
+  // if the object does not have the 'output' key, then try using the object directly
+  // (user may have passed in the response output directly to the span)
+  const output: unknown = get(obj, 'output') ?? obj;
 
   // list of output items
   if (isArray(output) && output.length > 0 && output.every(isOpenAIResponsesOutputItem)) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/openai.ts
@@ -138,9 +138,7 @@ const normalizeOpenAIResponsesInputMessage = (obj: OpenAIResponsesInputMessage):
 };
 
 export const normalizeOpenAIResponsesInput = (obj: unknown): ModelTraceChatMessage[] | null => {
-  // if the object does not have the 'input' key, then try using the object directly
-  // (user may have passed in the response input directly to the span)
-  const input: unknown = get(obj, 'input') ?? obj;
+  const input: unknown = get(obj, 'input');
 
   if (isString(input)) {
     const message = prettyPrintChatMessage({ type: 'message', content: input, role: 'user' });
@@ -203,9 +201,7 @@ export const normalizeOpenAIResponsesOutput = (obj: unknown): ModelTraceChatMess
     return null;
   }
 
-  // if the object does not have the 'output' key, then try using the object directly
-  // (user may have passed in the response output directly to the span)
-  const output: unknown = get(obj, 'output') ?? obj;
+  const output: unknown = get(obj, 'output');
 
   // list of output items
   if (isArray(output) && output.length > 0 && output.every(isOpenAIResponsesOutputItem)) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -39,6 +39,10 @@ export const ModelTraceExplorerFieldRenderer = ({
   const isRetrieverDocuments =
     Array.isArray(parsedData) && parsedData.length > 0 && every(parsedData, isRetrieverDocument);
 
+  if (chatMessages && chatMessages.length > 0) {
+    return <ModelTraceExplorerConversation messages={chatMessages} />;
+  }
+
   if (renderMode === 'json') {
     return <ModelTraceExplorerCodeSnippet title={title} data={data} initialRenderMode={CodeSnippetRenderMode.JSON} />;
   }
@@ -49,10 +53,6 @@ export const ModelTraceExplorerFieldRenderer = ({
 
   if (dataIsString) {
     return <ModelTraceExplorerTextFieldRenderer title={title} value={parsedData} />;
-  }
-
-  if (chatMessages && chatMessages.length > 0) {
-    return <ModelTraceExplorerConversation messages={chatMessages} />;
   }
 
   if (isChatTools) {

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -13,10 +13,12 @@ export const ModelTraceExplorerFieldRenderer = ({
   title,
   data,
   renderMode,
+  chatMessageFormat,
 }: {
   title: string;
   data: string;
   renderMode: 'default' | 'json' | 'text';
+  chatMessageFormat?: string;
 }) => {
   const parsedData = useMemo(() => {
     try {
@@ -27,7 +29,7 @@ export const ModelTraceExplorerFieldRenderer = ({
   }, [data]);
 
   const dataIsString = isString(parsedData);
-  const chatMessages = normalizeConversation(parsedData);
+  const chatMessages = normalizeConversation(parsedData, chatMessageFormat);
   const isChatTools = Array.isArray(parsedData) && parsedData.length > 0 && every(parsedData, isModelTraceChatTool);
   const isRetrieverDocuments =
     Array.isArray(parsedData) && parsedData.length > 0 && every(parsedData, isRetrieverDocument);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -29,7 +29,12 @@ export const ModelTraceExplorerFieldRenderer = ({
   }, [data]);
 
   const dataIsString = isString(parsedData);
-  const chatMessages = normalizeConversation(parsedData, chatMessageFormat);
+  // wrap the value in an object with the title as key. this helps normalizeConversation
+  // recognize the format, as this util function was designed to receive the whole input
+  // object rather than value by value. it does not work for complex cases where we need
+  // to check multiple keys in the object (e.g. anthropic), but works for cases where we're
+  // basically just looking for the field that contains chat messages.
+  const chatMessages = normalizeConversation(title ? { [title]: parsedData } : parsedData, chatMessageFormat);
   const isChatTools = Array.isArray(parsedData) && parsedData.length > 0 && every(parsedData, isModelTraceChatTool);
   const isRetrieverDocuments =
     Array.isArray(parsedData) && parsedData.length > 0 && every(parsedData, isRetrieverDocument);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryIntermediateNode.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryIntermediateNode.tsx
@@ -27,6 +27,7 @@ export const ModelTraceExplorerSummaryIntermediateNode = ({
   const inputList = useMemo(() => createListFromObject(node.inputs), [node]);
   const outputList = useMemo(() => createListFromObject(node.outputs), [node]);
   const exceptionEvents = getSpanExceptionEvents(node);
+  const chatMessageFormat = node.chatMessageFormat;
 
   const hasException = exceptionEvents.length > 0;
   const containsInputs = inputList.length > 0;
@@ -135,6 +136,7 @@ export const ModelTraceExplorerSummaryIntermediateNode = ({
                       title={key}
                       data={value}
                       renderMode={renderMode}
+                      chatMessageFormat={chatMessageFormat}
                     />
                   ))}
                 </div>
@@ -160,7 +162,13 @@ export const ModelTraceExplorerSummaryIntermediateNode = ({
                   }}
                 >
                   {outputList.map(({ key, value }) => (
-                    <ModelTraceExplorerFieldRenderer key={key} title={key} data={value} renderMode={renderMode} />
+                    <ModelTraceExplorerFieldRenderer
+                      key={key}
+                      title={key}
+                      data={value}
+                      renderMode={renderMode}
+                      chatMessageFormat={chatMessageFormat}
+                    />
                   ))}
                 </div>
               </ModelTraceExplorerCollapsibleSection>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
@@ -25,6 +25,7 @@ export const ModelTraceExplorerSummarySpans = ({
 
   const rootInputs = rootNode.inputs;
   const rootOutputs = rootNode.outputs;
+  const chatMessageFormat = rootNode.chatMessageFormat;
   const exceptions = getSpanExceptionEvents(rootNode);
   const hasIntermediateNodes = intermediateNodes.length > 0;
   const hasExceptions = exceptions.length > 0;
@@ -84,7 +85,13 @@ export const ModelTraceExplorerSummarySpans = ({
       >
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
           {inputList.map(({ key, value }, index) => (
-            <ModelTraceExplorerFieldRenderer key={key || index} title={key} data={value} renderMode={renderMode} />
+            <ModelTraceExplorerFieldRenderer
+              key={key || index}
+              title={key}
+              data={value}
+              renderMode={renderMode}
+              chatMessageFormat={chatMessageFormat}
+            />
           ))}
         </div>
       </ModelTraceExplorerCollapsibleSection>
@@ -104,7 +111,13 @@ export const ModelTraceExplorerSummarySpans = ({
       >
         <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
           {outputList.map(({ key, value }, index) => (
-            <ModelTraceExplorerFieldRenderer key={key || index} title={key} data={value} renderMode={renderMode} />
+            <ModelTraceExplorerFieldRenderer
+              key={key || index}
+              title={key}
+              data={value}
+              renderMode={renderMode}
+              chatMessageFormat={chatMessageFormat}
+            />
           ))}
         </div>
       </ModelTraceExplorerCollapsibleSection>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/18454?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18454/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18454/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18454/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Porting this fix from upstream, we need to pass message format into the summary view renderers

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Before:

<img width="1177" height="932" alt="Screenshot 2025-10-22 at 3 44 24 PM" src="https://github.com/user-attachments/assets/861fc84b-0836-4c20-8bdc-387494b650d9" />

After:

<img width="1178" height="934" alt="Screenshot 2025-10-22 at 3 44 38 PM" src="https://github.com/user-attachments/assets/481240ee-8621-4229-897d-6e4bc3075209" />

**Note:** There are still some issues caused by the fact that Summary View parses each field of the output separately. This causes some issues with validating some message formats like Anthropic, which rely on multiple keys in the output to determine message status. However, this PR should still fix common cases like LangChain at the top level

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
