### PR TITLE
Add validation to correctness judge expectation fields

### DIFF
--- a/mlflow/genai/judges/builtin.py
+++ b/mlflow/genai/judges/builtin.py
@@ -2,6 +2,7 @@ from functools import wraps
 from typing import Any
 
 from mlflow.entities.assessment import Feedback
+from mlflow.exceptions import MlflowException
 from mlflow.genai.judges.prompts.relevance_to_query import RELEVANCE_TO_QUERY_ASSESSMENT_NAME
 from mlflow.genai.judges.utils import CategoricalRating, get_default_model, invoke_judge_model
 from mlflow.utils.docstring_utils import format_docstring
@@ -247,7 +248,6 @@ def is_correct(
             )
             print(feedback.value)  # "no"
     """
-    from mlflow.exceptions import MlflowException
     from mlflow.genai.judges.prompts.correctness import CORRECTNESS_FEEDBACK_NAME, get_prompt
 
     if expected_response is not None and expected_facts is not None:

--- a/mlflow/genai/judges/builtin.py
+++ b/mlflow/genai/judges/builtin.py
@@ -247,7 +247,13 @@ def is_correct(
             )
             print(feedback.value)  # "no"
     """
+    from mlflow.exceptions import MlflowException
     from mlflow.genai.judges.prompts.correctness import CORRECTNESS_FEEDBACK_NAME, get_prompt
+
+    if expected_response is not None and expected_facts is not None:
+        raise MlflowException(
+            "Only one of expected_response or expected_facts should be provided, not both."
+        )
 
     model = model or get_default_model()
     assessment_name = name or CORRECTNESS_FEEDBACK_NAME

--- a/tests/genai/judges/test_builtin.py
+++ b/tests/genai/judges/test_builtin.py
@@ -10,6 +10,7 @@ from mlflow.entities.assessment import (
     AssessmentSourceType,
     Feedback,
 )
+from mlflow.exceptions import MlflowException
 from mlflow.genai import judges
 from mlflow.genai.evaluation.entities import EvalItem, EvalResult
 from mlflow.genai.judges.utils import CategoricalRating
@@ -304,6 +305,19 @@ def test_is_correct_oss():
     assert "What is the capital of France?" in prompt
     assert "Paris is the capital of France." in prompt
     assert "Paris" in prompt
+
+
+def test_is_correct_rejects_both_expected_response_and_expected_facts():
+    with pytest.raises(
+        MlflowException,
+        match="Only one of expected_response or expected_facts should be provided, not both",
+    ):
+        judges.is_correct(
+            request="What is the capital of France?",
+            response="Paris is the capital of France.",
+            expected_response="Paris",
+            expected_facts=["Paris is the capital of France"],
+        )
 
 
 def test_is_context_sufficient_oss():

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -82,6 +82,11 @@ def test_trace_passed_to_builtin_scorers_correctly(
     # Disable logging traces to MLflow to avoid calling mlflow APIs which need to be mocked
     monkeypatch.setenv("AGENT_EVAL_LOG_TRACES_TO_MLFLOW_ENABLED", "false")
 
+    # Remove expected_facts from trace to avoid validation error (can only have one)
+    sample_rag_trace.info.assessments = [
+        a for a in sample_rag_trace.info.assessments if a.name != "expected_facts"
+    ]
+
     with (
         patch(
             "databricks.agents.evals.judges.correctness",
@@ -112,7 +117,7 @@ def test_trace_passed_to_builtin_scorers_correctly(
     mock_correctness.assert_called_once_with(
         request="{'question': 'query'}",
         response="answer",
-        expected_facts=["fact1", "fact2"],
+        expected_facts=None,
         expected_response="expected answer",
         assessment_name="correctness",
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19026?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19026/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19026/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19026/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
For parity with managed MLflow, we should ensure that only one of `expected_facts` or `expected_response` is provided. The current behavior is that we prioritize `expected_response`, but this is not ideal because adding both is likely unintentional and this masks this case.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
