### PR TITLE
Allow passing custom parameters to SIMBA for judge optimization

### DIFF
--- a/mlflow/genai/judges/optimizers/simba.py
+++ b/mlflow/genai/judges/optimizers/simba.py
@@ -88,7 +88,7 @@ class SIMBAAlignmentOptimizer(DSPyAlignmentOptimizer):
         """
         super().__init__(model=model, **kwargs)
         self._batch_size = batch_size
-        self._seed = seed if seed is not None else self.DEFAULT_SEED
+        self._seed = seed or self.DEFAULT_SEED
         self._simba_kwargs = simba_kwargs or {}
 
     def _get_batch_size(self) -> int:

--- a/mlflow/genai/judges/optimizers/simba.py
+++ b/mlflow/genai/judges/optimizers/simba.py
@@ -62,16 +62,34 @@ class SIMBAAlignmentOptimizer(DSPyAlignmentOptimizer):
     # Class constants for default SIMBA parameters
     DEFAULT_SEED: ClassVar[int] = 42
 
-    def __init__(self, model: str | None = None, **kwargs):
+    def __init__(
+        self,
+        model: str | None = None,
+        batch_size: int | None = None,
+        seed: int | None = None,
+        simba_kwargs: dict[str, Any] | None = None,
+        **kwargs,
+    ):
         """
-        Initialize SIMBA optimizer with default parameters.
+        Initialize SIMBA optimizer with customizable parameters.
 
         Args:
             model: Model to use for DSPy optimization. If None, uses get_default_model().
+            batch_size: Batch size for SIMBA evaluation. If None, uses get_min_traces_required().
+            seed: Random seed for reproducibility. If None, uses DEFAULT_SEED (42).
+            simba_kwargs: Additional keyword arguments to pass directly to dspy.SIMBA().
+                         Supported parameters include:
+                         - metric: Custom metric function (overrides default agreement_metric)
+                         - max_demos: Maximum number of demonstrations to use
+                         - num_threads: Number of threads for parallel optimization
+                         - max_steps: Maximum number of optimization steps
+                         See https://dspy.ai/api/optimizers/SIMBA/ for full list.
             **kwargs: Additional keyword arguments passed to parent class
         """
         super().__init__(model=model, **kwargs)
-        self._seed = self.DEFAULT_SEED
+        self._batch_size = batch_size
+        self._seed = seed if seed is not None else self.DEFAULT_SEED
+        self._simba_kwargs = simba_kwargs or {}
 
     def _get_batch_size(self) -> int:
         """
@@ -80,7 +98,7 @@ class SIMBAAlignmentOptimizer(DSPyAlignmentOptimizer):
         Returns:
             The batch size to use for SIMBA optimization.
         """
-        return self.get_min_traces_required()
+        return self._batch_size if self._batch_size is not None else self.get_min_traces_required()
 
     def _dspy_optimize(
         self,
@@ -96,14 +114,21 @@ class SIMBAAlignmentOptimizer(DSPyAlignmentOptimizer):
         Args:
             program: The DSPy program to optimize
             examples: Examples for optimization
-            metric_fn: Metric function for optimization
+            metric_fn: Default metric function for optimization
 
         Returns:
             Optimized DSPy program
         """
         with _suppress_verbose_logging("dspy.teleprompt.simba"):
-            # Create SIMBA optimizer (default max_steps=8)
-            optimizer = dspy.SIMBA(metric=metric_fn, bsize=self._get_batch_size())
+            # Build SIMBA optimizer kwargs starting with required parameters
+            # If metric is in simba_kwargs, it will override the default metric_fn
+            optimizer_kwargs = {
+                "metric": metric_fn,
+                "bsize": self._get_batch_size(),
+                **self._simba_kwargs,  # Pass through any additional SIMBA parameters
+            }
+
+            optimizer = dspy.SIMBA(**optimizer_kwargs)
 
             _logger.info(
                 f"Starting SIMBA optimization with {len(examples)} examples "

--- a/tests/genai/judges/optimizers/test_simba.py
+++ b/tests/genai/judges/optimizers/test_simba.py
@@ -45,3 +45,91 @@ def test_full_alignment_workflow(mock_judge, sample_traces_with_assessments):
     # The judge instructions should be the raw optimized instructions
     expected_instructions = "Optimized instructions with {{inputs}} and {{outputs}}"
     assert result.instructions == expected_instructions
+
+
+def test_custom_batch_size(mock_judge, sample_traces_with_assessments):
+    """Test that custom batch_size parameter is passed to SIMBA."""
+    mock_simba = MagicMock()
+    mock_compiled_program = MagicMock()
+    mock_compiled_program.signature = MagicMock()
+    mock_compiled_program.signature.instructions = (
+        "Optimized instructions with {{inputs}} and {{outputs}}"
+    )
+    mock_simba.compile.return_value = mock_compiled_program
+
+    custom_batch_size = 15
+    with patch("dspy.SIMBA") as mock_simba_class, patch("dspy.LM", MagicMock()):
+        mock_simba_class.return_value = mock_simba
+        optimizer = SIMBAAlignmentOptimizer(batch_size=custom_batch_size)
+        with patch.object(SIMBAAlignmentOptimizer, "get_min_traces_required", return_value=5):
+            optimizer.align(mock_judge, sample_traces_with_assessments)
+
+        # Verify SIMBA was initialized with custom batch_size
+        mock_simba_class.assert_called_once()
+        call_kwargs = mock_simba_class.call_args.kwargs
+        assert call_kwargs["bsize"] == custom_batch_size
+
+
+def test_custom_simba_parameters(mock_judge, sample_traces_with_assessments):
+    """Test that custom SIMBA parameters including metric are passed through via simba_kwargs."""
+    mock_simba = MagicMock()
+    mock_compiled_program = MagicMock()
+    mock_compiled_program.signature = MagicMock()
+    mock_compiled_program.signature.instructions = (
+        "Optimized instructions with {{inputs}} and {{outputs}}"
+    )
+    mock_simba.compile.return_value = mock_compiled_program
+
+    def custom_metric(example, pred, trace=None):
+        return True
+
+    with patch("dspy.SIMBA") as mock_simba_class, patch("dspy.LM", MagicMock()):
+        mock_simba_class.return_value = mock_simba
+        optimizer = SIMBAAlignmentOptimizer(
+            seed=123,
+            simba_kwargs={
+                "metric": custom_metric,
+                "max_demos": 5,
+                "num_threads": 2,
+                "max_steps": 10,
+            },
+        )
+        with patch.object(SIMBAAlignmentOptimizer, "get_min_traces_required", return_value=5):
+            optimizer.align(mock_judge, sample_traces_with_assessments)
+
+        # Verify SIMBA was initialized with custom parameters
+        mock_simba_class.assert_called_once()
+        call_kwargs = mock_simba_class.call_args.kwargs
+        assert call_kwargs["metric"] == custom_metric
+        assert call_kwargs["max_demos"] == 5
+        assert call_kwargs["num_threads"] == 2
+        assert call_kwargs["max_steps"] == 10
+
+        # Verify seed is passed to compile
+        mock_simba.compile.assert_called_once()
+        compile_kwargs = mock_simba.compile.call_args.kwargs
+        assert compile_kwargs["seed"] == 123
+
+
+def test_default_parameters_not_passed(mock_judge, sample_traces_with_assessments):
+    """Test that only required parameters are passed to SIMBA when no simba_kwargs provided."""
+    mock_simba = MagicMock()
+    mock_compiled_program = MagicMock()
+    mock_compiled_program.signature = MagicMock()
+    mock_compiled_program.signature.instructions = (
+        "Optimized instructions with {{inputs}} and {{outputs}}"
+    )
+    mock_simba.compile.return_value = mock_compiled_program
+
+    with patch("dspy.SIMBA") as mock_simba_class, patch("dspy.LM", MagicMock()):
+        mock_simba_class.return_value = mock_simba
+        optimizer = SIMBAAlignmentOptimizer()
+        with patch.object(SIMBAAlignmentOptimizer, "get_min_traces_required", return_value=5):
+            optimizer.align(mock_judge, sample_traces_with_assessments)
+
+        # Verify only required parameters are passed
+        mock_simba_class.assert_called_once()
+        call_kwargs = mock_simba_class.call_args.kwargs
+        assert "metric" in call_kwargs
+        assert "bsize" in call_kwargs
+        assert len(call_kwargs) == 2


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19023?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19023/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19023/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19023/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - allows you to pass params into `dspy.SIMBA` from `SIMBAAlignmentOptimizer`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
