### PR TITLE
[ML-59816][1/n] Add new fields to the genai_evaluation event telemetry

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -26,6 +26,7 @@ from mlflow.genai.judges.utils import (
 )
 from mlflow.genai.scorers.base import (
     _SERIALIZATION_VERSION,
+    ScorerKind,
     SerializedScorer,
 )
 from mlflow.genai.utils.trace_utils import (
@@ -140,6 +141,10 @@ class InstructionsJudge(Judge):
 
         self._validate_model_format()
         self._validate_instructions_template()
+
+    @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.INSTRUCTIONS
 
     @property
     def model(self) -> str:

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -30,9 +30,16 @@ class ScorerKind(Enum):
     CLASS = "class"
     BUILTIN = "builtin"
     DECORATOR = "decorator"
+    INSTRUCTIONS = "instructions"
+    GUIDELINES = "guidelines"
 
 
-_ALLOWED_SCORERS_FOR_REGISTRATION = [ScorerKind.BUILTIN, ScorerKind.DECORATOR]
+_ALLOWED_SCORERS_FOR_REGISTRATION = [
+    ScorerKind.BUILTIN,
+    ScorerKind.DECORATOR,
+    ScorerKind.INSTRUCTIONS,
+    ScorerKind.GUIDELINES,
+]
 
 
 class ScorerStatus(Enum):

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -755,6 +755,10 @@ class Guidelines(BuiltInScorer):
     )
 
     @property
+    def kind(self) -> ScorerKind:
+        return ScorerKind.GUIDELINES
+
+    @property
     def instructions(self) -> str:
         """Get the instructions of what this scorer evaluates."""
         return GUIDELINES_PROMPT_INSTRUCTIONS

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,4 +1,5 @@
 import sys
+from collections import Counter
 from enum import Enum
 from typing import Any
 
@@ -76,6 +77,7 @@ class GenAIEvaluateEvent(Event):
 
     @classmethod
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        from mlflow.genai.scorers.base import Scorer
         from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 
         record_params = {}
@@ -89,6 +91,12 @@ class GenAIEvaluateEvent(Event):
             type(scorer).__name__ for scorer in scorers if isinstance(scorer, BuiltInScorer)
         }
         record_params["builtin_scorers"] = sorted(builtin_scorers)
+
+        # Track scorer kind counts
+        scorer_kind_count = Counter[str](
+            scorer.kind.value for scorer in scorers if isinstance(scorer, Scorer)
+        )
+        record_params["scorer_kind_count"] = dict[str, int](sorted(scorer_kind_count.items()))
 
         return record_params
 

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -78,11 +78,19 @@ class GenAIEvaluateEvent(Event):
     def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
         from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 
+        record_params = {}
+
+        # Track if predict_fn is provided
+        record_params["predict_fn_provided"] = arguments.get("predict_fn") is not None
+
+        # Track builtin scorers
         scorers = arguments.get("scorers") or []
         builtin_scorers = {
             type(scorer).__name__ for scorer in scorers if isinstance(scorer, BuiltInScorer)
         }
-        return {"builtin_scorers": list[str](builtin_scorers)}
+        record_params["builtin_scorers"] = sorted(builtin_scorers)
+
+        return record_params
 
 
 class CreateLoggedModelEvent(Event):

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -844,7 +844,7 @@ def test_kind_property():
         model="openai:/gpt-4",
     )
 
-    assert judge.kind == ScorerKind.BUILTIN
+    assert judge.kind == ScorerKind.INSTRUCTIONS
 
 
 @pytest.mark.parametrize(

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -21,7 +21,7 @@ from mlflow.genai.scorers import (
     RetrievalSufficiency,
     Safety,
 )
-from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.base import Scorer, ScorerKind
 from mlflow.genai.scorers.builtin_scorers import (
     ExtractedFields,
     _construct_field_extraction_config,
@@ -692,6 +692,21 @@ def test_guidelines_with_trace():
         assert result.name == "guidelines"
         assert result.value is True
         mock_meets_guidelines.assert_called_once()
+
+
+def test_builtin_scorers_kind_property():
+    # Test scorers returned by get_all_scorers() - they should all be BUILTIN
+    for scorer in get_all_scorers():
+        assert scorer.kind == ScorerKind.BUILTIN, (
+            f"{scorer.__class__.__name__} should have kind BUILTIN, got {scorer.kind}"
+        )
+
+    # Test Guidelines explicitly - it has its own kind (not included in get_all_scorers)
+    guidelines_scorer = Guidelines(
+        name="test_guidelines",
+        guidelines=["Be polite", "Be helpful"],
+    )
+    assert guidelines_scorer.kind == ScorerKind.GUIDELINES
 
 
 def test_relevance_to_query_with_trace():

--- a/tests/telemetry/helper_functions.py
+++ b/tests/telemetry/helper_functions.py
@@ -28,7 +28,9 @@ def validate_telemetry_record(
     assert data["event_name"] == event_name
     if check_params:
         if params:
-            assert data["params"] == json.dumps(params)
+            # Compare as dictionaries instead of JSON strings to avoid order-dependency
+            actual_params = json.loads(data["params"]) if data["params"] else None
+            assert actual_params == params
         else:
             assert data["params"] is None
     assert data["status"] == status

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -15,7 +15,7 @@ from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent
 from mlflow.genai.datasets import create_dataset
 from mlflow.genai.judges import make_judge
 from mlflow.genai.judges.base import AlignmentOptimizer
-from mlflow.genai.scorers.builtin_scorers import RelevanceToQuery
+from mlflow.genai.scorers.builtin_scorers import Guidelines, RelevanceToQuery
 from mlflow.pyfunc.model import ResponsesAgent, ResponsesAgentRequest, ResponsesAgentResponse
 from mlflow.telemetry.client import TelemetryClient
 from mlflow.telemetry.events import (
@@ -353,7 +353,7 @@ def test_create_webhook(mock_requests, mock_telemetry_client: TelemetryClient):
 
 def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
     @mlflow.genai.scorer
-    def sample_scorer(inputs, outputs, expectations):
+    def sample_scorer():
         return 1.0
 
     model = TestModel()
@@ -372,6 +372,7 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
         expected_params = {
             "builtin_scorers": ["RelevanceToQuery"],
             "predict_fn_provided": True,
+            "scorer_kind_count": {"decorator": 1, "builtin": 1},
         }
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
@@ -385,6 +386,73 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
         expected_params = {
             "builtin_scorers": [],
             "predict_fn_provided": False,
+            "scorer_kind_count": {"decorator": 1},
+        }
+        validate_telemetry_record(
+            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+        )
+
+
+def test_genai_evaluate_scorer_kind_count(mock_requests, mock_telemetry_client: TelemetryClient):
+    # Create scorers of different kinds
+    @mlflow.genai.scorer
+    def custom_scorer_1():
+        return 1.0
+
+    @mlflow.genai.scorer
+    def custom_scorer_2():
+        return 2.0
+
+    # Create an InstructionsJudge
+    instructions_judge = make_judge(
+        name="quality_judge",
+        instructions="Evaluate if {{ outputs }} is high quality",
+        model="openai:/gpt-4",
+    )
+
+    # Create a Guidelines scorer
+    guidelines_scorer = Guidelines(
+        name="politeness",
+        guidelines=["Be polite", "Be respectful"],
+    )
+
+    # Create builtin scorers
+    builtin_scorer_1 = RelevanceToQuery(name="relevance1")
+    builtin_scorer_2 = RelevanceToQuery(name="relevance2")
+
+    data = [
+        {
+            "inputs": {"question": "What is MLflow?"},
+            "outputs": "MLflow is an open source platform.",
+        }
+    ]
+
+    with (
+        mock.patch("mlflow.genai.judges.is_context_relevant"),
+        mock.patch("mlflow.genai.judges.meets_guidelines"),
+        mock.patch("mlflow.genai.judges.utils.invocation_utils.invoke_judge_model"),
+    ):
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=[
+                custom_scorer_1,
+                custom_scorer_2,
+                instructions_judge,
+                guidelines_scorer,
+                builtin_scorer_1,
+                builtin_scorer_2,
+            ],
+        )
+
+        expected_params = {
+            "builtin_scorers": ["Guidelines", "RelevanceToQuery"],
+            "predict_fn_provided": False,
+            "scorer_kind_count": {
+                "builtin": 2,
+                "decorator": 2,
+                "guidelines": 1,
+                "instructions": 1,
+            },
         }
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -369,7 +369,23 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
             scorers=[sample_scorer, RelevanceToQuery(name="my_judge")],
             predict_fn=model.predict,
         )
-        expected_params = {"builtin_scorers": ["RelevanceToQuery"]}
+        expected_params = {
+            "builtin_scorers": ["RelevanceToQuery"],
+            "predict_fn_provided": True,
+        }
+        validate_telemetry_record(
+            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+        )
+
+        # Test without predict_fn
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=[sample_scorer],
+        )
+        expected_params = {
+            "builtin_scorers": [],
+            "predict_fn_provided": False,
+        }
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
         )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19018/files) to review incremental changes.
- [**stack/ML-59816**](https://github.com/mlflow/mlflow/pull/19018) [[Files changed](https://github.com/mlflow/mlflow/pull/19018/files)]
  - [stack/ML-59816-part-2](https://github.com/mlflow/mlflow/pull/19040) [[Files changed](https://github.com/mlflow/mlflow/pull/19040/files/d605f37988ba38a124fe15047aaefbdcf5fa1f75..6f9390c59a5dba1997d40277c7e061348d2f740d)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
We would like to add a few new fields to the `genai_evaluate` event logging. This logging changes has been reviewed and approved in http://[go/.c441888](https://databricks-be.glean.com/qe/go/.c441888). We hope that these new fields will help us have a better understanding of the distribution of eval dataset size and distribution of usage across different scorer types. This information will help us better prioritize features that add the most user value.

**Logging Spec (Part One Covers Bold Items):**
- eval_data_size: int
- eval_data_type: one of the str values below 
    - “genai.EvaluationDataset”,
    - “entities.EvaluationDataset”,
    - “list[Trace]”,
    - “List[dict]”,
    - “pyspark.DataFrame”,
    - “pandas.DataFrame”
- eval_data_provided_fields: set{“inputs” | “outputs” | “expectations” | “trace”}?
- **predict_fn_provided: bool**
- **scorer_kind_count: dict<**
**one of the str values:  "builtin" | "decorator" | "instructions" | "guidelines",**
**int**
**>**
- Existing builtin_scorers: str[] 
    - str is the ClassName of the BuiltInScore (including Guidelines) 

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
### Manual Test Plan
Tested the telemetry by running the following the python notebook:
```
from mlflow.genai.scorers import Safety, RelevanceToQuery, Guidelines

@mlflow.genai.scorer(name="custom_scorer_2")
def custom_scorer_2():
        return 2.0


result = mlflow.genai.evaluate(
        data=_EVALUATION_TEST_CASES,
        predict_fn=predict_fn,
        scorers=[Safety(name="my_secret_app's_safety_scorer"), RelevanceToQuery(), Guidelines(
                name="test_guidelines",
                guidelines=["The response must be helpful and accurate"],
        ),
        custom_scorer_2
        ],
);
```

**Record Parameter**
| Before | After |
|--------|--------|
| `{'builtin_scorers': ['Safety', 'RelevanceToQuery', 'Guidelines']}` | `{'predict_fn_provided': True, 'builtin_scorers': ['Guidelines', 'RelevanceToQuery', 'Safety'], 'scorer_kind_count': {'builtin': 2, 'decorator': 1, 'guidelines': 1}}` |


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
