### PR TITLE
Fix _parse_model_uri to support providers with underscores (e.g., vertex_ai, azure_ai)

### DIFF
--- a/mlflow/metrics/genai/model_utils.py
+++ b/mlflow/metrics/genai/model_utils.py
@@ -76,19 +76,26 @@ def score_model_on_payload(
         error_code=INVALID_PARAMETER_VALUE,
     )
 
+def _parse_model_uri(model_uri: str):
+    """Parse a model URI of the form "<provider>:/<model-name>"."""
 
-def _parse_model_uri(model_uri):
-    parsed = urllib.parse.urlparse(model_uri, allow_fragments=False)
-    scheme = parsed.scheme
-    path = parsed.path
-    if not path.startswith("/") or len(path) <= 1:
+    if ":/" not in model_uri:
         raise MlflowException(
             f"Malformed model uri '{model_uri}'. The URI must be in the format of "
             "<provider>:/<model-name>, e.g., 'openai:/gpt-4.1-mini'.",
             error_code=INVALID_PARAMETER_VALUE,
         )
-    path = path.lstrip("/")
-    return scheme, path
+
+    provider, model_path = model_uri.split(":/", 1)
+
+    if not provider or not model_path:
+        raise MlflowException(
+            f"Malformed model uri '{model_uri}'. The URI must be in the format of "
+            "<provider>:/<model-name>, e.g., 'openai:/gpt-4.1-mini'.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    return provider, model_path
 
 
 _PREDICT_ERROR_MSG = """\

--- a/mlflow/metrics/genai/test_parse_model_uri_simple.py
+++ b/mlflow/metrics/genai/test_parse_model_uri_simple.py
@@ -1,0 +1,16 @@
+from mlflow.metrics.genai.model_utils import _parse_model_uri
+import pytest
+
+def test_parse_model_uri_with_underscore_provider():
+    provider, model = _parse_model_uri("vertex_ai:/gemini-2.0")
+    assert provider == "vertex_ai"
+    assert model == "gemini-2.0"
+
+def test_parse_model_uri_standard_provider():
+    provider, model = _parse_model_uri("openai:/gpt-4.1-mini")
+    assert provider == "openai"
+    assert model == "gpt-4.1-mini"
+
+def test_parse_model_uri_invalid_format():
+    with pytest.raises(Exception):
+        _parse_model_uri("vertex_ai:gemini")  # missing '/'


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/RohanRouth/mlflow/pull/18848?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18848/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18848/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18848/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

None
<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
This PR fixes a bug in _parse_model_uri where provider names containing underscores (e.g., vertex_ai, azure_ai, google_ai_studio) are rejected due to reliance on urllib.parse.urlparse.
Because MLflow model URIs are not URLs and do not follow RFC 3986 scheme rules, urlparse incorrectly places the entire URI into the path component, causing valid URIs to fail with:

Malformed model uri '<provider>:/<model>'

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
<img width="2014" height="645" alt="image" src="https://github.com/user-attachments/assets/106f52c4-65e5-48ce-b50b-be2757c2c785" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.
Fixes a bug where valid model URIs using providers like vertex_ai:/gemini-2.0 were incorrectly rejected.
<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
