### PR TITLE
Fix migration for pre-existing auth tables

### DIFF
--- a/mlflow/server/auth/db/utils.py
+++ b/mlflow/server/auth/db/utils.py
@@ -1,10 +1,13 @@
 from pathlib import Path
 
-from alembic.command import upgrade
+from alembic.command import stamp, upgrade
 from alembic.config import Config
 from alembic.migration import MigrationContext
 from alembic.script import ScriptDirectory
+from sqlalchemy import inspect
 from sqlalchemy.engine.base import Engine
+
+INITIAL_REVISION = "8606fa83a998"
 
 
 def _get_alembic_dir() -> str:
@@ -21,7 +24,43 @@ def _get_alembic_config(url: str) -> Config:
     return alembic_cfg
 
 
+def _is_legacy_database(engine: Engine) -> bool:
+    """Check if this is a pre-3.6.0 auth database that needs version table migration.
+
+    Returns True if:
+    - Auth tables (users, experiment_permissions, etc.) exist
+    - alembic_version_auth table does NOT exist
+
+    This indicates a database from MLflow < 3.6.0 that was using the old
+    initialization method without Alembic version tracking.
+    """
+    inspector = inspect(engine)
+    existing_tables = inspector.get_table_names()
+
+    has_auth_tables = "users" in existing_tables
+    has_version_table = "alembic_version_auth" in existing_tables
+
+    return has_auth_tables and not has_version_table
+
+
+def _stamp_legacy_database(engine: Engine, revision: str) -> None:
+    """Stamp a legacy database with the initial Alembic revision.
+
+    This creates the alembic_version_auth table and marks the database
+    as being at the specified revision, avoiding the need to re-run
+    the initial migration on databases that already have the tables.
+    """
+    alembic_cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
+    with engine.begin() as conn:
+        alembic_cfg.attributes["connection"] = conn
+        stamp(alembic_cfg, revision)
+
+
 def migrate(engine: Engine, revision: str) -> None:
+    if _is_legacy_database(engine):
+        _stamp_legacy_database(engine, INITIAL_REVISION)
+        return
+
     alembic_cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
     with engine.begin() as conn:
         alembic_cfg.attributes["connection"] = conn
@@ -29,6 +68,10 @@ def migrate(engine: Engine, revision: str) -> None:
 
 
 def migrate_if_needed(engine: Engine, revision: str) -> None:
+    if _is_legacy_database(engine):
+        _stamp_legacy_database(engine, INITIAL_REVISION)
+        return
+
     alembic_cfg = _get_alembic_config(engine.url.render_as_string(hide_password=False))
     script_dir = ScriptDirectory.from_config(alembic_cfg)
     with engine.begin() as conn:

--- a/tests/server/auth/db/test_cli.py
+++ b/tests/server/auth/db/test_cli.py
@@ -50,3 +50,68 @@ def test_auth_and_tracking_store_coexist(tmp_path: Path) -> None:
     assert "registered_model_permissions" in tables
     assert "experiments" in tables
     assert "runs" in tables
+
+
+def test_upgrade_from_legacy_database(tmp_path: Path) -> None:
+    """Test upgrading from a pre-3.6.0 database that has auth tables but no alembic_version_auth."""
+    runner = CliRunner()
+    db = tmp_path / "test.db"
+    db_url = f"sqlite:///{db}"
+
+    with sqlite3.connect(db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("""
+            CREATE TABLE users (
+                id INTEGER NOT NULL PRIMARY KEY,
+                username VARCHAR(255),
+                password_hash VARCHAR(255),
+                is_admin BOOLEAN,
+                UNIQUE (username)
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE experiment_permissions (
+                id INTEGER NOT NULL PRIMARY KEY,
+                experiment_id VARCHAR(255) NOT NULL,
+                user_id INTEGER NOT NULL,
+                permission VARCHAR(255),
+                FOREIGN KEY(user_id) REFERENCES users (id),
+                UNIQUE (experiment_id, user_id)
+            )
+        """)
+        cursor.execute("""
+            CREATE TABLE registered_model_permissions (
+                id INTEGER NOT NULL PRIMARY KEY,
+                name VARCHAR(255) NOT NULL,
+                user_id INTEGER NOT NULL,
+                permission VARCHAR(255),
+                FOREIGN KEY(user_id) REFERENCES users (id),
+                UNIQUE (name, user_id)
+            )
+        """)
+        cursor.execute(
+            "INSERT INTO users (username, password_hash, is_admin) VALUES (?, ?, ?)",
+            ("testuser", "hash123", True),
+        )
+        conn.commit()
+
+    res = runner.invoke(cli.upgrade, ["--url", db_url], catch_exceptions=False)
+    assert res.exit_code == 0, res.output
+
+    with sqlite3.connect(db) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type='table';")
+        tables = {t[0] for t in cursor.fetchall()}
+
+        cursor.execute("SELECT version_num FROM alembic_version_auth;")
+        version = cursor.fetchone()
+
+        cursor.execute("SELECT username, is_admin FROM users;")
+        user = cursor.fetchone()
+
+    assert "alembic_version_auth" in tables
+    assert "users" in tables
+    assert "experiment_permissions" in tables
+    assert "registered_model_permissions" in tables
+    assert version[0] == "8606fa83a998"
+    assert user == ("testuser", 1)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18793?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18793/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18793/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18793/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #18760 

### What changes are proposed in this pull request?

Adds a migration handler to ensure that pre-existing auth tables will be properly recognized by alembic when migrating externally managed auth migration history tables. This fixes an issue that was introduced while adding support for same-server auth management in 3.6.0.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
