### PR TITLE
[Endpoints] [1/x] Add backend DB tables for Endpoints

### DIFF
--- a/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
+++ b/mlflow/store/db_migrations/versions/1bd49d398cd23_add_secrets_tables.py
@@ -1,0 +1,185 @@
+"""add secrets tables
+
+Create Date: 2025-11-20 12:22:19.451124
+
+"""
+
+import time
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "1b49d398cd23"
+down_revision = "bf29a5ff90ea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "secrets",
+        sa.Column("secret_id", sa.String(length=36), nullable=False),
+        sa.Column("secret_name", sa.String(length=255), nullable=False),
+        sa.Column("encrypted_value", sa.LargeBinary(), nullable=False),
+        sa.Column("encrypted_auth_config", sa.LargeBinary(), nullable=True),
+        sa.Column("wrapped_dek", sa.LargeBinary(), nullable=False),
+        sa.Column("kek_version", sa.Integer(), nullable=False, default=1),
+        sa.Column("masked_value", sa.String(length=100), nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=True),
+        sa.Column("credential_name", sa.String(length=255), nullable=True),
+        sa.Column("wrapped_auth_config_dek", sa.LargeBinary(), nullable=True),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "last_updated_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("secret_id", name="secrets_pk"),
+    )
+    with op.batch_alter_table("secrets", schema=None) as batch_op:
+        batch_op.create_index("unique_secret_name", ["secret_name"], unique=True)
+
+    op.create_table(
+        "endpoints",
+        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=True),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "last_updated_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("endpoint_id", name="endpoints_pk"),
+    )
+    with op.batch_alter_table("endpoints", schema=None) as batch_op:
+        batch_op.create_index("unique_endpoint_name", ["name"], unique=True)
+
+    op.create_table(
+        "model_definitions",
+        sa.Column("model_definition_id", sa.String(length=36), nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("secret_id", sa.String(length=36), nullable=False),
+        sa.Column("provider", sa.String(length=64), nullable=False),
+        sa.Column("model_name", sa.String(length=256), nullable=False),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "last_updated_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["secret_id"],
+            ["secrets.secret_id"],
+            name="fk_model_definitions_secret_id",
+        ),
+        sa.PrimaryKeyConstraint("model_definition_id", name="model_definitions_pk"),
+    )
+    with op.batch_alter_table("model_definitions", schema=None) as batch_op:
+        batch_op.create_index("unique_model_definition_name", ["name"], unique=True)
+        batch_op.create_index("index_model_definitions_secret_id", ["secret_id"], unique=False)
+        batch_op.create_index("index_model_definitions_provider", ["provider"], unique=False)
+
+    op.create_table(
+        "endpoint_model_mappings",
+        sa.Column("mapping_id", sa.String(length=36), nullable=False),
+        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+        sa.Column("model_definition_id", sa.String(length=36), nullable=False),
+        sa.Column("weight", sa.Integer(), nullable=False, default=1),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["endpoint_id"],
+            ["endpoints.endpoint_id"],
+            name="fk_endpoint_model_mappings_endpoint_id",
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["model_definition_id"],
+            ["model_definitions.model_definition_id"],
+            name="fk_endpoint_model_mappings_model_definition_id",
+        ),
+        sa.PrimaryKeyConstraint("mapping_id", name="endpoint_model_mappings_pk"),
+    )
+    with op.batch_alter_table("endpoint_model_mappings", schema=None) as batch_op:
+        batch_op.create_index(
+            "index_endpoint_model_mappings_endpoint_id", ["endpoint_id"], unique=False
+        )
+        batch_op.create_index(
+            "index_endpoint_model_mappings_model_definition_id",
+            ["model_definition_id"],
+            unique=False,
+        )
+        batch_op.create_index(
+            "unique_endpoint_model_mapping",
+            ["endpoint_id", "model_definition_id"],
+            unique=True,
+        )
+
+    op.create_table(
+        "endpoint_bindings",
+        sa.Column("endpoint_id", sa.String(length=36), nullable=False),
+        sa.Column("resource_type", sa.String(length=50), nullable=False),
+        sa.Column("resource_id", sa.String(length=255), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.Column("created_by", sa.String(length=255), nullable=True),
+        sa.Column(
+            "last_updated_at",
+            sa.BigInteger(),
+            default=lambda: int(time.time() * 1000),
+            nullable=False,
+        ),
+        sa.Column("last_updated_by", sa.String(length=255), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["endpoint_id"],
+            ["endpoints.endpoint_id"],
+            name="fk_endpoint_bindings_endpoint_id",
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint(
+            "endpoint_id", "resource_type", "resource_id", name="endpoint_bindings_pk"
+        ),
+    )
+
+
+def downgrade():
+    op.drop_table("endpoint_bindings")
+    op.drop_table("endpoint_model_mappings")
+    op.drop_table("model_definitions")
+    op.drop_table("endpoints")
+    op.drop_table("secrets")

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -5,6 +5,17 @@ CREATE TABLE alembic_version (
 )
 
 
+CREATE TABLE endpoints (
+	endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	name VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT endpoints_pk PRIMARY KEY (endpoint_id)
+)
+
+
 CREATE TABLE entity_associations (
 	association_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	source_type VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
@@ -83,6 +94,26 @@ CREATE TABLE registered_models (
 )
 
 
+CREATE TABLE secrets (
+	secret_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	secret_name VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	encrypted_value VARBINARY NOT NULL,
+	encrypted_auth_config VARBINARY,
+	wrapped_dek VARBINARY NOT NULL,
+	kek_version INTEGER NOT NULL,
+	masked_value VARCHAR(100) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	provider VARCHAR(64) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	credential_name VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	wrapped_auth_config_dek VARBINARY,
+	description VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT secrets_pk PRIMARY KEY (secret_id)
+)
+
+
 CREATE TABLE webhooks (
 	webhook_id VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
@@ -108,6 +139,19 @@ CREATE TABLE datasets (
 	dataset_profile VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
 	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_bindings (
+	endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	resource_type VARCHAR(50) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	resource_id VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	created_at BIGINT NOT NULL,
+	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	CONSTRAINT endpoint_bindings_pk PRIMARY KEY (endpoint_id, resource_type, resource_id),
+	CONSTRAINT fk_endpoint_bindings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
 )
 
 
@@ -163,6 +207,21 @@ CREATE TABLE logged_models (
 	status_message VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE model_definitions (
+	model_definition_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	name VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	secret_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	provider VARCHAR(64) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	model_name VARCHAR(256) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT model_definitions_pk PRIMARY KEY (model_definition_id),
+	CONSTRAINT fk_model_definitions_secret_id FOREIGN KEY(secret_id) REFERENCES secrets (secret_id)
 )
 
 
@@ -274,6 +333,19 @@ CREATE TABLE assessments (
 	assessment_metadata VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
 	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_model_mappings (
+	mapping_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	endpoint_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	model_definition_id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	weight INTEGER NOT NULL,
+	created_by VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS",
+	created_at BIGINT NOT NULL,
+	CONSTRAINT endpoint_model_mappings_pk PRIMARY KEY (mapping_id),
+	CONSTRAINT fk_endpoint_model_mappings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_endpoint_model_mappings_model_definition_id FOREIGN KEY(model_definition_id) REFERENCES model_definitions (model_definition_id)
 )
 
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -5,6 +5,17 @@ CREATE TABLE alembic_version (
 )
 
 
+CREATE TABLE endpoints (
+	endpoint_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255),
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	PRIMARY KEY (endpoint_id)
+)
+
+
 CREATE TABLE entity_associations (
 	association_id VARCHAR(36) NOT NULL,
 	source_type VARCHAR(36) NOT NULL,
@@ -84,6 +95,26 @@ CREATE TABLE registered_models (
 )
 
 
+CREATE TABLE secrets (
+	secret_id VARCHAR(36) NOT NULL,
+	secret_name VARCHAR(255) NOT NULL,
+	encrypted_value BLOB NOT NULL,
+	encrypted_auth_config BLOB,
+	wrapped_dek BLOB NOT NULL,
+	kek_version INTEGER NOT NULL,
+	masked_value VARCHAR(100) NOT NULL,
+	provider VARCHAR(64),
+	credential_name VARCHAR(255),
+	wrapped_auth_config_dek BLOB,
+	description TEXT,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	PRIMARY KEY (secret_id)
+)
+
+
 CREATE TABLE webhooks (
 	webhook_id VARCHAR(256) NOT NULL,
 	name VARCHAR(256) NOT NULL,
@@ -109,6 +140,19 @@ CREATE TABLE datasets (
 	dataset_profile MEDIUMTEXT,
 	PRIMARY KEY (experiment_id, name, digest),
 	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_bindings (
+	endpoint_id VARCHAR(36) NOT NULL,
+	resource_type VARCHAR(50) NOT NULL,
+	resource_id VARCHAR(255) NOT NULL,
+	created_at BIGINT NOT NULL,
+	created_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	PRIMARY KEY (endpoint_id, resource_type, resource_id),
+	CONSTRAINT fk_endpoint_bindings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
 )
 
 
@@ -165,6 +209,21 @@ CREATE TABLE logged_models (
 	PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK ((`lifecycle_stage` in (_utf8mb4'active',_utf8mb4'deleted')))
+)
+
+
+CREATE TABLE model_definitions (
+	model_definition_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	secret_id VARCHAR(36) NOT NULL,
+	provider VARCHAR(64) NOT NULL,
+	model_name VARCHAR(256) NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	PRIMARY KEY (model_definition_id),
+	CONSTRAINT fk_model_definitions_secret_id FOREIGN KEY(secret_id) REFERENCES secrets (secret_id)
 )
 
 
@@ -279,6 +338,19 @@ CREATE TABLE assessments (
 	assessment_metadata TEXT,
 	PRIMARY KEY (assessment_id),
 	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_model_mappings (
+	mapping_id VARCHAR(36) NOT NULL,
+	endpoint_id VARCHAR(36) NOT NULL,
+	model_definition_id VARCHAR(36) NOT NULL,
+	weight INTEGER NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	PRIMARY KEY (mapping_id),
+	CONSTRAINT fk_endpoint_model_mappings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_endpoint_model_mappings_model_definition_id FOREIGN KEY(model_definition_id) REFERENCES model_definitions (model_definition_id)
 )
 
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -5,6 +5,17 @@ CREATE TABLE alembic_version (
 )
 
 
+CREATE TABLE endpoints (
+	endpoint_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255),
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT endpoints_pk PRIMARY KEY (endpoint_id)
+)
+
+
 CREATE TABLE entity_associations (
 	association_id VARCHAR(36) NOT NULL,
 	source_type VARCHAR(36) NOT NULL,
@@ -85,6 +96,26 @@ CREATE TABLE registered_models (
 )
 
 
+CREATE TABLE secrets (
+	secret_id VARCHAR(36) NOT NULL,
+	secret_name VARCHAR(255) NOT NULL,
+	encrypted_value BYTEA NOT NULL,
+	encrypted_auth_config BYTEA,
+	wrapped_dek BYTEA NOT NULL,
+	kek_version INTEGER NOT NULL,
+	masked_value VARCHAR(100) NOT NULL,
+	provider VARCHAR(64),
+	credential_name VARCHAR(255),
+	wrapped_auth_config_dek BYTEA,
+	description TEXT,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT secrets_pk PRIMARY KEY (secret_id)
+)
+
+
 CREATE TABLE webhooks (
 	webhook_id VARCHAR(256) NOT NULL,
 	name VARCHAR(256) NOT NULL,
@@ -110,6 +141,19 @@ CREATE TABLE datasets (
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
 	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_bindings (
+	endpoint_id VARCHAR(36) NOT NULL,
+	resource_type VARCHAR(50) NOT NULL,
+	resource_id VARCHAR(255) NOT NULL,
+	created_at BIGINT NOT NULL,
+	created_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	CONSTRAINT endpoint_bindings_pk PRIMARY KEY (endpoint_id, resource_type, resource_id),
+	CONSTRAINT fk_endpoint_bindings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
 )
 
 
@@ -167,6 +211,21 @@ CREATE TABLE logged_models (
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage::text = ANY (ARRAY['active'::character varying, 'deleted'::character varying]::text[]))
+)
+
+
+CREATE TABLE model_definitions (
+	model_definition_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	secret_id VARCHAR(36) NOT NULL,
+	provider VARCHAR(64) NOT NULL,
+	model_name VARCHAR(256) NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT model_definitions_pk PRIMARY KEY (model_definition_id),
+	CONSTRAINT fk_model_definitions_secret_id FOREIGN KEY(secret_id) REFERENCES secrets (secret_id)
 )
 
 
@@ -281,6 +340,19 @@ CREATE TABLE assessments (
 	assessment_metadata TEXT,
 	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
 	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_model_mappings (
+	mapping_id VARCHAR(36) NOT NULL,
+	endpoint_id VARCHAR(36) NOT NULL,
+	model_definition_id VARCHAR(36) NOT NULL,
+	weight INTEGER NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	CONSTRAINT endpoint_model_mappings_pk PRIMARY KEY (mapping_id),
+	CONSTRAINT fk_endpoint_model_mappings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_endpoint_model_mappings_model_definition_id FOREIGN KEY(model_definition_id) REFERENCES model_definitions (model_definition_id)
 )
 
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -5,6 +5,17 @@ CREATE TABLE alembic_version (
 )
 
 
+CREATE TABLE endpoints (
+	endpoint_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255),
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT endpoints_pk PRIMARY KEY (endpoint_id)
+)
+
+
 CREATE TABLE entity_associations (
 	association_id VARCHAR(36) NOT NULL,
 	source_type VARCHAR(36) NOT NULL,
@@ -86,6 +97,26 @@ CREATE TABLE registered_models (
 )
 
 
+CREATE TABLE secrets (
+	secret_id VARCHAR(36) NOT NULL,
+	secret_name VARCHAR(255) NOT NULL,
+	encrypted_value BLOB NOT NULL,
+	encrypted_auth_config BLOB,
+	wrapped_dek BLOB NOT NULL,
+	kek_version INTEGER NOT NULL,
+	masked_value VARCHAR(100) NOT NULL,
+	provider VARCHAR(64),
+	credential_name VARCHAR(255),
+	wrapped_auth_config_dek BLOB,
+	description TEXT,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT secrets_pk PRIMARY KEY (secret_id)
+)
+
+
 CREATE TABLE webhooks (
 	webhook_id VARCHAR(256) NOT NULL,
 	name VARCHAR(256) NOT NULL,
@@ -111,6 +142,19 @@ CREATE TABLE datasets (
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
 	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_bindings (
+	endpoint_id VARCHAR(36) NOT NULL,
+	resource_type VARCHAR(50) NOT NULL,
+	resource_id VARCHAR(255) NOT NULL,
+	created_at BIGINT NOT NULL,
+	created_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	CONSTRAINT endpoint_bindings_pk PRIMARY KEY (endpoint_id, resource_type, resource_id),
+	CONSTRAINT fk_endpoint_bindings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
 )
 
 
@@ -168,6 +212,21 @@ CREATE TABLE logged_models (
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage IN ('active', 'deleted'))
+)
+
+
+CREATE TABLE model_definitions (
+	model_definition_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	secret_id VARCHAR(36) NOT NULL,
+	provider VARCHAR(64) NOT NULL,
+	model_name VARCHAR(256) NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT model_definitions_pk PRIMARY KEY (model_definition_id),
+	CONSTRAINT fk_model_definitions_secret_id FOREIGN KEY(secret_id) REFERENCES secrets (secret_id)
 )
 
 
@@ -282,6 +341,19 @@ CREATE TABLE assessments (
 	assessment_metadata TEXT,
 	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
 	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_model_mappings (
+	mapping_id VARCHAR(36) NOT NULL,
+	endpoint_id VARCHAR(36) NOT NULL,
+	model_definition_id VARCHAR(36) NOT NULL,
+	weight INTEGER NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	CONSTRAINT endpoint_model_mappings_pk PRIMARY KEY (mapping_id),
+	CONSTRAINT fk_endpoint_model_mappings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_endpoint_model_mappings_model_definition_id FOREIGN KEY(model_definition_id) REFERENCES model_definitions (model_definition_id)
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -5,6 +5,17 @@ CREATE TABLE alembic_version (
 )
 
 
+CREATE TABLE endpoints (
+	endpoint_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255),
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT endpoints_pk PRIMARY KEY (endpoint_id)
+)
+
+
 CREATE TABLE entity_associations (
 	association_id VARCHAR(36) NOT NULL,
 	source_type VARCHAR(36) NOT NULL,
@@ -86,6 +97,26 @@ CREATE TABLE registered_models (
 )
 
 
+CREATE TABLE secrets (
+	secret_id VARCHAR(36) NOT NULL,
+	secret_name VARCHAR(255) NOT NULL,
+	encrypted_value BLOB NOT NULL,
+	encrypted_auth_config BLOB,
+	wrapped_dek BLOB NOT NULL,
+	kek_version INTEGER NOT NULL,
+	masked_value VARCHAR(100) NOT NULL,
+	provider VARCHAR(64),
+	credential_name VARCHAR(255),
+	wrapped_auth_config_dek BLOB,
+	description TEXT,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT secrets_pk PRIMARY KEY (secret_id)
+)
+
+
 CREATE TABLE webhooks (
 	webhook_id VARCHAR(256) NOT NULL,
 	name VARCHAR(256) NOT NULL,
@@ -111,6 +142,19 @@ CREATE TABLE datasets (
 	dataset_profile TEXT,
 	CONSTRAINT dataset_pk PRIMARY KEY (experiment_id, name, digest),
 	CONSTRAINT fk_datasets_experiment_id_experiments FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_bindings (
+	endpoint_id VARCHAR(36) NOT NULL,
+	resource_type VARCHAR(50) NOT NULL,
+	resource_id VARCHAR(255) NOT NULL,
+	created_at BIGINT NOT NULL,
+	created_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	CONSTRAINT endpoint_bindings_pk PRIMARY KEY (endpoint_id, resource_type, resource_id),
+	CONSTRAINT fk_endpoint_bindings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE
 )
 
 
@@ -168,6 +212,21 @@ CREATE TABLE logged_models (
 	CONSTRAINT logged_models_pk PRIMARY KEY (model_id),
 	CONSTRAINT fk_logged_models_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT logged_models_lifecycle_stage_check CHECK (lifecycle_stage IN ('active', 'deleted'))
+)
+
+
+CREATE TABLE model_definitions (
+	model_definition_id VARCHAR(36) NOT NULL,
+	name VARCHAR(255) NOT NULL,
+	secret_id VARCHAR(36) NOT NULL,
+	provider VARCHAR(64) NOT NULL,
+	model_name VARCHAR(256) NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	last_updated_by VARCHAR(255),
+	last_updated_at BIGINT NOT NULL,
+	CONSTRAINT model_definitions_pk PRIMARY KEY (model_definition_id),
+	CONSTRAINT fk_model_definitions_secret_id FOREIGN KEY(secret_id) REFERENCES secrets (secret_id)
 )
 
 
@@ -282,6 +341,19 @@ CREATE TABLE assessments (
 	assessment_metadata TEXT,
 	CONSTRAINT assessments_pk PRIMARY KEY (assessment_id),
 	CONSTRAINT fk_assessments_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
+)
+
+
+CREATE TABLE endpoint_model_mappings (
+	mapping_id VARCHAR(36) NOT NULL,
+	endpoint_id VARCHAR(36) NOT NULL,
+	model_definition_id VARCHAR(36) NOT NULL,
+	weight INTEGER NOT NULL,
+	created_by VARCHAR(255),
+	created_at BIGINT NOT NULL,
+	CONSTRAINT endpoint_model_mappings_pk PRIMARY KEY (mapping_id),
+	CONSTRAINT fk_endpoint_model_mappings_endpoint_id FOREIGN KEY(endpoint_id) REFERENCES endpoints (endpoint_id) ON DELETE CASCADE,
+	CONSTRAINT fk_endpoint_model_mappings_model_definition_id FOREIGN KEY(model_definition_id) REFERENCES model_definitions (model_definition_id)
 )
 
 

--- a/tests/store/tracking/test_sqlalchemy_store_schema.py
+++ b/tests/store/tracking/test_sqlalchemy_store_schema.py
@@ -153,3 +153,34 @@ def test_index_for_dataset_tables(tmp_path, db_url):
             "index_inputs_destination_type_destination_id_source_type",
         }
         assert new_index_names.issubset(all_index_names)
+
+
+def test_secrets_and_endpoints_tables(tmp_path, db_url):
+    SqlAlchemyStore(db_url, tmp_path.joinpath("ARTIFACTS").as_uri())
+    with sqlite3.connect(db_url[len("sqlite:///") :]) as conn:
+        cursor = conn.cursor()
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'table'")
+        all_table_names = [r[0] for r in cursor.fetchall()]
+        expected_tables = {
+            "secrets",
+            "endpoints",
+            "model_definitions",
+            "endpoint_model_mappings",
+            "endpoint_bindings",
+        }
+        assert expected_tables.issubset(all_table_names)
+        cursor.execute("SELECT name FROM sqlite_master WHERE type = 'index'")
+        all_index_names = [r[0] for r in cursor.fetchall()]
+        expected_indexes = {
+            "index_model_definitions_secret_id",
+            "index_model_definitions_provider",
+            "unique_model_definition_name",
+            "index_endpoint_model_mappings_endpoint_id",
+            "index_endpoint_model_mappings_model_definition_id",
+            "unique_endpoint_model_mapping",
+            # endpoint_bindings uses composite PK (endpoint_id, resource_type, resource_id)
+            # which serves as an implicit index
+            "unique_secret_name",
+            "unique_endpoint_name",
+        }
+        assert expected_indexes.issubset(all_index_names)


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19002/files) to review incremental changes.
- [**stack/endpoints/db**](https://github.com/mlflow/mlflow/pull/19002) [[Files changed](https://github.com/mlflow/mlflow/pull/19002/files)]
  - [stack/endpoints/crypto](https://github.com/mlflow/mlflow/pull/19003) [[Files changed](https://github.com/mlflow/mlflow/pull/19003/files/6a64a6ac50829e12d9e4ab6b0bd1c73d67b396fe..79cefae0939fcb245562ced698fc3711d3d537bc)]
    - [stack/endpoints/entities](https://github.com/mlflow/mlflow/pull/19004) [[Files changed](https://github.com/mlflow/mlflow/pull/19004/files/79cefae0939fcb245562ced698fc3711d3d537bc..09aba4ec4898bd5cbae936268bb8bdf2b469c377)]
      - [stack/endpoints/abstract](https://github.com/mlflow/mlflow/pull/19005) [[Files changed](https://github.com/mlflow/mlflow/pull/19005/files/09aba4ec4898bd5cbae936268bb8bdf2b469c377..3a572c2932e46e36a06fd0fa34dce740f31ca31a)]
        - [stack/endpoints/sql-store](https://github.com/mlflow/mlflow/pull/19006) [[Files changed](https://github.com/mlflow/mlflow/pull/19006/files/3a572c2932e46e36a06fd0fa34dce740f31ca31a..e7427074819c6e3e5266ebdecd8022df259e4daf)]
          - [stack/endpoints/rest](https://github.com/mlflow/mlflow/pull/19007) [[Files changed](https://github.com/mlflow/mlflow/pull/19007/files/e7427074819c6e3e5266ebdecd8022df259e4daf..2c91f2ab764d2b677ae6444ed4d3a93ef24892bd)]
            - [stack/endpoints/rest-2](https://github.com/mlflow/mlflow/pull/19008) [[Files changed](https://github.com/mlflow/mlflow/pull/19008/files/2c91f2ab764d2b677ae6444ed4d3a93ef24892bd..6915f33796c05bc243d61a404422db8f25e991da)]
              - [stack/endpoints/cache](https://github.com/mlflow/mlflow/pull/19014) [[Files changed](https://github.com/mlflow/mlflow/pull/19014/files/6915f33796c05bc243d61a404422db8f25e991da..f0df939158bd389fa29109e6fba3146271cf613c)]
                - [stack/endpoints/litellm](https://github.com/mlflow/mlflow/pull/19009) [[Files changed](https://github.com/mlflow/mlflow/pull/19009/files/f0df939158bd389fa29109e6fba3146271cf613c..a46368712d37827ee56f25bb281cf92f2ffb95d0)]
                  - [stack/endpoints/ui-apis](https://github.com/mlflow/mlflow/pull/19010) [[Files changed](https://github.com/mlflow/mlflow/pull/19010/files/a46368712d37827ee56f25bb281cf92f2ffb95d0..3278274053f1f5d1d6dc20f1cb247f40c86943d9)]
                    - [stack/endpoints/ui-create-endpoint](https://github.com/mlflow/mlflow/pull/19042) [[Files changed](https://github.com/mlflow/mlflow/pull/19042/files/3278274053f1f5d1d6dc20f1cb247f40c86943d9..346ab42658df05e9547be8f1d98d3a00c958eb42)]
                      - [stack/endpoints/ui-tabs](https://github.com/mlflow/mlflow/pull/19070) [[Files changed](https://github.com/mlflow/mlflow/pull/19070/files/346ab42658df05e9547be8f1d98d3a00c958eb42..622e44aa8b14086d54e907ae3dc0ae121b4e5074)]
                        - [stack/endpoints/key-management](https://github.com/mlflow/mlflow/pull/19071) [[Files changed](https://github.com/mlflow/mlflow/pull/19071/files/622e44aa8b14086d54e907ae3dc0ae121b4e5074..0adf6e0012a3382c3368e4372925347c4079f91a)]
                          - [stack/endpoints/models](https://github.com/mlflow/mlflow/pull/19074) [[Files changed](https://github.com/mlflow/mlflow/pull/19074/files/0adf6e0012a3382c3368e4372925347c4079f91a..e10697600ca7f0b9b76fca50b26742ac4e8f55c1)]
                            - [stack/endpoints/passphrase](https://github.com/mlflow/mlflow/pull/19176) [[Files changed](https://github.com/mlflow/mlflow/pull/19176/files/e10697600ca7f0b9b76fca50b26742ac4e8f55c1..0f7cdfd787bf876003aa56eab9761d42d2603138)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add the secret storage and endpoint definition tables. 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
