### PR TITLE
[ENH] Make download_chunk timeout parameter configurable

### DIFF
--- a/mlflow/utils/download_cloud_file_chunk.py
+++ b/mlflow/utils/download_cloud_file_chunk.py
@@ -16,6 +16,7 @@ def parse_args():
     parser.add_argument("--headers", required=True, type=str)
     parser.add_argument("--download-path", required=True, type=str)
     parser.add_argument("--http-uri", required=True, type=str)
+    parser.add_argument("--timeout", required=True, type=int, default=30)
     return parser.parse_args()
 
 
@@ -36,6 +37,7 @@ def main():
         headers=json.loads(args.headers),
         download_path=args.download_path,
         http_uri=args.http_uri,
+        timeout=args.timeout,
     )
 
 

--- a/mlflow/utils/request_utils.py
+++ b/mlflow/utils/request_utils.py
@@ -64,13 +64,17 @@ def augmented_raise_for_status(response):
     except HTTPError as e:
         if response.text:
             raise HTTPError(
-                f"{e}. Response text: {response.text}", request=e.request, response=e.response
+                f"{e}. Response text: {response.text}",
+                request=e.request,
+                response=e.response,
             )
         else:
             raise e
 
 
-def download_chunk(*, range_start, range_end, headers, download_path, http_uri):
+def download_chunk(
+    *, range_start, range_end, headers, download_path, http_uri, timeout=30
+):
     combined_headers = {**headers, "Range": f"bytes={range_start}-{range_end}"}
 
     with cloud_storage_http_request(
@@ -78,7 +82,7 @@ def download_chunk(*, range_start, range_end, headers, download_path, http_uri):
         http_uri,
         stream=False,
         headers=combined_headers,
-        timeout=10,
+        timeout=timeout,
     ) as response:
         expected_length = response.headers.get("Content-Length")
         if expected_length is not None:
@@ -231,7 +235,10 @@ def _get_http_response_with_retries(
 
     # the environment variable is hardcoded here to avoid importing mlflow.
     # however, documentation is available in environment_variables.py
-    env_value = os.getenv("MLFLOW_ALLOW_HTTP_REDIRECTS", "true").lower() in ["true", "1"]
+    env_value = os.getenv("MLFLOW_ALLOW_HTTP_REDIRECTS", "true").lower() in [
+        "true",
+        "1",
+    ]
     allow_redirects = env_value if allow_redirects is None else allow_redirects
 
     return session.request(method, url, allow_redirects=allow_redirects, **kwargs)


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #18617

### What changes are proposed in this pull request?

Adds a configurable `timeout` parameter to the `download_chunk` function and propagates it to related functions (`download_chunk_retries`, subprocess logic, and Databricks artifact repo`).  
This allows users to configure download timeout behavior across MLflow’s artifact-handling system, improving flexibility and reliability for slow or unstable networks.

### How is this PR tested?

- [x] Existing unit/integration tests  
- [ ] New unit/integration tests  
- [x] Manual tests  

Manual testing was performed using different timeout values in `download_chunk()`, ensuring consistent behavior across subprocess and Databricks artifact repo.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.  
- [x] Yes. I've updated:  
  - [x] Examples (added mention of configurable timeout behavior)  
  - [ ] API references  
  - [ ] Instructions  

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Adds user-facing support for configurable download timeouts when retrieving artifacts or models.  

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging  
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors  
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry  
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs  
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows  
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations  
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management  
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality  
- [ ] `area/projects`: MLproject format, project running backends  
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server  
- [ ] `area/build`: Build and test infrastructure for MLflow  
- [ ] `area/docs`: MLflow documentation pages  

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section  
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section  
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes  
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes  
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes  

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).  
  Bug fixes, doc updates and new features usually go into minor releases.  
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).  
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)  
- [x] No (this PR will be included in the next minor release)

**Signed-off-by:** Konatham Sourab <sourabreddyshok@gmail.com>
