### PR TITLE
Attributes translation for OTel clients

### DIFF
--- a/.github/workflows/tracing.yaml
+++ b/.github/workflows/tracing.yaml
@@ -59,6 +59,7 @@ jobs:
             --ignore tests/tracing/test_assessment.py \
             --ignore tests/tracing/test_otel_logging.py \
             --ignore tests/tracing/processor/test_otel_metrics.py \
+            --ignore tests/tracing/test_otel_loading.py \
             --import-mode=importlib
 
   # TODO: Add a job to run autologging tests against integrated libraries (latest versions)

--- a/mlflow/entities/span.py
+++ b/mlflow/entities/span.py
@@ -60,6 +60,10 @@ class SpanType:
     RERANKER = "RERANKER"
     MEMORY = "MEMORY"
     UNKNOWN = "UNKNOWN"
+    WORKFLOW = "WORKFLOW"
+    TASK = "TASK"
+    GUARDRAIL = "GUARDRAIL"
+    EVALUATOR = "EVALUATOR"
 
 
 def create_mlflow_span(

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -106,6 +106,7 @@ from mlflow.tracing.analysis import TraceFilterCorrelationResult
 from mlflow.tracing.constant import (
     SpanAttributeKey,
     SpansLocation,
+    TokenUsageKey,
     TraceMetadataKey,
     TraceTagKey,
 )
@@ -3362,10 +3363,22 @@ class SqlAlchemyStore(AbstractStore):
                 synchronize_session=False,
             )
 
-            span_dicts = []
+            aggregated_token_usage = {}
             for span in spans:
                 span_dict = translate_span_when_storing(span)
-                span_dicts.append(span_dict)
+                if span_token_usage := span_dict.get("attributes", {}).get(
+                    SpanAttributeKey.CHAT_USAGE
+                ):
+                    span_token_usage = json.loads(span_token_usage)
+                    for key in [
+                        TokenUsageKey.INPUT_TOKENS,
+                        TokenUsageKey.OUTPUT_TOKENS,
+                        TokenUsageKey.TOTAL_TOKENS,
+                    ]:
+                        aggregated_token_usage[key] = (
+                            aggregated_token_usage.get(key, 0) + span_token_usage[key]
+                        )
+
                 content_json = json.dumps(span_dict, cls=TraceJSONEncoder)
 
                 sql_span = SqlSpan(
@@ -3406,6 +3419,33 @@ class SqlAlchemyStore(AbstractStore):
                     update_dict[SqlTraceInfo.response_preview] = truncate_request_response_preview(
                         trace_outputs
                     )
+
+            trace_token_usage = (
+                session.query(SqlTraceMetadata)
+                .filter(
+                    SqlTraceMetadata.request_id == trace_id,
+                    SqlTraceMetadata.key == TraceMetadataKey.TOKEN_USAGE,
+                )
+                .one_or_none()
+            )
+            trace_token_usage = json.loads(trace_token_usage.value) if trace_token_usage else {}
+            if aggregated_token_usage:
+                for key in [
+                    TokenUsageKey.INPUT_TOKENS,
+                    TokenUsageKey.OUTPUT_TOKENS,
+                    TokenUsageKey.TOTAL_TOKENS,
+                ]:
+                    trace_token_usage[key] = (
+                        trace_token_usage.get(key, 0) + aggregated_token_usage[key]
+                    )
+
+                session.merge(
+                    SqlTraceMetadata(
+                        request_id=trace_id,
+                        key=TraceMetadataKey.TOKEN_USAGE,
+                        value=json.dumps(trace_token_usage),
+                    )
+                )
 
             session.query(SqlTraceInfo).filter(SqlTraceInfo.request_id == trace_id).update(
                 update_dict,

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -38,7 +38,7 @@ from mlflow.telemetry.events import LogAssessmentEvent, StartTraceEvent
 from mlflow.telemetry.track import record_usage_event
 from mlflow.tracing.constant import (
     GET_TRACE_V4_RETRY_TIMEOUT_SECONDS,
-    TRACKING_STORE,
+    SpansLocation,
     TraceMetadataKey,
     TraceTagKey,
 )
@@ -177,7 +177,7 @@ class TracingClient:
                 trace_info = self.get_trace_info(trace_id)
                 # if the trace is stored in the tracking store, load spans from the tracking store
                 # otherwise, load spans from the artifact repository
-                if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE:
+                if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.TRACKING_STORE:
                     trace_data = self.store.batch_get_traces([trace_info.trace_id])[0].data
                 else:
                     trace_data = self._download_trace_data(trace_info)
@@ -443,7 +443,7 @@ class TracingClient:
             elif trace_info.trace_location.mlflow_experiment:
                 # New traces in SQL store store spans in the tracking store, while for old traces or
                 # traces with File store, spans are stored in artifact repository.
-                if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE:
+                if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.TRACKING_STORE:
                     # location is not used for traces with mlflow experiment location in tracking
                     # store, so we use None as the location
                     tracking_store_trace_infos_by_location[None].append(trace_info)

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -36,7 +36,12 @@ from mlflow.store.entities.paged_list import PagedList
 from mlflow.store.tracking import SEARCH_TRACES_DEFAULT_MAX_RESULTS
 from mlflow.telemetry.events import LogAssessmentEvent, StartTraceEvent
 from mlflow.telemetry.track import record_usage_event
-from mlflow.tracing.constant import GET_TRACE_V4_RETRY_TIMEOUT_SECONDS, TraceMetadataKey
+from mlflow.tracing.constant import (
+    GET_TRACE_V4_RETRY_TIMEOUT_SECONDS,
+    TRACKING_STORE,
+    TraceMetadataKey,
+    TraceTagKey,
+)
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracing.utils import TraceJSONEncoder, exclude_immutable_tags, parse_trace_id_v4
 from mlflow.tracing.utils.artifact_utils import get_artifact_uri_for_trace
@@ -49,7 +54,7 @@ _logger = logging.getLogger(__name__)
 
 
 class TraceInfoGroups(NamedTuple):
-    tracking_store_trace_infos: list[TraceInfo]
+    tracking_store_trace_infos_by_location: dict[str, list[TraceInfo]]
     artifact_repo_trace_infos: list[TraceInfo]
 
 
@@ -168,10 +173,14 @@ class TracingClient:
                 error_code=NOT_FOUND,
             )
         else:
-            # V3 trace, load spans from artifact repository.
             try:
                 trace_info = self.get_trace_info(trace_id)
-                trace_data = self._download_trace_data(trace_info)
+                # if the trace is stored in the tracking store, load spans from the tracking store
+                # otherwise, load spans from the artifact repository
+                if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE:
+                    trace_data = self.store.batch_get_traces([trace_info.trace_id])[0].data
+                else:
+                    trace_data = self._download_trace_data(trace_info)
             except MlflowTraceDataNotFound:
                 raise MlflowException(
                     message=(
@@ -327,27 +336,29 @@ class TracingClient:
                 )
 
                 if include_spans:
-                    location_to_trace_infos = self._group_trace_infos_by_location(trace_infos)
-                    for location, location_trace_infos in location_to_trace_infos.items():
-                        if "." in location:
-                            # UC schema location. Get full traces from v4 BatchGetTraces.
-                            # All traces in a single call must be located in the same table.
-                            trace_ids = [t.trace_id for t in location_trace_infos]
-                            traces.extend(
-                                self._download_spans_from_batch_get_traces(
-                                    trace_ids, location, executor
-                                )
+                    trace_info_groups = self._group_trace_infos_by_location(trace_infos)
+                    for (
+                        location,
+                        location_trace_infos,
+                    ) in trace_info_groups.tracking_store_trace_infos_by_location.items():
+                        # Get full traces with BatchGetTraces, all traces in a single call
+                        # must be located in the same table.
+                        trace_ids = [t.trace_id for t in location_trace_infos]
+                        traces.extend(
+                            self._download_spans_from_batch_get_traces(
+                                trace_ids, location, executor
                             )
-                        else:
-                            # MLflow experiment location. Load spans from artifact repository.
-                            traces.extend(
-                                trace
-                                for trace in executor.map(
-                                    self._download_spans_from_artifact_repo,
-                                    location_trace_infos,
-                                )
-                                if trace
-                            )
+                        )
+
+                    # MLflow experiment location. Load spans from artifact repository.
+                    traces.extend(
+                        trace
+                        for trace in executor.map(
+                            self._download_spans_from_artifact_repo,
+                            trace_info_groups.artifact_repo_trace_infos,
+                        )
+                        if trace
+                    )
                 else:
                     traces.extend(Trace(t, TraceData(spans=[])) for t in trace_infos)
 
@@ -413,25 +424,32 @@ class TracingClient:
         else:
             return Trace(trace_info, trace_data)
 
-    def _group_trace_infos_by_location(
-        self, trace_infos: list[TraceInfo]
-    ) -> dict[str, list[TraceInfo]]:
+    def _group_trace_infos_by_location(self, trace_infos: list[TraceInfo]) -> TraceInfoGroups:
         """
         Group the trace infos based on where the trace data is stored.
 
         Returns:
-            A dictionary mapping location to a list of trace infos.
+            A TraceInfoGroups object containing:
+                - tracking_store_trace_infos_by_location: A dictionary mapping location to a list
+                    of trace infos.
+                - artifact_repo_trace_infos: A list of trace infos.
         """
-        location_to_trace_infos = defaultdict(list)
+        tracking_store_trace_infos_by_location = defaultdict(list)
+        artifact_repo_trace_infos = []
         for trace_info in trace_infos:
             if uc_schema := trace_info.trace_location.uc_schema:
                 location = f"{uc_schema.catalog_name}.{uc_schema.schema_name}"
-                location_to_trace_infos[location].append(trace_info)
-            elif mlflow_experiment := trace_info.trace_location.mlflow_experiment:
-                location_to_trace_infos[mlflow_experiment.experiment_id].append(trace_info)
+                tracking_store_trace_infos_by_location[location].append(trace_info)
+            elif trace_info.trace_location.mlflow_experiment:
+                if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE:
+                    # location is not used for traces with mlflow experiment location in tracking
+                    # store, so we use None as the location
+                    tracking_store_trace_infos_by_location[None].append(trace_info)
+                else:
+                    artifact_repo_trace_infos.append(trace_info)
             else:
                 _logger.warning(f"Unsupported location: {trace_info.trace_location}. Skipping.")
-        return location_to_trace_infos
+        return TraceInfoGroups(tracking_store_trace_infos_by_location, artifact_repo_trace_infos)
 
     def calculate_trace_filter_correlation(
         self,

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -178,7 +178,7 @@ class TracingClient:
                 # if the trace is stored in the tracking store, load spans from the tracking store
                 # otherwise, load spans from the artifact repository
                 if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.TRACKING_STORE:
-                    trace_data = self.store.batch_get_traces([trace_info.trace_id])[0].data
+                    return self.store.batch_get_traces([trace_info.trace_id])[0]
                 else:
                     trace_data = self._download_trace_data(trace_info)
             except MlflowTraceDataNotFound:

--- a/mlflow/tracing/client.py
+++ b/mlflow/tracing/client.py
@@ -441,6 +441,8 @@ class TracingClient:
                 location = f"{uc_schema.catalog_name}.{uc_schema.schema_name}"
                 tracking_store_trace_infos_by_location[location].append(trace_info)
             elif trace_info.trace_location.mlflow_experiment:
+                # New traces in SQL store store spans in the tracking store, while for old traces or
+                # traces with File store, spans are stored in artifact repository.
                 if trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE:
                     # location is not used for traces with mlflow experiment location in tracking
                     # store, so we use None as the location

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1316,7 +1316,9 @@ def add_trace(trace: Trace | dict[str, Any], target: LiveSpan | None = None):
                 for k, v in remote_root_span.attributes.items()
                 if k != SpanAttributeKey.REQUEST_ID
             },
-            start_time_ns=remote_root_span.start_time_ns,
+            # ensure this span has a smaller start time than the remote trace
+            # so when it's loaded the order is correct when sorting by start time
+            start_time_ns=remote_root_span.start_time_ns - 1,
         )
         _merge_trace(
             trace=trace,
@@ -1448,8 +1450,13 @@ def _merge_trace(
             parent_span_id=parent_span_id,
             trace_id=target_trace_id,
             otel_trace_id=new_trace_id,
+            # the trace should be ended after it's registered in the trace manager
+            # otherwise the exporter cannot find the trace to export
+            end_trace=False,
         )
         trace_manager.register_span(cloned_span)
+        # end the cloned span to ensure it's processed by the exporter
+        cloned_span.end(end_time_ns=span.end_time_ns)
 
     # Merge the tags and metadata from the child trace to the parent trace.
     with trace_manager.get_trace(target_trace_id) as parent_trace:

--- a/mlflow/tracing/fluent.py
+++ b/mlflow/tracing/fluent.py
@@ -1318,6 +1318,7 @@ def add_trace(trace: Trace | dict[str, Any], target: LiveSpan | None = None):
             },
             # ensure this span has a smaller start time than the remote trace
             # so when it's loaded the order is correct when sorting by start time
+            # TODO: deprecate this function once we fully support OTel traces
             start_time_ns=remote_root_span.start_time_ns - 1,
         )
         _merge_trace(

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -217,7 +217,10 @@ def deduplicate_span_names_in_place(spans: list[LiveSpan]):
     for span in spans:
         if count := span_name_counter.get(span._original_name):
             span_name_counter[span._original_name] += 1
-            span._span._name = f"{span._original_name}_{count}"
+            # only rename starting from the second duplicate, to be consistent with the case
+            # each span is exported individually and deduplication doesn't apply to the first span.
+            if count > 1:
+                span._span._name = f"{span._original_name}_{count}"
 
 
 def aggregate_usage_from_spans(spans: list[LiveSpan]) -> dict[str, int] | None:

--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -698,3 +698,15 @@ def construct_trace_id_v4(location: str, trace_id: str) -> str:
     Construct a trace ID for the given location and trace ID.
     """
     return f"{TRACE_ID_V4_PREFIX}{location}/{trace_id}"
+
+
+def truncate_request_response_preview(request_or_response: str) -> str:
+    """
+    Truncate the request or response preview to fit the max length.
+    """
+    value = json.loads(request_or_response)
+    if isinstance(value, str):
+        return value[:100]
+    if isinstance(value, (list, dict)):
+        return str(value)[:100]
+    return request_or_response[:100]

--- a/mlflow/tracing/utils/span_translation.py
+++ b/mlflow/tracing/utils/span_translation.py
@@ -1,0 +1,209 @@
+"""
+Utilities for translating OTEL span kinds to MLflow span types.
+
+This module provides functions to translate span kind attributes from various
+OTEL semantic conventions (OpenInference, Traceloop) to MLflow span types.
+"""
+
+import json
+import logging
+from typing import Any
+
+from mlflow.entities.span import Span, SpanType
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+from mlflow.tracing.utils import dump_span_attribute_value
+
+_logger = logging.getLogger(__name__)
+
+OPENINFERENCE_SPAN_KIND_ATTRIBUTE_KEY = "openinference.span.kind"
+# Mapping from OpenInference span kinds to MLflow span types
+# Reference: https://github.com/Arize-ai/openinference/blob/50eaf3c943d818f12fdc8e37b7c305c763c82050/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L356
+OPENINFERENCE_SPAN_KIND_TO_MLFLOW_TYPE = {
+    "TOOL": SpanType.TOOL,
+    "CHAIN": SpanType.CHAIN,
+    "LLM": SpanType.LLM,
+    "RETRIEVER": SpanType.RETRIEVER,
+    "EMBEDDING": SpanType.EMBEDDING,
+    "AGENT": SpanType.AGENT,
+    "RERANKER": SpanType.RERANKER,
+    "UNKNOWN": SpanType.UNKNOWN,
+    "GUARDRAIL": SpanType.GUARDRAIL,
+    "EVALUATOR": SpanType.EVALUATOR,
+}
+
+TRACELOOP_SPAN_KIND_ATTRIBUTE_KEY = "traceloop.span.kind"
+# Mapping from Traceloop span kinds to MLflow span types
+# Reference: https://github.com/traceloop/openllmetry/blob/e66894fd7f8324bd7b2972d7f727da39e7d93181/packages/opentelemetry-semantic-conventions-ai/opentelemetry/semconv_ai/__init__.py#L301
+TRACELOOP_SPAN_KIND_TO_MLFLOW_TYPE = {
+    "workflow": SpanType.WORKFLOW,
+    "task": SpanType.TASK,
+    "agent": SpanType.AGENT,
+    "tool": SpanType.TOOL,
+    "unknown": SpanType.UNKNOWN,
+}
+
+INPUT_TOKEN_ATTRIBUTE_KEYS = {
+    # OTEL semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#genai-attributes
+    "gen_ai.usage.input_tokens",
+    # openllmetry semantic conventions: https://github.com/traceloop/openllmetry/blob/e66894fd7f8324bd7b2972d7f727da39e7d93181/packages/opentelemetry-semantic-conventions-ai/opentelemetry/semconv_ai/__init__.py#L80
+    "gen_ai.usage.prompt_tokens",
+    # openinference semantic conventions: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L93
+    "llm.token_count.prompt",
+}
+
+OUTPUT_TOKEN_ATTRIBUTE_KEYS = {
+    # OTEL semantic conventions: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/#genai-attributes
+    "gen_ai.usage.output_tokens",
+    # openllmetry semantic conventions: https://github.com/traceloop/openllmetry/blob/e66894fd7f8324bd7b2972d7f727da39e7d93181/packages/opentelemetry-semantic-conventions-ai/opentelemetry/semconv_ai/__init__.py#L78
+    "gen_ai.usage.completion_tokens",
+    # openinference semantic conventions: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L81
+    "llm.token_count.completion",
+}
+
+TOTAL_TOKEN_ATTRIBUTE_KEYS = {
+    # openllmetry semantic conventions: https://github.com/traceloop/openllmetry/blob/e66894fd7f8324bd7b2972d7f727da39e7d93181/packages/opentelemetry-semantic-conventions-ai/opentelemetry/semconv_ai/__init__.py#L91
+    "llm.usage.total_tokens",
+    # openinference semantic conventions: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L119
+    "llm.token_count.total",
+}
+
+INPUTS_KEYS = {
+    # openinference semantic conventions: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L12
+    "input.value",
+    # openllmetry semantic conventions: https://github.com/traceloop/openllmetry/blob/e66894fd7f8324bd7b2972d7f727da39e7d93181/packages/opentelemetry-semantic-conventions-ai/opentelemetry/semconv_ai/__init__.py#L138
+    "traceloop.entity.input",
+}
+
+OUTPUTS_KEYS = {
+    # openinference semantic conventions: https://github.com/Arize-ai/openinference/blob/c80c81b8d6fa564598bd359cdd7313f4472ceca8/python/openinference-semantic-conventions/src/openinference/semconv/trace/__init__.py#L6
+    "output.value",
+    # openllmetry semantic conventions: https://github.com/traceloop/openllmetry/blob/e66894fd7f8324bd7b2972d7f727da39e7d93181/packages/opentelemetry-semantic-conventions-ai/opentelemetry/semconv_ai/__init__.py#L139
+    "traceloop.entity.output",
+}
+
+
+def translate_span_type_from_otel(attributes: dict[str, Any]) -> str | None:
+    """
+    Translate OTEL span kind attributes to MLflow span type.
+
+    This function checks for OpenInference and Traceloop span kind attributes
+    and maps them to MLflow span types.
+
+    Args:
+        attributes: Dictionary of span attributes
+
+    Returns:
+        MLflow span type string or None if no mapping found
+    """
+    # Check for OpenInference span kind
+    if openinference_kind := attributes.get(OPENINFERENCE_SPAN_KIND_ATTRIBUTE_KEY):
+        # Handle JSON-serialized values
+        if isinstance(openinference_kind, str):
+            try:
+                openinference_kind = json.loads(openinference_kind)
+            except (json.JSONDecodeError, TypeError):
+                pass  # Use the string value as-is
+
+        mlflow_type = OPENINFERENCE_SPAN_KIND_TO_MLFLOW_TYPE.get(openinference_kind)
+        if mlflow_type is None:
+            _logger.debug(
+                f"OpenInference span kind '{openinference_kind}' is not supported "
+                "by MLflow Span Type"
+            )
+        return mlflow_type
+
+    # Check for Traceloop span kind
+    if traceloop_kind := attributes.get(TRACELOOP_SPAN_KIND_ATTRIBUTE_KEY):
+        # Handle JSON-serialized values
+        if isinstance(traceloop_kind, str):
+            try:
+                traceloop_kind = json.loads(traceloop_kind)
+            except (json.JSONDecodeError, TypeError):
+                pass  # Use the string value as-is
+
+        mlflow_type = TRACELOOP_SPAN_KIND_TO_MLFLOW_TYPE.get(traceloop_kind)
+        if mlflow_type is None:
+            _logger.debug(
+                f"Traceloop span kind '{traceloop_kind}' is not supported by MLflow Span Type"
+            )
+        return mlflow_type
+
+
+def translate_span_when_storing(span: Span) -> dict[str, Any]:
+    """
+    Apply attributes translations to a span's dictionary when storing.
+
+    Supported translations:
+    - Token usage attributes
+    - Inputs and outputs attributes
+
+    Args:
+        span: Span object
+
+    Returns:
+        Translated span dictionary
+    """
+
+    span_dict = span.to_dict()
+    attributes = span_dict.get("attributes", {})
+
+    if span.parent_id is None:
+        # update inputs and outputs for root span
+        if SpanAttributeKey.INPUTS not in attributes:
+            if input_value := next(
+                (attributes.get(key) for key in INPUTS_KEYS if key in attributes), None
+            ):
+                attributes[SpanAttributeKey.INPUTS] = input_value
+        if SpanAttributeKey.OUTPUTS not in attributes:
+            if output_value := next(
+                (attributes.get(key) for key in OUTPUTS_KEYS if key in attributes), None
+            ):
+                attributes[SpanAttributeKey.OUTPUTS] = output_value
+
+    # translate token usage
+    if SpanAttributeKey.CHAT_USAGE not in attributes:
+        input_tokens = next(
+            (attributes.get(key) for key in INPUT_TOKEN_ATTRIBUTE_KEYS if key in attributes), None
+        )
+        output_tokens = next(
+            (attributes.get(key) for key in OUTPUT_TOKEN_ATTRIBUTE_KEYS if key in attributes), None
+        )
+        total_tokens = next(
+            (attributes.get(key) for key in TOTAL_TOKEN_ATTRIBUTE_KEYS if key in attributes), None
+        )
+        if input_tokens and output_tokens and (total_tokens is None):
+            total_tokens = int(input_tokens) + int(output_tokens)
+        if total_tokens:
+            usage_dict = {
+                TokenUsageKey.INPUT_TOKENS: int(input_tokens),
+                TokenUsageKey.OUTPUT_TOKENS: int(output_tokens),
+                TokenUsageKey.TOTAL_TOKENS: int(total_tokens),
+            }
+            attributes[SpanAttributeKey.CHAT_USAGE] = dump_span_attribute_value(usage_dict)
+
+    span_dict["attributes"] = attributes
+    return span_dict
+
+
+def translate_loaded_span(span_dict: dict[str, Any]) -> dict[str, Any]:
+    """
+    Apply attributes translations to a span dictionary when loading.
+
+    Supported translations:
+    - OTEL span kind attributes
+
+    Args:
+        span_dict: Span dictionary (will be modified in-place)
+
+    Returns:
+        Modified span dictionary
+    """
+    attributes = span_dict.get("attributes", {})
+
+    if SpanAttributeKey.SPAN_TYPE not in attributes:
+        if mlflow_type := translate_span_type_from_otel(attributes):
+            # Serialize to match how MLflow stores attributes
+            attributes[SpanAttributeKey.SPAN_TYPE] = dump_span_attribute_value(mlflow_type)
+
+    span_dict["attributes"] = attributes
+    return span_dict

--- a/tests/entities/test_trace.py
+++ b/tests/entities/test_trace.py
@@ -280,13 +280,13 @@ def test_trace_pandas_dataframe_columns():
 @pytest.mark.parametrize(
     ("span_type", "name", "expected"),
     [
-        (None, None, ["run", "add_one_1", "add_one_2", "add_two", "multiply_by_two"]),
+        (None, None, ["run", "add_one", "add_one_2", "add_two", "multiply_by_two"]),
         (SpanType.CHAIN, None, ["run"]),
         (None, "add_two", ["add_two"]),
-        (None, re.compile(r"add.*"), ["add_one_1", "add_one_2", "add_two"]),
-        (None, re.compile(r"^add"), ["add_one_1", "add_one_2", "add_two"]),
+        (None, re.compile(r"add.*"), ["add_one", "add_one_2", "add_two"]),
+        (None, re.compile(r"^add"), ["add_one", "add_one_2", "add_two"]),
         (None, re.compile(r"_two$"), ["add_two", "multiply_by_two"]),
-        (None, re.compile(r".*ONE", re.IGNORECASE), ["add_one_1", "add_one_2"]),
+        (None, re.compile(r".*ONE", re.IGNORECASE), ["add_one", "add_one_2"]),
         (SpanType.TOOL, "multiply_by_two", ["multiply_by_two"]),
         (SpanType.AGENT, None, []),
         (None, "non_existent", []),

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -188,7 +188,7 @@ def test_intermediate_outputs_from_spans():
 
     assert trace.data.intermediate_outputs == {
         "retrieved_documents": ["document 1", "document 2"],
-        "llm_1": "Hi, this is LLM 1",
+        "llm": "Hi, this is LLM 1",
         "llm_2": "Hi, this is LLM 2",
     }
 

--- a/tests/langchain/test_langchain_autolog.py
+++ b/tests/langchain/test_langchain_autolog.py
@@ -368,10 +368,10 @@ def test_runnable_sequence_autolog(async_logging_enabled):
         # Since the chain includes parallel execution, the order of some
         # spans is not deterministic.
         assert spans == {
-            ("RunnableSequence_1", "CHAIN"),
+            ("RunnableSequence", "CHAIN"),
             ("RunnableParallel<question,chat_history>", "CHAIN"),
             ("RunnableSequence_2", "CHAIN"),
-            ("RunnableLambda_1", "CHAIN"),
+            ("RunnableLambda", "CHAIN"),
             ("extract_question", "CHAIN"),
             ("RunnableSequence_3", "CHAIN"),
             ("RunnableLambda_2", "CHAIN"),

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -99,6 +99,7 @@ from mlflow.store.tracking.dbmodels.models import (
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore, _get_orderby_clauses
 from mlflow.tracing.constant import (
     MAX_CHARS_IN_TRACE_INFO_TAGS_VALUE,
+    SpanAttributeKey,
     SpansLocation,
     TraceMetadataKey,
     TraceTagKey,
@@ -9102,3 +9103,207 @@ def test_batch_get_traces_integration_with_trace_handler(store: SqlAlchemyStore)
     loaded_spans = traces[0].data.spans
     assert len(loaded_spans) == 1
     assert loaded_spans[0].name == "integration_span"
+
+
+def test_log_spans_token_usage(store: SqlAlchemyStore) -> None:
+    experiment_id = store.create_experiment("test_log_spans_token_usage")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    otel_span = create_test_otel_span(
+        trace_id=trace_id,
+        name="llm_call",
+        start_time=1_000_000_000,
+        end_time=2_000_000_000,
+        trace_id_num=12345,
+        span_id_num=111,
+    )
+
+    otel_span._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+        SpanAttributeKey.CHAT_USAGE: json.dumps(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        ),
+    }
+
+    span = create_mlflow_span(otel_span, trace_id, "LLM")
+    store.log_spans(experiment_id, [span])
+
+    # verify token usage is stored in the trace info
+    trace_info = store.get_trace_info(trace_id)
+    assert trace_info.token_usage == {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "total_tokens": 150,
+    }
+
+    # verify loaded trace has same token usage
+    traces = store.batch_get_traces([trace_id])
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.token_usage is not None
+    assert trace.info.token_usage["input_tokens"] == 100
+    assert trace.info.token_usage["output_tokens"] == 50
+    assert trace.info.token_usage["total_tokens"] == 150
+
+
+def test_log_spans_update_token_usage_incrementally(store: SqlAlchemyStore) -> None:
+    experiment_id = store.create_experiment("test_log_spans_update_token_usage")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    otel_span1 = create_test_otel_span(
+        trace_id=trace_id,
+        name="first_llm_call",
+        start_time=1_000_000_000,
+        end_time=2_000_000_000,
+        trace_id_num=12345,
+        span_id_num=111,
+    )
+    otel_span1._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+        SpanAttributeKey.CHAT_USAGE: json.dumps(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        ),
+    }
+    span1 = create_mlflow_span(otel_span1, trace_id, "LLM")
+    store.log_spans(experiment_id, [span1])
+
+    traces = store.batch_get_traces([trace_id])
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.token_usage["input_tokens"] == 100
+    assert trace.info.token_usage["output_tokens"] == 50
+    assert trace.info.token_usage["total_tokens"] == 150
+
+    otel_span2 = create_test_otel_span(
+        trace_id=trace_id,
+        name="second_llm_call",
+        start_time=3_000_000_000,
+        end_time=4_000_000_000,
+        trace_id_num=12345,
+        span_id_num=222,
+    )
+    otel_span2._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+        SpanAttributeKey.CHAT_USAGE: json.dumps(
+            {
+                "input_tokens": 200,
+                "output_tokens": 75,
+                "total_tokens": 275,
+            }
+        ),
+    }
+    span2 = create_mlflow_span(otel_span2, trace_id, "LLM")
+    store.log_spans(experiment_id, [span2])
+
+    traces = store.batch_get_traces([trace_id])
+    assert len(traces) == 1
+    trace = traces[0]
+    assert trace.info.token_usage["input_tokens"] == 300
+    assert trace.info.token_usage["output_tokens"] == 125
+    assert trace.info.token_usage["total_tokens"] == 425
+
+
+def test_batch_get_traces_token_usage(store: SqlAlchemyStore) -> None:
+    experiment_id = store.create_experiment("test_batch_get_traces_token_usage")
+
+    trace_id_1 = f"tr-{uuid.uuid4().hex}"
+    otel_span1 = create_test_otel_span(
+        trace_id=trace_id_1,
+        name="trace1_span",
+        start_time=1_000_000_000,
+        end_time=2_000_000_000,
+        trace_id_num=12345,
+        span_id_num=111,
+    )
+    otel_span1._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id_1, cls=TraceJSONEncoder),
+        SpanAttributeKey.CHAT_USAGE: json.dumps(
+            {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "total_tokens": 150,
+            }
+        ),
+    }
+    span1 = create_mlflow_span(otel_span1, trace_id_1, "LLM")
+    store.log_spans(experiment_id, [span1])
+
+    trace_id_2 = f"tr-{uuid.uuid4().hex}"
+    otel_span2 = create_test_otel_span(
+        trace_id=trace_id_2,
+        name="trace2_span",
+        start_time=3_000_000_000,
+        end_time=4_000_000_000,
+        trace_id_num=67890,
+        span_id_num=222,
+    )
+    otel_span2._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id_2, cls=TraceJSONEncoder),
+        SpanAttributeKey.CHAT_USAGE: json.dumps(
+            {
+                "input_tokens": 200,
+                "output_tokens": 100,
+                "total_tokens": 300,
+            }
+        ),
+    }
+    span2 = create_mlflow_span(otel_span2, trace_id_2, "LLM")
+    store.log_spans(experiment_id, [span2])
+
+    trace_id_3 = f"tr-{uuid.uuid4().hex}"
+    otel_span3 = create_test_otel_span(
+        trace_id=trace_id_3,
+        name="trace3_span",
+        start_time=5_000_000_000,
+        end_time=6_000_000_000,
+        trace_id_num=11111,
+        span_id_num=333,
+    )
+    otel_span3._attributes = {
+        "mlflow.traceRequestId": json.dumps(trace_id_3, cls=TraceJSONEncoder),
+    }
+    span3 = create_mlflow_span(otel_span3, trace_id_3, "UNKNOWN")
+    store.log_spans(experiment_id, [span3])
+
+    trace_infos = [
+        store.get_trace_info(trace_id) for trace_id in [trace_id_1, trace_id_2, trace_id_3]
+    ]
+    assert trace_infos[0].token_usage == {
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "total_tokens": 150,
+    }
+    assert trace_infos[1].token_usage == {
+        "input_tokens": 200,
+        "output_tokens": 100,
+        "total_tokens": 300,
+    }
+    assert trace_infos[2].token_usage is None
+
+    traces = store.batch_get_traces([trace_id_1, trace_id_2, trace_id_3])
+    assert len(traces) == 3
+
+    traces_by_id = {trace.info.trace_id: trace for trace in traces}
+
+    trace1 = traces_by_id[trace_id_1]
+    assert trace1.info.token_usage is not None
+    assert trace1.info.token_usage["input_tokens"] == 100
+    assert trace1.info.token_usage["output_tokens"] == 50
+    assert trace1.info.token_usage["total_tokens"] == 150
+
+    trace2 = traces_by_id[trace_id_2]
+    assert trace2.info.token_usage is not None
+    assert trace2.info.token_usage["input_tokens"] == 200
+    assert trace2.info.token_usage["output_tokens"] == 100
+    assert trace2.info.token_usage["total_tokens"] == 300
+
+    trace3 = traces_by_id[trace_id_3]
+    assert trace3.info.token_usage is None

--- a/tests/tracing/processor/test_mlflow_v3_processor.py
+++ b/tests/tracing/processor/test_mlflow_v3_processor.py
@@ -122,7 +122,7 @@ def test_incremental_span_name_deduplication():
     processor.on_end(child1)
     with trace_manager.get_trace(request_id) as trace:
         names = [s.name for s in trace.span_dict.values()]
-        assert "process_1" in names
+        assert "process" in names
         assert "process_2" in names
 
     # End child3 - should correctly number third "process" as process_3
@@ -135,7 +135,7 @@ def test_incremental_span_name_deduplication():
     processor.on_end(child4)
     with trace_manager.get_trace(request_id) as trace:
         names = [s.name for s in trace.span_dict.values()]
-        assert "query_1" in names
+        assert "query" in names
         assert "query_2" in names
 
     # Final check after all spans processed
@@ -144,7 +144,7 @@ def test_incremental_span_name_deduplication():
     with trace_manager.get_trace(request_id) as trace:
         spans_sorted_by_creation = sorted(trace.span_dict.values(), key=lambda s: s.start_time_ns)
         final_names = [s.name for s in spans_sorted_by_creation]
-        assert final_names == ["process_1", "process_2", "query_1", "process_3", "query_2"]
+        assert final_names == ["process", "process_2", "query", "process_3", "query_2"]
 
 
 def test_on_end():

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -178,6 +178,14 @@ def mock_client():
         yield client
 
 
+@pytest.fixture
+def mock_otel_trace_start_time():
+    # mock the start time of a trace, ensuring the root span has
+    # a smaller start time than child spans.
+    with mock.patch("opentelemetry.sdk.trace.time_ns", return_value=0):
+        yield
+
+
 @pytest.mark.parametrize("with_active_run", [True, False])
 @pytest.mark.parametrize("wrap_sync_func", [True, False])
 def test_trace(wrap_sync_func, with_active_run, async_logging_enabled):
@@ -299,7 +307,7 @@ def test_trace_stream(wrap_sync_func):
 
     # Spans for the chid 'square' function
     for i in range(3):
-        assert trace.data.spans[i + 1].name == f"square_{i + 1}"
+        assert trace.data.spans[i + 1].name == f"square_{i + 1}" if i > 0 else "square"
         assert trace.data.spans[i + 1].inputs == {"t": i}
         assert trace.data.spans[i + 1].outputs == i**2
         assert trace.data.spans[i + 1].parent_id == root_span.span_id
@@ -538,7 +546,7 @@ def test_trace_handle_exception_during_streaming():
     assert len(spans) == 3
     assert spans[0].name == "predict_stream"
     assert spans[0].status.status_code == SpanStatusCode.ERROR
-    assert spans[1].name == "some_operation_raise_error_1"
+    assert spans[1].name == "some_operation_raise_error"
     assert spans[1].status.status_code == SpanStatusCode.OK
     assert spans[2].name == "some_operation_raise_error_2"
     assert spans[2].status.status_code == SpanStatusCode.ERROR
@@ -719,7 +727,7 @@ def test_start_span_context_manager(async_logging_enabled):
     }
 
     # Span with duplicate name should be renamed to have an index number like "_1", "_2", ...
-    child_span_1 = span_name_to_span["child_span_1"]
+    child_span_1 = span_name_to_span["child_span"]
     assert child_span_1.parent_id == root_span.span_id
     assert child_span_1.attributes == {
         "delta": 2,
@@ -1180,21 +1188,21 @@ def test_search_traces_with_multiple_spans_with_same_name():
 
     df = mlflow.search_traces(
         extract_fields=[
-            "duplicate_name.inputs.y",
             "duplicate_name.inputs.x",
-            "duplicate_name.inputs.z",
-            "duplicate_name_1.inputs.x",
-            "duplicate_name_1.inputs.y",
+            "duplicate_name.inputs.y",
             "duplicate_name_2.inputs.z",
+            "duplicate_name_1.inputs.y",
+            "duplicate_name_1.inputs.x",
+            "duplicate_name_1.inputs.z",
         ]
     )
     # Duplicate spans would all be null
-    assert df["duplicate_name.inputs.y"].isnull().all()
-    assert df["duplicate_name.inputs.x"].isnull().all()
-    assert df["duplicate_name.inputs.z"].isnull().all()
-    assert df["duplicate_name_1.inputs.x"].tolist() == [2]
-    assert df["duplicate_name_1.inputs.y"].tolist() == [5]
+    assert df["duplicate_name.inputs.x"].tolist() == [2]
+    assert df["duplicate_name.inputs.y"].tolist() == [5]
     assert df["duplicate_name_2.inputs.z"].tolist() == [7]
+    assert df["duplicate_name_1.inputs.y"].isnull().all()
+    assert df["duplicate_name_1.inputs.x"].isnull().all()
+    assert df["duplicate_name_1.inputs.z"].isnull().all()
 
 
 # Test a field that doesn't exist for extraction - we shouldn't throw, just return empty column
@@ -1968,7 +1976,7 @@ _SAMPLE_REMOTE_TRACE = {
 }
 
 
-def test_add_trace():
+def test_add_trace(mock_otel_trace_start_time):
     # Mimic a remote service call that returns a trace as a part of the response
     def dummy_remote_call():
         return {"prediction": 1, "trace": _SAMPLE_REMOTE_TRACE}
@@ -2025,7 +2033,7 @@ def test_add_trace_no_current_active_trace():
     parent_span, child_span, grandchild_span = trace.data.spans
     assert parent_span.name == "Remote Trace <remote>"
     rs = remote_trace.data.spans[0]
-    assert parent_span.start_time_ns == rs.start_time_ns
+    assert parent_span.start_time_ns == rs.start_time_ns - 1
     assert parent_span.end_time_ns == rs.end_time_ns
     assert child_span.name == rs.name
     assert child_span.parent_id is parent_span.span_id
@@ -2040,7 +2048,7 @@ def test_add_trace_no_current_active_trace():
         assert child_span.attributes[k] == rs.attributes[k]
 
 
-def test_add_trace_specific_target_span():
+def test_add_trace_specific_target_span(mock_otel_trace_start_time):
     span = start_span_no_context(name="parent")
     mlflow.add_trace(_SAMPLE_REMOTE_TRACE, target=span)
     span.end()

--- a/tests/tracing/test_otel_loading.py
+++ b/tests/tracing/test_otel_loading.py
@@ -1,0 +1,450 @@
+"""
+Tests for get_trace functionality with OpenTelemetry traces.
+This test suite verifies that traces sent via OpenTelemetry can be retrieved
+using MLflow's get_trace functionality, ensuring proper OTel to MLflow conversion.
+"""
+
+import uuid
+
+import pytest
+from opentelemetry import trace as otel_trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.resources import Resource as OTelSDKResource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.trace import Status, StatusCode
+from opentelemetry.util._once import Once
+
+import mlflow
+from mlflow.entities import SpanStatusCode
+from mlflow.entities.assessment import AssessmentSource, Expectation, Feedback
+from mlflow.entities.assessment_source import AssessmentSourceType
+from mlflow.tracing.provider import _get_trace_exporter
+from mlflow.tracing.utils import encode_trace_id
+from mlflow.tracing.utils.otlp import MLFLOW_EXPERIMENT_ID_HEADER
+from mlflow.tracking._tracking_service.utils import _use_tracking_uri
+from mlflow.version import IS_TRACING_SDK_ONLY
+
+from tests.tracking.integration_test_utils import _init_server
+
+if IS_TRACING_SDK_ONLY:
+    pytest.skip("OTel get_trace tests require full MLflow server", allow_module_level=True)
+
+
+@pytest.fixture
+def mlflow_server(tmp_path):
+    backend_store_uri = f"sqlite:///{tmp_path / 'mlflow.db'}"
+    artifact_root = tmp_path.as_uri()
+
+    # Use _init_server with FastAPI (which is now the default)
+    with _init_server(backend_store_uri, artifact_root) as url:
+        yield url
+
+
+@pytest.fixture(autouse=True)
+def tracking_uri_setup(mlflow_server):
+    with _use_tracking_uri(mlflow_server):
+        yield
+
+
+@pytest.fixture(params=[True, False])
+def is_async(request, monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING", "true" if request.param else "false")
+
+
+def _flush_async_logging():
+    exporter = _get_trace_exporter()
+    assert hasattr(exporter, "_async_queue"), "Async queue is not initialized"
+    exporter._async_queue.flush(terminate=True)
+
+
+@pytest.fixture
+def otel_tracer_setup(mlflow_server):
+    def _create_tracer(experiment_id, service_name="test-service"):
+        resource = OTelSDKResource.create(
+            {"service.name": service_name, "service.version": "1.0.0"}
+        )
+        tracer_provider = TracerProvider(resource=resource)
+
+        exporter = OTLPSpanExporter(
+            endpoint=f"{mlflow_server}/v1/traces",
+            headers={MLFLOW_EXPERIMENT_ID_HEADER: experiment_id},
+            timeout=10,
+        )
+
+        span_processor = SimpleSpanProcessor(exporter)
+        tracer_provider.add_span_processor(span_processor)
+
+        # Reset the global tracer provider
+        otel_trace._TRACER_PROVIDER_SET_ONCE = Once()
+        otel_trace._TRACER_PROVIDER = None
+        otel_trace.set_tracer_provider(tracer_provider)
+
+        return otel_trace.get_tracer(__name__)
+
+    return _create_tracer
+
+
+def test_get_trace_for_otel_sent_span(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-get-trace-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "test-service-get-trace")
+
+    # Create a span with various attributes to test conversion
+    with tracer.start_as_current_span("otel-test-span") as span:
+        span.set_attribute("test.string", "string-value")
+        span.set_attribute("test.number", 42)
+        span.set_attribute("test.boolean", True)
+        span.set_attribute("operation.type", "llm_request")
+
+        # Capture the OTel trace ID
+        otel_trace_id = span.get_span_context().trace_id
+        assert span.get_span_context().is_valid
+        assert otel_trace_id != 0
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+
+    assert len(traces) > 0, "No traces found in the database"
+
+    trace_id = traces[0].info.trace_id
+    retrieved_trace = mlflow.get_trace(trace_id)
+
+    assert retrieved_trace.info.trace_id == trace_id
+    assert retrieved_trace.info.trace_location.mlflow_experiment.experiment_id == experiment_id
+
+    assert len(retrieved_trace.data.spans) == 1
+    span = retrieved_trace.data.spans[0]
+
+    assert span.name == "otel-test-span"
+    assert span.trace_id == trace_id
+    # OTel spans default to UNSET status if not explicitly set
+    assert span.status.status_code == SpanStatusCode.UNSET
+
+    # Verify attributes were converted correctly
+    assert span.attributes["test.string"] == "string-value"
+    assert span.attributes["test.number"] == 42
+    assert span.attributes["test.boolean"] is True
+    assert span.attributes["operation.type"] == "llm_request"
+
+    # Verify the trace ID matches the expected format
+    expected_trace_id = f"tr-{encode_trace_id(otel_trace_id)}"
+    assert trace_id == expected_trace_id
+
+
+def test_get_trace_for_otel_nested_spans(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-nested-spans-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "nested-test-service")
+
+    # Create nested spans
+    with tracer.start_as_current_span("parent-span") as parent_span:
+        parent_span.set_attribute("span.level", "parent")
+
+        with tracer.start_as_current_span("child-span") as child_span:
+            child_span.set_attribute("span.level", "child")
+            child_span.set_attribute("child.operation", "process_data")
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+
+    assert len(traces) > 0, "No traces found in the database"
+
+    trace_id = traces[0].info.trace_id
+    retrieved_trace = mlflow.get_trace(trace_id)
+
+    assert len(retrieved_trace.data.spans) == 2
+
+    spans_by_name = {span.name: span for span in retrieved_trace.data.spans}
+
+    assert "parent-span" in spans_by_name
+    assert "child-span" in spans_by_name
+
+    parent_span = spans_by_name["parent-span"]
+    child_span = spans_by_name["child-span"]
+
+    assert parent_span.attributes["span.level"] == "parent"
+    assert parent_span.parent_id is None  # Root span has no parent
+
+    assert child_span.attributes["span.level"] == "child"
+    assert child_span.attributes["child.operation"] == "process_data"
+    assert child_span.parent_id == parent_span.span_id  # Child should reference parent
+
+
+def test_get_trace_with_otel_span_events(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-events-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "events-test-service")
+
+    # Create span with events using OTel SDK
+    with tracer.start_as_current_span("span-with-events") as span:
+        span.add_event("test_event", attributes={"event.type": "processing"})
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+
+    trace_id = traces[0].info.trace_id
+    retrieved_trace = mlflow.get_trace(trace_id)
+
+    assert len(retrieved_trace.data.spans) == 1
+    retrieved_span = retrieved_trace.data.spans[0]
+
+    assert retrieved_span.name == "span-with-events"
+    assert len(retrieved_span.events) == 1
+    event = retrieved_span.events[0]
+    assert event.name == "test_event"
+    assert event.attributes["event.type"] == "processing"
+
+
+def test_get_trace_nonexistent_otel_trace(mlflow_server: str):
+    # Create a fake trace ID in OTel format
+    fake_otel_trace_id = uuid.uuid4().hex
+    fake_trace_id = f"tr-{fake_otel_trace_id}"
+
+    # MLflow get_trace returns None for non-existent traces
+    trace = mlflow.get_trace(fake_trace_id)
+    assert trace is None
+
+
+def test_get_trace_with_otel_span_status(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-status-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "status-test-service")
+
+    # Create span with error status using OTel SDK
+    with tracer.start_as_current_span("error-span") as span:
+        span.set_status(Status(StatusCode.ERROR, "Something went wrong"))
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+
+    trace_id = traces[0].info.trace_id
+    retrieved_trace = mlflow.get_trace(trace_id)
+
+    assert len(retrieved_trace.data.spans) == 1
+    retrieved_span = retrieved_trace.data.spans[0]
+
+    assert retrieved_span.name == "error-span"
+    assert retrieved_span.status.status_code == SpanStatusCode.ERROR
+    assert "Something went wrong" in retrieved_span.status.description
+
+
+def test_set_trace_tag_on_otel_trace(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-tag-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "tag-test-service")
+
+    with tracer.start_as_current_span("tagged-span") as span:
+        span.set_attribute("test.attribute", "value")
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+    trace_id = traces[0].info.trace_id
+
+    mlflow.set_trace_tag(trace_id, "environment", "test")
+    mlflow.set_trace_tag(trace_id, "version", "1.0.0")
+
+    retrieved_trace = mlflow.get_trace(trace_id)
+    assert retrieved_trace.info.tags["environment"] == "test"
+    assert retrieved_trace.info.tags["version"] == "1.0.0"
+
+
+def test_log_expectation_on_otel_trace(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-expectation-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "expectation-test-service")
+
+    # Create a span that represents a question-answer scenario
+    with tracer.start_as_current_span("qa-span") as span:
+        span.set_attribute("question", "What is MLflow?")
+        span.set_attribute("answer", "MLflow is an open-source ML platform")
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+    trace_id = traces[0].info.trace_id
+
+    expectation_source = AssessmentSource(
+        source_type=AssessmentSourceType.HUMAN, source_id="test_user@example.com"
+    )
+
+    logged_assessment = mlflow.log_expectation(
+        trace_id=trace_id,
+        name="expected_answer",
+        value="MLflow is an open-source machine learning platform",
+        source=expectation_source,
+        metadata={"confidence": "high", "reviewed_by": "expert"},
+    )
+    expectation = mlflow.get_assessment(
+        trace_id=trace_id, assessment_id=logged_assessment.assessment_id
+    )
+    assert expectation.name == "expected_answer"
+    assert expectation.value == "MLflow is an open-source machine learning platform"
+    assert expectation.source.source_type == AssessmentSourceType.HUMAN
+    assert expectation.metadata["confidence"] == "high"
+
+
+def test_log_feedback_on_otel_trace(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-feedback-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "feedback-test-service")
+
+    # Create a span representing a model prediction
+    with tracer.start_as_current_span("prediction-span") as span:
+        span.set_attribute("model", "gpt-4")
+        span.set_attribute("prediction", "The weather is sunny")
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+    assert len(traces) > 0, "No traces found in the database"
+    trace_id = traces[0].info.trace_id
+
+    llm_source = AssessmentSource(
+        source_type=AssessmentSourceType.LLM_JUDGE, source_id="gpt-4o-mini"
+    )
+
+    logged_quality = mlflow.log_feedback(
+        trace_id=trace_id,
+        name="quality_score",
+        value=8.5,
+        source=llm_source,
+        metadata={"scale": "1-10", "criterion": "accuracy"},
+    )
+    feedback = mlflow.get_assessment(trace_id=trace_id, assessment_id=logged_quality.assessment_id)
+    assert feedback.name == "quality_score"
+    assert feedback.value == 8.5
+    assert feedback.source.source_type == AssessmentSourceType.LLM_JUDGE
+
+    human_source = AssessmentSource(
+        source_type=AssessmentSourceType.HUMAN, source_id="reviewer@example.com"
+    )
+
+    logged_approval = mlflow.log_feedback(
+        trace_id=trace_id,
+        name="approved",
+        value=True,
+        source=human_source,
+        metadata={"review_date": "2024-01-15"},
+    )
+    feedback = mlflow.get_assessment(trace_id=trace_id, assessment_id=logged_approval.assessment_id)
+    assert feedback.name == "approved"
+    assert feedback.value is True
+    assert feedback.source.source_type == AssessmentSourceType.HUMAN
+
+
+def test_multiple_assessments_on_otel_trace(mlflow_server: str, otel_tracer_setup, is_async):
+    experiment = mlflow.set_experiment("otel-multi-assessment-test")
+    experiment_id = experiment.experiment_id
+
+    tracer = otel_tracer_setup(experiment_id, "multi-assessment-test-service")
+
+    # Create a complex trace with nested spans
+    with tracer.start_as_current_span("conversation") as parent_span:
+        parent_span.set_attribute("user_query", "Explain quantum computing")
+
+        with tracer.start_as_current_span("retrieval") as retrieval_span:
+            retrieval_span.set_attribute("documents_found", 5)
+
+        with tracer.start_as_current_span("generation") as generation_span:
+            generation_span.set_attribute("model", "gpt-4")
+            generation_span.set_attribute("response", "Quantum computing uses quantum mechanics...")
+
+    if is_async:
+        _flush_async_logging()
+
+    traces = mlflow.search_traces(
+        experiment_ids=[experiment_id], include_spans=False, return_type="list"
+    )
+    trace_id = traces[0].info.trace_id
+
+    mlflow.set_trace_tag(trace_id, "topic", "quantum_computing")
+    mlflow.set_trace_tag(trace_id, "complexity", "high")
+
+    human_source = AssessmentSource(AssessmentSourceType.HUMAN, "expert@physics.edu")
+    llm_source = AssessmentSource(AssessmentSourceType.LLM_JUDGE, "claude-3")
+
+    expectation = Expectation(
+        name="expected_quality",
+        value="Should explain quantum superposition and entanglement",
+        source=human_source,
+    )
+    mlflow.log_assessment(trace_id=trace_id, assessment=expectation)
+    feedback_items = [
+        Feedback(name="accuracy", value=9.0, source=llm_source, metadata={"max_score": "10"}),
+        Feedback(name="clarity", value=8.5, source=llm_source, metadata={"max_score": "10"}),
+        Feedback(
+            name="helpfulness",
+            value=True,
+            source=human_source,
+            metadata={"reviewer_expertise": "quantum_physics"},
+        ),
+        Feedback(
+            name="contains_errors",
+            value=False,
+            source=human_source,
+            metadata={"fact_checked": "True"},
+        ),
+    ]
+
+    for feedback in feedback_items:
+        mlflow.log_assessment(trace_id=trace_id, assessment=feedback)
+
+    retrieved_trace = mlflow.get_trace(trace_id)
+    assessments = retrieved_trace.info.assessments
+    assert len(assessments) == 5
+    assert [a.name for a in assessments] == [
+        "expected_quality",
+        "accuracy",
+        "clarity",
+        "helpfulness",
+        "contains_errors",
+    ]
+
+    assert retrieved_trace.info.tags["topic"] == "quantum_computing"
+    assert retrieved_trace.info.tags["complexity"] == "high"
+
+    assert len(retrieved_trace.data.spans) == 3
+    span_names = {span.name for span in retrieved_trace.data.spans}
+    assert span_names == {"conversation", "retrieval", "generation"}
+
+    tagged_traces = mlflow.search_traces(
+        experiment_ids=[experiment_id],
+        filter_string='tags.topic = "quantum_computing"',
+        return_type="list",
+    )
+    assert len(tagged_traces) == 1
+    assert tagged_traces[0].info.trace_id == trace_id

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -9,7 +9,7 @@ import mlflow
 from mlflow.entities.span import create_mlflow_span
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
 from mlflow.tracing.client import TracingClient
-from mlflow.tracing.constant import TRACKING_STORE, TraceTagKey
+from mlflow.tracing.constant import SpansLocation, TraceTagKey
 from mlflow.tracing.utils import TraceJSONEncoder
 
 from tests.tracing.helper import skip_when_testing_trace_sdk
@@ -176,7 +176,7 @@ def test_tracing_client_get_trace_with_database_stored_spans():
     trace = client.get_trace(trace_id)
 
     assert trace.info.trace_id == trace_id
-    assert trace.info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE
+    assert trace.info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.TRACKING_STORE
 
     assert len(trace.data.spans) == 1
     loaded_span = trace.data.spans[0]

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -143,16 +143,12 @@ def test_tracing_client_calculate_trace_filter_correlation_without_base_filter()
 
 @skip_when_testing_trace_sdk
 def test_tracing_client_get_trace_with_database_stored_spans():
-    from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
-
     client = TracingClient()
 
     experiment_id = mlflow.create_experiment("test")
     trace_id = f"tr-{uuid.uuid4().hex}"
 
     store = client.store
-    if not isinstance(store, SqlAlchemyStore):
-        return
 
     otel_span = OTelReadableSpan(
         name="test_span",

--- a/tests/tracing/test_tracing_client.py
+++ b/tests/tracing/test_tracing_client.py
@@ -1,9 +1,16 @@
 import json
+import uuid
 from unittest.mock import Mock, patch
 
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
+
 import mlflow
+from mlflow.entities.span import create_mlflow_span
 from mlflow.tracing.analysis import TraceFilterCorrelationResult
 from mlflow.tracing.client import TracingClient
+from mlflow.tracing.constant import TRACKING_STORE, TraceTagKey
+from mlflow.tracing.utils import TraceJSONEncoder
 
 from tests.tracing.helper import skip_when_testing_trace_sdk
 
@@ -132,3 +139,55 @@ def test_tracing_client_calculate_trace_filter_correlation_without_base_filter()
         assert result.filter2_count == 0
         assert result.joint_count == 0
         assert result.total_count == 100
+
+
+@skip_when_testing_trace_sdk
+def test_tracing_client_get_trace_with_database_stored_spans():
+    from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+
+    client = TracingClient()
+
+    experiment_id = mlflow.create_experiment("test")
+    trace_id = f"tr-{uuid.uuid4().hex}"
+
+    store = client.store
+    if not isinstance(store, SqlAlchemyStore):
+        return
+
+    otel_span = OTelReadableSpan(
+        name="test_span",
+        context=trace_api.SpanContext(
+            trace_id=12345,
+            span_id=111,
+            is_remote=False,
+            trace_flags=trace_api.TraceFlags(1),
+        ),
+        parent=None,
+        attributes={
+            "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+            "llm.model_name": "test-model",
+            "custom.attribute": "test-value",
+        },
+        start_time=1_000_000_000,
+        end_time=2_000_000_000,
+        resource=None,
+    )
+
+    span = create_mlflow_span(otel_span, trace_id, "LLM")
+
+    store.log_spans(experiment_id, [span])
+
+    trace = client.get_trace(trace_id)
+
+    assert trace.info.trace_id == trace_id
+    assert trace.info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE
+
+    assert len(trace.data.spans) == 1
+    loaded_span = trace.data.spans[0]
+
+    assert loaded_span.name == "test_span"
+    assert loaded_span.trace_id == trace_id
+    assert loaded_span.start_time_ns == 1_000_000_000
+    assert loaded_span.end_time_ns == 2_000_000_000
+    assert loaded_span.attributes.get("llm.model_name") == "test-model"
+    assert loaded_span.attributes.get("custom.attribute") == "test-value"

--- a/tests/tracing/utils/test_span_translation.py
+++ b/tests/tracing/utils/test_span_translation.py
@@ -1,0 +1,287 @@
+import json
+from unittest import mock
+
+import pytest
+
+from mlflow.entities.span import Span, SpanType
+from mlflow.tracing.constant import SpanAttributeKey, TokenUsageKey
+from mlflow.tracing.utils.span_translation import (
+    translate_loaded_span,
+    translate_span_type_from_otel,
+    translate_span_when_storing,
+)
+
+
+@pytest.mark.parametrize(
+    ("attr_key", "otel_kind", "expected_type"),
+    [
+        ("openinference.span.kind", "LLM", SpanType.LLM),
+        ("openinference.span.kind", "CHAIN", SpanType.CHAIN),
+        ("openinference.span.kind", "AGENT", SpanType.AGENT),
+        ("openinference.span.kind", "TOOL", SpanType.TOOL),
+        ("openinference.span.kind", "RETRIEVER", SpanType.RETRIEVER),
+        ("openinference.span.kind", "EMBEDDING", SpanType.EMBEDDING),
+        ("openinference.span.kind", "RERANKER", SpanType.RERANKER),
+        ("openinference.span.kind", "GUARDRAIL", SpanType.GUARDRAIL),
+        ("openinference.span.kind", "EVALUATOR", SpanType.EVALUATOR),
+        ("traceloop.span.kind", "workflow", SpanType.WORKFLOW),
+        ("traceloop.span.kind", "task", SpanType.TASK),
+        ("traceloop.span.kind", "agent", SpanType.AGENT),
+        ("traceloop.span.kind", "tool", SpanType.TOOL),
+    ],
+)
+def test_translate_span_type_from_otel(attr_key, otel_kind, expected_type):
+    attributes = {attr_key: otel_kind}
+    result = translate_span_type_from_otel(attributes)
+    assert result == expected_type
+
+
+@pytest.mark.parametrize(
+    "attributes",
+    [
+        {"some.other.attribute": "value"},
+        {"openinference.span.kind": "UNKNOWN_TYPE"},
+        {"traceloop.span.kind": "unknown_type"},
+    ],
+)
+def test_translate_span_type_returns_none(attributes):
+    result = translate_span_type_from_otel(attributes)
+    assert result is None
+
+
+@pytest.mark.parametrize(
+    ("attr_key", "attr_value", "expected_type"),
+    [
+        ("openinference.span.kind", json.dumps("LLM"), SpanType.LLM),
+        ("traceloop.span.kind", json.dumps("agent"), SpanType.AGENT),
+    ],
+)
+def test_json_serialized_values(attr_key, attr_value, expected_type):
+    attributes = {attr_key: attr_value}
+    result = translate_span_type_from_otel(attributes)
+    assert result == expected_type
+
+
+def test_openinference_takes_precedence():
+    attributes = {
+        "openinference.span.kind": "LLM",
+        "traceloop.span.kind": "workflow",
+    }
+    result = translate_span_type_from_otel(attributes)
+    assert result == SpanType.LLM
+
+
+@pytest.mark.parametrize(
+    ("attr_key", "attr_value", "expected_type"),
+    [
+        ("openinference.span.kind", "LLM", SpanType.LLM),
+        ("traceloop.span.kind", "agent", SpanType.AGENT),
+    ],
+)
+def test_translate_loaded_span_sets_span_type(attr_key, attr_value, expected_type):
+    span_dict = {"attributes": {attr_key: attr_value}}
+    result = translate_loaded_span(span_dict)
+
+    assert SpanAttributeKey.SPAN_TYPE in result["attributes"]
+    span_type = json.loads(result["attributes"][SpanAttributeKey.SPAN_TYPE])
+    assert span_type == expected_type
+
+
+@pytest.mark.parametrize(
+    ("span_dict", "should_have_span_type", "expected_type"),
+    [
+        (
+            {
+                "attributes": {
+                    SpanAttributeKey.SPAN_TYPE: json.dumps(SpanType.TOOL),
+                    "openinference.span.kind": "LLM",
+                }
+            },
+            True,
+            SpanType.TOOL,
+        ),
+        ({"attributes": {"some.other.attribute": "value"}}, False, None),
+        ({}, False, None),
+    ],
+)
+def test_translate_loaded_span_edge_cases(span_dict, should_have_span_type, expected_type):
+    result = translate_loaded_span(span_dict)
+    if should_have_span_type:
+        assert SpanAttributeKey.SPAN_TYPE in result["attributes"]
+        span_type = json.loads(result["attributes"][SpanAttributeKey.SPAN_TYPE])
+        assert span_type == expected_type
+    else:
+        assert SpanAttributeKey.SPAN_TYPE not in result.get("attributes", {})
+
+
+@pytest.mark.parametrize(
+    ("input_tokens_key", "output_tokens_key", "total_tokens_key"),
+    [
+        ("gen_ai.usage.input_tokens", "gen_ai.usage.output_tokens", "llm.usage.total_tokens"),
+        ("gen_ai.usage.prompt_tokens", "gen_ai.usage.completion_tokens", None),
+        ("llm.token_count.prompt", "llm.token_count.completion", "llm.token_count.total"),
+    ],
+)
+def test_translate_token_usage_from_otel(input_tokens_key, output_tokens_key, total_tokens_key):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {
+        "attributes": {
+            input_tokens_key: 100,
+            output_tokens_key: 50,
+        }
+    }
+    if total_tokens_key:
+        span_dict["attributes"][total_tokens_key] = 150
+
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert SpanAttributeKey.CHAT_USAGE in result["attributes"]
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == 100
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == 50
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == 150
+
+
+@pytest.mark.parametrize(
+    ("attributes", "expected_input", "expected_output", "expected_total"),
+    [
+        (
+            {"gen_ai.usage.input_tokens": 75, "gen_ai.usage.output_tokens": 25},
+            75,
+            25,
+            100,
+        ),
+        (
+            {
+                SpanAttributeKey.CHAT_USAGE: json.dumps(
+                    {
+                        TokenUsageKey.INPUT_TOKENS: 200,
+                        TokenUsageKey.OUTPUT_TOKENS: 100,
+                        TokenUsageKey.TOTAL_TOKENS: 300,
+                    }
+                ),
+                "gen_ai.usage.input_tokens": 50,
+                "gen_ai.usage.output_tokens": 25,
+            },
+            200,
+            100,
+            300,
+        ),
+    ],
+)
+def test_translate_token_usage_edge_cases(
+    attributes, expected_input, expected_output, expected_total
+):
+    span = mock.Mock(spec=Span)
+    span.parent_id = "parent_123"
+    span_dict = {"attributes": attributes}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    usage = json.loads(result["attributes"][SpanAttributeKey.CHAT_USAGE])
+    assert usage[TokenUsageKey.INPUT_TOKENS] == expected_input
+    assert usage[TokenUsageKey.OUTPUT_TOKENS] == expected_output
+    assert usage[TokenUsageKey.TOTAL_TOKENS] == expected_total
+
+
+@pytest.mark.parametrize(
+    ("input_key", "input_value"),
+    [
+        ("input.value", "test input"),
+        ("traceloop.entity.input", {"query": "test"}),
+    ],
+)
+def test_translate_inputs_for_root_span(input_key, input_value):
+    span = mock.Mock(spec=Span)
+    span.parent_id = None  # Root span
+    span_dict = {"attributes": {input_key: input_value}}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert result["attributes"][SpanAttributeKey.INPUTS] == input_value
+
+
+@pytest.mark.parametrize(
+    ("output_key", "output_value"),
+    [
+        ("output.value", "test output"),
+        ("traceloop.entity.output", {"result": "success"}),
+    ],
+)
+def test_translate_outputs_for_root_span(output_key, output_value):
+    span = mock.Mock(spec=Span)
+    span.parent_id = None  # Root span
+    span_dict = {"attributes": {output_key: output_value}}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    assert result["attributes"][SpanAttributeKey.OUTPUTS] == output_value
+
+
+@pytest.mark.parametrize(
+    (
+        "parent_id",
+        "attributes",
+        "should_have_inputs",
+        "expected_inputs",
+        "should_have_outputs",
+        "expected_outputs",
+    ),
+    [
+        (
+            "parent_123",
+            {"input.value": "test input", "output.value": "test output"},
+            False,
+            None,
+            False,
+            None,
+        ),
+        (
+            None,
+            {
+                SpanAttributeKey.INPUTS: json.dumps("existing input"),
+                SpanAttributeKey.OUTPUTS: json.dumps("existing output"),
+                "input.value": "new input",
+                "output.value": "new output",
+            },
+            True,
+            "existing input",
+            True,
+            "existing output",
+        ),
+    ],
+)
+def test_translate_inputs_outputs_edge_cases(
+    parent_id,
+    attributes,
+    should_have_inputs,
+    expected_inputs,
+    should_have_outputs,
+    expected_outputs,
+):
+    span = mock.Mock(spec=Span)
+    span.parent_id = parent_id
+    span_dict = {"attributes": attributes}
+    span.to_dict.return_value = span_dict
+
+    result = translate_span_when_storing(span)
+
+    if should_have_inputs:
+        assert SpanAttributeKey.INPUTS in result["attributes"]
+        inputs = json.loads(result["attributes"][SpanAttributeKey.INPUTS])
+        assert inputs == expected_inputs
+    else:
+        assert SpanAttributeKey.INPUTS not in result["attributes"]
+
+    if should_have_outputs:
+        assert SpanAttributeKey.OUTPUTS in result["attributes"]
+        outputs = json.loads(result["attributes"][SpanAttributeKey.OUTPUTS])
+        assert outputs == expected_outputs
+    else:
+        assert SpanAttributeKey.OUTPUTS not in result["attributes"]

--- a/tests/tracing/utils/test_timeout.py
+++ b/tests/tracing/utils/test_timeout.py
@@ -88,7 +88,7 @@ def test_trace_halted_after_timeout(monkeypatch):
     )
 
     first_span = trace.data.spans[1]
-    assert first_span.name == "slow_function_1"
+    assert first_span.name == "slow_function"
     assert first_span.status.status_code == SpanStatusCode.OK
 
     # The rest of the spans should not be logged to the backend.

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -58,9 +58,9 @@ def test_deduplicate_span_names():
     deduplicate_span_names_in_place(spans)
 
     assert [span.name for span in spans] == [
-        "red_1",
+        "red",
         "red_2",
-        "blue_1",
+        "blue",
         "red_3",
         "green",
         "blue_2",

--- a/tests/tracing/utils/test_utils.py
+++ b/tests/tracing/utils/test_utils.py
@@ -34,6 +34,7 @@ from mlflow.tracing.utils import (
     get_otel_attribute,
     maybe_get_request_id,
     parse_trace_id_v4,
+    truncate_request_response_preview,
 )
 
 from tests.tracing.helper import create_mock_otel_span
@@ -450,3 +451,19 @@ def test_generate_trace_id_v4_from_otel_trace_id():
     parsed_location, parsed_id = parse_trace_id_v4(result)
     assert parsed_location == location
     assert parsed_id == expected_hex_id
+
+
+@pytest.mark.parametrize(
+    ("input_data", "expected_result"),
+    [
+        ("hello world", "hello world"),
+        ("a" * 200, "a" * 100),
+        ({"key": "value"}, "{'key': 'value'}"),
+        ({"key": "value" * 100}, str({"key": "value" * 100})[:100]),
+        ([1, 2, 3, 4, 5], "[1, 2, 3, 4, 5]"),
+    ],
+)
+def test_truncate_request_response_preview_string(input_data, expected_result):
+    json_string = json.dumps(input_data)
+    result = truncate_request_response_preview(json_string)
+    assert result == expected_result

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -57,7 +57,7 @@ from mlflow.store.model_registry.sqlalchemy_store import (
 )
 from mlflow.store.tracking import SEARCH_EVALUATION_DATASETS_MAX_RESULTS, SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore as SqlAlchemyTrackingStore
-from mlflow.tracing.constant import TRACKING_STORE, TraceMetadataKey, TraceTagKey
+from mlflow.tracing.constant import SpansLocation, TraceMetadataKey, TraceTagKey
 from mlflow.tracing.provider import _get_tracer, trace_disabled
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.tracking import set_registry_uri
@@ -524,7 +524,7 @@ def test_client_search_traces_with_get_traces_tracking_store(
             request_time=123,
             execution_duration=456,
             state=TraceState.OK,
-            tags={TraceTagKey.SPANS_LOCATION: TRACKING_STORE},
+            tags={TraceTagKey.SPANS_LOCATION: SpansLocation.TRACKING_STORE},
         )
         for i in range(num_results)
     ]
@@ -3470,14 +3470,14 @@ def test_log_spans_and_get_trace_with_sqlalchemy_store(tmp_path: Path) -> None:
 
         # Verify the trace has the spans location tag set
         trace_info = store.get_trace_info(trace_id)
-        assert trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE
+        assert trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.TRACKING_STORE
 
         # Now test that mlflow.get_trace() works and loads spans from the database
         trace = mlflow.get_trace(trace_id)
 
         # Verify trace structure
         assert trace.info.trace_id == trace_id
-        assert trace.info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE
+        assert trace.info.tags.get(TraceTagKey.SPANS_LOCATION) == SpansLocation.TRACKING_STORE
 
         # Verify spans were loaded from database
         assert len(trace.data.spans) == 2

--- a/tests/tracking/test_client.py
+++ b/tests/tracking/test_client.py
@@ -3,11 +3,14 @@ import os
 import pickle
 import sys
 import time
+import uuid
 from pathlib import Path
 from unittest import mock
 from unittest.mock import Mock, patch
 
 import pytest
+from opentelemetry import trace as trace_api
+from opentelemetry.sdk.trace import ReadableSpan as OTelReadableSpan
 
 import mlflow
 from mlflow import MlflowClient, flush_async_logging
@@ -35,6 +38,7 @@ from mlflow.entities.model_registry import ModelVersion, ModelVersionTag
 from mlflow.entities.model_registry.model_version_status import ModelVersionStatus
 from mlflow.entities.model_registry.prompt_version import IS_PROMPT_TAG_KEY
 from mlflow.entities.param import Param
+from mlflow.entities.span import create_mlflow_span
 from mlflow.entities.trace_data import TraceData
 from mlflow.entities.trace_location import TraceLocation, TraceLocationType, UCSchemaLocation
 from mlflow.entities.trace_state import TraceState
@@ -53,8 +57,9 @@ from mlflow.store.model_registry.sqlalchemy_store import (
 )
 from mlflow.store.tracking import SEARCH_EVALUATION_DATASETS_MAX_RESULTS, SEARCH_MAX_RESULTS_DEFAULT
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore as SqlAlchemyTrackingStore
-from mlflow.tracing.constant import TraceMetadataKey
+from mlflow.tracing.constant import TRACKING_STORE, TraceMetadataKey, TraceTagKey
 from mlflow.tracing.provider import _get_tracer, trace_disabled
+from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.tracking import set_registry_uri
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
 from mlflow.tracking._model_registry.utils import (
@@ -508,10 +513,61 @@ def test_client_search_traces_mixed(mock_store, mock_artifact_repo, include_span
 
 
 @pytest.mark.parametrize("include_spans", [True, False])
+@pytest.mark.parametrize("num_results", [0, 5])
+def test_client_search_traces_with_get_traces_tracking_store(
+    mock_store, mock_artifact_repo, include_spans, num_results
+):
+    mock_trace_infos = [
+        TraceInfo(
+            trace_id=f"tr-123456789{i}",
+            trace_location=TraceLocation.from_experiment_id(f"exp-{i}"),
+            request_time=123,
+            execution_duration=456,
+            state=TraceState.OK,
+            tags={TraceTagKey.SPANS_LOCATION: TRACKING_STORE},
+        )
+        for i in range(num_results)
+    ]
+    mock_store.search_traces.return_value = (mock_trace_infos, None)
+    mock_store.batch_get_traces.return_value = [
+        Trace(info=info, data=TraceData(spans=[])) for info in mock_trace_infos
+    ]
+
+    results = MlflowClient().search_traces(
+        locations=["exp-0", "exp-1", "exp-2"],
+        include_spans=include_spans,
+    )
+    mock_store.search_traces.assert_called_once_with(
+        experiment_ids=None,
+        filter_string=None,
+        max_results=100,
+        order_by=None,
+        page_token=None,
+        model_id=None,
+        locations=["exp-0", "exp-1", "exp-2"],
+    )
+    assert len(results) == num_results
+
+    if include_spans and num_results > 0:
+        mock_store.batch_get_traces.assert_called_once_with(
+            [f"tr-123456789{i}" for i in range(num_results)],
+            None,
+        )
+    else:
+        mock_store.batch_get_traces.assert_not_called()
+
+    mock_artifact_repo.download_trace_data.assert_not_called()
+
+    # The TraceInfo is already fetched prior to the upload_trace_data call,
+    # so we should not call _get_trace_info again
+    mock_store.get_trace_info.assert_not_called()
+
+
+@pytest.mark.parametrize("include_spans", [True, False])
 def test_client_search_traces_with_artifact_repo(mock_store, mock_artifact_repo, include_spans):
     mock_traces = [
         TraceInfo(
-            trace_id="1234567",
+            trace_id="tr-1234567",
             trace_location=TraceLocation.from_experiment_id("1"),
             request_time=123,
             execution_duration=456,
@@ -519,7 +575,7 @@ def test_client_search_traces_with_artifact_repo(mock_store, mock_artifact_repo,
             tags={"mlflow.artifactLocation": "dbfs:/path/to/artifacts/1"},
         ),
         TraceInfo(
-            trace_id="8910",
+            trace_id="tr-8910",
             trace_location=TraceLocation.from_experiment_id("2"),
             request_time=456,
             execution_duration=789,
@@ -784,6 +840,8 @@ def test_start_and_end_trace_capture_falsy_input_and_output(tracking_uri):
     assert trace.data.spans[1].outputs is False
 
 
+# TODO: we should investigate whether we need to support this
+@pytest.mark.skip(reason="This is not supported by latest span-level export")
 @pytest.mark.usefixtures("reset_active_experiment")
 def test_start_and_end_trace_before_all_span_end(async_logging_enabled):
     # This test is to verify that the trace is still exported even if some spans are not ended
@@ -3340,3 +3398,107 @@ def test_mlflow_client_dataset_associations_databricks_blocking(mock_store):
         ) as exc_info:
             client.remove_dataset_from_experiments("dataset_123", ["1", "2"])
         assert exc_info.value.error_code == "INVALID_PARAMETER_VALUE"
+
+
+def test_log_spans_and_get_trace_with_sqlalchemy_store(tmp_path: Path) -> None:
+    tracking_uri = f"sqlite:///{tmp_path}/test.db"
+
+    with _use_tracking_uri(tracking_uri):
+        client = MlflowClient()
+
+        assert isinstance(client._tracking_client.store, SqlAlchemyTrackingStore)
+
+        experiment_id = client.create_experiment("test_log_spans_get_trace")
+        trace_id = f"tr-{uuid.uuid4().hex}"
+
+        # Create test spans using OpenTelemetry format
+        otel_span1 = OTelReadableSpan(
+            name="parent_span",
+            context=trace_api.SpanContext(
+                trace_id=12345,
+                span_id=111,
+                is_remote=False,
+                trace_flags=trace_api.TraceFlags(1),
+            ),
+            parent=None,
+            attributes={
+                "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+                "llm.model_name": "test-model",
+                "custom.attribute": "parent-value",
+            },
+            start_time=1_000_000_000,
+            end_time=2_000_000_000,
+            resource=None,
+        )
+
+        otel_span2 = OTelReadableSpan(
+            name="child_span",
+            context=trace_api.SpanContext(
+                trace_id=12345,
+                span_id=222,
+                is_remote=False,
+                trace_flags=trace_api.TraceFlags(1),
+            ),
+            parent=trace_api.SpanContext(
+                trace_id=12345,
+                span_id=111,
+                is_remote=False,
+                trace_flags=trace_api.TraceFlags(1),
+            ),
+            attributes={
+                "mlflow.traceRequestId": json.dumps(trace_id, cls=TraceJSONEncoder),
+                "operation.type": "database_query",
+                "custom.attribute": "child-value",
+            },
+            start_time=1_200_000_000,
+            end_time=1_800_000_000,
+            resource=None,
+        )
+
+        # Convert to MLflow spans
+        mlflow_spans = [
+            create_mlflow_span(otel_span1, trace_id, "LLM"),
+            create_mlflow_span(otel_span2, trace_id, "LLM"),
+        ]
+
+        # Log spans directly to the store (simulating OTLP endpoint)
+        store = client._tracking_client.store
+        logged_spans = store.log_spans(experiment_id, mlflow_spans)
+
+        # Verify spans were logged
+        assert len(logged_spans) == 2
+
+        # Verify the trace has the spans location tag set
+        trace_info = store.get_trace_info(trace_id)
+        assert trace_info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE
+
+        # Now test that mlflow.get_trace() works and loads spans from the database
+        trace = mlflow.get_trace(trace_id)
+
+        # Verify trace structure
+        assert trace.info.trace_id == trace_id
+        assert trace.info.tags.get(TraceTagKey.SPANS_LOCATION) == TRACKING_STORE
+
+        # Verify spans were loaded from database
+        assert len(trace.data.spans) == 2
+
+        # Sort spans by start time for consistent testing
+        spans_by_start_time = sorted(trace.data.spans, key=lambda s: s.start_time_ns)
+
+        # Verify parent span
+        parent_span = spans_by_start_time[0]
+        assert parent_span.name == "parent_span"
+        assert parent_span.trace_id == trace_id
+        assert parent_span.start_time_ns == 1_000_000_000
+        assert parent_span.end_time_ns == 2_000_000_000
+        assert parent_span.attributes.get("llm.model_name") == "test-model"
+        assert parent_span.attributes.get("custom.attribute") == "parent-value"
+
+        # Verify child span
+        child_span = spans_by_start_time[1]
+        assert child_span.name == "child_span"
+        assert child_span.trace_id == trace_id
+        assert child_span.start_time_ns == 1_200_000_000
+        assert child_span.end_time_ns == 1_800_000_000
+        assert child_span.attributes.get("operation.type") == "database_query"
+        assert child_span.attributes.get("custom.attribute") == "child-value"

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -38,6 +38,8 @@ from mlflow.entities import (
     RunInputs,
     RunTag,
     Span,
+    SpanEvent,
+    SpanStatusCode,
     ViewType,
 )
 from mlflow.entities.logged_model_input import LoggedModelInput
@@ -2581,6 +2583,22 @@ def test_start_trace(mlflow_client):
         assert "Failed to log span to MLflow backend" not in str(call)
 
 
+def test_get_trace(mlflow_client):
+    mlflow.set_tracking_uri(mlflow_client.tracking_uri)
+    experiment_id = mlflow_client.create_experiment("get trace")
+    span = mlflow_client.start_trace(name="test", experiment_id=experiment_id)
+    mlflow_client.end_trace(request_id=span.request_id, status=TraceStatus.OK)
+    trace = mlflow_client.get_trace(span.request_id)
+    assert trace is not None
+    assert trace.info.request_id == span.request_id
+    assert trace.info.experiment_id == experiment_id
+    assert trace.info.state == TraceState.OK
+    assert len(trace.data.spans) == 1
+    assert trace.data.spans[0].name == "test"
+    assert trace.data.spans[0].status.status_code == SpanStatusCode.OK
+    assert trace.data.spans[0].status.description == ""
+
+
 def test_search_traces(mlflow_client):
     mlflow.set_tracking_uri(mlflow_client.tracking_uri)
     experiment_id = mlflow_client.create_experiment("search traces")
@@ -2791,6 +2809,7 @@ def test_get_trace_artifact_handler(mlflow_client):
     span = mlflow_client.start_trace(name="test", experiment_id=experiment_id)
     request_id = span.request_id
     span.set_attributes({"fruit": "apple"})
+    span.add_event(SpanEvent("test_event", timestamp=99999, attributes={"foo": "bar"}))
     mlflow_client.end_trace(request_id=request_id)
 
     response = requests.get(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/18456?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18456/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18456/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18456/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Translate span attributes for main OTel clients including openinference, openllmetry and OTel semantic convention:
- inputs
- outputs
- token usage
- span type

TODO: rebase after https://github.com/mlflow/mlflow/pull/18368 is merged.

Manually verified inputs/outputs and span type are correctly rendered on UI:
<img width="1264" height="618" alt="image" src="https://github.com/user-attachments/assets/af1b062d-0ff7-48f0-ab28-11f56a1907d8" />
<img width="904" height="600" alt="image" src="https://github.com/user-attachments/assets/55ec2d3f-fd92-4c46-8ae1-2e210ea1c596" />

Token counts aggregation showing up at traces tab:
<img width="1151" height="542" alt="image" src="https://github.com/user-attachments/assets/d5aa3203-92b2-48ff-a2fd-6f22ee0af5fc" />
It's also validated by `mlflow.get_trace` API.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
