### PR TITLE
Fix docker-compose bash commands multiline parsing

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -44,12 +44,14 @@ services:
     depends_on:
       minio:
         condition: service_healthy
-    entrypoint: >
-      /bin/sh -c '
-        mc alias set myminio http://${MINIO_HOST}:${MINIO_PORT} \
-          ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD} &&
-        mc mb --ignore-existing myminio/${MINIO_BUCKET:-mlflow}
-      '
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+          set -x
+          mc alias set myminio "http://${MINIO_HOST}:${MINIO_PORT}" \
+            "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
+          mc mb --ignore-existing "myminio/${MINIO_BUCKET:-mlflow}"
     restart: "no"
 
   mlflow:
@@ -77,15 +79,17 @@ services:
       MLFLOW_HOST: ${MLFLOW_HOST}
       MLFLOW_PORT: ${MLFLOW_PORT}
 
-    command: >
-      /bin/bash -c "
-        pip install --no-cache-dir psycopg2-binary boto3 &&
-        mlflow server \
-          --backend-store-uri ${MLFLOW_BACKEND_STORE_URI} \
-          --default-artifact-root ${MLFLOW_DEFAULT_ARTIFACT_ROOT} \
-          --host ${MLFLOW_HOST} \
-          --port ${MLFLOW_PORT}
-      "
+    command:
+      - /bin/bash
+      - -c
+      - |
+          set -x
+          pip install --no-cache-dir psycopg2-binary boto3
+          mlflow server \
+            --backend-store-uri "${MLFLOW_BACKEND_STORE_URI}" \
+            --default-artifact-root "${MLFLOW_DEFAULT_ARTIFACT_ROOT}" \
+            --host "${MLFLOW_HOST}" \
+            --port "${MLFLOW_PORT}"
     ports:
       - "${MLFLOW_PORT}:${MLFLOW_PORT}"
     healthcheck:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -48,7 +48,6 @@ services:
       - /bin/sh
       - -c
       - |
-          set -x
           mc alias set myminio "http://${MINIO_HOST}:${MINIO_PORT}" \
             "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
           mc mb --ignore-existing "myminio/${MINIO_BUCKET:-mlflow}"
@@ -83,7 +82,6 @@ services:
       - /bin/bash
       - -c
       - |
-          set -x
           pip install --no-cache-dir psycopg2-binary boto3
           mlflow server \
             --backend-store-uri "${MLFLOW_BACKEND_STORE_URI}" \

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -48,9 +48,9 @@ services:
       - /bin/sh
       - -c
       - |
-          mc alias set myminio "http://${MINIO_HOST}:${MINIO_PORT}" \
-            "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
-          mc mb --ignore-existing "myminio/${MINIO_BUCKET:-mlflow}"
+        mc alias set myminio "http://${MINIO_HOST}:${MINIO_PORT}" \
+          "${MINIO_ROOT_USER}" "${MINIO_ROOT_PASSWORD}"
+        mc mb --ignore-existing "myminio/${MINIO_BUCKET:-mlflow}"
     restart: "no"
 
   mlflow:
@@ -82,12 +82,12 @@ services:
       - /bin/bash
       - -c
       - |
-          pip install --no-cache-dir psycopg2-binary boto3
-          mlflow server \
-            --backend-store-uri "${MLFLOW_BACKEND_STORE_URI}" \
-            --default-artifact-root "${MLFLOW_DEFAULT_ARTIFACT_ROOT}" \
-            --host "${MLFLOW_HOST}" \
-            --port "${MLFLOW_PORT}"
+        pip install --no-cache-dir psycopg2-binary boto3
+        mlflow server \
+          --backend-store-uri "${MLFLOW_BACKEND_STORE_URI}" \
+          --default-artifact-root "${MLFLOW_DEFAULT_ARTIFACT_ROOT}" \
+          --host "${MLFLOW_HOST}" \
+          --port "${MLFLOW_PORT}"
     ports:
       - "${MLFLOW_PORT}:${MLFLOW_PORT}"
     healthcheck:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/UnfixedMold/mlflow/pull/18922?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18922/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18922/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18922/merge
```

</p>
</details>



<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

Resolve https://github.com/mlflow/mlflow/issues/18899

### What changes are proposed in this pull request?

- switched from shell form to exec array form
- changed > to |
- added quotes around env vars for safe expansion

#### Why?
Initially I noticed that the bash script was running `mlflow server` without any command-line arguments. The root issue was that backslashes were not parsed correctly when the command was wrapped in double quotes inside a folded YAML block. Switching to single quotes would have fixed it, but moving to the exec array form is a cleaner and more reliable solution. I also updated the bash script in the `create-bucket` service for consistency and to avoid similar issues in the future (it worked previously only because it already used single quotes).

I also switched `>` to `|` so the script keeps its actual line breaks instead of being folded into one long string. This doesn’t change behavior in this case but is cleaner and avoids future YAML folding issues.

Environment variables with special characters (e.g. passwords) were also breaking command parsing, so I added quotes around all env vars to make expansion safe.

#### How to test the fix

To see what the container is *actually* running, temporarily add `set -x` at the top of the command block, for example:
*This is only for debugging and shouldn’t be left in production code, since it exposes secrets in the logs.*

```yaml
command:
  - /bin/bash
  - -c
  - |
      set -x
      pip install ...
      mlflow server \
        --backend-store-uri "${MLFLOW_BACKEND_STORE_URI}" \
        ...
```

Then start the compose with
```bash
docker compose up -d
````

Then check the logs with 
```bash
docker logs mlflow-server
```

You should see the real expanded commands prefixed with +, for example:
```bash
+ mlflow server --backend-store-uri postgresql://... --default-artifact-root s3://... --host 0.0.0.0 --port 5000
```


### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
