### PR TITLE
Fix incorrect LangGraph autolog API in UI documentation

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils.tsx
@@ -86,7 +86,7 @@ chain.invoke("What is MLflow?")`,
         defaultMessage="Automatically log traces for LangGraph workflows by calling the {code} function. For example:"
         description="Description of how to log traces for the LangGraph package using MLflow autologging. This message is followed by a code example."
         values={{
-          code: <code>mlflow.langgraph.autolog()</code>,
+          code: <code>mlflow.langchain.autolog()</code>,
         }}
       />
     ),
@@ -95,7 +95,7 @@ chain.invoke("What is MLflow?")`,
 from langgraph.graph import StateGraph
 from typing import Annotated
 
-mlflow.langgraph.autolog()
+mlflow.langchain.autolog()
 
 # Ensure that the "OPENAI_API_KEY" environment variable is set
 model = ChatOpenAI(model="gpt-4o-mini")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/18726?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18726/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18726/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18726/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

The LangGraph quickstart guide in the MLflow UI incorrectly showed `mlflow.langgraph.autolog()` as the API to enable tracing for LangGraph workflows. This PR corrects it to `mlflow.langchain.autolog()`, which is the correct API since LangGraph tracing is handled through the LangChain integration.

**Changes:**
- Fixed the JSX code snippet in the LangGraph quickstart content (line 89)
- Fixed the Python code example in the LangGraph quickstart (line 98)

**File changed:**
- `mlflow/server/js/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils.tsx`

**Screenshot of the fix:**
<img width="1004" height="876" alt="image" src="https://github.com/user-attachments/assets/9dc87f42-27c6-48c4-9d80-256c12852e04" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing:**
- Started the MLflow dev server and verified the LangGraph quickstart guide now displays the correct API: `mlflow.langchain.autolog()`
- Verified the code example in the quickstart shows the correct usage

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed incorrect API reference in the LangGraph tracing quickstart guide. The UI now correctly shows `mlflow.langchain.autolog()` instead of the non-existent `mlflow.langgraph.autolog()`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] \`area/tracking\`: Tracking Service, tracking client APIs, autologging
- [ ] \`area/models\`: MLmodel format, model serialization/deserialization, flavors
- [ ] \`area/model-registry\`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] \`area/scoring\`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] \`area/evaluation\`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] \`area/gateway\`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] \`area/prompts\`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] \`area/tracing\`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] \`area/projects\`: MLproject format, project running backends
- [x] \`area/uiux\`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] \`area/build\`: Build and test infrastructure for MLflow
- [ ] \`area/docs\`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] \`rn/none\` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] \`rn/breaking-change\` - The PR will be mentioned in the "Breaking Changes" section
- [ ] \`rn/feature\` - A new user-facing feature worth mentioning in the release notes
- [x] \`rn/bug-fix\` - A user-facing bug fix worth mentioning in the release notes
- [ ] \`rn/documentation\` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)