### PR TITLE
Fix langchain pin for docker test

### DIFF
--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -65,7 +65,7 @@ def save_model_with_latest_mlflow_version(flavor, extra_pip_requirements=None, *
     if flavor == "langchain":
         kwargs["pip_requirements"] = [
             f"mlflow[gateway]=={latest_mlflow_version}",
-            "langchain<1.0.0",
+            "langchain<1.0.0",  # TODO: Remove after supporting langchain 1.x
         ]
     else:
         extra_pip_requirements = extra_pip_requirements or []

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -65,7 +65,7 @@ def save_model_with_latest_mlflow_version(flavor, extra_pip_requirements=None, *
     if flavor == "langchain":
         kwargs["pip_requirements"] = [
             f"mlflow[gateway]=={latest_mlflow_version}",
-            "langchain>=0.3.4,<=0.3.27",
+            "langchain<1.0.0",
         ]
     else:
         extra_pip_requirements = extra_pip_requirements or []

--- a/tests/pyfunc/docker/conftest.py
+++ b/tests/pyfunc/docker/conftest.py
@@ -63,7 +63,10 @@ def save_model_with_latest_mlflow_version(flavor, extra_pip_requirements=None, *
     """
     latest_mlflow_version = get_released_mlflow_version()
     if flavor == "langchain":
-        kwargs["pip_requirements"] = [f"mlflow[gateway]=={latest_mlflow_version}", "langchain"]
+        kwargs["pip_requirements"] = [
+            f"mlflow[gateway]=={latest_mlflow_version}",
+            "langchain>=0.3.4,<=0.3.27",
+        ]
     else:
         extra_pip_requirements = extra_pip_requirements or []
         extra_pip_requirements.append(f"mlflow=={latest_mlflow_version}")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18461?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18461/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18461/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18461/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Apply the langchain pin to the slow tests docker test for langchain

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
