### PR TITLE
[Sessions UI] Improve rendering for chat turns without messages

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3587,6 +3587,10 @@
     "defaultMessage": "No results",
     "description": "Experiment page > group by runs control > no results after filtering by search query"
   },
+  "adVHxN": {
+    "defaultMessage": "Outputs",
+    "description": "Section title for the outputs of a single chat turn"
+  },
   "akmaST": {
     "defaultMessage": "Irrelevant",
     "description": "Evaluation results > retrieval relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query."
@@ -4902,6 +4906,10 @@
   "nIk08y": {
     "defaultMessage": "Trace view",
     "description": "Tooltip for traces preview mode toggle in evaluation runs table controls"
+  },
+  "nJxDSh": {
+    "defaultMessage": "Inputs",
+    "description": "Section title for the inputs of a single chat turn"
   },
   "nNIors": {
     "defaultMessage": "Error when fetching related runs data: {error}",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -12,14 +12,14 @@ import { ModelTraceExplorerCodeSnippet } from '../ModelTraceExplorerCodeSnippet'
 import { ModelTraceExplorerConversation } from '../right-pane/ModelTraceExplorerConversation';
 import { FormattedMessage } from '@mlflow/mlflow/src/i18n/i18n';
 
-const MAX_VISIBLE_MESSAGES = 3;
+export const DEFAULT_MAX_VISIBLE_CHAT_MESSAGES = 3;
 
 export const ModelTraceExplorerFieldRenderer = ({
   title,
   data,
   renderMode,
   chatMessageFormat,
-  maxVisibleMessages = MAX_VISIBLE_MESSAGES,
+  maxVisibleMessages = DEFAULT_MAX_VISIBLE_CHAT_MESSAGES,
 }: {
   title: string;
   data: string;

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/field-renderers/ModelTraceExplorerFieldRenderer.tsx
@@ -19,11 +19,13 @@ export const ModelTraceExplorerFieldRenderer = ({
   data,
   renderMode,
   chatMessageFormat,
+  maxVisibleMessages = MAX_VISIBLE_MESSAGES,
 }: {
   title: string;
   data: string;
   renderMode: 'default' | 'json' | 'text';
   chatMessageFormat?: string;
+  maxVisibleMessages?: number;
 }) => {
   const { theme } = useDesignSystemTheme();
   const [messagesExpanded, setMessagesExpanded] = useState(false);
@@ -51,9 +53,9 @@ export const ModelTraceExplorerFieldRenderer = ({
     Array.isArray(parsedData) && parsedData.length > 0 && every(parsedData, isRetrieverDocument);
 
   if (chatMessages && chatMessages.length > 0) {
-    const shouldTruncateMessages = chatMessages.length > MAX_VISIBLE_MESSAGES;
+    const shouldTruncateMessages = chatMessages.length > maxVisibleMessages;
     const visibleMessages =
-      messagesExpanded || !shouldTruncateMessages ? chatMessages : chatMessages.slice(-MAX_VISIBLE_MESSAGES);
+      messagesExpanded || !shouldTruncateMessages ? chatMessages : chatMessages.slice(-maxVisibleMessages);
     const hiddenMessageCount = shouldTruncateMessages ? chatMessages.length - visibleMessages.length : 0;
 
     return (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
@@ -2,8 +2,9 @@ import { useDesignSystemTheme } from '@databricks/design-system';
 
 import type { ModelTrace } from '../ModelTrace.types';
 import { parseModelTraceToTree, createListFromObject } from '../ModelTraceExplorer.utils';
-import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
 import { ModelTraceExplorerChatMessage } from '../right-pane/ModelTraceExplorerChatMessage';
+import { ModelTraceExplorerSummarySection } from '../summary-view/ModelTraceExplorerSummarySection';
+import { FormattedMessage } from 'react-intl';
 
 export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
   const { theme } = useDesignSystemTheme();
@@ -37,15 +38,13 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
     );
   }
 
-  // take the first input and output. maybe in the future this can be
-  // expandable, but for now the user can simply click on the trace to
-  // view the full input and output.
-  const inputList = createListFromObject(rootSpan.inputs);
-  const outputList = createListFromObject(rootSpan.outputs);
-
-  // try to get the first nonnull if possible
-  const input = inputList.find((item) => item.value !== null) ?? inputList[0];
-  const output = outputList.find((item) => item.value !== null) ?? outputList[0];
+  // reverse to show the first param before the cutoff
+  const inputList = createListFromObject(rootSpan.inputs)
+    .filter((item) => item.value !== 'null')
+    .reverse();
+  const outputList = createListFromObject(rootSpan.outputs)
+    .filter((item) => item.value !== 'null')
+    .reverse();
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
@@ -59,10 +58,17 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
           backgroundColor: theme.colors.backgroundPrimary,
         }}
       >
-        <ModelTraceExplorerFieldRenderer
-          title={input?.key ?? 'input'}
-          data={input?.value ?? 'null'}
+        <ModelTraceExplorerSummarySection
+          title={
+            <FormattedMessage
+              defaultMessage="Inputs"
+              description="Section title for the inputs of a single chat turn"
+            />
+          }
+          data={inputList}
           renderMode="default"
+          sectionKey="summary-inputs"
+          maxVisibleItems={1}
         />
       </div>
       <div
@@ -75,10 +81,17 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
           backgroundColor: theme.colors.backgroundPrimary,
         }}
       >
-        <ModelTraceExplorerFieldRenderer
-          title={output?.key ?? 'output'}
-          data={output?.value ?? 'null'}
+        <ModelTraceExplorerSummarySection
+          title={
+            <FormattedMessage
+              defaultMessage="Outputs"
+              description="Section title for the outputs of a single chat turn"
+            />
+          }
+          data={outputList}
           renderMode="default"
+          sectionKey="summary-outputs"
+          maxVisibleItems={1}
         />
       </div>
     </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnMessages.tsx
@@ -69,6 +69,7 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
           renderMode="default"
           sectionKey="summary-inputs"
           maxVisibleItems={1}
+          maxVisibleChatMessages={1}
         />
       </div>
       <div
@@ -92,6 +93,7 @@ export const SingleChatTurnMessages = ({ trace }: { trace: ModelTrace }) => {
           renderMode="default"
           sectionKey="summary-outputs"
           maxVisibleItems={1}
+          maxVisibleChatMessages={1}
         />
       </div>
     </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryIntermediateNode.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummaryIntermediateNode.tsx
@@ -127,7 +127,7 @@ export const ModelTraceExplorerSummaryIntermediateNode = ({
                     flexDirection: 'column',
                     gap: theme.spacing.sm,
                     paddingLeft: theme.spacing.lg,
-                    marginBottom: containsOutputs ? 0 : theme.spacing.sm,
+                    marginBottom: theme.spacing.sm,
                   }}
                 >
                   {inputList.map(({ key, value }, index) => (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
@@ -1,6 +1,9 @@
 import { Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
-import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
+import {
+  ModelTraceExplorerFieldRenderer,
+  DEFAULT_MAX_VISIBLE_CHAT_MESSAGES,
+} from '../field-renderers/ModelTraceExplorerFieldRenderer';
 import { useState } from 'react';
 
 const DEFAULT_MAX_VISIBLE_ITEMS = 3;
@@ -11,6 +14,7 @@ export const ModelTraceExplorerSummarySection = ({
   renderMode,
   sectionKey,
   maxVisibleItems = DEFAULT_MAX_VISIBLE_ITEMS,
+  maxVisibleChatMessages = DEFAULT_MAX_VISIBLE_CHAT_MESSAGES,
   className,
   chatMessageFormat,
 }: {
@@ -19,6 +23,7 @@ export const ModelTraceExplorerSummarySection = ({
   renderMode: 'default' | 'json' | 'text';
   sectionKey: string;
   maxVisibleItems?: number;
+  maxVisibleChatMessages?: number;
   className?: string;
   chatMessageFormat?: string;
 }) => {
@@ -48,6 +53,7 @@ export const ModelTraceExplorerSummarySection = ({
             data={value}
             renderMode={renderMode}
             chatMessageFormat={chatMessageFormat}
+            maxVisibleMessages={maxVisibleChatMessages}
           />
         ))}
       </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySection.tsx
@@ -1,0 +1,56 @@
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
+import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
+import { useState } from 'react';
+
+const DEFAULT_MAX_VISIBLE_ITEMS = 3;
+
+export const ModelTraceExplorerSummarySection = ({
+  title,
+  data,
+  renderMode,
+  sectionKey,
+  maxVisibleItems = DEFAULT_MAX_VISIBLE_ITEMS,
+  className,
+  chatMessageFormat,
+}: {
+  title: React.ReactElement;
+  data: { key: string; value: string }[];
+  renderMode: 'default' | 'json' | 'text';
+  sectionKey: string;
+  maxVisibleItems?: number;
+  className?: string;
+  chatMessageFormat?: string;
+}) => {
+  const { theme } = useDesignSystemTheme();
+  const [expanded, setExpanded] = useState(false);
+  const shouldTruncateItems = data.length > maxVisibleItems;
+
+  const visibleItems = shouldTruncateItems && !expanded ? data.slice(-maxVisibleItems) : data;
+  const hiddenItemCount = shouldTruncateItems ? data.length - visibleItems.length : 0;
+
+  return (
+    <ModelTraceExplorerCollapsibleSection withBorder title={title} className={className} sectionKey={sectionKey}>
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+        {shouldTruncateItems && (
+          <Typography.Link
+            css={{ alignSelf: 'flex-start', marginLeft: theme.spacing.xs }}
+            componentId="shared.model-trace-explorer.conversation-toggle"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? 'Show less' : `Show ${hiddenItemCount} more`}
+          </Typography.Link>
+        )}
+        {visibleItems.map(({ key, value }, index) => (
+          <ModelTraceExplorerFieldRenderer
+            key={key || index}
+            title={key}
+            data={value}
+            renderMode={renderMode}
+            chatMessageFormat={chatMessageFormat}
+          />
+        ))}
+      </div>
+    </ModelTraceExplorerCollapsibleSection>
+  );
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/summary-view/ModelTraceExplorerSummarySpans.tsx
@@ -10,6 +10,7 @@ import { createListFromObject, getSpanExceptionEvents } from '../ModelTraceExplo
 import { ModelTraceExplorerCollapsibleSection } from '../ModelTraceExplorerCollapsibleSection';
 import { AssessmentPaneToggle } from '../assessments-pane/AssessmentPaneToggle';
 import { ModelTraceExplorerFieldRenderer } from '../field-renderers/ModelTraceExplorerFieldRenderer';
+import { ModelTraceExplorerSummarySection } from './ModelTraceExplorerSummarySection';
 
 export const SUMMARY_SPANS_MIN_WIDTH = 400;
 
@@ -72,8 +73,7 @@ export const ModelTraceExplorerSummarySpans = ({
         </div>
       </div>
       {hasExceptions && <ModelTraceExplorerSummaryViewExceptionsSection node={rootNode} />}
-      <ModelTraceExplorerCollapsibleSection
-        withBorder
+      <ModelTraceExplorerSummarySection
         title={
           <FormattedMessage
             defaultMessage="Inputs"
@@ -82,25 +82,15 @@ export const ModelTraceExplorerSummarySpans = ({
         }
         css={{ marginBottom: hasIntermediateNodes ? 0 : theme.spacing.md }}
         sectionKey="summary-inputs"
-      >
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-          {inputList.map(({ key, value }, index) => (
-            <ModelTraceExplorerFieldRenderer
-              key={key || index}
-              title={key}
-              data={value}
-              renderMode={renderMode}
-              chatMessageFormat={chatMessageFormat}
-            />
-          ))}
-        </div>
-      </ModelTraceExplorerCollapsibleSection>
+        data={inputList}
+        renderMode={renderMode}
+        chatMessageFormat={chatMessageFormat}
+      />
       {hasIntermediateNodes &&
         intermediateNodes.map((node) => (
           <ModelTraceExplorerSummaryIntermediateNode key={node.key} node={node} renderMode={renderMode} />
         ))}
-      <ModelTraceExplorerCollapsibleSection
-        withBorder
+      <ModelTraceExplorerSummarySection
         title={
           <FormattedMessage
             defaultMessage="Outputs"
@@ -108,19 +98,10 @@ export const ModelTraceExplorerSummarySpans = ({
           />
         }
         sectionKey="summary-outputs"
-      >
-        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-          {outputList.map(({ key, value }, index) => (
-            <ModelTraceExplorerFieldRenderer
-              key={key || index}
-              title={key}
-              data={value}
-              renderMode={renderMode}
-              chatMessageFormat={chatMessageFormat}
-            />
-          ))}
-        </div>
-      </ModelTraceExplorerCollapsibleSection>
+        data={outputList}
+        renderMode={renderMode}
+        chatMessageFormat={chatMessageFormat}
+      />
     </div>
   );
 };


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/18681?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18681/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18681/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18681/merge
```

</p>
</details>

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a `ModelTraceExplorerSummarySection` component that takes a list of inputs / outputs and truncates them according to some limit, rendering the rest of the inputs behind a "Show x more" button.

This component is reused in both Trace UI summary view and Session view.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


https://github.com/user-attachments/assets/cbd45ca1-65ae-4cc5-9410-06937cd42adc


https://github.com/user-attachments/assets/b080249e-2d0a-414b-bead-110a53abd0f9



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
