### PR TITLE
Improve file store deprecation warning messages

### DIFF
--- a/mlflow/store/model_registry/file_store.py
+++ b/mlflow/store/model_registry/file_store.py
@@ -134,10 +134,11 @@ class FileStore(AbstractStore):
 
         super().__init__()
         warnings.warn(
-            "Filesystem tracking backend (e.g., './mlruns') will be deprecated. "
-            "Please switch to a database backend (e.g., 'sqlite:///mlflow.db'). "
-            "See https://github.com/mlflow/mlflow/issues/18534 for feedback and how to migrate "
-            "existing data.",
+            "The filesystem model registry backend (e.g., './mlruns') will be deprecated in "
+            "February 2026. Consider transitioning to a database backend (e.g., "
+            "'sqlite:///mlflow.db') to take advantage of the latest MLflow features. "
+            "See https://github.com/mlflow/mlflow/issues/18534 for more details and migration "
+            "guidance.",
             FutureWarning,
             stacklevel=2,
         )

--- a/mlflow/store/tracking/file_store.py
+++ b/mlflow/store/tracking/file_store.py
@@ -217,10 +217,11 @@ class FileStore(AbstractStore):
         """
         super().__init__()
         warnings.warn(
-            "Filesystem tracking backend (e.g., './mlruns') will be deprecated. "
-            "Please switch to a database backend (e.g., 'sqlite:///mlflow.db'). "
-            "See https://github.com/mlflow/mlflow/issues/18534 for feedback and how to migrate "
-            "existing data.",
+            "The filesystem tracking backend (e.g., './mlruns') will be deprecated in "
+            "February 2026. Consider transitioning to a database backend (e.g., "
+            "'sqlite:///mlflow.db') to take advantage of the latest MLflow features. "
+            "See https://github.com/mlflow/mlflow/issues/18534 for more details and migration "
+            "guidance.",
             FutureWarning,
             stacklevel=2,
         )

--- a/tests/store/model_registry/test_file_store.py
+++ b/tests/store/model_registry/test_file_store.py
@@ -61,7 +61,7 @@ def rm_data(registered_model_names, tmp_path):
 
 
 def test_file_store_deprecation_warning(tmp_path):
-    with pytest.warns(FutureWarning, match="Filesystem tracking backend.* deprecated"):
+    with pytest.warns(FutureWarning, match="filesystem model registry backend.*will be deprecated"):
         FileStore(str(tmp_path / "model_registry"))
 
 

--- a/tests/store/tracking/test_file_store.py
+++ b/tests/store/tracking/test_file_store.py
@@ -148,7 +148,7 @@ def create_experiments(store, experiment_names):
 
 
 def test_file_store_deprecation_warning(tmp_path):
-    with pytest.warns(FutureWarning, match="Filesystem tracking backend.* deprecated"):
+    with pytest.warns(FutureWarning, match="filesystem tracking backend.*will be deprecated"):
         FileStore(str(tmp_path / "mlruns"))
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/18900?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18900/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18900/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18900/merge
```

</p>
</details>

### Related Issues/PRs

Addresses https://github.com/mlflow/mlflow/pull/18497#discussion_r2539280190

### What changes are proposed in this pull request?

This PR improves the deprecation warning messages for both tracking and model registry file stores to be more informative and less alarming to users. The warnings now include:
- Specific deprecation timeframe (February 2026)
- More reassuring language ("Consider transitioning" instead of "Please switch")

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests

Updated test regex patterns to match the new warning messages. Both tests pass successfully.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved deprecation warning messages for file-based tracking and model registry backends with specific timeline (February 2026) and clearer migration guidance.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)