### PR TITLE
[Doc fix] Fix table in prompt optimization / rewriting pages

### DIFF
--- a/docs/docs/genai/prompt-registry/optimize-prompts.mdx
+++ b/docs/docs/genai/prompt-registry/optimize-prompts.mdx
@@ -4,6 +4,7 @@ sidebar_label: Optimize Prompts
 ---
 
 import { APILink } from "@site/src/components/APILink";
+import { CardGroup, Card } from "@site/src/components/Card";
 
 # Optimize Prompts (Experimental)
 
@@ -94,9 +95,8 @@ The API will produce an improved prompt that performs better on your evaluation 
 
 ### Example: Simple Prompt → Optimized Prompt
 
-<table>
-<tr>
-<td width="50%" valign="top">
+<CardGroup cols={2}>
+<Card style={{ justifyContent: 'flex-start' }}>
 
 **Before Optimization:**
 
@@ -104,8 +104,8 @@ The API will produce an improved prompt that performs better on your evaluation 
 Answer this question: {{question}}
 ```
 
-</td>
-<td width="50%" valign="top">
+</Card>
+<Card style={{ justifyContent: 'flex-start' }}>
 
 **After Optimization:**
 
@@ -140,9 +140,8 @@ Adhere strictly to these guidelines to maintain consistency
 and quality in your responses.
 ```
 
-</td>
-</tr>
-</table>
+</Card>
+</CardGroup>
 
 ## Components
 

--- a/docs/docs/genai/prompt-registry/rewrite-prompts.mdx
+++ b/docs/docs/genai/prompt-registry/rewrite-prompts.mdx
@@ -4,6 +4,7 @@ sidebar_label: Auto-rewrite Prompts for New Models 🆕
 ---
 
 import { APILink } from "@site/src/components/APILink";
+import { CardGroup, Card } from "@site/src/components/Card";
 
 # Auto-rewrite Prompts for New Models (Experimental)
 
@@ -27,9 +28,8 @@ The `optimize_prompts` API requires **MLflow >= 3.5.0**.
 
 ### Example: Simple Prompt → Optimized Prompt
 
-<table>
-<tr>
-<td width="50%" valign="top">
+<CardGroup cols={2}>
+<Card style={{ justifyContent: 'flex-start' }}>
 
 **Before Optimization:**
 
@@ -40,8 +40,8 @@ or 'negative' or 'neutral'.
 Text: {{text}}
 ```
 
-</td>
-<td width="50%" valign="top">
+</Card>
+<Card style={{ justifyContent: 'flex-start' }}>
 
 **After Optimization:**
 
@@ -69,9 +69,8 @@ Your response must match this exact format with
 no additional explanation.
 ```
 
-</td>
-</tr>
-</table>
+</Card>
+</CardGroup>
 
 ## When to Use Prompt Rewriting
 

--- a/docs/src/components/Card/card.module.css
+++ b/docs/src/components/Card/card.module.css
@@ -39,6 +39,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  max-width: 100%;
+  min-width: 0;
 }
 
 .CardBordered {

--- a/docs/src/components/Card/index.tsx
+++ b/docs/src/components/Card/index.tsx
@@ -14,13 +14,17 @@ export const CardGroup = ({ children, isSmall, cols, noGap }): JSX.Element => (
   </div>
 );
 
-export const Card = ({ children, link = '' }): JSX.Element => {
+export const Card = ({ children, link = '', style = undefined }): JSX.Element => {
   if (!link) {
-    return <div className={clsx(styles.Card, styles.CardBordered)}>{children}</div>;
+    return (
+      <div className={clsx(styles.Card, styles.CardBordered)} style={style}>
+        {children}
+      </div>
+    );
   }
 
   return (
-    <Link className={clsx(styles.Link, styles.Card, styles.CardBordered)} to={link}>
+    <Link className={clsx(styles.Link, styles.Card, styles.CardBordered)} style={style} to={link}>
       {children}
     </Link>
   );

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -805,6 +805,11 @@ In headlines Docusaurus adds this for us. */
   margin-bottom: 1.5rem;
 }
 
+.theme-code-block {
+  max-width: 100%;
+  min-width: 0;
+}
+
 /* Inline code */
 :not(pre) > code {
   border-radius: 4px;


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/18646?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18646/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18646/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18646/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR fixes this issue in prod:

- https://mlflow.org/docs/latest/genai/prompt-registry/optimize-prompts/#example-simple-prompt--optimized-prompt
- https://mlflow.org/docs/latest/genai/prompt-registry/rewrite-prompts/#example-simple-prompt--optimized-prompt

<img width="1262" height="992" alt="Screenshot 2025-11-04 at 10 04 53 AM" src="https://github.com/user-attachments/assets/691a073f-cebc-461f-ba1c-28d2ede64f37" />

Fix by applying a couple of changes:
1. I noticed that code blocks don't respect the parent width, so I put `min-width: 0` and `max-width: 100%` to ensure they're allowed to shrink and be bounded by the parent
2. Switch to using `<CardGroup>` rather than table to get the vertical stacking effect on narrow widths

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Optimize page:



https://github.com/user-attachments/assets/d16c5cfb-c503-42f2-8345-fbdc28efa765


Rewrite page:

https://github.com/user-attachments/assets/3f4908e9-1b8a-4ec7-b1e5-6a79981c601e


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
