### PR TITLE
Add GEPA additional keyword arguments to GepaPromptOptimizer (#18851)

### DIFF
--- a/mlflow/genai/optimize/optimizers/gepa_optimizer.py
+++ b/mlflow/genai/optimize/optimizers/gepa_optimizer.py
@@ -30,6 +30,21 @@ class GepaPromptOptimizer(BasePromptOptimizer):
             Default: 100
         display_progress_bar: Whether to show a progress bar during optimization.
             Default: False
+        gepa_kwargs: Additional keyword arguments to pass directly to
+            gepa.optimize <https://github.com/gepa-ai/gepa/blob/main/src/gepa/api.py>.
+            Useful for accessing advanced GEPA features not directly exposed
+            through MLflow's GEPA interface.
+
+            Note: Parameters already handled by MLflow's GEPA class will be overridden by the direct
+            parameters and should not be passed through gepa_kwargs. List of predefined params:
+
+            - max_metric_calls
+            - display_progress_bar
+            - seed_candidate
+            - trainset
+            - adapter
+            - reflection_lm
+            - use_mlflow
 
     Example:
 
@@ -76,10 +91,12 @@ class GepaPromptOptimizer(BasePromptOptimizer):
         reflection_model: str,
         max_metric_calls: int = 100,
         display_progress_bar: bool = False,
+        gepa_kwargs: dict[str, Any] | None = None,
     ):
         self.reflection_model = reflection_model
         self.max_metric_calls = max_metric_calls
         self.display_progress_bar = display_progress_bar
+        self.gepa_kwargs = gepa_kwargs or {}
 
     def optimize(
         self,
@@ -206,7 +223,7 @@ class GepaPromptOptimizer(BasePromptOptimizer):
 
         adapter = MlflowGEPAAdapter(eval_fn, target_prompts)
 
-        kwargs = {
+        kwargs = self.gepa_kwargs | {
             "seed_candidate": target_prompts,
             "trainset": train_data,
             "adapter": adapter,

--- a/tests/genai/optimize/optimizers/test_gepa_optimizer.py
+++ b/tests/genai/optimize/optimizers/test_gepa_optimizer.py
@@ -64,6 +64,7 @@ def test_gepa_optimizer_initialization():
     assert optimizer.reflection_model == "openai:/gpt-4o"
     assert optimizer.max_metric_calls == 100
     assert optimizer.display_progress_bar is False
+    assert optimizer.gepa_kwargs == {}
 
 
 def test_gepa_optimizer_initialization_with_custom_params():
@@ -75,6 +76,19 @@ def test_gepa_optimizer_initialization_with_custom_params():
     assert optimizer.reflection_model == "openai:/gpt-4o"
     assert optimizer.max_metric_calls == 100
     assert optimizer.display_progress_bar is True
+    assert optimizer.gepa_kwargs == {}
+
+
+def test_gepa_optimizer_initialization_with_gepa_kwargs():
+    gepa_kwargs_example = {"foo": "bar"}
+    optimizer = GepaPromptOptimizer(
+        reflection_model="openai:/gpt-4o",
+        gepa_kwargs=gepa_kwargs_example,
+    )
+    assert optimizer.reflection_model == "openai:/gpt-4o"
+    assert optimizer.max_metric_calls == 100
+    assert optimizer.display_progress_bar is False
+    assert optimizer.gepa_kwargs == gepa_kwargs_example
 
 
 def test_gepa_optimizer_optimize(
@@ -158,6 +172,38 @@ def test_gepa_optimizer_optimize_with_custom_reflection_model(
 
     call_kwargs = mock_gepa_module.optimize.call_args.kwargs
     assert call_kwargs["reflection_lm"] == "anthropic/claude-3-5-sonnet-20241022"
+
+
+def test_gepa_optimizer_optimize_with_custom_gepa_params(
+    sample_train_data: list[dict[str, Any]],
+    sample_target_prompts: dict[str, str],
+    mock_eval_fn: Any,
+):
+    mock_gepa_module = MagicMock()
+    mock_modules = {
+        "gepa": mock_gepa_module,
+        "gepa.core": MagicMock(),
+        "gepa.core.adapter": MagicMock(),
+    }
+    mock_result = Mock()
+    mock_result.best_candidate = sample_target_prompts
+    mock_result.val_aggregate_scores = []
+    mock_gepa_module.optimize.return_value = mock_result
+    mock_gepa_module.EvaluationBatch = MagicMock()
+
+    optimizer = GepaPromptOptimizer(
+        reflection_model="openai:/gpt-4o-mini", gepa_kwargs={"foo": "bar"}
+    )
+
+    with patch.dict(sys.modules, mock_modules):
+        optimizer.optimize(
+            eval_fn=mock_eval_fn,
+            train_data=sample_train_data,
+            target_prompts=sample_target_prompts,
+        )
+
+    call_kwargs = mock_gepa_module.optimize.call_args.kwargs
+    assert call_kwargs["foo"] == "bar"
 
 
 def test_gepa_optimizer_optimize_model_name_parsing(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BnnaFish/mlflow/pull/18894?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18894/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18894/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18894/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

Resolve #18851

### What changes are proposed in this pull request?

Pass gepa_kwargs to GepaPromptOptimizer.

The solution is inspired by the same feature in [DSPy](https://github.com/stanfordnlp/dspy/blob/main/dspy/teleprompt/gepa/gepa.py#L362).

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

GepaPromptOptimizer now accepts a wildcard dictionary of arguments, that will be passed to gepa.optimize method.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
