### PR TITLE
UI: Request TraceInfo and Trace Assessments from a relative API path 

### DIFF
--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/api.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/api.ts
@@ -15,7 +15,7 @@ import { fetchAPI, getAjaxUrl } from './ModelTraceExplorer.request.utils';
 import { createTraceV4SerializedLocation } from './ModelTraceExplorer.utils';
 
 export const deleteAssessment = ({ traceId, assessmentId }: { traceId: string; assessmentId: string }) =>
-  fetchAPI(`/ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`, 'DELETE');
+  fetchAPI(`ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`, 'DELETE');
 
 // these fields are set by the server on create
 export type CreateAssessmentPayload = {
@@ -31,10 +31,10 @@ export const createAssessment = ({
 }: {
   payload: CreateAssessmentPayload;
 }): Promise<CreateAssessmentV3Response> =>
-  fetchAPI(`/ajax-api/3.0/mlflow/traces/${payload.assessment.trace_id}/assessments`, 'POST', payload);
+  fetchAPI(`ajax-api/3.0/mlflow/traces/${payload.assessment.trace_id}/assessments`, 'POST', payload);
 
 export const fetchTraceInfoV3 = ({ traceId }: { traceId: string }) =>
-  fetchAPI(`/ajax-api/3.0/mlflow/traces/${traceId}`);
+  fetchAPI(`ajax-api/3.0/mlflow/traces/${traceId}`);
 
 export type UpdateAssessmentPayload = {
   // we only support updating these fields
@@ -61,7 +61,7 @@ export const updateAssessment = ({
   traceId: string;
   assessmentId: string;
   payload: UpdateAssessmentPayload;
-}) => fetchAPI(`/ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`, 'PATCH', payload);
+}) => fetchAPI(`ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`, 'PATCH', payload);
 
 export type CreateAssessmentV4Response = Assessment;
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/api.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/api.ts
@@ -15,7 +15,7 @@ import { fetchAPI, getAjaxUrl } from './ModelTraceExplorer.request.utils';
 import { createTraceV4SerializedLocation } from './ModelTraceExplorer.utils';
 
 export const deleteAssessment = ({ traceId, assessmentId }: { traceId: string; assessmentId: string }) =>
-  fetchAPI(`ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`, 'DELETE');
+  fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`), 'DELETE');
 
 // these fields are set by the server on create
 export type CreateAssessmentPayload = {
@@ -31,10 +31,10 @@ export const createAssessment = ({
 }: {
   payload: CreateAssessmentPayload;
 }): Promise<CreateAssessmentV3Response> =>
-  fetchAPI(`ajax-api/3.0/mlflow/traces/${payload.assessment.trace_id}/assessments`, 'POST', payload);
+  fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${payload.assessment.trace_id}/assessments`), 'POST', payload);
 
 export const fetchTraceInfoV3 = ({ traceId }: { traceId: string }) =>
-  fetchAPI(`ajax-api/3.0/mlflow/traces/${traceId}`);
+  fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${traceId}`));
 
 export type UpdateAssessmentPayload = {
   // we only support updating these fields
@@ -61,7 +61,7 @@ export const updateAssessment = ({
   traceId: string;
   assessmentId: string;
   payload: UpdateAssessmentPayload;
-}) => fetchAPI(`ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`, 'PATCH', payload);
+}) => fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/traces/${traceId}/assessments/${assessmentId}`), 'PATCH', payload);
 
 export type CreateAssessmentV4Response = Assessment;
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/kbolashev/mlflow/pull/19032?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19032/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19032/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19032/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
#19031

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Change API calls happening in `mlflow/server/js/src/shared/web-shared/model-trace-explorer/api.ts` to happen from relative path, and not absolute.
This way, if MLflow is being proxied under `http://localhost:8080/mlflow`, the call to e.g. get the trace info gets fired to:
```
http://localhost:8080/mlflow/ajax-api/3.0/mlflow/traces/${traceId}
```

instead of 

```
http://localhost:8080/ajax-api/3.0/mlflow/traces/${traceId}
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

https://github.com/user-attachments/assets/9fbc24f0-f52b-4984-bc42-cbfdf9d7e0e7



### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

Trace Assessments can now be edited in the UI, when MLflow is served behind a reverse proxy on a subpath

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
