### PR TITLE
docs: add link to “good first issue” list for new contributors

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,10 @@
 # Contributing to MLflow
 
-We welcome community contributions to MLflow. This page provides useful information about contributing to MLflow.
+Thank you for your interest in contributing to MLflow.
+
+If you are new to MLflow, a great place to start is the list of open issues labeled “good first issue”: https://github.com/mlflow/mlflow/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22
+
+(Then the rest of the file continues…)
 
 **Table of Contents**
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

Add a short note in `CONTRIBUTING.md` directing first-time contributors to MLflow's open issues 
labeled “good first issue”. This helps new contributors find beginner-friendly tasks quickly.

## How is this patch tested?

This is a documentation-only change and does not affect code or runtime behavior.

## Release Notes

### Is this a user-facing change?

- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.
- [x] No. You can skip the rest of this section.

## What component(s) does this PR affect?

- [x] Documentation
- [ ] Models
- [ ] Tracking
- [ ] Scoring
- [ ] Artifacts
- [ ] Other (please specify):

## Related Issues

None.

## How does this PR make the codebase better?

- Helps new contributors get started faster.
- Increases visibility of existing beginner-friendly issues.
- Improves onboarding and documentation clarity.

## Does this PR introduce any breaking changes?

- [ ] Yes
- [x] No
