### PR TITLE
Pin numpy<2 in CI to fix pmdarima binary incompatibility

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -83,6 +83,8 @@ jobs:
           source ./dev/install-common-deps.sh --ml
           # transformers doesn't support Keras 3 yet. tf-keras needs to be installed as a workaround.
           pip install tf-keras
+          # Pin numpy<2 for pmdarima compatibility (https://github.com/alkaline-ml/pmdarima/issues/577)
+          pip install "numpy<2"
           # Ensure `databricks-connect` and `databricks-agents` are not installed
           pip uninstall -y databricks-connect databricks-agents
           pip install --no-deps --force-reinstall pyspark


### PR DESCRIPTION
### Related Issues/PRs

Fixes https://github.com/mlflow/mlflow/actions/runs/18897234262/job/53937212380
Related upstream issue: https://github.com/alkaline-ml/pmdarima/issues/577

### What changes are proposed in this pull request?

Pin numpy to <2 in the python job of the master workflow to work around binary incompatibility between pmdarima and numpy 2.x.

The pmdarima package contains Cython-compiled extensions built against numpy 1.x that raise a `ValueError` when imported with numpy 2.x. This change ensures pmdarima and diviner can still be tested in the lazy import check while we wait for upstream numpy 2.x support.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)