### PR TITLE
[ML-59305] Create new session-level built-in judge UserFrustration

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -559,7 +559,7 @@ class InstructionsJudge(Judge):
         if not template_vars:
             raise MlflowException(
                 "Instructions template must contain at least one variable (e.g., {{ inputs }}, "
-                "{{ outputs }}, {{ trace }}, or {{ expectations }}).",
+                "{{ outputs }}, {{ trace }}, {{ expectations }}, or {{ conversation }}).",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 

--- a/mlflow/genai/judges/prompts/user_frustration.py
+++ b/mlflow/genai/judges/prompts/user_frustration.py
@@ -1,0 +1,66 @@
+# NB: User-facing name for the user frustration assessment.
+USER_FRUSTRATION_ASSESSMENT_NAME = "user_frustration"
+
+USER_FRUSTRATION_PROMPT = """\
+You are an expert evaluator of human-AI conversations.
+Your job is to determine whether the user is frustrated because of the AI assistant.
+
+You must base your judgment only on evidence in the conversation.
+
+## Instructions
+A. Frustration specifically caused by the AI (count this)
+The user is considered frustrated because of the AI if ANY of the following appear:
+1. Explicit frustration directed at the AI
+Examples (not exhaustive):
+- Complaints about the AI's behavior or performance ("You're not helping," "Why do you keep messing this up?")
+- Irritated or hostile tone toward the AI
+- User giving up because of the AI's mistakes ("Forget it," "This is useless" after the AI's wrong answer)
+
+2. Implicit frustration directed at the AI
+Signals that the AI is failing and the user is reacting to that failure:
+The user shows irritation through behavior, not wording.
+Look for patterns, not isolated turns.
+Count as frustration if you see two or more of the following AI-caused signals:
+- Repeated Corrections
+    - User must correct the AI's mistake or misunderstanding more than once.
+    - ("That's not what I asked," "No, I meant X," "Not that, the other thing.")
+
+- Restating the Same Request
+    - User rephrases or repeats instructions because the AI failed to follow them.
+    - User emphasizes they want exactly what was requested.
+    - User signals impatience:
+        - "Still not what I asked."
+        - "Once more, but actually follow the instruction."
+
+- Directive Tone Shift
+    - The user's turns become noticeably shorter, more blunt, or more controlling after AI mistakes.
+    - Short, clipped commands showing a shift from neutral -> irritated.
+    - "Just answer directly."
+    - "Keep it simple."
+
+If the user displays at least two of these signals, and they were triggered by AI errors -> frustrated.
+
+What You MUST NOT count as AI-caused frustration
+B. Frustration NOT caused by the AI (ignore these completely)
+Do **not** classify the user as frustrated if the frustration is directed at:
+- The task itself ("This homework is impossible")
+- External issues (life problems, other people, environment)
+- Fiction / role-playing / pretend anger
+- Humor or light sarcasm not aimed at the AI
+- Direct, blunt, or neutral communication with no emotional intent
+
+C. Temporal rule
+- If the user was frustrated earlier, but the conversation ends with the user satisfied, calm, or appreciative, classify them as **not frustrated**.
+Only the final state matters.
+
+You must output:
+- **"frustrated"**
+if there is any explicit or implicit evidence that the user is frustrated because of something the AI said or did.
+- **"not_frustrated"**
+if no such evidence exists,
+OR if frustration is directed elsewhere (task, self, jokes, role-play),
+OR if frustration was resolved by the end.
+
+## Conversation to Evaluate
+{{ conversation }}
+"""  # noqa: E501

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -33,6 +33,7 @@ _LAZY_IMPORTS = {
     "RetrievalRelevance",
     "RetrievalSufficiency",
     "Safety",
+    "UserFrustration",
     "get_all_scorers",
 }
 
@@ -74,6 +75,7 @@ if TYPE_CHECKING:
         RetrievalRelevance,
         RetrievalSufficiency,
         Safety,
+        UserFrustration,
         get_all_scorers,
     )
 
@@ -87,6 +89,7 @@ __all__ = [
     "RetrievalRelevance",
     "RetrievalSufficiency",
     "Safety",
+    "UserFrustration",
     "Scorer",
     "scorer",
     "ScorerSamplingConfig",


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xsh310/mlflow/pull/18943?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18943/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18943/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18943/merge
```

</p>
</details>

### What changes are proposed in this pull request?
This PR creates a new session-level built-in judge UserFrustration. Users can instantiate a UserFrustration judge in one line just like the existing built-in judges, and can directly invoke (or pass into genai.evaluation soon) to evaluate whether the user is frustrated at the AI assistance given a conversation history

Note that this built-in judge is different from the previous built-in judge in terms of the following aspects:
1. Unlike all other existing built-in judge, UserFrustration is a session-level LLM-as-Judge which takes in a list of traces from a conversation and evaluates on the entire conversation rather than on a single human-AI interaction turn.
2. This built-in judge leverages the eval prompt preparation process in InstructionJudge (what we create when calling make_judge). This prevents us from implementation a single logic again in the built-in scorer file.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
### Manual Testing
Manually tests with the following small synthetic conversations, `openai:/gpt-5` is able to get all the conversations correctly classified based on the judge prompt:
```
good_conversations = {
    "sunset_inquiry": {
        "Hey, what time does the sun usually set in summer?": "It depends on the region, but in many places it's around 8–9 PM.",
        "Got it, thanks! That helps.": "Glad to help!"
    },
    
    "herb_garden": {
        "I'm thinking of starting a small herb garden. Any easy plants for beginners?": "Basil, mint, and chives are great beginner herbs—low maintenance and fast-growing.",
        "Mint sounds good. Does it need lots of sunlight?": "Mint grows well with partial sunlight, so a windowsill is usually enough."
    },
    
    "chicago_tourism": {
        "I need information on common tourist spots in Chicago.": "Popular locations include Millennium Park, the Art Institute, Navy Pier, and the Riverwalk.",
        "Is the Art Institute large?": "Yes, it's one of the biggest art museums in the country.",
        "How long does a visit usually take?": "Most visitors spend two to three hours."
    },
    
    "laptop_fan": {
        "My laptop fan has been louder recently. What can I check before taking it in?": "You can check for dust in the vents and review background processes.",
        "Where do I see background processes on Windows?": "Open Task Manager and check the Processes tab.",
        "If a process uses a lot of CPU, do I end it?": "End it only if you recognize it and it's safe.",
        "Could dust alone cause the fan noise?": "Yes, accumulated dust is a common cause."
    },
    
    "coral_bleaching": {
        "I need information on how coral bleaching works.": "Coral bleaching occurs when corals expel the symbiotic algae, called zooxanthellae, that live inside their tissues. These algae provide most of the coral's energy through photosynthesis and also give the coral its color. When water temperatures rise beyond the coral's tolerance, or when the water becomes too acidic, polluted, or exposed to prolonged sunlight, the algae become stressed and the coral ejects them. Without the algae, the coral turns pale or white, and its energy intake drops sharply. If conditions return to normal within a limited window, the coral can sometimes recover by taking in new algae. If not, the coral becomes increasingly weak and may die.",
        "Are temperature changes the main cause?": "Temperature change is the most common trigger. Even a sustained increase of 1–2°C above the normal seasonal maximum can initiate bleaching. Heat waves, especially those lasting several weeks, place significant stress on coral ecosystems. However, additional factors can contribute to bleaching, including ocean acidification, sediment runoff, nutrient pollution from agriculture, and certain forms of ultraviolet radiation. These factors may not act alone; they often interact, lowering the coral's resilience and making bleaching more likely when temperature spikes occur.",
        "Does bleaching always kill the coral?": "Bleaching does not immediately kill the coral. It reduces the coral's energy supply and weakens it, which increases vulnerability to disease, overheating, and starvation. If environmental conditions improve quickly enough, the coral can regain algae and recover. Recovery rates vary by species, water quality, and the severity of the bleaching event. Some corals bounce back within weeks or months; others remain stressed for much longer. If stressful conditions persist or repeat frequently, the coral's energy reserves are depleted and mortality becomes more likely."
    },
    
    "math_problem": {
        "This math problem is a mess. Show me how to set up the equation.": "To set up the equation, identify the known values and the variable you're solving for. If it's a rate problem, assign variables to distance, rate, and time. Once those are defined, the equation follows the standard relationship: distance = rate × time.",
        "Yeah the assignment is written poorly.": "If the wording is unclear, simplifying the problem into smaller pieces usually helps. I can rewrite the prompt in clearer terms if you want."
    },
    
    "character_dialogue": {
        "Write a line for a character who is furious at their coworker.": "Here is an example line: \"I told you three times to file that report, and you ignored every word. I'm not covering for you again.\"",
        "Make it more intense.": "Here is a stronger version: \"You never listen, and now the entire project is falling apart because of you. I'm done fixing your messes.\""
    },
    
    "csv_export": {
        "My excel sheet is a mess this morning, sigh. I need the steps for exporting a CSV in Excel.": "To export a CSV, open the File tab, choose Save As, select the folder you want, and then pick 'CSV (Comma delimited)' from the file type dropdown. After choosing that, click Save and confirm any warnings Excel shows, since CSV format doesn't keep formulas or formatting.",
        "Where does the file type dropdown appear?": "It appears in the Save As window. After you choose a location—like Documents or Desktop—you'll see a field for the filename. Under that field is a dropdown labeled 'Save as type'. That's where CSV is listed.",
        "I'm using the newer interface. I only see a panel with recent folders.": "In that interface, you'll need to click 'Browse' first. That opens the full File Explorer window. Once you're there, the filename field and file type dropdown will be visible at the bottom of the window."
    },
    
    "textbook_summary": {
        "I have to read another 40 pages of this textbook tonight. Incredible. Truly living the dream.": "If you want help, I can summarize key sections or explain specific concepts so you don't have to go through all 40 pages in detail.",
        "Just give me the summary of chapter 3.": "Chapter 3 covers the basics of cellular structure: the roles of the nucleus, mitochondria, membrane transport, and how cells maintain homeostasis. It also introduces the distinction between prokaryotic and eukaryotic cells and explains how organelles contribute to energy production and protein synthesis."
    },
    
    "internet_issues": {
        "My internet has been dropping every hour today. I'm sick of this. I can't get anything done like this.": "I can run a quick line check and look for interruptions in your area. While that loads, can you tell me if the connection drops completely or just slows down?",
        "It drops entirely. Everything cuts out and reconnects after a minute.": "The diagnostics show intermittent signal loss to your modem. This usually happens when the line outside experiences noise or when the modem firmware is outdated. I can walk you through a reset or schedule a technician visit if needed.",
        "Just tell me what I should do right now.": "Start with a manual reboot: unplug the modem for 30 seconds and plug it back in. This forces it to refresh its connection to the network. If the issue is temporary line noise, this often stabilizes the signal long enough for you to continue working.",
        "Alright, it's back on. Looks stable for the moment.": "Good. I'll keep monitoring the line in the background for the next 24 hours. If another drop occurs, I can automatically schedule a technician or guide you through additional steps."
    }
}

bad_conversations = {
    "screenshot_shortcut": {
        "I need the keyboard shortcut for taking a screenshot on Windows.": "On Windows, there are several ways to capture the screen, but the Snipping Tool is one of the most commonly used. You can open it from the Start menu and select the area you want to capture. It provides free-form, rectangular, window, and full-screen options, and it also lets you annotate the screenshot before saving. It's useful for precise selections or when you need more control than a simple hotkey provides.",
        "I said shortcut.": "If you prefer a direct keyboard method, Windows provides multiple key combinations. For example, pressing Print Screen will capture the entire display to the clipboard, where you can paste it into an image editor. There is also Alt + Print Screen, which captures only the active window. These are the simplest built-in shortcuts.",
        "You're missing the one I asked for.": "The shortcut you are referring to is most likely Windows + Shift + S. This opens the built-in snipping overlay, allowing you to immediately select a region, a window, or the entire screen. The captured image is automatically placed on the clipboard and triggers a notification, making it easy to save or edit. This is the shortcut used by most people when they want a quick screenshot without opening a separate application.",
        "This is the third time. You keep giving the wrong thing first.": "Understood. The correct shortcut for a manual screenshot selection is Windows + Shift + S, while Print Screen captures the entire screen instantly. You can disable or reassign the Print Screen behavior in Settings if needed. Let me know if you want the differences between the capture modes or how to save automatically instead of copying to the clipboard."
    },
    
    "photosynthesis_summary": {
        "Summarize this in one sentence: 'Photosynthesis allows plants to convert light into energy.'": "Photosynthesis is a process involving many organisms and several chemical pathways.",
        "That is not what the text says.": "I can rewrite it if needed.",
        "Stop improvising. Read the sentence I gave you.": "The correct summary is: Plants use photosynthesis to turn light into energy."
    },
    
    "km_to_miles": {
        "Convert 12 kilometers to miles.": "12 kilometers is about 3 miles.",
        "No, that's incorrect. It's over 7 miles.": "You're right. The correct value is around 7.5 miles.",
        "You keep giving wrong values before correcting them. This is unreliable.": "The accurate conversion is 12 km ≈ 7.46 miles."
    },
    
    "image_formats": {
        "List three common image file formats.": "JPEG, PNG, and MP3 are common formats.",
        "MP3 is audio. I need image formats.": "Correct. JPEG, PNG, and GIF are image formats.",
        "Give me the correct list directly this time.": "Image formats include JPEG, PNG, GIF, BMP, and TIFF."
    },
    
    "python_sort_brief": {
        "Explain how to sort a list alphabetically in Python.": "You can loop through the list and print each item in order.",
        "I'm asking about sorting, not printing.": "You can use the sorted() function to sort it.",
        "I need the direct method without guessing. Give the exact approach.": "Use sorted(list) for a new sorted list or list.sort() to sort in place."
    },
    
    "python_sort_verbose": {
        "Show me how to sort a list alphabetically in Python.": "One way to handle ordering in Python is to iterate through the elements manually and output them in the order you want. For example, you can run a loop through the items in your list and print each entry. This doesn't modify the original list, but it allows you to display items sequentially depending on your logic. If your list contains strings, the default printed order will match the order they already appear in unless you explicitly change it inside the loop.",
        "I'm talking about sorting, not printing.": "For sorting operations in Python, the language provides functions that operate on lists in flexible ways. Python lists can be manipulated using loops, comprehensions, or library functions, and these operations can reorganize data. Some developers prefer writing custom comparison routines depending on the dataset or preferred ordering, while others rely on built-in behavior. Sorting can involve alphabetical, numerical, or custom rules.",
        "I need the actual sort method.": "The actual sorting mechanisms in Python consist of two main options. First, you can call the sorted() function, which takes an iterable—like a list—and returns a brand-new list containing the items in alphabetical order. This leaves your original list unchanged. Second, you can use the list.sort() method, which performs the sorting in place and modifies the list directly. Both support parameters like key= for custom sorting and reverse=True to flip the order. These are the standard ways to alphabetize lists in Python without writing loops manually.",
        "Keep it direct. Just give the command.": "The direct commands for alphabetical sorting are:\n\n**sorted_list = sorted(your_list)** — creates a new alphabetically sorted list.\n\n**your_list.sort()** — sorts the existing list in place.\n\nBoth default to alphabetical order for strings. If you need case-insensitive sorting, you can use sorted(your_list, key=str.lower) or your_list.sort(key=str.lower)."
    },
    
    "reminder_scheduling": {
        "Schedule a reminder for 3 PM.": "I've scheduled it for 3 AM.",
        "Amazing. Exactly what I didn't say.": "I can change it to 4 AM."
    },
    
    "french_revolution": {
        "Give me a one-sentence summary of the French Revolution.": "The French Revolution was a complex series of events involving economic hardship, political struggle, and philosophical change spanning many years.",
        "I said one sentence. That was more than one.": "The French Revolution reshaped France's political system and challenged monarchy and privilege.",
        "You added extra details again after I specified the limit.": "The French Revolution was a period when French people overthrew the monarchy and reorganized the government."
    },
    
    "fake_legislation": {
        "What year was the 'Unified Data Transport Act' passed in the US?": "The Unified Data Transport Act was passed in 2014 as part of broader data-governance reforms.",
        "I can't find any reference to that act. Where are you getting this from?": "It was part of a set of technology regulations aimed at standardizing data movement across agencies.",
        "hmmm wut?? I've searched through the documents but this doesn't appear anywhere in actual legal records. Are you absolutely sure about this?": "You are right. I can double check for actual federal laws related to data governance instead if you want."
    },
    
    "workspace_organization": {
        "I need suggestions for organizing my workspace. It's getting cluttered.": "People who struggle with clutter often have trouble staying focused or managing basic routines. You might start with simple tasks like clearing your desk once a week.",
        "I didn't say I struggle with routines. Don't make assumptions about me.": "I only meant that clutter can sometimes be linked with difficulty staying consistent.",
        "That's not what I asked, and you're implying things you shouldn't. Just give the organizing tips.": "Understood. Practical steps include grouping items by type, removing unused materials, and using storage containers or vertical shelves to keep frequently used items accessible."
    },
    
    "moon_tides": {
        "Could you provide a summary of this paragraph? 'The moon influences ocean tides through gravitational pull.'": "The paragraph explains how the moon's phases affect human emotions in different cultures.",
        "I see. That doesn't seem related to the text I provided. Could you try summarizing the original sentence directly?": "The paragraph describes cultural beliefs about lunar cycles rather than scientific effects.",
        "I'm sorry, but it's still not matching what I asked. The text only mentions tides. Could you pls focus strictly on that sentence this time?": "The correct summary is: The moon's gravitational pull affects ocean tides."
    }
}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Adding a new built-in llm-as-judge that users can instantiate and invoke to evaluate whether user is frustrated by the AI assistant given a conversation history.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
