### PR TITLE
Fix bug in chat sessions view where new sessions created after UI launch are not visible due to incorrect timestamp filtering

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPage.tsx
@@ -13,7 +13,7 @@ import {
   createTraceLocationForUCSchema,
   useSearchMlflowTraces,
 } from '@databricks/web-shared/genai-traces-table';
-import { useMonitoringConfig } from '../../hooks/useMonitoringConfig';
+import { MonitoringConfigProvider, useMonitoringConfig } from '../../hooks/useMonitoringConfig';
 import { getAbsoluteStartEndTime, useMonitoringFilters } from '../../hooks/useMonitoringFilters';
 import { SESSION_ID_METADATA_KEY, shouldUseTracesV4API } from '@databricks/web-shared/model-trace-explorer';
 import { useGetExperimentQuery } from '../../hooks/useExperimentQuery';
@@ -85,7 +85,9 @@ const ExperimentChatSessionsPageImpl = () => {
 const ExperimentChatSessionsPage = () => {
   return (
     <ExperimentChatSessionsPageWrapper>
-      <ExperimentChatSessionsPageImpl />
+      <MonitoringConfigProvider>
+        <ExperimentChatSessionsPageImpl />
+      </MonitoringConfigProvider>
     </ExperimentChatSessionsPageWrapper>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPageWrapper.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPageWrapper.tsx
@@ -3,5 +3,9 @@ import { ExperimentChatSessionsGenericErrorState } from './ExperimentChatSession
 import { MonitoringConfigProvider } from '../../hooks/useMonitoringConfig';
 
 export const ExperimentChatSessionsPageWrapper = ({ children }: { children: React.ReactNode }) => {
-  return <ErrorBoundary fallback={<ExperimentChatSessionsGenericErrorState />}>{children}</ErrorBoundary>;
+  return (
+    <ErrorBoundary fallback={<ExperimentChatSessionsGenericErrorState />}>
+      <MonitoringConfigProvider>{children}</MonitoringConfigProvider>
+    </ErrorBoundary>
+  );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPageWrapper.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/ExperimentChatSessionsPageWrapper.tsx
@@ -1,11 +1,6 @@
 import { ErrorBoundary } from 'react-error-boundary';
 import { ExperimentChatSessionsGenericErrorState } from './ExperimentChatSessionsGenericErrorState';
-import { MonitoringConfigProvider } from '../../hooks/useMonitoringConfig';
 
 export const ExperimentChatSessionsPageWrapper = ({ children }: { children: React.ReactNode }) => {
-  return (
-    <ErrorBoundary fallback={<ExperimentChatSessionsGenericErrorState />}>
-      <MonitoringConfigProvider>{children}</MonitoringConfigProvider>
-    </ErrorBoundary>
-  );
+  return <ErrorBoundary fallback={<ExperimentChatSessionsGenericErrorState />}>{children}</ErrorBoundary>;
 };

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -7,7 +7,7 @@ module.exports = function (app) {
   // Exception: If the caller has specified an MLFLOW_PROXY, we instead forward server requests
   // there.
   // eslint-disable-next-line no-undef
-  const proxyTarget = process.env.MLFLOW_PROXY || 'http://127.0.0.1:5000/';
+  const proxyTarget = process.env.MLFLOW_PROXY || 'http://localhost:5000/';
   // eslint-disable-next-line no-undef
   const proxyStaticTarget = process.env.MLFLOW_STATIC_PROXY || proxyTarget;
   app.use(

--- a/mlflow/server/js/src/setupProxy.js
+++ b/mlflow/server/js/src/setupProxy.js
@@ -7,7 +7,7 @@ module.exports = function (app) {
   // Exception: If the caller has specified an MLFLOW_PROXY, we instead forward server requests
   // there.
   // eslint-disable-next-line no-undef
-  const proxyTarget = process.env.MLFLOW_PROXY || 'http://localhost:5000/';
+  const proxyTarget = process.env.MLFLOW_PROXY || 'http://127.0.0.1:5000/';
   // eslint-disable-next-line no-undef
   const proxyStaticTarget = process.env.MLFLOW_STATIC_PROXY || proxyTarget;
   app.use(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/18928?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18928/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18928/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18928/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix bug in chat sessions view where new sessions created after UI launch are not visible due to incorrect timestamp filtering

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

**Before*

```
{locations: [{type: "MLFLOW_EXPERIMENT", mlflow_experiment: {experiment_id: "1"}}],…}
filter
: 
"attributes.timestamp_ms > 1762987653712 AND attributes.timestamp_ms < 1763592453712 AND request_metadata.mlflow.trace.session ILIKE '%%'"
locations
: 
[{type: "MLFLOW_EXPERIMENT", mlflow_experiment: {experiment_id: "1"}}]
max_results
: 
500
```

<img width="1893" height="1124" alt="Screenshot 2025-11-19 at 2 48 53 PM" src="https://github.com/user-attachments/assets/86046981-9e20-4b97-90ee-240124decc9d" />

**After**

Sessions show up because timestamp filter is correct:

```
{locations: [{type: "MLFLOW_EXPERIMENT", mlflow_experiment: {experiment_id: "1"}}],…}
filter
: 
"attributes.timestamp_ms > 1762987653712 AND attributes.timestamp_ms < 1763592609398 AND request_metadata.mlflow.trace.session ILIKE '%%'"
locations
: 
[{type: "MLFLOW_EXPERIMENT", mlflow_experiment: {experiment_id: "1"}}]
max_results
: 
500
```

<img width="1832" height="1154" alt="Screenshot 2025-11-19 at 2 50 43 PM" src="https://github.com/user-attachments/assets/ed88490a-cd1a-4b39-9a58-b01ab58ac2bb" />


### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

Fix bug causing newly-created chat sessions to be hidden from the UI

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
