### PR TITLE
Fix timeout in plugin regression tests

### DIFF
--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -11138,14 +11138,7 @@ from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 from mlflow.entities import EvaluationDataset
 """
 
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-
-    assert result.returncode == 0
+    subprocess.check_call([sys.executable, "-c", code], timeout=20)
 
 
 def test_plugin_entrypoint_registration_does_not_fail():
@@ -11167,14 +11160,7 @@ class CustomTrackingStore(SqlAlchemyStore):
 
 """
 
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-
-    assert result.returncode == 0
+    subprocess.check_call([sys.executable, "-c", code], timeout=20)
 
 
 def test_plugin_can_create_dataset_without_name_error():
@@ -11205,14 +11191,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     assert dataset.name == "test_dataset"
 """
 
-    result = subprocess.run(
-        [sys.executable, "-c", code],
-        capture_output=True,
-        text=True,
-        timeout=10,
-    )
-
-    assert result.returncode == 0
+    subprocess.check_call([sys.executable, "-c", code], timeout=20)
 
 
 def test_evaluation_dataset_not_in_entities_all():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18663?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18663/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18663/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18663/merge
```

</p>
</details>

### Related Issues/PRs

Related to https://github.com/mlflow/mlflow/actions/runs/19060832019/job/54440128548?pr=18653

### What changes are proposed in this pull request?

Fixes timeouts in three plugin regression tests on slower CI environments (particularly Windows runners) by:
- Increasing timeout from 10 to 20 seconds
- Removing `capture_output=True` to allow stdout/stderr visibility for debugging

The affected tests verify that SqlAlchemyStore plugins work correctly when loaded via entrypoints and can perform dataset operations without circular import issues.

### How is this PR tested?

- [x] Existing unit/integration tests

Verified locally that all three tests pass:
- `test_sqlalchemy_store_import_does_not_cause_circular_import`
- `test_plugin_entrypoint_registration_does_not_fail`
- `test_plugin_can_create_dataset_without_name_error`

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)