### PR TITLE
Fix otel test flakiness on windows

### DIFF
--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -1,3 +1,5 @@
+import time
+
 from opentelemetry import trace as otel_trace
 
 import mlflow
@@ -33,6 +35,11 @@ def test_mlflow_and_opentelemetry_unified_tracing_with_otel_root_span(monkeypatc
                 child_span.set_status(otel_trace.Status(otel_trace.StatusCode.OK))
 
             mlflow_span.set_outputs({"text": "world"})
+
+            # In windows, timestamp granularity is 100ns so adding a small delay to ensure
+            # the order of spans timestamp is deterministic.
+            time.sleep(0.1)
+        time.sleep(0.1)
 
         root_span.set_status(otel_trace.Status(otel_trace.StatusCode.OK))
 
@@ -84,6 +91,11 @@ def test_mlflow_and_opentelemetry_unified_tracing_with_mlflow_root_span(monkeypa
 
             with mlflow.start_span("child_span") as child_span:
                 child_span.set_attribute("key4", "value4")
+
+            # In windows, timestamp granularity is 100ns so adding a small delay to ensure
+            # the order of spans timestamp is deterministic.
+            time.sleep(0.1)
+        time.sleep(0.1)
 
         mlflow_span.set_outputs({"text": "world"})
 

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -1,3 +1,4 @@
+import pytest
 import time
 
 from opentelemetry import trace as otel_trace
@@ -11,6 +12,7 @@ from mlflow.environment_variables import MLFLOW_USE_DEFAULT_TRACER_PROVIDER
 from tests.tracing.helper import get_traces
 
 
+@pytest.mark.repeat(10)
 def test_mlflow_and_opentelemetry_unified_tracing_with_otel_root_span(monkeypatch):
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
 
@@ -38,8 +40,8 @@ def test_mlflow_and_opentelemetry_unified_tracing_with_otel_root_span(monkeypatc
 
             # In windows, timestamp granularity is 100ns so adding a small delay to ensure
             # the order of spans timestamp is deterministic.
-            time.sleep(0.1)
-        time.sleep(0.1)
+            # time.sleep(0.1)
+        # time.sleep(0.1)
 
         root_span.set_status(otel_trace.Status(otel_trace.StatusCode.OK))
 
@@ -76,6 +78,7 @@ def test_mlflow_and_opentelemetry_unified_tracing_with_otel_root_span(monkeypatc
     assert spans[2].status.status_code == SpanStatusCode.OK
 
 
+@pytest.mark.repeat(10)
 def test_mlflow_and_opentelemetry_unified_tracing_with_mlflow_root_span(monkeypatch):
     monkeypatch.setenv(MLFLOW_USE_DEFAULT_TRACER_PROVIDER.name, "false")
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18624?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18624/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18624/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18624/merge
```

</p>
</details>

### What changes are proposed in this pull request?

wip

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
