### PR TITLE
Fix notebook download URLs to use versioned paths

### DIFF
--- a/dev/update_mlflow_versions.py
+++ b/dev/update_mlflow_versions.py
@@ -22,7 +22,7 @@ _JAVA_VERSION_FILES = Path("mlflow", "java").rglob("*.java")
 
 _JAVA_POM_XML_FILES = Path("mlflow", "java").rglob("*.xml")
 
-_JS_VERSION_FILES = [
+_TS_VERSION_FILES = [
     Path(
         "mlflow",
         "server",
@@ -30,7 +30,8 @@ _JS_VERSION_FILES = [
         "src",
         "common",
         "constants.tsx",
-    )
+    ),
+    Path("docs", "src", "constants.ts"),
 ]
 
 _R_VERSION_FILES = [Path("mlflow", "R", "mlflow", "DESCRIPTION")]
@@ -94,7 +95,7 @@ def replace_pyproject_toml(new_py_version: str, paths: list[Path]) -> None:
     )
 
 
-def replace_js(old_version: str, new_py_version: str, paths: list[Path]) -> None:
+def replace_ts(old_version: str, new_py_version: str, paths: list[Path]) -> None:
     replace_occurrences(
         files=paths,
         pattern=re.escape(old_version),
@@ -165,7 +166,7 @@ def update_versions(new_py_version: str) -> None:
 
     replace_python(old_py_version, new_py_version, _PYTHON_VERSION_FILES)
     replace_pyproject_toml(new_py_version, _PYPROJECT_TOML_FILES)
-    replace_js(old_py_version, new_py_version, _JS_VERSION_FILES)
+    replace_ts(old_py_version, new_py_version, _TS_VERSION_FILES)
     replace_java(old_py_version, new_py_version, _JAVA_VERSION_FILES)
     replace_java_pom_xml(old_py_version, new_py_version, _JAVA_POM_XML_FILES)
     replace_r(old_py_version, new_py_version, _R_VERSION_FILES)

--- a/docs/src/components/NotebookDownloadButton/index.tsx
+++ b/docs/src/components/NotebookDownloadButton/index.tsx
@@ -1,4 +1,5 @@
 import { MouseEvent, ReactNode, useCallback } from 'react';
+import { Version } from '@site/src/constants';
 
 interface NotebookDownloadButtonProps {
   children: ReactNode;
@@ -18,6 +19,12 @@ export function NotebookDownloadButton({ children, href }: NotebookDownloadButto
         } catch {
           // do nothing if the gtag call fails
         }
+      }
+
+      if (!Version.includes('dev')) {
+        // Replace 'master' with the current version to pin the download to the released version
+        // and avoid 404 errors
+        href = href.replace(/\/master\//, `/v${Version}/`);
       }
 
       const response = await fetch(href);

--- a/docs/src/constants.ts
+++ b/docs/src/constants.ts
@@ -1,0 +1,1 @@
+export const Version = '3.6.1.dev0';

--- a/tests/dev/test_update_mlflow_versions.py
+++ b/tests/dev/test_update_mlflow_versions.py
@@ -9,10 +9,10 @@ from dev.update_mlflow_versions import (
     get_current_py_version,
     replace_java,
     replace_java_pom_xml,
-    replace_js,
     replace_pyproject_toml,
     replace_python,
     replace_r,
+    replace_ts,
 )
 
 # { filename: expected lines changed }
@@ -36,10 +36,13 @@ _JAVA_XML_FILES = {
     },
 }
 
-_JS_FILES = {
+_TS_FILES = {
     "mlflow/server/js/src/common/constants.tsx": {
         12: "export const Version = '{new_version}';",
-    }
+    },
+    "docs/src/constants.ts": {
+        1: "export const Version = '{new_version}';",
+    },
 }
 
 _PYTHON_FILES = {
@@ -113,7 +116,7 @@ def copy_and_run_change_func(monkeypatch, tmp_path, paths_to_copy, replace_func,
             _NEW_PY_VERSION + "rc1",
             _NEW_PY_VERSION + "-SNAPSHOT",
         ),
-        (replace_js, _JS_FILES, _NEW_PY_VERSION, _NEW_PY_VERSION),
+        (replace_ts, _TS_FILES, _NEW_PY_VERSION, _NEW_PY_VERSION),
         (replace_python, _PYTHON_FILES, _NEW_PY_VERSION, _NEW_PY_VERSION),
         (replace_pyproject_toml, _PYPROJECT_TOML_FILES, _NEW_PY_VERSION, _NEW_PY_VERSION),
         (replace_r, _R_FILES, _NEW_PY_VERSION, _NEW_PY_VERSION),


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18806?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18806/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18806/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18806/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Notebook download URLs were using `/master/` branch paths, causing 404 errors on released documentation versions. This change pins downloads to the current release version when not in dev mode.

Also updated the version update script to include the new TypeScript constants file used by the documentation site.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed 404 errors when downloading example notebooks from the documentation site on released versions.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)