### PR TITLE
Add `MajorVersionCheck` clint rule for major version comparisons

### DIFF
--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -794,6 +794,11 @@ class Linter(ast.NodeVisitor):
             self._check(Range.from_node(node), rules.OsEnvironDeleteInTest())
         self.generic_visit(node)
 
+    def visit_Compare(self, node: ast.Compare) -> None:
+        if rules.VersionMajorCheck.check(node, self.resolver):
+            self._check(Range.from_node(node), rules.VersionMajorCheck())
+        self.generic_visit(node)
+
     def visit_type_annotation(self, node: ast.expr) -> None:
         visitor = TypeAnnotationVisitor(self)
         visitor.visit(node)

--- a/dev/clint/src/clint/linter.py
+++ b/dev/clint/src/clint/linter.py
@@ -795,8 +795,8 @@ class Linter(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit_Compare(self, node: ast.Compare) -> None:
-        if rules.VersionMajorCheck.check(node, self.resolver):
-            self._check(Range.from_node(node), rules.VersionMajorCheck())
+        if rules.MajorVersionCheck.check(node, self.resolver):
+            self._check(Range.from_node(node), rules.MajorVersionCheck())
         self.generic_visit(node)
 
     def visit_type_annotation(self, node: ast.expr) -> None:

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -44,6 +44,7 @@ from clint.rules.unknown_mlflow_function import UnknownMlflowFunction
 from clint.rules.unnamed_thread import UnnamedThread
 from clint.rules.unparameterized_generic_type import UnparameterizedGenericType
 from clint.rules.use_sys_executable import UseSysExecutable
+from clint.rules.version_major_check import VersionMajorCheck
 
 ALL_RULES = {rule.name for rule in Rule.__subclasses__()}
 
@@ -94,4 +95,5 @@ __all__ = [
     "UnnamedThread",
     "UnparameterizedGenericType",
     "UseSysExecutable",
+    "VersionMajorCheck",
 ]

--- a/dev/clint/src/clint/rules/__init__.py
+++ b/dev/clint/src/clint/rules/__init__.py
@@ -44,7 +44,7 @@ from clint.rules.unknown_mlflow_function import UnknownMlflowFunction
 from clint.rules.unnamed_thread import UnnamedThread
 from clint.rules.unparameterized_generic_type import UnparameterizedGenericType
 from clint.rules.use_sys_executable import UseSysExecutable
-from clint.rules.version_major_check import VersionMajorCheck
+from clint.rules.version_major_check import MajorVersionCheck
 
 ALL_RULES = {rule.name for rule in Rule.__subclasses__()}
 
@@ -95,5 +95,5 @@ __all__ = [
     "UnnamedThread",
     "UnparameterizedGenericType",
     "UseSysExecutable",
-    "VersionMajorCheck",
+    "MajorVersionCheck",
 ]

--- a/dev/clint/src/clint/rules/version_major_check.py
+++ b/dev/clint/src/clint/rules/version_major_check.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from clint.resolver import Resolver
 
 
-class VersionMajorCheck(Rule):
+class MajorVersionCheck(Rule):
     def _message(self) -> str:
         return (
             "Use `.major` field for major version comparisons instead of full version strings. "
@@ -27,14 +27,14 @@ class VersionMajorCheck(Rule):
 
         if not (
             isinstance(node.left, ast.Call)
-            and VersionMajorCheck._is_version_call(node.left, resolver)
+            and MajorVersionCheck._is_version_call(node.left, resolver)
         ):
             return False
 
         comparator = node.comparators[0]
         if not (
             isinstance(comparator, ast.Call)
-            and VersionMajorCheck._is_version_call(comparator, resolver)
+            and MajorVersionCheck._is_version_call(comparator, resolver)
         ):
             return False
 
@@ -44,7 +44,7 @@ class VersionMajorCheck(Rule):
             and isinstance(comparator.args[0].value, str)
         ):
             version_str = comparator.args[0].value
-            return VersionMajorCheck._is_major_only_version(version_str)
+            return MajorVersionCheck._is_major_only_version(version_str)
 
         return False
 

--- a/dev/clint/src/clint/rules/version_major_check.py
+++ b/dev/clint/src/clint/rules/version_major_check.py
@@ -1,0 +1,60 @@
+import ast
+import re
+from typing import TYPE_CHECKING
+
+from clint.rules.base import Rule
+
+if TYPE_CHECKING:
+    from clint.resolver import Resolver
+
+
+class VersionMajorCheck(Rule):
+    def _message(self) -> str:
+        return (
+            "Use `.major` field for major version comparisons instead of full version strings. "
+            "This is more explicit, and efficient (avoids creating a second Version object). "
+            "For example, use `Version(__version__).major >= 1` instead of "
+            '`Version(__version__) >= Version("1.0.0")`.'
+        )
+
+    @staticmethod
+    def check(node: ast.Compare, resolver: "Resolver") -> bool:
+        if len(node.ops) != 1 or len(node.comparators) != 1:
+            return False
+
+        if not isinstance(node.ops[0], (ast.GtE, ast.LtE, ast.Gt, ast.Lt, ast.Eq, ast.NotEq)):
+            return False
+
+        if not (
+            isinstance(node.left, ast.Call)
+            and VersionMajorCheck._is_version_call(node.left, resolver)
+        ):
+            return False
+
+        comparator = node.comparators[0]
+        if not (
+            isinstance(comparator, ast.Call)
+            and VersionMajorCheck._is_version_call(comparator, resolver)
+        ):
+            return False
+
+        if (
+            len(comparator.args) == 1
+            and isinstance(comparator.args[0], ast.Constant)
+            and isinstance(comparator.args[0].value, str)
+        ):
+            version_str = comparator.args[0].value
+            return VersionMajorCheck._is_major_only_version(version_str)
+
+        return False
+
+    @staticmethod
+    def _is_version_call(node: ast.Call, resolver: "Resolver") -> bool:
+        if resolved := resolver.resolve(node.func):
+            return resolved == ["packaging", "version", "Version"]
+        return False
+
+    @staticmethod
+    def _is_major_only_version(version_str: str) -> bool:
+        pattern = r"^(\d+)\.0\.0$"
+        return re.match(pattern, version_str) is not None

--- a/dev/clint/src/clint/rules/version_major_check.py
+++ b/dev/clint/src/clint/rules/version_major_check.py
@@ -38,13 +38,10 @@ class MajorVersionCheck(Rule):
         ):
             return False
 
-        if (
-            len(comparator.args) == 1
-            and isinstance(comparator.args[0], ast.Constant)
-            and isinstance(comparator.args[0].value, str)
-        ):
-            version_str = comparator.args[0].value
-            return MajorVersionCheck._is_major_only_version(version_str)
+        match comparator.args:
+            case [arg] if isinstance(arg, ast.Constant) and isinstance(arg.value, str):
+                version_str = arg.value
+                return MajorVersionCheck._is_major_only_version(version_str)
 
         return False
 

--- a/dev/clint/tests/rules/test_version_major_check.py
+++ b/dev/clint/tests/rules/test_version_major_check.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from clint.config import Config
+from clint.linter import lint_file
+from clint.rules.version_major_check import VersionMajorCheck
+
+
+def test_version_major_check(index_path: Path) -> None:
+    code = """
+from packaging.version import Version
+
+Version("0.9.0") >= Version("1.0.0")
+Version("1.2.3").major >= 1
+Version("1.0.0") >= Version("0.83.0")
+Version("1.5.0") >= Version("2.0.0")
+Version("1.5.0") == Version("3.0.0")
+Version("1.5.0") != Version("4.0.0")
+"""
+    config = Config(select={VersionMajorCheck.name})
+    violations = lint_file(Path("test.py"), code, config, index_path)
+    assert len(violations) == 4
+    assert all(isinstance(v.rule, VersionMajorCheck) for v in violations)
+    assert violations[0].range.start.line == 3
+    assert violations[1].range.start.line == 6
+    assert violations[2].range.start.line == 7
+    assert violations[3].range.start.line == 8
+
+
+def test_version_major_check_no_violations(index_path: Path) -> None:
+    code = """
+from packaging.version import Version
+
+Version("1.2.3").major >= 1
+Version("1.0.0") >= Version("0.83.0")
+Version("1.5.0") >= Version("1.0.1")
+Version("1.5.0") >= Version("1.0.0.dev0")
+5 >= 3
+"""
+    config = Config(select={VersionMajorCheck.name})
+    violations = lint_file(Path("test.py"), code, config, index_path)
+    assert len(violations) == 0

--- a/dev/clint/tests/rules/test_version_major_check.py
+++ b/dev/clint/tests/rules/test_version_major_check.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from clint.config import Config
 from clint.linter import lint_file
-from clint.rules.version_major_check import VersionMajorCheck
+from clint.rules.version_major_check import MajorVersionCheck
 
 
 def test_version_major_check(index_path: Path) -> None:
@@ -16,10 +16,10 @@ Version("1.5.0") >= Version("2.0.0")
 Version("1.5.0") == Version("3.0.0")
 Version("1.5.0") != Version("4.0.0")
 """
-    config = Config(select={VersionMajorCheck.name})
+    config = Config(select={MajorVersionCheck.name})
     violations = lint_file(Path("test.py"), code, config, index_path)
     assert len(violations) == 4
-    assert all(isinstance(v.rule, VersionMajorCheck) for v in violations)
+    assert all(isinstance(v.rule, MajorVersionCheck) for v in violations)
     assert violations[0].range.start.line == 3
     assert violations[1].range.start.line == 6
     assert violations[2].range.start.line == 7
@@ -36,6 +36,6 @@ Version("1.5.0") >= Version("1.0.1")
 Version("1.5.0") >= Version("1.0.0.dev0")
 5 >= 3
 """
-    config = Config(select={VersionMajorCheck.name})
+    config = Config(select={MajorVersionCheck.name})
     violations = lint_file(Path("test.py"), code, config, index_path)
     assert len(violations) == 0

--- a/examples/spacy/train.py
+++ b/examples/spacy/train.py
@@ -7,7 +7,7 @@ from spacy.util import compounding, minibatch
 
 import mlflow.spacy
 
-IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__) >= Version("3.0.0")
+IS_SPACY_VERSION_NEWER_THAN_OR_EQUAL_TO_3_0_0 = Version(spacy.__version__).major >= 3
 
 # training data
 TRAIN_DATA = [

--- a/mlflow/keras/__init__.py
+++ b/mlflow/keras/__init__.py
@@ -2,7 +2,7 @@
 import keras
 from packaging.version import Version
 
-if Version(keras.__version__) < Version("3.0.0"):
+if Version(keras.__version__).major < 3:
     from mlflow.tensorflow import (
         # Redirect `mlflow.keras._load_pyfunc` to `mlflow.tensorflow._load_pyfunc`,
         # For backwards compatibility on loading keras model saved by old mlflow versions.

--- a/mlflow/transformers/__init__.py
+++ b/mlflow/transformers/__init__.py
@@ -2933,11 +2933,7 @@ def autolog(
 
         safe_patch(
             FLAVOR_NAME,
-            (
-                setfit.SetFitTrainer
-                if Version(setfit.__version__) < Version("1.0.0")
-                else setfit.Trainer
-            ),
+            (setfit.SetFitTrainer if Version(setfit.__version__).major < 1 else setfit.Trainer),
             "train",
             functools.partial(train),
             manage_run=False,

--- a/tests/tensorflow/test_keras_model_export.py
+++ b/tests/tensorflow/test_keras_model_export.py
@@ -58,7 +58,7 @@ def fix_random_seed():
     random.seed(SEED)
     np.random.seed(SEED)
 
-    if Version(tf.__version__) >= Version("2.0.0"):
+    if Version(tf.__version__).major >= 2:
         tf.random.set_seed(SEED)
     else:
         tf.set_random_seed(SEED)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18821?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18821/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18821/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18821/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR adds a new clint rule `MajorVersionCheck` that detects version comparisons using major-only version strings (e.g., `Version(...) >= Version("1.0.0")`) and suggests using the `.major` field instead (e.g., `Version(...).major >= 1`). This approach is more explicit, efficient (avoids creating a second Version object), and clearer in intent.

The rule also fixes 4 existing violations in the codebase.

### How is this PR tested?

- [x] New unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)