### PR TITLE
Fix eval result button link

### DIFF
--- a/mlflow/genai/utils/display_utils.py
+++ b/mlflow/genai/utils/display_utils.py
@@ -1,8 +1,11 @@
 import sys
 
+from mlflow.entities import Run
 from mlflow.store.tracking.rest_store import RestStore
 from mlflow.tracing.display.display_handler import _is_jupyter
-from mlflow.tracking._tracking_service.utils import _get_store
+from mlflow.tracking._tracking_service.utils import _get_store, get_tracking_uri
+from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WORKSPACE_URL
+from mlflow.utils.uri import is_databricks_uri
 
 _EVAL_OUTPUT_HTML = """
 <!DOCTYPE html>
@@ -114,10 +117,6 @@ def display_evaluation_output(run_id: str):
     """
     Displays summary of the evaluation result, errors and warnings if any,
     and instructions on what to do after running `mlflow.evaluate`.
-
-    TODO: This function only works for OSS tracking server, does not resolve
-    Databricks workspace URL. When we migrate Databricks users to OSS harness,
-    update this logic to resolve the workspace URL.
     """
     store = _get_store()
     run = store.get_run(run_id)
@@ -131,11 +130,7 @@ To view the detailed evaluation results with sample-wise scores,
 open the \033[93m\033[1mTraces\033[0m tab in the Run page in the MLflow UI.\n\n""")
         return
 
-    host_url = store.get_host_creds().host.rstrip("/")
-    experiment_id = run.info.experiment_id
-    # Navigate to 'traces' tab that shows assessments and aggregations.
-    uri = f"{host_url}/#/experiments/{experiment_id}/runs/{run_id}/traces"
-
+    uri = _resolve_evaluation_results_url(store, run)
     if _is_jupyter():
         from IPython.display import HTML, display
 
@@ -143,3 +138,17 @@ open the \033[93m\033[1mTraces\033[0m tab in the Run page in the MLflow UI.\n\n"
     else:
         sys.stdout.write(_NON_IPYTHON_OUTPUT_TEXT.format(run_name=run.info.run_name, run_id=run_id))
         sys.stdout.write(f"View the evaluation results at \033[93m{uri}\033[0m\n\n")
+
+
+def _resolve_evaluation_results_url(store: RestStore, run: Run) -> str:
+    experiment_id = run.info.experiment_id
+
+    if is_databricks_uri(get_tracking_uri()):
+        workspace_url = run.data.tags[MLFLOW_DATABRICKS_WORKSPACE_URL]
+        url_base = f"{workspace_url}/ml"
+    else:
+        host_url = store.get_host_creds().host.rstrip("/")
+        url_base = f"{host_url}/#"
+    return (
+        f"{url_base}/experiments/{experiment_id}/evaluation-runs?selectedRunUuid={run.info.run_id}"
+    )

--- a/mlflow/genai/utils/display_utils.py
+++ b/mlflow/genai/utils/display_utils.py
@@ -144,7 +144,9 @@ def _resolve_evaluation_results_url(store: RestStore, run: Run) -> str:
     experiment_id = run.info.experiment_id
 
     if is_databricks_uri(get_tracking_uri()):
-        workspace_url = run.data.tags[MLFLOW_DATABRICKS_WORKSPACE_URL]
+        workspace_url = run.data.tags.get(MLFLOW_DATABRICKS_WORKSPACE_URL)
+        if not workspace_url:
+            workspace_url = store.get_host_creds().host.rstrip("/")
         url_base = f"{workspace_url}/ml"
     else:
         host_url = store.get_host_creds().host.rstrip("/")

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -509,6 +509,9 @@ def construct_eval_result_df(
     """
     import pandas as pd
 
+    if not traces:
+        return None
+
     try:
         trace_id_to_info = {t.info.trace_id: t.info for t in traces}
         traces = [

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -491,16 +491,17 @@ def _should_keep_trace(trace: Trace, eval_start_time: int) -> bool:
 
 def construct_eval_result_df(
     run_id: str,
-    traces_wo_spans: list[Trace],
+    traces: list[Trace],
     eval_results: list["EvalResult"],
 ) -> "pd.DataFrame | None":
     """
-    Construct a pandas DataFrame from the traces (without spans) and eval results.
+    Construct a pandas DataFrame from the traces and eval results.
 
     Args:
         run_id: The MLflow run ID of the evaluation run.
-        traces_wo_spans: List of traces (without spans). This is the result of
-            `mlflow.search_traces(include_spans=False)` to fetch the assessments from the backend.
+        traces: List of traces. Only TraceInfo is used here, and **spans are ignored&**.
+            The expected input to this function is the result of
+            `mlflow.search_traces(include_spans=False, return_type="list")`.
         eval_results: List of eval results containing the full spans.
 
     Returns:
@@ -509,7 +510,7 @@ def construct_eval_result_df(
     import pandas as pd
 
     try:
-        trace_id_to_info = {t.info.trace_id: t.info for t in traces_wo_spans}
+        trace_id_to_info = {t.info.trace_id: t.info for t in traces}
         traces = [
             Trace(
                 info=trace_id_to_info[eval_result.eval_item.trace.info.trace_id],

--- a/mlflow/tracing/processor/mlflow_v3.py
+++ b/mlflow/tracing/processor/mlflow_v3.py
@@ -49,5 +49,4 @@ class MlflowV3SpanProcessor(BaseMlflowSpanProcessor):
             tags=self._get_basic_trace_tags(root_span),
         )
         self._trace_manager.register_trace(root_span.context.trace_id, trace_info)
-
         return trace_info

--- a/tests/genai/utils/test_display_utils.py
+++ b/tests/genai/utils/test_display_utils.py
@@ -1,7 +1,5 @@
 from unittest import mock
 
-import pytest
-
 import mlflow
 from mlflow.genai.utils import display_utils
 from mlflow.store.tracking.rest_store import RestStore
@@ -9,34 +7,26 @@ from mlflow.tracking.client import MlflowClient
 from mlflow.utils.mlflow_tags import MLFLOW_DATABRICKS_WORKSPACE_URL
 
 
-@pytest.fixture
-def run_id():
-    """Create an actual MLflow run and return its ID"""
-    with mlflow.start_run() as run:
-        return run.info.run_id
-
-
-def test_display_outputs_jupyter(run_id, monkeypatch):
+def test_display_outputs_jupyter(monkeypatch):
     mock_store = mock.MagicMock(spec=RestStore)
     mock_store.get_run = MlflowClient().get_run
     mock_store.get_host_creds = lambda: mock.MagicMock(host="https://mlflow.example.com/")
 
-    mock_display = mock.MagicMock()
-    monkeypatch.setattr("IPython.display.display", mock_display)
-
     with (
+        mock.patch("IPython.display.display") as mock_display,
         mock.patch.object(display_utils, "_get_store", return_value=mock_store),
         mock.patch.object(display_utils, "_is_jupyter", return_value=True),
+        mlflow.start_run() as run,
     ):
-        display_utils.display_evaluation_output(run_id)
+        display_utils.display_evaluation_output(run.info.run_id)
 
-    exp_id = MlflowClient().get_run(run_id).info.experiment_id
-    expected_url = f"https://mlflow.example.com/#/experiments/{exp_id}/evaluation-runs?selectedRunUuid={run_id}"
+    exp_id = run.info.experiment_id
+    expected_url = f"https://mlflow.example.com/#/experiments/{exp_id}/evaluation-runs?selectedRunUuid={run.info.run_id}"
     html_content = mock_display.call_args[0][0].data
     assert expected_url in html_content
 
 
-def test_display_outputs_non_ipython(run_id, capsys):
+def test_display_outputs_non_ipython(capsys):
     mock_store = mock.MagicMock(spec=RestStore)
     mock_store.get_run = mlflow.tracking.MlflowClient().get_run
     mock_store.get_host_creds = lambda: mock.MagicMock(host="https://mlflow.example.com/")
@@ -44,43 +34,47 @@ def test_display_outputs_non_ipython(run_id, capsys):
     with (
         mock.patch.object(display_utils, "_get_store", return_value=mock_store),
         mock.patch.object(display_utils, "_is_jupyter", return_value=False),
+        mlflow.start_run() as run,
     ):
-        display_utils.display_evaluation_output(run_id)
+        display_utils.display_evaluation_output(run.info.run_id)
 
     captured = capsys.readouterr().out
-    exp_id = MlflowClient().get_run(run_id).info.experiment_id
-    expected_url = f"https://mlflow.example.com/#/experiments/{exp_id}/evaluation-runs?selectedRunUuid={run_id}"
+    exp_id = run.info.experiment_id
+    expected_url = f"https://mlflow.example.com/#/experiments/{exp_id}/evaluation-runs?selectedRunUuid={run.info.run_id}"
     assert expected_url in captured
 
 
-def test_display_outputs_databricks(run_id, monkeypatch):
+def test_display_outputs_databricks(monkeypatch):
     host = "https://workspace.databricks.com"
     client = mlflow.tracking.MlflowClient()
-    client.set_tag(run_id, MLFLOW_DATABRICKS_WORKSPACE_URL, host)
 
     mock_store = mock.MagicMock(spec=RestStore)
     mock_store.get_run = client.get_run
     mock_store.get_host_creds = lambda: mock.MagicMock(host=host)
 
-    mock_display = mock.MagicMock()
-    monkeypatch.setattr("IPython.display.display", mock_display)
+    with mlflow.start_run() as run:
+        client.set_tag(run.info.run_id, MLFLOW_DATABRICKS_WORKSPACE_URL, host)
 
-    with (
-        mock.patch.object(display_utils, "_get_store", return_value=mock_store),
-        mock.patch.object(display_utils, "_is_jupyter", return_value=True),
-        mock.patch.object(display_utils, "is_databricks_uri", return_value=True),
-    ):
-        display_utils.display_evaluation_output(run_id)
+        with (
+            mock.patch("IPython.display.display") as mock_display,
+            mock.patch.object(display_utils, "_get_store", return_value=mock_store),
+            mock.patch.object(display_utils, "_is_jupyter", return_value=True),
+            mock.patch.object(display_utils, "is_databricks_uri", return_value=True),
+        ):
+            display_utils.display_evaluation_output(run.info.run_id)
 
-    exp_id = MlflowClient().get_run(run_id).info.experiment_id
-    expected_url = f"{host}/ml/experiments/{exp_id}/evaluation-runs?selectedRunUuid={run_id}"
+    exp_id = run.info.experiment_id
+    expected_url = (
+        f"{host}/ml/experiments/{exp_id}/evaluation-runs?selectedRunUuid={run.info.run_id}"
+    )
     html_content = mock_display.call_args[0][0].data
     assert expected_url in html_content
 
 
-def test_display_summary_with_local_store(run_id, capsys):
-    display_utils.display_evaluation_output(run_id)
+def test_display_summary_with_local_store(capsys):
+    with mlflow.start_run() as run:
+        display_utils.display_evaluation_output(run.info.run_id)
 
     captured = capsys.readouterr().out
-    assert run_id in captured
+    assert run.info.run_id in captured
     assert "Traces" in captured


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18667?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18667/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18667/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18667/merge
```

</p>
</details>

## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18667/files/aa6cfa418e85c2c3bbd39c9f0e187ffa871f0de8..6d50989e49a781c68491cf9a06e83383704ee6e7) to review incremental changes.
- [stack/1-remove-noise-traces](https://github.com/mlflow/mlflow/pull/18654) [[Files changed](https://github.com/mlflow/mlflow/pull/18654/files)]
  - [stack/2-add-back-eval-df](https://github.com/mlflow/mlflow/pull/18666) [[Files changed](https://github.com/mlflow/mlflow/pull/18666/files/6056b490a1db81bf3d04e06f4c5a798283b37c1a..aa6cfa418e85c2c3bbd39c9f0e187ffa871f0de8)]
    - [**stack/3-fix-result-button**](https://github.com/mlflow/mlflow/pull/18667) [[Files changed](https://github.com/mlflow/mlflow/pull/18667/files/aa6cfa418e85c2c3bbd39c9f0e187ffa871f0de8..6d50989e49a781c68491cf9a06e83383704ee6e7)]

---------

### What changes are proposed in this pull request?

Fix the "View Evaluation Result" button link. The result is now shown under "Evaluation" tab not in Run details.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
