### PR TITLE
Add LoadPromptEvent for telemetry tracking

### DIFF
--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -172,6 +172,11 @@ For events with None in the `Tracked Parameters` column, only the event name is 
       <td>None</td>
     </tr>
     <tr>
+      <td>load_prompt</td>
+      <td>Whether alias is used</td>
+      <td>`{"uses_alias": True}`</td>
+    </tr>
+    <tr>
       <td>start_trace</td>
       <td>None</td>
       <td>None</td>
@@ -198,8 +203,8 @@ For events with None in the `Tracked Parameters` column, only the event name is 
     </tr>
     <tr>
       <td>prompt_optimization</td>
-      <td>None</td>
-      <td>None</td>
+      <td>Optimizer type, number of prompts, and number of scorers</td>
+      <td>`{"optimizer_type": True, "prompt_count": 5, "scorer_count": 1}`</td>
     </tr>
     <tr>
       <td>log_dataset</td>

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -28,6 +28,17 @@ class CreatePromptEvent(Event):
     name: str = "create_prompt"
 
 
+class LoadPromptEvent(Event):
+    name: str = "load_prompt"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        name_or_uri = arguments.get("name_or_uri", "")
+        # Check if alias is used (format: "prompts:/name@alias" or just "name@alias")
+        uses_alias = "@" in name_or_uri
+        return {"uses_alias": uses_alias}
+
+
 class StartTraceEvent(Event):
     name: str = "start_trace"
 

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -34,7 +34,7 @@ class LoadPromptEvent(Event):
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
         name_or_uri = arguments.get("name_or_uri", "")
-        # Check if alias is used (format: "prompts:/name@alias" or just "name@alias")
+        # Check if alias is used (format: "prompts:/name@alias")
         uses_alias = "@" in name_or_uri
         return {"uses_alias": uses_alias}
 

--- a/mlflow/tracking/_model_registry/fluent.py
+++ b/mlflow/tracking/_model_registry/fluent.py
@@ -32,6 +32,8 @@ from mlflow.store.model_registry import (
     SEARCH_MODEL_VERSION_MAX_RESULTS_DEFAULT,
     SEARCH_REGISTERED_MODEL_MAX_RESULTS_DEFAULT,
 )
+from mlflow.telemetry.events import LoadPromptEvent
+from mlflow.telemetry.track import record_usage_event
 from mlflow.tracing.fluent import get_active_trace_id
 from mlflow.tracing.trace_manager import InMemoryTraceManager
 from mlflow.tracking._model_registry import DEFAULT_AWAIT_MAX_SLEEP_SECONDS
@@ -666,6 +668,7 @@ def search_prompts(
 
 
 @require_prompt_registry
+@record_usage_event(LoadPromptEvent)
 def load_prompt(
     name_or_uri: str,
     version: str | int | None = None,

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -34,6 +34,7 @@ from mlflow.telemetry.events import (
     GetLoggedModelEvent,
     GitModelVersioningEvent,
     InvokeCustomJudgeModelEvent,
+    LoadPromptEvent,
     LogAssessmentEvent,
     LogBatchEvent,
     LogDatasetEvent,
@@ -826,3 +827,39 @@ def test_autologging(mock_requests, mock_telemetry_client: TelemetryClient):
         assert json.dumps({"flavor": "all", "log_traces": True, "disable": False}) in params
     finally:
         mlflow.autolog(disable=True)
+
+
+def test_load_prompt(mock_requests, mock_telemetry_client: TelemetryClient):
+    # Register a prompt first
+    prompt = mlflow.genai.register_prompt(
+        name="test_prompt",
+        template="Hello {{name}}",
+    )
+    mock_telemetry_client.flush()
+
+    # Set an alias for testing
+    mlflow.genai.set_prompt_alias(name="test_prompt", version=prompt.version, alias="production")
+
+    # Test load_prompt with version (no alias)
+    mlflow.genai.load_prompt(name_or_uri="test_prompt", version=prompt.version)
+    validate_telemetry_record(
+        mock_telemetry_client, mock_requests, LoadPromptEvent.name, {"uses_alias": False}
+    )
+
+    # Test load_prompt with URI and version (no alias)
+    mlflow.genai.load_prompt(name_or_uri=f"prompts:/test_prompt/{prompt.version}")
+    validate_telemetry_record(
+        mock_telemetry_client, mock_requests, LoadPromptEvent.name, {"uses_alias": False}
+    )
+
+    # Test load_prompt with alias
+    mlflow.genai.load_prompt(name_or_uri="prompts:/test_prompt@production")
+    validate_telemetry_record(
+        mock_telemetry_client, mock_requests, LoadPromptEvent.name, {"uses_alias": True}
+    )
+
+    # Test load_prompt with @latest (special alias)
+    mlflow.genai.load_prompt(name_or_uri="prompts:/test_prompt@latest")
+    validate_telemetry_record(
+        mock_telemetry_client, mock_requests, LoadPromptEvent.name, {"uses_alias": True}
+    )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18569?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18569/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18569/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18569/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add load_prompt event. The decorator is specifically attached to the load_prompt fluent API since the MLflowClient is not called if there is a cache hit.

- Introduced LoadPromptEvent class to track prompt loading events.
- Updated load_prompt function to record usage events using LoadPromptEvent.
- Added tests to validate telemetry records for different loading scenarios, including alias usage.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
