### PR TITLE
Remove the ability to register or load custom scorers

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -14,6 +14,7 @@ from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.tracking import get_tracking_uri
 from mlflow.utils.annotations import experimental
+from mlflow.utils.databricks_utils import is_in_databricks_runtime
 from mlflow.utils.uri import is_databricks_uri
 
 _logger = logging.getLogger(__name__)
@@ -300,15 +301,44 @@ class Scorer(BaseModel):
         from mlflow.genai.scorers.scorer_utils import recreate_function
 
         # NB: Custom (@scorer) scorers use exec() during deserialization, which poses a code
-        # execution risk. Only allow loading with Databricks tracking URIs where the execution
-        # environment is controlled.
-        if not is_databricks_uri(get_tracking_uri()):
-            raise MlflowException.invalid_parameter_value(
-                f"Loading custom scorer '{serialized.name}' is not supported for "
-                "non-Databricks tracking URIs due to security concerns. Custom scorers require "
-                "arbitrary code execution during deserialization. Please use a Databricks "
-                "tracking URI, built-in scorers, or make_judge() scorers instead."
+        # execution risk. Only allow loading in Databricks runtime environments where the
+        # execution environment is controlled.
+        if not is_in_databricks_runtime():
+            code_snippet = (
+                "\n\nfrom mlflow.genai import scorer\n\n"
+                f"@scorer\ndef {serialized.original_func_name}{serialized.call_signature}:\n"
             )
+            for line in serialized.call_source.split("\n"):
+                code_snippet += f"    {line}\n"
+
+            is_databricks_remote = is_databricks_uri(get_tracking_uri())
+
+            if is_databricks_remote:
+                error_msg = (
+                    f"Loading custom scorer '{serialized.name}' via remote access is not "
+                    "supported. You are connected to a Databricks workspace but executing code "
+                    "outside of it. Custom scorers require arbitrary code execution during "
+                    "deserialization and must be loaded within the Databricks workspace for "
+                    "security reasons.\n\n"
+                    "To use this scorer:\n"
+                    "1. Run your code inside the Databricks workspace (notebook or job), or\n"
+                    "2. Copy the code below and use it directly in your source code, or\n"
+                    "3. Use built-in scorers or make_judge() scorers instead\n\n"
+                    f"Registered scorer code:\n{code_snippet}"
+                )
+            else:
+                error_msg = (
+                    f"Loading custom scorer '{serialized.name}' is not supported outside of "
+                    "Databricks runtime environments due to security concerns. Custom scorers "
+                    "require arbitrary code execution during deserialization.\n\n"
+                    "To use this scorer, please:\n"
+                    "1. Copy the code below and save it in your source code repository\n"
+                    "2. Import and use it directly in your code, or\n"
+                    "3. Use built-in scorers or make_judge() scorers instead\n\n"
+                    f"Registered scorer code:\n{code_snippet}"
+                )
+
+            raise MlflowException.invalid_parameter_value(error_msg)
 
         try:
             recreated_func = recreate_function(
@@ -791,14 +821,19 @@ class Scorer(BaseModel):
             raise MlflowException.invalid_parameter_value(error_message)
 
         # NB: Custom (@scorer) scorers use exec() during deserialization, which poses a code
-        # execution risk. Only allow registration with Databricks tracking URIs where the
-        # execution environment is controlled.
+        # execution risk. Only allow registration when using Databricks tracking URI.
+        # Registration itself is safe (just stores code), but we restrict it to Databricks
+        # to ensure loaded scorers can only be executed in controlled environments.
         if self.kind == ScorerKind.DECORATOR and not is_databricks_uri(get_tracking_uri()):
             raise MlflowException.invalid_parameter_value(
-                "Custom scorer registration (using @scorer decorator) is not supported for "
-                "non-Databricks tracking URIs due to security concerns. Custom scorers require "
-                "code execution during deserialization. Please use a Databricks tracking URI, "
-                "built-in scorers, or make_judge() scorers instead."
+                "Custom scorer registration (using @scorer decorator) is not supported "
+                "outside of Databricks tracking environments due to security concerns. "
+                "Custom scorers require arbitrary code execution during deserialization.\n\n"
+                "To use custom scorers:\n"
+                "1. Configure MLflow to use a Databricks tracking URI, or\n"
+                "2. Manage your custom scorer code in a source code repository "
+                "(e.g., GitHub) and import it directly, or\n"
+                "3. Use built-in scorers or make_judge() scorers instead"
             )
 
         store = _get_scorer_store()

--- a/tests/cli/test_scorers.py
+++ b/tests/cli/test_scorers.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from click.testing import CliRunner
@@ -9,6 +10,15 @@ from mlflow.cli.scorers import commands
 from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import list_scorers, scorer
 from mlflow.utils.string_utils import _create_table
+
+
+@pytest.fixture
+def mock_databricks_environment():
+    with (
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
+    ):
+        yield
 
 
 @pytest.fixture
@@ -88,6 +98,7 @@ def test_list_scorers_table_output(
     correctness_scorer: Any,
     safety_scorer: Any,
     relevance_scorer: Any,
+    mock_databricks_environment: Any,
 ):
     correctness_scorer.register(experiment_id=experiment, name="Correctness")
     safety_scorer.register(experiment_id=experiment, name="Safety")
@@ -115,6 +126,7 @@ def test_list_scorers_json_output(
     correctness_scorer: Any,
     safety_scorer: Any,
     relevance_scorer: Any,
+    mock_databricks_environment: Any,
 ):
     correctness_scorer.register(experiment_id=experiment, name="Correctness")
     safety_scorer.register(experiment_id=experiment, name="Safety")
@@ -158,7 +170,7 @@ def test_list_scorers_empty_experiment(
 
 
 def test_list_scorers_with_experiment_id_env_var(
-    runner: CliRunner, experiment: str, correctness_scorer: Any
+    runner: CliRunner, experiment: str, correctness_scorer: Any, mock_databricks_environment: Any
 ):
     correctness_scorer.register(experiment_id=experiment, name="Correctness")
 
@@ -183,7 +195,7 @@ def test_list_scorers_invalid_output_format(runner: CliRunner, experiment: str):
 
 
 def test_list_scorers_special_characters_in_names(
-    runner: CliRunner, experiment: str, generic_scorer: Any
+    runner: CliRunner, experiment: str, generic_scorer: Any, mock_databricks_environment: Any
 ):
     generic_scorer.register(experiment_id=experiment, name="Scorer With Spaces")
     generic_scorer.register(experiment_id=experiment, name="Scorer.With.Dots")
@@ -204,7 +216,11 @@ def test_list_scorers_special_characters_in_names(
     ["table", "json"],
 )
 def test_list_scorers_single_scorer(
-    runner: CliRunner, experiment: str, generic_scorer: Any, output_format: str
+    runner: CliRunner,
+    experiment: str,
+    generic_scorer: Any,
+    output_format: str,
+    mock_databricks_environment: Any,
 ):
     generic_scorer.register(experiment_id=experiment, name="OnlyScorer")
 
@@ -227,7 +243,11 @@ def test_list_scorers_single_scorer(
     ["table", "json"],
 )
 def test_list_scorers_long_names(
-    runner: CliRunner, experiment: str, generic_scorer: Any, output_format: str
+    runner: CliRunner,
+    experiment: str,
+    generic_scorer: Any,
+    output_format: str,
+    mock_databricks_environment: Any,
 ):
     long_name = "VeryLongScorerNameThatShouldNotBeTruncatedEvenIfItIsReallyReallyLong"
     generic_scorer.register(experiment_id=experiment, name=long_name)

--- a/tests/genai/scorers/test_registered_scorers_scheduling.py
+++ b/tests/genai/scorers/test_registered_scorers_scheduling.py
@@ -8,7 +8,7 @@ from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig
 
 
 @pytest.fixture(autouse=True)
-def mock_databricks_tracking_uri():
+def mock_databricks_runtime():
     from mlflow.genai.scorers.registry import DatabricksStore
 
     with (
@@ -16,6 +16,7 @@ def mock_databricks_tracking_uri():
         patch(
             "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
         ),
+        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
         patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
         patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
     ):

--- a/tests/genai/scorers/test_registered_scorers_scheduling.py
+++ b/tests/genai/scorers/test_registered_scorers_scheduling.py
@@ -9,9 +9,18 @@ from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig
 
 @pytest.fixture(autouse=True)
 def mock_databricks_tracking_uri():
-    with patch(
-        "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
+    from mlflow.genai.scorers.registry import DatabricksStore
+
+    with (
+        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
+        patch(
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
+        ),
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+        patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
     ):
+        mock_store = DatabricksStore()
+        mock_get_store.return_value = mock_store
         yield
 
 

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -8,9 +8,11 @@ import mlflow
 from mlflow.entities import Assessment, AssessmentSource, AssessmentSourceType, Feedback
 from mlflow.entities.assessment_error import AssessmentError
 from mlflow.genai import Scorer, scorer
+from mlflow.genai.judges import make_judge
 from mlflow.genai.judges.utils import CategoricalRating
 from mlflow.genai.scorers import Correctness, Guidelines, RetrievalGroundedness
 from mlflow.genai.scorers.base import SerializedScorer
+from mlflow.genai.scorers.registry import get_scorer, list_scorers
 
 from tests.tracing.helper import get_traces, purge_traces
 
@@ -500,9 +502,6 @@ def complex_scorer(outputs):
 
 
 def test_make_judge_scorer_works_without_databricks_uri():
-    from mlflow.genai.judges import make_judge
-    from mlflow.genai.scorers.registry import get_scorer, list_scorers
-
     experiment_id = mlflow.create_experiment("test_make_judge_experiment")
 
     judge_scorer = make_judge(

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -12,7 +12,10 @@ from mlflow.genai.scorers.registry import (
 
 
 def test_mlflow_backend_scorer_operations():
-    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
+    with (
+        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+    ):
         experiment_id = mlflow.create_experiment("test_scorer_mlflow_backend_experiment")
         mlflow.set_experiment(experiment_id=experiment_id)
 
@@ -95,6 +98,7 @@ def test_databricks_backend_scorer_operations():
 
     with (
         patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
+        patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True),
         patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
         patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
         patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add,

--- a/tests/genai/scorers/test_scorer_CRUD.py
+++ b/tests/genai/scorers/test_scorer_CRUD.py
@@ -2,7 +2,7 @@ from unittest.mock import ANY, Mock, patch
 
 import mlflow
 from mlflow.genai.scorers import Scorer, scorer
-from mlflow.genai.scorers.base import Scorer, ScorerSamplingConfig, ScorerStatus
+from mlflow.genai.scorers.base import ScorerSamplingConfig, ScorerStatus
 from mlflow.genai.scorers.registry import (
     delete_scorer,
     get_scorer,
@@ -12,77 +12,79 @@ from mlflow.genai.scorers.registry import (
 
 
 def test_mlflow_backend_scorer_operations():
-    """Test all scorer operations with MLflow backend"""
+    with patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True):
+        experiment_id = mlflow.create_experiment("test_scorer_mlflow_backend_experiment")
+        mlflow.set_experiment(experiment_id=experiment_id)
 
-    experiment_id = mlflow.create_experiment("test_scorer_mlflow_backend_experiment")
-    mlflow.set_experiment(experiment_id=experiment_id)
+        @scorer
+        def test_mlflow_scorer_v1(outputs) -> bool:
+            return len(outputs) > 0
 
-    @scorer
-    def test_mlflow_scorer_v1(outputs) -> bool:
-        return len(outputs) > 0
+        assert test_mlflow_scorer_v1.status == ScorerStatus.UNREGISTERED
+        # Test register operation
+        registered_scorer_v1 = test_mlflow_scorer_v1.register(
+            experiment_id=experiment_id, name="test_mlflow_scorer"
+        )
 
-    assert test_mlflow_scorer_v1.status == ScorerStatus.UNREGISTERED
-    # Test register operation
-    registered_scorer_v1 = test_mlflow_scorer_v1.register(
-        experiment_id=experiment_id, name="test_mlflow_scorer"
-    )
+        assert registered_scorer_v1.status == ScorerStatus.STOPPED
 
-    assert registered_scorer_v1.status == ScorerStatus.STOPPED
+        # Register a second version of the scorer
+        @scorer
+        def test_mlflow_scorer_v2(outputs) -> bool:
+            return len(outputs) > 10  # Different logic for v2
 
-    # Register a second version of the scorer
-    @scorer
-    def test_mlflow_scorer_v2(outputs) -> bool:
-        return len(outputs) > 10  # Different logic for v2
+        # Register the scorer in the active experiment.
+        registered_scorer_v2 = test_mlflow_scorer_v2.register(name="test_mlflow_scorer")
+        assert registered_scorer_v2.name == "test_mlflow_scorer"
 
-    # Register the scorer in the active experiment.
-    registered_scorer_v2 = test_mlflow_scorer_v2.register(name="test_mlflow_scorer")
-    assert registered_scorer_v2.name == "test_mlflow_scorer"
+        # Test list operation
+        scorers = list_scorers(experiment_id=experiment_id)
+        assert len(scorers) == 1
+        assert scorers[0]._original_func.__name__ == "test_mlflow_scorer_v2"
 
-    # Test list operation
-    scorers = list_scorers(experiment_id=experiment_id)
-    assert len(scorers) == 1
-    assert scorers[0]._original_func.__name__ == "test_mlflow_scorer_v2"
+        # Test list versions
+        scorer_versions = list_scorer_versions(
+            name="test_mlflow_scorer", experiment_id=experiment_id
+        )
+        assert len(scorer_versions) == 2
 
-    # Test list versions
-    scorer_versions = list_scorer_versions(name="test_mlflow_scorer", experiment_id=experiment_id)
-    assert len(scorer_versions) == 2
+        # Test get_scorer with specific version
+        retrieved_scorer_v1 = get_scorer(
+            name="test_mlflow_scorer", experiment_id=experiment_id, version=1
+        )
+        assert retrieved_scorer_v1._original_func.__name__ == "test_mlflow_scorer_v1"
 
-    # Test get_scorer with specific version
-    retrieved_scorer_v1 = get_scorer(
-        name="test_mlflow_scorer", experiment_id=experiment_id, version=1
-    )
-    assert retrieved_scorer_v1._original_func.__name__ == "test_mlflow_scorer_v1"
+        retrieved_scorer_v2 = get_scorer(
+            name="test_mlflow_scorer", experiment_id=experiment_id, version=2
+        )
+        assert retrieved_scorer_v2._original_func.__name__ == "test_mlflow_scorer_v2"
 
-    retrieved_scorer_v2 = get_scorer(
-        name="test_mlflow_scorer", experiment_id=experiment_id, version=2
-    )
-    assert retrieved_scorer_v2._original_func.__name__ == "test_mlflow_scorer_v2"
+        retrieved_scorer_latest = get_scorer(name="test_mlflow_scorer", experiment_id=experiment_id)
+        assert retrieved_scorer_latest._original_func.__name__ == "test_mlflow_scorer_v2"
 
-    retrieved_scorer_latest = get_scorer(name="test_mlflow_scorer", experiment_id=experiment_id)
-    assert retrieved_scorer_latest._original_func.__name__ == "test_mlflow_scorer_v2"
+        # Test delete_scorer with specific version
+        delete_scorer(name="test_mlflow_scorer", experiment_id=experiment_id, version=2)
+        scorers_after_delete = list_scorers(experiment_id=experiment_id)
+        assert len(scorers_after_delete) == 1
+        assert scorers_after_delete[0]._original_func.__name__ == "test_mlflow_scorer_v1"
 
-    # Test delete_scorer with specific version
-    delete_scorer(name="test_mlflow_scorer", experiment_id=experiment_id, version=2)
-    scorers_after_delete = list_scorers(experiment_id=experiment_id)
-    assert len(scorers_after_delete) == 1
-    assert scorers_after_delete[0]._original_func.__name__ == "test_mlflow_scorer_v1"
+        delete_scorer(name="test_mlflow_scorer", experiment_id=experiment_id, version=1)
+        scorers_after_delete = list_scorers(experiment_id=experiment_id)
+        assert len(scorers_after_delete) == 0
 
-    delete_scorer(name="test_mlflow_scorer", experiment_id=experiment_id, version=1)
-    scorers_after_delete = list_scorers(experiment_id=experiment_id)
-    assert len(scorers_after_delete) == 0
+        # test delete all versions
+        test_mlflow_scorer_v1.register(experiment_id=experiment_id, name="test_mlflow_scorer")
+        test_mlflow_scorer_v2.register(experiment_id=experiment_id, name="test_mlflow_scorer")
+        delete_scorer(name="test_mlflow_scorer", experiment_id=experiment_id, version="all")
+        assert len(list_scorers(experiment_id=experiment_id)) == 0
 
-    # test delete all versions
-    test_mlflow_scorer_v1.register(experiment_id=experiment_id, name="test_mlflow_scorer")
-    test_mlflow_scorer_v2.register(experiment_id=experiment_id, name="test_mlflow_scorer")
-    delete_scorer(name="test_mlflow_scorer", experiment_id=experiment_id, version="all")
-    assert len(list_scorers(experiment_id=experiment_id)) == 0
-
-    # Clean up
-    mlflow.delete_experiment(experiment_id)
+        # Clean up
+        mlflow.delete_experiment(experiment_id)
 
 
 def test_databricks_backend_scorer_operations():
     """Test all scorer operations with Databricks backend"""
+    from mlflow.genai.scorers.registry import DatabricksStore
 
     # Mock the scheduled scorer responses
     mock_scheduled_scorer = Mock()
@@ -92,9 +94,9 @@ def test_databricks_backend_scorer_operations():
     mock_scheduled_scorer.filter_string = "test_filter"
 
     with (
-        patch(
-            "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
-        ),
+        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+        patch("mlflow.genai.scorers.registry._get_scorer_store") as mock_get_store,
         patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer") as mock_add,
         patch(
             "mlflow.genai.scorers.registry.DatabricksStore.list_scheduled_scorers",
@@ -109,6 +111,10 @@ def test_databricks_backend_scorer_operations():
             return_value=None,
         ) as mock_delete,
     ):
+        # Set up the store mock
+        mock_store = DatabricksStore()
+        mock_get_store.return_value = mock_store
+
         # Test register operation
         @scorer
         def test_databricks_scorer(outputs) -> bool:

--- a/tests/genai/scorers/test_scorer_description.py
+++ b/tests/genai/scorers/test_scorer_description.py
@@ -1,9 +1,20 @@
+from unittest.mock import patch
+
 import pytest
 
 from mlflow.genai import scorer
 from mlflow.genai.judges import make_judge
 from mlflow.genai.judges.instructions_judge import InstructionsJudge
 from mlflow.genai.scorers import RelevanceToQuery
+
+
+@pytest.fixture(autouse=True)
+def mock_databricks_tracking_uri():
+    with (
+        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+    ):
+        yield
 
 
 def test_decorator_scorer_with_description():

--- a/tests/genai/scorers/test_scorer_description.py
+++ b/tests/genai/scorers/test_scorer_description.py
@@ -9,11 +9,8 @@ from mlflow.genai.scorers import RelevanceToQuery
 
 
 @pytest.fixture(autouse=True)
-def mock_databricks_tracking_uri():
-    with (
-        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
-        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
-    ):
+def mock_databricks_runtime():
+    with patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True):
         yield
 
 

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -8,6 +8,16 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.scorers import Scorer, scorer
 from mlflow.genai.scorers.builtin_scorers import Guidelines
 
+
+@pytest.fixture(autouse=True)
+def mock_databricks_tracking_uri():
+    with (
+        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
+        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
+    ):
+        yield
+
+
 # ============================================================================
 # FORMAT VALIDATION TESTS (Minimal - just check serialization structure)
 # ============================================================================

--- a/tests/genai/scorers/test_serialization.py
+++ b/tests/genai/scorers/test_serialization.py
@@ -10,11 +10,8 @@ from mlflow.genai.scorers.builtin_scorers import Guidelines
 
 
 @pytest.fixture(autouse=True)
-def mock_databricks_tracking_uri():
-    with (
-        patch("mlflow.tracking.get_tracking_uri", return_value="databricks"),
-        patch("mlflow.genai.scorers.base.is_databricks_uri", return_value=True),
-    ):
+def mock_databricks_runtime():
+    with patch("mlflow.genai.scorers.base.is_in_databricks_runtime", return_value=True):
         yield
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18493?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18493/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18493/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18493/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Disable the ability to register or get custom scorers containing custom code outside of databricks uri's.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
