### PR TITLE
Move internal telemetry env vars from environmet_variables.py

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1060,21 +1060,6 @@ MLFLOW_WEBHOOK_CACHE_TTL = _EnvironmentVariable("MLFLOW_WEBHOOK_CACHE_TTL", int,
 MLFLOW_DISABLE_TELEMETRY = _BooleanEnvironmentVariable("MLFLOW_DISABLE_TELEMETRY", False)
 
 
-#: Internal flag to enable telemetry in mlflow tests.
-#: (default: ``False``)
-_MLFLOW_TESTING_TELEMETRY = _BooleanEnvironmentVariable("_MLFLOW_TESTING_TELEMETRY", False)
-
-
-#: Internal environment variable to set the telemetry session id when TelemetryClient is initialized
-#: This should never be set by users or explicitly.
-#: (default: ``None``)
-_MLFLOW_TELEMETRY_SESSION_ID = _EnvironmentVariable("_MLFLOW_TELEMETRY_SESSION_ID", str, None)
-
-
-#: Internal flag to enable telemetry logging
-#: (default: ``False``)
-_MLFLOW_TELEMETRY_LOGGING = _BooleanEnvironmentVariable("_MLFLOW_TELEMETRY_LOGGING", False)
-
 #: Internal environment variable to indicate which SGI is being used,
 #: e.g. "uvicorn" or "gunicorn".
 #: This should never be set by users or explicitly.

--- a/mlflow/telemetry/utils.py
+++ b/mlflow/telemetry/utils.py
@@ -3,11 +3,7 @@ import os
 
 from packaging.version import Version
 
-from mlflow.environment_variables import (
-    _MLFLOW_TELEMETRY_LOGGING,
-    _MLFLOW_TESTING_TELEMETRY,
-    MLFLOW_DISABLE_TELEMETRY,
-)
+from mlflow.environment_variables import MLFLOW_DISABLE_TELEMETRY
 from mlflow.telemetry.constant import CONFIG_STAGING_URL, CONFIG_URL
 from mlflow.version import VERSION
 
@@ -63,7 +59,7 @@ def _is_in_databricks() -> bool:
 _IS_MLFLOW_DEV_VERSION = Version(VERSION).is_devrelease
 _IS_IN_CI_ENV_OR_TESTING = _is_ci_env_or_testing()
 _IS_IN_DATABRICKS = _is_in_databricks()
-_IS_MLFLOW_TESTING_TELEMETRY = _MLFLOW_TESTING_TELEMETRY.get()
+_IS_MLFLOW_TESTING_TELEMETRY = os.environ.get("_MLFLOW_TESTING_TELEMETRY", "false").lower() == "true"
 
 
 def is_telemetry_disabled() -> bool:
@@ -100,5 +96,5 @@ def _get_config_url(version: str) -> str | None:
 
 
 def _log_error(message: str) -> None:
-    if _MLFLOW_TELEMETRY_LOGGING.get():
+    if os.environ.get("_MLFLOW_TELEMETRY_LOGGING", "false").lower() == "true":
         _logger.error(message, exc_info=True)

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -7,7 +7,6 @@ from unittest import mock
 import pytest
 
 import mlflow
-from mlflow.environment_variables import _MLFLOW_TELEMETRY_SESSION_ID
 from mlflow.telemetry.client import (
     BATCH_SIZE,
     BATCH_TIME_INTERVAL_SECONDS,
@@ -38,10 +37,10 @@ def test_telemetry_client_initialization(mock_telemetry_client: TelemetryClient,
 def test_telemetry_client_session_id(
     mock_telemetry_client: TelemetryClient, mock_requests, monkeypatch
 ):
-    monkeypatch.setenv(_MLFLOW_TELEMETRY_SESSION_ID.name, "test_session_id")
+    monkeypatch.setenv("_MLFLOW_TELEMETRY_SESSION_ID", "test_session_id")
     with TelemetryClient() as telemetry_client:
         assert telemetry_client.info["session_id"] == "test_session_id"
-    monkeypatch.delenv(_MLFLOW_TELEMETRY_SESSION_ID.name, raising=False)
+    monkeypatch.delenv("_MLFLOW_TELEMETRY_SESSION_ID", raising=False)
     with TelemetryClient() as telemetry_client:
         assert telemetry_client.info["session_id"] != "test_session_id"
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18880?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18880/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18880/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18880/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Telemetry testing env var should not be exposed to users. Having it in `environment_variable.py` makes it easy to find. Also having many env vars named with "telemetry" is confusing (e.g., `_MLFLOW_TELEMETRY_LOGGING` set to false looks like it disables telemetry).

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
