### PR TITLE
Show date string in trace header

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1642,6 +1642,10 @@
     "defaultMessage": "Request",
     "description": "Column label for request"
   },
+  "F/VdVK": {
+    "defaultMessage": "Delete",
+    "description": "Label for the delete experiments action on the projects list page"
+  },
   "F16DNA": {
     "defaultMessage": "Version {versionNum}",
     "description": "Title text for model version page"
@@ -1733,6 +1737,10 @@
   "FpjDSq": {
     "defaultMessage": "Compare",
     "description": "Text for compare button to compare versions under details tab\n                       on the model view page"
+  },
+  "FxxI/f": {
+    "defaultMessage": "Create Project",
+    "description": "Label for the create project action on the GenAI projects list page"
   },
   "G/zTTY": {
     "defaultMessage": "Error",
@@ -2534,6 +2542,10 @@
     "defaultMessage": "Running",
     "description": "Run page > Overview > Run status cell > Value for running state"
   },
+  "Ov2MZH": {
+    "defaultMessage": "Compare",
+    "description": "Label for the compare experiments action on the projects list page"
+  },
   "OzyPl3": {
     "defaultMessage": "Please select parameters",
     "description": "Placeholder text for parameters in parallel coordinates plot in MLflow"
@@ -2541,6 +2553,10 @@
   "P/Uvf4": {
     "defaultMessage": "Classification",
     "description": "Label for experiments focused on classification modeling"
+  },
+  "P6hz/A": {
+    "defaultMessage": "Time",
+    "description": "Label for the request time section"
   },
   "PBeZnP": {
     "defaultMessage": "You can start logging traces to this logged model by calling {code} first:",
@@ -3959,6 +3975,10 @@
     "defaultMessage": "No results match this search.",
     "description": "No results message in datasets drawer table"
   },
+  "dpwDqC": {
+    "defaultMessage": "Tag filter",
+    "description": "Button to open the tags filter popover in the projects page"
+  },
   "dq8MJd": {
     "defaultMessage": "Contour Plot",
     "description": "Tab text for contour plot on the model comparison page"
@@ -4723,6 +4743,10 @@
     "defaultMessage": "Last modified",
     "description": "Header for the last modified column in the experiments table"
   },
+  "l7MCfv": {
+    "defaultMessage": "Filter projects by name",
+    "description": "Placeholder text inside GenAI projects search bar"
+  },
   "l8Z2nP": {
     "defaultMessage": "Remove filter",
     "description": "Button to remove a filter in the tags filter popover for experiments page search by tags"
@@ -5414,6 +5438,10 @@
   "rs7Iic": {
     "defaultMessage": "Tags",
     "description": "Run page > Overview > Run tags section label"
+  },
+  "rsJIMO": {
+    "defaultMessage": "Projects",
+    "description": "Header title for the GenAI projects experiments page"
   },
   "rxMHgr": {
     "defaultMessage": "Stage transition",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderDetails.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceHeaderDetails.tsx
@@ -25,6 +25,16 @@ import { spanTimeFormatter } from './timeline-tree/TimelineTree.utils';
 
 const BASE_NOTIFICATION_COMPONENT_ID = 'mlflow.model_trace_explorer.header_details.notification';
 
+const DATE_FORMAT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: 'short',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  timeZoneName: 'short',
+};
+
 export const ModelTraceHeaderDetails = ({ modelTraceInfo }: { modelTraceInfo: ModelTrace['info'] }) => {
   const { theme } = useDesignSystemTheme();
   const [showNotification, setShowNotification] = useState(false);
@@ -65,6 +75,18 @@ export const ModelTraceHeaderDetails = ({ modelTraceInfo }: { modelTraceInfo: Mo
     return undefined;
   }, [rootNode]);
 
+  const requestTime = useMemo(() => {
+    // NB: Not handling V2 intentionally, this functionality is not critical so is not worth
+    // the complexity of supporting two different logic for old versions.
+    if (isV3ModelTraceInfo(modelTraceInfo) && modelTraceInfo.request_time) {
+      const requestDate = new Date(modelTraceInfo.request_time);
+      if (!Number.isNaN(requestDate.getTime())) {
+        return requestDate.toLocaleString(undefined, DATE_FORMAT_OPTIONS);
+      }
+    }
+    return undefined;
+  }, [modelTraceInfo]);
+
   const handleTagClick = (text: string) => {
     navigator.clipboard.writeText(text);
   };
@@ -86,6 +108,16 @@ export const ModelTraceHeaderDetails = ({ modelTraceInfo }: { modelTraceInfo: Mo
             value={modelTraceId}
             displayValue={modelTraceIdToDisplay}
             color="purple"
+            getTruncatedLabel={getTruncatedLabel}
+            onCopy={handleCopy}
+          />
+        )}
+        {requestTime && (
+          <ModelTraceHeaderMetricSection
+            label={<FormattedMessage defaultMessage="Time" description="Label for the request time section" />}
+            icon={<ClockIcon css={{ fontSize: 12, display: 'flex', alignItems: 'center', justifyContent: 'center' }} />}
+            value={requestTime}
+            displayValue={requestTime}
             getTruncatedLabel={getTruncatedLabel}
             onCopy={handleCopy}
           />


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/18952?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18952/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/18952/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/18952/merge
```

</p>
</details>

### What changes are proposed in this pull request?

PRISM request. Show timestamp in the trace header. Currently trace table shows a timestamp column, but it is not available when. users directly see the trace (e.g. from notebook) outside trace table.

<img width="984" height="130" alt="Screenshot 2025-11-21 at 16 44 54" src="https://github.com/user-attachments/assets/7f24d8ba-4eaa-4b35-95e4-8362d1b2088f" />

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
