### PR TITLE
Fix race condition in `test_prompt_webhook_with_mixed_events`

### DIFF
--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -895,6 +895,7 @@ def test_prompt_webhook_with_mixed_events(
     logs = app_client.wait_for_logs(expected_count=4, timeout=10)
     assert len(logs) == 4
 
+    # Webhooks are processed asynchronously and may arrive out of order
     expected_payloads = [
         {
             "name": "regular_model",
@@ -922,7 +923,6 @@ def test_prompt_webhook_with_mixed_events(
             "tags": {},
         },
     ]
-
     actual_payloads = [log.payload for log in logs]
     assert sorted(actual_payloads, key=str) == sorted(expected_payloads, key=str)
 

--- a/tests/webhooks/test_e2e.py
+++ b/tests/webhooks/test_e2e.py
@@ -895,32 +895,36 @@ def test_prompt_webhook_with_mixed_events(
     logs = app_client.wait_for_logs(expected_count=4, timeout=10)
     assert len(logs) == 4
 
-    log_0, log_1, log_2, log_3 = logs
-    assert log_0.payload == {
-        "name": "regular_model",
-        "description": "Regular model description",
-        "tags": {},
-    }
-    assert log_1.payload == {
-        "name": "test_prompt_mixed",
-        "description": "Prompt description",
-        "tags": {},
-    }
-    assert log_2.payload == {
-        "name": "regular_model",
-        "source": "s3://bucket/model",
-        "run_id": "1234567890abcdef",
-        "version": "1",
-        "description": None,
-        "tags": {},
-    }
-    assert log_3.payload == {
-        "name": "test_prompt_mixed",
-        "template": "Hello {{name}}!",
-        "version": "1",
-        "description": None,
-        "tags": {},
-    }
+    expected_payloads = [
+        {
+            "name": "regular_model",
+            "description": "Regular model description",
+            "tags": {},
+        },
+        {
+            "name": "test_prompt_mixed",
+            "description": "Prompt description",
+            "tags": {},
+        },
+        {
+            "name": "regular_model",
+            "source": "s3://bucket/model",
+            "run_id": "1234567890abcdef",
+            "version": "1",
+            "description": None,
+            "tags": {},
+        },
+        {
+            "name": "test_prompt_mixed",
+            "template": "Hello {{name}}!",
+            "version": "1",
+            "description": None,
+            "tags": {},
+        },
+    ]
+
+    actual_payloads = [log.payload for log in logs]
+    assert sorted(actual_payloads, key=str) == sorted(expected_payloads, key=str)
 
 
 def test_prompt_webhook_test_endpoint(mlflow_client: MlflowClient, app_client: AppClient) -> None:


### PR DESCRIPTION
### Related Issues/PRs

Fixes flaky test failure from https://github.com/mlflow/mlflow/actions/runs/19416355823/job/55545319550?pr=18858

### What changes are proposed in this pull request?

Fix a race condition in the `test_prompt_webhook_with_mixed_events` test where webhooks were being delivered out of order, causing intermittent test failures.

The test was assuming webhooks would arrive in sequential order, but webhook processing is asynchronous. The failure manifested as:

```
AssertionError: assert {'description...t/model', ...} == {'description...', 'tags': {}}
Differing items:
{'description': None} != {'description': 'Prompt description'}
{'name': 'regular_model'} != {'name': 'test_prompt_mixed'}
```

The fix sorts both expected and actual webhook payloads before comparison, making the test order-independent while still verifying all expected webhooks are delivered.

### How is this PR tested?

- [x] Existing unit/integration tests

Verified that `test_prompt_webhook_with_mixed_events` and all other webhook tests pass consistently.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)