### PR TITLE
Add chat conversion for Otel GenAI Semconv

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/index.ts
@@ -14,3 +14,4 @@ export { normalizeLangchainChatInput, normalizeLangchainChatResult } from './lan
 export { normalizeLlamaIndexChatInput, normalizeLlamaIndexChatResponse } from './llamaindex';
 export { normalizeDspyChatInput, normalizeDspyChatOutput } from './dspy';
 export { normalizeVercelAIChatInput, normalizeVercelAIChatOutput } from './vercelai';
+export { isOtelGenAIChatMessage, normalizeOtelGenAIChatMessage } from './otel';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.test.ts
@@ -1,0 +1,65 @@
+import { normalizeConversation } from '../ModelTraceExplorer.utils';
+
+describe('normalizeConversation (OTEL GenAI)', () => {
+  it('normalizes simple text messages', () => {
+    const input = [
+      {
+        role: 'user',
+        parts: [{ type: 'text', content: 'Hello there' }],
+      },
+      {
+        role: 'assistant',
+        parts: [{ type: 'text', content: 'Hi! How can I help?' }],
+      },
+    ];
+
+    const result = normalizeConversation(input);
+
+    expect(result).toEqual([
+      expect.objectContaining({ role: 'user', content: 'Hello there' }),
+      expect.objectContaining({ role: 'assistant', content: 'Hi! How can I help?' }),
+    ]);
+  });
+
+  it('normalizes tool call request and response', () => {
+    const input = [
+      {
+        role: 'assistant',
+        parts: [
+          { type: 'text', content: 'Let me check the weather.' },
+          { type: 'tool_call', id: 'call_weather_1', name: 'get_weather', arguments: { city: 'NYC' } },
+        ],
+      },
+      {
+        role: 'assistant',
+        parts: [{ type: 'tool_call_response', id: 'call_weather_1', response: { tempC: 22 } }],
+      },
+    ];
+
+    const result = normalizeConversation(input);
+    expect(result).toHaveLength(2);
+
+    // First message: assistant with a tool_call
+    expect(result?.[0]).toEqual(
+      expect.objectContaining({
+        role: 'assistant',
+        content: expect.stringContaining('Let me check the weather.'),
+        tool_calls: [
+          expect.objectContaining({
+            id: 'call_weather_1',
+            function: expect.objectContaining({ name: 'get_weather', arguments: expect.any(String) }),
+          }),
+        ],
+      }),
+    );
+
+    // Second message: tool response mapped to role 'tool'
+    expect(result?.[1]).toEqual(
+      expect.objectContaining({
+        role: 'tool',
+        tool_call_id: 'call_weather_1',
+        content: expect.stringContaining('tempC'),
+      }),
+    );
+  });
+});

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.ts
@@ -1,0 +1,136 @@
+import { get, has, isArray, isNil, isObject, isString } from 'lodash';
+
+import type { ModelTraceChatMessage, ModelTraceContentParts, ModelTraceToolCall } from '../ModelTrace.types';
+import { prettyPrintChatMessage } from '../ModelTraceExplorer.utils';
+
+// This file normalizes OpenTelemetry GenAI semantic convention input messages
+// Schema reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json
+// Supported parts: TextPart, ToolCallRequestPart, ToolCallResponsePart
+// Not supported (rejected): BlobPart, FilePart, UriPart, ReasoningPart, GenericPart
+
+type OtelBasePart = { type: string } & Record<string, unknown>;
+
+type OtelTextPart = OtelBasePart & { type: 'text'; content: string };
+
+type OtelToolCallRequestPart = OtelBasePart & {
+  type: 'tool_call';
+  id?: string | null;
+  name: string;
+  arguments?: unknown;
+};
+
+type OtelToolCallResponsePart = OtelBasePart & {
+  type: 'tool_call_response';
+  id?: string | null;
+  response: unknown;
+};
+
+type OTelGenAIPart = OtelTextPart | OtelToolCallRequestPart | OtelToolCallResponsePart;
+
+type OtelGenAIMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  name?: string;
+  parts: OTelGenAIPart[];
+};
+
+const isOtelTextPart = (obj: unknown): obj is OtelTextPart => {
+  return isObject(obj) && get(obj, 'type') === 'text' && isString(get(obj, 'content'));
+};
+
+const isOtelToolCallRequestPart = (obj: unknown): obj is OtelToolCallRequestPart => {
+  if (!isObject(obj) || get(obj, 'type') !== 'tool_call') return false;
+  if (!isString(get(obj, 'name'))) return false;
+  const id = get(obj, 'id');
+  return isNil(id) || isString(id);
+};
+
+const isOtelToolCallResponsePart = (obj: unknown): obj is OtelToolCallResponsePart => {
+  if (!isObject(obj) || get(obj, 'type') !== 'tool_call_response') return false;
+  const id = get(obj, 'id');
+  if (!(isNil(id) || isString(id))) return false;
+  return has(obj, 'response');
+};
+
+const isSupportedOtelPart = (obj: unknown): obj is OTelGenAIPart => {
+  return isOtelTextPart(obj) || isOtelToolCallRequestPart(obj) || isOtelToolCallResponsePart(obj);
+};
+
+export const isOtelGenAIChatMessage = (obj: unknown): obj is OtelGenAIMessage => {
+  if (!isObject(obj)) return false;
+  const role = get(obj, 'role');
+  if (!isString(role) || !['system', 'user', 'assistant', 'tool'].includes(role)) return false;
+  if (!has(obj, 'parts') || !isArray((obj as any).parts) || (obj as any).parts.length === 0) return false;
+  return (obj as any).parts.every(isSupportedOtelPart);
+};
+
+const normalizeToolCallRequestPart = (part: OtelToolCallRequestPart): ModelTraceToolCall => {
+  const args = get(part, 'arguments') as unknown;
+  let argumentsStr = '';
+  try {
+    argumentsStr = JSON.stringify(args ?? {});
+  } catch {
+    argumentsStr = String(args);
+  }
+  return {
+    id: String(get(part, 'id') ?? get(part, 'name') ?? ''),
+    function: {
+      name: String(get(part, 'name')),
+      arguments: argumentsStr,
+    },
+  };
+};
+const normalizeToolCallResponsePart = (part: OtelToolCallResponsePart): ModelTraceChatMessage => {
+  const callId = String(get(part, 'id') ?? '');
+  const response = get(part, 'response');
+  const content = isString(response)
+    ? response
+    : (() => {
+        try {
+          return JSON.stringify(response);
+        } catch {
+          return String(response);
+        }
+      })();
+  return {
+    role: 'tool',
+    tool_call_id: callId,
+    content,
+  };
+};
+
+// Convert a single OTEL GenAI message into a single UI message.
+export const normalizeOtelGenAIChatMessage = (obj: OtelGenAIMessage): ModelTraceChatMessage | null => {
+  if (!isOtelGenAIChatMessage(obj)) return null;
+  const role: ModelTraceChatMessage['role'] = obj.role as any;
+
+  const contentParts: ModelTraceContentParts[] = [];
+  const toolCalls: ModelTraceToolCall[] = [];
+  let toolResultMessage: ModelTraceChatMessage | null = null;
+
+  for (const part of obj.parts) {
+    if (isOtelTextPart(part)) {
+      contentParts.push({ type: 'text', text: part.content });
+      continue;
+    }
+    if (isOtelToolCallRequestPart(part)) {
+      toolCalls.push(normalizeToolCallRequestPart(part));
+      continue;
+    }
+    if (isOtelToolCallResponsePart(part)) {
+      toolResultMessage = normalizeToolCallResponsePart(part);
+      continue;
+    }
+  }
+
+  if (toolResultMessage && contentParts.length === 0 && toolCalls.length === 0) {
+    return toolResultMessage;
+  }
+
+  return prettyPrintChatMessage({
+    type: 'message',
+    role,
+    ...(obj.name && { name: obj.name }),
+    ...(contentParts.length > 0 && { content: contentParts }),
+    ...(toolCalls.length > 0 && { tool_calls: toolCalls }),
+  });
+};

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.types.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/chat-utils/otel.types.ts
@@ -1,0 +1,27 @@
+// Type definitions for OpenTelemetry GenAI semantic convention input messages
+// Schema reference: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json
+
+export type OtelBasePart = { type: string } & Record<string, unknown>;
+
+export type OtelTextPart = OtelBasePart & { type: 'text'; content: string };
+
+export type OtelToolCallRequestPart = OtelBasePart & {
+  type: 'tool_call' | 'function_call';
+  id?: string | null;
+  name: string;
+  arguments?: unknown;
+};
+
+export type OtelToolCallResponsePart = OtelBasePart & {
+  type: 'tool_call_response';
+  id?: string | null;
+  response: unknown;
+};
+
+export type SupportedOtelPart = OtelTextPart | OtelToolCallRequestPart | OtelToolCallResponsePart;
+
+export type OtelGenAIMessage = {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  name?: string;
+  parts: SupportedOtelPart[];
+};


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18731?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18731/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18731/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18731/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The rich chat UI rendering is broken for GenAI SemConv spans.
<img width="1532" height="473" alt="Screenshot 2025-11-07 at 17 03 18" src="https://github.com/user-attachments/assets/f215940a-c53c-4d4b-8c0e-9458d1d2629a" />


The reason is that `isRawModelTraceChatMessage` recognize it as a chat style, but GenAI semconv actually has a bit different format.

MLflow:
```
{"role": "user", "content": [<content parts>, ...]}
```

OTel (https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-input-messages.json)
```
{"role": "user", "parts": [<content parts>, ...]}
```

The chat util renders `message.content` in the chat box, which is undefined in this case.

This PR adds another parser for Otel Semconv to fix this.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

After the change:

<img width="1529" height="662" alt="Screenshot 2025-11-07 at 16 57 18" src="https://github.com/user-attachments/assets/fb8ae039-e97a-45da-8ed2-43a6a12a47a9" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
