### PR TITLE
[Sessions UI Columns][5/5] Persist column selection state

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/GenAIChatSessionsTable.tsx
@@ -23,6 +23,7 @@ import { SessionSourceCellRenderer } from './cell-renderers/SessionSourceCellRen
 import { SessionTableColumn } from './types';
 import { GenAIChatSessionsToolbar } from './GenAIChatSessionsToolbar';
 import { SessionNumericCellRenderer } from './cell-renderers/SessionNumericCellRenderer';
+import { useSessionsTableColumnVisibility } from './hooks/useSessionsTableColumnVisibility';
 
 const columns: SessionTableColumn[] = [
   {
@@ -121,11 +122,9 @@ export const GenAIChatSessionsTable = ({
 
   const sessionTableRows = useMemo(() => getSessionTableRows(experimentId, traces), [experimentId, traces]);
   const [sorting, setSorting] = useState<SortingState>([{ id: 'sessionStartTime', desc: true }]);
-  const [columnVisibility, setColumnVisibility] = useState<Record<string, boolean>>(() => {
-    return columns.reduce((acc, column) => {
-      acc[column.id] = column.defaultVisibility;
-      return acc;
-    }, {} as Record<string, boolean>);
+  const { columnVisibility, setColumnVisibility } = useSessionsTableColumnVisibility({
+    experimentId,
+    columns,
   });
 
   const table = useReactTable<SessionTableRow>({

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/hooks/useSessionsTableColumnVisibility.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/sessions-table/hooks/useSessionsTableColumnVisibility.tsx
@@ -1,0 +1,32 @@
+import { useLocalStorage } from '@databricks/web-shared/hooks';
+import { useMemo, useState } from 'react';
+import { SessionTableColumn } from '../types';
+
+const LOCAL_STORAGE_KEY = 'experiment-chat-sessions-table-column-visibility';
+const LOCAL_STORAGE_VERSION = 1;
+
+export const useSessionsTableColumnVisibility = ({
+  experimentId,
+  columns,
+}: {
+  experimentId: string;
+  columns: SessionTableColumn[];
+}) => {
+  const defaultColumnVisibility = useMemo(() => {
+    return columns.reduce((acc, column) => {
+      acc[column.id] = column.defaultVisibility;
+      return acc;
+    }, {} as Record<string, boolean>);
+  }, [columns]);
+
+  const [columnVisibility, setColumnVisibility] = useLocalStorage<Record<string, boolean>>({
+    key: `${LOCAL_STORAGE_KEY}-${experimentId}`,
+    version: LOCAL_STORAGE_VERSION,
+    initialValue: defaultColumnVisibility,
+  });
+
+  return {
+    columnVisibility,
+    setColumnVisibility,
+  };
+};


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18660/files) to review incremental changes.
- [**stack/columns-part-5**](https://github.com/mlflow/mlflow/pull/18660) [[Files changed](https://github.com/mlflow/mlflow/pull/18660/files)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Currently the column visibility state is not persisted, so on refresh it will go back to default. To fix this, I add a new hook to dump the column visibility into localStorage.

This is on a per-experiment basis, so each experiment saves separately.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/8040bd76-89ab-4205-ada8-ba4093627434




### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
