### PR TITLE
Relax Polars digest assertions to support multiple versions

### DIFF
--- a/tests/data/test_polars_dataset.py
+++ b/tests/data/test_polars_dataset.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from datetime import date, datetime
 from pathlib import Path
 
@@ -122,7 +123,8 @@ def test_conversion_to_json(source: SampleDatasetSource) -> None:
 def test_digest_property_has_expected_value(source: SampleDatasetSource) -> None:
     dataset = PolarsDataset(df=pl.DataFrame([1, 2, 3], schema=["Numbers"]), source=source)
     assert dataset.digest == dataset._compute_digest()
-    assert dataset.digest == "7776762068187136295"
+    # Digest value varies across Polars versions due to hash_rows() implementation changes
+    assert re.match(r"^\d+$", dataset.digest)
 
 
 def test_digest_consistent(source: SampleDatasetSource) -> None:

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2,6 +2,7 @@ import json
 import multiprocessing
 import os
 import random
+import re
 import subprocess
 import sys
 import threading
@@ -1395,7 +1396,8 @@ def test_log_input_polars(tmp_path):
 
     assert len(dataset_inputs) == 1
     assert dataset_inputs[0].dataset.name == "dataset"
-    assert dataset_inputs[0].dataset.digest == "6421470605044910196"
+    # Digest value varies across Polars versions due to hash_rows() implementation changes
+    assert re.match(r"^\d+$", dataset_inputs[0].dataset.digest)
     assert dataset_inputs[0].dataset.source_type == "local"
 
 


### PR DESCRIPTION
### Related Issues/PRs

Related to #18525

### What changes are proposed in this pull request?

Polars 1.35.0 was yanked after #18525 updated test digest values to match its new `hash_rows()` implementation. This caused test failures when users ran tests with older Polars versions that produce different hash values.

This PR relaxes the digest assertions to use regex validation (`^\d+$`) instead of hard-coded values, making tests robust across Polars versions while still validating digest computation consistency.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)