### PR TITLE
Fix model registry to preserve run_id when registering models via UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.intg.test.tsx
@@ -119,7 +119,7 @@ describe('RunViewHeaderRegisterModelButton integration', () => {
     expect(createRegisteredModelApi).toHaveBeenCalledWith('a-new-model', expect.anything());
     expect(createModelVersionApi).toHaveBeenCalledWith(
       'a-new-model',
-      'file://some/artifact/path/another_artifact_path',
+      'runs:/testRunUuid/another_artifact_path',
       'testRunUuid',
       [],
       expect.anything(),

--- a/mlflow/server/js/src/model-registry/components/RegisterModel.tsx
+++ b/mlflow/server/js/src/model-registry/components/RegisterModel.tsx
@@ -131,7 +131,19 @@ export class RegisterModelImpl extends React.Component<RegisterModelImplProps, R
   handleRegisterModel = () => {
     return this.form.current.validateFields().then((values: any) => {
       this.setState({ confirmLoading: true });
-      const { runUuid, modelPath } = this.props;
+      const { runUuid, modelPath, modelRelativePath, loggedModelId } = this.props;
+      // Construct source URI to maintain connection to source run:
+      // 1. For logged models (MLflow 3.0+), use models:/{model_id} format
+      // 2. For regular artifacts with run context, use runs:/<run_id>/<model_path> format
+      // 3. Otherwise, fall back to the absolute artifact URI for backward compatibility
+      let sourceUri;
+      if (loggedModelId) {
+        sourceUri = `models:/${loggedModelId}`;
+      } else if (modelRelativePath && runUuid) {
+        sourceUri = `runs:/${runUuid}/${modelRelativePath}`;
+      } else {
+        sourceUri = modelPath;
+      }
       const selectedModelName = values[SELECTED_MODEL_FIELD];
       if (selectedModelName === CREATE_NEW_MODEL_OPTION_VALUE) {
         // When user choose to create a new registered model during the registration, we need to
@@ -142,7 +154,7 @@ export class RegisterModelImpl extends React.Component<RegisterModelImplProps, R
           .then(() =>
             this.props.createModelVersionApi(
               values[MODEL_NAME_FIELD],
-              modelPath,
+              sourceUri,
               runUuid,
               [],
               this.createModelVersionRequestId,
@@ -158,7 +170,7 @@ export class RegisterModelImpl extends React.Component<RegisterModelImplProps, R
         return this.props
           .createModelVersionApi(
             selectedModelName,
-            modelPath,
+            sourceUri,
             runUuid,
             [],
             this.createModelVersionRequestId,

--- a/mlflow/server/js/src/model-registry/components/RegisterModel.tsx
+++ b/mlflow/server/js/src/model-registry/components/RegisterModel.tsx
@@ -136,13 +136,11 @@ export class RegisterModelImpl extends React.Component<RegisterModelImplProps, R
       // 1. For logged models (MLflow 3.0+), use models:/{model_id} format
       // 2. For regular artifacts with run context, use runs:/<run_id>/<model_path> format
       // 3. Otherwise, fall back to the absolute artifact URI for backward compatibility
-      let sourceUri;
+      let sourceUri = modelPath;
       if (loggedModelId) {
         sourceUri = `models:/${loggedModelId}`;
       } else if (modelRelativePath && runUuid) {
         sourceUri = `runs:/${runUuid}/${modelRelativePath}`;
-      } else {
-        sourceUri = modelPath;
       }
       const selectedModelName = values[SELECTED_MODEL_FIELD];
       if (selectedModelName === CREATE_NEW_MODEL_OPTION_VALUE) {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/18501?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18501/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18501/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18501/merge
```

</p>
</details>

### Related Issues/PRs

Resolve #18489

### What changes are proposed in this pull request?

Fix the UI to preserve `run_id` and maintain traceability when registering models through the MLflow UI. The fix constructs proper source URIs:
- For logged models (MLflow 3.0+): Use `models:/{model_id}` format
- For regular artifacts: Use `runs:/{run_id}/{artifact_path}` format
- Fallback to absolute URI for backward compatibility

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests (5 new test cases)
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed bug where models registered via UI lost their `run_id` connection, making them untraceable to source training runs. The UI now correctly preserves run metadata and displays "Source Run" links.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)