### PR TITLE
Fix Click 8.3.0 `Sentinel.UNSET` handling in MCP server

### DIFF
--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -42,7 +42,11 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
             "type": param_type_to_json_schema_type(p.type),
         }
         if p.default is not None:
-            schema["default"] = p.default
+            schema["default"] = p.default and (
+                # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
+                # provided. Skip setting the default in this case.
+                not isinstance(p.default, str) and repr(p.default) != "Sentinel.UNSET"
+            )
         if isinstance(p, click.Option):
             schema["description"] = (p.help or "").strip()
         if isinstance(p.type, click.Choice):

--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -45,6 +45,7 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
             schema["default"] = p.default and (
                 # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
                 # provided. Skip setting the default in this case.
+                # https://github.com/pallets/click/commit/b64ea07128a6368b5f6f93035c75d5693c7ba572
                 not isinstance(p.default, str) and repr(p.default) != "Sentinel.UNSET"
             )
         if isinstance(p, click.Option):

--- a/mlflow/mcp/server.py
+++ b/mlflow/mcp/server.py
@@ -41,13 +41,13 @@ def get_input_schema(params: list[click.Parameter]) -> dict[str, Any]:
         schema = {
             "type": param_type_to_json_schema_type(p.type),
         }
-        if p.default is not None:
-            schema["default"] = p.default and (
-                # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
-                # provided. Skip setting the default in this case.
-                # https://github.com/pallets/click/commit/b64ea07128a6368b5f6f93035c75d5693c7ba572
-                not isinstance(p.default, str) and repr(p.default) != "Sentinel.UNSET"
-            )
+        if p.default is not None and (
+            # In click >= 8.3.0, the default value is set to `Sentinel.UNSET` when no default is
+            # provided. Skip setting the default in this case.
+            # See https://github.com/pallets/click/pull/3030 for more details.
+            not isinstance(p.default, str) and repr(p.default) != "Sentinel.UNSET"
+        ):
+            schema["default"] = p.default
         if isinstance(p, click.Option):
             schema["description"] = (p.help or "").strip()
         if isinstance(p.type, click.Choice):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,7 +198,6 @@ build = ["pip", "setuptools", "wheel", "build"]
 [tool.uv]
 required-version = "==0.9.8"
 constraint-dependencies = [
-  "click!=8.3.0",
   "langchain<1.0.0",
   # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
   # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,9 +11,6 @@ json_repair!=0.45.0
 # https://github.com/huggingface/transformers/issues/38269
 transformers!=4.52.2
 transformers!=4.52.1
-# https://github.com/pallets/click/issues/3065
-# click 8.3.0 has a bug that causes tests to hang
-click!=8.3.0
 # xgboost 3.1.0 changed base_score format to vector for multi-output models, breaking shap compatibility
 # https://xgboost.readthedocs.io/en/latest/changes/v3.1.0.html#multi-target-class-intercept
 xgboost<3.1.0

--- a/uv.lock
+++ b/uv.lock
@@ -1045,14 +1045,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.2.1"
+version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/60/6c/8ca2efa64cf75a977a0d7fac081354553ebe483345c734fb6b6515d96bbc/click-8.2.1.tar.gz", hash = "sha256:27c491cc05d968d271d5a1db13e3b5a184636d9d930f148c50b038f0d0646202", size = 286342, upload-time = "2025-05-20T23:19:49.832Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/32/10bb5764d90a8eee674e9dc6f4db6a0ab47c8c4d0d83c27f7c39ac415a4d/click-8.2.1-py3-none-any.whl", hash = "sha256:61a3265b914e850b85317d0b3109c7f8cd35a670f963866005d6ef1d5175a12b", size = 102215, upload-time = "2025-05-20T23:19:47.796Z" },
+    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,6 @@ members = [
     "mlflow-test-plugin",
 ]
 constraints = [
-    { name = "click", specifier = "!=8.3.0" },
     { name = "langchain", specifier = "<1.0.0" },
     { name = "xgboost", specifier = "<3.1.0" },
 ]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18858?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18858/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18858/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18858/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Click 8.3.0 introduced a new `Sentinel.UNSET` value for default parameters when no default is provided. This change updates the MCP server to handle this new value correctly and removes the `click!=8.3.0` constraint that was blocking users from using the latest Click version.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed MCP server compatibility with Click 8.3.0 by handling the new Sentinel.UNSET default value.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)