### PR TITLE
Show ID and tags on dataset UI

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsToolbar.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/components/ExperimentEvaluationDatasetRecordsToolbar.tsx
@@ -2,14 +2,21 @@ import {
   Button,
   ColumnsIcon,
   DropdownMenu,
+  Notification,
   RowsIcon,
   Typography,
   useDesignSystemTheme,
+  Tag,
+  Tooltip,
+  Overflow,
 } from '@databricks/design-system';
 import { ColumnDef } from '@tanstack/react-table';
+import { useCallback, useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { EvaluationDataset, EvaluationDatasetRecord } from '../types';
-import { parseJSONSafe } from '@mlflow/mlflow/src/common/utils/TagUtils';
+import { isUserFacingTag, parseJSONSafe } from '@mlflow/mlflow/src/common/utils/TagUtils';
+
+const BASE_NOTIFICATION_COMPONENT_ID = 'mlflow.eval-datasets.records-toolbar.notification';
 
 const getTotalRecordsCount = (profile: string | undefined): number | undefined => {
   if (!profile) {
@@ -38,100 +45,193 @@ export const ExperimentEvaluationDatasetRecordsToolbar = ({
   setRowSize: (rowSize: 'sm' | 'md' | 'lg') => void;
 }) => {
   const { theme } = useDesignSystemTheme();
+  const [showNotification, setShowNotification] = useState(false);
+
   const datasetName = dataset?.name;
   const profile = dataset?.profile;
+  const datasetId = dataset?.dataset_id;
+  const parsedTags = (dataset?.tags && parseJSONSafe(dataset.tags)) || {};
+  const userFacingTags = Object.entries(parsedTags as Record<string, any>)
+    .filter(([key]) => isUserFacingTag(key))
+    .map(([key, value]) => ({ key, value }));
   const totalRecordsCount = getTotalRecordsCount(profile);
   const loadedRecordsCount = datasetRecords.length;
 
+  const handleCopy = useCallback(() => {
+    setShowNotification(true);
+    setTimeout(() => setShowNotification(false), 2000);
+  }, []);
+
   return (
-    <div
-      css={{
-        display: 'flex',
-        alignItems: 'flex-start',
-        justifyContent: 'space-between',
-        marginBottom: theme.spacing.sm,
-      }}
-    >
+    <>
       <div
         css={{
           display: 'flex',
-          flexDirection: 'column',
-          paddingLeft: theme.spacing.sm,
-          paddingRight: theme.spacing.sm,
+          alignItems: 'flex-start',
+          justifyContent: 'space-between',
+          marginBottom: theme.spacing.sm,
+          paddingTop: theme.spacing.sm,
+          paddingBottom: theme.spacing.sm,
         }}
       >
-        <Typography.Title level={3} withoutMargins>
-          {datasetName}
-        </Typography.Title>
-        <Typography.Text color="secondary" size="sm">
-          <FormattedMessage
-            defaultMessage="Displaying {loadedRecordsCount} of {totalRecordsCount, plural, =1 {1 record} other {# records}}"
-            description="Label for the number of records displayed"
-            values={{ loadedRecordsCount: loadedRecordsCount ?? 0, totalRecordsCount: totalRecordsCount ?? 0 }}
-          />
-        </Typography.Text>
-      </div>
-      <div css={{ display: 'flex', alignItems: 'flex-start' }}>
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <Button componentId="mlflow.eval-datasets.records-toolbar.row-size-toggle" icon={<RowsIcon />} />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Content align="end">
-            <DropdownMenu.RadioGroup
-              componentId="mlflow.eval-datasets.records-toolbar.row-size-radio"
-              value={rowSize}
-              onValueChange={(value) => setRowSize(value as 'sm' | 'md' | 'lg')}
-            >
-              <DropdownMenu.Label>
-                <Typography.Text color="secondary">
-                  <FormattedMessage defaultMessage="Row height" description="Label for the row height radio group" />
+        <div
+          css={{
+            display: 'flex',
+            flexDirection: 'column',
+            paddingLeft: theme.spacing.sm,
+            paddingRight: theme.spacing.sm,
+            gap: theme.spacing.xs,
+          }}
+        >
+          <Typography.Title level={3} withoutMargins>
+            {datasetName}
+          </Typography.Title>
+          <div
+            css={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+              flexWrap: 'wrap',
+              marginTop: theme.spacing.xs,
+              marginBottom: theme.spacing.xs,
+            }}
+          >
+            {' '}
+            {/* ID pill (copy on click) */}
+            {datasetId && (
+              <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+                <Typography.Text color="secondary" size="sm">
+                  <FormattedMessage defaultMessage="ID" description="Label for the dataset id pill" />
                 </Typography.Text>
-              </DropdownMenu.Label>
-              <DropdownMenu.RadioItem key="sm" value="sm">
-                <DropdownMenu.ItemIndicator />
-                <Typography.Text>
-                  <FormattedMessage defaultMessage="Small" description="Small row size" />
+                <Tooltip componentId="mlflow.eval-datasets.records-toolbar.dataset-id.tooltip" content={datasetId}>
+                  <Tag
+                    componentId="mlflow.eval-datasets.records-toolbar.dataset-id"
+                    color="indigo"
+                    css={{ cursor: 'pointer' }}
+                    onClick={() => {
+                      navigator.clipboard.writeText(datasetId);
+                      handleCopy();
+                    }}
+                  >
+                    <Typography.Text css={{ fontFamily: 'monospace' }}>{datasetId}</Typography.Text>
+                  </Tag>
+                </Tooltip>
+              </div>
+            )}
+            {/* Tags pills */}
+            {userFacingTags.length > 0 && (
+              <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+                <Typography.Text color="secondary" size="sm">
+                  <FormattedMessage defaultMessage="Tags" description="Label for the dataset tags pills" />
                 </Typography.Text>
-              </DropdownMenu.RadioItem>
-              <DropdownMenu.RadioItem key="md" value="md">
-                <DropdownMenu.ItemIndicator />
-                <Typography.Text>
-                  <FormattedMessage defaultMessage="Medium" description="Medium row size" />
-                </Typography.Text>
-              </DropdownMenu.RadioItem>
-              <DropdownMenu.RadioItem key="lg" value="lg">
-                <DropdownMenu.ItemIndicator />
-                <Typography.Text>
-                  <FormattedMessage defaultMessage="Large" description="Large row size" />
-                </Typography.Text>
-              </DropdownMenu.RadioItem>
-            </DropdownMenu.RadioGroup>
-          </DropdownMenu.Content>
-        </DropdownMenu.Root>
-        <DropdownMenu.Root>
-          <DropdownMenu.Trigger asChild>
-            <Button componentId="mlflow.eval-datasets.records-toolbar.columns-toggle" icon={<ColumnsIcon />} />
-          </DropdownMenu.Trigger>
-          <DropdownMenu.Content>
-            {columns.map((column) => (
-              <DropdownMenu.CheckboxItem
-                componentId="YOUR_TRACKING_ID"
-                key={column.id}
-                checked={columnVisibility[column.id ?? ''] ?? false}
-                onCheckedChange={(checked) =>
-                  setColumnVisibility({
-                    ...columnVisibility,
-                    [column.id ?? '']: checked,
-                  })
-                }
+                <Overflow noMargin>
+                  {userFacingTags.map(({ key, value }) => {
+                    const fullText = `${key}: ${String(value)}`;
+                    const compId = `mlflow.eval-datasets.records-toolbar.dataset-tag.${key}`;
+                    return (
+                      <Tooltip key={compId} componentId={compId} content={fullText}>
+                        <Tag
+                          componentId={compId}
+                          color="teal"
+                          css={{ cursor: 'pointer' }}
+                          onClick={() => {
+                            navigator.clipboard.writeText(fullText);
+                            handleCopy();
+                          }}
+                        >
+                          {fullText}
+                        </Tag>
+                      </Tooltip>
+                    );
+                  })}
+                </Overflow>
+              </div>
+            )}
+          </div>
+          <Typography.Text color="secondary" size="sm">
+            <FormattedMessage
+              defaultMessage="Displaying {loadedRecordsCount} of {totalRecordsCount, plural, =1 {1 record} other {# records}}"
+              description="Label for the number of records displayed"
+              values={{ loadedRecordsCount: loadedRecordsCount ?? 0, totalRecordsCount: totalRecordsCount ?? 0 }}
+            />
+          </Typography.Text>
+        </div>
+        <div css={{ display: 'flex', alignItems: 'flex-start' }}>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <Button componentId="mlflow.eval-datasets.records-toolbar.row-size-toggle" icon={<RowsIcon />} />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content align="end">
+              <DropdownMenu.RadioGroup
+                componentId="mlflow.eval-datasets.records-toolbar.row-size-radio"
+                value={rowSize}
+                onValueChange={(value) => setRowSize(value as 'sm' | 'md' | 'lg')}
               >
-                <DropdownMenu.ItemIndicator />
-                <Typography.Text>{column.header}</Typography.Text>
-              </DropdownMenu.CheckboxItem>
-            ))}
-          </DropdownMenu.Content>
-        </DropdownMenu.Root>
+                <DropdownMenu.Label>
+                  <Typography.Text color="secondary">
+                    <FormattedMessage defaultMessage="Row height" description="Label for the row height radio group" />
+                  </Typography.Text>
+                </DropdownMenu.Label>
+                <DropdownMenu.RadioItem key="sm" value="sm">
+                  <DropdownMenu.ItemIndicator />
+                  <Typography.Text>
+                    <FormattedMessage defaultMessage="Small" description="Small row size" />
+                  </Typography.Text>
+                </DropdownMenu.RadioItem>
+                <DropdownMenu.RadioItem key="md" value="md">
+                  <DropdownMenu.ItemIndicator />
+                  <Typography.Text>
+                    <FormattedMessage defaultMessage="Medium" description="Medium row size" />
+                  </Typography.Text>
+                </DropdownMenu.RadioItem>
+                <DropdownMenu.RadioItem key="lg" value="lg">
+                  <DropdownMenu.ItemIndicator />
+                  <Typography.Text>
+                    <FormattedMessage defaultMessage="Large" description="Large row size" />
+                  </Typography.Text>
+                </DropdownMenu.RadioItem>
+              </DropdownMenu.RadioGroup>
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+          <DropdownMenu.Root>
+            <DropdownMenu.Trigger asChild>
+              <Button componentId="mlflow.eval-datasets.records-toolbar.columns-toggle" icon={<ColumnsIcon />} />
+            </DropdownMenu.Trigger>
+            <DropdownMenu.Content>
+              {columns.map((column) => (
+                <DropdownMenu.CheckboxItem
+                  componentId="YOUR_TRACKING_ID"
+                  key={column.id}
+                  checked={columnVisibility[column.id ?? ''] ?? false}
+                  onCheckedChange={(checked) =>
+                    setColumnVisibility({
+                      ...columnVisibility,
+                      [column.id ?? '']: checked,
+                    })
+                  }
+                >
+                  <DropdownMenu.ItemIndicator />
+                  <Typography.Text>{column.header}</Typography.Text>
+                </DropdownMenu.CheckboxItem>
+              ))}
+            </DropdownMenu.Content>
+          </DropdownMenu.Root>
+        </div>
       </div>
-    </div>
+
+      {showNotification && (
+        <Notification.Provider>
+          <Notification.Root severity="success" componentId={BASE_NOTIFICATION_COMPONENT_ID}>
+            <Notification.Title>
+              <FormattedMessage
+                defaultMessage="Copied to clipboard"
+                description="Success message for the notification"
+              />
+            </Notification.Title>
+          </Notification.Root>
+          <Notification.Viewport />
+        </Notification.Provider>
+      )}
+    </>
   );
 };

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -231,6 +231,10 @@
     "defaultMessage": "Delete logged model",
     "description": "A header of the modal used for deleting logged models"
   },
+  "0KWpQU": {
+    "defaultMessage": "Tags",
+    "description": "Label for the dataset tags pills"
+  },
   "0M7VVC": {
     "defaultMessage": "Irrelevant",
     "description": "Evaluation results > relevancy assessment > negative value label. Displayed if evaluation result is considered as irrelevant to the query."
@@ -4390,6 +4394,10 @@
   "i+RyPC": {
     "defaultMessage": "Your request could not be fulfilled. Please try again.",
     "description": "A message shown on the experiment page if the runs request fails"
+  },
+  "i/2wuq": {
+    "defaultMessage": "ID",
+    "description": "Label for the dataset id pill"
   },
   "i/pJvo": {
     "defaultMessage": "Automatically log traces for AutoGen conversations by calling the {code} function. For example:",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18800?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18800/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18800/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18800/merge
```

</p>
</details>

### What changes are proposed in this pull request?

The `get_dataset` API requires dataset ID, but the UI doesn't show it anywhere today. Adding headers to show ID and tags.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<img width="783" height="397" alt="Screenshot 2025-11-12 at 13 48 34" src="https://github.com/user-attachments/assets/f59e8c7f-9c89-4eee-a490-f2d0b3d36608" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
