### PR TITLE
Paginate `delete_traces` calls to Databricks MLflow server

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -957,6 +957,10 @@ _MLFLOW_SEARCH_TRACES_MAX_BATCH_SIZE = _EnvironmentVariable(
     "MLFLOW_SEARCH_TRACES_MAX_BATCH_SIZE", int, 10
 )
 
+_MLFLOW_DELETE_TRACES_MAX_BATCH_SIZE = _EnvironmentVariable(
+    "MLFLOW_DELETE_TRACES_MAX_BATCH_SIZE", int, 100
+)
+
 #: Specifies the logging level for MLflow. This can be set to any valid logging level
 #: (e.g., "DEBUG", "INFO"). This environment must be set before importing mlflow to take
 #: effect. To modify the logging level after importing mlflow, use `importlib.reload(mlflow)`.

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -406,7 +406,7 @@ class RestStore(AbstractStore):
     ) -> int:
         # If deleting by trace_ids, split into batches to avoid hitting the
         # Databricks server limit
-        if trace_ids and len(trace_ids):
+        if trace_ids:
             batch_size = _MLFLOW_DELETE_TRACES_MAX_BATCH_SIZE.get()
             total_deleted = 0
             for i in range(0, len(trace_ids), batch_size):

--- a/mlflow/store/tracking/rest_store.py
+++ b/mlflow/store/tracking/rest_store.py
@@ -404,9 +404,9 @@ class RestStore(AbstractStore):
         max_traces: int | None = None,
         trace_ids: list[str] | None = None,
     ) -> int:
-        # If deleting by trace_ids and the number exceeds the batch size limit,
-        # split into batches to avoid hitting the Databricks server limit
-        if trace_ids and len(trace_ids) > _MLFLOW_DELETE_TRACES_MAX_BATCH_SIZE.get():
+        # If deleting by trace_ids, split into batches to avoid hitting the
+        # Databricks server limit
+        if trace_ids and len(trace_ids):
             batch_size = _MLFLOW_DELETE_TRACES_MAX_BATCH_SIZE.get()
             total_deleted = 0
             for i in range(0, len(trace_ids), batch_size):
@@ -414,8 +414,8 @@ class RestStore(AbstractStore):
                 req_body = message_to_json(
                     DeleteTraces(
                         experiment_id=experiment_id,
-                        max_timestamp_millis=None,
-                        max_traces=None,
+                        max_timestamp_millis=max_timestamp_millis,
+                        max_traces=max_traces,
                         request_ids=batch,
                     )
                 )

--- a/tests/store/tracking/test_rest_store.py
+++ b/tests/store/tracking/test_rest_store.py
@@ -908,6 +908,48 @@ def test_delete_traces(delete_traces_kwargs):
         assert res == 1
 
 
+def test_delete_traces_with_batching():
+    """Test that delete_traces batches requests when trace_ids exceed the batch size limit."""
+    from mlflow.environment_variables import _MLFLOW_DELETE_TRACES_MAX_BATCH_SIZE
+
+    creds = MlflowHostCreds("https://hello")
+    store = RestStore(lambda: creds)
+    response = mock.MagicMock()
+    response.status_code = 200
+
+    # Create 250 trace IDs to test batching (should create 3 batches: 100, 100, 50)
+    num_traces = 250
+    trace_ids = [f"tr-{i}" for i in range(num_traces)]
+
+    # Each batch returns some number of deleted traces
+    response.text = json.dumps({"traces_deleted": 100})
+
+    batch_size = _MLFLOW_DELETE_TRACES_MAX_BATCH_SIZE.get()
+
+    with mock.patch("mlflow.utils.rest_utils.http_request", return_value=response) as mock_http:
+        res = store.delete_traces(experiment_id="0", trace_ids=trace_ids)
+
+        # Verify that we made 3 API calls (250 / 100 = 3 batches)
+        expected_num_calls = math.ceil(num_traces / batch_size)
+        assert mock_http.call_count == expected_num_calls
+
+        # Verify that the first batch contains exactly batch_size trace IDs
+        first_call_kwargs = mock_http.call_args_list[0][1]
+        first_call_body = first_call_kwargs["json"]
+        assert len(first_call_body["request_ids"]) == batch_size
+
+        # Verify that the last batch contains the remaining trace IDs
+        last_call_kwargs = mock_http.call_args_list[-1][1]
+        last_call_body = last_call_kwargs["json"]
+        expected_last_batch_size = (
+            num_traces % batch_size if num_traces % batch_size != 0 else batch_size
+        )
+        assert len(last_call_body["request_ids"]) == expected_last_batch_size
+
+        # Verify that the total deleted count is correct (3 batches * 100 each = 300)
+        assert res == expected_num_calls * 100
+
+
 def test_set_trace_tag():
     creds = MlflowHostCreds("https://hello")
     store = RestStore(lambda: creds)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbrx-euirim/mlflow/pull/18563?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18563/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18563/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18563/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

The Databricks MLflow server enforces a hard limit of 100 trace IDs per delete_traces request. When users attempt to delete more than 100 traces at once, the request fails with a validation error. This causes some downstream logic to fail in some cases, like trace cleanup in `trace_utils.clean_up_extra_traces`.

This PR adds automatic pagination in `RestStore._delete_traces` to transparently batch requests when the number of trace IDs exceeds 100.

`DatabricksTracingRestStore` extends `RestStore`, so it automatically inherits the pagination logic, but so do MLflow OSS servers which do not have this limit. However, the pagination logic is still beneficial to prevent server overloading.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
