### PR TITLE
Added bucket-ownership checks for Amazon S3

### DIFF
--- a/docs/docs/self-hosting/architecture/artifact-store.mdx
+++ b/docs/docs/self-hosting/architecture/artifact-store.mdx
@@ -72,6 +72,24 @@ export MLFLOW_S3_UPLOAD_EXTRA_ARGS='{"ServerSideEncryption": "aws:kms", "SSEKMSK
 
 For a list of available extra args see [Boto3 ExtraArgs Documentation](https://github.com/boto/boto3/blob/develop/docs/source/guide/s3-uploading-files.rst#the-extraargs-parameter).
 
+#### Bucket Ownership Verification
+
+To protect against bucket takeover attacks where a deleted bucket is recreated by a different AWS account, you can set `MLFLOW_S3_EXPECTED_BUCKET_OWNER` to the expected AWS account ID that owns your S3 bucket:
+
+```bash
+export MLFLOW_S3_EXPECTED_BUCKET_OWNER=123456789012
+```
+
+When set, MLflow will include the `ExpectedBucketOwner` parameter in all S3 API calls. If the bucket is owned by a different account, S3 will reject the operation with an access denied error, preventing unauthorized access to artifacts.
+
+This is particularly important for scenarios where:
+
+- S3 bucket names are globally unique across all AWS accounts
+- A bucket could be deleted and recreated by an attacker with the same name
+- MLflow would unknowingly send artifacts to the attacker's bucket
+
+For more information, see the [AWS S3 Bucket Owner Condition documentation](https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-owner-condition.html).
+
 #### Setting Custom S3 Endpoints
 
 To store artifacts in a custom endpoint, set the `MLFLOW_S3_ENDPOINT_URL` to your endpoint's URL. For example, if you are using Digital Ocean Spaces:

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -203,6 +203,13 @@ MLFLOW_S3_IGNORE_TLS = _BooleanEnvironmentVariable("MLFLOW_S3_IGNORE_TLS", False
 #: (default: ``None``)
 MLFLOW_S3_UPLOAD_EXTRA_ARGS = _EnvironmentVariable("MLFLOW_S3_UPLOAD_EXTRA_ARGS", str, None)
 
+#: Specifies the expected AWS account ID that owns the S3 bucket for bucket ownership verification.
+#: When set, all S3 API calls will include the ExpectedBucketOwner parameter to prevent
+#: bucket takeover attacks. This helps protect against scenarios where a bucket is deleted
+#: and recreated by a different AWS account with the same name.
+#: (default: ``None``)
+MLFLOW_S3_EXPECTED_BUCKET_OWNER = _EnvironmentVariable("MLFLOW_S3_EXPECTED_BUCKET_OWNER", str, None)
+
 #: Specifies the location of a Kerberos ticket cache to use for HDFS artifact operations.
 #: (default: ``None``)
 MLFLOW_KERBEROS_TICKET_CACHE = _EnvironmentVariable("MLFLOW_KERBEROS_TICKET_CACHE", str, None)

--- a/mlflow/store/artifact/optimized_s3_artifact_repo.py
+++ b/mlflow/store/artifact/optimized_s3_artifact_repo.py
@@ -353,7 +353,9 @@ class OptimizedS3ArtifactRepository(CloudArtifactRepository):
         s3_full_path = posixpath.join(self.bucket_path, remote_file_path)
 
         def try_func(creds):
-            download_kwargs = {"ExtraArgs": p} if (p := self._bucket_owner_params) else {}
+            download_kwargs = (
+                {"ExtraArgs": self._bucket_owner_params} if self._bucket_owner_params else {}
+            )
             creds.download_file(self.bucket, s3_full_path, local_path, **download_kwargs)
 
         _retry_with_new_creds(

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -189,7 +189,11 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         self._access_key_id = access_key_id
         self._secret_access_key = secret_access_key
         self._session_token = session_token
-        self._bucket_owner = MLFLOW_S3_EXPECTED_BUCKET_OWNER.get()
+        self._bucket_owner_params = (
+            {"ExpectedBucketOwner": owner}
+            if (owner := MLFLOW_S3_EXPECTED_BUCKET_OWNER.get())
+            else {}
+        )
 
     def _get_s3_client(self):
         return _get_s3_client(
@@ -197,12 +201,6 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             secret_access_key=self._secret_access_key,
             session_token=self._session_token,
         )
-
-    def _get_bucket_owner_params(self) -> dict[str, str]:
-        """
-        Return dict with ExpectedBucketOwner if bucket owner is configured, otherwise empty dict.
-        """
-        return {"ExpectedBucketOwner": self._bucket_owner} if self._bucket_owner else {}
 
     def parse_s3_compliant_uri(self, uri):
         """
@@ -249,7 +247,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             extra_args["ContentType"] = guessed_type
         if guessed_encoding is not None:
             extra_args["ContentEncoding"] = guessed_encoding
-        extra_args.update(self._get_bucket_owner_params())
+        extra_args.update(self._bucket_owner_params)
         environ_extra_args = self.get_s3_file_upload_extra_args()
         if environ_extra_args is not None:
             extra_args.update(environ_extra_args)
@@ -337,7 +335,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             s3_client = self._get_s3_client()
             paginator = s3_client.get_paginator("list_objects_v2")
             results = paginator.paginate(
-                Bucket=bucket, Prefix=prefix, Delimiter="/", **self._get_bucket_owner_params()
+                Bucket=bucket, Prefix=prefix, Delimiter="/", **self._bucket_owner_params
             )
             for result in results:
                 yield result
@@ -424,7 +422,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         (bucket, s3_root_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         s3_full_path = posixpath.join(s3_root_path, remote_file_path)
         s3_client = self._get_s3_client()
-        download_kwargs = {"ExtraArgs": p} if (p := self._get_bucket_owner_params()) else {}
+        download_kwargs = {"ExtraArgs": p} if (p := self._bucket_owner_params) else {}
         s3_client.download_file(bucket, s3_full_path, local_path, **download_kwargs)
 
     def delete_artifacts(self, artifact_path=None):
@@ -435,9 +433,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         dest_path = dest_path.rstrip("/") if dest_path else ""
         s3_client = self._get_s3_client()
         paginator = s3_client.get_paginator("list_objects_v2")
-        results = paginator.paginate(
-            Bucket=bucket, Prefix=dest_path, **self._get_bucket_owner_params()
-        )
+        results = paginator.paginate(Bucket=bucket, Prefix=dest_path, **self._bucket_owner_params)
         for result in results:
             keys = []
             for to_delete_obj in result.get("Contents", []):
@@ -448,7 +444,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 keys.append({"Key": file_path})
             if keys:
                 s3_client.delete_objects(
-                    Bucket=bucket, Delete={"Objects": keys}, **self._get_bucket_owner_params()
+                    Bucket=bucket, Delete={"Objects": keys}, **self._bucket_owner_params
                 )
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
@@ -480,7 +476,9 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         s3_client = self._get_s3_client()
         create_response = s3_client.create_multipart_upload(
-            Bucket=bucket, Key=dest_path, **self._get_bucket_owner_params()
+            Bucket=bucket,
+            Key=dest_path,
+            **self._bucket_owner_params,
         )
         upload_id = create_response["UploadId"]
         credentials = []
@@ -492,7 +490,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                     "Key": dest_path,
                     "PartNumber": i,
                     "UploadId": upload_id,
-                    **self._get_bucket_owner_params(),
+                    **self._bucket_owner_params,
                 },
             )
             credentials.append(
@@ -536,7 +534,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             Key=dest_path,
             UploadId=upload_id,
             MultipartUpload={"Parts": parts},
-            **self._get_bucket_owner_params(),
+            **self._bucket_owner_params,
         )
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
@@ -563,5 +561,5 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             Bucket=bucket,
             Key=dest_path,
             UploadId=upload_id,
-            **self._get_bucket_owner_params(),
+            **self._bucket_owner_params,
         )

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -422,7 +422,9 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         (bucket, s3_root_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         s3_full_path = posixpath.join(s3_root_path, remote_file_path)
         s3_client = self._get_s3_client()
-        download_kwargs = {"ExtraArgs": p} if (p := self._bucket_owner_params) else {}
+        download_kwargs = (
+            {"ExtraArgs": self._bucket_owner_params} if self._bucket_owner_params else {}
+        )
         s3_client.download_file(bucket, s3_full_path, local_path, **download_kwargs)
 
     def delete_artifacts(self, artifact_path=None):

--- a/mlflow/store/artifact/s3_artifact_repo.py
+++ b/mlflow/store/artifact/s3_artifact_repo.py
@@ -14,6 +14,7 @@ from mlflow.entities.multipart_upload import (
 from mlflow.environment_variables import (
     MLFLOW_BOTO_CLIENT_ADDRESSING_STYLE,
     MLFLOW_S3_ENDPOINT_URL,
+    MLFLOW_S3_EXPECTED_BUCKET_OWNER,
     MLFLOW_S3_IGNORE_TLS,
     MLFLOW_S3_UPLOAD_EXTRA_ARGS,
 )
@@ -188,6 +189,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         self._access_key_id = access_key_id
         self._secret_access_key = secret_access_key
         self._session_token = session_token
+        self._bucket_owner = MLFLOW_S3_EXPECTED_BUCKET_OWNER.get()
 
     def _get_s3_client(self):
         return _get_s3_client(
@@ -195,6 +197,12 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             secret_access_key=self._secret_access_key,
             session_token=self._session_token,
         )
+
+    def _add_bucket_owner_if_present(self, kwargs):
+        """Add ExpectedBucketOwner to kwargs if bucket owner is configured."""
+        if self._bucket_owner:
+            kwargs["ExpectedBucketOwner"] = self._bucket_owner
+        return kwargs
 
     def parse_s3_compliant_uri(self, uri):
         """
@@ -241,6 +249,7 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             extra_args["ContentType"] = guessed_type
         if guessed_encoding is not None:
             extra_args["ContentEncoding"] = guessed_encoding
+        self._add_bucket_owner_if_present(extra_args)
         environ_extra_args = self.get_s3_file_upload_extra_args()
         if environ_extra_args is not None:
             extra_args.update(environ_extra_args)
@@ -327,7 +336,9 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         try:
             s3_client = self._get_s3_client()
             paginator = s3_client.get_paginator("list_objects_v2")
-            results = paginator.paginate(Bucket=bucket, Prefix=prefix, Delimiter="/")
+            paginate_kwargs = {"Bucket": bucket, "Prefix": prefix, "Delimiter": "/"}
+            self._add_bucket_owner_if_present(paginate_kwargs)
+            results = paginator.paginate(**paginate_kwargs)
             for result in results:
                 yield result
         except ClientError as error:
@@ -413,7 +424,8 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         (bucket, s3_root_path) = self.parse_s3_compliant_uri(self.artifact_uri)
         s3_full_path = posixpath.join(s3_root_path, remote_file_path)
         s3_client = self._get_s3_client()
-        s3_client.download_file(bucket, s3_full_path, local_path)
+        download_kwargs = {"ExtraArgs": self._add_bucket_owner_if_present({})}
+        s3_client.download_file(bucket, s3_full_path, local_path, **download_kwargs)
 
     def delete_artifacts(self, artifact_path=None):
         (bucket, dest_path) = self.parse_s3_compliant_uri(self.artifact_uri)
@@ -423,7 +435,9 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         dest_path = dest_path.rstrip("/") if dest_path else ""
         s3_client = self._get_s3_client()
         paginator = s3_client.get_paginator("list_objects_v2")
-        results = paginator.paginate(Bucket=bucket, Prefix=dest_path)
+        paginate_kwargs = {"Bucket": bucket, "Prefix": dest_path}
+        self._add_bucket_owner_if_present(paginate_kwargs)
+        results = paginator.paginate(**paginate_kwargs)
         for result in results:
             keys = []
             for to_delete_obj in result.get("Contents", []):
@@ -433,7 +447,9 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
                 )
                 keys.append({"Key": file_path})
             if keys:
-                s3_client.delete_objects(Bucket=bucket, Delete={"Objects": keys})
+                delete_kwargs = {"Bucket": bucket, "Delete": {"Objects": keys}}
+                self._add_bucket_owner_if_present(delete_kwargs)
+                s3_client.delete_objects(**delete_kwargs)
 
     def create_multipart_upload(self, local_file, num_parts=1, artifact_path=None):
         """
@@ -463,22 +479,20 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         s3_client = self._get_s3_client()
-        create_response = s3_client.create_multipart_upload(
-            Bucket=bucket,
-            Key=dest_path,
-        )
+        create_kwargs = {"Bucket": bucket, "Key": dest_path}
+        self._add_bucket_owner_if_present(create_kwargs)
+        create_response = s3_client.create_multipart_upload(**create_kwargs)
         upload_id = create_response["UploadId"]
         credentials = []
         for i in range(1, num_parts + 1):  # part number must be in [1, 10000]
-            url = s3_client.generate_presigned_url(
-                "upload_part",
-                Params={
-                    "Bucket": bucket,
-                    "Key": dest_path,
-                    "PartNumber": i,
-                    "UploadId": upload_id,
-                },
-            )
+            presigned_params = {
+                "Bucket": bucket,
+                "Key": dest_path,
+                "PartNumber": i,
+                "UploadId": upload_id,
+            }
+            self._add_bucket_owner_if_present(presigned_params)
+            url = s3_client.generate_presigned_url("upload_part", Params=presigned_params)
             credentials.append(
                 MultipartUploadCredential(
                     url=url,
@@ -515,9 +529,14 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         parts = [{"PartNumber": part.part_number, "ETag": part.etag} for part in parts]
         s3_client = self._get_s3_client()
-        s3_client.complete_multipart_upload(
-            Bucket=bucket, Key=dest_path, UploadId=upload_id, MultipartUpload={"Parts": parts}
-        )
+        complete_kwargs = {
+            "Bucket": bucket,
+            "Key": dest_path,
+            "UploadId": upload_id,
+            "MultipartUpload": {"Parts": parts},
+        }
+        self._add_bucket_owner_if_present(complete_kwargs)
+        s3_client.complete_multipart_upload(**complete_kwargs)
 
     def abort_multipart_upload(self, local_file, upload_id, artifact_path=None):
         """
@@ -539,8 +558,6 @@ class S3ArtifactRepository(ArtifactRepository, MultipartUploadMixin):
             dest_path = posixpath.join(dest_path, artifact_path)
         dest_path = posixpath.join(dest_path, os.path.basename(local_file))
         s3_client = self._get_s3_client()
-        s3_client.abort_multipart_upload(
-            Bucket=bucket,
-            Key=dest_path,
-            UploadId=upload_id,
-        )
+        abort_kwargs = {"Bucket": bucket, "Key": dest_path, "UploadId": upload_id}
+        self._add_bucket_owner_if_present(abort_kwargs)
+        s3_client.abort_multipart_upload(**abort_kwargs)

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -520,10 +520,7 @@ def test_trace_data(s3_artifact_root):
 def test_bucket_ownership_verification_with_env_var(s3_artifact_repo, tmp_path, monkeypatch):
     file_name = "test.txt"
     file_path = tmp_path / file_name
-    file_text = "Hello world!"
-
-    with open(file_path, "w") as f:
-        f.write(file_text)
+    file_path.touch()
 
     monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
 
@@ -544,10 +541,7 @@ def test_bucket_ownership_verification_without_env_var(s3_artifact_repo, tmp_pat
     monkeypatch.delenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", raising=False)
     file_name = "test.txt"
     file_path = tmp_path / file_name
-    file_text = "Hello world!"
-
-    with open(file_path, "w") as f:
-        f.write(file_text)
+    file_path.touch()
 
     assert s3_artifact_repo._bucket_owner_params == {}
 
@@ -606,7 +600,7 @@ def test_list_artifacts_with_bucket_owner(s3_artifact_repo, tmp_path, monkeypatc
     subdir = tmp_path / "subdir"
     subdir.mkdir()
     path_a = subdir / "a.txt"
-    path_a.write_text("A")
+    path_a.touch()
 
     monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
 
@@ -652,7 +646,7 @@ def test_delete_artifacts_with_bucket_owner(s3_artifact_repo, tmp_path, monkeypa
     subdir = tmp_path / "subdir"
     subdir.mkdir()
     path_a = subdir / "a.txt"
-    path_a.write_text("A")
+    path_a.touch()
 
     monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
 

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -528,7 +528,7 @@ def test_bucket_ownership_verification_with_env_var(s3_artifact_repo, tmp_path, 
     monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
 
     repo_with_owner = S3ArtifactRepository(s3_artifact_repo.artifact_uri)
-    assert repo_with_owner._bucket_owner == "123456789012"
+    assert repo_with_owner._bucket_owner_params == {"ExpectedBucketOwner": "123456789012"}
 
     mock_s3 = mock.Mock()
 
@@ -549,7 +549,7 @@ def test_bucket_ownership_verification_without_env_var(s3_artifact_repo, tmp_pat
     with open(file_path, "w") as f:
         f.write(file_text)
 
-    assert s3_artifact_repo._bucket_owner is None
+    assert s3_artifact_repo._bucket_owner_params == {}
 
     mock_s3 = mock.Mock()
 

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -531,10 +531,11 @@ def test_bucket_ownership_verification_with_env_var(s3_artifact_repo, tmp_path, 
 
     with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
         repo_with_owner.log_artifact(file_path)
-        mock_s3.upload_file.assert_called_once()
-        call_kwargs = mock_s3.upload_file.call_args[1]
-        assert "ExtraArgs" in call_kwargs
-        assert call_kwargs["ExtraArgs"]["ExpectedBucketOwner"] == "123456789012"
+
+    mock_s3.upload_file.assert_called_once()
+    call_kwargs = mock_s3.upload_file.call_args[1]
+    assert "ExtraArgs" in call_kwargs
+    assert call_kwargs["ExtraArgs"]["ExpectedBucketOwner"] == "123456789012"
 
 
 def test_bucket_ownership_verification_without_env_var(s3_artifact_repo, tmp_path, monkeypatch):
@@ -549,9 +550,10 @@ def test_bucket_ownership_verification_without_env_var(s3_artifact_repo, tmp_pat
 
     with mock.patch.object(s3_artifact_repo, "_get_s3_client", return_value=mock_s3):
         s3_artifact_repo.log_artifact(file_path)
-        mock_s3.upload_file.assert_called_once()
-        call_kwargs = mock_s3.upload_file.call_args[1]
-        assert "ExpectedBucketOwner" not in call_kwargs.get("ExtraArgs", {})
+
+    mock_s3.upload_file.assert_called_once()
+    call_kwargs = mock_s3.upload_file.call_args[1]
+    assert "ExpectedBucketOwner" not in call_kwargs.get("ExtraArgs", {})
 
 
 def test_bucket_takeover_scenario(s3_artifact_root, tmp_path, monkeypatch):
@@ -614,10 +616,11 @@ def test_list_artifacts_with_bucket_owner(s3_artifact_repo, tmp_path, monkeypatc
 
     with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
         repo_with_owner.list_artifacts()
-        mock_paginator.paginate.assert_called_once()
-        call_kwargs = mock_paginator.paginate.call_args[1]
-        assert "ExpectedBucketOwner" in call_kwargs
-        assert call_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+    mock_paginator.paginate.assert_called_once()
+    call_kwargs = mock_paginator.paginate.call_args[1]
+    assert "ExpectedBucketOwner" in call_kwargs
+    assert call_kwargs["ExpectedBucketOwner"] == "123456789012"
 
 
 def test_multipart_upload_with_bucket_owner(s3_artifact_root, monkeypatch):
@@ -631,15 +634,16 @@ def test_multipart_upload_with_bucket_owner(s3_artifact_root, monkeypatch):
 
     with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
         repo_with_owner.create_multipart_upload("local_file", num_parts=2)
-        mock_s3.create_multipart_upload.assert_called_once()
-        call_kwargs = mock_s3.create_multipart_upload.call_args[1]
-        assert "ExpectedBucketOwner" in call_kwargs
-        assert call_kwargs["ExpectedBucketOwner"] == "123456789012"
-        presigned_calls = mock_s3.generate_presigned_url.call_args_list
-        for call in presigned_calls:
-            params = call[1]["Params"]
-            assert "ExpectedBucketOwner" in params
-            assert params["ExpectedBucketOwner"] == "123456789012"
+
+    mock_s3.create_multipart_upload.assert_called_once()
+    call_kwargs = mock_s3.create_multipart_upload.call_args[1]
+    assert "ExpectedBucketOwner" in call_kwargs
+    assert call_kwargs["ExpectedBucketOwner"] == "123456789012"
+    presigned_calls = mock_s3.generate_presigned_url.call_args_list
+    for call in presigned_calls:
+        params = call[1]["Params"]
+        assert "ExpectedBucketOwner" in params
+        assert params["ExpectedBucketOwner"] == "123456789012"
 
 
 def test_delete_artifacts_with_bucket_owner(s3_artifact_repo, tmp_path, monkeypatch):
@@ -662,11 +666,12 @@ def test_delete_artifacts_with_bucket_owner(s3_artifact_repo, tmp_path, monkeypa
 
     with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
         repo_with_owner.delete_artifacts()
-        mock_paginator.paginate.assert_called_once()
-        paginate_call_kwargs = mock_paginator.paginate.call_args[1]
-        assert "ExpectedBucketOwner" in paginate_call_kwargs
-        assert paginate_call_kwargs["ExpectedBucketOwner"] == "123456789012"
-        mock_s3.delete_objects.assert_called_once()
-        delete_call_kwargs = mock_s3.delete_objects.call_args[1]
-        assert "ExpectedBucketOwner" in delete_call_kwargs
-        assert delete_call_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+    mock_paginator.paginate.assert_called_once()
+    paginate_call_kwargs = mock_paginator.paginate.call_args[1]
+    assert "ExpectedBucketOwner" in paginate_call_kwargs
+    assert paginate_call_kwargs["ExpectedBucketOwner"] == "123456789012"
+    mock_s3.delete_objects.assert_called_once()
+    delete_call_kwargs = mock_s3.delete_objects.call_args[1]
+    assert "ExpectedBucketOwner" in delete_call_kwargs
+    assert delete_call_kwargs["ExpectedBucketOwner"] == "123456789012"

--- a/tests/store/artifact/test_s3_artifact_repo.py
+++ b/tests/store/artifact/test_s3_artifact_repo.py
@@ -515,3 +515,164 @@ def test_trace_data(s3_artifact_root):
     mock_trace_data = {"spans": [], "request": {"test": 1}, "response": {"test": 2}}
     repo.upload_trace_data(json.dumps(mock_trace_data))
     assert repo.download_trace_data() == mock_trace_data
+
+
+def test_bucket_ownership_verification_with_env_var(s3_artifact_repo, tmp_path, monkeypatch):
+    file_name = "test.txt"
+    file_path = tmp_path / file_name
+    file_text = "Hello world!"
+
+    with open(file_path, "w") as f:
+        f.write(file_text)
+
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    repo_with_owner = S3ArtifactRepository(s3_artifact_repo.artifact_uri)
+    assert repo_with_owner._bucket_owner == "123456789012"
+
+    mock_s3 = mock.Mock()
+
+    with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
+        repo_with_owner.log_artifact(file_path)
+        mock_s3.upload_file.assert_called_once()
+        call_kwargs = mock_s3.upload_file.call_args[1]
+        assert "ExtraArgs" in call_kwargs
+        assert call_kwargs["ExtraArgs"]["ExpectedBucketOwner"] == "123456789012"
+
+
+def test_bucket_ownership_verification_without_env_var(s3_artifact_repo, tmp_path, monkeypatch):
+    monkeypatch.delenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", raising=False)
+    file_name = "test.txt"
+    file_path = tmp_path / file_name
+    file_text = "Hello world!"
+
+    with open(file_path, "w") as f:
+        f.write(file_text)
+
+    assert s3_artifact_repo._bucket_owner is None
+
+    mock_s3 = mock.Mock()
+
+    with mock.patch.object(s3_artifact_repo, "_get_s3_client", return_value=mock_s3):
+        s3_artifact_repo.log_artifact(file_path)
+        mock_s3.upload_file.assert_called_once()
+        call_kwargs = mock_s3.upload_file.call_args[1]
+        assert "ExpectedBucketOwner" not in call_kwargs.get("ExtraArgs", {})
+
+
+def test_bucket_takeover_scenario(s3_artifact_root, tmp_path, monkeypatch):
+    """
+    Test the bucket takeover scenario where:
+    1. A user creates and uses a bucket (e.g., `my-mlflow-artifacts`)
+    2. The bucket is deleted
+    3. An attacker creates a new bucket with the same name
+    4. MLflow continues to use the same bucket URI, unknowingly sending
+       artifacts to the attacker's bucket
+
+    This test verifies that when MLFLOW_S3_EXPECTED_BUCKET_OWNER is set, operations
+    will fail if the bucket owner doesn't match, preventing the takeover attack.
+    """
+    file_name = "sensitive_data.txt"
+    file_path = tmp_path / file_name
+    file_text = "Sensitive information"
+
+    with open(file_path, "w") as f:
+        f.write(file_text)
+
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    repo_with_owner = S3ArtifactRepository(s3_artifact_root)
+
+    mock_s3 = mock.Mock()
+    mock_s3.upload_file.side_effect = botocore.exceptions.ClientError(
+        {
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": "The bucket owner does not match the expected bucket owner",
+            }
+        },
+        "PutObject",
+    )
+
+    with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
+        with pytest.raises(
+            botocore.exceptions.ClientError,
+            match=r"The bucket owner does not match the expected bucket owner",
+        ):
+            repo_with_owner.log_artifact(file_path)
+
+
+def test_list_artifacts_with_bucket_owner(s3_artifact_repo, tmp_path, monkeypatch):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    path_a = subdir / "a.txt"
+    path_a.write_text("A")
+
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    repo_with_owner = S3ArtifactRepository(s3_artifact_repo.artifact_uri)
+    repo_with_owner.log_artifacts(str(subdir))
+
+    mock_s3 = mock.Mock()
+    mock_paginator = mock.Mock()
+    mock_s3.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = [{"Contents": [], "CommonPrefixes": []}]
+
+    with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
+        repo_with_owner.list_artifacts()
+        mock_paginator.paginate.assert_called_once()
+        call_kwargs = mock_paginator.paginate.call_args[1]
+        assert "ExpectedBucketOwner" in call_kwargs
+        assert call_kwargs["ExpectedBucketOwner"] == "123456789012"
+
+
+def test_multipart_upload_with_bucket_owner(s3_artifact_root, monkeypatch):
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    repo_with_owner = S3ArtifactRepository(s3_artifact_root)
+
+    mock_s3 = mock.Mock()
+    mock_s3.create_multipart_upload.return_value = {"UploadId": "test-upload-id"}
+    mock_s3.generate_presigned_url.return_value = "https://example.com/presigned"
+
+    with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
+        repo_with_owner.create_multipart_upload("local_file", num_parts=2)
+        mock_s3.create_multipart_upload.assert_called_once()
+        call_kwargs = mock_s3.create_multipart_upload.call_args[1]
+        assert "ExpectedBucketOwner" in call_kwargs
+        assert call_kwargs["ExpectedBucketOwner"] == "123456789012"
+        presigned_calls = mock_s3.generate_presigned_url.call_args_list
+        for call in presigned_calls:
+            params = call[1]["Params"]
+            assert "ExpectedBucketOwner" in params
+            assert params["ExpectedBucketOwner"] == "123456789012"
+
+
+def test_delete_artifacts_with_bucket_owner(s3_artifact_repo, tmp_path, monkeypatch):
+    subdir = tmp_path / "subdir"
+    subdir.mkdir()
+    path_a = subdir / "a.txt"
+    path_a.write_text("A")
+
+    monkeypatch.setenv("MLFLOW_S3_EXPECTED_BUCKET_OWNER", "123456789012")
+
+    repo_with_owner = S3ArtifactRepository(s3_artifact_repo.artifact_uri)
+    repo_with_owner.log_artifacts(str(subdir))
+
+    mock_s3 = mock.Mock()
+    mock_paginator = mock.Mock()
+    mock_s3.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = [
+        {"Contents": [{"Key": "some/path/a.txt"}], "CommonPrefixes": []}
+    ]
+
+    with mock.patch.object(repo_with_owner, "_get_s3_client", return_value=mock_s3):
+        repo_with_owner.delete_artifacts()
+        mock_paginator.paginate.assert_called_once()
+        paginate_call_kwargs = mock_paginator.paginate.call_args[1]
+        assert "ExpectedBucketOwner" in paginate_call_kwargs
+        assert paginate_call_kwargs["ExpectedBucketOwner"] == "123456789012"
+        mock_s3.delete_objects.assert_called_once()
+        delete_call_kwargs = mock_s3.delete_objects.call_args[1]
+        assert "ExpectedBucketOwner" in delete_call_kwargs
+        assert delete_call_kwargs["ExpectedBucketOwner"] == "123456789012"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kingroryg/mlflow/pull/18542?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18542/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18542/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18542/merge
```

</p>
</details>

### Related Issues/PRs

Fix https://github.com/mlflow/mlflow/issues/18541

### What changes are proposed in this pull request?

1. Environment Variable (`mlflow/environment_variables.py`)
Added `MLFLOW_S3_BUCKET_OWNER `environment variable to specify the expected AWS account ID that owns the S3 bucket. This is optional and backward compatible - when not set, the system behaves as before.
2. S3 Artifact Repository (`mlflow/store/artifact/s3_artifact_repo.py`)
    - Added `_bucket_owner` attribute initialized from the environment variable
    - Updated all S3 API calls to include `ExpectedBucketOwner` parameter when configured:
        - `upload_file` (single file uploads)
        - `download_file` (file downloads)
        - `list_objects_v2` (listing artifacts)
        - `delete_objects` (deleting artifacts)
        - `create_multipart_upload` (multipart upload initiation)
        - `complete_multipart_upload` (multipart upload completion)
        - `abort_multipart_upload` (multipart upload abortion)
        - `generate_presigned_url` (presigned URL generation)
3. Optimized S3 Artifact Repository (`mlflow/store/artifact/optimized_s3_artifact_repo.py`)
    - Applied the same bucket ownership checks to all S3 operations
    - Updated head_bucket, upload_file, download_file, list_objects_v2, delete_objects, multipart upload operations, and presigned URL generation
4. Tests (`tests/store/artifact/test_s3_artifact_repo.py`)
    - Bucket ownership verification with environment variable set
    - Backward compatibility when environment variable is not set
    - Bucket takeover scenario simulation
    - List artifacts with bucket owner
    - Multipart upload with bucket owner
    - Delete artifacts with bucket owner

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)


<img width="617" height="150" alt="Screenshot 2025-10-27 at 3 32 52 PM" src="https://github.com/user-attachments/assets/638ffe1f-db84-49ee-a0a6-38145e4f59bc" />

