### PR TITLE
[ML-59815] Use class name instead of scorer name in genai_evaluate telemetry event

### DIFF
--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -79,8 +79,10 @@ class GenAIEvaluateEvent(Event):
         from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 
         scorers = arguments.get("scorers") or []
-        builtin_scorers = {scorer.name for scorer in scorers if isinstance(scorer, BuiltInScorer)}
-        return {"builtin_scorers": list(builtin_scorers)}
+        builtin_scorers = {
+            type(scorer).__name__ for scorer in scorers if isinstance(scorer, BuiltInScorer)
+        }
+        return {"builtin_scorers": list[str](builtin_scorers)}
 
 
 class CreateLoggedModelEvent(Event):

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -365,9 +365,11 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
     ]
     with mock.patch("mlflow.genai.judges.is_context_relevant"):
         mlflow.genai.evaluate(
-            data=data, scorers=[sample_scorer, RelevanceToQuery()], predict_fn=model.predict
+            data=data,
+            scorers=[sample_scorer, RelevanceToQuery(name="my_judge")],
+            predict_fn=model.predict,
         )
-        expected_params = {"builtin_scorers": ["relevance_to_query"]}
+        expected_params = {"builtin_scorers": ["RelevanceToQuery"]}
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
         )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/18990/files) to review incremental changes.
- [**stack/ML-59815**](https://github.com/mlflow/mlflow/pull/18990) [[Files changed](https://github.com/mlflow/mlflow/pull/18990/files)]
  - [stack/ML-59816](https://github.com/mlflow/mlflow/pull/19018) [[Files changed](https://github.com/mlflow/mlflow/pull/19018/files/b520975eef762029d08534383e3b0a58fc58a843..234346faf9688db95d4ca7086605500e484c8d6d)]
    - [stack/ML-59816-part-2](https://github.com/mlflow/mlflow/pull/19040) [[Files changed](https://github.com/mlflow/mlflow/pull/19040/files/234346faf9688db95d4ca7086605500e484c8d6d..63a5a08f1f4f8c0bfa113636e0b23a8a7e40ce5a)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Currently we log all the `name` of the `BuiltInScorer` passed into the `mlflow.genai.evaluate`, which can included user-defined scorer name, especially for `Guidelines` judge which extends `BuiltInScorer` and typically user will defined a custom scorer name. Synced with @B-Step62 before, we should remove these user-defined scorer name in our OSS telemetry. In this PR, I'm changing it from the `name` to the name of the scorer class to remove user-defined names.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
## Manual Test Plan
Invoke the following code snippet
```
from mlflow.genai.scorers import Safety, RelevanceToQuery, Guidelines

result = mlflow.genai.evaluate(
        data=_EVALUATION_TEST_CASES,
        predict_fn=predict_fn,
        scorers=[Safety(name="my_secret_app's_safety_scorer"), RelevanceToQuery(), Guidelines(
                name="test_guidelines",
                guidelines=["The response must be helpful and accurate"],
        )],
);
```

Printing the `genai_evaluate`'s record_params
| Before | After |
|--------|--------|
| `Logged telemetry event: genai_evaluate, record_params: {'builtin_scorers': ['test_guidelines', 'relevance_to_query', "my_secret_app's_safety_scorer"]}` | `Logged telemetry event: genai_evaluate, record_params: {'builtin_scorers': ['Guidelines', 'RelevanceToQuery', 'Safety']}` |

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
