### PR TITLE
[Sessions UI Columns][1/5] Fix source cell rendering

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -11,6 +11,7 @@ import type { SessionTableRow } from './utils';
 import { getSessionTableRows } from './utils';
 import MlflowUtils from '../utils/MlflowUtils';
 import { Link } from '../utils/RoutingUtils';
+import { SessionSourceCellRenderer } from './cell-renderers/SessionSourceCellRenderer';
 
 // TODO: add following columns:
 // 1. conversation start time
@@ -29,7 +30,7 @@ const columns = [
   },
   {
     header: 'Source',
-    accessorKey: 'source.name',
+    cell: SessionSourceCellRenderer,
   },
 ];
 

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/cell-renderers/SessionSourceCellRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/cell-renderers/SessionSourceCellRenderer.tsx
@@ -1,0 +1,8 @@
+import { Row } from '@tanstack/react-table';
+import { SourceCellRenderer } from '../../cellRenderers/Source/SourceRenderer';
+import { SessionTableRow } from '../utils';
+
+export const SessionSourceCellRenderer = ({ row }: { row: Row<SessionTableRow> }) => {
+  const firstTrace = row.original.firstTrace;
+  return <SourceCellRenderer traceInfo={firstTrace} isComparing={false} />;
+};

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/utils.tsx
@@ -1,19 +1,11 @@
 import { compact, sortBy } from 'lodash';
 
-import {
-  type ModelTraceInfoV3,
-  SESSION_ID_METADATA_KEY,
-  SOURCE_NAME_METADATA_KEY,
-  SOURCE_TYPE_METADATA_KEY,
-} from '@databricks/web-shared/model-trace-explorer';
+import { type ModelTraceInfoV3, SESSION_ID_METADATA_KEY } from '@databricks/web-shared/model-trace-explorer';
 
 export type SessionTableRow = {
   sessionId: string;
   requestPreview?: string;
-  source?: {
-    name: string;
-    type: string;
-  };
+  firstTrace: ModelTraceInfoV3;
   experimentId: string;
 };
 
@@ -44,23 +36,15 @@ export const getSessionTableRows = (experimentId: string, traces: ModelTraceInfo
 
       // sort traces within a session by time (earliest first)
       const sortedTraces = sortBy(traces, (trace) => new Date(trace.request_time));
+      const firstTrace = sortedTraces[0];
 
       // take request preview from the first trace
-      const requestPreview = sortedTraces[0].request_preview;
-      const sourceName = sortedTraces[0].trace_metadata?.[SOURCE_NAME_METADATA_KEY];
-      const sourceType = sortedTraces[0].trace_metadata?.[SOURCE_TYPE_METADATA_KEY];
-      const source =
-        sourceName && sourceType
-          ? {
-              name: sourceName,
-              type: sourceType,
-            }
-          : undefined;
+      const requestPreview = firstTrace.request_preview;
 
       return {
         sessionId,
         requestPreview,
-        source,
+        firstTrace,
         experimentId,
       };
     }),

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/MlflowUtils.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/MlflowUtils.test.tsx
@@ -408,15 +408,16 @@ test('renderSourceFromMetadata', () => {
       'mlflow.source.git.commit': 'b2fda8216f2568b62213ee99314f5bf4ce89be96',
     },
   };
-  expect(MlflowUtils.renderSourceFromMetadata(gitSourceWithCommit)).toEqual(
+  expect(MlflowUtils.renderSourceFromMetadata(gitSourceWithCommit)).toMatchInlineSnapshot(`
     <a
-      target="_blank"
-      rel="noopener noreferrer"
       href="https://github.com/username/repo/tree/b2fda8216f2568b62213ee99314f5bf4ce89be96/runner.py"
+      onClick={[Function]}
+      rel="noopener noreferrer"
+      target="_blank"
     >
       runner.py
-    </a>,
-  );
+    </a>
+  `);
 
   // Test git repository with branch
   const gitSourceWithBranch: any = {
@@ -427,11 +428,16 @@ test('renderSourceFromMetadata', () => {
       'mlflow.source.git.branch': 'main',
     },
   };
-  expect(MlflowUtils.renderSourceFromMetadata(gitSourceWithBranch)).toEqual(
-    <a target="_blank" rel="noopener noreferrer" href="https://github.com/username/repo/tree/main/runner.py">
+  expect(MlflowUtils.renderSourceFromMetadata(gitSourceWithBranch)).toMatchInlineSnapshot(`
+    <a
+      href="https://github.com/username/repo/tree/main/runner.py"
+      onClick={[Function]}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
       runner.py
-    </a>,
-  );
+    </a>
+  `);
 
   // Test git repository with GitLab
   const gitSourceGitLab: any = {
@@ -442,15 +448,16 @@ test('renderSourceFromMetadata', () => {
       'mlflow.source.git.commit': 'b2fda8216f2568b62213ee99314f5bf4ce89be96',
     },
   };
-  expect(MlflowUtils.renderSourceFromMetadata(gitSourceGitLab)).toEqual(
+  expect(MlflowUtils.renderSourceFromMetadata(gitSourceGitLab)).toMatchInlineSnapshot(`
     <a
-      target="_blank"
-      rel="noopener noreferrer"
       href="https://gitlab.com/username/repo/-/tree/b2fda8216f2568b62213ee99314f5bf4ce89be96/runner.py"
+      onClick={[Function]}
+      rel="noopener noreferrer"
+      target="_blank"
     >
       runner.py
-    </a>,
-  );
+    </a>
+  `);
 
   // Test notebook source
   const notebookSource: any = {

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/MlflowUtils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/MlflowUtils.tsx
@@ -432,7 +432,14 @@ class MlflowUtils {
       }
 
       res = (
-        <a target="_blank" rel="noopener noreferrer" href={url}>
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href={url}
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+        >
           {res}
         </a>
       );


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18656/files) to review incremental changes.
- [**stack/columns-part-1**](https://github.com/mlflow/mlflow/pull/18656) [[Files changed](https://github.com/mlflow/mlflow/pull/18656/files)]
  - [stack/columns-part-2](https://github.com/mlflow/mlflow/pull/18657) [[Files changed](https://github.com/mlflow/mlflow/pull/18657/files/6bb7c47d0d242da501f79046a7af99c12ced07bf..a813d9023cd442a0154cd37f5d1528275214e15a)]
    - [stack/columns-part-3](https://github.com/mlflow/mlflow/pull/18658) [[Files changed](https://github.com/mlflow/mlflow/pull/18658/files/a813d9023cd442a0154cd37f5d1528275214e15a..6c132f711e4ea40fcfca284afceb3f6fa1a93f8b)]
      - [stack/columns-part-4](https://github.com/mlflow/mlflow/pull/18659) [[Files changed](https://github.com/mlflow/mlflow/pull/18659/files/6c132f711e4ea40fcfca284afceb3f6fa1a93f8b..010ab25f99cf9bce06697af3ee7b4683afdb6ab2)]
        - [stack/columns-part-5](https://github.com/mlflow/mlflow/pull/18660) [[Files changed](https://github.com/mlflow/mlflow/pull/18660/files/010ab25f99cf9bce06697af3ee7b4683afdb6ab2..08cefe261e672119d762a74efa91651b143caf4f)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently the source cell renderer in the sessions table is just a plain string. This PR changes it to reuse the source renderer from the main trace table. In OSS this is not so important (besides linking to git) but in Databricks it links to notebooks, jobs, etc.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/29f095cc-799b-4ac9-8947-b2e614a20ed0



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
