### PR TITLE
Update support URL to use UI bug report template

### DIFF
--- a/mlflow/server/js/src/common/constants.tsx
+++ b/mlflow/server/js/src/common/constants.tsx
@@ -37,7 +37,7 @@ export const LoggingRunsDocUrl = `${DOCS_ROOT}/tracking.html#logging-data-to-run
 
 export const onboarding = 'onboarding';
 
-export const SupportPageUrl = 'https://github.com/mlflow/mlflow/issues';
+export const SupportPageUrl = 'https://github.com/mlflow/mlflow/issues/new?template=ui_bug_report_template.yaml';
 
 export const ModelSignatureUrl = `${DOCS_ROOT}/models.html#model-signature`;
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18828?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18828/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18828/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18828/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Updated the support page URL in `constants.tsx` to point directly to the UI bug report template (`/issues/new?template=ui_bug_report_template.yaml`) instead of the generic issues page. This provides a better user experience by pre-selecting the appropriate issue template for UI-related feedback.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The support link in the MLflow UI now opens the UI bug report template directly, making it easier for users to report UI-specific issues.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)