### PR TITLE
Replace deprecated Pydantic methods with v2 equivalents

### DIFF
--- a/mlflow/llama_index/tracer.py
+++ b/mlflow/llama_index/tracer.py
@@ -293,7 +293,7 @@ class MlflowSpanHandler(BaseSpanHandler[_LlamaSpan], extra="allow"):
         attr = {SpanAttributeKey.MESSAGE_FORMAT: "llamaindex"}
         if metadata := instance.metadata:
             attr["model_name"] = metadata.model_name
-            if params_str := metadata.json(exclude_unset=True):
+            if params_str := metadata.model_dump_json(exclude_unset=True):
                 attr["invocation_params"] = json.loads(params_str)
         return attr
 

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -164,7 +164,7 @@ def test_generate_content_enable_disable_autolog(is_async):
             "model": "gemini-1.5-flash",
             "config": None,
         }
-        assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
+        assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.model_dump()
 
         span1 = traces[0].data.spans[1]
         assert span1.name == f"{cls}._generate_content"
@@ -174,7 +174,7 @@ def test_generate_content_enable_disable_autolog(is_async):
             "model": "gemini-1.5-flash",
             "config": None,
         }
-        assert span1.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
+        assert span1.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.model_dump()
 
         assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
             TokenUsageKey.INPUT_TOKENS: 6,
@@ -253,7 +253,7 @@ def test_generate_content_image_autolog():
         **extra,
     }
     assert span.inputs["contents"][1] == "Caption this image"
-    assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
+    assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.model_dump()
 
     span1 = traces[0].data.spans[1]
     assert span1.name == f"{cls}._generate_content"
@@ -266,7 +266,7 @@ def test_generate_content_image_autolog():
         **extra,
     }
     assert span1.inputs["contents"][1] == "Caption this image"
-    assert span1.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
+    assert span1.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.model_dump()
 
     assert span.get_attribute(SpanAttributeKey.CHAT_USAGE) == {
         TokenUsageKey.INPUT_TOKENS: 6,
@@ -491,7 +491,7 @@ def test_chat_session_autolog(is_async):
         assert span.name == "AsyncChat.send_message" if is_async else "Chat.send_message"
         assert span.span_type == SpanType.CHAT_MODEL
         assert span.inputs == {"message": "test content"}
-        assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.dict()
+        assert span.outputs == _DUMMY_GENERATE_CONTENT_RESPONSE.model_dump()
 
         mlflow.gemini.autolog(disable=True)
         _create_chat_and_send_message(is_async, "test content")

--- a/tests/gemini/test_gemini_autolog.py
+++ b/tests/gemini/test_gemini_autolog.py
@@ -441,9 +441,9 @@ def test_generate_content_tool_calling_chat_history_autolog(is_async):
     assert span.name == f"{cls}.generate_content"
     assert span.span_type == SpanType.LLM
     assert span.inputs["contents"] == [
-        question_content.dict(),
-        tool_call_content.dict(),
-        tool_response_content.dict(),
+        question_content.model_dump(),
+        tool_call_content.model_dump(),
+        tool_response_content.model_dump(),
     ]
     assert span.inputs["model"] == "gemini-1.5-flash"
     assert span.get_attribute("mlflow.chat.tools") == TOOL_ATTRIBUTE
@@ -454,9 +454,9 @@ def test_generate_content_tool_calling_chat_history_autolog(is_async):
     assert span1.span_type == SpanType.LLM
     assert span1.parent_id == span.span_id
     assert span1.inputs["contents"] == [
-        question_content.dict(),
-        tool_call_content.dict(),
-        tool_response_content.dict(),
+        question_content.model_dump(),
+        tool_call_content.model_dump(),
+        tool_response_content.model_dump(),
     ]
     assert span1.inputs["model"] == "gemini-1.5-flash"
     assert span1.get_attribute("mlflow.chat.tools") == TOOL_ATTRIBUTE

--- a/tests/llama_index/test_llama_index_serialization.py
+++ b/tests/llama_index/test_llama_index_serialization.py
@@ -83,7 +83,7 @@ def test_object_to_dict_one_required_param():
 
 
 def test_construct_prompt_template_object_success(qa_prompt_template):
-    kwargs = qa_prompt_template.dict()
+    kwargs = qa_prompt_template.model_dump()
     observed = _construct_prompt_template_object(PromptTemplate, kwargs)
     assert observed == qa_prompt_template
 

--- a/tests/llama_index/test_llama_index_tracer.py
+++ b/tests/llama_index/test_llama_index_tracer.py
@@ -399,7 +399,7 @@ def test_trace_llm_error(monkeypatch, is_stream):
     assert len(spans) == 1
     assert spans[0].name == "OpenAI.stream_chat" if is_stream else "OpenAI.chat"
     assert spans[0].span_type == SpanType.CHAT_MODEL
-    assert spans[0].inputs == {"messages": [message.dict()]}
+    assert spans[0].inputs == {"messages": [message.model_dump()]}
     assert spans[0].outputs is None
     events = traces[0].data.spans[0].events
     assert len(events) == 1


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18517?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18517/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18517/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18517/merge
```

</p>
</details>

### Related Issues/PRs

Follow-up to #18468

### What changes are proposed in this pull request?

This PR addresses Pydantic v2 compatibility issues that were exposed when #18468 turned `PydanticDeprecatedSince20` warnings into errors.

**Main changes:**
- Replace deprecated `.dict()` with `.model_dump()`
- Replace deprecated `.json()` with `.model_dump_json()`

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)