### PR TITLE
[ML-59303] Support multiturn judge creation with make_judge api and direct judge invocation

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -29,12 +29,14 @@ from mlflow.genai.scorers.base import (
     SerializedScorer,
 )
 from mlflow.genai.utils.trace_utils import (
+    resolve_conversation_from_session_traces,
     resolve_expectations_from_trace,
     resolve_inputs_from_trace,
     resolve_outputs_from_trace,
 )
 from mlflow.prompt.constants import PROMPT_TEMPLATE_VARIABLE_PATTERN, PROMPT_TEXT_DISPLAY_LIMIT
 from mlflow.protos.databricks_pb2 import INVALID_PARAMETER_VALUE
+from mlflow.tracing.constant import TraceMetadataKey
 
 _logger = logging.getLogger(__name__)
 
@@ -51,11 +53,13 @@ class InstructionsJudge(Judge):
     _TEMPLATE_VARIABLE_OUTPUTS = "outputs"
     _TEMPLATE_VARIABLE_TRACE = "trace"
     _TEMPLATE_VARIABLE_EXPECTATIONS = "expectations"
+    _TEMPLATE_VARIABLE_CONVERSATION = "conversation"
     _RESERVED_INSTRUCTION_TEMPLATE_VARIABLES = [
         _TEMPLATE_VARIABLE_INPUTS,
         _TEMPLATE_VARIABLE_OUTPUTS,
         _TEMPLATE_VARIABLE_TRACE,
         _TEMPLATE_VARIABLE_EXPECTATIONS,
+        _TEMPLATE_VARIABLE_CONVERSATION,
     ]
 
     _instructions: str = PrivateAttr()
@@ -148,6 +152,11 @@ class InstructionsJudge(Judge):
         return self._instructions_prompt.variables
 
     @property
+    def is_multi_turn(self) -> bool:
+        """Get whether this judge is a multi-turn judge based on template variables."""
+        return self._TEMPLATE_VARIABLE_CONVERSATION in self.template_variables
+
+    @property
     def instructions(self) -> str:
         """Get the instructions of this judge."""
         return self._instructions
@@ -178,7 +187,10 @@ class InstructionsJudge(Judge):
         return fields
 
     def _validate_parameter_types(
-        self, expectations: dict[str, Any] | None, trace: Trace | None
+        self,
+        expectations: dict[str, Any] | None,
+        trace: Trace | None,
+        session_traces: list[Trace] | None,
     ) -> None:
         """Validate that parameters have correct types."""
         if expectations is not None and not isinstance(expectations, dict):
@@ -191,6 +203,20 @@ class InstructionsJudge(Judge):
                 f"'trace' must be a Trace object, got {type(trace).__name__}",
                 error_code=INVALID_PARAMETER_VALUE,
             )
+        if session_traces is not None and not isinstance(session_traces, list):
+            raise MlflowException(
+                f"'session_traces' must be a list of Trace objects, "
+                f"got {type(session_traces).__name__}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+        if session_traces is not None and not all(
+            isinstance(trace, Trace) for trace in session_traces
+        ):
+            raise MlflowException(
+                f"All elements in 'session_traces' must be Trace objects, "
+                f"got {type(session_traces[0]).__name__}",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
 
     def _check_required_parameters(
         self,
@@ -198,6 +224,7 @@ class InstructionsJudge(Judge):
         outputs: Any | None,
         expectations: dict[str, Any] | None,
         trace: Trace | None,
+        session_traces: list[Trace] | None,
     ) -> None:
         """Check that all required parameters are provided."""
         missing_params = []
@@ -209,6 +236,11 @@ class InstructionsJudge(Judge):
             missing_params.append("expectations")
         if self._TEMPLATE_VARIABLE_TRACE in self.template_variables and trace is None:
             missing_params.append("trace")
+        if (
+            self._TEMPLATE_VARIABLE_CONVERSATION in self.template_variables
+            and session_traces is None
+        ):
+            missing_params.append("session_traces")
 
         if missing_params:
             missing_str = "', '".join(missing_params)
@@ -217,12 +249,37 @@ class InstructionsJudge(Judge):
                 error_code=INVALID_PARAMETER_VALUE,
             )
 
+    def _validate_session_traces(self, session_traces: list[Trace]) -> None:
+        """Validate that all session traces belong to the same session."""
+        session_id_to_trace_ids: dict[str, list[str]] = {}
+        for trace in session_traces:
+            session_id = trace.info.trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
+            if session_id is None:
+                raise MlflowException(
+                    f"All traces in session_traces must have a session_id. "
+                    f"Trace {trace.info.trace_id} is missing session_id.",
+                    error_code=INVALID_PARAMETER_VALUE,
+                )
+            if session_id not in session_id_to_trace_ids:
+                session_id_to_trace_ids[session_id] = []
+            session_id_to_trace_ids[session_id].append(trace.info.trace_id)
+
+        if len(session_id_to_trace_ids) != 1:
+            session_details = "\n".join(
+                f"session_id '{sid}': trace_ids {trace_ids}"
+                for sid, trace_ids in session_id_to_trace_ids.items()
+            )
+            raise MlflowException.invalid_parameter_value(
+                f"All traces in session_traces must belong to the same session. "
+                f"Found {len(session_id_to_trace_ids)} different session(s):\n{session_details}"
+            )
+
     def _warn_unused_parameters(
         self,
         inputs: Any | None,
         outputs: Any | None,
         expectations: dict[str, Any] | None,
-        trace: Trace | None,
+        conversation: list[dict[str, str]] | None,
     ) -> None:
         """Warn about parameters that were provided but aren't used."""
         # Don't warn about unused parameters when using trace-based evaluation
@@ -240,6 +297,11 @@ class InstructionsJudge(Judge):
             and self._TEMPLATE_VARIABLE_EXPECTATIONS not in self.template_variables
         ):
             unused_params.append("expectations")
+        if (
+            conversation is not None
+            and self._TEMPLATE_VARIABLE_CONVERSATION not in self.template_variables
+        ):
+            unused_params.append("conversation")
 
         if unused_params:
             unused_str = "', '".join(unused_params)
@@ -300,10 +362,10 @@ class InstructionsJudge(Judge):
         inputs: Any | None,
         outputs: Any | None,
         expectations: dict[str, Any] | None,
-        is_trace_based: bool,
+        conversation: list[dict[str, str]] | None,
     ) -> str:
         """Build the user message with field values."""
-        template_values = self._build_template_values(inputs, outputs, expectations)
+        template_values = self._build_template_values(inputs, outputs, expectations, conversation)
 
         field_vars = [
             var for var in self._ordered_template_variables if var != self._TEMPLATE_VARIABLE_TRACE
@@ -325,7 +387,11 @@ class InstructionsJudge(Judge):
         )
 
     def _build_template_values(
-        self, inputs: Any | None, outputs: Any | None, expectations: dict[str, Any] | None
+        self,
+        inputs: Any | None,
+        outputs: Any | None,
+        expectations: dict[str, Any] | None,
+        conversation: list[dict[str, str]] | None,
     ) -> dict[str, str]:
         """Build dictionary of template variable values."""
         template_values = {}
@@ -344,6 +410,14 @@ class InstructionsJudge(Judge):
                 expectations
             )
 
+        if (
+            conversation is not None
+            and self._TEMPLATE_VARIABLE_CONVERSATION in self.template_variables
+        ):
+            template_values[self._TEMPLATE_VARIABLE_CONVERSATION] = self._safe_json_dumps(
+                conversation
+            )
+
         return template_values
 
     def _safe_json_dumps(self, value: Any) -> str:
@@ -360,6 +434,7 @@ class InstructionsJudge(Judge):
         outputs: Any = None,
         expectations: dict[str, Any] | None = None,
         trace: Trace | None = None,
+        session_traces: list[Trace] | None = None,
     ) -> Feedback:
         """
         Evaluate the provided data using the judge's instructions.
@@ -373,6 +448,8 @@ class InstructionsJudge(Judge):
                 will be extracted from the trace's expectation assessments.
             trace: Trace object for evaluation. When the template uses {{ inputs }}, {{ outputs }},
                 or {{ expectations }}, the values will be extracted from the trace.
+            session_traces: List of traces from the same session. When the template uses
+                {{ conversation }}, the conversation history will be extracted from these traces.
 
         Returns:
             Evaluation results
@@ -388,8 +465,13 @@ class InstructionsJudge(Judge):
           - inputs/outputs: From the trace's root span
           - expectations: From the trace's human-set expectation assessments (ground truth only)
 
+        **Note on Session Traces Behavior**:
+        - Traces are expected to be in the same session and exception will be raised
+          if they are not.
+        - The conversation history will be extracted from the traces in chronological order.
         """
-        self._validate_parameter_types(expectations, trace)
+
+        self._validate_parameter_types(expectations, trace, session_traces)
 
         original_inputs = inputs
         original_outputs = outputs
@@ -412,15 +494,20 @@ class InstructionsJudge(Judge):
                 extract_if_none=self._TEMPLATE_VARIABLE_EXPECTATIONS in self.template_variables,
             )
 
-        self._check_required_parameters(inputs, outputs, expectations, trace)
+        conversation = None
+        if session_traces is not None and session_traces:
+            self._validate_session_traces(session_traces)
+            conversation = resolve_conversation_from_session_traces(session_traces)
+
+        self._check_required_parameters(inputs, outputs, expectations, trace, conversation)
         self._warn_unused_parameters(
-            original_inputs, original_outputs, original_expectations, trace
+            original_inputs, original_outputs, original_expectations, conversation
         )
 
         is_trace_based = self._TEMPLATE_VARIABLE_TRACE in self.template_variables
 
         system_content = self._build_system_message(is_trace_based)
-        user_content = self._build_user_message(inputs, outputs, expectations, is_trace_based)
+        user_content = self._build_user_message(inputs, outputs, expectations, conversation)
 
         from mlflow.types.llm import ChatMessage
 
@@ -459,8 +546,10 @@ class InstructionsJudge(Judge):
 
     def _validate_instructions_template(self) -> None:
         """
-        Validate that instructions contain at least one variable.
-
+        Validate that instruction:
+        1. contains at least one variable.
+        2. does not contain any template variables other than expectation
+           if conversation is provided.
         """
         template_vars = self.template_variables
 
@@ -468,6 +557,16 @@ class InstructionsJudge(Judge):
             raise MlflowException(
                 "Instructions template must contain at least one variable (e.g., {{ inputs }}, "
                 "{{ outputs }}, {{ trace }}, or {{ expectations }}).",
+                error_code=INVALID_PARAMETER_VALUE,
+            )
+
+        if self._TEMPLATE_VARIABLE_CONVERSATION in template_vars and template_vars - {
+            self._TEMPLATE_VARIABLE_EXPECTATIONS,
+            self._TEMPLATE_VARIABLE_CONVERSATION,
+        }:
+            raise MlflowException(
+                "Instructions template must not contain any template variables "
+                "other than {{ expectations }} if {{ conversation }} is provided.",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 

--- a/mlflow/genai/judges/make_judge.py
+++ b/mlflow/genai/judges/make_judge.py
@@ -110,8 +110,10 @@ def make_judge(
         name: The name of the judge
         instructions: Natural language instructions for evaluation. Must contain at least one
                       template variable: {{ inputs }}, {{ outputs }}, {{ expectations }},
-                      or {{ trace }} to reference evaluation data. Custom variables are not
-                      supported.
+                      {{ conversation }}, or {{ trace }} to reference evaluation data. Custom
+                      variables are not supported.
+                      Note: {{ conversation }} can only coexist with {{ expectations }}.
+                      It cannot be used together with {{ inputs }}, {{ outputs }}, or {{ trace }}.
         model: The model identifier to use for evaluation (e.g., "openai:/gpt-4")
         description: A description of what the judge evaluates
         feedback_value_type: Type specification for the 'value' field in the Feedback
@@ -191,6 +193,26 @@ def make_judge(
             for trace in traces:
                 feedback = trace_judge(trace=trace)
                 print(f"Trace {trace.info.trace_id}: {feedback.value} - {feedback.rationale}")
+
+            # Create a multi-turn judge that detects user frustration
+            frustration_judge = make_judge(
+                name="user_frustration",
+                instructions=(
+                    "Analyze the {{ conversation }} to detect signs of user frustration. "
+                    "Look for indicators such as repeated questions, negative language, "
+                    "or expressions of dissatisfaction."
+                ),
+                model="openai:/gpt-4",
+                feedback_value_type=Literal["high", "medium", "low", "none"],
+            )
+
+            # Evaluate a multi-turn conversation using session traces
+            session_traces = mlflow.search_traces(
+                experiment_ids=["1"],
+                filter_string="metadata.`mlflow.trace.session` = 'session_123'",
+                return_type="list",
+            )
+            result = frustration_judge(session_traces=session_traces)
 
             # Align a judge with human feedback
             aligned_judge = quality_judge.align(traces)

--- a/mlflow/genai/judges/make_judge.py
+++ b/mlflow/genai/judges/make_judge.py
@@ -203,16 +203,16 @@ def make_judge(
                     "or expressions of dissatisfaction."
                 ),
                 model="openai:/gpt-4",
-                feedback_value_type=Literal["high", "medium", "low", "none"],
+                feedback_value_type=Literal["frustrated", "not frustrated"],
             )
 
             # Evaluate a multi-turn conversation using session traces
-            session_traces = mlflow.search_traces(
+            session = mlflow.search_traces(
                 experiment_ids=["1"],
                 filter_string="metadata.`mlflow.trace.session` = 'session_123'",
                 return_type="list",
             )
-            result = frustration_judge(session_traces=session_traces)
+            result = frustration_judge(session=session)
 
             # Align a judge with human feedback
             aligned_judge = quality_judge.align(traces)

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -118,6 +118,15 @@ class Scorer(BaseModel):
     _registered_backend: str | None = PrivateAttr(default=None)
 
     @property
+    def is_multi_turn(self) -> bool:
+        """Get whether this scorer is a multi-turn scorer.
+
+        Defaults to False. Child classes can override this property to return True
+        or compute the value dynamically based on their configuration.
+        """
+        return False
+
+    @property
     def sample_rate(self) -> float | None:
         """Get the sample rate for this scorer. Available when registered for monitoring."""
         return self._sampling_config.sample_rate if self._sampling_config else None
@@ -431,6 +440,7 @@ class Scorer(BaseModel):
         outputs: Any = None,
         expectations: dict[str, Any] | None = None,
         trace: Trace | None = None,
+        session_traces: list[Trace] | None = None,
     ) -> int | float | bool | str | Feedback | list[Feedback]:
         """
         Implement the custom scorer's logic here.
@@ -485,6 +495,12 @@ class Scorer(BaseModel):
             * - ``trace``
               - A trace object corresponding to the prediction for the row.
               - Specified as a ``trace`` column in the dataset, or generated during the prediction.
+
+            * - ``session_traces``
+              - A list of trace objects belonging to the same conversation session.
+              - Available only for multi-turn scorers (scorers with ``is_multi_turn = True``).
+                * Only traces with the same ``mlflow.trace.session`` metadata value can be passed in
+                  this parameter, otherwise an error will be raised.
 
         Example:
 

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -440,7 +440,7 @@ class Scorer(BaseModel):
         outputs: Any = None,
         expectations: dict[str, Any] | None = None,
         trace: Trace | None = None,
-        session_traces: list[Trace] | None = None,
+        session: list[Trace] | None = None,
     ) -> int | float | bool | str | Feedback | list[Feedback]:
         """
         Implement the custom scorer's logic here.
@@ -496,7 +496,7 @@ class Scorer(BaseModel):
               - A trace object corresponding to the prediction for the row.
               - Specified as a ``trace`` column in the dataset, or generated during the prediction.
 
-            * - ``session_traces``
+            * - ``session``
               - A list of trace objects belonging to the same conversation session.
               - Available only for multi-turn scorers (scorers with ``is_multi_turn = True``).
                 * Only traces with the same ``mlflow.trace.session`` metadata value can be passed in

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -149,34 +149,34 @@ def resolve_outputs_from_trace(
     return outputs
 
 
-def resolve_conversation_from_session_traces(
-    session_traces: list[Trace],
+def resolve_conversation_from_session(
+    session: list[Trace],
 ) -> list[dict[str, str]]:
     """
-    Extract conversation history from session traces.
+    Extract conversation history from traces in session.
 
     Args:
-        session_traces: List of traces from the same session, sorted by creation time.
+        session: List of traces from the same session.
 
     Returns:
         List of conversation messages in the format [{"role": "user"|"assistant", "content": str}].
         Each trace contributes two messages: user (from input) and assistant (from output).
     """
     # Sort traces by creation time (timestamp_ms)
-    sorted_traces = sorted(session_traces, key=lambda t: t.info.timestamp_ms)
+    sorted_traces = sorted(session, key=lambda t: t.info.timestamp_ms)
 
     conversation = []
     for trace in sorted_traces:
         # Extract and parse input (user message)
         inputs = extract_inputs_from_trace(trace)
-        if not _is_empty(inputs):
+        if inputs:
             user_content = parse_inputs_to_str(inputs)
             if user_content and user_content.strip():
                 conversation.append({"role": "user", "content": user_content})
 
         # Extract and parse output (assistant message)
         outputs = extract_outputs_from_trace(trace)
-        if not _is_empty(outputs):
+        if outputs:
             assistant_content = parse_outputs_to_str(outputs)
             if assistant_content and assistant_content.strip():
                 conversation.append({"role": "assistant", "content": assistant_content})
@@ -307,17 +307,6 @@ def is_none_or_nan(value: Any) -> bool:
     """
     # isinstance(value, float) check is needed to ensure that math.isnan is not called on an array.
     return value is None or (isinstance(value, float) and math.isnan(value))
-
-
-def _is_empty(value: Any) -> bool:
-    """
-    Check if a value is empty (None, empty dict, empty list, empty string, etc.).
-    """
-    if value is None:
-        return True
-    if isinstance(value, (dict, list, str)):
-        return len(value) == 0
-    return False
 
 
 def parse_inputs_to_str(value: Any) -> str:

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -149,6 +149,41 @@ def resolve_outputs_from_trace(
     return outputs
 
 
+def resolve_conversation_from_session_traces(
+    session_traces: list[Trace],
+) -> list[dict[str, str]]:
+    """
+    Extract conversation history from session traces.
+
+    Args:
+        session_traces: List of traces from the same session, sorted by creation time.
+
+    Returns:
+        List of conversation messages in the format [{"role": "user"|"assistant", "content": str}].
+        Each trace contributes two messages: user (from input) and assistant (from output).
+    """
+    # Sort traces by creation time (timestamp_ms)
+    sorted_traces = sorted(session_traces, key=lambda t: t.info.timestamp_ms)
+
+    conversation = []
+    for trace in sorted_traces:
+        # Extract and parse input (user message)
+        inputs = extract_inputs_from_trace(trace)
+        if not _is_empty(inputs):
+            user_content = parse_inputs_to_str(inputs)
+            if user_content and user_content.strip():
+                conversation.append({"role": "user", "content": user_content})
+
+        # Extract and parse output (assistant message)
+        outputs = extract_outputs_from_trace(trace)
+        if not _is_empty(outputs):
+            assistant_content = parse_outputs_to_str(outputs)
+            if assistant_content and assistant_content.strip():
+                conversation.append({"role": "assistant", "content": assistant_content})
+
+    return conversation
+
+
 def resolve_expectations_from_trace(
     expectations: dict[str, Any] | None,
     trace: Trace,
@@ -272,6 +307,17 @@ def is_none_or_nan(value: Any) -> bool:
     """
     # isinstance(value, float) check is needed to ensure that math.isnan is not called on an array.
     return value is None or (isinstance(value, float) and math.isnan(value))
+
+
+def _is_empty(value: Any) -> bool:
+    """
+    Check if a value is empty (None, empty dict, empty list, empty string, etc.).
+    """
+    if value is None:
+        return True
+    if isinstance(value, (dict, list, str)):
+        return len(value) == 0
+    return False
 
 
 def parse_inputs_to_str(value: Any) -> str:

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -3,7 +3,7 @@ import sys
 import types
 import typing
 from dataclasses import asdict
-from typing import Literal
+from typing import Any, Literal
 from unittest import mock
 from unittest.mock import patch
 
@@ -32,6 +32,7 @@ from mlflow.genai.judges.instructions_judge.constants import JUDGE_BASE_PROMPT
 from mlflow.genai.judges.utils import _NATIVE_PROVIDERS, validate_judge_model
 from mlflow.genai.scorers.base import Scorer, ScorerKind, SerializedScorer
 from mlflow.genai.scorers.registry import _get_scorer_store
+from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.tracing.utils import build_otel_context
 from mlflow.types.llm import ChatMessage
 
@@ -2850,3 +2851,487 @@ def test_make_judge_with_default_feedback_value_type(monkeypatch):
 
     assert result.value == "Good quality"
     assert result.rationale == "The response is clear and accurate"
+
+
+def test_conversation_template_variable_extraction():
+    """Test that conversation template variable is correctly extracted."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate the {{ conversation }} for quality",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    assert judge.template_variables == {"conversation"}
+
+
+def test_is_multi_turn_property():
+    """Test that is_multi_turn property returns True when conversation is in template variables."""
+    conversation_judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    assert conversation_judge.is_multi_turn is True
+
+    regular_judge = make_judge(
+        name="regular_judge",
+        instructions="Evaluate {{ outputs }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    assert regular_judge.is_multi_turn is False
+
+
+def test_conversation_with_expectations_allowed():
+    """Test that conversation can be used with expectations."""
+    judge = make_judge(
+        name="conversation_expectations_judge",
+        instructions="Evaluate {{ conversation }} against {{ expectations }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    assert judge.template_variables == {"conversation", "expectations"}
+
+
+def test_conversation_with_other_variables_rejected():
+    """Test that conversation cannot be used with inputs, outputs, or trace."""
+    with pytest.raises(
+        MlflowException,
+        match=(
+            "Instructions template must not contain any template variables "
+            "other than {{ expectations }} if {{ conversation }} is provided"
+        ),
+    ):
+        make_judge(
+            name="invalid_judge",
+            instructions="Evaluate {{ conversation }} and {{ inputs }}",
+            feedback_value_type=str,
+            model="openai:/gpt-4",
+        )
+
+    with pytest.raises(
+        MlflowException,
+        match=(
+            "Instructions template must not contain any template variables "
+            "other than {{ expectations }} if {{ conversation }} is provided"
+        ),
+    ):
+        make_judge(
+            name="invalid_judge",
+            instructions="Evaluate {{ conversation }} and {{ outputs }}",
+            feedback_value_type=str,
+            model="openai:/gpt-4",
+        )
+
+    with pytest.raises(
+        MlflowException,
+        match=(
+            "Instructions template must not contain any template variables "
+            "other than {{ expectations }} if {{ conversation }} is provided"
+        ),
+    ):
+        make_judge(
+            name="invalid_judge",
+            instructions="Evaluate {{ conversation }} and {{ trace }}",
+            feedback_value_type=str,
+            model="openai:/gpt-4",
+        )
+
+
+def test_session_traces_validation_type_error():
+    """Test that session_traces must be a list."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(
+        MlflowException, match="'session_traces' must be a list of Trace objects, got str"
+    ):
+        judge(session_traces="not a list")
+
+
+def test_session_traces_validation_not_all_traces():
+    """Test that all elements in session_traces must be Trace objects."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(
+        MlflowException, match="All elements in 'session_traces' must be Trace objects"
+    ):
+        judge(session_traces=["not a trace", "also not a trace"])
+
+
+def create_trace_with_session(
+    trace_id: str,
+    session_id: str | None = None,
+    inputs: dict[str, Any] | None = None,
+    outputs: dict[str, Any] | None = None,
+    timestamp_ms: int = 1000,
+):
+    """Helper function to create a trace, optionally with a session ID."""
+    trace_metadata = {
+        "mlflow.trace_schema.version": "2",
+        "mlflow.traceInputs": json.dumps(inputs or {}),
+        "mlflow.traceOutputs": json.dumps(outputs or {}),
+    }
+    if session_id is not None:
+        trace_metadata[TraceMetadataKey.TRACE_SESSION] = session_id
+
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=TraceLocation.from_experiment_id("0"),
+        request_time=timestamp_ms,  # timestamp_ms property returns request_time
+        execution_duration=1000,
+        state=TraceState.OK,
+        trace_metadata=trace_metadata,
+        tags={
+            "mlflow.traceName": "test_trace",
+            "mlflow.source.name": "test",
+            "mlflow.source.type": "LOCAL",
+        },
+    )
+    spans = [
+        create_test_span(
+            span_id=1,
+            parent_id=None,
+            name="root_span",
+            inputs=inputs or {},
+            outputs=outputs or {},
+            span_type=SpanType.CHAIN,
+        ),
+    ]
+    trace_data = TraceData(spans=spans)
+    return Trace(info=trace_info, data=trace_data)
+
+
+def test_validate_session_traces_missing_session_id():
+    """Test that _validate_session_traces raises error when trace is missing session_id."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace_without_session = create_trace_with_session("trace-1", session_id=None)
+
+    with pytest.raises(
+        MlflowException,
+        match="All traces in session_traces must have a session_id",
+    ):
+        judge._validate_session_traces([trace_without_session])
+
+
+def test_validate_session_traces_different_sessions():
+    """Test that _validate_session_traces raises error when traces belong to different sessions."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session("trace-1", "session-1")
+    trace2 = create_trace_with_session("trace-2", "session-2")
+
+    with pytest.raises(
+        MlflowException,
+        match="All traces in session_traces must belong to the same session",
+    ) as exception_info:
+        judge._validate_session_traces([trace1, trace2])
+
+    # Verify the exception message includes trace_ids grouped by session_id
+    error_message = str(exception_info.value)
+    assert "Found 2 different session(s):" in error_message
+    assert "session_id 'session-1': trace_ids ['trace-1']" in error_message
+    assert "session_id 'session-2': trace_ids ['trace-2']" in error_message
+
+
+def test_validate_session_traces_different_sessions_multiple_traces():
+    """Test that _validate_session_traces shows all trace_ids when multiple traces
+    belong to different sessions.
+    """
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session("trace-1", "session-1")
+    trace2 = create_trace_with_session("trace-2", "session-1")
+    trace3 = create_trace_with_session("trace-3", "session-2")
+    trace4 = create_trace_with_session("trace-4", "session-2")
+    trace5 = create_trace_with_session("trace-5", "session-3")
+
+    with pytest.raises(
+        MlflowException,
+        match="All traces in session_traces must belong to the same session",
+    ) as exception_info:
+        judge._validate_session_traces([trace1, trace2, trace3, trace4, trace5])
+
+    # Verify the exception message includes all trace_ids grouped by session_id
+    error_message = str(exception_info.value)
+    assert "Found 3 different session(s):" in error_message
+    assert "session_id 'session-1': trace_ids" in error_message
+    assert "trace-1" in error_message
+    assert "trace-2" in error_message
+    assert "session_id 'session-2': trace_ids" in error_message
+    assert "trace-3" in error_message
+    assert "trace-4" in error_message
+    assert "session_id 'session-3': trace_ids" in error_message
+    assert "trace-5" in error_message
+
+
+def test_validate_session_traces_same_session():
+    """Test that _validate_session_traces passes when all traces belong to the same session."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session("trace-1", "session-1")
+    trace2 = create_trace_with_session("trace-2", "session-1")
+
+    # Should not raise
+    judge._validate_session_traces([trace1, trace2])
+
+
+def test_conversation_extraction_from_session_traces(mock_invoke_judge_model):
+    """Test that conversation is correctly extracted from session traces."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }} for quality",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session(
+        "trace-1",
+        "session-1",
+        inputs={"question": "What is MLflow?"},
+        outputs={"answer": "MLflow is an open source platform"},
+        timestamp_ms=1000,
+    )
+    trace2 = create_trace_with_session(
+        "trace-2",
+        "session-1",
+        inputs={"question": "How do I use it?"},
+        outputs={"answer": "You can use mlflow.start_run()"},
+        timestamp_ms=2000,
+    )
+
+    result = judge(session_traces=[trace1, trace2])
+
+    assert isinstance(result, Feedback)
+    assert len(mock_invoke_judge_model.calls) == 1
+    _, prompt, _ = mock_invoke_judge_model.calls[0]
+
+    # Check that conversation is in the user message
+    user_msg = prompt[1]
+    assert "conversation:" in user_msg.content
+    assert "What is MLflow?" in user_msg.content
+    assert "MLflow is an open source platform" in user_msg.content
+    assert "How do I use it?" in user_msg.content
+    assert "You can use mlflow.start_run()" in user_msg.content
+
+
+def test_conversation_extraction_chronological_order(mock_invoke_judge_model):
+    """Test that conversation messages are extracted in chronological order."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    # Create traces out of order
+    trace2 = create_trace_with_session(
+        "trace-2",
+        "session-1",
+        inputs={"question": "Second question"},
+        outputs={"answer": "Second answer"},
+        timestamp_ms=2000,
+    )
+    trace1 = create_trace_with_session(
+        "trace-1",
+        "session-1",
+        inputs={"question": "First question"},
+        outputs={"answer": "First answer"},
+        timestamp_ms=1000,
+    )
+
+    judge(session_traces=[trace2, trace1])  # Pass in reverse order
+
+    _, prompt, _ = mock_invoke_judge_model.calls[0]
+    user_msg = prompt[1]
+    content = user_msg.content
+
+    # Check that messages are in chronological order (first question before second)
+    first_pos = content.find("First question")
+    second_pos = content.find("Second question")
+    assert first_pos < second_pos
+
+
+def test_conversation_with_expectations(mock_invoke_judge_model):
+    """Test that conversation can be used with expectations."""
+    judge = make_judge(
+        name="conversation_expectations_judge",
+        instructions="Evaluate {{ conversation }} against {{ expectations }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session(
+        "trace-1",
+        "session-1",
+        inputs={"question": "What is MLflow?"},
+        outputs={"answer": "MLflow is a platform"},
+        timestamp_ms=1000,
+    )
+
+    expectations = {"criteria": "Should be accurate and helpful"}
+
+    result = judge(session_traces=[trace1], expectations=expectations)
+
+    assert isinstance(result, Feedback)
+    _, prompt, _ = mock_invoke_judge_model.calls[0]
+    user_msg = prompt[1]
+
+    assert "conversation:" in user_msg.content
+    assert "expectations:" in user_msg.content
+    assert "What is MLflow?" in user_msg.content
+    assert "Should be accurate and helpful" in user_msg.content
+
+
+def test_conversation_missing_session_traces():
+    """Test that missing session_traces raises error when conversation is required."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(
+        MlflowException, match="Must specify 'session_traces' - required by template variables"
+    ):
+        judge()
+
+
+def test_conversation_empty_session_traces():
+    """Test that empty session_traces list is handled."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    with pytest.raises(
+        MlflowException, match="Must specify 'session_traces' - required by template variables"
+    ):
+        judge(session_traces=[])
+
+
+def test_conversation_with_empty_inputs_outputs_filtered(mock_invoke_judge_model):
+    """Test that empty inputs/outputs are filtered out from conversation."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session(
+        "trace-1",
+        "session-1",
+        inputs={},  # Empty inputs
+        outputs={"answer": "Valid answer"},
+        timestamp_ms=1000,
+    )
+    trace2 = create_trace_with_session(
+        "trace-2",
+        "session-1",
+        inputs={"question": "Valid question"},
+        outputs={},  # Empty outputs
+        timestamp_ms=2000,
+    )
+
+    judge(session_traces=[trace1, trace2])
+
+    _, prompt, _ = mock_invoke_judge_model.calls[0]
+    user_msg = prompt[1]
+
+    # Should only contain non-empty messages
+    assert "Valid answer" in user_msg.content
+    assert "Valid question" in user_msg.content
+
+
+def test_conversation_unused_parameter_warning(mock_invoke_judge_model):
+    """Test that unused conversation parameter triggers warning."""
+    judge = make_judge(
+        name="outputs_judge",
+        instructions="Evaluate {{ outputs }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session(
+        "trace-1",
+        "session-1",
+        inputs={"question": "Test"},
+        outputs={"answer": "Test answer"},
+    )
+
+    with patch("mlflow.genai.judges.instructions_judge._logger") as mock_logger:
+        judge(outputs={"answer": "Test"}, session_traces=[trace1])
+
+        mock_logger.warning.assert_called_once()
+        warning_msg = mock_logger.warning.call_args[0][0]
+        assert "conversation" in warning_msg or "session_traces" in warning_msg
+        assert "not used by this judge" in warning_msg
+
+
+def test_conversation_no_warning_when_used(mock_invoke_judge_model):
+    """Test that no warning is shown when conversation is used."""
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate {{ conversation }}",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    trace1 = create_trace_with_session(
+        "trace-1",
+        "session-1",
+        inputs={"question": "Test"},
+        outputs={"answer": "Test answer"},
+    )
+
+    with patch("mlflow.genai.judges.instructions_judge._logger") as mock_logger:
+        judge(session_traces=[trace1])
+
+        # Should not warn about conversation being unused
+        # Check that no warnings were called, or if they were, they're not about conversation
+        if mock_logger.warning.called:
+            for call in mock_logger.warning.call_args_list:
+                if call and call[0]:
+                    warning_msg = call[0][0]
+                    # Should not contain both "conversation" and "not used" together
+                    if "conversation" in warning_msg.lower():
+                        assert "not used" not in warning_msg.lower()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xsh310/mlflow/pull/18897?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18897/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18897/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18897/merge
```

</p>
</details>

### What changes are proposed in this pull request?
- Adding support for multi-turn judge creation for the `make_judge` api by adding a new `{{conversation}}` template type that represent the conversation history between user and assistant. 
- Add `session_traces` as an input param to base scorer's `__call__` so that users can invoke multi-turn scorers by providing a list of traces from the same session
- Add a `is_multi_turn` property to the base scorer class to annotate whether a scorer is multi-turn or not, which would be useful when add multi-turn support for batch evaluate api `mlflow.genai.evaluate`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

### Test Plan
Added new unit tests.

Test manually with a mock agent:
```
frustrating_conversation_judge = make_judge(
            name="frustration",
            instructions=(
                "## Instructions:\n"
                "Evaluate the conversation between the user and the agent and determine if the user is frustrated with the agent's response at any point in the conversation.\n"
                "## Conversation History: {{ conversation }}\n"
            ),
            feedback_value_type=Literal["frustrated", "not frustrated"],
)

session_traces = mlflow.search_traces(
    experiment_ids=[experiment_id],
    filter_string=f"metadata.`mlflow.trace.session` = '{SESSION_ID}'",
    return_type="list",
)

result = frustrating_conversation_judge(session_traces=session_traces)
```

Printed the following output:
```
inputs: None
outputs: None
expectations: None
trace: None
session_traces: [Trace(trace_id=tr-a7289692b6e0ec5dbedd3a50be6856cf), Trace(trace_id=tr-4f4246d3669cc88a69c26e5fc0e2577b), Trace(trace_id=tr-13a76496dd1b8d5579ac416eea9457c2)]


conversation: [{'role': 'user', 'content': "{'prompt': 'My account was charged twice for the same order'}"}, {'role': 'assistant', 'content': 'Thank you for contacting us! Have you tried clearing your browser cache and cookies?'}, {'role': 'user', 'content': "{'prompt': 'No, I need a refund! Why would clearing cache help with duplicate charges?'}"}, {'role': 'assistant', 'content': "I understand your concern. For the best experience, please make sure you're using the latest version of your browser."}, {'role': 'user', 'content': "{'prompt': 'This is ridiculous. I want to speak to a human about my double charge NOW!'}"}, {'role': 'assistant', 'content': "I'm here to help! Is there anything else I can assist you with today?"}]


output_fields: [JudgeField(name='result', description='The evaluation rating/result', value_type=typing.Literal['frustrated', 'not frustrated']), JudgeField(name='rationale', description='Detailed explanation for the evaluation', value_type=<class 'str'>)]


system_content: You are an expert judge tasked with evaluating the performance of an AI
agent on a particular query. You will be given instructions that describe the criteria and
methodology for evaluating the agent's performance on the query.

Your task: ## Instructions:
Evaluate the conversation between the user and the agent and determine if the user is frustrated with the agent's response at any point in the conversation.
## Conversation History: {{ conversation }}
.

Please provide your assessment in the following JSON format only (no markdown):

{
    "result": "The evaluation rating/result",
    "rationale": "Detailed explanation for the evaluation"
}


user_content: conversation: [
  {
    "role": "user",
    "content": "{'prompt': 'My account was charged twice for the same order'}"
  },
  {
    "role": "assistant",
    "content": "Thank you for contacting us! Have you tried clearing your browser cache and cookies?"
  },
  {
    "role": "user",
    "content": "{'prompt': 'No, I need a refund! Why would clearing cache help with duplicate charges?'}"
  },
  {
    "role": "assistant",
    "content": "I understand your concern. For the best experience, please make sure you're using the latest version of your browser."
  },
  {
    "role": "user",
    "content": "{'prompt': 'This is ridiculous. I want to speak to a human about my double charge NOW!'}"
  },
  {
    "role": "assistant",
    "content": "I'm here to help! Is there anything else I can assist you with today?"
  }
]

frustrating_conversation_judge result: Feedback(name='frustration', source=AssessmentSource(source_type='LLM_JUDGE', source_id='openai:/gpt-4.1-mini'), trace_id=None, run_id=None, rationale='The user expresses clear frustration in their responses, particularly when they say, "No, I need a refund! Why would clearing cache help with duplicate charges?" and later, "This is ridiculous. I want to speak to a human about my double charge NOW!" These statements indicate dissatisfaction and impatience with the assistant\'s unhelpful responses that do not address the user\'s core issue of a double charge and refund request.', metadata={'mlflow.assessment.judgeCost': 0.000322}, span_id=None, create_time_ms=1763487265828, last_update_time_ms=1763487265828, assessment_id=None, error=None, expectation=None, feedback=FeedbackValue(value='frustrated', error=None), overrides=None, valid=True)
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->


Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
