### PR TITLE
Improve cherry-pick warning message for better clarity

### DIFF
--- a/.github/workflows/cherry-picks-warn.yml
+++ b/.github/workflows/cherry-picks-warn.yml
@@ -21,5 +21,17 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '### 🚨 Important Reminder:\nAre you cherry-picking commits to a release branch? If so, please ensure you use the `Rebase and merge` option when merging this pull request. Do not use the `Squash and merge` option, as it makes reverting individual commits impossible. If the `Rebase and merge` option is disabled (it usually is), follow [Configuring commit rebasing for pull requests](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-rebasing-for-pull-requests) to temporarily enable it, and disable it once the PR is merged.'
+              body: `# ⚠️ Important: Cherry-Pick Merge Instructions
+
+            **If you are cherry-picking commits to a release branch, "Rebase and merge" must be used when merging this PR, NOT "Squash and merge".**
+
+            ### Why "Squash and merge" causes problems:
+
+            - It makes reverting individual commits impossible
+            - It removes the association between original and cherry-picked commits
+            - It makes it difficult to track which commits have been cherry-picked
+            - It disrupts the [\`update-release-labels.yml\`](.github/workflows/update-release-labels.yml) workflow
+            - It disrupts the [\`update_changelog.py\`](dev/update_changelog.py) script
+
+            If "Rebase and merge" is disabled, follow [Configuring commit rebasing for pull requests](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-rebasing-for-pull-requests) to enable it.`
             });

--- a/.github/workflows/cherry-picks-warn.yml
+++ b/.github/workflows/cherry-picks-warn.yml
@@ -30,8 +30,10 @@ jobs:
             - It makes reverting individual commits impossible
             - It removes the association between original and cherry-picked commits
             - It makes it difficult to track which commits have been cherry-picked
-            - It disrupts the [\`update-release-labels.yml\`](.github/workflows/update-release-labels.yml) workflow
-            - It disrupts the [\`update_changelog.py\`](dev/update_changelog.py) script
+            - It causes incorrect results in:
+              - [\`update-release-labels.yml\`](.github/workflows/update-release-labels.yml)
+              - [\`update_changelog.py\`](dev/update_changelog.py)
+              - [\`check_patch_prs.py\`](dev/check_patch_prs.py)
 
             If "Rebase and merge" is disabled, follow [Configuring commit rebasing for pull requests](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-rebasing-for-pull-requests) to enable it.`
             });


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18756?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18756/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18756/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18756/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR improves the warning message shown on cherry-pick PRs to release branches. The new message is clearer, better structured, and provides more context about why "Squash and merge" should be avoided.

Key improvements:
- Changed to H1 heading for better visibility
- Restructured with clearer language and formatting
- Added specific examples of workflows/scripts affected
- Replaced technical jargon with simpler terms

### How is this PR tested?

- [x] Manual tests

The workflow will trigger on PRs targeting release branches (branch-X.Y pattern) and post the improved warning message.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)