### PR TITLE
tests(genai): add regression test to ensure final_eval_score == 0.0 is logged (fixes #18267)

### DIFF
--- a/tests/genai/test_optimize_logging.py
+++ b/tests/genai/test_optimize_logging.py
@@ -1,0 +1,47 @@
+import mlflow
+import pandas as pd
+
+from mlflow.genai.optimize.types import PromptOptimizerOutput
+from mlflow.genai.optimize.util import prompt_optimization_autolog
+
+
+class StubPrompt:
+    def __init__(self, uri="prompts:/test/1"):
+        self.uri = uri
+
+
+def test_final_eval_score_zero_should_be_logged(tmp_path):
+    # Minimal training data
+    df = pd.DataFrame([
+        {"inputs": {"q": "hello"}, "outputs": "world"}
+    ])
+
+    # Fake optimizer output with final_eval_score = 0.0
+    output = PromptOptimizerOutput(
+        optimized_prompts={"p": "template"},
+        initial_eval_score=1.0,
+        final_eval_score=0.0,
+    )
+
+    with prompt_optimization_autolog(
+        optimizer_name="test_opt",
+        num_prompts=1,
+        num_training_samples=1,
+        train_data_df=df,
+    ) as results:
+        results["optimizer_output"] = output
+
+    # Verify metric logged
+    client = mlflow.tracking.MlflowClient()
+
+    runs = client.search_runs(
+        experiment_ids=["0"],
+        order_by=["attribute.start_time DESC"],
+        max_results=1,
+    )
+    assert runs, "No MLflow run found"
+    run = runs[0]
+
+    data = client.get_run(run.info.run_id).data
+    assert "final_eval_score" in data.metrics
+    assert float(data.metrics["final_eval_score"]) == 0.0


### PR DESCRIPTION


Fixes #18267

### Related Issues/PRs
<!-- Resolve --> #18267

### What changes are proposed in this pull request?
Add a focused regression test that verifies a `final_eval_score` of `0.0` is correctly logged
during prompt optimization. The upstream code already uses `is not None` checks for logging,
but a regression test was missing — this PR supplies that test so future refactors cannot
reintroduce the bug.

Files added:
- `tests/genai/test_optimize_logging.py`

### How is this PR tested?
- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

The new test `tests/genai/test_optimize_logging.py` executes the `prompt_optimization_autolog`
context with a `PromptOptimizerOutput` whose `final_eval_score == 0.0`, then asserts that the
metric `final_eval_score` is present in the created run and equals `0.0`.

I ran the new test locally:
- `pytest -q tests/genai/test_optimize_logging.py `

### Does this PR require documentation update?
- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?
- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?
Components
- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [x] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:
- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [ ] `rn/documentation`

#### Should this PR be included in the next patch release?
- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
