### PR TITLE
Infrastructure setup for multi-turn evaluation support

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -675,6 +675,14 @@ MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING = _BooleanEnvironmentVariable(
     "MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING", False
 )
 
+#: Enable multi-turn evaluation support in mlflow.genai.evaluate. This is an experimental feature
+#: that allows evaluation of entire conversation sessions using multi-turn scorers.
+#: Multi-turn scorers process groups of traces belonging to the same session, with assessments
+#: logged to the first trace chronologically. (default: False)
+MLFLOW_ENABLE_MULTI_TURN_EVALUATION = _BooleanEnvironmentVariable(
+    "MLFLOW_ENABLE_MULTI_TURN_EVALUATION", False
+)
+
 #: Whether to warn (default) or raise (opt-in) for unresolvable requirements inference for
 #: a model's dependency inference. If set to True, an exception will be raised if requirements
 #: inference or the process of capturing imported modules encounters any errors.

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -494,10 +494,7 @@ class Scorer(BaseModel):
               - Available only for multi-turn scorers (scorers with
                 ``_is_multi_turn_scorer = True``).
 
-                * Multi-turn scorers receive all traces in a session, ordered chronologically
-                  by ``trace.info.request_time``.
                 * Only traces with the same ``mlflow.trace.session`` metadata value are grouped.
-                * This parameter is ``None`` for single-turn scorers.
 
         Example:
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -116,6 +116,7 @@ class Scorer(BaseModel):
     _cached_dump: dict[str, Any] | None = PrivateAttr(default=None)
     _sampling_config: ScorerSamplingConfig | None = PrivateAttr(default=None)
     _registered_backend: str | None = PrivateAttr(default=None)
+    _is_multi_turn_scorer: bool = PrivateAttr(default=False)
 
     @property
     def sample_rate(self) -> float | None:
@@ -431,6 +432,7 @@ class Scorer(BaseModel):
         outputs: Any = None,
         expectations: dict[str, Any] | None = None,
         trace: Trace | None = None,
+        session_traces: list[Trace] | None = None,
     ) -> int | float | bool | str | Feedback | list[Feedback]:
         """
         Implement the custom scorer's logic here.

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -372,7 +372,7 @@ class Scorer(BaseModel):
         object.__setattr__(scorer_instance, "_cached_dump", original_serialized_data)
         return scorer_instance
 
-    def run(self, *, inputs=None, outputs=None, expectations=None, trace=None):
+    def run(self, *, inputs=None, outputs=None, expectations=None, trace=None, session_traces=None):
         from mlflow.evaluation import Assessment as LegacyAssessment
 
         merged = {
@@ -380,6 +380,7 @@ class Scorer(BaseModel):
             "outputs": outputs,
             "expectations": expectations,
             "trace": trace,
+            "session_traces": session_traces,
         }
         # Filter to only the parameters the function actually expects
         sig = inspect.signature(self.__call__)
@@ -487,6 +488,16 @@ class Scorer(BaseModel):
             * - ``trace``
               - A trace object corresponding to the prediction for the row.
               - Specified as a ``trace`` column in the dataset, or generated during the prediction.
+
+            * - ``session_traces``
+              - A list of trace objects belonging to the same conversation session.
+              - Available only for multi-turn scorers (scorers with
+                ``_is_multi_turn_scorer = True``).
+
+                * Multi-turn scorers receive all traces in a session, ordered chronologically
+                  by ``trace.info.request_time``.
+                * Only traces with the same ``mlflow.trace.session`` metadata value are grouped.
+                * This parameter is ``None`` for single-turn scorers.
 
         Example:
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AveshCSingh/mlflow/pull/18896?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18896/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18896/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18896/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->


### What changes are proposed in this pull request?

This PR implements the following changes to enable multi-turn evaluation support in
  `mlflow.genai.evaluate`.

  1. **Add `MLFLOW_ENABLE_MULTI_TURN_EVALUATION` environment variable**
     - Controls whether multi-turn evaluation is enabled

  2. **Update Scorer base class for multi-turn support**
     - Add and document `session_traces` parameter to `Scorer.__call__()` and `scorer.run()`. The name of this parameter may change.
     - Add `_is_multi_turn_scorer` attribute to indicate when a scorer evalautes multi-turn conversations.

### How is this PR tested?

This PR is a no-op, so does not include additional tests.

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
