### PR TITLE
Define `LoggedModelOutput.to_dictionary()` so `LoggedModelOutput` and runs containing them can be JSON serialized

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -385,6 +385,7 @@ mlflow.entities.LoggedModelInput.from_proto
 mlflow.entities.LoggedModelInput.to_proto
 mlflow.entities.LoggedModelOutput
 mlflow.entities.LoggedModelOutput.from_proto
+mlflow.entities.LoggedModelOutput.to_dictionary
 mlflow.entities.LoggedModelOutput.to_proto
 mlflow.entities.LoggedModelParameter
 mlflow.entities.LoggedModelParameter.from_proto

--- a/mlflow/entities/logged_model_output.py
+++ b/mlflow/entities/logged_model_output.py
@@ -27,6 +27,9 @@ class LoggedModelOutput(_MlflowObject):
     def to_proto(self):
         return ModelOutput(model_id=self.model_id, step=self.step)
 
+    def to_dictionary(self) -> dict[str, str | int]:
+        return {"model_id": self.model_id, "step": self.step}
+
     @classmethod
     def from_proto(cls, proto):
         return cls(proto.model_id, proto.step)

--- a/mlflow/entities/run_outputs.py
+++ b/mlflow/entities/run_outputs.py
@@ -31,7 +31,7 @@ class RunOutputs(_MlflowObject):
 
     def to_dictionary(self) -> dict[Any, Any]:
         return {
-            "model_outputs": self.model_outputs,
+            "model_outputs": [model_output.to_dictionary() for model_output in self.model_outputs],
         }
 
     @classmethod

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 import mlflow
 from mlflow import experiments
 from mlflow.exceptions import MlflowException
-from mlflow.runs import create_run, describe_run, link_traces, list_run
+from mlflow.runs import create_run, link_traces, list_run
 
 
 @pytest.fixture(autouse=True)
@@ -73,47 +73,6 @@ def test_csv_generation(tmp_path):
         )
         with open(result_filename) as fd:
             assert expected_csv == fd.read()
-
-
-def test_describe_run():
-    run_name = "apple"
-    with mlflow.start_run(run_name=run_name) as run:
-        run_id = run.info.run_id
-        mlflow.pyfunc.log_model(name="my_model", python_model=mlflow.pyfunc.PythonModel())
-    result = CliRunner().invoke(describe_run, ["--run-id", run_id])
-    assert result.exit_code == 0
-    output = json.loads(result.output)
-    # info
-    assert "info" in output
-    info = output["info"]
-    assert "artifact_uri" in info
-    assert "end_time" in info
-    assert "experiment_id" in info
-    assert "lifecycle_stage" in info
-    assert "run_id" in info
-    assert info["run_name"] == run_name
-    assert "start_time" in info
-    assert "status" in info
-    assert "user_id" in info
-    # data
-    assert "data" in output
-    data = output["data"]
-    assert "metrics" in data
-    assert "params" in data
-    assert "tags" in data
-    assert data["tags"]["mlflow.runName"] == run_name
-    # inputs
-    assert "inputs" in output
-    inputs = output["inputs"]
-    assert "dataset_inputs" in inputs
-    assert "model_inputs" in inputs
-    # outputs
-    assert "outputs" in output
-    outputs = output["outputs"]
-    assert "model_outputs" in outputs
-    assert len(outputs["model_outputs"]) == 1
-    assert "model_id" in outputs["model_outputs"][0]
-    assert "step" in outputs["model_outputs"][0]
 
 
 def test_create_run_with_experiment_id():

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -11,7 +11,7 @@ from click.testing import CliRunner
 import mlflow
 from mlflow import experiments
 from mlflow.exceptions import MlflowException
-from mlflow.runs import create_run, link_traces, list_run
+from mlflow.runs import create_run, describe_run, link_traces, list_run
 
 
 @pytest.fixture(autouse=True)
@@ -73,6 +73,47 @@ def test_csv_generation(tmp_path):
         )
         with open(result_filename) as fd:
             assert expected_csv == fd.read()
+
+
+def test_describe_run():
+    run_name = "apple"
+    with mlflow.start_run(run_name=run_name) as run:
+        run_id = run.info.run_id
+        mlflow.pyfunc.log_model(name="my_model", python_model=mlflow.pyfunc.PythonModel())
+    result = CliRunner().invoke(describe_run, ["--run-id", run_id])
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    # info
+    assert "info" in output
+    info = output["info"]
+    assert "artifact_uri" in info
+    assert "end_time" in info
+    assert "experiment_id" in info
+    assert "lifecycle_stage" in info
+    assert "run_id" in info
+    assert info["run_name"] == run_name
+    assert "start_time" in info
+    assert "status" in info
+    assert "user_id" in info
+    # data
+    assert "data" in output
+    data = output["data"]
+    assert "metrics" in data
+    assert "params" in data
+    assert "tags" in data
+    assert data["tags"]["mlflow.runName"] == run_name
+    # inputs
+    assert "inputs" in output
+    inputs = output["inputs"]
+    assert "dataset_inputs" in inputs
+    assert "model_inputs" in inputs
+    # outputs
+    assert "outputs" in output
+    outputs = output["outputs"]
+    assert "model_outputs" in outputs
+    assert len(outputs["model_outputs"]) == 1
+    assert "model_id" in outputs["model_outputs"][0]
+    assert "step" in outputs["model_outputs"][0]
 
 
 def test_create_run_with_experiment_id():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/nicklamiller/mlflow/pull/19017?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19017/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19017/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19017/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

Fixes: #19016

### What changes are proposed in this pull request?

- Adds a unit test for `mlflow.runs.describe_run`, specifically for a run that includes a `LoggedModelOutput`
- Adds `LoggedModelOutput.to_dictionary()` so it can ultimately be called when a `Run` is serialized via `mlflow runs describe`, see linked [Issue OP](https://github.com/mlflow/mlflow/issues/19016#issue-3661402969) for more details

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Allows user to call `mlflow runs describe` on runs that have logged models.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
