### PR TITLE
Prevent scorers from returning multiple feedback objects with the same name

### DIFF
--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -855,14 +855,6 @@ class Scorer(BaseModel):
             sig = inspect.signature(self.__call__)
             params = {param: None for param in sig.parameters if param != "self"}
             result = self(**params)
-
-            # Only validate if the result is a list of Feedback objects
-            if isinstance(result, list) and len(result) > 0:
-                if all(isinstance(item, Feedback) for item in result):
-                    validate_feedback_names_unique(result, self.name)
-        except MlflowException:
-            # Re-raise MlflowException from validation - these are intentional errors
-            raise
         except Exception as e:
             # If the scorer can't be called with None values, skip validation
             # This is acceptable because:
@@ -872,6 +864,12 @@ class Scorer(BaseModel):
                 f"Skipping multi-feedback name validation for scorer '{self.name}' "
                 f"because it cannot be called with None parameters: {e}"
             )
+            return
+
+        # Only validate if the result is a list of Feedback objects
+        if isinstance(result, list) and len(result) > 0:
+            if all(isinstance(item, Feedback) for item in result):
+                validate_feedback_names_unique(result, self.name)
 
     def _check_can_be_registered(self, error_message: str | None = None) -> None:
         from mlflow.genai.judges.instructions_judge import InstructionsJudge

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -315,7 +315,7 @@ def test_validate_feedback_names_unique_with_single_feedback():
 def mock_databricks_tracking_uri():
     """Mock Databricks tracking URI."""
     with mock.patch(
-        "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
+        "mlflow.tracking._tracking_service.utils._resolve_tracking_uri", return_value="databricks"
     ) as mock_uri:
         yield mock_uri
 

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -312,15 +312,18 @@ def test_validate_feedback_names_unique_with_single_feedback():
 
 
 @pytest.fixture
-def mock_databricks_tracking_uri():
-    """Mock tracking URI to simulate Databricks environment."""
-    with mock.patch(
-        "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
+def mock_databricks_env():
+    """Mock Databricks environment for scorer registration tests."""
+    with (
+        mock.patch(
+            "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
+        ),
+        mock.patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"),
     ):
         yield
 
 
-def test_register_scorer_with_duplicate_feedback_names_fails(mock_databricks_tracking_uri):
+def test_register_scorer_with_duplicate_feedback_names_fails(mock_databricks_env):
     @scorer
     def scorer_with_duplicates(outputs: str):
         return [
@@ -337,7 +340,7 @@ def test_register_scorer_with_duplicate_feedback_names_fails(mock_databricks_tra
     assert "duplicate names" in error_msg
 
 
-def test_register_scorer_with_default_feedback_names_fails(mock_databricks_tracking_uri):
+def test_register_scorer_with_default_feedback_names_fails(mock_databricks_env):
     @scorer
     def scorer_unnamed_feedbacks(outputs: str):
         return [
@@ -355,7 +358,7 @@ def test_register_scorer_with_default_feedback_names_fails(mock_databricks_track
     assert "feedback" in error_msg
 
 
-def test_register_scorer_with_unique_feedback_names_succeeds(mock_databricks_tracking_uri):
+def test_register_scorer_with_unique_feedback_names_succeeds(mock_databricks_env):
     @scorer
     def scorer_with_unique_names(outputs: str):
         return [
@@ -368,7 +371,7 @@ def test_register_scorer_with_unique_feedback_names_succeeds(mock_databricks_tra
     scorer_with_unique_names._check_can_be_registered()
 
 
-def test_register_scorer_with_single_feedback_succeeds(mock_databricks_tracking_uri):
+def test_register_scorer_with_single_feedback_succeeds(mock_databricks_env):
     @scorer
     def scorer_with_single_feedback(outputs: str):
         return Feedback(value=True, rationale="Good")
@@ -377,7 +380,7 @@ def test_register_scorer_with_single_feedback_succeeds(mock_databricks_tracking_
     scorer_with_single_feedback._check_can_be_registered()
 
 
-def test_register_scorer_returning_primitive_succeeds(mock_databricks_tracking_uri):
+def test_register_scorer_returning_primitive_succeeds(mock_databricks_env):
     @scorer
     def scorer_returning_bool(outputs: str) -> bool:
         return True

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -317,12 +317,9 @@ def mock_databricks_tracking_uri():
     # Ensure scorer store resolves to Databricks regardless of ambient env
     with (
         mock.patch(
-            "mlflow.genai.scorers.registry.utils._resolve_tracking_uri", return_value="databricks"
-        ) as mock_uri,
-        mock.patch(
             "mlflow.tracking._tracking_service.utils._resolve_tracking_uri",
             return_value="databricks",
-        ),
+        ) as mock_uri,
         mock.patch(
             "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
         ),

--- a/tests/genai/scorers/test_validation.py
+++ b/tests/genai/scorers/test_validation.py
@@ -312,18 +312,15 @@ def test_validate_feedback_names_unique_with_single_feedback():
 
 
 @pytest.fixture
-def mock_databricks_env():
-    """Mock Databricks environment for scorer registration tests."""
-    with (
-        mock.patch(
-            "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
-        ),
-        mock.patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"),
-    ):
-        yield
+def mock_databricks_tracking_uri():
+    """Mock Databricks tracking URI."""
+    with mock.patch(
+        "mlflow.tracking._tracking_service.utils.get_tracking_uri", return_value="databricks"
+    ) as mock_uri:
+        yield mock_uri
 
 
-def test_register_scorer_with_duplicate_feedback_names_fails(mock_databricks_env):
+def test_register_scorer_with_duplicate_feedback_names_fails(mock_databricks_tracking_uri):
     @scorer
     def scorer_with_duplicates(outputs: str):
         return [
@@ -331,16 +328,17 @@ def test_register_scorer_with_duplicate_feedback_names_fails(mock_databricks_env
             Feedback(name="score", value=1.0),  # Duplicate name
         ]
 
-    with pytest.raises(
-        MlflowException, match="Cannot register scorer 'scorer_with_duplicates'"
-    ) as exc_info:
-        scorer_with_duplicates._check_can_be_registered()
+    with mock.patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"):
+        with pytest.raises(
+            MlflowException, match="Cannot register scorer 'scorer_with_duplicates'"
+        ) as exc_info:
+            scorer_with_duplicates._check_can_be_registered()
 
-    error_msg = str(exc_info.value)
-    assert "duplicate names" in error_msg
+        error_msg = str(exc_info.value)
+        assert "duplicate names" in error_msg
 
 
-def test_register_scorer_with_default_feedback_names_fails(mock_databricks_env):
+def test_register_scorer_with_default_feedback_names_fails(mock_databricks_tracking_uri):
     @scorer
     def scorer_unnamed_feedbacks(outputs: str):
         return [
@@ -348,17 +346,18 @@ def test_register_scorer_with_default_feedback_names_fails(mock_databricks_env):
             Feedback(value=1, rationale="ok"),
         ]
 
-    with pytest.raises(
-        MlflowException, match="Cannot register scorer 'scorer_unnamed_feedbacks'"
-    ) as exc_info:
-        scorer_unnamed_feedbacks._check_can_be_registered()
+    with mock.patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"):
+        with pytest.raises(
+            MlflowException, match="Cannot register scorer 'scorer_unnamed_feedbacks'"
+        ) as exc_info:
+            scorer_unnamed_feedbacks._check_can_be_registered()
 
-    error_msg = str(exc_info.value)
-    assert "duplicate names" in error_msg
-    assert "feedback" in error_msg
+        error_msg = str(exc_info.value)
+        assert "duplicate names" in error_msg
+        assert "feedback" in error_msg
 
 
-def test_register_scorer_with_unique_feedback_names_succeeds(mock_databricks_env):
+def test_register_scorer_with_unique_feedback_names_succeeds(mock_databricks_tracking_uri):
     @scorer
     def scorer_with_unique_names(outputs: str):
         return [
@@ -367,23 +366,23 @@ def test_register_scorer_with_unique_feedback_names_succeeds(mock_databricks_env
             Feedback(name="length", value=150, rationale="Good length"),
         ]
 
-    # Should not raise an exception during validation
-    scorer_with_unique_names._check_can_be_registered()
+    with mock.patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"):
+        scorer_with_unique_names._check_can_be_registered()
 
 
-def test_register_scorer_with_single_feedback_succeeds(mock_databricks_env):
+def test_register_scorer_with_single_feedback_succeeds(mock_databricks_tracking_uri):
     @scorer
     def scorer_with_single_feedback(outputs: str):
         return Feedback(value=True, rationale="Good")
 
-    # Should not raise an exception during validation
-    scorer_with_single_feedback._check_can_be_registered()
+    with mock.patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"):
+        scorer_with_single_feedback._check_can_be_registered()
 
 
-def test_register_scorer_returning_primitive_succeeds(mock_databricks_env):
+def test_register_scorer_returning_primitive_succeeds(mock_databricks_tracking_uri):
     @scorer
     def scorer_returning_bool(outputs: str) -> bool:
         return True
 
-    # Should not raise an exception during validation
-    scorer_returning_bool._check_can_be_registered()
+    with mock.patch("mlflow.genai.scorers.registry.DatabricksStore.add_registered_scorer"):
+        scorer_returning_bool._check_can_be_registered()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbrx-euirim/mlflow/pull/18512?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18512/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18512/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18512/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR prevents scorers from returning multiple feedback objects with the same name on registration. This would not be allowed:

```python
# Class returning multiple Feedback objects without names
class ScorerUnnamedFeedbacks(Scorer):
    # CONFLICT: metric name = "scorer_unnamed_feedbacks" for both feedbacks
    name: str = "scorer_unnamed_feedbacks"
    def __call__(self, outputs: str) -> List[Feedback]:
        return [
          Feedback(value=True, rationale="Good"),
          Feedback(value=1, rationale="ok"),
        ]
```

This validation is only done on registration to preserve backwards compatibility with scorers previously registered with duplicate feedback names.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
