### PR TITLE
Fix `mlflow.spark.load_model` to handle Unity Catalog Volumes paths correctly

### DIFF
--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -411,7 +411,8 @@ def dbfs_hdfs_uri_to_fuse_path(dbfs_uri: str) -> str:
             is "dbfs:/" (e.g. Databricks)
 
     Returns:
-        A DBFS FUSE-style path, e.g. "/dbfs/my-directory"
+        A DBFS FUSE-style path, e.g. "/dbfs/my-directory". For UC Volumes paths
+        (e.g., "/Volumes/..."), returns the path unchanged.
 
     """
     if _is_uc_volumes_path(dbfs_uri):

--- a/mlflow/utils/uri.py
+++ b/mlflow/utils/uri.py
@@ -402,7 +402,7 @@ def is_valid_dbfs_uri(uri):
     return not parsed.netloc or db_profile_uri is not None
 
 
-def dbfs_hdfs_uri_to_fuse_path(dbfs_uri):
+def dbfs_hdfs_uri_to_fuse_path(dbfs_uri: str) -> str:
     """Converts the provided DBFS URI into a DBFS FUSE path
 
     Args:
@@ -414,6 +414,8 @@ def dbfs_hdfs_uri_to_fuse_path(dbfs_uri):
         A DBFS FUSE-style path, e.g. "/dbfs/my-directory"
 
     """
+    if _is_uc_volumes_path(dbfs_uri):
+        return dbfs_uri  # UC Volumes paths do not need conversion
     if not is_valid_dbfs_uri(dbfs_uri) and dbfs_uri == posixpath.abspath(dbfs_uri):
         # Convert posixpaths (e.g. "/tmp/mlflow") to DBFS URIs by adding "dbfs:/" as a prefix
         dbfs_uri = "dbfs:" + dbfs_uri


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18672?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18672/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18672/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18672/merge
```

</p>
</details>

### Related Issues/PRs

Fix #18668

### What changes are proposed in this pull request?

This PR fixes a bug where `mlflow.spark.load_model` incorrectly prepends `/dbfs/` to Unity Catalog Volumes paths when using `dfs_tmpdir` on Databricks clusters with Dedicated access mode.

The issue occurs because `dbfs_hdfs_uri_to_fuse_path()` was converting all paths to DBFS FUSE paths (e.g., `/dbfs/...`), but UC Volumes paths (e.g., `/Volumes/...`) should not be converted as they don't use the `/dbfs` prefix.

**Changes:**
- Modified `dbfs_hdfs_uri_to_fuse_path()` in `mlflow/utils/uri.py` to detect UC Volumes paths and return them unchanged
- Added type hints to the function signature for better code clarity
- Updated the function's docstring to document the UC Volumes behavior

This brings `load_model` behavior in line with `save_model`, which already supports UC Volumes as `dfs_tmpdir` on Dedicated clusters.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The fix was manually tested on Databricks Runtime 17.3 LTS ML with a Dedicated cluster using UC Volumes as `dfs_tmpdir`.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed `mlflow.spark.load_model` to properly handle Unity Catalog Volumes paths when using `dfs_tmpdir` on Databricks clusters with Dedicated access mode. Previously, the function incorrectly prepended `/dbfs/` to UC Volumes paths, causing I/O errors.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)