### PR TITLE
Fix assessment editing UI resetting field values when selecting name

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
@@ -38,10 +38,6 @@ const TestWrapper = ({ children, assessments = [] }: { children: React.ReactNode
   );
 };
 
-// Helper function to get select buttons by their ID
-const getSelectButton = (id: string) => {
-  return document.querySelector(`#${id.replace(/\./g, '\\.')}`) as HTMLButtonElement;
-};
 
 describe('AssessmentCreateForm', () => {
   const mockSetExpanded = jest.fn();
@@ -71,8 +67,8 @@ describe('AssessmentCreateForm', () => {
       );
 
       // Get the select buttons
-      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
-      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
+      const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
       expect(assessmentTypeSelect).toBeInTheDocument();
       expect(dataTypeSelect).toBeInTheDocument();
@@ -127,8 +123,8 @@ describe('AssessmentCreateForm', () => {
       );
 
       // Get the select buttons
-      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
-      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
+      const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
       // Change assessment type to expectation and data type to number
       await user.click(assessmentTypeSelect);
@@ -178,8 +174,8 @@ describe('AssessmentCreateForm', () => {
       );
 
       // Get the select buttons
-      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
-      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
+      const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
       // Change to non-default values
       await user.click(assessmentTypeSelect);
@@ -250,8 +246,8 @@ describe('AssessmentCreateForm', () => {
       );
 
       // Get the select buttons
-      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
-      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
+      const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
       // Change to non-default values
       await user.click(assessmentTypeSelect);
@@ -290,8 +286,8 @@ describe('AssessmentCreateForm', () => {
       );
 
       // Get the select buttons
-      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
-      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
+      const dataTypeSelect = screen.getByLabelText('Data Type') as HTMLButtonElement;
 
       // Change values first
       await user.click(assessmentTypeSelect);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
@@ -1,0 +1,323 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { DesignSystemProvider } from '@databricks/design-system';
+import { IntlProvider } from '@databricks/i18n';
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+
+import { AssessmentCreateForm } from './AssessmentCreateForm';
+import { AssessmentSchemaContextProvider } from '../contexts/AssessmentSchemaContext';
+import type { Assessment } from '../ModelTrace.types';
+import { MOCK_ASSESSMENT, MOCK_EXPECTATION } from '../ModelTraceExplorer.test-utils';
+
+// Mock the hooks
+jest.mock('../hooks/useCreateAssessment', () => ({
+  useCreateAssessment: jest.fn(() => ({
+    createAssessmentMutation: jest.fn(),
+    isLoading: false,
+  })),
+}));
+
+const TestWrapper = ({ children, assessments = [] }: { children: React.ReactNode; assessments?: Assessment[] }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return (
+    <IntlProvider locale="en">
+      <DesignSystemProvider>
+        <QueryClientProvider client={queryClient}>
+          <AssessmentSchemaContextProvider assessments={assessments}>{children}</AssessmentSchemaContextProvider>
+        </QueryClientProvider>
+      </DesignSystemProvider>
+    </IntlProvider>
+  );
+};
+
+// Helper function to get select buttons by their ID
+const getSelectButton = (id: string) => {
+  return document.querySelector(`#${id.replace(/\./g, '\\.')}`) as HTMLButtonElement;
+};
+
+describe('AssessmentCreateForm', () => {
+  const mockSetExpanded = jest.fn();
+  const defaultProps = {
+    traceId: 'test-trace-id',
+    setExpanded: mockSetExpanded,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('handleChangeSchema - existing schemas', () => {
+    it('should update all fields when selecting an existing schema', async () => {
+      const user = userEvent.setup();
+
+      // Mock existing assessments to populate schemas
+      const existingAssessments: Assessment[] = [
+        MOCK_ASSESSMENT, // name: 'Relevance', feedback (string type)
+        MOCK_EXPECTATION, // name: 'expected_facts', expectation (json type)
+      ];
+
+      render(
+        <TestWrapper assessments={existingAssessments}>
+          <AssessmentCreateForm {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Get the select buttons
+      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
+      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+
+      expect(assessmentTypeSelect).toBeInTheDocument();
+      expect(dataTypeSelect).toBeInTheDocument();
+
+      // Verify initial values
+      expect(assessmentTypeSelect).toHaveTextContent('Feedback');
+      expect(dataTypeSelect).toHaveTextContent('Boolean');
+
+      // Change assessment type to expectation and data type to number
+      await user.click(assessmentTypeSelect);
+      await user.click(screen.getByText('Expectation'));
+      await waitFor(() => {
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+      });
+
+      await user.click(dataTypeSelect);
+      await user.click(screen.getAllByText('Number')[0]);
+      await waitFor(() => {
+        expect(dataTypeSelect).toHaveTextContent('Number');
+      });
+
+      // Open the name typeahead
+      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      await user.click(nameInput);
+
+      // Select an existing schema (expected_facts which is expectation/json)
+      await waitFor(() => {
+        expect(screen.getByText('expected_facts')).toBeInTheDocument();
+      });
+      await user.click(screen.getByText('expected_facts'));
+
+      // All fields should be updated to match the schema
+      await waitFor(() => {
+        expect(nameInput).toHaveValue('expected_facts');
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+        expect(dataTypeSelect).toHaveTextContent('JSON');
+      });
+    });
+  });
+
+  describe('handleChangeSchema - new assessment names', () => {
+    it('should preserve user-selected fields when typing a new assessment name', async () => {
+      const user = userEvent.setup();
+
+      // Mock existing assessments to populate schemas
+      const existingAssessments: Assessment[] = [MOCK_ASSESSMENT];
+
+      render(
+        <TestWrapper assessments={existingAssessments}>
+          <AssessmentCreateForm {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Get the select buttons
+      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
+      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+
+      // Change assessment type to expectation and data type to number
+      await user.click(assessmentTypeSelect);
+      await user.click(screen.getByText('Expectation'));
+      await waitFor(() => {
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+      });
+
+      await user.click(dataTypeSelect);
+      await user.click(screen.getByText('Number'));
+      await waitFor(() => {
+        expect(dataTypeSelect).toHaveTextContent('Number');
+      });
+
+      // Type a new assessment name that doesn't exist in schemas
+      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      await user.type(nameInput, 'my_new_assessment');
+
+      // Open the dropdown
+      await user.click(nameInput);
+
+      // The new name should appear in the typeahead
+      await waitFor(() => {
+        expect(screen.getByText('my_new_assessment')).toBeInTheDocument();
+      });
+
+      // Select the new name
+      await user.click(screen.getByText('my_new_assessment'));
+
+      // Name should be updated, but assessment type and data type should be preserved
+      await waitFor(() => {
+        expect(nameInput).toHaveValue('my_new_assessment');
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+        expect(dataTypeSelect).toHaveTextContent('Number');
+      });
+    });
+
+    it('should preserve user-selected fields when pressing Enter on a new name', async () => {
+      const user = userEvent.setup();
+
+      const existingAssessments: Assessment[] = [MOCK_ASSESSMENT];
+
+      render(
+        <TestWrapper assessments={existingAssessments}>
+          <AssessmentCreateForm {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Get the select buttons
+      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
+      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+
+      // Change to non-default values
+      await user.click(assessmentTypeSelect);
+      await user.click(screen.getByText('Expectation'));
+
+      await user.click(dataTypeSelect);
+      await user.click(screen.getAllByText('String')[0]);
+
+      await waitFor(() => {
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+        expect(dataTypeSelect).toHaveTextContent('String');
+      });
+
+      // Type a new name and press Enter
+      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      await user.type(nameInput, 'another_new_name');
+      await user.keyboard('{Enter}');
+
+      // Fields should be preserved
+      await waitFor(() => {
+        expect(nameInput).toHaveValue('another_new_name');
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+        expect(dataTypeSelect).toHaveTextContent('String');
+      });
+    });
+  });
+
+  describe('handleChangeSchema - clearing selection', () => {
+    it('should reset all fields when clearing the name', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper assessments={[MOCK_ASSESSMENT]}>
+          <AssessmentCreateForm {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Get the select button
+      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
+
+      // Change some values
+      await user.click(assessmentTypeSelect);
+      await user.click(screen.getByText('Expectation'));
+
+      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      await user.type(nameInput, 'test_name');
+
+      // Clear the input (simulating the clear button)
+      await user.clear(nameInput);
+
+      // All fields should reset to defaults
+      await waitFor(() => {
+        expect(nameInput).toHaveValue('');
+        // Note: We can't easily test the internal state reset here
+        // as the selects may not visibly change until interaction
+      });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should handle empty schemas list', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <TestWrapper assessments={[]}>
+          <AssessmentCreateForm {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Get the select buttons
+      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
+      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+
+      // Change to non-default values
+      await user.click(assessmentTypeSelect);
+      await user.click(screen.getByText('Expectation'));
+
+      await user.click(dataTypeSelect);
+      await user.click(screen.getByText('Number'));
+
+      await waitFor(() => {
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+        expect(dataTypeSelect).toHaveTextContent('Number');
+      });
+
+      // Type a name when there are no existing schemas
+      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      await user.type(nameInput, 'first_assessment');
+      await user.keyboard('{Enter}');
+
+      // Fields should be preserved since this is a new name
+      await waitFor(() => {
+        expect(nameInput).toHaveValue('first_assessment');
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+        expect(dataTypeSelect).toHaveTextContent('Number');
+      });
+    });
+
+    it('should handle schema with same name as typed value', async () => {
+      const user = userEvent.setup();
+
+      const existingAssessments: Assessment[] = [MOCK_ASSESSMENT]; // name: 'Relevance'
+
+      render(
+        <TestWrapper assessments={existingAssessments}>
+          <AssessmentCreateForm {...defaultProps} />
+        </TestWrapper>,
+      );
+
+      // Get the select buttons
+      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
+      const dataTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-data-type-select');
+
+      // Change values first
+      await user.click(assessmentTypeSelect);
+      await user.click(screen.getByText('Expectation'));
+
+      await waitFor(() => {
+        expect(assessmentTypeSelect).toHaveTextContent('Expectation');
+      });
+
+      // Type the exact name of an existing schema
+      const nameInput = screen.getByPlaceholderText('Enter an assessment name');
+      await user.type(nameInput, 'Relevance');
+      await user.click(nameInput);
+
+      // Select it from the dropdown
+      await waitFor(() => {
+        expect(screen.getByTestId('assessment-name-typeahead-item-Relevance')).toBeInTheDocument();
+      });
+      await user.click(screen.getByTestId('assessment-name-typeahead-item-Relevance'));
+
+      // Since 'Relevance' is an existing schema (feedback/string), it should update all fields
+      await waitFor(() => {
+        expect(nameInput).toHaveValue('Relevance');
+        expect(assessmentTypeSelect).toHaveTextContent('Feedback');
+        expect(dataTypeSelect).toHaveTextContent('String');
+      });
+    });
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
@@ -38,7 +38,6 @@ const TestWrapper = ({ children, assessments = [] }: { children: React.ReactNode
   );
 };
 
-
 describe('AssessmentCreateForm', () => {
   const mockSetExpanded = jest.fn();
   const defaultProps = {
@@ -214,7 +213,7 @@ describe('AssessmentCreateForm', () => {
       );
 
       // Get the select button
-      const assessmentTypeSelect = getSelectButton('shared.model-trace-explorer.assessment-type-select');
+      const assessmentTypeSelect = screen.getByLabelText('Assessment Type') as HTMLButtonElement;
 
       // Change some values
       await user.click(assessmentTypeSelect);

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
@@ -22,6 +22,7 @@ import { TextInput } from './components/TextInput';
 import type { AssessmentValueInputFieldProps } from './components/types';
 import type { CreateAssessmentPayload } from '../api';
 import type { AssessmentSchema } from '../contexts/AssessmentSchemaContext';
+import { useAssessmentSchemas } from '../contexts/AssessmentSchemaContext';
 import { useCreateAssessment } from '../hooks/useCreateAssessment';
 
 const ComponentMap: Record<AssessmentFormInputDataType, React.ComponentType<AssessmentValueInputFieldProps>> = {
@@ -51,6 +52,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
     ref,
   ) => {
     const { theme } = useDesignSystemTheme();
+    const { schemas } = useAssessmentSchemas();
 
     const [name, setName] = useState('');
     const [assessmentType, setAssessmentType] = useState<'feedback' | 'expectation'>('feedback');
@@ -131,36 +133,50 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
       createAssessmentMutation,
     ]);
 
-    const handleChangeSchema = useCallback((schema: AssessmentSchema | null) => {
-      // clear the form back to defaults
-      if (!schema) {
-        setName('');
-        setAssessmentType('feedback');
-        setDataType('boolean');
-        setValue(true);
-        setRationale('');
-        setValueError(null);
-        return;
-      }
-
-      setName(schema.name);
-      setAssessmentType(schema.assessmentType);
-      setDataType(schema.dataType);
-
-      // set the appropriate empty value for the data type
-      switch (schema.dataType) {
-        case 'string':
-        case 'json':
-          setValue('');
-          break;
-        case 'number':
-          setValue(0);
-          break;
-        case 'boolean':
+    const handleChangeSchema = useCallback(
+      (schema: AssessmentSchema | null) => {
+        // clear the form back to defaults
+        if (!schema) {
+          setName('');
+          setAssessmentType('feedback');
+          setDataType('boolean');
           setValue(true);
-          break;
-      }
-    }, []);
+          setRationale('');
+          setValueError(null);
+          return;
+        }
+
+        // Check if this is a real schema from the schemas list or a fake one created for a new name
+        const isRealSchema = schemas.some((s) => s.name === schema.name);
+
+        // Only update the name if it's a new assessment name (not in schemas)
+        // This preserves the user's selections for assessment type and data type
+        if (!isRealSchema) {
+          setName(schema.name);
+          return;
+        }
+
+        // For existing schemas, update all fields
+        setName(schema.name);
+        setAssessmentType(schema.assessmentType);
+        setDataType(schema.dataType);
+
+        // set the appropriate empty value for the data type
+        switch (schema.dataType) {
+          case 'string':
+          case 'json':
+            setValue('');
+            break;
+          case 'number':
+            setValue(0);
+            break;
+          case 'boolean':
+            setValue(true);
+            break;
+        }
+      },
+      [schemas],
+    );
 
     return (
       <div

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
@@ -200,6 +200,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
         <SimpleSelect
           id="shared.model-trace-explorer.assessment-type-select"
           componentId="shared.model-trace-explorer.assessment-type-select"
+          label="Assessment Type"
           value={assessmentType}
           disabled={isLoading}
           onChange={(e) => {
@@ -246,6 +247,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
         <SimpleSelect
           id="shared.model-trace-explorer.assessment-data-type-select"
           componentId="shared.model-trace-explorer.assessment-data-type-select"
+          label="Data Type"
           value={dataType}
           disabled={isLoading}
           onChange={(e) => {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/18474?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18474/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18474/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18474/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #18322

### What changes are proposed in this pull request?

Fixed a bug where selecting an assessment name from the dropdown while editing would reset assessment type and data type fields to defaults. Now only the name field is updated for new assessment names, preserving user selections. Existing schemas still update all fields as expected.

### How is this PR tested?

- [x] New unit/integration tests

Added comprehensive tests covering:
- Selecting new vs. existing assessment names
- Preserving user-selected fields
- Edge cases with empty schemas

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed assessment creation UI bug where selecting a name from the dropdown would reset assessment type and data type fields.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)