### PR TITLE
Add CI check to fail on whitespace-only changes with label bypass

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,6 +37,7 @@ jobs:
     timeout-minutes: 30
     permissions:
       contents: read
+      pull-requests: read
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     name: ${{ matrix.os == 'ubuntu-latest' && 'lint' || 'lint-macos' }}
     steps:
@@ -78,3 +79,10 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         run: |
           uv run --no-project dev/check_function_signatures.py
+
+      - name: Check blank line changes
+        if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+        run: |
+          uv run --no-project dev/check_blank_lines.py \
+            --repo ${{ github.repository }} \
+            --pr ${{ github.event.pull_request.number }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,8 +7,6 @@ on:
       - synchronize
       - reopened
       - ready_for_review
-      - labeled
-      - unlabeled
   push:
     branches:
       - master

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Check blank line changes
         if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           uv run --no-project dev/check_blank_lines.py \
             --repo ${{ github.repository }} \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,8 @@ on:
       - synchronize
       - reopened
       - ready_for_review
+      - labeled
+      - unlabeled
   push:
     branches:
       - master
@@ -80,11 +82,11 @@ jobs:
         run: |
           uv run --no-project dev/check_function_signatures.py
 
-      - name: Check blank line changes
+      - name: Check whitespace-only changes
         if: matrix.os == 'ubuntu-latest' && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          uv run --no-project dev/check_blank_lines.py \
+          uv run --no-project dev/check_whitespace_only.py \
             --repo ${{ github.repository }} \
             --pr ${{ github.event.pull_request.number }}

--- a/bin/install.py
+++ b/bin/install.py
@@ -1,5 +1,6 @@
 """
 Install binary tools for MLflow development.
+
 """
 
 # ruff: noqa: T201

--- a/dev/check_blank_lines.py
+++ b/dev/check_blank_lines.py
@@ -1,0 +1,110 @@
+"""
+Detect files where all changes are blank lines.
+
+This helps avoid unnecessary commit history noise from blank line-only changes.
+"""
+
+import argparse
+import os
+import sys
+import urllib.request
+
+
+def get_diff_from_github_api(owner: str, repo: str, pull_number: int) -> str:
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}"
+    headers = {
+        "Accept": "application/vnd.github.v3.diff",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    # Add authorization if token is available
+    github_token = os.environ.get("GITHUB_TOKEN")
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        return response.read().decode("utf-8")
+
+
+def parse_diff(diff_text: str | None) -> list[str]:
+    if not diff_text:
+        return []
+
+    files: list[str] = []
+    current_file: str | None = None
+    changes: list[str] = []
+
+    for line in diff_text.split("\n"):
+        # New file
+        if line.startswith("diff --git"):
+            # Process previous file - flag if all changes are blank
+            if current_file and changes and all(c.strip() == "" for c in changes):
+                files.append(current_file)
+
+            # Reset for new file
+            current_file = None
+            changes = []
+
+        elif line.startswith("--- a/"):
+            # Extract file path (skip new files indicated by /dev/null)
+            current_file = None if line == "--- /dev/null" else line[6:]
+
+        elif line.startswith("+++ b/"):
+            # This is the new file path, use this one (skip deleted files)
+            current_file = None if line == "+++ /dev/null" else line[6:]
+
+        elif line.startswith("+") or line.startswith("-"):
+            # Collect the content of additions and deletions
+            content = line[1:]  # Remove +/- prefix
+            changes.append(content)
+
+    # Process last file
+    if current_file and changes and all(c.strip() == "" for c in changes):
+        files.append(current_file)
+
+    return files
+
+
+def parse_args() -> tuple[str, str, int]:
+    parser = argparse.ArgumentParser(
+        description="Check for unnecessary blank line changes in the diff"
+    )
+    parser.add_argument(
+        "--repo",
+        required=True,
+        help='Repository in the format "owner/repo" (e.g., "mlflow/mlflow")',
+    )
+    parser.add_argument(
+        "--pr",
+        type=int,
+        required=True,
+        help="Pull request number",
+    )
+    args = parser.parse_args()
+
+    owner, repo = args.repo.split("/")
+    return owner, repo, args.pr
+
+
+def main() -> int:
+    owner, repo, pull_number = parse_args()
+    diff_text = get_diff_from_github_api(owner, repo, pull_number)
+    files = parse_diff(diff_text)
+
+    if files:
+        message = (
+            "This file only has blank line changes. "
+            "If unintentional, please revert them to avoid unnecessary commit history noise."
+        )
+        for file_path in files:
+            # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message
+            print(f"::warning file={file_path},line=1,col=1::{message}")
+
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/check_blank_lines.py
+++ b/dev/check_blank_lines.py
@@ -6,7 +6,6 @@ This helps avoid unnecessary commit history noise from blank line-only changes.
 
 import argparse
 import os
-import sys
 import urllib.request
 
 
@@ -18,8 +17,7 @@ def get_diff_from_github_api(owner: str, repo: str, pull_number: int) -> str:
     }
 
     # Add authorization if token is available
-    github_token = os.environ.get("GITHUB_TOKEN")
-    if github_token:
+    if github_token := os.environ.get("GITHUB_TOKEN"):
         headers["Authorization"] = f"Bearer {github_token}"
 
     request = urllib.request.Request(url, headers=headers)
@@ -87,12 +85,10 @@ def parse_args() -> tuple[str, str, int]:
     return owner, repo, args.pr
 
 
-def main() -> int:
+def main() -> None:
     owner, repo, pull_number = parse_args()
     diff_text = get_diff_from_github_api(owner, repo, pull_number)
-    files = parse_diff(diff_text)
-
-    if files:
+    if files := parse_diff(diff_text):
         message = (
             "This file only has blank line changes. "
             "If unintentional, please revert them to avoid unnecessary commit history noise."
@@ -101,10 +97,6 @@ def main() -> int:
             # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message
             print(f"::warning file={file_path},line=1,col=1::{message}")
 
-        return 1
-
-    return 0
-
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/dev/check_whitespace_only.py
+++ b/dev/check_whitespace_only.py
@@ -1,12 +1,16 @@
 """
-Detect files where all changes are blank lines.
+Detect files where all changes are whitespace-only.
 
-This helps avoid unnecessary commit history noise from blank line-only changes.
+This helps avoid unnecessary commit history noise from whitespace-only changes.
 """
 
 import argparse
+import json
 import os
+import sys
 import urllib.request
+
+BYPASS_LABEL = "allow-whitespace-only"
 
 
 def get_diff_from_github_api(owner: str, repo: str, pull_number: int) -> str:
@@ -16,13 +20,28 @@ def get_diff_from_github_api(owner: str, repo: str, pull_number: int) -> str:
         "X-GitHub-Api-Version": "2022-11-28",
     }
 
-    # Add authorization if token is available
     if github_token := os.environ.get("GITHUB_TOKEN"):
         headers["Authorization"] = f"Bearer {github_token}"
 
     request = urllib.request.Request(url, headers=headers)
     with urllib.request.urlopen(request, timeout=30) as response:
         return response.read().decode("utf-8")
+
+
+def get_pr_labels(owner: str, repo: str, pull_number: int) -> list[str]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/pulls/{pull_number}"
+    headers = {
+        "Accept": "application/vnd.github.v3+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    if github_token := os.environ.get("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {github_token}"
+
+    request = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(request, timeout=30) as response:
+        data = json.loads(response.read().decode("utf-8"))
+        return [label_obj["name"] for label_obj in data.get("labels", [])]
 
 
 def parse_diff(diff_text: str | None) -> list[str]:
@@ -34,30 +53,23 @@ def parse_diff(diff_text: str | None) -> list[str]:
     changes: list[str] = []
 
     for line in diff_text.split("\n"):
-        # New file
         if line.startswith("diff --git"):
-            # Process previous file - flag if all changes are blank
             if current_file and changes and all(c.strip() == "" for c in changes):
                 files.append(current_file)
 
-            # Reset for new file
             current_file = None
             changes = []
 
         elif line.startswith("--- a/"):
-            # Extract file path (skip new files indicated by /dev/null)
             current_file = None if line == "--- /dev/null" else line[6:]
 
         elif line.startswith("+++ b/"):
-            # This is the new file path, use this one (skip deleted files)
             current_file = None if line == "+++ /dev/null" else line[6:]
 
         elif line.startswith("+") or line.startswith("-"):
-            # Collect the content of additions and deletions
-            content = line[1:]  # Remove +/- prefix
+            content = line[1:]
             changes.append(content)
 
-    # Process last file
     if current_file and changes and all(c.strip() == "" for c in changes):
         files.append(current_file)
 
@@ -66,7 +78,7 @@ def parse_diff(diff_text: str | None) -> list[str]:
 
 def parse_args() -> tuple[str, str, int]:
     parser = argparse.ArgumentParser(
-        description="Check for unnecessary blank line changes in the diff"
+        description="Check for unnecessary whitespace-only changes in the diff"
     )
     parser.add_argument(
         "--repo",
@@ -89,13 +101,25 @@ def main() -> None:
     owner, repo, pull_number = parse_args()
     diff_text = get_diff_from_github_api(owner, repo, pull_number)
     if files := parse_diff(diff_text):
+        pr_labels = get_pr_labels(owner, repo, pull_number)
+        has_bypass_label = BYPASS_LABEL in pr_labels
+
+        level = "warning" if has_bypass_label else "error"
         message = (
-            "This file only has blank line changes. "
-            "If unintentional, please revert them to avoid unnecessary commit history noise."
+            f"This file only has whitespace changes (bypassed with '{BYPASS_LABEL}' label)."
+            if has_bypass_label
+            else (
+                f"This file only has whitespace changes. "
+                f"Please revert them or apply the '{BYPASS_LABEL}' label to bypass this check "
+                f"if they are necessary."
+            )
         )
+
         for file_path in files:
-            # https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#setting-a-warning-message
-            print(f"::warning file={file_path},line=1,col=1::{message}")
+            print(f"::{level} file={file_path},line=1,col=1::{message}")
+
+        if not has_bypass_label:
+            sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/dev/check_whitespace_only.py
+++ b/dev/check_whitespace_only.py
@@ -110,6 +110,7 @@ def main() -> None:
         )
 
         for file_path in files:
+            # https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions
             print(f"::{level} file={file_path},line=1,col=1::{message}")
 
         if not has_bypass_label:

--- a/dev/clint/src/clint/rules/no_shebang.py
+++ b/dev/clint/src/clint/rules/no_shebang.py
@@ -9,7 +9,6 @@ class NoShebang(Rule):
     def check(file_content: str) -> bool:
         """
         Returns True if the file contains a shebang line at the beginning.
-
         A shebang line is a line that starts with '#!' (typically #!/usr/bin/env python).
         """
         return file_content.startswith("#!")

--- a/dev/clint/src/clint/rules/os_environ_delete_in_test.py
+++ b/dev/clint/src/clint/rules/os_environ_delete_in_test.py
@@ -12,6 +12,8 @@ class OsEnvironDeleteInTest(Rule):
     def check(node: ast.Delete, resolver: Resolver) -> bool:
         """
         Returns True if the deletion is from os.environ[...].
+
+        foo
         """
         if len(node.targets) == 1 and isinstance(node.targets[0], ast.Subscript):
             resolved = resolver.resolve(node.targets[0].value)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18717?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18717/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18717/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18717/merge
```

</p>
</details>

### Related Issues/PRs

Related to #18667

### What changes are proposed in this pull request?

Adds `dev/check_whitespace_only.py` that detects and fails on files where all changes are whitespace-only. This prevents unnecessary commit history noise.

- **Fails by default** when whitespace-only changes are detected
- **Apply `allow-whitespace-only` label** to bypass the check (errors → warnings)
- **Auto re-runs** when labels are added/removed

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)