### PR TITLE
[ML-59678] Create new session-level built-in judge ConversationCompleteness

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -842,6 +842,10 @@ mlflow.genai.scorers.Safety
 mlflow.genai.scorers.Safety.get_input_fields
 mlflow.genai.scorers.Safety.model_post_init
 mlflow.genai.scorers.ScorerSamplingConfig
+mlflow.genai.scorers.UserFrustration
+mlflow.genai.scorers.UserFrustration.align
+mlflow.genai.scorers.UserFrustration.get_input_fields
+mlflow.genai.scorers.UserFrustration.model_post_init
 mlflow.genai.scorers.base.Scorer
 mlflow.genai.scorers.base.ScorerSamplingConfig
 mlflow.genai.scorers.builtin_scorers.Correctness
@@ -853,6 +857,7 @@ mlflow.genai.scorers.builtin_scorers.RetrievalGroundedness
 mlflow.genai.scorers.builtin_scorers.RetrievalRelevance
 mlflow.genai.scorers.builtin_scorers.RetrievalSufficiency
 mlflow.genai.scorers.builtin_scorers.Safety
+mlflow.genai.scorers.builtin_scorers.UserFrustration
 mlflow.genai.scorers.delete_scorer
 mlflow.genai.scorers.get_all_scorers
 mlflow.genai.scorers.get_scorer

--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -810,6 +810,10 @@ mlflow.genai.optimize_prompts
 mlflow.genai.register_prompt
 mlflow.genai.scheduled_scorers.ScorerScheduleConfig
 mlflow.genai.scorer
+mlflow.genai.scorers.ConversationCompleteness
+mlflow.genai.scorers.ConversationCompleteness.align
+mlflow.genai.scorers.ConversationCompleteness.get_input_fields
+mlflow.genai.scorers.ConversationCompleteness.model_post_init
 mlflow.genai.scorers.Correctness
 mlflow.genai.scorers.Correctness.get_input_fields
 mlflow.genai.scorers.Correctness.model_post_init
@@ -848,6 +852,7 @@ mlflow.genai.scorers.UserFrustration.get_input_fields
 mlflow.genai.scorers.UserFrustration.model_post_init
 mlflow.genai.scorers.base.Scorer
 mlflow.genai.scorers.base.ScorerSamplingConfig
+mlflow.genai.scorers.builtin_scorers.ConversationCompleteness
 mlflow.genai.scorers.builtin_scorers.Correctness
 mlflow.genai.scorers.builtin_scorers.Equivalence
 mlflow.genai.scorers.builtin_scorers.ExpectationsGuidelines

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -559,7 +559,7 @@ class InstructionsJudge(Judge):
         if not template_vars:
             raise MlflowException(
                 "Instructions template must contain at least one variable (e.g., {{ inputs }}, "
-                "{{ outputs }}, {{ trace }}, or {{ expectations }}).",
+                "{{ outputs }}, {{ trace }}, {{ expectations }}, or {{ conversation }}).",
                 error_code=INVALID_PARAMETER_VALUE,
             )
 

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -67,6 +67,7 @@ class InstructionsJudge(Judge):
     _instructions_prompt: PromptVersion = PrivateAttr()
     _ordered_template_variables: list[str] = PrivateAttr()
     _feedback_value_type: Any = PrivateAttr()
+    _generate_rationale_first: bool = PrivateAttr(default=False)
 
     def __init__(
         self,
@@ -75,6 +76,7 @@ class InstructionsJudge(Judge):
         model: str | None = None,
         description: str | None = None,
         feedback_value_type: Any = str,
+        generate_rationale_first: bool = False,
         **kwargs,
     ):
         """
@@ -106,6 +108,7 @@ class InstructionsJudge(Judge):
         self._instructions = instructions
         self._model = model or get_default_model()
         self._feedback_value_type = feedback_value_type
+        self._generate_rationale_first = generate_rationale_first
 
         # NB: We create a dummy PromptVersion here to leverage its existing template variable
         # extraction logic. This allows us to reuse the well-tested regex patterns and variable
@@ -339,18 +342,21 @@ class InstructionsJudge(Judge):
 
     def get_output_fields(self) -> list[JudgeField]:
         """Get the output fields for this judge."""
-        return [
-            JudgeField(
-                name="result",
-                description=self.description or _RESULT_FIELD_DESCRIPTION,
-                value_type=self._feedback_value_type,
-            ),
-            JudgeField(
-                name="rationale",
-                description=_RATIONALE_FIELD_DESCRIPTION,
-                value_type=str,
-            ),
-        ]
+        result_field = JudgeField(
+            name="result",
+            description=self.description or _RESULT_FIELD_DESCRIPTION,
+            value_type=self._feedback_value_type,
+        )
+        rationale_field = JudgeField(
+            name="rationale",
+            description=_RATIONALE_FIELD_DESCRIPTION,
+            value_type=str,
+        )
+        return (
+            [rationale_field, result_field]
+            if self._generate_rationale_first
+            else [result_field, rationale_field]
+        )
 
     def _format_type(self, value_type: Any) -> str:
         if value_type in (str, int, float, bool):
@@ -519,14 +525,7 @@ class InstructionsJudge(Judge):
             ChatMessage(role="user", content=user_content),
         ]
 
-        response_format = pydantic.create_model(
-            "ResponseFormat",
-            result=(
-                self._feedback_value_type or str,
-                pydantic.Field(description=self.description or _RESULT_FIELD_DESCRIPTION),
-            ),
-            rationale=(str, pydantic.Field(description=_RATIONALE_FIELD_DESCRIPTION)),
-        )
+        response_format = self._create_response_format_model()
 
         return invoke_judge_model(
             model_uri=self._model,
@@ -535,6 +534,21 @@ class InstructionsJudge(Judge):
             trace=trace if is_trace_based else None,
             response_format=response_format,
         )
+
+    def _create_response_format_model(self) -> type[pydantic.BaseModel]:
+        result_field = (
+            self._feedback_value_type or str,
+            pydantic.Field(description=self.description or _RESULT_FIELD_DESCRIPTION),
+        )
+        rationale_field = (str, pydantic.Field(description=_RATIONALE_FIELD_DESCRIPTION))
+
+        fields = (
+            {"rationale": rationale_field, "result": result_field}
+            if self._generate_rationale_first
+            else {"result": result_field, "rationale": rationale_field}
+        )
+
+        return pydantic.create_model("ResponseFormat", **fields)
 
     def _validate_model_format(self) -> None:
         """

--- a/mlflow/genai/judges/prompts/conversation_completeness.py
+++ b/mlflow/genai/judges/prompts/conversation_completeness.py
@@ -1,0 +1,58 @@
+# NB: User-facing name for the conversation completeness assessment.
+CONVERSATION_COMPLETENESS_ASSESSMENT_NAME = "conversation_completeness"
+
+CONVERSATION_COMPLETENESS_PROMPT = """\
+You are an expert evaluator of AI assistant conversations.
+Your task is to determine whether the AI assistant has fully addressed all user questions.
+Your judgment must rely only on evidence found directly in the conversation, not assumptions.
+
+You will examine the conversation step-by-step, identify whether user needs were met, and then return a single label: "complete" or "incomplete".
+
+## Step-by-Step Instructions
+- First, list all explicit user questions and requested items, including multiple questions in a single user message (e.g., "Do X and also Y?").
+For each one, check whether the assistant's replies actually provide a direct answer or deliverable.
+If any one of them is missing, the conversation is **incomplete**.
+- The assistant's reply must contain a clear, direct response to each question or requested item.
+You must not count something as answered just because it is "implied" or could be guessed; if you cannot point to a specific sentence that answers it, treat it as unanswered.
+- Check whether all follow-up questions or refinements were addressed.
+- Look for signs of completion or incompletion and then decide.
+
+## Criteria
+Label the conversation **complete** if:
+1. All explicit questions are answered
+    - No ignored or partially answered questions
+    - Clarifications were handled correctly if needed
+2. Follow-up questions are addressed
+    - Context is maintained
+    - The user did not need to repeat themselves
+3. Completion signals appear
+    - User expresses satisfaction
+    - Clear final deliverable provided
+
+Label the conversation **incomplete** if:
+- Explicit user question or requested deliverable remains unanswered or unfulfilled, or is only "implied" but not clearly stated in the assistant's messages.
+If you cannot locate a concrete sentence that answers it, you must treat it as unanswered.
+- The assistant misunderstood or failed to meet the user's underlying intent
+- Follow-up questions were ignored or mishandled
+- The conversation ends with unresolved needs or missing deliverables
+- User gives up without achieving their goal because the assistant couldn't fulfill a reasonable request.
+- User expresses dissatisfaction with the completeness of answers (eg. "But what about...", "You didn't answer my question")
+
+## Important Notes
+- A short conversation can still be complete.
+- A long conversation can still be incomplete.
+- If the user's question or requested deliverable is unsafe/impossible for the assistant to fulfill,
+ and the assistant gives clear and proper refusal for each request that is unsafe/impossible, it should still be considered as complete.
+- Only evaluate what actually happened in the conversation.
+- Focus on whether every explicit question and requested item in the conversation was satisfied by the end, not just the user's overall vibe or apparent satisfaction.
+- User satisfaction is **not** enough to be considered as complete: A polite or positive reply from the user does not make the conversation complete if some explicit
+part of their request was never answered. You must still verify that all explicit questions and requested items have been provided.
+- Do not infer missing answers from context or intent. If you find yourself thinking the assistant "probably meant" or "implied" an answer, that means the question was not explicitly answered
+and the conversation should be marked incomplete.
+
+## Output Instruction
+You must output **complete** or **incomplete** based on the criteria above.
+
+## Conversation to Evaluate
+{{ conversation }}
+"""  # noqa: E501

--- a/mlflow/genai/judges/prompts/conversation_completeness.py
+++ b/mlflow/genai/judges/prompts/conversation_completeness.py
@@ -3,7 +3,7 @@ CONVERSATION_COMPLETENESS_ASSESSMENT_NAME = "conversation_completeness"
 
 CONVERSATION_COMPLETENESS_PROMPT = """\
 Consider the following conversation history between a user and an assistant.
-Your task is to output exactly one label: "complete" or "incomplete" based on the criteria below.
+Your task is to output exactly one label: "yes" or "no" based on the criteria below.
 
 First, list all explicit user requests made throughout the conversation in the rationale section.
 Second, for each request, determine whether it was addressed by the assistant by the end of the conversation,\
@@ -12,7 +12,7 @@ If there is no explicit response to a request—or the response can only be infe
 Requests may be satisfied at any point in the dialogue as long as they are resolved by the final turn.
 A refusal counts as addressed only if the assistant provides a clear and explicit explanation; refusals without reasoning should be marked incomplete.
 Do not assume completeness merely because the user seems satisfied; evaluate solely whether each identified request was actually fulfilled.
-Mark the conversation incomplete only if one or more user requests remain unaddressed in the final state.
+Output "no" only if one or more user requests remain unaddressed in the final state. Output "yes" if all requests were addressed.
 Base your judgment strictly on information explicitly stated or strongly implied in the conversation, without using outside assumptions.
 
 <conversation>{{ conversation }}</conversation>

--- a/mlflow/genai/judges/prompts/conversation_completeness.py
+++ b/mlflow/genai/judges/prompts/conversation_completeness.py
@@ -2,57 +2,18 @@
 CONVERSATION_COMPLETENESS_ASSESSMENT_NAME = "conversation_completeness"
 
 CONVERSATION_COMPLETENESS_PROMPT = """\
-You are an expert evaluator of AI assistant conversations.
-Your task is to determine whether the AI assistant has fully addressed all user questions.
-Your judgment must rely only on evidence found directly in the conversation, not assumptions.
+Consider the following conversation history between a user and an assistant.
+Your task is to output exactly one label: "complete" or "incomplete" based on the criteria below.
 
-You will examine the conversation step-by-step, identify whether user needs were met, and then return a single label: "complete" or "incomplete".
+First, list all explicit user requests made throughout the conversation in the rationale section.
+Second, for each request, determine whether it was addressed by the assistant by the end of the conversation,\
+and **quote** the assistant's explicit response in the rationale section if you judge the request as addressed.
+If there is no explicit response to a request—or the response can only be inferred from context—mark that request as incomplete.
+Requests may be satisfied at any point in the dialogue as long as they are resolved by the final turn.
+A refusal counts as addressed only if the assistant provides a clear and explicit explanation; refusals without reasoning should be marked incomplete.
+Do not assume completeness merely because the user seems satisfied; evaluate solely whether each identified request was actually fulfilled.
+Mark the conversation incomplete only if one or more user requests remain unaddressed in the final state.
+Base your judgment strictly on information explicitly stated or strongly implied in the conversation, without using outside assumptions.
 
-## Step-by-Step Instructions
-- First, list all explicit user questions and requested items, including multiple questions in a single user message (e.g., "Do X and also Y?").
-For each one, check whether the assistant's replies actually provide a direct answer or deliverable.
-If any one of them is missing, the conversation is **incomplete**.
-- The assistant's reply must contain a clear, direct response to each question or requested item.
-You must not count something as answered just because it is "implied" or could be guessed; if you cannot point to a specific sentence that answers it, treat it as unanswered.
-- Check whether all follow-up questions or refinements were addressed.
-- Look for signs of completion or incompletion and then decide.
-
-## Criteria
-Label the conversation **complete** if:
-1. All explicit questions are answered
-    - No ignored or partially answered questions
-    - Clarifications were handled correctly if needed
-2. Follow-up questions are addressed
-    - Context is maintained
-    - The user did not need to repeat themselves
-3. Completion signals appear
-    - User expresses satisfaction
-    - Clear final deliverable provided
-
-Label the conversation **incomplete** if:
-- Explicit user question or requested deliverable remains unanswered or unfulfilled, or is only "implied" but not clearly stated in the assistant's messages.
-If you cannot locate a concrete sentence that answers it, you must treat it as unanswered.
-- The assistant misunderstood or failed to meet the user's underlying intent
-- Follow-up questions were ignored or mishandled
-- The conversation ends with unresolved needs or missing deliverables
-- User gives up without achieving their goal because the assistant couldn't fulfill a reasonable request.
-- User expresses dissatisfaction with the completeness of answers (eg. "But what about...", "You didn't answer my question")
-
-## Important Notes
-- A short conversation can still be complete.
-- A long conversation can still be incomplete.
-- If the user's question or requested deliverable is unsafe/impossible for the assistant to fulfill,
- and the assistant gives clear and proper refusal for each request that is unsafe/impossible, it should still be considered as complete.
-- Only evaluate what actually happened in the conversation.
-- Focus on whether every explicit question and requested item in the conversation was satisfied by the end, not just the user's overall vibe or apparent satisfaction.
-- User satisfaction is **not** enough to be considered as complete: A polite or positive reply from the user does not make the conversation complete if some explicit
-part of their request was never answered. You must still verify that all explicit questions and requested items have been provided.
-- Do not infer missing answers from context or intent. If you find yourself thinking the assistant "probably meant" or "implied" an answer, that means the question was not explicitly answered
-and the conversation should be marked incomplete.
-
-## Output Instruction
-You must output **complete** or **incomplete** based on the criteria above.
-
-## Conversation to Evaluate
-{{ conversation }}
+<conversation>{{ conversation }}</conversation>
 """  # noqa: E501

--- a/mlflow/genai/judges/prompts/user_frustration.py
+++ b/mlflow/genai/judges/prompts/user_frustration.py
@@ -1,0 +1,19 @@
+# NB: User-facing name for the user frustration assessment.
+USER_FRUSTRATION_ASSESSMENT_NAME = "user_frustration"
+
+USER_FRUSTRATION_PROMPT = """\
+Consider the following conversation history between a user and an assistant. Your task is to
+determine the user's emotional trajectory and output exactly one of the following labels:
+"no_frustration", "frustration_resolved", or "frustration_not_resolved".\
+
+"no_frustration" means the user never expresses frustration;
+"frustration_resolved" means the user is frustrated at some point but clearly ends the conversation satisfied or reassured;
+    - Do not assume the user is satisfied just because the assistant's final response is helpful, constructive, or polite;
+    - Only label a conversation as "frustration_resolved" if the user explicitly or strongly implies satisfaction, relief, or acceptance in their own final turns.
+"frustration_not_resolved" means the user is frustrated near the end or leaves without clear satisfaction.
+
+Base your decision only on explicit or strongly implied signals in the conversation and do not
+use outside knowledge or assumptions.
+
+<conversation>{{ conversation }}</conversation>
+"""  # noqa: E501

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -33,6 +33,7 @@ _LAZY_IMPORTS = {
     "RetrievalRelevance",
     "RetrievalSufficiency",
     "Safety",
+    "UserFrustration",
     "get_all_scorers",
 }
 
@@ -74,6 +75,7 @@ if TYPE_CHECKING:
         RetrievalRelevance,
         RetrievalSufficiency,
         Safety,
+        UserFrustration,
         get_all_scorers,
     )
 
@@ -87,6 +89,7 @@ __all__ = [
     "RetrievalRelevance",
     "RetrievalSufficiency",
     "Safety",
+    "UserFrustration",
     "Scorer",
     "scorer",
     "ScorerSamplingConfig",

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -34,6 +34,7 @@ _LAZY_IMPORTS = {
     "RetrievalSufficiency",
     "Safety",
     "UserFrustration",
+    "ConversationCompleteness",
     "get_all_scorers",
 }
 
@@ -66,6 +67,7 @@ def __dir__():
 # This gives us the best of both worlds: type hints without circular imports.
 if TYPE_CHECKING:
     from mlflow.genai.scorers.builtin_scorers import (
+        ConversationCompleteness,
         Correctness,
         Equivalence,
         ExpectationsGuidelines,
@@ -80,6 +82,7 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
+    "ConversationCompleteness",
     "Correctness",
     "ExpectationsGuidelines",
     "Guidelines",

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1683,8 +1683,8 @@ class ConversationCompleteness(BuiltInScorer):
     and high-level intentions throughout a conversation session.
 
     This scorer analyzes a complete conversation (represented as a list of traces) to determine
-    if the AI successfully satisfied the user's needs, answered all questions, and fulfilled
-    their high-level intent. It returns "complete" or "incomplete".
+    if the AI successfully addressed all the user's requests in a conversation. It returns
+    "complete" or "incomplete".
 
     You can invoke the scorer directly with a session for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
@@ -1742,6 +1742,7 @@ class ConversationCompleteness(BuiltInScorer):
                 model=self.model,
                 description=self.description,
                 feedback_value_type=Literal["complete", "incomplete"],
+                generate_rationale_first=True,
             )
         return self._judge
 
@@ -1778,8 +1779,8 @@ class ConversationCompleteness(BuiltInScorer):
         Evaluate conversation completeness based on a list of traces from the same session.
 
         This scorer analyzes a conversation to determine if the AI assistant fully addressed
-        all user questions and satisfied their high-level intentions. It evaluates whether
-        the conversation reached a successful conclusion where the user's needs were met.
+        all user requests at the end of the conversation.
+
 
         Args:
             session: A list of Trace objects belonging to the same conversation session.

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -2,7 +2,7 @@ import logging
 import math
 from abc import abstractmethod
 from dataclasses import asdict, dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import pydantic
 
@@ -21,14 +21,20 @@ from mlflow.genai import judges
 from mlflow.genai.judges.base import Judge, JudgeField
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.constants import _AFFIRMATIVE_VALUES, _NEGATIVE_VALUES
+from mlflow.genai.judges.instructions_judge import InstructionsJudge
 from mlflow.genai.judges.prompts.context_sufficiency import (
     CONTEXT_SUFFICIENCY_PROMPT_INSTRUCTIONS,
 )
 from mlflow.genai.judges.prompts.correctness import CORRECTNESS_PROMPT_INSTRUCTIONS
+from mlflow.genai.judges.prompts.equivalence import EQUIVALENCE_PROMPT_INSTRUCTIONS
 from mlflow.genai.judges.prompts.groundedness import GROUNDEDNESS_PROMPT_INSTRUCTIONS
 from mlflow.genai.judges.prompts.guidelines import GUIDELINES_PROMPT_INSTRUCTIONS
 from mlflow.genai.judges.prompts.relevance_to_query import (
     RELEVANCE_TO_QUERY_PROMPT_INSTRUCTIONS,
+)
+from mlflow.genai.judges.prompts.user_frustration import (
+    USER_FRUSTRATION_ASSESSMENT_NAME,
+    USER_FRUSTRATION_PROMPT,
 )
 from mlflow.genai.judges.utils import (
     CategoricalRating,
@@ -51,6 +57,7 @@ from mlflow.genai.utils.trace_utils import (
     resolve_inputs_from_trace,
     resolve_outputs_from_trace,
 )
+from mlflow.utils.annotations import experimental
 from mlflow.utils.docstring_utils import format_docstring
 from mlflow.utils.uri import is_databricks_uri
 
@@ -1564,6 +1571,132 @@ class Equivalence(BuiltInScorer):
         return _sanitize_feedback(feedback)
 
 
+@experimental(version="3.7.0")
+class UserFrustration(BuiltInScorer):
+    """
+    UserFrustration evaluates the user's frustration state throughout the conversation
+    with the AI assistant based on a conversation session.
+
+    This scorer analyzes a session of conversation (represented as a list of traces) to
+    determine if the user shows explicit or implicit frustration directed at the AI.
+    It evaluates the entire conversation and returns one of three values:
+    - "no_frustration": user not frustrated at any point in the conversation
+    - "frustration_resolved": user is frustrated at some point in the conversation,
+      but leaves the conversation satisfied
+    - "frustration_not_resolved": user is still frustrated at the end of the conversation
+
+    You can invoke the scorer directly with a session for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "user_frustration".
+        model: {{ model }}
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import UserFrustration
+
+        # Retrieve a list of traces with the same session ID
+        session = traces_from_my_session = mlflow.search_traces(
+            experiment_ids=[experiment_id],
+            filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
+            return_type="list",
+        )
+
+        assessment = UserFrustration(name="my_user_frustration_judge")(session=session)
+        print(assessment)
+        # Feedback with value "no_frustration", "frustration_resolved", or
+        # "frustration_not_resolved"
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import UserFrustration
+
+        session = traces_from_my_session = mlflow.search_traces(
+            experiment_ids=[experiment_id],
+            filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
+            return_type="list",
+        )
+        result = mlflow.genai.evaluate(data=session, scorers=[UserFrustration()])
+    """
+
+    name: str = USER_FRUSTRATION_ASSESSMENT_NAME
+    model: str | None = None
+    required_columns: set[str] = {"session"}
+    description: str = "Evaluate the user's frustration state throughout the conversation."
+    _judge: InstructionsJudge | None = pydantic.PrivateAttr(default=None)
+
+    def _get_judge(self) -> InstructionsJudge:
+        """Return a session-level InstructionsJudge with the user frustration prompt."""
+        if self._judge is None:
+            self._judge = InstructionsJudge(
+                name=self.name,
+                instructions=self.instructions,
+                model=self.model,
+                description=self.description,
+                feedback_value_type=Literal[
+                    "no_frustration", "frustration_resolved", "frustration_not_resolved"
+                ],
+            )
+        return self._judge
+
+    @property
+    def is_session_level_scorer(self) -> bool:
+        """Return True as UserFrustration requires a session of traces for evaluation."""
+        return True
+
+    @property
+    def instructions(self) -> str:
+        """Get the instructions of what this scorer evaluates."""
+        return USER_FRUSTRATION_PROMPT
+
+    def get_input_fields(self) -> list[JudgeField]:
+        """
+        Get the input fields for the UserFrustration judge.
+
+        Returns:
+            List of JudgeField objects defining the input fields based on the __call__ method.
+        """
+        return [
+            JudgeField(
+                name="session",
+                description="A list of trace objects belonging to the same conversation session.",
+            ),
+        ]
+
+    def __call__(
+        self,
+        *,
+        session: list[Trace] | None = None,
+    ) -> Feedback:
+        """
+        Evaluate user frustration based on a list of traces from the same session.
+
+        This scorer analyzes a conversation to determine the user's frustration state
+        throughout the conversation with the AI assistant. It evaluates explicit frustration
+        (complaints, hostile tone) and implicit frustration (repeated corrections,
+        restating requests) directed at the AI, and determines if the frustration was resolved.
+
+        Args:
+            session: A list of Trace objects belonging to the same conversation session.
+                The traces should represent the full conversation history to evaluate.
+
+        Returns:
+            A Feedback object with one of three values:
+            - "no_frustration": user not frustrated at any point in the conversation
+            - "frustration_resolved": user is frustrated at some point but leaves satisfied
+            - "frustration_not_resolved": user is still frustrated at the end of the conversation
+            The feedback also includes a rationale explaining the assessment.
+        """
+        return self._get_judge()(session=session)
+
+
 def get_all_scorers() -> list[BuiltInScorer]:
     """
     Returns a list of all built-in scorers.
@@ -1591,6 +1724,7 @@ def get_all_scorers() -> list[BuiltInScorer]:
         RetrievalSufficiency(),
         RetrievalGroundedness(),
         Equivalence(),
+        UserFrustration(),
     ]
     if is_databricks_uri(mlflow.get_tracking_uri()):
         scorers.extend([Safety(), RetrievalRelevance()])

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -3349,7 +3349,6 @@ def test_conversation_no_warning_when_used(mock_invoke_judge_model):
 
 
 def test_instructions_judge_generate_rationale_first():
-    """Test that generate_rationale_first flag properly orders fields in response format."""
     # Test with generate_rationale_first=False (default)
     judge_default = InstructionsJudge(
         name="test_judge",

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1321,7 +1321,6 @@ def test_validate_required_fields_all_present():
 
 
 def test_user_frustration_with_session():
-    """Test UserFrustration scorer with a list of traces from the same session."""
     session_id = "test_session_123"
     traces = []
     for i in range(3):

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -20,6 +20,7 @@ from mlflow.genai.scorers import (
     RetrievalRelevance,
     RetrievalSufficiency,
     Safety,
+    UserFrustration,
 )
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.builtin_scorers import (
@@ -29,6 +30,7 @@ from mlflow.genai.scorers.builtin_scorers import (
     get_all_scorers,
     resolve_scorer_fields,
 )
+from mlflow.tracing.constant import TraceMetadataKey
 from mlflow.utils.uri import is_databricks_uri
 
 from tests.genai.conftest import databricks_only
@@ -573,7 +575,7 @@ def test_get_all_scorers_oss(tracking_uri):
     scorers = get_all_scorers()
 
     # Safety and RetrievalRelevance are only available in Databricks
-    assert len(scorers) == (8 if tracking_uri == "databricks" else 6)
+    assert len(scorers) == (9 if tracking_uri == "databricks" else 7)
     assert all(isinstance(scorer, Scorer) for scorer in scorers)
 
 
@@ -1316,3 +1318,54 @@ def test_validate_required_fields_all_present():
     fields = ExtractedFields(inputs="some input", outputs="some output")
 
     _validate_required_fields(fields, judge, "TestScorer")
+
+
+def test_user_frustration_with_session():
+    """Test UserFrustration scorer with a list of traces from the same session."""
+    session_id = "test_session_123"
+    traces = []
+    for i in range(3):
+        with mlflow.start_span(name=f"conversation_turn_{i}") as span:
+            span.set_inputs({"question": f"User question {i}"})
+            span.set_outputs(f"AI response {i}")
+            mlflow.update_current_trace(metadata={TraceMetadataKey.TRACE_SESSION: session_id})
+        traces.append(mlflow.get_trace(span.trace_id))
+
+    with patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=Feedback(
+            name="user_frustration", value="no_frustration", rationale="User is satisfied"
+        ),
+    ) as mock_invoke_judge:
+        scorer = UserFrustration()
+        result = scorer(session=traces)
+
+        assert result.name == "user_frustration"
+        assert result.value == "no_frustration"
+        assert result.rationale == "User is satisfied"
+        mock_invoke_judge.assert_called_once()
+
+
+def test_user_frustration_with_custom_name_and_model(monkeypatch: pytest.MonkeyPatch):
+    session_id = "test_session_456"
+    traces = []
+    with mlflow.start_span(name="test_turn") as span:
+        span.set_inputs({"question": "Test question"})
+        span.set_outputs("Test response")
+        mlflow.update_current_trace(metadata={TraceMetadataKey.TRACE_SESSION: session_id})
+    traces.append(mlflow.get_trace(span.trace_id))
+
+    with patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=Feedback(
+            name="custom_frustration_check",
+            value="frustration_resolved",
+            rationale="User was initially frustrated but satisfied by the end",
+        ),
+    ) as mock_invoke_judge:
+        scorer = UserFrustration(name="custom_frustration_check", model="openai:/gpt-4")
+        result = scorer(session=traces)
+
+        assert result.name == "custom_frustration_check"
+        assert result.value == "frustration_resolved"
+        mock_invoke_judge.assert_called_once()

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1379,8 +1379,6 @@ def test_user_frustration_with_custom_name_and_model(monkeypatch: pytest.MonkeyP
     ],
 )
 def test_conversation_completeness_with_session(name, model, expected_name):
-    """Test ConversationCompleteness scorer with a list of traces from the same session."""
-    # Create multiple traces representing a conversation session
     session_id = "test_session_789"
     traces = []
     for i in range(3):
@@ -1392,9 +1390,7 @@ def test_conversation_completeness_with_session(name, model, expected_name):
 
     with patch(
         "mlflow.genai.judges.instructions_judge.invoke_judge_model",
-        return_value=Feedback(
-            name=expected_name, value="complete", rationale="All needs addressed"
-        ),
+        return_value=Feedback(name=expected_name, value="yes", rationale="All needs addressed"),
     ) as mock_invoke_judge:
         kwargs = {}
         if name:
@@ -1405,6 +1401,6 @@ def test_conversation_completeness_with_session(name, model, expected_name):
         result = scorer(session=traces)
 
         assert result.name == expected_name
-        assert result.value == "complete"
+        assert result.value == "yes"
         assert result.rationale == "All needs addressed"
         mock_invoke_judge.assert_called_once()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18967/files/cc2c12eac24b3323259faf5fbaf6aa64ed12094d..7968ca3553cdafa0afbfb9aed7825500cd756f4d) to review incremental changes.
- [stack/P0_builtin_judges_stack](https://github.com/mlflow/mlflow/pull/18966) [[Files changed](https://github.com/mlflow/mlflow/pull/18966/files)]
  - [**stack/P0_builtin_judges_stack_ML_59678**](https://github.com/mlflow/mlflow/pull/18967) [[Files changed](https://github.com/mlflow/mlflow/pull/18967/files/cc2c12eac24b3323259faf5fbaf6aa64ed12094d..7968ca3553cdafa0afbfb9aed7825500cd756f4d)]
    - [stack/P0_builtin_judges_stack_ML_59674](https://github.com/mlflow/mlflow/pull/18968) [[Files changed](https://github.com/mlflow/mlflow/pull/18968/files/7968ca3553cdafa0afbfb9aed7825500cd756f4d..85ebe6c58d43d9a39e821c7293524c3bfc8106b3)]
      - [stack/multi_turn_judge_align_handling_fix](https://github.com/mlflow/mlflow/pull/19045) [[Files changed](https://github.com/mlflow/mlflow/pull/19045/files/85ebe6c58d43d9a39e821c7293524c3bfc8106b3..26ccac34929a08df1587ed8132dffdb7da129066)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

### What changes are proposed in this pull request?
This PR creates a new session-level built-in judge ConversationCompleteness. Users can instantiate a ConversationCompleteness judge in one line just like the existing built-in judges, and can directly invoke (or pass into genai.evaluation soon) to evaluate whether the AI assistant is able to address all user questions and requests throughout the entire conversation.
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Manual Testing
Manually tested with the following synthetic conversations, `openai:/gpt-5` is able to get all the conversations correctly classified based on the ConversationCompleteness judge prompt and `gpt-4.1 mini` is able to get 19/20 of the conversations correctly classified when generating the rationale before lable.
```
complete_conversations = {
  "data_strategy_one_pager": {
    "I need help drafting a one-page data strategy for our company. Can you outline the structure I should follow?": "Absolutely. A clear one-page data strategy usually has five sections: vision, business objectives, data capabilities, governance, and roadmap. Start with a brief vision statement describing how data will create value for the business. Then link that vision to 3–5 concrete business objectives such as revenue growth, risk reduction, or operational efficiency. Next, describe the key data capabilities you need, like analytics platforms, data quality processes, and talent. Add a short governance section covering ownership, standards, and compliance. Finish with a simple 12–24 month roadmap that highlights major milestones rather than detailed tasks.",
    "What should I put in the vision section so it doesn't sound generic?": "Aim to tie the vision directly to how your company competes and wins. Instead of saying “be data-driven,” say something like “use trusted, timely data to make faster decisions in sales and operations.” Make it clear how data will improve decisions, customer experience, or margins. Keep it to two or three sentences so it remains readable on a single page. If you can, reference specific themes your leadership already uses, so it feels familiar and aligned.",
    "Okay, and for the business objectives, should I list tech goals or business KPIs?": "Prioritize business KPIs first and only reference technology where it enables those results. For example, you might say “increase forecast accuracy by 15%” or “reduce manual reporting time by 30%.” Under each objective, you can add a short note about data or tooling that supports it. This keeps the document focused on outcomes rather than tools. Tech teams can then use those objectives to drive more detailed technical plans.",
    "How detailed should the data capabilities section be on a one-pager?": "Keep it high-level and grouped into themes rather than specific tools. For example, you can talk about analytics and BI, data integration, data quality, and advanced analytics or AI. Under each theme, include one sentence about what “good” looks like in your organization. Avoid naming every product; instead, describe the capability in business terms like “self-serve reporting for non-technical users.” This helps non-technical stakeholders understand the direction without getting lost in jargon.",
    "Can you give me an example sentence for the governance part?": "Sure. You could write: “We will define clear data ownership, access policies, and quality standards so that critical metrics are trusted and compliant with regulatory requirements.” If you want to expand slightly, add: “A cross-functional data council will review key definitions, resolve conflicts, and prioritize data initiatives.” That signals structure and accountability without overwhelming detail. The goal is to show that governance is an enabler, not just a control mechanism.",
    "For the roadmap, should I break it out by quarter or just by phases?": "On a one-page strategy, phases usually work better than detailed quarterly plans. You might use three phases: foundation, scale, and optimization. Under each phase, list two or three major initiatives like “centralize core data,” “roll out self-serve dashboards,” or “implement data quality monitoring.” This gives leadership a sense of sequencing without locking you into specific dates that may shift. You can maintain a more detailed roadmap separately for execution teams.",
    "We’re a mid-sized B2B SaaS company. Should I highlight anything specific for our context?": "Yes, you can emphasize customer lifecycle visibility, product usage analytics, and revenue operations. For example, call out the goal of having a single view of accounts across sales, customer success, and billing. You can also mention using product usage data to drive expansion and retention strategies. This ties the data strategy directly to metrics your leadership already cares about, like net revenue retention and churn.",
    "Is there a good way to show trade-offs, or should I leave that out of the one-pager?": "You can briefly acknowledge trade-offs in the roadmap or governance sections without going deep. For example, note that you are balancing speed of delivery with data quality and governance. You might also mention that not every department will get all requested dashboards in phase one. A single sentence about prioritization shows realism and maturity without cluttering the page.",
    "If I follow this structure, do you think the one-pager will feel complete to executives?": "Yes, this structure is designed to answer the questions executives typically have: why data matters, what outcomes you’re targeting, what capabilities you’ll build, how you’ll govern it, and how you’ll phase the work. As long as you keep the language business-focused and concise, it will read as strategic rather than technical. You can always attach more detailed appendices later for specialized audiences. The one-pager’s job is to create alignment and buy-in, not to describe every implementation detail.",
    "Great, I have enough to draft this now. Thanks for the clear guidance!": "You’re very welcome. Start with short bullet points under each section and then refine the wording to keep it tight and readable. Once you have a draft, you can test it with one or two stakeholders to see if anything is unclear or missing. That feedback loop will help you finalize a version that resonates with your leadership team. Good luck with the strategy document!"
  },

  "performance_review_coaching": {
    "I need help writing a performance review for a senior engineer on my team. Can you help me structure it?": "Definitely. A solid performance review usually covers impact, competencies, growth, and expectations for the next period. Start with a short summary paragraph that fairly reflects their overall contribution and level. Then highlight 3–5 specific impact examples tied to business results or team outcomes. After that, comment on core competencies like technical depth, collaboration, ownership, and communication. Finally, close with clear expectations and development areas so the engineer knows what success looks like in the next cycle.",
    "Should I start with strengths or areas of improvement?": "It’s usually best to start with strengths so the review feels grounded in what they’ve done well. Leading with impact and strengths also builds trust and makes it easier to receive constructive feedback. After you establish that base, you can transition into growth areas using a neutral, forward-looking tone. For example, you might say, “To have an even broader impact, here are a few areas to focus on next cycle.” This framing keeps the conversation balanced and developmental rather than punitive.",
    "They led a big migration project. How can I phrase that impact clearly?": "You could say something like: “You successfully led the X migration, coordinating across three teams, de-risking the cutover plan, and completing the rollout with minimal downtime.” Then connect it to outcomes: “This reduced infrastructure costs by Y% and simplified our deployment pipeline, enabling faster releases.” Be specific about what they did and what changed as a result. Clear impact statements help both the engineer and leadership understand the value of their work. Whenever possible, include metrics or qualitative feedback from stakeholders.",
    "I also want to acknowledge their mentorship work. Any suggestions?": "You can highlight mentorship as a multiplier of team effectiveness. For example: “You consistently invested in mentoring two junior engineers, helping them ramp up on the codebase and adopt better design practices.” If you’ve observed concrete results, add them: “As a result, they now contribute independently to critical services and ship features with fewer iterations.” This shows that their mentorship isn’t just time spent; it generates tangible value. It also supports the case for their seniority and leadership capabilities.",
    "Their main area for improvement is communication in cross-team projects. How do I phrase that constructively?": "You can frame it with observation, impact, and a specific suggestion. For instance: “In several cross-team projects, updates and decisions have sometimes reached stakeholders later than needed, which created confusion around timelines and ownership.” Then add a forward-looking recommendation: “To increase your impact, I’d like to see more proactive communication of risks, decisions, and status in shared channels, especially when multiple teams depend on your work.” This keeps the focus on behaviors and outcomes rather than personality. It also makes it clear what “better” looks like.",
    "Is it okay to include their own self-assessment points, or should I keep it separate?": "It’s actually helpful to connect your feedback with their self-assessment where appropriate. If they’ve identified the same strengths or areas of improvement, you can mention that alignment explicitly. This shows that you’re listening and that the review is a conversation, not a one-way judgment. Just avoid copying their wording verbatim; instead, reference it and add your own examples and perspective. Where you disagree, explain why with concrete observations.",
    "What about future expectations—how specific should I be?": "Be as specific as you reasonably can without turning it into a long task list. For example, you might say: “In the next cycle, I’d like you to take end-to-end ownership of at least one cross-team initiative, including coordination, status updates, and risk management.” Pair that with expectations on technical depth or architectural input if relevant. The key is to give them a clear picture of the scope and behaviors associated with their level or the next level. This makes it easier for them to prioritize and self-assess progress during the cycle.",
    "We’re using a rating system too. Should I justify the rating in the text?": "Yes, you should align the narrative with the rating so it doesn’t feel disconnected or arbitrary. You don’t have to write “you are a 4,” but your examples and summary should clearly support the level you’re assigning. If the rating is lower than they might expect, it’s especially important to provide concrete examples and forward-looking guidance. This helps keep the conversation fair and transparent, even when the message is difficult.",
    "If I structure it like this, will the review feel balanced and fair?": "Yes, this structure—summary, impact, competencies, growth areas, and future expectations—tends to feel balanced to most engineers. It acknowledges what they’ve done well while also giving them actionable guidance for growth. As long as your examples are specific and grounded in observed behavior, they will likely perceive it as fair, even if some feedback is tough. You can also share the review draft verbally and invite questions or clarifications before finalizing it.",
  },

  "incident_postmortem_collaboration": {
    "I need to write a postmortem for a production incident we had yesterday. Can you help me structure it?": "Absolutely. A strong postmortem typically includes a summary, impact, timeline, root cause analysis, remediation items, and lessons learned. The summary should be one short paragraph describing what happened at a high level. The impact section details which users or systems were affected and for how long. The timeline lists key events in chronological order, from detection to full recovery. Root cause explains what actually failed and why, ideally separating proximate causes from underlying systemic issues. Remediation and lessons learned turn the findings into concrete actions and process improvements.",
    "What should I include in the summary so it’s clear but not overly detailed?": "Keep the summary to three or four sentences that answer who, what, when, and high-level why. For example, mention the affected service, the nature of the failure, and the duration of impact. Avoid deep technical details in this section; those belong in root cause and timeline. The goal is for an executive or non-technical stakeholder to understand the incident quickly. You can always link to more detailed sections for readers who want to dive deeper.",
    "We had around 25 minutes of partial outage for our checkout service. How should I describe the impact?": "In the impact section, quantify the effect as much as possible. You might write: “From 10:05 to 10:30 UTC, approximately 30% of checkout requests failed with 5xx errors, affecting an estimated X% of active users.” If you have revenue or transaction impact, describe it in ranges if exact numbers aren’t finalized yet. Also mention if any data integrity or compliance issues occurred; if none did, say so explicitly. Clarity here helps prioritize follow-up actions and communicate transparently with stakeholders.",
    "Our timeline is messy because teams were trying multiple things in parallel. How do I represent that?": "You can still use a chronological list, but group related actions and note concurrency when it matters. For example, list timestamps with short entries like “10:12: On-call engineer rolls back deployment A” and “10:13: SRE joins and starts log analysis.” If two streams of work were happening simultaneously, you can annotate that or use separate sublists for each team. The main goal is to show how understanding evolved over time and which actions moved the incident toward resolution. Don’t worry about perfection; accuracy and clarity are more important than formatting elegance.",
    "The root cause was a misconfigured feature flag that increased load on one service. How deep should I go in that section?": "Go deep enough that a knowledgeable engineer can understand not just what broke but why it was possible. Explain how the feature flag was configured, why it increased load, and why safeguards didn’t catch it. If there were assumptions in the design or testing process that turned out to be wrong, call those out. Also note any missing monitoring, capacity checks, or reviews that could have prevented the issue. This section should inform your remediation items directly.",
    "We also had some confusion about who was leading the incident. Should that go in lessons learned?": "Yes, that’s a great lesson learned to capture. You can note that the lack of a clearly designated incident commander led to duplicated efforts and slower decision-making. Then propose a concrete change, such as always assigning an incident commander within the first five minutes and documenting their name in the incident channel. Lessons learned should connect specific observations to specific process changes. This way, they become actionable rather than just reflective.",
    "How many remediation items are reasonable to include without overwhelming the team?": "It’s better to have a small number of high-impact, clearly owned remediation items than a long wish list. Aim for three to seven items that directly address both the technical and process causes. For each, include an owner, a target date, and a brief description of what success looks like. You can also tag them by priority so it’s clear which ones are critical versus nice-to-have. This increases the likelihood that they actually get completed.",
    "Should we share the postmortem outside engineering, like with customer success or leadership?": "In most organizations, yes, especially for incidents that affect customers or revenue. You may want a slightly simplified version for non-technical audiences that focuses on impact, customer communication, and key mitigations. Sharing transparently builds trust and shows that you take reliability seriously. Just make sure the language is clear and avoids internal jargon that non-engineers won’t understand.",
    "If I follow this structure, will the postmortem count as complete for our leadership team?": "Yes, this structure—summary, impact, timeline, root cause, remediation, and lessons learned—covers what leadership typically wants to see. It shows you understand what happened, you’ve quantified the effect, and you’re taking concrete steps to prevent recurrence. As long as the content is honest, specific, and balanced between technical and process factors, it will feel thorough and responsible. You can always iterate on the format based on feedback from your first few postmortems.",
  },
    
   ## Next 3 conversation where each turn user asks several questions

    "product_roadmap_prioritization": {
        "We're planning next quarter's product roadmap; what criteria should we use to prioritize items, how do we balance tech debt vs new features, and is there an ideal number of themes to focus on?": "You can prioritize using three main criteria: impact on business goals, effort/complexity, and risk or urgency. Impact should be tied directly to OKRs like revenue, retention, or cost reduction, not just “nice to have” ideas. To balance tech debt vs new features, dedicate a fixed percentage of capacity (for example 20–30%) to tech debt and platform work each sprint, and prioritize those items that unlock speed or reliability for multiple teams. New features should be chosen based on clear customer value and alignment with strategy, not just stakeholder pressure. As for themes, most teams perform best when they focus on 2–3 major themes per quarter so context switching stays low while still covering a meaningful spread of business objectives.",
        "How should we score items against those criteria, should we involve stakeholders in that scoring, and what's a good way to handle disagreements about priority?": "A simple approach is to use a weighted scoring model where you rate each item on impact, effort, and risk on a consistent scale (for example 1–5) and assign weights that reflect your strategy. Impact might get a higher weight than effort if growth is the priority, while risk/urgency might be weighted higher if you have regulatory or reliability concerns. Yes, you should involve stakeholders in the scoring, but in a structured way: ask them to provide input on impact and customer value, while engineering estimates effort and risk. When disagreements arise, bring them back to shared, agreed-upon goals and the scoring model rather than personal preferences. If necessary, designate a final decision-maker—often the product leader—who resolves ties in line with company strategy.",
        "We also have a lot of small items; should we bundle them, how do we avoid the roadmap looking like a grab bag, and how often should we revisit the priorities during the quarter?": "For many small items, bundling them into thematic “initiatives” helps maintain coherence, such as a “usability polish” or “billing reliability” initiative that contains multiple minor tasks. This avoids a roadmap that looks like a scattered list of unrelated tickets and makes it easier to explain value to stakeholders. To avoid the grab-bag effect, make sure every item or bundle is clearly tied to a theme and that every theme is clearly tied to an OKR. As for revisiting priorities, a common pattern is to commit at a quarterly level but review and adjust every 2–4 weeks as you learn more, while being transparent about changes. That way, you stay adaptable without constantly reshuffling everything and eroding trust.",
        "When presenting this roadmap, should I show the scoring details, should I commit to timelines, and how do I communicate the tech debt work so it doesn't look like 'invisible' effort?": "You can summarize the scoring details rather than showing every raw number—highlight that you used a structured model and give examples so stakeholders trust the process. Share the relative rankings and the rationale instead of a full spreadsheet unless your audience specifically wants that level of detail. For timelines, commit to ranges or sequencing (now/next/later or by month) rather than exact dates for every item, especially if there are unknowns. To communicate tech debt, frame it as an investment that improves reliability, speed of delivery, or security, and connect each item to the business risk it reduces or the velocity it unlocks. Including tech debt as explicit roadmap items with clear outcomes makes it visible and defensible.",
        "If a new executive request appears mid-quarter, how should we evaluate it, how do we prevent constant churn, and when is it reasonable to say no?": "You should run the new request through the same scoring criteria you use for everything else—impact, effort, and risk—so it can be compared fairly to existing items. To prevent constant churn, set expectations that mid-quarter changes will usually require deprioritizing something else, and show what would be displaced in a visual trade-off. It’s reasonable to say no or “not right now” when the new request scores lower than current work, conflicts with agreed strategic priorities, or would create unsustainable disruption for the team. In those cases, explain your reasoning in terms of trade-offs and business goals rather than bandwidth alone, and offer an alternative timeline or a smaller first slice if that helps. This keeps the roadmap aligned, the team focused, and the process transparent.",
    },

    "vendor_selection_process": {
        "We're kicking off a vendor selection for a CRM tool; what information should we gather from internal teams, how many vendors should we shortlist, and what criteria should we use initially?": "Internally, start by gathering use cases from sales, marketing, and customer success—ask them what workflows they run today, what’s painful, and what outcomes they want from a new CRM. Capture integration requirements with existing systems like billing, support, and data warehouse, and clarify any security, compliance, or data residency constraints. For an initial shortlist, three to five vendors is usually a good range: enough to compare meaningfully without overwhelming everyone. Your initial criteria can include core feature fit, integration options, security posture, pricing model, and evidence of success with companies similar to yours. This early filter will help you avoid doing deep evaluations on tools that are obviously misaligned.",
        "For the next stage, should we do RFPs or demos first, how do we structure a good proof of concept, and who should be involved in that PoC?": "If your requirements are still somewhat fuzzy, do focused demos first to refine them, then follow with a lightweight RFP or structured questionnaire. If you already have clear, detailed requirements, you can run a short RFP and use the responses to decide whom to invite for deeper demos. A good proof of concept should use a small but realistic subset of your data and workflows, with clear success criteria such as time-to-implementation, usability for end users, and reporting capabilities. Involve at least one representative from each key function—sales, marketing, customer success—and one technical owner for integrations and security. That mix ensures you evaluate both usability and technical feasibility, and that you have champions ready if you move forward.",
        "How should we compare pricing models, how do we make sure we don't miss hidden costs, and should we negotiate before or after we pick a preferred vendor?": "When comparing pricing models, normalize them around realistic usage scenarios for your company, such as number of seats, records, or API calls over the next 1–3 years. Ask each vendor to provide total cost of ownership estimates including implementation, onboarding, training, support tiers, and any required add-ons. To avoid hidden costs, explicitly ask about overage fees, mandatory professional services, and price changes tied to growth milestones. It’s usually best to narrow down to one or two preferred vendors based on fit, then use that competitive tension in negotiations rather than negotiating with five at once. You can negotiate both price and non-price terms like contract length, exit clauses, and implementation support.",
        "We also care a lot about long-term vendor viability; what should we look at to assess that, how do we factor roadmap alignment, and is it appropriate to ask about their financials?": "To assess long-term viability, examine the vendor’s customer base, market position, and the pace of product development as shown by release notes and roadmap disclosures. Look for signals like a strong partner ecosystem, presence in analyst reports, and reference customers who have scaled on the platform. For roadmap alignment, ask how their upcoming features map to your expected needs over the next 2–3 years and how they handle customer input on roadmap. It’s appropriate, especially for larger contracts, to ask high-level questions about their financial health, funding, and runway, though you might not get detailed numbers if they’re private. Combining these factors gives you a clearer picture of whether they’ll be a strategic partner rather than just a short-term tool.",
        "This gives me a clear framework; I think I can run a structured vendor selection with this and defend our final choice.": "That’s exactly the goal. If you convert this into a simple evaluation matrix and a short decision memo, you’ll have a repeatable process you can use for future tools as well. Sharing the process transparently will also build confidence that decisions aren’t arbitrary or based solely on loudest voices. Over time, this kind of structure makes technology selection faster, fairer, and more aligned with business priorities."
    },

    "team_capacity_planning": {
        "We're doing quarterly capacity planning; how do we estimate realistic capacity, how should we factor in meetings and interruptions, and what's the best way to account for vacations and holidays?": "Start by looking at historical delivery data—such as completed story points, tickets, or cycle times—to get a baseline of what the team actually delivered, not what they hoped to deliver. Then reduce that baseline to reflect time spent on meetings, support, and unplanned work; many teams find that only 60–70% of total time is available for planned project work. To factor in interruptions, explicitly reserve a buffer (for example 10–20% of capacity) for unplanned issues depending on how volatile your environment is. For vacations and holidays, mark them on a shared calendar and subtract that time from your total capacity before allocating work. This ensures you don’t silently overcommit and then blame the team for “underperforming.”",
        "Should capacity be planned at the individual level or team level, how do we handle specialists vs generalists, and how do we communicate this to stakeholders?": "It’s usually better to plan at the team level, because individual plans tend to create false precision and can be brittle when priorities change. However, you should still be aware of constraints created by specialists, such as a single data engineer or designer, and reflect those as specific capacity limits in certain skill areas. For specialists, consider cross-training over time so the team is less dependent on one person, but be realistic about short-term constraints. When communicating with stakeholders, present capacity in terms of how many initiatives or features the team can realistically take on, using ranges rather than exact numbers. Explain your assumptions clearly so stakeholders understand that adding more items doesn’t increase capacity; it just increases risk and delays.",
        "We also have support and on-call duties; should we separate that capacity, how do we rotate it fairly, and how do we avoid burning people out?": "Yes, you should treat support and on-call as first-class consumers of capacity, not as invisible side work. Allocate a portion of the team’s time or assign one or two people to a support/on-call rotation, and reduce their project commitments accordingly for that period. Rotate the responsibility on a predictable schedule—weekly or bi-weekly—so the load is shared fairly. To avoid burnout, ensure that on-call engineers have recovery time after intense weeks and that the team is actively fixing recurring issues rather than just firefighting. Tracking the volume and nature of support work also helps you justify investments in reliability and tooling.",
        "When priorities change mid-quarter, how should we replan, how often is it reasonable to adjust, and how do we show the impact of changes to leadership?": "When priorities shift, first evaluate whether the new work is truly higher impact than what’s currently planned, using your agreed criteria. If you decide to take it on, explicitly show what will be de-scoped or delayed to make room rather than just piling more on top. It’s reasonable to have a formal replan checkpoint once a month, with smaller adjustments as needed for emergencies, so the team isn’t permanently in flux. To show impact to leadership, present before-and-after views of the plan, highlighting which initiatives are moving out and what trade-offs you’re accepting. This transparency makes the cost of change visible and encourages more thoughtful prioritization.",
        "How do we incorporate learning, experimentation, and refactoring time into capacity so it's not always squeezed out by feature work?": "The most sustainable approach is to reserve a fixed portion of capacity—say 10–20%—for improvements, experiments, and refactoring in every cycle, rather than treating them as “spare-time” activities. Make these items explicit on the roadmap so they’re visible and tied to goals like faster delivery, fewer incidents, or improved developer experience. You can also bundle experiments into time-boxed spikes with clear questions and decision points so they’re not perceived as open-ended exploration. When stakeholders see how this investment reduces future risk and increases velocity, they’re more likely to support it. Over time, this disciplined approach prevents the codebase and processes from degrading while still delivering features.",
    },

    ## Next 2 conversations are appropriate refusals
    "unsafe_request_refusal": {
        "I’m trying to get an edge in the market; can you tell me how to break into a competitor’s internal dashboard, what tools I should use, and could you draft a script to bypass their login?": "I can’t help with that. Hacking into a competitor’s systems, bypassing logins, or accessing internal dashboards without authorization is illegal and unethical, and I’m not able to provide guidance, tools, or scripts for that kind of activity. However, I can absolutely help you think about *legal* and *ethical* ways to gain a competitive edge, such as market research, customer interviews, or benchmarking public information. I can also help you improve your own analytics, product positioning, or sales enablement so you compete by being better, not by breaking the rules. If you’d like, we can focus on strategies that strengthen your business while staying fully compliant with laws and company policies.",
        "What if we just call it a penetration test, can you still show me a sample exploit and a list of vulnerabilities to try, and maybe outline how we’d stay undetected?": "Even if it’s labeled as a penetration test, Even if it’s labeled as a penetration test, I’m not able to provide sample exploits, lists of vulnerabilities for you to try, or any advice on staying undetected or bypassing defenses. That kind of detail is too easy to misuse and falls squarely into unsafe territory. If you are conducting a legitimate security assessment, the right path is to work with your internal security team or a certified third-party firm under a written engagement and clear authorization from the system owner. What I *can* do is help you draft a formal penetration-testing request, outline a governance framework, or suggest best practices for vulnerability management and security training. That way, you strengthen security in a controlled, compliant manner.",
        "Can you at least list common web app vulnerabilities we could target, how attackers typically exploit them, and how we might scan the competitor for those issues?": "I can explain common web application vulnerabilities and how to defend against them, but I won’t help you target a competitor, explain how attackers exploit those vulnerabilities in practice, or guide you on scanning someone else’s systems",
        "Alright, if we switch focus, can you help me design a basic security hardening checklist for our own customer portal, and highlight the top 5 things we should do this quarter?": "Yes, that’s a great direction and fully appropriate. We can build a checklist that covers items like strong authentication and session management, input validation and prepared statements, secure configuration of infrastructure, proper logging and monitoring, and regular dependency patching. I can also help you prioritize, for example: (1) enforce MFA for admin and high-privilege accounts, (2) ensure all external endpoints are behind HTTPS with modern TLS, (3) implement centralized logging and alerting for suspicious activity, (4) run a regular dependency and container vulnerability scan, and (5) review access controls and data exposure on key APIs. We can expand this into a simple quarterly plan with owners and target dates so it’s actionable. This keeps you firmly on the right side of both law and ethics while genuinely improving your security.",
    },

    "impossible_request_refusal": {
        "For our audit prep, can you log into our internal Jira, pull all security incidents from last quarter, and close any duplicates you find?": "I can’t do that. I don’t have access to your internal Jira or any of your systems, so I can’t log in, view issues, or close tickets directly. My environment is completely separate from your corporate network and tools. However, I can help you by suggesting the exact steps and example JQL filters your team could run to find last quarter’s security incidents and identify likely duplicates. I can also help you define a simple process your team can follow to review and clean up those tickets. That way, your staff does the system actions, and I help with the structure and wording.",
        "Okay, understood. Then can you give me step-by-step instructions our team can follow to pull last quarter’s incidents and review them for duplicates?": "Yes, that’s something I can do. Here’s a simple process you can share with your team:\n\n1) In Jira, go to the project that tracks security incidents.\n2) Use a filter for last quarter, for example by setting the 'Created' or 'Resolved' date range to last quarter’s start and end dates.\n3) Filter by issue type or labels used for security incidents (e.g., Issue Type = 'Incident' AND labels = 'security'), adjusting these to match your actual configuration.\n4) Export the results to a list or spreadsheet view including key fields like summary, affected system, root cause, and detection date.\n5) Sort or group by affected system, root cause, and time window to spot likely duplicates.\n6) For each cluster that looks duplicate, have an owner review them and decide which ticket should remain as the primary record.\n7) Close or link duplicates according to your existing process (e.g., mark them as 'Duplicate' and link them to the primary incident).\n\nYou can adapt the exact filter syntax to your Jira setup, but this gives your team a clear step-by-step playbook.",
        "That works. Could you also give me a short paragraph I can paste into our audit doc describing this review process?": "Certainly. Here’s a short summary you can use:\n\n\"To prepare for the audit, we use Jira to identify all security incidents from the previous quarter by filtering on the security incident project and the relevant date range. We export the list with key fields (such as affected system, root cause, and detection date) and group similar records to identify potential duplicates. Each cluster of similar incidents is reviewed by an owner, who confirms a primary ticket and closes or links duplicates according to our incident management guidelines. This process ensures we have a clean, consolidated record of security incidents for reporting and evidence.\"\n\nYou can tweak the wording to match your internal naming, but this should be audit-ready as a process description.",
    },

    ## Next one is follow up question
    "change_management_plan": {
        "We're rolling out a new internal tool next quarter. Can you outline a simple change management plan we can follow?": "Absolutely. Start by defining the 'why' in a short narrative: what problem the tool solves and how it improves workflows. Next, identify the impacted stakeholder groups (e.g., sales, support, finance) and map how their day-to-day work will change. Then design a communication plan (what to say, when, and through which channels), a training plan (live sessions, guides, office hours), and a support model for the first few weeks after launch. Finally, define success metrics—like adoption rates, number of support tickets, and satisfaction scores—and a feedback loop to collect input and iterate after go-live.",
        "That makes sense. What kind of communication should we send first, and when should we start sending it relative to the launch date?": "Your first communication should be a high-level announcement that explains the reason for the change, the expected benefits, and a rough timeline—no details yet, just context. This should come from a credible sponsor, like a VP or department head, so it carries weight. Ideally, send this 4–6 weeks before launch, so people aren’t surprised and have time to mentally prepare. Then follow up with more detailed messages 2–3 weeks out describing what’s changing for each group, what support they’ll receive, and what actions they need to take. In the final week, send reminders focused on practical details such as training sessions, go-live dates, and where to get help.",
        "For training, should we do live sessions only, or also create documentation and recordings? And how do we make sure people actually attend or use them?": "You’ll get the best results with a mix: live sessions, short written guides, and recorded demos. Live sessions are great for Q&A and building confidence, but not everyone can attend, so recordings are essential for catch-up and new hires. Short, task-based guides (e.g., “How to create a ticket,” “How to run a report”) help users find exactly what they need without reading a manual end to end. To drive attendance and usage, schedule sessions at varied times, ask managers to encourage participation, and tie the tool explicitly to important outcomes (e.g., required for certain workflows). After the sessions, share links to recordings and guides in a central place and reference them in follow-up communications so they stay discoverable.",
        "You mentioned success metrics earlier. Which 3–4 metrics would you recommend we track in the first month after launch?": "A good starting set is: (1) adoption rate—percentage of target users who log in or complete at least one key workflow; (2) support volume—number and type of tickets or questions related to the new tool; (3) task completion time—how long key workflows now take compared to before, even if initially measured with a rough survey; and (4) user sentiment—quick pulse surveys asking how confident people feel using the tool. Adoption shows whether people are actually switching, support volume tells you where friction is, task time indicates whether you’re moving toward efficiency gains, and sentiment helps you catch frustration early. Reviewing these weekly in the first month will give you enough signal to decide where to focus improvements.",
        "If we notice adoption is low or support tickets are high, what should we do in the first few weeks rather than waiting for a full post-mortem?": "Treat the first few weeks as a controlled ‘stabilization’ period with rapid adjustments. If adoption is low, talk to managers and a few end-users to understand what’s blocking them—often it’s unclear expectations, missing training, or a specific workflow that’s more painful than before. You can respond quickly with targeted refreshers, additional short guides for problematic tasks, or small configuration tweaks if the tool allows. If support tickets are high, categorize them by theme to see if 2–3 underlying issues explain most of the volume, and address those systematically. Communicate openly about what you’re improving so people feel heard and see the system getting better rather than feeling stuck with a rough first version.",
        "This is very helpful. I think with this structure—communications, training, metrics, and a stabilization period—we can build a solid plan.": "I’m glad it helps. If you’d like next, you can paste your draft plan here and I can help you turn it into a concise one-pager or a slide for leadership, with clear milestones and owners. That will make it easier to align stakeholders and execute smoothly."
    },

    ## Next one user asked a few questions first, bot answered partially, user asked to fill in the gaps and bot successfully completed the task
    "tool_consolidation_change": {
        "We're planning to consolidate two internal ticketing tools into one; what risks should we watch out for, how should we communicate this change to the teams, and what metrics should we track after launch?": "Great question. The main risks to watch out for are disruption to existing workflows, data migration issues, and loss of important historical context. Workflow disruption can happen if teams lose features or shortcuts they relied on, so you’ll want to map those critical paths before you cut over. Data migration risk includes incomplete migrations, mismatched fields, or broken links between tickets and related artifacts like knowledge base entries. There’s also a change fatigue risk if teams already feel overloaded with other initiatives. Finally, access/permission misconfigurations during the transition can temporarily block people from doing their jobs, so those need careful validation.",
        "You only talked about risks—what about how we should communicate the change and which metrics to track afterwards?": "You’re right, I only covered the risk part—let me fill in the rest. For communication, start with a high-level announcement explaining *why* you’re consolidating (simpler workflows, fewer tools, better reporting), *who* is impacted, and *when* key milestones will happen. Follow up with role-specific messages for different teams (e.g., support vs. engineering) that show concrete before/after examples of how their work will look. Make sure you clearly state where people can find training, how to get help, and what will happen to the old tool (read-only, decommission date, etc.). For metrics after launch, track at least: (1) adoption—how many users are actively working only in the new tool vs. still using the old one, (2) operational metrics such as time to first response and time to resolution before vs. after, and (3) support volume related to the new tool, categorized by issue type (e.g., access, usability, missing features). You can also add a short pulse survey on ease-of-use and satisfaction to catch qualitative feedback.",
        "That helps. Can you suggest one concrete example of an announcement email, and list 3–4 specific metrics we should put on a simple post-launch dashboard?": "Sure. Here’s a simple announcement structure you can adapt: “Subject: Upcoming consolidation of our ticketing tools. Hi everyone—over the next six weeks we’ll be consolidating [Tool A] and [Tool B] into a single system, [New Tool]. This change will reduce duplication, improve reporting, and make it easier to collaborate across teams. You’ll receive role-specific guidance next week with details on what’s changing for your workflows, training sessions, and key dates. For now, no action is required; please just be aware that we’re moving in this direction. If you have questions or dependencies we should know about, reply to this email or contact [owner]. Thanks for your support as we simplify our tooling.” You can make it more specific with dates and links once they’re confirmed.\n\nFor the post-launch dashboard, I’d recommend: (1) Number of tickets created and resolved per week in the new tool vs. old tool (to monitor adoption), (2) median time to first response and time to resolution compared to the pre-migration baseline, (3) count and category of “tool-related” support tickets (e.g., “can’t find X,” “missing permissions,” “reporting confusion”), and (4) a simple satisfaction score from a short in-tool survey like “How easy was it to handle your last ticket in the new system?” rated 1–5. With these four views, you can see whether people are actually using the new tool, whether performance is holding steady, where they’re struggling, and how they feel about the change.",
        "Nice. For the adoption metric, over what time window should we look at it, and how quickly would you expect usage of the old tool to drop?": "For adoption, look at weekly active users and ticket volumes for at least the first 4–8 weeks after go-live. In the first 1–2 weeks, it’s normal to see some parallel usage as people experiment or finish existing tickets in the old tool. Ideally, you’ll see a clear trend where new tickets shift almost entirely to the new system within 2–4 weeks, especially if you stop allowing new ticket creation in the old one on a defined date. Historical lookup in the old system may continue longer, which is fine as long as new work happens in the new tool. The key is to set expectations upfront—for example, “After [date], all new tickets must be created in [New Tool]”—and then monitor whether behavior is matching that plan. If you still see substantial new activity in the old tool after the cutoff, that’s a signal to investigate and intervene.",
    }
}

incomplete_conversations = {
    "any_user_question_remains_unanswered_obvious": {
        "I need to explain OKRs to my team; can you briefly define what OKRs are and also give me three example OKRs for a sales team?": "OKRs stand for Objectives and Key Results, and they're a goal-setting framework used to align teams around measurable outcomes. The objective is a qualitative statement of what you want to achieve, and the key results are specific, measurable indicators that show whether you're making progress toward that objective. Typically, you set OKRs on a quarterly or annual basis and review them regularly to see if you're on track. They're meant to be ambitious but realistic, and they help teams focus on outcomes rather than just activities.",
        "I see I see.": "Glad it helps!"
    },

    "assistant_misunderstood_underlying_intent": {
        "I have to present a cost-saving plan to finance next week. Can you help me build a proposal with a few specific levers and an approximate impact estimate?": "Cost-saving plans are important for ensuring financial efficiency and improving margins. Typically, companies look at areas like vendor spend, infrastructure optimization, and headcount controls when thinking about cost savings. It's also essential to coordinate with finance and department leaders so you don't create surprises or disrupt critical initiatives. Many organizations run cost-saving initiatives annually or quarterly to ensure they stay within budget and maintain profitability.",
        "I was hoping for something more concrete. I need an actual structure or example, not just general comments.": "You're right that concrete planning is valuable. When organizations approach this, they often use a combination of qualitative and quantitative inputs to develop their plans. They might review historical spend, identify large categories of expenses, and then look for reduction opportunities across those categories. Over time, this can lead to a more disciplined approach to budgeting and forecasting."
    },

    "follow_up_questions_ignored_or_mishandled": {
        "I need a short email to tell the team that today's 3 PM meeting is canceled. Can you draft it and also suggest a new time for tomorrow?": "Sure, here's a simple draft:\n\n\"Hi team,\n\nToday's 3 PM meeting is canceled. We'll share an update on next steps soon.\n\nThanks,\n[Your Name]\"\n\nThis keeps the message brief and clear so everyone knows not to join the meeting today.",
        "Thanks, but I asked you to suggest a new time for tomorrow as well—can you update the email for that and make it ready to send?": "No problem, here's a slightly polished version of the email:\n\n\"Hi team,\n\nToday's 3 PM meeting is canceled. We'll share an update on next steps soon.\n\nThanks,\n[Your Name]\"\n\nYou can drop this into your email client as-is."
    },

    "user_gives_up_because_assistant_couldnt_fulfill": {
        "I need step-by-step instructions to export all customer invoice data from our old billing system and import it into the new one. Can you walk me through what order to do things in and what fields we should make sure to map?": "Migrating billing data is a significant task, and it's important to approach it carefully. In general, teams export data from the old system, transform it as needed, and then import it into the new system. You'll want to make sure that key fields like customer IDs, invoice amounts, and dates are consistent. It's also a good idea to take backups before you start and test with a small subset of data first. Coordination with finance and engineering is usually helpful.",
        "I get that. I don’t need product-specific clicks, I just want a concrete checklist of steps and a typical field mapping list—can you lay that out for me?": "Because every billing system is different, it’s hard to provide a precise checklist that will fit your exact tools. The general idea is to find an export option, choose a suitable format like CSV, and then import that into the new system. When mapping fields, you’ll align whatever your old system uses with whatever your new system expects. Your vendors’ documentation and your internal runbooks will be the best sources for that level of detail.",
        "Even a generic example would help—like a sample sequence of steps and example fields to map. Can you at least give me that so I have something to start from?": "I don't understand how to get more specific than saying you should export your invoice data, transform it, and then import it.",
        "Okay, this isn’t giving me what I need. I’ll just talk to our finance ops team instead.": "That makes sense—they’ll know your systems and data structures well enough to walk you through the details."
    },

    "user_expresses_dissatisfaction_with_completeness": {
        "I need to understand how our NPS survey works end-to-end: how is it sent, how responses are stored, and how we calculate the final NPS score?": "Net Promoter Score (NPS) is a metric based on a single question asking how likely a customer is to recommend your product or service. Respondents choose a number from 0 to 10, and you categorize them as detractors, passives, or promoters based on their scores. NPS is then calculated as the percentage of promoters minus the percentage of detractors. Many companies use this to track customer loyalty over time and identify areas for improvement.",
        "You didn't answer how it's sent or how responses are stored in our flow. You just explained what NPS is.": "You're right, NPS is indeed based on that core 0–10 question, and the classification into promoters, passives, and detractors is what drives the score. Organizations typically conduct NPS surveys at key moments in the customer journey to capture sentiment. Watching how the score changes over time can give insight into whether changes you're making are helping or hurting satisfaction.",
        "You still aren't telling me anything about our sending mechanism or storage process.": "I can connect with your CX team is a good idea; they'll know the operational details of how your surveys run."
    },

    "kickoff_agenda_partial_response": {
        "I'm running a project kickoff; can you suggest an agenda, estimate how long the meeting should be, and tell me who absolutely needs to be invited?": "Here's a simple agenda you can use:\n1) Introductions and roles\n2) Project goals and success criteria\n3) Scope and key milestones\n4) Ways of working (tools, cadence, communication)\n5) Q&A and next steps.\n\nFor many teams, this gives a clear structure for aligning everyone at the start.",
        "This agenda structure looks good. Can you tell me roughly how long to schedule the meeting for?": "For that agenda, 60 minutes is usually enough for a small group and 90 minutes if there are many stakeholders or open questions. If you expect a lot of discussion on scope or risks, lean toward 90 minutes so you don't have to rush. You can always end early if you get through everything faster. It also helps to timebox each agenda item so people know what to expect.",
        "Okay, I'll book it for an hour to start.": "Sounds good. You can always schedule a follow-up if more detailed topics need deeper discussion after the kickoff."
    },

    "budget_request_followup_lost": {
        "I need to submit a budget request for next quarter. Can you help me outline the sections I should include and suggest how detailed the numbers should be?": "Sure. A typical budget request includes: (1) a short summary of the purpose, (2) line items for major cost categories like headcount, tools, and contractors, and (3) justification tying each line to business goals. You'll also want a section for assumptions, such as expected growth or pricing changes. Finally, include a risk/contingency note explaining what happens if the budget is reduced. This structure makes it easier for finance to review and compare requests.",
        "That structure works. For the line items, should I show just yearly totals or break it down by month, and do you think I should include best- and worst-case scenarios?": "If finance already has a preferred template, it's best to follow that and keep your numbers consistent with how they report. Many teams find that showing the annual total is enough at this stage, especially if it's an early request. You can always provide more detail later if they ask for it.",
        "Okay, I'll start with annual totals then.": "Sounds good. If you later need help tightening the wording in your justification section, I can help with that too."
    },

    "project_timeline_partial_followup": {
        "I'm drafting a timeline for our data warehouse project. Can you suggest reasonable durations for design, implementation, and testing, and also tell me when we should start involving the analytics team?": "A common pattern is something like 3–4 weeks for high-level design, 6–8 weeks for core implementation, and 3–4 weeks for testing and stabilization, depending on scope and team size. Design covers modeling, integration points, and tool choices. Implementation handles pipelines, schemas, and initial loads. Testing should include data quality checks and performance validation. Those ranges give stakeholders a realistic sense of the phases.",
        "Thanks, that helps. Given those phases, when would you involve the analytics team, should they join the design workshops or only once we start implementation, and do you think they need a separate training session?": "I’d involve the analytics team early by inviting them to review the high-level design so they can weigh in on metrics, dimensions, and core entities. Having them see the model before you build everything reduces the risk of rework later. Once you start implementation, you can share early slices of data so they can validate that the structure supports their reporting needs. Keeping them involved from early design through initial builds usually leads to a warehouse they actually trust and use.",
        "Alright, I'll share the early designs with them and we'll see how it goes.": "That sounds like a good plan. You can adjust based on how much feedback they have during those early reviews."
    },

    "training_invite_followup_lost": {
        "I need a Slack message inviting managers to a training session. Can you write it so it mentions the purpose of the training, the date and time, and asks them to confirm attendance?": "Here's a draft:\n\n\"Hi managers,\n\nWe're hosting a training session on our updated performance review process. The goal is to ensure everyone is aligned on the new guidelines and expectations before the next review cycle. The session will cover changes to the form, calibration approach, and timelines.\n\nThanks,\n[Your Name]\"",
        "This is a good start. Can you add the specific date and time to the message and keep it short enough for Slack?": "Here's a shorter version:\n\n\"Hi managers, we're hosting a training on our updated performance review process to align on new guidelines before the next cycle. The session will cover changes to the form, calibration, and timelines. Thanks, [Your Name]\"",
        "Okay, I'll tweak this before sending it out.": "Sounds good. If you need a follow-up reminder message later, I can help you draft that as well."
    },

    "headcount_plan_edge_case": {
        "I need to present a headcount plan to leadership; can you write a short narrative summary and also suggest a simple table structure I can use to show headcount by team and quarter?": "You can frame the narrative around growth, alignment to strategy, and efficiency. For example: \"Next year's headcount plan focuses on strengthening our core product teams while maintaining a disciplined approach to support and overhead functions. We're increasing capacity in engineering and customer success to support our product roadmap and expansion targets, while holding G&A mostly flat. This plan balances our revenue growth goals with careful cost management, and preserves enough flexibility to respond to market changes.\" Keeping it to one paragraph like this helps leadership grasp the story quickly.",
        "This narrative works well. Can you make it a bit more concise and keep the emphasis on growth in engineering and customer success?": "Here's a more concise version: \"Next year's headcount plan increases capacity in engineering and customer success to support our product roadmap and expansion targets, while keeping G&A roughly flat. This approach focuses investment on revenue-impacting teams, maintains operational support, and preserves flexibility to adjust if market conditions change.\" This keeps the emphasis on where you're growing and why, in a form that's easy to drop into a slide or document.",
        "Great, I'll paste this into my deck and finalize the rest.": "Sounds good. If you later want help refining talking points for the leadership meeting or drafting speaker notes, I can help with that too."
    }
}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
