### PR TITLE
Make cloud_storage_http_request timeout parameter configurable

### DIFF
--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -268,7 +268,7 @@ def cloud_storage_http_request(
     if method.lower() not in ("put", "get", "patch", "delete"):
         raise ValueError("Illegal http method: " + method)
     
-    # New addition: make timeout configurable via env var
+    # New addition -- make timeout configurable via env var
     if timeout is None:
         try:
             timeout = float(os.getenv("MLFLOW_HTTP_REQUEST_TIMEOUT", "0")) or None

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -267,6 +267,14 @@ def cloud_storage_http_request(
     """
     if method.lower() not in ("put", "get", "patch", "delete"):
         raise ValueError("Illegal http method: " + method)
+    
+    # New addition: make timeout configurable via env var
+    if timeout is None:
+        try:
+            timeout = float(os.getenv("MLFLOW_HTTP_REQUEST_TIMEOUT", "0")) or None
+        except ValueError:
+            timeout = None
+            
     return _get_http_response_with_retries(
         method,
         url,


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #18621

### What changes are proposed in this pull request?

<!--  made a small update to make the HTTP request timeout configurable instead of being hardcoded. In some cases, I noticed that long-running requests could fail due to timeouts, and it wasn’t easy to adjust that without changing the code.

So now, the timeout can be set using an environment variable called MLFLOW_HTTP_REQUEST_TIMEOUT.
If this variable isn’t set or has an invalid value, it just falls back to the default behavior (no timeout), so nothing breaks for existing users.

Here’s the change I added:

New addition: make timeout configurable via env var
if timeout is None:
try:
timeout = float(os.getenv("MLFLOW_HTTP_REQUEST_TIMEOUT", "0")) or None
except ValueError:
timeout = None

This makes it easier to tweak the timeout in different environments (like CI/CD, cloud setups, or slow networks) without modifying the code directly.

I’ve tested it locally by setting different timeout values, and it’s working as expected -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
