### PR TITLE
Pin database Docker images and show digests in CI

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -124,7 +124,7 @@ jobs:
       - name: Build
         run: |
           ./tests/db/compose.sh pull -q postgresql mysql mssql
-          docker images
+          docker images --digests
           ./tests/db/compose.sh build --build-arg DEPENDENCIES="$(python dev/extract_deps.py)"
       - name: Run tests
         run: |

--- a/tests/db/compose.yml
+++ b/tests/db/compose.yml
@@ -65,7 +65,7 @@ services:
     command: tests/db/check_migration.sh
 
   mssql:
-    image: mcr.microsoft.com/mssql/server
+    image: mcr.microsoft.com/mssql/server@sha256:54b23ca766287dab5f6f55162923325f07cdec6ccb42108f37c55c87e7688ebd
     restart: always
     environment:
       ACCEPT_EULA: Y

--- a/tests/db/compose.yml
+++ b/tests/db/compose.yml
@@ -12,7 +12,7 @@ services:
       DISABLE_RESET_MLFLOW_URI_FIXTURE: "true"
 
   postgresql:
-    image: postgres
+    image: postgres@sha256:c1f0abd909b477d6088c72e4cd6eb01ea525344caca1b58689ae884204369502
     restart: always
     environment:
       POSTGRES_DB: mlflowdb
@@ -38,7 +38,7 @@ services:
     command: tests/db/check_migration.sh
 
   mysql:
-    image: mysql
+    image: mysql@sha256:569c4128dfa625ac2ac62cdd8af588a3a6a60a049d1a8d8f0fac95880ecdbbe5
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: root-password

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -145,7 +145,7 @@ CREATE TABLE experiment_tags (
 	value VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	experiment_id INTEGER NOT NULL,
 	CONSTRAINT experiment_tag_pk PRIMARY KEY (key, experiment_id),
-	CONSTRAINT "FK__experimen__exper__4F7CD00D" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT "FK__experimen__exper__628FA481" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 
@@ -181,7 +181,7 @@ CREATE TABLE model_versions (
 	run_link VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	storage_location VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT model_version_pk PRIMARY KEY (name, version),
-	CONSTRAINT "FK__model_vers__name__5812160E" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT "FK__model_vers__name__6B24EA82" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )
 
 
@@ -199,7 +199,7 @@ CREATE TABLE registered_model_tags (
 	value VARCHAR(5000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT registered_model_tag_pk PRIMARY KEY (key, name),
-	CONSTRAINT "FK__registered__name__5BE2A6F2" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
+	CONSTRAINT "FK__registered__name__6EF57B66" FOREIGN KEY(name) REFERENCES registered_models (name) ON UPDATE CASCADE
 )
 
 
@@ -219,7 +219,7 @@ CREATE TABLE runs (
 	experiment_id INTEGER,
 	deleted_time BIGINT,
 	CONSTRAINT run_pk PRIMARY KEY (run_uuid),
-	CONSTRAINT "FK__runs__experiment__3E52440B" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT "FK__runs__experiment__5165187F" FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
 )
 
 
@@ -251,7 +251,7 @@ CREATE TABLE webhook_events (
 	entity VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	action VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT webhook_event_pk PRIMARY KEY (webhook_id, entity, action),
-	CONSTRAINT "FK__webhook_e__webho__1332DBDC" FOREIGN KEY(webhook_id) REFERENCES webhooks (webhook_id) ON DELETE CASCADE
+	CONSTRAINT "FK__webhook_e__webho__2645B050" FOREIGN KEY(webhook_id) REFERENCES webhooks (webhook_id) ON DELETE CASCADE
 )
 
 
@@ -285,7 +285,7 @@ CREATE TABLE latest_metrics (
 	is_nan BIT NOT NULL,
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT latest_metric_pk PRIMARY KEY (key, run_uuid),
-	CONSTRAINT "FK__latest_me__run_u__52593CB8" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__latest_me__run_u__656C112C" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 
 
@@ -337,7 +337,7 @@ CREATE TABLE metrics (
 	step BIGINT DEFAULT ('0') NOT NULL,
 	is_nan BIT DEFAULT ('0') NOT NULL,
 	CONSTRAINT metric_pk PRIMARY KEY (key, timestamp, step, run_uuid, value, is_nan),
-	CONSTRAINT "FK__metrics__run_uui__440B1D61" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__metrics__run_uui__571DF1D5" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 
 
@@ -347,7 +347,7 @@ CREATE TABLE model_version_tags (
 	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	version INTEGER NOT NULL,
 	CONSTRAINT model_version_tag_pk PRIMARY KEY (key, name, version),
-	CONSTRAINT "FK__model_version_ta__5EBF139D" FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
+	CONSTRAINT "FK__model_version_ta__71D1E811" FOREIGN KEY(name, version) REFERENCES model_versions (name, version) ON UPDATE CASCADE
 )
 
 
@@ -356,7 +356,7 @@ CREATE TABLE params (
 	value VARCHAR(8000) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT param_pk PRIMARY KEY (key, run_uuid),
-	CONSTRAINT "FK__params__run_uuid__46E78A0C" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__params__run_uuid__59FA5E80" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 
 
@@ -393,7 +393,7 @@ CREATE TABLE tags (
 	value VARCHAR(8000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	run_uuid VARCHAR(32) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT tag_pk PRIMARY KEY (key, run_uuid),
-	CONSTRAINT "FK__tags__run_uuid__412EB0B6" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
+	CONSTRAINT "FK__tags__run_uuid__5441852A" FOREIGN KEY(run_uuid) REFERENCES runs (run_uuid)
 )
 
 


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR addresses MSSQL schema instability caused by Docker image updates and improves CI observability:

1. **Pin all database images to specific digests** to prevent automatic updates from changing schema/behavior
2. **Update MSSQL schema file** with constraint names from the current image
3. **Add `--digests` flag** to show SHA256 digests in CI logs

#### Background

MSSQL Docker image was recently updated from `a2fbff321505` (1.61GB) to `55c3fe0f8428` (1.79GB):

```
REPOSITORY                       TAG       IMAGE ID       CREATED        SIZE
postgres                         latest    80c0891f5de9   11 hours ago   456MB
mcr.microsoft.com/mssql/server   latest    a2fbff321505   3 weeks ago    1.61GB 👈
mysql                            latest    f6b0ca07d79d   3 weeks ago    934MB
```

→

```
REPOSITORY                       TAG       DIGEST                                                                    IMAGE ID       CREATED        SIZE
postgres                         latest    sha256:c1f0abd909b477d6088c72e4cd6eb01ea525344caca1b58689ae884204369502   80c0891f5de9   20 hours ago   456MB
mcr.microsoft.com/mssql/server   latest    sha256:54b23ca766287dab5f6f55162923325f07cdec6ccb42108f37c55c87e7688ebd   55c3fe0f8428   3 weeks ago    1.79GB 👈
mysql                            latest    sha256:569c4128dfa625ac2ac62cdd8af588a3a6a60a049d1a8d8f0fac95880ecdbbe5   f6b0ca07d79d   4 weeks ago    934MB
```

SQL Server auto-generates foreign key constraint names with hex suffixes based on internal object IDs. When the Docker image updates, these IDs change, resulting in different constraint names even though the schema structure remains identical.

Example constraint name changes:
- `FK__experimen__exper__4F7CD00D` → `FK__experimen__exper__628FA481`
- `FK__model_vers__name__5812160E` → `FK__model_vers__name__6B24EA82`

#### Pinned image digests

All database images are now pinned to prevent future automatic updates:
- **PostgreSQL**: `sha256:c1f0abd909b477d6088c72e4cd6eb01ea525344caca1b58689ae884204369502`
- **MySQL**: `sha256:569c4128dfa625ac2ac62cdd8af588a3a6a60a049d1a8d8f0fac95880ecdbbe5`
- **MSSQL**: `sha256:54b23ca766287dab5f6f55162923325f07cdec6ccb42108f37c55c87e7688ebd`

### How is this PR tested?

- [x] Existing unit/integration tests

The MSSQL schema file is auto-generated during CI runs. This update ensures the checked-in schema matches the pinned Docker image.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)