### PR TITLE
Fix evaluate_traces MCP tool error: use result_df instead of tables

### DIFF
--- a/mlflow/cli/eval.py
+++ b/mlflow/cli/eval.py
@@ -95,7 +95,7 @@ def evaluate_traces(
     except Exception as e:
         raise click.UsageError(f"Evaluation failed: {e}")
 
-    results_df = results.tables["eval_results"]
+    results_df = results.result_df
     output_data = extract_assessments_from_results(results_df, evaluation_run_id)
 
     if output_format == "json":

--- a/tests/cli/test_eval.py
+++ b/tests/cli/test_eval.py
@@ -190,30 +190,31 @@ def test_evaluate_traces_integration():
         """Simple scorer that always returns 1.0"""
         return 1.0
 
-    with mock.patch("mlflow.cli.eval.resolve_scorers", return_value=[simple_scorer]):
+    with mock.patch(
+        "mlflow.cli.eval.resolve_scorers", return_value=[simple_scorer]
+    ) as mock_resolve:
         evaluate_traces(
             experiment_id=experiment_id,
             trace_ids=",".join(trace_ids),
             scorers="simple_scorer",  # This will be intercepted by our mock
             output_format="table",
         )
+        mock_resolve.assert_called_once()
 
     # Verify that the evaluation results are correct
     # Get the traces and check that assessments were added
     traces = mlflow.search_traces(locations=[experiment_id], return_type="list")
-    assert len(traces) == 3, f"Expected 3 traces, got {len(traces)}"
+    assert len(traces) == 3
 
     # Verify each trace has the assessment
     for trace in traces:
         assessments = trace.info.assessments
-        assert len(assessments) > 0, f"Trace {trace.info.trace_id} has no assessments"
+        assert len(assessments) > 0
 
         # Find the simple_scorer assessment
         scorer_assessments = [a for a in assessments if a.name == "simple_scorer"]
-        assert len(scorer_assessments) == 1, (
-            f"Expected 1 simple_scorer assessment, got {len(scorer_assessments)}"
-        )
+        assert len(scorer_assessments) == 1
 
         # Verify the assessment value
         assessment = scorer_assessments[0]
-        assert assessment.value == 1.0, f"Expected value 1.0, got {assessment.value}"
+        assert assessment.value == 1.0

--- a/tests/cli/test_eval.py
+++ b/tests/cli/test_eval.py
@@ -1,3 +1,4 @@
+import re
 from unittest import mock
 
 import click
@@ -188,8 +189,6 @@ def test_evaluate_traces_integration():
     @scorer
     def simple_scorer(outputs):
         """Extract the digit from the output string and return it as the score"""
-        import re
-
         match = re.search(r"\d+", outputs)
         if match:
             return float(match.group())


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/18825?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18825/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18825/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18825/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR fixes a critical bug where the `evaluate_traces` MCP tool and CLI command were failing with the error: `'EvaluationResult' object has no attribute 'tables'`.

**Root Cause:** The GenAI evaluation framework was refactored to use a simpler `EvaluationResult` dataclass (from `mlflow.genai.evaluation.entities`) that directly contains a `result_df` attribute instead of managing artifacts through a `tables` dictionary. The CLI code wasn't updated to match this new interface.

**Changes:**
- Updated `mlflow/cli/eval.py` line 98 to access `results.result_df` instead of `results.tables["eval_results"]`
- Updated test mocks in `tests/cli/test_eval.py` to use `result_df` instead of `tables` dict
- Added integration test `test_evaluate_traces_integration` that calls real `mlflow.genai.evaluate()` to verify the fix works with actual `EvaluationResult` objects
- Added comprehensive assertions to verify evaluation results and assessments are properly added to traces

### How is this PR tested?

- [x] Existing unit/integration tests (4 tests updated)
- [x] New unit/integration tests (1 integration test added)
- [x] Manual tests (tested with real Databricks experiment and traces)

**Test Results:**
- All 5 tests in `tests/cli/test_eval.py` pass
- Manual test with Databricks backend: `mlflow traces evaluate --experiment-id "1981078730619533" --trace-ids "tr-98265006e34f528e6023e1ce996872f1,tr-d0deba0f53fb1cfca14ef46086fb7cec,tr-9bf63029098e62ebca51e9c246663411" --scorers "RelevanceToQuery"` completed successfully
- Integration test validates the complete evaluation flow without mocking

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

**Description:** Fixed a bug where the `mlflow traces evaluate` CLI command and the MCP tool `evaluate_traces` would fail with `'EvaluationResult' object has no attribute 'tables'` when evaluating traces. The command now correctly accesses the evaluation results using the current API.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)