### PR TITLE
Add show/hide visibility control for Evaluation runs chart view (#18797)

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsVisibilityHeaderCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsVisibilityHeaderCell.tsx
@@ -26,9 +26,9 @@ export const EvalRunsVisibilityHeaderCell = React.memo(() => {
             description: 'Evaluation runs table > toggle visibility of runs > accessible label',
           })}
         >
-          {visibilityMode === RUNS_VISIBILITY_MODE.HIDEALL || 
-           visibilityMode === RUNS_VISIBILITY_MODE.HIDE_FINISHED_RUNS || 
-           allRunsHidden ? (
+          {visibilityMode === RUNS_VISIBILITY_MODE.HIDEALL ||
+          visibilityMode === RUNS_VISIBILITY_MODE.HIDE_FINISHED_RUNS ||
+          allRunsHidden ? (
             <VisibleOffIcon />
           ) : (
             <VisibleIcon />
@@ -106,4 +106,3 @@ const styles = {
     },
   }),
 };
-

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsVisibilityHeaderCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/EvalRunsVisibilityHeaderCell.tsx
@@ -1,0 +1,109 @@
+import { DashIcon, DropdownMenu, VisibleIcon, VisibleOffIcon, useDesignSystemTheme } from '@databricks/design-system';
+import type { Theme } from '@emotion/react';
+import React from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { RUNS_VISIBILITY_MODE } from '../../components/experiment-page/models/ExperimentPageUIState';
+import { useExperimentEvaluationRunsRowVisibility } from './hooks/useExperimentEvaluationRunsRowVisibility';
+
+/**
+ * Header cell component for the visibility column in evaluation runs table.
+ * Displays an eye icon button that opens a dropdown menu with visibility mode options.
+ */
+export const EvalRunsVisibilityHeaderCell = React.memo(() => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const { visibilityMode, setVisibilityMode, usingCustomVisibility, allRunsHidden } =
+    useExperimentEvaluationRunsRowVisibility();
+
+  return (
+    <DropdownMenu.Root modal={false}>
+      <DropdownMenu.Trigger asChild>
+        <button
+          css={styles.actionButton(theme)}
+          data-testid="eval-runs-visibility-column-header"
+          aria-label={intl.formatMessage({
+            defaultMessage: 'Toggle visibility of evaluation runs',
+            description: 'Evaluation runs table > toggle visibility of runs > accessible label',
+          })}
+        >
+          {visibilityMode === RUNS_VISIBILITY_MODE.HIDEALL || 
+           visibilityMode === RUNS_VISIBILITY_MODE.HIDE_FINISHED_RUNS || 
+           allRunsHidden ? (
+            <VisibleOffIcon />
+          ) : (
+            <VisibleIcon />
+          )}
+        </button>
+      </DropdownMenu.Trigger>
+
+      <DropdownMenu.Content>
+        <DropdownMenu.RadioGroup
+          componentId="mlflow.eval-runs.visibility-mode-selector"
+          value={visibilityMode}
+          onValueChange={(value) => setVisibilityMode(value as RUNS_VISIBILITY_MODE)}
+        >
+          <DropdownMenu.RadioItem value={RUNS_VISIBILITY_MODE.FIRST_10_RUNS}>
+            {/* Dropdown menu does not support indeterminate state, so we're doing it manually */}
+            <DropdownMenu.ItemIndicator>{usingCustomVisibility ? <DashIcon /> : null}</DropdownMenu.ItemIndicator>
+            <FormattedMessage
+              defaultMessage="Show first 10"
+              description="Menu option for showing only 10 first runs in the evaluation runs table"
+            />
+          </DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value={RUNS_VISIBILITY_MODE.FIRST_20_RUNS}>
+            <DropdownMenu.ItemIndicator>{usingCustomVisibility ? <DashIcon /> : null}</DropdownMenu.ItemIndicator>
+            <FormattedMessage
+              defaultMessage="Show first 20"
+              description="Menu option for showing only 20 first runs in the evaluation runs table"
+            />
+          </DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value={RUNS_VISIBILITY_MODE.SHOWALL}>
+            <DropdownMenu.ItemIndicator>{usingCustomVisibility ? <DashIcon /> : null}</DropdownMenu.ItemIndicator>
+            <FormattedMessage
+              defaultMessage="Show all runs"
+              description="Menu option for revealing all hidden runs in the evaluation runs table"
+            />
+          </DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value={RUNS_VISIBILITY_MODE.HIDEALL}>
+            <DropdownMenu.ItemIndicator>{usingCustomVisibility ? <DashIcon /> : null}</DropdownMenu.ItemIndicator>
+            <FormattedMessage
+              defaultMessage="Hide all runs"
+              description="Menu option for hiding all runs in the evaluation runs table"
+            />
+          </DropdownMenu.RadioItem>
+          <DropdownMenu.RadioItem value={RUNS_VISIBILITY_MODE.HIDE_FINISHED_RUNS}>
+            <DropdownMenu.ItemIndicator>{usingCustomVisibility ? <DashIcon /> : null}</DropdownMenu.ItemIndicator>
+            <FormattedMessage
+              defaultMessage="Hide finished runs"
+              description="Menu option for hiding all finished runs in the evaluation runs table"
+            />
+          </DropdownMenu.RadioItem>
+        </DropdownMenu.RadioGroup>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  );
+});
+
+const styles = {
+  actionButton: (theme: Theme) => ({
+    background: 'transparent',
+    border: 'none',
+    cursor: 'pointer',
+    padding: 0,
+    margin: 0,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'flex-start',
+    verticalAlign: 'text-bottom',
+    minWidth: 24,
+    minHeight: 24,
+    svg: {
+      width: theme.general.iconFontSize,
+      height: theme.general.iconFontSize,
+      cursor: 'pointer',
+      color: theme.colors.textPrimary,
+      flexShrink: 0,
+    },
+  }),
+};
+

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.constants.tsx
@@ -13,6 +13,7 @@ import type { ColumnDef } from '@tanstack/react-table';
 import type { Theme, Interpolation } from '@emotion/react';
 import type { RunEntityOrGroupData } from './ExperimentEvaluationRunsPage.utils';
 import { ExperimentEvaluationRunsPageMode } from './hooks/useExperimentEvaluationRunsPageMode';
+import { EvalRunsVisibilityHeaderCell } from './EvalRunsVisibilityHeaderCell';
 
 export interface ExperimentEvaluationRunsTableMeta {
   setSelectedRunUuid: (runUuid: string) => void;
@@ -124,10 +125,12 @@ export const getExperimentEvalRunsDefaultColumns = (
   if (viewMode === ExperimentEvaluationRunsPageMode.CHARTS) {
     unselectableColumns.push({
       id: EvalRunsTableColumnId.visibility,
+      header: EvalRunsVisibilityHeaderCell,
       cell: VisiblityCell,
-      enableResizing: true,
-      size: 32,
-      meta: { styles: { minWidth: 32, maxWidth: 32 } },
+      enableResizing: false,
+      enableSorting: false,
+      size: 40,
+      meta: { styles: { minWidth: 40, maxWidth: 40, padding: '0 4px' } },
     });
   }
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTable.tsx
@@ -145,6 +145,7 @@ export const ExperimentEvaluationRunsTable = forwardRef<HTMLDivElement, Experime
         {!isLoading &&
           table.getRowModel().rows.map((row) => {
             const isActive = 'info' in row.original ? row.original.info.runUuid === selectedRunUuid : false;
+            const runStatus = 'info' in row.original ? row.original.info.status : undefined;
             return (
               <ExperimentEvaluationRunsTableRow
                 key={row.id}
@@ -152,7 +153,7 @@ export const ExperimentEvaluationRunsTable = forwardRef<HTMLDivElement, Experime
                 isActive={isActive}
                 isSelected={rowSelection[row.id]}
                 isExpanded={row.getIsExpanded()}
-                isHidden={isRowHidden(row.id)}
+                isHidden={isRowHidden(row.id, row.index, runStatus)}
                 columns={columns}
               />
             );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/ExperimentEvaluationRunsTableCellRenderers.tsx
@@ -296,7 +296,9 @@ export const VisiblityCell: ColumnDef<RunEntityOrGroupData>['cell'] = ({ row, ta
     return <div>-</div>;
   }
   const runUuid = row.original.info.runUuid;
-  const Icon = isRowHidden(runUuid) ? VisibleOffIcon : VisibleIcon;
+  const rowIndex = row.index;
+  const runStatus = row.original.info.status;
+  const Icon = isRowHidden(runUuid, rowIndex, runStatus) ? VisibleOffIcon : VisibleIcon;
 
-  return <Icon onClick={() => toggleRowVisibility(runUuid)} />;
+  return <Icon onClick={() => toggleRowVisibility(runUuid)} css={{ cursor: 'pointer' }} />;
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/charts/ExperimentEvaluationRunsPageCharts.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/charts/ExperimentEvaluationRunsPageCharts.tsx
@@ -51,7 +51,7 @@ const ExperimentEvaluationRunsPageChartsImpl = ({
   const chartData: RunsChartsRunData[] = useMemo(() => {
     return runs
       .filter((run) => run.info)
-      .map<RunsChartsRunData>((run) => {
+      .map<RunsChartsRunData>((run, index) => {
         const metricsByKey = keyBy(run.data?.metrics, 'key');
         const paramsByKey = keyBy(run.data?.params, 'key');
         const tagsByKey = keyBy(run.data?.tags, 'key');
@@ -65,7 +65,7 @@ const ExperimentEvaluationRunsPageChartsImpl = ({
           uuid: run.info.runUuid,
           color: getRunColor(run.info.runUuid),
           runInfo: run.info,
-          hidden: isRowHidden(run.info.runUuid),
+          hidden: isRowHidden(run.info.runUuid, index, run.info.status),
         };
       });
   }, [runs, isRowHidden, getRunColor]);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsRowVisibility.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsRowVisibility.tsx
@@ -1,21 +1,56 @@
 import { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import { RUNS_VISIBILITY_MODE } from '../../../components/experiment-page/models/ExperimentPageUIState';
 
-const ExperimentEvaluationRunsRowVisibilityContext = createContext<{
-  isRowHidden: (rowUuid: string) => boolean;
+interface ExperimentEvaluationRunsRowVisibilityContextValue {
+  isRowHidden: (rowUuid: string, rowIndex: number, runStatus?: string) => boolean;
   toggleRowVisibility: (rowUuid: string) => void;
-}>({
+  setVisibilityMode: (mode: RUNS_VISIBILITY_MODE) => void;
+  visibilityMode: RUNS_VISIBILITY_MODE;
+  usingCustomVisibility: boolean;
+  allRunsHidden: boolean;
+}
+
+const ExperimentEvaluationRunsRowVisibilityContext = createContext<ExperimentEvaluationRunsRowVisibilityContextValue>({
   isRowHidden: () => false,
   toggleRowVisibility: () => {},
+  setVisibilityMode: () => {},
+  visibilityMode: RUNS_VISIBILITY_MODE.SHOWALL,
+  usingCustomVisibility: false,
+  allRunsHidden: false,
 });
 
 export const ExperimentEvaluationRunsRowVisibilityProvider = ({ children }: { children: React.ReactNode }) => {
   const [hiddenRuns, setHiddenRuns] = useState<Set<string>>(new Set());
+  const [visibilityMode, setVisibilityModeState] = useState<RUNS_VISIBILITY_MODE>(RUNS_VISIBILITY_MODE.SHOWALL);
 
   const isRowHidden = useCallback(
-    (rowUuid: string) => {
-      return hiddenRuns.has(rowUuid);
+    (rowUuid: string, rowIndex: number, runStatus?: string) => {
+      // If custom mode, check the hiddenRuns set
+      if (visibilityMode === RUNS_VISIBILITY_MODE.CUSTOM) {
+        return hiddenRuns.has(rowUuid);
+      }
+
+      // For other modes, apply the mode logic
+      if (visibilityMode === RUNS_VISIBILITY_MODE.HIDEALL) {
+        return true;
+      }
+
+      if (visibilityMode === RUNS_VISIBILITY_MODE.FIRST_10_RUNS) {
+        return rowIndex >= 10;
+      }
+
+      if (visibilityMode === RUNS_VISIBILITY_MODE.FIRST_20_RUNS) {
+        return rowIndex >= 20;
+      }
+
+      if (visibilityMode === RUNS_VISIBILITY_MODE.HIDE_FINISHED_RUNS) {
+        return ['FINISHED', 'FAILED', 'KILLED'].includes(runStatus ?? '');
+      }
+
+      // SHOWALL mode - show everything
+      return false;
     },
-    [hiddenRuns],
+    [hiddenRuns, visibilityMode],
   );
 
   const toggleRowVisibility = useCallback(
@@ -29,11 +64,34 @@ export const ExperimentEvaluationRunsRowVisibilityProvider = ({ children }: { ch
         }
         return newHiddenRuns;
       });
+      // Switch to custom mode when manually toggling
+      setVisibilityModeState(RUNS_VISIBILITY_MODE.CUSTOM);
     },
-    [setHiddenRuns],
+    [],
   );
 
-  const value = useMemo(() => ({ isRowHidden, toggleRowVisibility }), [isRowHidden, toggleRowVisibility]);
+  const setVisibilityMode = useCallback((mode: RUNS_VISIBILITY_MODE) => {
+    setVisibilityModeState(mode);
+    // Clear custom hidden runs when switching to a predefined mode
+    if (mode !== RUNS_VISIBILITY_MODE.CUSTOM) {
+      setHiddenRuns(new Set());
+    }
+  }, []);
+
+  const usingCustomVisibility = visibilityMode === RUNS_VISIBILITY_MODE.CUSTOM && hiddenRuns.size > 0;
+  const allRunsHidden = visibilityMode === RUNS_VISIBILITY_MODE.HIDEALL;
+
+  const value = useMemo(
+    () => ({
+      isRowHidden,
+      toggleRowVisibility,
+      setVisibilityMode,
+      visibilityMode,
+      usingCustomVisibility,
+      allRunsHidden,
+    }),
+    [isRowHidden, toggleRowVisibility, setVisibilityMode, visibilityMode, usingCustomVisibility, allRunsHidden],
+  );
 
   return (
     <ExperimentEvaluationRunsRowVisibilityContext.Provider value={value}>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsRowVisibility.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-runs/hooks/useExperimentEvaluationRunsRowVisibility.tsx
@@ -53,22 +53,19 @@ export const ExperimentEvaluationRunsRowVisibilityProvider = ({ children }: { ch
     [hiddenRuns, visibilityMode],
   );
 
-  const toggleRowVisibility = useCallback(
-    (rowUuid: string) => {
-      setHiddenRuns((prevHiddenRuns) => {
-        const newHiddenRuns = new Set(prevHiddenRuns);
-        if (newHiddenRuns.has(rowUuid)) {
-          newHiddenRuns.delete(rowUuid);
-        } else {
-          newHiddenRuns.add(rowUuid);
-        }
-        return newHiddenRuns;
-      });
-      // Switch to custom mode when manually toggling
-      setVisibilityModeState(RUNS_VISIBILITY_MODE.CUSTOM);
-    },
-    [],
-  );
+  const toggleRowVisibility = useCallback((rowUuid: string) => {
+    setHiddenRuns((prevHiddenRuns) => {
+      const newHiddenRuns = new Set(prevHiddenRuns);
+      if (newHiddenRuns.has(rowUuid)) {
+        newHiddenRuns.delete(rowUuid);
+      } else {
+        newHiddenRuns.add(rowUuid);
+      }
+      return newHiddenRuns;
+    });
+    // Switch to custom mode when manually toggling
+    setVisibilityModeState(RUNS_VISIBILITY_MODE.CUSTOM);
+  }, []);
 
   const setVisibilityMode = useCallback((mode: RUNS_VISIBILITY_MODE) => {
     setVisibilityModeState(mode);

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2398,6 +2398,10 @@
     "defaultMessage": "Retrieval Relevance",
     "description": "LLM template option"
   },
+  "LK+UHk": {
+    "defaultMessage": "Show first 20",
+    "description": "Menu option for showing only 20 first runs in the evaluation runs table"
+  },
   "LKAZ2n": {
     "defaultMessage": "Disable grouped runs to compare",
     "description": "Experiment tracking > components > runs-charts > RunsChartsConfigureDifferenceCharts > disable grouped runs info message"
@@ -2833,6 +2837,10 @@
     "defaultMessage": "No params",
     "description": "Experiment page > group by runs control > no params to group by"
   },
+  "Q7MSrQ": {
+    "defaultMessage": "Hide finished runs",
+    "description": "Menu option for hiding all finished runs in the evaluation runs table"
+  },
   "QAyzA3": {
     "defaultMessage": "Delete",
     "description": "Experiment page > traces view controls > Delete button"
@@ -2856,6 +2864,10 @@
   "QGiy9C": {
     "defaultMessage": "About this run",
     "description": "Title for the details/metadata section on the run details page"
+  },
+  "QH2RJZ": {
+    "defaultMessage": "Hide all runs",
+    "description": "Menu option for hiding all runs in the evaluation runs table"
   },
   "QHTLV9": {
     "defaultMessage": "Models",
@@ -3407,6 +3419,10 @@
   "W8bOkn": {
     "defaultMessage": "250",
     "description": "Label for 250 first runs visible in run count selector within runs compare configuration modal"
+  },
+  "WDqWWa": {
+    "defaultMessage": "Show all runs",
+    "description": "Menu option for revealing all hidden runs in the evaluation runs table"
   },
   "WELl8J": {
     "defaultMessage": "+{count} more",
@@ -6103,6 +6119,10 @@
     "defaultMessage": "Suggested actions",
     "description": "Evaluation review > assessments > suggested actions > title"
   },
+  "vEuvEt": {
+    "defaultMessage": "Show first 10",
+    "description": "Menu option for showing only 10 first runs in the evaluation runs table"
+  },
   "vHNP+J": {
     "defaultMessage": "Add tags",
     "description": "Button text to add tags to a trace in the experiment traces table"
@@ -6218,6 +6238,10 @@
   "wFvyI1": {
     "defaultMessage": "Registered at:",
     "description": "A label for the registration timestamp in the prompt details page"
+  },
+  "wKXJ6U": {
+    "defaultMessage": "Toggle visibility of evaluation runs",
+    "description": "Evaluation runs table > toggle visibility of runs > accessible label"
   },
   "wMG8+P": {
     "defaultMessage": "To search by tags or by names and tags, use a simplified version{newline}of the SQL {whereBold} clause.",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/pradpalnis/mlflow/pull/18852?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18852/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18852/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18852/merge
```

</p>
</details>

- Added header eye icon dropdown with visibility modes (Show first 10/20, Show all, Hide all, Hide finished runs)
- Implemented EvalRunsVisibilityHeaderCell component for bulk visibility control
- Enhanced useExperimentEvaluationRunsRowVisibility hook to support visibility modes
- Updated chart rendering to respect visibility settings
- Aligned icon styling with traditional runs page design

Fixes #18797

### Related Issues/PRs

<!-- Resolve --> #18797

### What changes are proposed in this pull request?

This PR adds show/hide visibility control functionality to the Evaluation runs page (CHARTS mode only), matching the existing functionality in the traditional runs page. Users can now:

- Use a header eye icon dropdown to apply bulk visibility filters (Show first 10/20, Show all, Hide all, Hide finished runs)
- Toggle individual run visibility while maintaining custom state
- See consistent visual alignment and behavior with the traditional runs page eye icon

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

**Manual testing performed:**
- Verified all visibility modes work correctly in CHARTS view
- Tested individual row toggles work alongside bulk controls
- Confirmed icon alignment and styling matches traditional runs page
- Validated chart rendering respects visibility settings for all modes
- Tested interaction between custom visibility and predefined modes

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added visibility control dropdown to Evaluation runs chart view, allowing users to bulk show/hide runs using the same eye icon functionality available in the traditional runs page.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)