### PR TITLE
Fix crewai autologging tests

### DIFF
--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -420,14 +420,14 @@ def test_kickoff_tool_calling(tool_agent_1, task_1_with_tool, autolog):
     assert span_2.outputs == _LLM_ANSWER
     # LLM - tool calling
     span_3 = traces[0].data.spans[3]
-    assert span_3.name == "LLM.call_1"
+    assert span_3.name == "LLM.call"
     assert span_3.span_type == SpanType.LLM
     assert span_3.parent_id is span_2.span_id
     assert span_3.inputs["messages"] is not None
     assert "Action: TestTool" in span_3.outputs
     # LLM - return answer
     span_4 = traces[0].data.spans[4]
-    assert span_4.name == "LLM.call_2"
+    assert span_4.name == "LLM.call"
     assert span_4.span_type == SpanType.LLM
     assert span_4.parent_id is span_2.span_id
     assert span_4.inputs["messages"] is not None
@@ -514,7 +514,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     }
     # Task
     span_1 = traces[0].data.spans[1]
-    assert span_1.name == "Task.execute_sync_1"
+    assert span_1.name == "Task.execute_sync"
     assert span_1.span_type == SpanType.CHAIN
     assert span_1.parent_id is span_0.span_id
     assert span_1.inputs == {
@@ -534,7 +534,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     }
     # Agent
     span_2 = traces[0].data.spans[2]
-    assert span_2.name == "Agent.execute_task_1"
+    assert span_2.name == "Agent.execute_task"
     assert span_2.span_type == SpanType.AGENT
     assert span_2.parent_id is span_1.span_id
     assert span_2.inputs == {
@@ -544,7 +544,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_2.outputs == _LLM_ANSWER
     # LLM
     span_3 = traces[0].data.spans[3]
-    assert span_3.name == "LLM.call_1"
+    assert span_3.name == "LLM.call"
     assert span_3.span_type == SpanType.LLM
     assert span_3.parent_id is span_2.span_id
     assert span_3.inputs["messages"] is not None
@@ -552,7 +552,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
 
     # Create Long Term Memory
     span_4 = traces[0].data.spans[4]
-    assert span_4.name == "CrewAgentExecutor._create_long_term_memory_1"
+    assert span_4.name == "CrewAgentExecutor._create_long_term_memory"
     assert span_4.span_type == SpanType.MEMORY
     assert span_4.parent_id is span_2.span_id
     assert span_4.inputs == {
@@ -566,7 +566,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
 
     # Task
     span_5 = traces[0].data.spans[5]
-    assert span_5.name == "Task.execute_sync_2"
+    assert span_5.name == "Task.execute_sync"
     assert span_5.span_type == SpanType.CHAIN
     assert span_5.parent_id is span_0.span_id
     assert span_5.inputs == {
@@ -586,7 +586,7 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     }
     # Agent
     span_6 = traces[0].data.spans[6]
-    assert span_6.name == "Agent.execute_task_2"
+    assert span_6.name == "Agent.execute_task"
     assert span_6.span_type == SpanType.AGENT
     assert span_6.parent_id is span_5.span_id
     assert span_6.inputs == {
@@ -596,14 +596,14 @@ def test_multi_tasks(simple_agent_1, simple_agent_2, task_1, task_2, autolog):
     assert span_6.outputs == _LLM_ANSWER
     # LLM
     span_7 = traces[0].data.spans[7]
-    assert span_7.name == "LLM.call_2"
+    assert span_7.name == "LLM.call"
     assert span_7.span_type == SpanType.LLM
     assert span_7.parent_id is span_6.span_id
     assert span_7.inputs["messages"] is not None
     assert span_7.outputs == f"{_FINAL_ANSWER_KEYWORD} {_LLM_ANSWER}"
     # Create Long Term Memory
     span_8 = traces[0].data.spans[8]
-    assert span_8.name == "CrewAgentExecutor._create_long_term_memory_2"
+    assert span_8.name == "CrewAgentExecutor._create_long_term_memory"
     assert span_8.span_type == SpanType.MEMORY
     assert span_8.parent_id is span_6.span_id
     assert span_8.inputs == {


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/18565?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18565/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18565/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18565/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Fix crewai autologging tests that fail due to dropping span name deduplication

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
