### PR TITLE
Add deprecation warnings for filesystem backends

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -135,7 +135,7 @@ class FileStore(AbstractStore):
         super().__init__()
         warnings.warn(
             "Filesystem model registry backend (e.g., './mlruns') is deprecated. "
-            "Please use a database backend (e.g., 'sqlite:///mlflow.db'). "
+            "Please switch to a database backend (e.g., 'sqlite:///mlflow.db'). "
             "For feedback, see: https://github.com/mlflow/mlflow/issues/18534",
             FutureWarning,
             stacklevel=2,

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -4,6 +4,7 @@ import shutil
 import sys
 import time
 import urllib
+import warnings
 from os.path import join
 
 from mlflow.entities.model_registry import (
@@ -132,6 +133,13 @@ class FileStore(AbstractStore):
         """
 
         super().__init__()
+        warnings.warn(
+            "The file-based model registry backend (e.g., './mlruns') is deprecated and will be "
+            "removed in a future version of MLflow. Please migrate to a database backend "
+            "(e.g., 'sqlite:///mlflow.db').",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())
         # Create models directory if needed
         if not exists(self.models_directory):

--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -134,9 +134,9 @@ class FileStore(AbstractStore):
 
         super().__init__()
         warnings.warn(
-            "The file-based model registry backend (e.g., './mlruns') is deprecated and will be "
-            "removed in a future version of MLflow. Please migrate to a database backend "
-            "(e.g., 'sqlite:///mlflow.db').",
+            "Filesystem model registry backend (e.g., './mlruns') is deprecated. "
+            "Please use a database backend (e.g., 'sqlite:///mlflow.db'). "
+            "For feedback, see: https://github.com/mlflow/mlflow/issues/18534",
             FutureWarning,
             stacklevel=2,
         )

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -6,6 +6,7 @@ import shutil
 import sys
 import time
 import uuid
+import warnings
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, NamedTuple, TypedDict
@@ -215,6 +216,13 @@ class FileStore(AbstractStore):
         Create a new FileStore with the given root directory and a given default artifact root URI.
         """
         super().__init__()
+        warnings.warn(
+            "The file-based tracking backend (e.g., './mlruns') is deprecated and will be "
+            "removed in a future version of MLflow. Please migrate to a database backend "
+            "(e.g., 'sqlite:///mlflow.db').",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.root_directory = local_file_uri_to_path(root_directory or _default_root_dir())
         if not artifact_root_uri:
             self.artifact_root_uri = path_to_local_file_uri(self.root_directory)

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -218,7 +218,7 @@ class FileStore(AbstractStore):
         super().__init__()
         warnings.warn(
             "Filesystem tracking backend (e.g., './mlruns') is deprecated. "
-            "Please use a database backend (e.g., 'sqlite:///mlflow.db'). "
+            "Please switch to a database backend (e.g., 'sqlite:///mlflow.db'). "
             "For feedback, see: https://github.com/mlflow/mlflow/issues/18534",
             FutureWarning,
             stacklevel=2,

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -217,9 +217,9 @@ class FileStore(AbstractStore):
         """
         super().__init__()
         warnings.warn(
-            "The file-based tracking backend (e.g., './mlruns') is deprecated and will be "
-            "removed in a future version of MLflow. Please migrate to a database backend "
-            "(e.g., 'sqlite:///mlflow.db').",
+            "Filesystem tracking backend (e.g., './mlruns') is deprecated. "
+            "Please use a database backend (e.g., 'sqlite:///mlflow.db'). "
+            "For feedback, see: https://github.com/mlflow/mlflow/issues/18534",
             FutureWarning,
             stacklevel=2,
         )

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -60,6 +60,11 @@ def rm_data(registered_model_names, tmp_path):
     return rm_data
 
 
+def test_file_store_deprecation_warning(tmp_path):
+    with pytest.warns(FutureWarning, match="file-based model registry backend.*is deprecated"):
+        FileStore(str(tmp_path))
+
+
 def test_create_registered_model(store):
     # Error cases
     with pytest.raises(MlflowException, match=r"Missing value for required parameter 'name'\."):

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -62,7 +62,7 @@ def rm_data(registered_model_names, tmp_path):
 
 def test_file_store_deprecation_warning(tmp_path):
     with pytest.warns(FutureWarning, match="file-based model registry backend.*is deprecated"):
-        FileStore(str(tmp_path))
+        FileStore(str(tmp_path / "model_registry"))
 
 
 def test_create_registered_model(store):

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -61,7 +61,7 @@ def rm_data(registered_model_names, tmp_path):
 
 
 def test_file_store_deprecation_warning(tmp_path):
-    with pytest.warns(FutureWarning, match="file-based model registry backend.*is deprecated"):
+    with pytest.warns(FutureWarning, match="Filesystem model registry backend.*is deprecated"):
         FileStore(str(tmp_path / "model_registry"))
 
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -148,7 +148,7 @@ def create_experiments(store, experiment_names):
 
 
 def test_file_store_deprecation_warning(tmp_path):
-    with pytest.warns(FutureWarning, match="file-based tracking backend.*is deprecated"):
+    with pytest.warns(FutureWarning, match="Filesystem tracking backend.*is deprecated"):
         FileStore(str(tmp_path / "mlruns"))
 
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -147,6 +147,11 @@ def create_experiments(store, experiment_names):
     return ids
 
 
+def test_file_store_deprecation_warning(tmp_path):
+    with pytest.warns(FutureWarning, match="file-based tracking backend.*is deprecated"):
+        FileStore(str(tmp_path / "mlruns"))
+
+
 def test_valid_root(store):
     store._check_root_dir()
     shutil.rmtree(store.root_directory)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18524?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18524/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18524/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18524/merge
```

</p>
</details>

### What changes are proposed in this pull request?

This PR adds deprecation warnings to file-based backends (tracking and model registry) to notify users about the planned sunset due to security concerns and maintenance burden. The warnings encourage users to migrate to database backends like SQLite.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. File-based backends (tracking and model registry) now emit deprecation warnings when initialized, informing users to migrate to database backends.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)