### PR TITLE
Allow to optimize prompts without expectations

### DIFF
--- a/mlflow/genai/optimize/optimize.py
+++ b/mlflow/genai/optimize/optimize.py
@@ -256,7 +256,9 @@ def _build_eval_fn(
         def _run_single(record: dict[str, Any]):
             inputs = record["inputs"]
             # use expectations if provided, otherwise use outputs
-            expectations = record.get("expectations") or {"expected_response": record.get("outputs")}
+            expectations = record.get("expectations") or {
+                "expected_response": record.get("outputs")
+            }
             eval_request_id = str(uuid.uuid4())
             # set prediction context to retrieve the trace by the request id,
             # and set is_evaluate to True to disable async trace logging
@@ -268,7 +270,7 @@ def _build_eval_fn(
 
             trace = mlflow.get_trace(eval_request_id, silent=True)
             # Use metric function created from scorers
-            score = metric_fn(
+            score, rationales = metric_fn(
                 inputs=inputs, outputs=program_outputs, expectations=expectations, trace=trace
             )
             return EvaluationResultRecord(
@@ -277,6 +279,7 @@ def _build_eval_fn(
                 expectations=expectations,
                 score=score,
                 trace=trace,
+                rationales=rationales,
             )
 
         try:

--- a/mlflow/genai/optimize/optimize.py
+++ b/mlflow/genai/optimize/optimize.py
@@ -224,7 +224,9 @@ def optimize_prompts(
 
 def _build_eval_fn(
     predict_fn: Callable[..., Any],
-    metric_fn: Callable[[dict[str, Any], dict[str, Any], dict[str, Any], Trace | None], float],
+    metric_fn: Callable[
+        [dict[str, Any], dict[str, Any], dict[str, Any], Trace | None], tuple[float, dict[str, str]]
+    ],
 ) -> Callable[[dict[str, str], list[dict[str, Any]]], list[EvaluationResultRecord]]:
     """
     Build an evaluation function that uses the candidate prompts to evaluate the predict_fn.

--- a/mlflow/genai/optimize/optimize.py
+++ b/mlflow/genai/optimize/optimize.py
@@ -256,7 +256,7 @@ def _build_eval_fn(
         def _run_single(record: dict[str, Any]):
             inputs = record["inputs"]
             # use expectations if provided, otherwise use outputs
-            outputs = record.get("expectations") or {"expected_response": record.get("outputs")}
+            expectations = record.get("expectations") or {"expected_response": record.get("outputs")}
             eval_request_id = str(uuid.uuid4())
             # set prediction context to retrieve the trace by the request id,
             # and set is_evaluate to True to disable async trace logging
@@ -269,12 +269,12 @@ def _build_eval_fn(
             trace = mlflow.get_trace(eval_request_id, silent=True)
             # Use metric function created from scorers
             score = metric_fn(
-                inputs=inputs, outputs=program_outputs, expectations=outputs, trace=trace
+                inputs=inputs, outputs=program_outputs, expectations=expectations, trace=trace
             )
             return EvaluationResultRecord(
                 inputs=inputs,
                 outputs=program_outputs,
-                expectations=outputs,
+                expectations=expectations,
                 score=score,
                 trace=trace,
             )

--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -195,6 +195,7 @@ class GepaPromptOptimizer(BasePromptOptimizer):
                                 "inputs": trajectory.inputs,
                                 "outputs": trajectory.outputs,
                                 "expectations": trajectory.expectations,
+                                "rationales": trajectory.rationales,
                                 "index": i,
                             }
                         )

--- a/mlflow/genai/optimize/types.py
+++ b/mlflow/genai/optimize/types.py
@@ -97,6 +97,7 @@ class EvaluationResultRecord:
         expectations: The expected outputs.
         score: The score of the evaluation result.
         trace: The trace of the evaluation execution.
+        rationales: The rationales of the evaluation result.
     """
 
     inputs: dict[str, Any]
@@ -104,6 +105,7 @@ class EvaluationResultRecord:
     expectations: Any
     score: float
     trace: Trace
+    rationales: dict[str, str]
 
 
 @experimental(version="3.5.0")

--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -181,7 +181,8 @@ def create_metric_from_scorers(
 
         # If all scores were convertible, use sum as default aggregation
         if len(numeric_scores) == len(scores):
-            return sum(numeric_scores.values()), rationales
+            # We average the scores to get the score between 0 and 1.
+            return sum(numeric_scores.values()) / len(numeric_scores), rationales
 
         # Otherwise, report error with actual types
         non_convertible = {

--- a/mlflow/genai/optimize/util.py
+++ b/mlflow/genai/optimize/util.py
@@ -140,12 +140,15 @@ def create_metric_from_scorers(
     from mlflow.genai.judges import CategoricalRating
 
     def _convert_to_numeric(score: Any) -> float | None:
-        """Convert a value to numeric, handling CategoricalRating and common types."""
-        if isinstance(score, (int, float, bool)):
+        """Convert a value to numeric, handling Feedback and primitive types."""
+        if isinstance(score, Feedback):
+            score = score.value
+        if score == CategoricalRating.YES:
+            return 1.0
+        elif score == CategoricalRating.NO:
+            return 0.0
+        elif isinstance(score, (int, float, bool)):
             return float(score)
-        elif isinstance(score, Feedback) and isinstance(score.value, CategoricalRating):
-            # Convert CategoricalRating to numeric: YES=1.0, NO=0.0
-            return 1.0 if score.value == CategoricalRating.YES else 0.0
         return None
 
     def metric(

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -50,6 +50,7 @@ def mock_eval_fn():
                     expectations=record["outputs"],
                     score=0.8,
                     trace={"info": "mock trace"},
+                    rationales={"score": "mock rationale"},
                 )
             )
         return results

--- a/tests/genai/optimize/test_optimize.py
+++ b/tests/genai/optimize/test_optimize.py
@@ -365,41 +365,25 @@ def test_optimize_prompts_with_custom_scorers(
 
 
 @pytest.mark.parametrize(
-    ("train_data", "error_type", "error_match"),
+    ("train_data", "error_match"),
     [
         # Empty dataset validation (handled by _convert_eval_set_to_df)
-        ([], "MlflowException", "The dataset is empty"),
+        ([], "The dataset is empty"),
         # Missing inputs validation (handled by _convert_eval_set_to_df)
-        ([{"outputs": "Hola"}], "MlflowException", "Either `inputs` or `trace` column is required"),
+        ([{"outputs": "Hola"}], "Either `inputs` or `trace` column is required"),
         # Empty inputs validation
         (
             [{"inputs": {}, "outputs": "Hola"}],
-            "ValueError",
             "Record 0 is missing required 'inputs' field or it is empty",
-        ),
-        # Missing both outputs and expectations
-        (
-            [{"inputs": {"text": "Hello"}}],
-            "ValueError",
-            r"Record 0 must have at least one non-empty field: 'outputs' or 'expectations'",
-        ),
-        # Both outputs and expectations are None
-        (
-            [{"inputs": {"text": "Hello"}, "outputs": None, "expectations": None}],
-            "ValueError",
-            r"Record 0 must have at least one non-empty field: 'outputs' or 'expectations'",
         ),
     ],
 )
 def test_optimize_prompts_validation_errors(
     sample_translation_prompt: PromptVersion,
     train_data: list[dict[str, Any]],
-    error_type: str,
     error_match: str,
 ):
-    error_class = MlflowException if error_type == "MlflowException" else ValueError
-
-    with pytest.raises(error_class, match=error_match):
+    with pytest.raises(MlflowException, match=error_match):
         optimize_prompts(
             predict_fn=sample_predict_fn,
             train_data=train_data,

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -141,28 +141,30 @@ def test_model_name_parameter(input_dict, model_name):
 def test_create_metric_from_scorers_with_categorical_rating(categorical_value, expected_score):
     @scorer(name="test_scorer")
     def test_scorer(inputs, outputs):
-        return Feedback(name="test_scorer", value=categorical_value)
+        return Feedback(name="test_scorer", value=categorical_value, rationale="test rationale")
 
     metric = create_metric_from_scorers([test_scorer])
 
     result = metric({"input": "test"}, {"output": "result"}, {}, None)
-    assert result == expected_score
+    assert result[0] == expected_score
+    assert result[1] == {"test_scorer": "test rationale"}
 
 
 def test_create_metric_from_scorers_with_multiple_categorical_ratings():
     @scorer(name="scorer1")
     def scorer1(inputs, outputs):
-        return Feedback(name="scorer1", value=CategoricalRating.YES)
+        return Feedback(name="scorer1", value=CategoricalRating.YES, rationale="rationale1")
 
     @scorer(name="scorer2")
     def scorer2(inputs, outputs):
-        return Feedback(name="scorer2", value=CategoricalRating.YES)
+        return Feedback(name="scorer2", value=CategoricalRating.YES, rationale="rationale2")
 
     metric = create_metric_from_scorers([scorer1, scorer2])
 
     # Should sum: 1.0 + 1.0 = 2.0
     result = metric({"input": "test"}, {"output": "result"}, {}, None)
-    assert result == 2.0
+    assert result[0] == 2.0
+    assert result[1] == {"scorer1": "rationale1", "scorer2": "rationale2"}
 
 
 @pytest.mark.parametrize(

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -132,16 +132,24 @@ def test_model_name_parameter(input_dict, model_name):
 
 
 @pytest.mark.parametrize(
-    ("categorical_value", "expected_score"),
+    ("score", "expected_score"),
     [
         (CategoricalRating.YES, 1.0),
         (CategoricalRating.NO, 0.0),
+        ("yes", 1.0),
+        ("no", 0.0),
+        (True, 1.0),
+        (False, 0.0),
+        (1, 1.0),
+        (0, 0.0),
+        (1.0, 1.0),
+        (0.0, 0.0),
     ],
 )
-def test_create_metric_from_scorers_with_categorical_rating(categorical_value, expected_score):
+def test_create_metric_from_scorers_with_single_score(score, expected_score):
     @scorer(name="test_scorer")
     def test_scorer(inputs, outputs):
-        return Feedback(name="test_scorer", value=categorical_value, rationale="test rationale")
+        return Feedback(name="test_scorer", value=score, rationale="test rationale")
 
     metric = create_metric_from_scorers([test_scorer])
 

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -169,9 +169,9 @@ def test_create_metric_from_scorers_with_multiple_categorical_ratings():
 
     metric = create_metric_from_scorers([scorer1, scorer2])
 
-    # Should sum: 1.0 + 1.0 = 2.0
+    # Should average: (1.0 + 1.0) / 2 = 1.0
     result = metric({"input": "test"}, {"output": "result"}, {}, None)
-    assert result[0] == 2.0
+    assert result[0] == 1.0
     assert result[1] == {"scorer1": "rationale1", "scorer2": "rationale2"}
 
 

--- a/tests/genai/optimize/test_util.py
+++ b/tests/genai/optimize/test_util.py
@@ -206,4 +206,6 @@ def test_validate_train_data_errors(train_data, scorers, expected_error):
     ],
 )
 def test_validate_train_data_success(train_data):
-    validate_train_data(train_data)
+    import pandas as pd
+
+    validate_train_data(pd.DataFrame(train_data), [], lambda **kwargs: None)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/18578?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18578/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18578/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18578/merge
```

</p>
</details>

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Currently, the `optimize_prompts` is designed for datasets containing expectations and returning categorical Feedback or primitive values. However, we saw a use case for evaluating output without expectations and including text rationale.
This pr allows skipping the expectations field of the dataset and using the rationale of the Feedback in `optimize_prompts`.

- Allow the dataset not to have expectations and allow scorers to use `trace`.
- Modified `_build_eval_fn` to include a `Trace` parameter in the metric function signature.
- Propagate Feedback.rational to optimizer algorithm
- Handle Feedback with primitive values (fixes #18561)

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
