### PR TITLE
Add Regal linter for Rego policy files

### DIFF
--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -1,91 +1,96 @@
-package main
+# regal ignore:directory-package-mismatch
+package github
 
-import future.keywords.in
+import rego.v1
 
-deny_jobs_without_permissions[msg] {
-    jobs_without_permissions := get_jobs_without_permissions(input.jobs)
-    count(jobs_without_permissions) > 0
-    msg := sprintf("The following jobs are missing permissions: %s",
-        [concat(", ", jobs_without_permissions)])
+deny_jobs_without_permissions contains msg if {
+	jobs := jobs_without_permissions(input.jobs)
+	count(jobs) > 0
+	msg := sprintf(
+		"The following jobs are missing permissions: %s",
+		[concat(", ", jobs)],
+	)
 }
 
-deny_top_level_permissions[msg] {
-    input.permissions
-    msg := "Do not use top-level permissions. Set permissions on the job level."
+deny_top_level_permissions contains msg if {
+	input.permissions
+	msg := "Do not use top-level permissions. Set permissions on the job level."
 }
 
-deny_unsafe_checkout[msg] {
-    # The "on" key gets transformed by conftest into "true" due to some legacy
-    # YAML standards, see https://stackoverflow.com/q/42283732/2148786 - so
-    # "on.push" becomes "true.push" which is why below statements use "true"
-    # instead of "on".
-    input["true"]["pull_request_target"]
-    some job in input["jobs"]
-    some step in job["steps"]
-    startswith(step["uses"], "actions/checkout@")
-    step["with"]["ref"]
-    msg := "Explicit checkout in a pull_request_target workflow is unsafe. See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests for more information."
+deny_unsafe_checkout contains msg if {
+	# The "on" key gets transformed by conftest into "true" due to some legacy
+	# YAML standards, see https://stackoverflow.com/q/42283732/2148786 - so
+	# "on.push" becomes "true.push" which is why below statements use "true"
+	# instead of "on".
+	input["true"].pull_request_target
+	some job in input.jobs
+	some step in job.steps
+	startswith(step.uses, "actions/checkout@")
+	step["with"].ref
+	msg := concat("", [
+		"Explicit checkout in a pull_request_target workflow is unsafe. ",
+		"See https://securitylab.github.com/resources/github-actions-preventing-pwn-requests for more information.",
+	])
 }
 
-deny_unnecessary_github_token[msg] {
-    some job in input["jobs"]
-    some step in job["steps"]
-    startswith(step["uses"], "actions/github-script@")
-    regex.match("\\$\\{\\{\\s*(secrets\\.GITHUB_TOKEN|github\\.token)\\s*\\}\\}", step["with"]["github-token"])
-    msg := "Unnecessary use of github-token for actions/github-script."
+deny_unnecessary_github_token contains msg if {
+	some job in input.jobs
+	some step in job.steps
+	startswith(step.uses, "actions/github-script@")
+	regex.match(`\$\{\{\s*(secrets\.GITHUB_TOKEN|github\.token)\s*\}\}`, step["with"]["github-token"])
+	msg := "Unnecessary use of github-token for actions/github-script."
 }
 
-deny_jobs_without_timeout[msg] {
-    jobs_without_timeout := get_jobs_without_timeout(input.jobs)
-    count(jobs_without_timeout) > 0
-    msg := sprintf("The following jobs are missing timeout-minutes: %s",
-        [concat(", ", jobs_without_timeout)])
+deny_jobs_without_timeout contains msg if {
+	jobs := jobs_without_timeout(input.jobs)
+	count(jobs) > 0
+	msg := sprintf(
+		"The following jobs are missing timeout-minutes: %s",
+		[concat(", ", jobs)],
+	)
 }
 
-deny_unpinned_actions[msg] {
-    unpinned_actions := get_unpinned_actions(input)
-    count(unpinned_actions) > 0
-    msg := sprintf("The following actions are not pinned by full commit SHA: %s. Use the full commit SHA instead (e.g., actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683).",
-        [concat(", ", unpinned_actions)])
+deny_unpinned_actions contains msg if {
+	actions := unpinned_actions(input)
+	count(actions) > 0
+	msg := sprintf(
+		concat("", [
+			"The following actions are not pinned by full commit SHA: %s. ",
+			"Use the full commit SHA instead ",
+			"(e.g., actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683).",
+		]),
+		[concat(", ", actions)],
+	)
 }
 
 ###########################   RULE HELPERS   ##################################
-get_jobs_without_permissions(jobs) = jobs_without_permissions {
-    jobs_without_permissions := { job_id |
-        job := jobs[job_id]
-        not job["permissions"]
-    }
+jobs_without_permissions(jobs) := {job_id |
+	some job_id, job in jobs
+	not job.permissions
 }
 
-get_jobs_without_timeout(jobs) = jobs_without_timeout {
-    jobs_without_timeout := { job_id |
-        job := jobs[job_id]
-        not job["timeout-minutes"]
-    }
+jobs_without_timeout(jobs) := {job_id |
+	some job_id, job in jobs
+	not job["timeout-minutes"]
 }
 
-is_step_unpinned(step) {
-    step["uses"]
-    not startswith(step["uses"], "./")
-    not regex.match("^[^@]+@[0-9a-f]{40}$", step["uses"])
+is_step_unpinned(step) if {
+	not startswith(step.uses, "./")
+	not regex.match(`^[^@]+@[0-9a-f]{40}$`, step.uses)
 }
 
-get_unpinned_actions(inp) = unpinned_actions {
-    # For workflow files with jobs
-    inp.jobs
-    all_steps := [ step | job := inp.jobs[_]; step := job.steps[_] ]
-    unpinned_actions := { step["uses"] |
-        step := all_steps[_]
-        is_step_unpinned(step)
-    }
+unpinned_actions(inp) := {step.uses |
+	# For workflow files with jobs
+	inp.jobs
+	some job in inp.jobs
+	some step in job.steps
+	is_step_unpinned(step)
 }
 
-get_unpinned_actions(inp) = unpinned_actions {
-    # For composite action files with runs
-    inp.runs.steps
-    not inp.jobs
-    unpinned_actions := { step["uses"] |
-        step := inp.runs.steps[_]
-        is_step_unpinned(step)
-    }
+unpinned_actions(inp) := {step.uses |
+	# For composite action files with runs
+	inp.runs.steps
+	not inp.jobs
+	some step in inp.runs.steps
+	is_step_unpinned(step)
 }

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -79,18 +79,22 @@ is_step_unpinned(step) if {
 	not regex.match(`^[^@]+@[0-9a-f]{40}$`, step.uses)
 }
 
-unpinned_actions(inp) := {step.uses |
+unpinned_actions(inp) := unpinned if {
 	# For workflow files with jobs
 	inp.jobs
-	some job in inp.jobs
-	some step in job.steps
-	is_step_unpinned(step)
+	unpinned := {step.uses |
+		some job in inp.jobs
+		some step in job.steps
+		is_step_unpinned(step)
+	}
 }
 
-unpinned_actions(inp) := {step.uses |
+unpinned_actions(inp) := unpinned if {
 	# For composite action files with runs
-	inp.runs.steps
 	not inp.jobs
-	some step in inp.runs.steps
-	is_step_unpinned(step)
+	inp.runs.steps
+	unpinned := {step.uses |
+		some step in inp.runs.steps
+		is_step_unpinned(step)
+	}
 }

--- a/.github/policy.rego
+++ b/.github/policy.rego
@@ -1,5 +1,5 @@
 # regal ignore:directory-package-mismatch
-package github
+package mlflow
 
 import rego.v1
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,7 +133,7 @@ repos:
 
       - id: conftest
         name: conftest
-        entry: bin/conftest test --namespace github --policy .github/policy.rego
+        entry: bin/conftest test --namespace mlflow --policy .github/policy.rego
         files: '^\.github/(workflows|actions)/.*\.ya?ml$'
         exclude: '^\.github/workflows/copilot-setup-steps\.yml$'
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -133,9 +133,17 @@ repos:
 
       - id: conftest
         name: conftest
-        entry: bin/conftest test --policy .github/policy.rego
+        entry: bin/conftest test --namespace github --policy .github/policy.rego
         files: '^\.github/(workflows|actions)/.*\.ya?ml$'
         exclude: '^\.github/workflows/copilot-setup-steps\.yml$'
+        language: system
+        stages: [pre-commit]
+        require_serial: true
+
+      - id: regal
+        name: regal
+        entry: bin/regal lint
+        files: '\.rego$'
         language: system
         stages: [pre-commit]
         require_serial: true


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18492?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18492/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18492/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18492/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR adds Regal v0.36.1 for linting Rego policy files and updates conftest to v0.63.0 for better Rego v1 support. The existing `.github/policy.rego` has been migrated to Rego v1 syntax with all linting violations fixed.

**Key improvements:**
- Regal catches bugs and enforces best practices in Rego policies
- Updated OPA from 0.69.0 to 1.9.0 (via conftest upgrade)
- Automatic linting via pre-commit hooks
- Clean Rego v1 syntax with modern keywords (`contains`, `if`, `some .. in`)

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

Verified:
- All pre-commit hooks pass
- Regal lints `.github/policy.rego` with 0 violations
- Conftest tests pass (6 tests) with Rego v1 policy
- Both tools work correctly in CI environment

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)