### PR TITLE
Add support for SGC run resumption from Databricks Jobs

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1130,5 +1130,5 @@ MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS"
 #: parameter and automatically resume MLflow runs associated with that Databricks job run ID.
 #: (default: ``True``)
 _MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS = _BooleanEnvironmentVariable(
-    "_MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", True
+    "MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", True
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1129,6 +1129,6 @@ MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS"
 #: When enabled, MLflow will check for the SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID job
 #: parameter and automatically resume MLflow runs associated with that Databricks job run ID.
 #: (default: ``True``)
-MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS = _BooleanEnvironmentVariable(
-    "MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", False
+_MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS = _BooleanEnvironmentVariable(
+    "_MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", True
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1130,5 +1130,5 @@ MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS"
 #: parameter and automatically resume MLflow runs associated with that Databricks job run ID.
 #: (default: ``True``)
 MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS = _BooleanEnvironmentVariable(
-    "MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", True
+    "MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", False
 )

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1123,3 +1123,12 @@ MLFLOW_SERVER_JOB_TRANSIENT_ERROR_RETRY_MAX_DELAY = _EnvironmentVariable(
 #: issues with the judge's reasoning.
 #: (default: ``30``)
 MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS", int, 30)
+
+
+#: Enable automatic run resumption for Serverless GPU Compute (SGC) jobs on Databricks.
+#: When enabled, MLflow will check for the SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID job
+#: parameter and automatically resume MLflow runs associated with that Databricks job run ID.
+#: (default: ``True``)
+MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS = _BooleanEnvironmentVariable(
+    "MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", True
+)

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -53,6 +53,7 @@ from mlflow.telemetry.track import _record_event
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
+from mlflow.tracking.client import MlflowClient
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import experimental
 from mlflow.utils.async_logging.run_operations import RunOperations
@@ -88,7 +89,6 @@ from mlflow.version import IS_TRACING_SDK_ONLY
 if not IS_TRACING_SDK_ONLY:
     from mlflow.data.dataset import Dataset
     from mlflow.tracking import _get_artifact_repo, _get_store, artifact_utils
-    from mlflow.tracking.client import MlflowClient
     from mlflow.tracking.context import registry as context_registry
     from mlflow.tracking.default_experiment import registry as default_experiment_registry
 
@@ -445,15 +445,13 @@ def start_run(
         )
     client = MlflowClient()
 
-    # Get SGC job run ID tag key for run resumption if applicable
-    sgc_job_run_id_tag_key = _get_sgc_job_run_id_tag_key()
-
     if run_id:
         existing_run_id = run_id
     elif run_id := MLFLOW_RUN_ID.get():
         existing_run_id = run_id
         del os.environ[MLFLOW_RUN_ID.name]
-    elif sgc_job_run_id_tag_key:
+    # Get SGC job run ID tag key for run resumption if applicable
+    elif sgc_job_run_id_tag_key := _get_sgc_job_run_id_tag_key():
         existing_run_id = _get_sgc_mlflow_run_id_for_resumption(
             client, experiment_id, sgc_job_run_id_tag_key
         )

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -300,7 +300,6 @@ def _get_sgc_mlflow_run_id_for_resumption(
     Returns:
         str or None: The MLflow run ID to resume, if found; otherwise None.
     """
-    # Determine the experiment ID to search in
     search_exp_id = experiment_id or _get_experiment_id()
 
     try:
@@ -444,7 +443,6 @@ def start_run(
             ).format(active_run_stack[0].info.run_id)
         )
     client = MlflowClient()
-
     if run_id:
         existing_run_id = run_id
     elif run_id := MLFLOW_RUN_ID.get():

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -444,6 +444,7 @@ def start_run(
             ).format(active_run_stack[0].info.run_id)
         )
     client = MlflowClient()
+    sgc_job_run_id_tag_key: str | None = None
     if run_id:
         existing_run_id = run_id
     elif run_id := MLFLOW_RUN_ID.get():

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -34,9 +34,9 @@ from mlflow.entities import (
 from mlflow.entities.lifecycle_stage import LifecycleStage
 from mlflow.environment_variables import (
     _MLFLOW_ACTIVE_MODEL_ID,
+    _MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS,
     MLFLOW_ACTIVE_MODEL_ID,
     MLFLOW_ENABLE_ASYNC_LOGGING,
-    MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS,
     MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
@@ -264,8 +264,24 @@ class ActiveRun(Run):
         return exc_type is None
 
 
+def _get_sgc_job_run_id_tag_key() -> str | None:
+    """
+    Get the SGC job run ID tag key for run resumption if enabled and available.
+
+    Returns:
+        str or None: The experiment tag key for SGC resumption, or None if not applicable.
+    """
+    if not _MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.get():
+        return None
+
+    if sgc_job_run_id := get_sgc_job_run_id():
+        return f"databricks_mlflow_sgc_resume_run_job_run_id_{sgc_job_run_id}"
+
+    return None
+
+
 def _get_sgc_mlflow_run_id_for_resumption(
-    client: "MlflowClient", experiment_id: str | None, sgc_job_run_id_tag_key: str | None
+    client: MlflowClient, experiment_id: str | None, sgc_job_run_id_tag_key: str | None
 ) -> str | None:
     """
     Retrieves the MLflow run ID associated with a specific SGC job run ID tag key
@@ -290,8 +306,7 @@ def _get_sgc_mlflow_run_id_for_resumption(
     try:
         exp = client.get_experiment(search_exp_id)
         # Check if experiment has the tag for resumption
-        if exp and exp.tags and sgc_job_run_id_tag_key in exp.tags:
-            prev_mlflow_run_id = exp.tags[sgc_job_run_id_tag_key]
+        if prev_mlflow_run_id := exp.tags.get(sgc_job_run_id_tag_key):
             _logger.info(
                 f"Resuming MLflow run: {prev_mlflow_run_id} "
                 f"using SGC tag key: {sgc_job_run_id_tag_key}"
@@ -430,12 +445,8 @@ def start_run(
         )
     client = MlflowClient()
 
-    # If SGC run resumption is enabled, get the SGC job run ID tag key
-    sgc_job_run_id_tag_key = None
-    if MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.get():
-        sgc_job_run_id = get_sgc_job_run_id()
-        if sgc_job_run_id:
-            sgc_job_run_id_tag_key = f"databricks_mlflow_sgc_resume_run_job_run_id_{sgc_job_run_id}"
+    # Get SGC job run ID tag key for run resumption if applicable
+    sgc_job_run_id_tag_key = _get_sgc_job_run_id_tag_key()
 
     if run_id:
         existing_run_id = run_id

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -72,6 +72,7 @@ from mlflow.utils.databricks_utils import (
 from mlflow.utils.file_utils import TempDir
 from mlflow.utils.import_hooks import register_post_import_hook
 from mlflow.utils.mlflow_tags import (
+    MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX,
     MLFLOW_DATASET_CONTEXT,
     MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER,
     MLFLOW_EXPERIMENT_PRIMARY_METRIC_NAME,
@@ -275,7 +276,7 @@ def _get_sgc_job_run_id_tag_key() -> str | None:
         return None
 
     if sgc_job_run_id := get_sgc_job_run_id():
-        return f"databricks_mlflow_sgc_resume_run_job_run_id_{sgc_job_run_id}"
+        return f"{MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.{sgc_job_run_id}"
 
     return None
 

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -264,7 +264,9 @@ class ActiveRun(Run):
         return exc_type is None
 
 
-def _get_sgc_mlflow_run_id_for_resumption(client: "MlflowClient", experiment_id: str | None, sgc_job_run_id_tag_key : str | None) -> str | None:
+def _get_sgc_mlflow_run_id_for_resumption(
+    client: "MlflowClient", experiment_id: str | None, sgc_job_run_id_tag_key: str | None
+) -> str | None:
     """
     Retrieves the MLflow run ID associated with a specific SGC job run ID tag key for potential run resumption.
 
@@ -292,7 +294,9 @@ def _get_sgc_mlflow_run_id_for_resumption(client: "MlflowClient", experiment_id:
         # Check if experiment has the tag for resumption
         if exp.tags and sgc_job_run_id_tag_key in exp.tags:
             prev_mlflow_run_id = exp.tags[sgc_job_run_id_tag_key]
-            _logger.info(f"Resuming MLflow run: {prev_mlflow_run_id} using SGC tag key: {sgc_job_run_id_tag_key}")
+            _logger.info(
+                f"Resuming MLflow run: {prev_mlflow_run_id} using SGC tag key: {sgc_job_run_id_tag_key}"
+            )
     except Exception as e:
         _logger.debug(f"Failed to retrieve SGC run ID: {e}")
     return prev_mlflow_run_id
@@ -424,21 +428,23 @@ def start_run(
             ).format(active_run_stack[0].info.run_id)
         )
     client = MlflowClient()
-    
+
     # If SGC run resumption is enabled, get the SGC job run ID tag key
     sgc_job_run_id_tag_key = None
     if MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.get():
         sgc_job_run_id = get_sgc_job_run_id()
         if sgc_job_run_id:
             sgc_job_run_id_tag_key = f"databricks_mlflow_sgc_resume_run_job_run_id_{sgc_job_run_id}"
-    
+
     if run_id:
         existing_run_id = run_id
     elif run_id := MLFLOW_RUN_ID.get():
         existing_run_id = run_id
         del os.environ[MLFLOW_RUN_ID.name]
     elif sgc_job_run_id_tag_key:
-        existing_run_id = _get_sgc_mlflow_run_id_for_resumption(client, experiment_id, sgc_job_run_id_tag_key)
+        existing_run_id = _get_sgc_mlflow_run_id_for_resumption(
+            client, experiment_id, sgc_job_run_id_tag_key
+        )
     else:
         existing_run_id = None
     if existing_run_id:
@@ -530,14 +536,15 @@ def start_run(
         # If SGC run resumption is enabled, set the experiment tag mapping SGC job_run_id to this run_id for future run resumption
         if sgc_job_run_id_tag_key:
             try:
-                client.set_experiment_tag(exp_id_for_run, sgc_job_run_id_tag_key, active_run_obj.info.run_id)
+                client.set_experiment_tag(
+                    exp_id_for_run, sgc_job_run_id_tag_key, active_run_obj.info.run_id
+                )
                 _logger.info(
                     f"Set experiment tag {sgc_job_run_id_tag_key} = {active_run_obj.info.run_id} "
                     f"for SGC run resumption"
                 )
             except Exception as e:
                 _logger.debug(f"Failed to set experiment tag for SGC resumption: {e}")
-
 
     if log_system_metrics is None:
         # If `log_system_metrics` is not specified, we will check environment variable.

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -53,7 +53,6 @@ from mlflow.telemetry.track import _record_event
 from mlflow.tracing.provider import _get_trace_exporter
 from mlflow.tracking._tracking_service.client import TrackingServiceClient
 from mlflow.tracking._tracking_service.utils import _resolve_tracking_uri
-from mlflow.tracking.client import MlflowClient
 from mlflow.utils import get_results_from_paginated_fn
 from mlflow.utils.annotations import experimental
 from mlflow.utils.async_logging.run_operations import RunOperations
@@ -89,6 +88,7 @@ from mlflow.version import IS_TRACING_SDK_ONLY
 if not IS_TRACING_SDK_ONLY:
     from mlflow.data.dataset import Dataset
     from mlflow.tracking import _get_artifact_repo, _get_store, artifact_utils
+    from mlflow.tracking.client import MlflowClient
     from mlflow.tracking.context import registry as context_registry
     from mlflow.tracking.default_experiment import registry as default_experiment_registry
 
@@ -281,7 +281,7 @@ def _get_sgc_job_run_id_tag_key() -> str | None:
 
 
 def _get_sgc_mlflow_run_id_for_resumption(
-    client: MlflowClient, experiment_id: str | None, sgc_job_run_id_tag_key: str | None
+    client, experiment_id: str | None, sgc_job_run_id_tag_key: str | None
 ) -> str | None:
     """
     Retrieves the MLflow run ID associated with a specific SGC job run ID tag key

--- a/mlflow/tracking/fluent.py
+++ b/mlflow/tracking/fluent.py
@@ -36,8 +36,8 @@ from mlflow.environment_variables import (
     _MLFLOW_ACTIVE_MODEL_ID,
     MLFLOW_ACTIVE_MODEL_ID,
     MLFLOW_ENABLE_ASYNC_LOGGING,
-    MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
     MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS,
+    MLFLOW_ENABLE_SYSTEM_METRICS_LOGGING,
     MLFLOW_EXPERIMENT_ID,
     MLFLOW_EXPERIMENT_NAME,
     MLFLOW_RUN_ID,
@@ -268,26 +268,24 @@ def _get_sgc_mlflow_run_id_for_resumption(
     client: "MlflowClient", experiment_id: str | None, sgc_job_run_id_tag_key: str | None
 ) -> str | None:
     """
-    Retrieves the MLflow run ID associated with a specific SGC job run ID tag key for potential run resumption.
+    Retrieves the MLflow run ID associated with a specific SGC job run ID tag key
+    for potential run resumption.
 
-    This function searches the experiment (specified by `experiment_id`, or the default if None) for an experiment tag
-    named `sgc_job_run_id_tag_key`. If the tag exists, its value (the run ID to resume) is returned;
-    otherwise, returns None.
+    This function searches the experiment (specified by `experiment_id`, or the
+    default if None) for an experiment tag named `sgc_job_run_id_tag_key`. If the
+    tag exists, its value (the run ID to resume) is returned; otherwise, returns None.
 
     Args:
         client: MlflowClient instance used to query experiment information.
-        experiment_id: The experiment ID to search, or None to use the default experiment.
-        sgc_job_run_id_tag_key: The experiment tag key that maps the SGC job run ID to an MLflow run ID.
+        experiment_id: The experiment ID to search, or None to use the default.
+        sgc_job_run_id_tag_key: The experiment tag key that maps the SGC job run ID
+            to an MLflow run ID.
 
     Returns:
         str or None: The MLflow run ID to resume, if found; otherwise None.
     """
     # Determine the experiment ID to search in
-    if experiment_id:
-        search_exp_id = experiment_id
-    else:
-        # Get the default experiment ID
-        search_exp_id = _get_experiment_id()
+    search_exp_id = experiment_id or _get_experiment_id()
 
     try:
         exp = client.get_experiment(search_exp_id)
@@ -295,7 +293,8 @@ def _get_sgc_mlflow_run_id_for_resumption(
         if exp and exp.tags and sgc_job_run_id_tag_key in exp.tags:
             prev_mlflow_run_id = exp.tags[sgc_job_run_id_tag_key]
             _logger.info(
-                f"Resuming MLflow run: {prev_mlflow_run_id} using SGC tag key: {sgc_job_run_id_tag_key}"
+                f"Resuming MLflow run: {prev_mlflow_run_id} "
+                f"using SGC tag key: {sgc_job_run_id_tag_key}"
             )
             return prev_mlflow_run_id
     except Exception as e:

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1047,6 +1047,15 @@ def check_databricks_secret_scope_access(scope_name):
                 f"Error: {e}"
             )
 
+def get_sgc_job_run_id() -> str | None:
+    dbutils = _get_dbutils()
+    if dbutils:
+        try:
+            return dbutils.jobs.taskValues.get("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", debugValue=None)
+        except Exception as e:
+            return None
+    return None
+
 
 def _construct_databricks_run_url(
     host: str,

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1056,6 +1056,7 @@ def get_sgc_job_run_id() -> str | None:
                 "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", debugValue=None
             )
         except Exception as e:
+            _logger.debug(f"Failed to retrieve SGC job run ID from task values: {e}", exc_info=True)
             return None
     return None
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1049,16 +1049,18 @@ def check_databricks_secret_scope_access(scope_name):
 
 
 def get_sgc_job_run_id() -> str | None:
-    dbutils = _get_dbutils()
-    if dbutils:
-        try:
-            return dbutils.jobs.taskValues.get(
-                "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", debugValue=None
-            )
-        except Exception as e:
-            _logger.debug(f"Failed to retrieve SGC job run ID from task values: {e}", exc_info=True)
-            return None
-    return None
+    try:
+        dbutils = _get_dbutils()
+    except _NoDbutilsError:
+        return None
+
+    try:
+        return dbutils.jobs.taskValues.get(
+            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", debugValue=None
+        )
+    except Exception as e:
+        _logger.debug(f"Failed to retrieve SGC job run ID from task values: {e}", exc_info=True)
+        return None
 
 
 def _construct_databricks_run_url(

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -9,8 +9,6 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, NamedTuple, ParamSpec, TypeVar
 
-from py4j.protocol import Py4JJavaError
-
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.request_utils import augmented_raise_for_status
 
@@ -1071,8 +1069,7 @@ def get_sgc_job_run_id() -> str | None:
         job_run_id = dbutils.widgets.get("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID")
         _logger.debug(f"SGC job run ID: {job_run_id}")
         return job_run_id
-    # dbutils.widgets.get can raise Py4JJavaError or ValueError
-    except (Py4JJavaError, ValueError) as e:
+    except Exception as e:
         _logger.debug(f"Failed to retrieve SGC job run ID from task values: {e}", exc_info=True)
         return None
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -9,6 +9,8 @@ import time
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Callable, NamedTuple, ParamSpec, TypeVar
 
+from py4j.protocol import Py4JJavaError
+
 from mlflow.utils.logging_utils import eprint
 from mlflow.utils.request_utils import augmented_raise_for_status
 
@@ -1049,16 +1051,28 @@ def check_databricks_secret_scope_access(scope_name):
 
 
 def get_sgc_job_run_id() -> str | None:
+    """
+    Retrieves the Serverless GPU Compute (SGC) job run ID from Databricks task values.
+
+    This function is used to enable automatic run resumption for SGC jobs by fetching
+    the job run ID from the Databricks task context. The job run ID is set by the
+    Databricks platform when running SGC jobs.
+
+    Returns:
+        str or None: The SGC job run ID if available, otherwise None. Returns None in
+        non-Databricks environments or when the task value is not set.
+    """
     try:
         dbutils = _get_dbutils()
     except _NoDbutilsError:
         return None
 
     try:
-        return dbutils.jobs.taskValues.get(
-            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", debugValue=None
-        )
-    except Exception as e:
+        job_run_id = dbutils.widgets.get("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID")
+        _logger.debug(f"SGC job run ID: {job_run_id}")
+        return job_run_id
+    # dbutils.widgets.get can raise Py4JJavaError or ValueError
+    except (Py4JJavaError, ValueError) as e:
         _logger.debug(f"Failed to retrieve SGC job run ID from task values: {e}", exc_info=True)
         return None
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1047,11 +1047,14 @@ def check_databricks_secret_scope_access(scope_name):
                 f"Error: {e}"
             )
 
+
 def get_sgc_job_run_id() -> str | None:
     dbutils = _get_dbutils()
     if dbutils:
         try:
-            return dbutils.jobs.taskValues.get("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", debugValue=None)
+            return dbutils.jobs.taskValues.get(
+                "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", debugValue=None
+            )
         except Exception as e:
             return None
     return None

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -69,6 +69,11 @@ MLFLOW_DATABRICKS_GIT_REPO_STATUS = "mlflow.databricks.gitRepoStatus"
 # Databricks model serving endpoint information
 MLFLOW_DATABRICKS_MODEL_SERVING_ENDPOINT_NAME = "mlflow.databricks.modelServingEndpointName"
 
+# For Serverless GPU Compute (SGC) run resumption
+# Experiment tag prefix that maps SGC job run IDs to MLflow run IDs for automatic resumption
+# Format: mlflow.databricks.sgc.resumeRun.jobRunId.{job_run_id} -> {mlflow_run_id}
+MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX = "mlflow.databricks.sgc.resumeRun.jobRunId"
+
 # For MLflow Dataset tracking
 MLFLOW_DATASET_CONTEXT = "mlflow.data.context"
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2555,10 +2555,8 @@ def test_start_run_sgc_resumption_disabled(empty_active_run_stack, monkeypatch):
     # Disable SGC resumption feature
     monkeypatch.setenv(MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.name, "false")
 
-    # Mock get_sgc_job_run_id
-    with mock.patch(
-        "mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id
-    ) as mock_get_sgc:
+    # Mock get_sgc_job_run_id (but won't be used since feature is disabled)
+    with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id):
         # Create first run
         with mlflow.start_run(experiment_id=experiment_id) as first_run:
             first_run_id = first_run.info.run_id
@@ -2566,9 +2564,6 @@ def test_start_run_sgc_resumption_disabled(empty_active_run_stack, monkeypatch):
         # Create second run - should be a new run since feature is disabled
         with mlflow.start_run(experiment_id=experiment_id) as second_run:
             second_run_id = second_run.info.run_id
-
-        # When disabled, the mock may not be called or may be called but ignored
-        # We just verify it was set up correctly
 
     # Verify they are different runs
     assert second_run_id != first_run_id
@@ -2584,8 +2579,8 @@ def test_start_run_sgc_resumption_no_job_run_id(empty_active_run_stack, monkeypa
 
     # Mock get_sgc_job_run_id to return None
     with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=None) as mock_get_sgc:
-        with mlflow.start_run(experiment_id=experiment_id) as run:
-            run_id = run.info.run_id
+        with mlflow.start_run(experiment_id=experiment_id):
+            pass
 
         mock_get_sgc.assert_called_once()
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2566,8 +2566,7 @@ def test_start_run_sgc_resumption_no_job_run_id(empty_active_run_stack, monkeypa
         # No tag should be set since job_run_id is None
         client = MlflowClient()
         exp = client.get_experiment(experiment_id)
-        # Check that no SGC tags were created
-        sgc_tags = [key for key in exp.tags.keys() if "sgc_resume" in key]
+        sgc_tags = [key for key in exp.tags.keys() if "sgc" in key.lower()]
         assert len(sgc_tags) == 0
 
 
@@ -2601,5 +2600,5 @@ def test_start_run_sgc_resumption_handles_tag_set_error(empty_active_run_stack, 
         # Should still create run successfully despite tag error
         with mlflow.start_run(experiment_id=experiment_id) as run:
             assert run.info.run_id is not None
-        mock_get_sgc.assert_called_once()
+        mock_get_sgc.assert_called()
         mock_set_tag.assert_called_once()

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2430,7 +2430,7 @@ def test_get_sgc_mlflow_run_id_for_resumption_with_tag(empty_active_run_stack):
     run = client.create_run(experiment_id)
     run_id = run.info.run_id
 
-    sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_12345"
+    sgc_tag_key = f"{mlflow_tags.MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.12345"
     client.set_experiment_tag(experiment_id, sgc_tag_key, run_id)
 
     # Test retrieval
@@ -2442,7 +2442,7 @@ def test_get_sgc_mlflow_run_id_for_resumption_without_tag(empty_active_run_stack
     experiment_id = mlflow.create_experiment("test_sgc_no_tag")
     client = MlflowClient()
 
-    sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_nonexistent"
+    sgc_tag_key = f"{mlflow_tags.MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.nonexistent"
 
     # Test retrieval when tag doesn't exist
     retrieved_run_id = _get_sgc_mlflow_run_id_for_resumption(client, experiment_id, sgc_tag_key)
@@ -2458,7 +2458,7 @@ def test_get_sgc_mlflow_run_id_for_resumption_with_default_experiment(empty_acti
     run = client.create_run(default_exp_id)
     run_id = run.info.run_id
 
-    sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_default"
+    sgc_tag_key = f"{mlflow_tags.MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.default"
     client.set_experiment_tag(default_exp_id, sgc_tag_key, run_id)
 
     # Test retrieval with None experiment_id
@@ -2470,7 +2470,7 @@ def test_get_sgc_mlflow_run_id_for_resumption_handles_exception():
     client = MlflowClient()
 
     # Test with non-existent experiment ID
-    sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_error"
+    sgc_tag_key = f"{mlflow_tags.MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.error"
     retrieved_run_id = _get_sgc_mlflow_run_id_for_resumption(
         client, "nonexistent_exp_id", sgc_tag_key
     )
@@ -2493,7 +2493,7 @@ def test_start_run_sgc_resumption_creates_tag(empty_active_run_stack, monkeypatc
         # Check that the experiment tag was set
         client = MlflowClient()
         exp = client.get_experiment(experiment_id)
-        expected_tag_key = f"databricks_mlflow_sgc_resume_run_job_run_id_{sgc_job_run_id}"
+        expected_tag_key = f"{mlflow_tags.MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.{sgc_job_run_id}"
         assert expected_tag_key in exp.tags
         assert exp.tags[expected_tag_key] == run_id
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2426,14 +2426,14 @@ def test_get_sgc_mlflow_run_id_for_resumption_with_tag(empty_active_run_stack):
     # Create an experiment with a tag
     experiment_id = mlflow.create_experiment("test_sgc_experiment")
     client = MlflowClient()
-    
+
     # Create a run and store its ID in experiment tag
     run = client.create_run(experiment_id)
     run_id = run.info.run_id
-    
+
     sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_12345"
     client.set_experiment_tag(experiment_id, sgc_tag_key, run_id)
-    
+
     # Test retrieval
     retrieved_run_id = _get_sgc_mlflow_run_id_for_resumption(client, experiment_id, sgc_tag_key)
     assert retrieved_run_id == run_id
@@ -2445,9 +2445,9 @@ def test_get_sgc_mlflow_run_id_for_resumption_without_tag(empty_active_run_stack
 
     experiment_id = mlflow.create_experiment("test_sgc_no_tag")
     client = MlflowClient()
-    
+
     sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_nonexistent"
-    
+
     # Test retrieval when tag doesn't exist
     retrieved_run_id = _get_sgc_mlflow_run_id_for_resumption(client, experiment_id, sgc_tag_key)
     assert retrieved_run_id is None
@@ -2460,14 +2460,14 @@ def test_get_sgc_mlflow_run_id_for_resumption_with_default_experiment(empty_acti
     # Use default experiment
     client = MlflowClient()
     default_exp_id = _get_experiment_id()
-    
+
     # Create a run and store its ID in experiment tag
     run = client.create_run(default_exp_id)
     run_id = run.info.run_id
-    
+
     sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_default"
     client.set_experiment_tag(default_exp_id, sgc_tag_key, run_id)
-    
+
     # Test retrieval with None experiment_id
     retrieved_run_id = _get_sgc_mlflow_run_id_for_resumption(client, None, sgc_tag_key)
     assert retrieved_run_id == run_id
@@ -2478,7 +2478,7 @@ def test_get_sgc_mlflow_run_id_for_resumption_handles_exception():
     from mlflow.tracking.fluent import _get_sgc_mlflow_run_id_for_resumption
 
     client = MlflowClient()
-    
+
     # Test with non-existent experiment ID
     sgc_tag_key = "databricks_mlflow_sgc_resume_run_job_run_id_error"
     retrieved_run_id = _get_sgc_mlflow_run_id_for_resumption(
@@ -2490,20 +2490,18 @@ def test_get_sgc_mlflow_run_id_for_resumption_handles_exception():
 def test_start_run_sgc_resumption_creates_tag(empty_active_run_stack, monkeypatch):
     """Test start_run sets experiment tag for SGC resumption when enabled."""
     from mlflow.environment_variables import MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS
-    
+
     experiment_id = mlflow.create_experiment("test_sgc_create_tag")
     sgc_job_run_id = "12345"
-    
+
     # Enable SGC resumption feature
     monkeypatch.setenv(MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.name, "true")
-    
+
     # Mock get_sgc_job_run_id to return a job run ID
-    with mock.patch(
-        "mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id
-    ):
+    with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id):
         with mlflow.start_run(experiment_id=experiment_id) as run:
             run_id = run.info.run_id
-        
+
         # Check that the experiment tag was set
         client = MlflowClient()
         exp = client.get_experiment(experiment_id)
@@ -2515,33 +2513,29 @@ def test_start_run_sgc_resumption_creates_tag(empty_active_run_stack, monkeypatc
 def test_start_run_sgc_resumption_resumes_run(empty_active_run_stack, monkeypatch):
     """Test start_run resumes existing run using SGC tag when available."""
     from mlflow.environment_variables import MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS
-    
+
     experiment_id = mlflow.create_experiment("test_sgc_resume")
     client = MlflowClient()
     sgc_job_run_id = "67890"
-    
+
     # Enable SGC resumption feature
     monkeypatch.setenv(MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.name, "true")
-    
+
     # Create an initial run and set the experiment tag
-    with mock.patch(
-        "mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id
-    ):
+    with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id):
         with mlflow.start_run(experiment_id=experiment_id) as first_run:
             first_run_id = first_run.info.run_id
             mlflow.log_param("initial_param", "value1")
-    
+
     # Start a new run with the same SGC job run ID - should resume the previous run
-    with mock.patch(
-        "mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id
-    ):
+    with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id):
         with mlflow.start_run(experiment_id=experiment_id) as resumed_run:
             resumed_run_id = resumed_run.info.run_id
             mlflow.log_param("resumed_param", "value2")
-    
+
     # Verify it's the same run
     assert resumed_run_id == first_run_id
-    
+
     # Verify both params are present
     run_data = client.get_run(resumed_run_id)
     assert run_data.data.params["initial_param"] == "value1"
@@ -2551,25 +2545,23 @@ def test_start_run_sgc_resumption_resumes_run(empty_active_run_stack, monkeypatc
 def test_start_run_sgc_resumption_disabled(empty_active_run_stack, monkeypatch):
     """Test start_run creates new run when SGC resumption is disabled."""
     from mlflow.environment_variables import MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS
-    
+
     experiment_id = mlflow.create_experiment("test_sgc_disabled")
     sgc_job_run_id = "11111"
-    
+
     # Disable SGC resumption feature
     monkeypatch.setenv(MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.name, "false")
-    
+
     # Mock get_sgc_job_run_id
-    with mock.patch(
-        "mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id
-    ):
+    with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id):
         # Create first run
         with mlflow.start_run(experiment_id=experiment_id) as first_run:
             first_run_id = first_run.info.run_id
-        
+
         # Create second run - should be a new run since feature is disabled
         with mlflow.start_run(experiment_id=experiment_id) as second_run:
             second_run_id = second_run.info.run_id
-    
+
     # Verify they are different runs
     assert second_run_id != first_run_id
 
@@ -2577,17 +2569,17 @@ def test_start_run_sgc_resumption_disabled(empty_active_run_stack, monkeypatch):
 def test_start_run_sgc_resumption_no_job_run_id(empty_active_run_stack, monkeypatch):
     """Test start_run creates new run when get_sgc_job_run_id returns None."""
     from mlflow.environment_variables import MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS
-    
+
     experiment_id = mlflow.create_experiment("test_sgc_no_job_id")
-    
+
     # Enable SGC resumption feature
     monkeypatch.setenv(MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.name, "true")
-    
+
     # Mock get_sgc_job_run_id to return None
     with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=None):
         with mlflow.start_run(experiment_id=experiment_id) as run:
             run_id = run.info.run_id
-        
+
         # No tag should be set since job_run_id is None
         client = MlflowClient()
         exp = client.get_experiment(experiment_id)
@@ -2601,29 +2593,27 @@ def test_start_run_sgc_resumption_explicit_run_id_takes_precedence(
 ):
     """Test that explicit run_id parameter takes precedence over SGC resumption."""
     from mlflow.environment_variables import MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS
-    
+
     experiment_id = mlflow.create_experiment("test_sgc_precedence")
     client = MlflowClient()
     sgc_job_run_id = "99999"
-    
+
     # Enable SGC resumption feature
     monkeypatch.setenv(MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.name, "true")
-    
+
     # Create two runs
     run1 = client.create_run(experiment_id)
     run1_id = run1.info.run_id
-    
+
     run2 = client.create_run(experiment_id)
     run2_id = run2.info.run_id
-    
+
     # Set experiment tag to point to run1
     sgc_tag_key = f"databricks_mlflow_sgc_resume_run_job_run_id_{sgc_job_run_id}"
     client.set_experiment_tag(experiment_id, sgc_tag_key, run1_id)
-    
+
     # Start run with explicit run_id=run2_id, should resume run2 not run1
-    with mock.patch(
-        "mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id
-    ):
+    with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id):
         with mlflow.start_run(run_id=run2_id, experiment_id=experiment_id) as resumed_run:
             assert resumed_run.info.run_id == run2_id
 
@@ -2631,13 +2621,13 @@ def test_start_run_sgc_resumption_explicit_run_id_takes_precedence(
 def test_start_run_sgc_resumption_handles_tag_set_error(empty_active_run_stack, monkeypatch):
     """Test start_run handles errors when setting experiment tag gracefully."""
     from mlflow.environment_variables import MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS
-    
+
     experiment_id = mlflow.create_experiment("test_sgc_tag_error")
     sgc_job_run_id = "error123"
-    
+
     # Enable SGC resumption feature
     monkeypatch.setenv(MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS.name, "true")
-    
+
     # Mock get_sgc_job_run_id
     with mock.patch("mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id):
         # Mock set_experiment_tag to raise an exception

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2493,7 +2493,9 @@ def test_start_run_sgc_resumption_creates_tag(empty_active_run_stack, monkeypatc
         # Check that the experiment tag was set
         client = MlflowClient()
         exp = client.get_experiment(experiment_id)
-        expected_tag_key = f"{mlflow_tags.MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.{sgc_job_run_id}"
+        expected_tag_key = (
+            f"{mlflow_tags.MLFLOW_DATABRICKS_SGC_RESUME_RUN_JOB_RUN_ID_PREFIX}.{sgc_job_run_id}"
+        )
         assert expected_tag_key in exp.tags
         assert exp.tags[expected_tag_key] == run_id
 

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -2422,7 +2422,6 @@ def test_log_metric_with_dataset_entity():
 
 
 def test_get_sgc_mlflow_run_id_for_resumption_with_tag(empty_active_run_stack):
-
     # Create an experiment with a tag
     experiment_id = mlflow.create_experiment("test_sgc_experiment")
     client = MlflowClient()
@@ -2440,7 +2439,6 @@ def test_get_sgc_mlflow_run_id_for_resumption_with_tag(empty_active_run_stack):
 
 
 def test_get_sgc_mlflow_run_id_for_resumption_without_tag(empty_active_run_stack):
-
     experiment_id = mlflow.create_experiment("test_sgc_no_tag")
     client = MlflowClient()
 
@@ -2452,7 +2450,6 @@ def test_get_sgc_mlflow_run_id_for_resumption_without_tag(empty_active_run_stack
 
 
 def test_get_sgc_mlflow_run_id_for_resumption_with_default_experiment(empty_active_run_stack):
-
     # Use default experiment
     client = MlflowClient()
     default_exp_id = _get_experiment_id()
@@ -2470,7 +2467,6 @@ def test_get_sgc_mlflow_run_id_for_resumption_with_default_experiment(empty_acti
 
 
 def test_get_sgc_mlflow_run_id_for_resumption_handles_exception():
-
     client = MlflowClient()
 
     # Test with non-existent experiment ID
@@ -2482,7 +2478,6 @@ def test_get_sgc_mlflow_run_id_for_resumption_handles_exception():
 
 
 def test_start_run_sgc_resumption_creates_tag(empty_active_run_stack, monkeypatch):
-
     experiment_id = mlflow.create_experiment("test_sgc_create_tag")
     sgc_job_run_id = "12345"
 
@@ -2504,7 +2499,6 @@ def test_start_run_sgc_resumption_creates_tag(empty_active_run_stack, monkeypatc
 
 
 def test_start_run_sgc_resumption_resumes_run(empty_active_run_stack, monkeypatch):
-
     experiment_id = mlflow.create_experiment("test_sgc_resume")
     client = MlflowClient()
     sgc_job_run_id = "67890"
@@ -2537,7 +2531,6 @@ def test_start_run_sgc_resumption_resumes_run(empty_active_run_stack, monkeypatc
 
 
 def test_start_run_sgc_resumption_disabled(empty_active_run_stack, monkeypatch):
-
     experiment_id = mlflow.create_experiment("test_sgc_disabled")
     sgc_job_run_id = "11111"
 
@@ -2559,7 +2552,6 @@ def test_start_run_sgc_resumption_disabled(empty_active_run_stack, monkeypatch):
 
 
 def test_start_run_sgc_resumption_no_job_run_id(empty_active_run_stack, monkeypatch):
-
     experiment_id = mlflow.create_experiment("test_sgc_no_job_id")
 
     # Mock get_sgc_job_run_id to return None
@@ -2577,37 +2569,21 @@ def test_start_run_sgc_resumption_no_job_run_id(empty_active_run_stack, monkeypa
         assert len(sgc_tags) == 0
 
 
-def test_start_run_sgc_resumption_explicit_run_id_takes_precedence(
-    empty_active_run_stack, monkeypatch
-):
-
+def test_start_run_sgc_resumption_explicit_run_id_takes_precedence(empty_active_run_stack):
     experiment_id = mlflow.create_experiment("test_sgc_precedence")
     client = MlflowClient()
-    sgc_job_run_id = "99999"
 
-    # Create two runs
+    # Create a run
     run1 = client.create_run(experiment_id)
     run1_id = run1.info.run_id
 
-    run2 = client.create_run(experiment_id)
-    run2_id = run2.info.run_id
-
-    # Set experiment tag to point to run1
-    sgc_tag_key = f"databricks_mlflow_sgc_resume_run_job_run_id_{sgc_job_run_id}"
-    client.set_experiment_tag(experiment_id, sgc_tag_key, run1_id)
-
-    # Start run with explicit run_id=run2_id, should resume run2 not run1
-    with mock.patch(
-        "mlflow.tracking.fluent.get_sgc_job_run_id", return_value=sgc_job_run_id
-    ) as mock_get_sgc:
-        with mlflow.start_run(run_id=run2_id, experiment_id=experiment_id) as resumed_run:
-            assert resumed_run.info.run_id == run2_id
-        # The mock should be called even though explicit run_id takes precedence
-        mock_get_sgc.assert_called()
+    # Start run with explicit run_id, should resume the specified run
+    # SGC logic is bypassed when explicit run_id is provided
+    with mlflow.start_run(run_id=run1_id, experiment_id=experiment_id) as resumed_run:
+        assert resumed_run.info.run_id == run1_id
 
 
 def test_start_run_sgc_resumption_handles_tag_set_error(empty_active_run_stack, monkeypatch):
-
     experiment_id = mlflow.create_experiment("test_sgc_tag_error")
     sgc_job_run_id = "error123"
 

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -18,12 +18,14 @@ from mlflow.utils import databricks_utils
 from mlflow.utils.databricks_utils import (
     DatabricksConfigProvider,
     DatabricksRuntimeVersion,
+    _NoDbutilsError,
     check_databricks_secret_scope_access,
     get_databricks_host_creds,
     get_databricks_runtime_major_minor_version,
     get_databricks_workspace_client_config,
     get_dbconnect_udf_sandbox_info,
     get_mlflow_credential_context_by_run_id,
+    get_sgc_job_run_id,
     get_workspace_info_from_databricks_secrets,
     get_workspace_info_from_dbutils,
     get_workspace_url,
@@ -865,3 +867,33 @@ def test_get_databricks_workspace_client_config_client_creation_error():
     ):
         with pytest.raises(Exception, match="Client creation failed"):
             get_databricks_workspace_client_config("databricks://profile")
+
+
+def test_get_sgc_job_run_id_success():
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.widgets.get.return_value = "test_job_run_id_12345"
+
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        result = get_sgc_job_run_id()
+        assert result == "test_job_run_id_12345"
+        mock_dbutils.widgets.get.assert_called_once_with(
+            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
+        )
+
+
+def test_get_sgc_job_run_id_no_dbutils():
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", side_effect=_NoDbutilsError()):
+        result = get_sgc_job_run_id()
+        assert result is None
+
+
+def test_get_sgc_job_run_id_value_error():
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.widgets.get.side_effect = ValueError("Widget not found")
+
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        result = get_sgc_job_run_id()
+        assert result is None
+        mock_dbutils.widgets.get.assert_called_once_with(
+            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
+        )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/19015?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19015/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19015/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19015/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Automatically associate a Databricks jobId with a MLflow run_id when specifying Databricks job parameter SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID. This allows MLflow runs to be resumed across Databricks Job invocations automatically.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests: https://e2-spog.staging.cloud.databricks.com/editor/notebooks/2450900058003568?o=6051921418418893

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
