### PR TITLE
Add Claude Code lint hook for test docstrings

### DIFF
--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -154,7 +154,7 @@ def get_source_and_diff_ranges(hook_input: HookInput) -> tuple[str, list[DiffRan
         diff_ranges = parse_diff_ranges(diff_output)
     else:
         # For Write or Edit on untracked files, lint the whole file
-        diff_ranges = [DiffRange(start=1, end=999999)]
+        diff_ranges = [DiffRange(start=1, end=sys.maxsize)]
     source = hook_input.file_path.read_text()
     return source, diff_ranges
 

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -57,7 +57,9 @@ def parse_diff_ranges(diff_output: str) -> dict[Path, list[DiffRange]]:
 
 
 def get_diff_ranges() -> dict[Path, list[DiffRange]]:
-    output = subprocess.check_output(["git", "diff", "-U0", "HEAD", "--", "*.py"], text=True)
+    output = subprocess.check_output(
+        ["git", "--no-pager", "diff", "-U0", "HEAD", "--", "*.py"], text=True
+    )
     return parse_diff_ranges(output)
 
 

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -19,10 +19,11 @@ FuncNode: TypeAlias = ast.FunctionDef | ast.AsyncFunctionDef
 class LintError:
     file: Path
     line: int
+    column: int
     message: str
 
     def __str__(self) -> str:
-        return f"{self.file}:{self.line}: {self.message}"
+        return f"{self.file}:{self.line}:{self.column}: {self.message}"
 
 
 @dataclass
@@ -84,6 +85,7 @@ class Visitor(ast.NodeVisitor):
                 LintError(
                     file=self.file_path,
                     line=docstring_node.lineno,
+                    column=docstring_node.col_offset + 1,
                     message=f"Redundant docstring in '{node.name}'",
                 )
             )
@@ -101,7 +103,7 @@ def lint(file_path: Path, source: str, diff_ranges: list[DiffRange]) -> list[Lin
     try:
         tree = ast.parse(source, filename=str(file_path))
     except SyntaxError as e:
-        return [LintError(file=file_path, line=0, message=f"Failed to parse: {e}")]
+        return [LintError(file=file_path, line=0, column=0, message=f"Failed to parse: {e}")]
 
     visitor = Visitor(file_path=file_path, diff_ranges=diff_ranges)
     visitor.visit(tree)

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -147,7 +147,8 @@ def main() -> int:
         error_details = "\n".join(f"  - {error}" for error in all_errors)
         reason = f"Lint errors found:\n{error_details}"
         sys.stdout.write(json.dumps({"decision": "block", "reason": reason}))
-        # See  https://code.claude.com/docs/en/hooks#simple:-exit-code for exit code
+        # See https://code.claude.com/docs/en/hooks#simple:-exit-code for how hooks communicate
+        # status through exit codes
         return 0
 
     return 0

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -72,6 +72,8 @@ class Visitor(ast.NodeVisitor):
         self.errors: list[LintError] = []
 
     def _check_docstring(self, node: DefNode) -> None:
+        if not node.name.startswith("test_"):
+            return
         docstring_node = get_docstring_node(node)
         if not docstring_node:
             return
@@ -164,8 +166,12 @@ def main() -> int:
     if not hook_input:
         return 0
 
-    # Only lint test files
-    if hook_input.file_path.suffix != ".py" or not is_test_file(hook_input.file_path):
+    # Ignore non-Python files
+    if hook_input.file_path.suffix != ".py":
+        return 0
+
+    # Ignore non-test files
+    if not is_test_file(hook_input.file_path):
         return 0
 
     source, diff_ranges = get_source_and_diff_ranges(hook_input)

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -1,0 +1,157 @@
+"""
+Lightweight hook for validating code written by Claude Code.
+"""
+
+import ast
+import json
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TypeAlias
+
+DefNode: TypeAlias = ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef
+
+
+@dataclass
+class LintError:
+    file: Path
+    line: int
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.file}:{self.line}: {self.message}"
+
+
+@dataclass
+class DiffRange:
+    start: int
+    end: int
+
+
+def parse_diff_ranges(diff_output: str) -> dict[Path, list[DiffRange]]:
+    """
+    Parse unified diff output and extract added line ranges per file.
+
+    Returns a dict mapping file paths to lists of line ranges that were added.
+    """
+    file_ranges: dict[Path, list[DiffRange]] = {}
+    current_file: Path | None = None
+
+    for line in diff_output.splitlines():
+        if line.startswith("+++ b/"):
+            current_file = Path(line[6:])
+            file_ranges[current_file] = []
+        elif line.startswith("@@ ") and current_file is not None:
+            match = re.search(r"\+(\d+)(?:,(\d+))?", line)
+            if match:
+                start = int(match.group(1))
+                count = int(match.group(2)) if match.group(2) else 1
+                file_ranges[current_file].append(DiffRange(start=start, end=start + count))
+
+    return file_ranges
+
+
+def get_diff_ranges() -> dict[Path, list[DiffRange]]:
+    output = subprocess.check_output(["git", "diff", "-U0", "HEAD", "--", "*.py"], text=True)
+    return parse_diff_ranges(output)
+
+
+def is_line_in_diff(line: int, ranges: list[DiffRange]) -> bool:
+    return any(r.start <= line < r.end for r in ranges)
+
+
+def get_docstring_node(node: DefNode) -> ast.Constant | None:
+    match node.body:
+        case [ast.Expr(value=ast.Constant(value=str()) as const), *_]:
+            return const
+    return None
+
+
+def is_redundant_docstring(node: DefNode) -> bool:
+    docstring = ast.get_docstring(node)
+    if not docstring:
+        return False
+    return "\n" not in docstring.strip()
+
+
+class Visitor(ast.NodeVisitor):
+    def __init__(self, file_path: Path, diff_ranges: list[DiffRange]) -> None:
+        self.file_path = file_path
+        self.diff_ranges = diff_ranges
+        self.errors: list[LintError] = []
+
+    def _check_docstring(self, node: DefNode) -> None:
+        docstring_node = get_docstring_node(node)
+        if not docstring_node:
+            return
+        if not is_line_in_diff(node.lineno, self.diff_ranges):
+            return
+        if is_redundant_docstring(node):
+            self.errors.append(
+                LintError(
+                    file=self.file_path,
+                    line=docstring_node.lineno,
+                    message=f"Redundant docstring in '{node.name}'",
+                )
+            )
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._check_docstring(node)
+        self.generic_visit(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._check_docstring(node)
+        self.generic_visit(node)
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> None:
+        self._check_docstring(node)
+        self.generic_visit(node)
+
+
+def lint_file(file_path: Path, diff_ranges: list[DiffRange]) -> list[LintError]:
+    try:
+        source = file_path.read_text()
+        tree = ast.parse(source, filename=str(file_path))
+    except (SyntaxError, OSError) as e:
+        return [LintError(file=file_path, line=0, message=f"Failed to parse: {e}")]
+
+    visitor = Visitor(file_path=file_path, diff_ranges=diff_ranges)
+    visitor.visit(tree)
+    return visitor.errors
+
+
+def main() -> int:
+    try:
+        file_diff_ranges = get_diff_ranges()
+    except subprocess.CalledProcessError as e:
+        sys.stderr.write(f"Error running git diff: {e}\n")
+        return 1
+
+    if not file_diff_ranges:
+        return 0
+
+    all_errors: list[LintError] = []
+    for file_path, ranges in file_diff_ranges.items():
+        if (
+            file_path.suffix == ".py"
+            and file_path.exists()
+            and file_path.parts[0] == "tests"
+            and file_path.name.startswith("test_")
+        ):
+            errors = lint_file(file_path, ranges)
+            all_errors.extend(errors)
+
+    if all_errors:
+        error_details = "\n".join(f"  - {error}" for error in all_errors)
+        reason = f"Lint errors found:\n{error_details}"
+        sys.stdout.write(json.dumps({"decision": "block", "reason": reason}))
+        # See  https://code.claude.com/docs/en/hooks#simple:-exit-code for exit code
+        return 0
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -160,6 +160,10 @@ def get_source_and_diff_ranges(hook_input: HookInput) -> tuple[str, list[DiffRan
 
 
 def main() -> int:
+    # Kill switch: disable hook if environment variable is set
+    if os.environ.get("CLAUDE_LINT_HOOK_DISABLED"):
+        return 0
+
     hook_input = HookInput.parse()
     if not hook_input:
         return 0
@@ -175,7 +179,10 @@ def main() -> int:
     source, diff_ranges = get_source_and_diff_ranges(hook_input)
     if errors := lint(hook_input.file_path, source, diff_ranges):
         error_details = "\n".join(f"  - {error}" for error in errors)
-        reason = f"Lint errors found:\n{error_details}"
+        reason = (
+            f"Lint errors found:\n{error_details}\n\n"
+            "To disable this hook, set CLAUDE_LINT_HOOK_DISABLED=1"
+        )
         # Exit code 2 = blocking error. stderr is fed back to Claude.
         # See: https://code.claude.com/docs/en/hooks#hook-output
         sys.stderr.write(reason + "\n")

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -14,6 +14,8 @@ from typing import Literal, TypeAlias
 
 FuncNode: TypeAlias = ast.FunctionDef | ast.AsyncFunctionDef
 
+KILL_SWITCH_ENV_VAR = "CLAUDE_LINT_HOOK_DISABLED"
+
 
 @dataclass
 class LintError:
@@ -161,7 +163,7 @@ def get_source_and_diff_ranges(hook_input: HookInput) -> tuple[str, list[DiffRan
 
 def main() -> int:
     # Kill switch: disable hook if environment variable is set
-    if os.environ.get("CLAUDE_LINT_HOOK_DISABLED"):
+    if os.environ.get(KILL_SWITCH_ENV_VAR):
         return 0
 
     hook_input = HookInput.parse()
@@ -181,7 +183,7 @@ def main() -> int:
         error_details = "\n".join(f"  - {error}" for error in errors)
         reason = (
             f"Lint errors found:\n{error_details}\n\n"
-            "To disable this hook, set CLAUDE_LINT_HOOK_DISABLED=1"
+            f"To disable this hook, set {KILL_SWITCH_ENV_VAR}=1"
         )
         # Exit code 2 = blocking error. stderr is fed back to Claude.
         # See: https://code.claude.com/docs/en/hooks#hook-output

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -125,14 +125,14 @@ class HookInput:
         data = json.loads(sys.stdin.read())
         tool_name = data.get("tool_name")
         tool_input = data.get("tool_input")
-        if tool_name not in ("Edit", "Write") or not tool_input:
+        if tool_name not in ("Edit", "Write"):
             return None
         file_path_str = tool_input.get("file_path")
         if not file_path_str:
             return None
         file_path = Path(file_path_str)
         if project_dir := os.environ.get("CLAUDE_PROJECT_DIR"):
-            file_path = file_path.relative_to(Path(project_dir))
+            file_path = file_path.relative_to(project_dir)
         return cls(
             tool_name=tool_name,
             file_path=file_path,

--- a/.claude/hooks/lint.py
+++ b/.claude/hooks/lint.py
@@ -3,7 +3,6 @@ Lightweight hook for validating code written by Claude Code.
 """
 
 import ast
-import json
 import re
 import subprocess
 import sys
@@ -151,10 +150,10 @@ def main() -> int:
     if all_errors:
         error_details = "\n".join(f"  - {error}" for error in all_errors)
         reason = f"Lint errors found:\n{error_details}"
-        sys.stdout.write(json.dumps({"decision": "block", "reason": reason}))
-        # See https://code.claude.com/docs/en/hooks#simple:-exit-code for how hooks communicate
-        # status through exit codes
-        return 0
+        # Exit code 2 = blocking error. stderr is fed back to Claude.
+        # See: https://code.claude.com/docs/en/hooks#hook-output
+        sys.stderr.write(reason + "\n")
+        return 2
 
     return 0
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "uv run --directory=$CLAUDE_PROJECT_DIR --no-project .claude/hooks/lint.py",
+            "timeout": 10.0
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ gunicorn.conf.py
 # except commands and skills
 !.claude/commands/
 !.claude/skills/
+!.claude/hooks/
+!.claude/settings.json


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Adds a Claude Code hook that enforces the project's code style guideline: "Only add docstrings in tests when they provide additional context." The hook detects single-line docstrings in test files within modified code and blocks commits when violations are found.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)