### PR TITLE
Fix delete trace tag 500 bug from #18721

### DIFF
--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -2777,6 +2777,18 @@ message DeleteTraceTag {
   option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
 
   // ID of the trace from which to delete the tag.
+  optional string request_id = 1;
+
+  // Name of the tag to delete.
+  optional string key = 2;
+
+  message Response {}
+}
+
+message DeleteTraceTagV3 {
+  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
+
+  // ID of the trace from which to delete the tag.
   optional string trace_id = 3;
 
   // Name of the tag to delete.
@@ -2785,20 +2797,7 @@ message DeleteTraceTag {
   message Response {}
 
   // request_id has been retired
-  reserved 1;
-  reserved "request_id";
-}
-
-message DeleteTraceTagV3 {
-  option (scalapb.message).extends = "com.databricks.rpc.RPC[$this.Response]";
-
-  // ID of the trace from which to delete the tag.
-  optional string request_id = 1;
-
-  // Name of the tag to delete.
-  optional string key = 2;
-
-  message Response {}
+  reserved 1;reserved "request_id";
 }
 
 message Trace {

--- a/mlflow/protos/service.proto
+++ b/mlflow/protos/service.proto
@@ -2797,7 +2797,8 @@ message DeleteTraceTagV3 {
   message Response {}
 
   // request_id has been retired
-  reserved 1;reserved "request_id";
+  reserved 1;
+  reserved "request_id";
 }
 
 message Trace {

--- a/mlflow/protos/service_pb2.pyi
+++ b/mlflow/protos/service_pb2.pyi
@@ -959,17 +959,6 @@ class SetTraceTagV3(_message.Message):
     def __init__(self, trace_id: _Optional[str] = ..., key: _Optional[str] = ..., value: _Optional[str] = ...) -> None: ...
 
 class DeleteTraceTag(_message.Message):
-    __slots__ = ("trace_id", "key")
-    class Response(_message.Message):
-        __slots__ = ()
-        def __init__(self) -> None: ...
-    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
-    KEY_FIELD_NUMBER: _ClassVar[int]
-    trace_id: str
-    key: str
-    def __init__(self, trace_id: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
-
-class DeleteTraceTagV3(_message.Message):
     __slots__ = ("request_id", "key")
     class Response(_message.Message):
         __slots__ = ()
@@ -979,6 +968,17 @@ class DeleteTraceTagV3(_message.Message):
     request_id: str
     key: str
     def __init__(self, request_id: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
+
+class DeleteTraceTagV3(_message.Message):
+    __slots__ = ("trace_id", "key")
+    class Response(_message.Message):
+        __slots__ = ()
+        def __init__(self) -> None: ...
+    TRACE_ID_FIELD_NUMBER: _ClassVar[int]
+    KEY_FIELD_NUMBER: _ClassVar[int]
+    trace_id: str
+    key: str
+    def __init__(self, trace_id: _Optional[str] = ..., key: _Optional[str] = ...) -> None: ...
 
 class Trace(_message.Message):
     __slots__ = ("trace_info", "spans")

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -3105,6 +3105,23 @@ def _delete_trace_tag(request_id):
 
 @catch_mlflow_exception
 @_disable_if_artifacts_only
+def _delete_trace_tag_v3(trace_id):
+    """
+    A request handler for `DELETE /mlflow/traces/{trace_id}/tags` to delete tags from a TraceInfo record.
+    Identical to `_delete_trace_tag`, but with request_id renamed to with trace_id.
+    """
+    request_message = _get_request_message(
+        DeleteTraceTagV3(),
+        schema={
+            "key": [_assert_string, _assert_required],
+        },
+    )
+    _get_tracking_store().delete_trace_tag(trace_id, request_message.key)
+    return _wrap_response(DeleteTraceTagV3.Response())
+
+
+@catch_mlflow_exception
+@_disable_if_artifacts_only
 def _link_traces_to_run():
     """
     A request handler for `POST /mlflow/traces/link-to-run` to link traces to a run.
@@ -4086,7 +4103,7 @@ HANDLERS = {
     DeleteTracesV3: _delete_traces,
     CalculateTraceFilterCorrelation: _calculate_trace_filter_correlation,
     SetTraceTagV3: _set_trace_tag_v3,
-    DeleteTraceTagV3: _delete_trace_tag,
+    DeleteTraceTagV3: _delete_trace_tag_v3,
     LinkTracesToRun: _link_traces_to_run,
     BatchGetTraces: _batch_get_traces,
     # Assessment APIs

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -3107,7 +3107,8 @@ def _delete_trace_tag(request_id):
 @_disable_if_artifacts_only
 def _delete_trace_tag_v3(trace_id):
     """
-    A request handler for `DELETE /mlflow/traces/{trace_id}/tags` to delete tags from a TraceInfo record.
+    A request handler for `DELETE /mlflow/traces/{trace_id}/tags` to delete tags
+    from a TraceInfo record.
     Identical to `_delete_trace_tag`, but with request_id renamed to with trace_id.
     """
     request_message = _get_request_message(

--- a/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
+++ b/mlflow/server/js/src/experiment-tracking/sdk/MlflowService.ts
@@ -324,10 +324,11 @@ export class MlflowService {
    * Traces API: delete trace tag V3
    */
   static deleteExperimentTraceTagV3 = (traceRequestId: string, key: string) =>
-    fetchEndpoint({
-      relativeUrl: `ajax-api/3.0/mlflow/traces/${traceRequestId}/tags?key=${encodeURIComponent(key)}`,
-      method: HTTPMethods.DELETE,
-      success: defaultResponseParser,
+    deleteJson({
+      relativeUrl: `ajax-api/3.0/mlflow/traces/${traceRequestId}/tags`,
+      data: {
+        key,
+      },
     });
 
   /**

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -45,6 +45,8 @@ from mlflow.protos.service_pb2 import (
     CalculateTraceFilterCorrelation,
     CreateExperiment,
     DeleteScorer,
+    DeleteTraceTag,
+    DeleteTraceTagV3,
     GetScorer,
     ListScorers,
     ListScorerVersions,
@@ -82,6 +84,8 @@ from mlflow.server.handlers import (
     _delete_registered_model_alias,
     _delete_registered_model_tag,
     _delete_scorer,
+    _delete_trace_tag,
+    _delete_trace_tag_v3,
     _deprecated_search_traces_v2,
     _get_dataset_experiment_ids_handler,
     _get_dataset_handler,
@@ -1993,3 +1997,87 @@ def test_batch_get_traces_handler_empty_list(mock_get_request_message, mock_trac
     # Verify response was created
     assert response is not None
     assert response.status_code == 200
+
+
+def test_delete_trace_tag_v2_handler(mock_get_request_message, mock_tracking_store):
+    """Test v2 delete_trace_tag handler with request_id parameter.
+    
+    Verifies that when the Flask route uses request_id path parameter,
+    the _delete_trace_tag handler is called and invokes store.delete_trace_tag().
+    """
+
+    request_id = "tr-123v2"
+    tag_key = "tk"
+
+    # Create the request message
+    request_msg = DeleteTraceTag(key=tag_key)
+    mock_get_request_message.return_value = request_msg
+
+    # Call the v2 handler with request_id parameter
+    response = _delete_trace_tag(request_id=request_id)
+
+    # Verify the store method was called with correct parameters
+    mock_tracking_store.delete_trace_tag.assert_called_once_with(request_id, tag_key)
+
+    assert response is not None
+    assert response.status_code == 200
+
+
+def test_delete_trace_tag_v3_handler(mock_get_request_message, mock_tracking_store):
+    """Test v3 delete_trace_tag handler with trace_id parameter.
+    
+    Verifies that when the Flask route uses trace_id path parameter,
+    the _delete_trace_tag_v3 handler is called and invokes store.delete_trace_tag().
+    This is similar to v2 but uses the v3 proto message and route parameter naming.
+    """
+    from mlflow.protos.service_pb2 import DeleteTraceTagV3
+
+    trace_id = "tr-v3-456"
+    tag_key = "tk"
+
+    # Create the request message (v3 version)
+    request_msg = DeleteTraceTagV3(key=tag_key)
+    mock_get_request_message.return_value = request_msg
+
+    # Call the v3 handler with trace_id parameter
+    response = _delete_trace_tag_v3(trace_id=trace_id)
+
+    # Verify the store method was called with correct parameters
+    # Both v2 and v3 call the same store method
+    mock_tracking_store.delete_trace_tag.assert_called_once_with(trace_id, tag_key)
+
+    assert response is not None
+    assert response.status_code == 200
+
+
+def test_delete_trace_tag_handlers_routing(mlflow_app_client, mock_tracking_store):
+    """Test Flask routes different paths to different handlers.
+    
+    This test ensures:
+    1. DELETE /api/2.0/mlflow/traces/{request_id}/tags routes to v2 handler
+    2. DELETE /api/2.0/mlflow/traces/{trace_id}/tags routes to v3 handler
+    
+    Both handlers call store.delete_trace_tag() but route parameter naming differs.
+    """
+    request_id_v2 = "tr-v2-789"
+    trace_id_v3 = "tr-v3-012"
+    tag_key = "test_key"
+
+    # Mock the store to verify it's called
+    mock_tracking_store.delete_trace_tag = mock.MagicMock(return_value=None)
+
+    # Test v2 endpoint with request_id
+    response_v2 = mlflow_app_client.delete(
+        f"/api/2.0/mlflow/traces/{request_id_v2}/tags",
+        data=json.dumps({"key": tag_key}),
+        content_type="application/json",
+    )
+    assert response_v2.status_code == 200
+
+    # Test v3 endpoint with trace_id
+    response_v3 = mlflow_app_client.delete(
+        f"/api/3.0/mlflow/traces/{trace_id_v3}/tags",
+        data=json.dumps({"key": tag_key}),
+        content_type="application/json",
+    )
+    assert response_v3.status_code == 200


### PR DESCRIPTION
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs
Resolve #18721


### What changes are proposed in this pull request?

1. Add the missing `_delete_trace_tag_v3` handler for Flask router, to be consistent with `_set_trace_tag_v3`.
2. Changed the frontend's `DELETE` request for `delete trace tag` from using url to body.
3. 6 new unit tests to make sure flask route to the correct handler for `delete_trace_tag` and `set_trace_tag` for both v2 and v3 version

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

https://github.com/user-attachments/assets/521b997b-ec6f-4103-b680-2871fd25f977


<!-- Attach code, screenshot, video used for manual testing here. -->


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fix the bug of unable to delete the trace tags. User may experience HTTP 400 bug when trying to delete the trace tags previously.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

Yes

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
