### PR TITLE
Migrate Python job in master.yml workflow to uv

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -77,7 +77,7 @@ jobs:
       - uses: ./.github/actions/setup-java
       - name: Install dependencies
         run: |
-          uv sync --extra 'extras,gateway,mcp'
+          uv sync --extra extras --extra gateway --extra mcp
           uv pip install \
             -r requirements/test-requirements.txt \
             -r requirements/extra-ml-requirements.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -75,40 +75,35 @@ jobs:
       - uses: ./.github/actions/setup-python
       - uses: ./.github/actions/setup-pyenv
       - uses: ./.github/actions/setup-java
-      - uses: ./.github/actions/cache-pip
       - name: Install dependencies
         run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          source ./dev/install-common-deps.sh --ml
-          # transformers doesn't support Keras 3 yet. tf-keras needs to be installed as a workaround.
-          pip install tf-keras
-          # Ensure `databricks-connect` and `databricks-agents` are not installed
-          pip uninstall -y databricks-connect databricks-agents
-          pip install --no-deps --force-reinstall pyspark
+          uv sync --extra 'extras,gateway,mcp'
+          uv pip install \
+            -r requirements/test-requirements.txt \
+            -r requirements/extra-ml-requirements.txt
       - uses: ./.github/actions/show-versions
       - uses: ./.github/actions/pipdeptree
       - name: Import check
         run: |
-          source .venv/bin/activate
           # `-I` is used to avoid importing modules from user-specific site-packages
           # that might conflict with the built-in modules (e.g. `types`).
-          python -I tests/check_mlflow_lazily_imports_ml_packages.py
+          uv run --no-sync python -I tests/check_mlflow_lazily_imports_ml_packages.py
       - name: Run tests
         run: |
-          source .venv/bin/activate
           source dev/setup-ssh.sh
-          pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} --quiet --requires-ssh \
-            --ignore-flavors --ignore=tests/examples --ignore=tests/evaluate \
-            --ignore tests/genai tests
+          uv run --no-sync pytest --splits=${{ matrix.splits }} --group=${{ matrix.group }} \
+            --quiet --requires-ssh --ignore-flavors \
+            --ignore=tests/examples \
+            --ignore=tests/evaluate \
+            --ignore=tests/genai \
+            tests
 
       - name: Run databricks-connect related tests
         run: |
           # this needs to be run in a separate job because installing databricks-connect could break other
           # tests that uses normal SparkSession instead of remote SparkSession
-          source .venv/bin/activate
-          pip install databricks-agents
-          pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
+          uv run --no-sync --with databricks-agents \
+            pytest tests/utils/test_requirements_utils.py::test_infer_pip_requirements_on_databricks_agents
 
   database:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false


### PR DESCRIPTION
### What changes are proposed in this pull request?

Migrate the Python job in `.github/workflows/master.yml` to use `uv` instead of manual venv management and pip, bringing it in line with other jobs in the workflow.

### Before (no cache)

<img width="786" height="65" alt="image" src="https://github.com/user-attachments/assets/b58a3ddd-f880-462c-85c7-a9b347fdd40d" />

### After (no cache)

<img width="786" height="65" alt="image" src="https://github.com/user-attachments/assets/a84f6fa8-f1d1-44ef-aae8-d6dbf225fdb0" />


### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)