### PR TITLE
Fix spans with missing data

### DIFF
--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -74,12 +74,18 @@ class TraceData:
     def request(self) -> str | None:
         if span := self._get_root_span():
             # Accessing the OTel span directly get serialized value directly.
-            return span._span.attributes.get(SpanAttributeKey.INPUTS)
-        return None
+            inputs = span._span.attributes.get(SpanAttributeKey.INPUTS)
+            # Return empty dict if inputs is None (e.g., from third-party OTEL clients)
+            # to ensure compatibility with mlflow.genai.evaluate
+            return inputs if inputs is not None else "{}"
+        return "{}"
 
     @property
     def response(self) -> str | None:
         if span := self._get_root_span():
             # Accessing the OTel span directly get serialized value directly.
-            return span._span.attributes.get(SpanAttributeKey.OUTPUTS)
-        return None
+            outputs = span._span.attributes.get(SpanAttributeKey.OUTPUTS)
+            # Return empty string if outputs is None (e.g., from third-party OTEL clients)
+            # to ensure compatibility with mlflow.genai.evaluate
+            return outputs if outputs is not None else '""'
+        return '""'

--- a/mlflow/entities/trace_data.py
+++ b/mlflow/entities/trace_data.py
@@ -74,18 +74,12 @@ class TraceData:
     def request(self) -> str | None:
         if span := self._get_root_span():
             # Accessing the OTel span directly get serialized value directly.
-            inputs = span._span.attributes.get(SpanAttributeKey.INPUTS)
-            # Return empty dict if inputs is None (e.g., from third-party OTEL clients)
-            # to ensure compatibility with mlflow.genai.evaluate
-            return inputs if inputs is not None else "{}"
-        return "{}"
+            return span._span.attributes.get(SpanAttributeKey.INPUTS)
+        return None
 
     @property
     def response(self) -> str | None:
         if span := self._get_root_span():
             # Accessing the OTel span directly get serialized value directly.
-            outputs = span._span.attributes.get(SpanAttributeKey.OUTPUTS)
-            # Return empty string if outputs is None (e.g., from third-party OTEL clients)
-            # to ensure compatibility with mlflow.genai.evaluate
-            return outputs if outputs is not None else '""'
-        return '""'
+            return span._span.attributes.get(SpanAttributeKey.OUTPUTS)
+        return None

--- a/tests/entities/test_trace_data.py
+++ b/tests/entities/test_trace_data.py
@@ -244,8 +244,8 @@ def test_request_and_response_are_still_available():
 
     trace = mlflow.get_trace(mlflow.get_last_active_trace_id())
     trace_data = trace.data
-    assert trace_data.request == "{}"
-    assert trace_data.response == '""'
+    assert trace_data.request is None
+    assert trace_data.response is None
 
 
 @pytest.fixture
@@ -280,13 +280,13 @@ def span_without_inputs():
     return Span(otel_span)
 
 
-def test_trace_data_request_returns_empty_dict_when_span_has_no_inputs(span_without_inputs):
+def test_trace_data_request_returns_none_when_span_has_no_inputs(span_without_inputs):
     trace_data = TraceData(spans=[span_without_inputs])
 
-    assert trace_data.request == "{}"
+    assert trace_data.request is None
 
 
-def test_trace_data_request_returns_empty_dict_when_no_root_span():
+def test_trace_data_request_returns_none_when_no_root_span():
     trace_id = 12345
     parent_id = 11111
     span_id = 67890
@@ -322,7 +322,7 @@ def test_trace_data_request_returns_empty_dict_when_no_root_span():
     span = Span(otel_span)
     trace_data = TraceData(spans=[span])
 
-    assert trace_data.request == "{}"
+    assert trace_data.request is None
 
 
 def test_trace_to_dataframe_with_missing_inputs(span_without_inputs):
@@ -337,5 +337,5 @@ def test_trace_to_dataframe_with_missing_inputs(span_without_inputs):
 
     row = trace.to_pandas_dataframe_row()
 
-    assert row["request"] == {}
+    assert row["request"] is None
     assert row["response"] == "some output"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/18878?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18878/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18878/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18878/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Addresses an issue where tool calling spans from 3rd party OTeL clients might not properly pass a function input value, resulted in a None being captured which causes a missing field in the pd.DataFrame return from search_traces, causing issues with evaluation. 
The adjustment here is to provide an empty placeholder for the inputs in the form of a string-wrapped empty dict and an empty string in the case of outputs that are not specified. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
