### PR TITLE
Fix router issue in TracesUI page

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -38,7 +38,8 @@ const MlflowRootRoute = () => {
   const [showSidebar, setShowSidebar] = useState(true);
   const { theme } = useDesignSystemTheme();
   const { experimentId } = useParams();
-  const { isDarkTheme, setIsDarkTheme } = useDarkThemeContext();
+  const { setIsDarkTheme } = useDarkThemeContext();
+  const isDarkTheme = theme.isDarkMode;
 
   // Hide sidebar if we are in a single experiment page
   const isSingleExperimentPage = Boolean(experimentId);

--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -4,16 +4,14 @@ import { LegacySkeleton, useDesignSystemTheme } from '@databricks/design-system'
 import ErrorModal from './experiment-tracking/components/modals/ErrorModal';
 import AppErrorBoundary from './common/components/error-boundaries/AppErrorBoundary';
 import {
-  HashRouter,
   createHashRouter,
   RouterProvider,
   Outlet,
-  Route,
-  Routes,
   createLazyRouteElement,
   useParams,
 } from './common/utils/RoutingUtils';
 import { MlflowHeader } from './common/components/MlflowHeader';
+import { useDarkThemeContext } from './common/contexts/DarkThemeContext';
 
 // Route definition imports:
 import { getRouteDefs as getExperimentTrackingRouteDefs } from './experiment-tracking/route-defs';
@@ -34,22 +32,13 @@ const landingRoute = {
 /**
  * This is root element for MLflow routes, containing app header.
  */
-const MlflowRootRoute = ({
-  isDarkTheme,
-  setIsDarkTheme,
-  useChildRoutesOutlet = false,
-  routes,
-}: {
-  isDarkTheme?: boolean;
-  setIsDarkTheme?: (isDarkTheme: boolean) => void;
-  useChildRoutesOutlet?: boolean;
-  routes?: any[];
-}) => {
+const MlflowRootRoute = () => {
   useInitializeExperimentRunColors();
 
   const [showSidebar, setShowSidebar] = useState(true);
   const { theme } = useDesignSystemTheme();
   const { experimentId } = useParams();
+  const { isDarkTheme, setIsDarkTheme } = useDarkThemeContext();
 
   // Hide sidebar if we are in a single experiment page
   const isSingleExperimentPage = Boolean(experimentId);
@@ -88,15 +77,7 @@ const MlflowRootRoute = ({
             }}
           >
             <React.Suspense fallback={<LegacySkeleton />}>
-              {useChildRoutesOutlet ? (
-                <Outlet />
-              ) : (
-                <Routes>
-                  {routes?.map(({ element, pageId, path }) => (
-                    <Route key={pageId} path={path} element={element} />
-                  ))}
-                </Routes>
-              )}
+              <Outlet />
             </React.Suspense>
           </main>
         </div>
@@ -104,13 +85,7 @@ const MlflowRootRoute = ({
     </div>
   );
 };
-export const MlflowRouter = ({
-  isDarkTheme,
-  setIsDarkTheme,
-}: {
-  isDarkTheme?: boolean;
-  setIsDarkTheme?: (isDarkTheme: boolean) => void;
-}) => {
+export const MlflowRouter = () => {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const routes = useMemo(
     () => [...getExperimentTrackingRouteDefs(), ...getModelRegistryRouteDefs(), landingRoute, ...getCommonRouteDefs()],
@@ -122,24 +97,16 @@ export const MlflowRouter = ({
       createHashRouter([
         {
           path: '/',
-          element: <MlflowRootRoute isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} useChildRoutesOutlet />,
+          element: <MlflowRootRoute />,
           children: routes,
         },
       ]),
-    [routes, isDarkTheme, setIsDarkTheme],
+    [routes],
   );
 
-  if (hashRouter) {
-    return (
-      <React.Suspense fallback={<LegacySkeleton />}>
-        <RouterProvider router={hashRouter} />
-      </React.Suspense>
-    );
-  }
-
   return (
-    <HashRouter>
-      <MlflowRootRoute routes={routes} isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
-    </HashRouter>
+    <React.Suspense fallback={<LegacySkeleton />}>
+      <RouterProvider router={hashRouter} />
+    </React.Suspense>
   );
 };

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -46,7 +46,7 @@ export function MLFlowRoot() {
           <DesignSystemContainer isDarkTheme={isDarkTheme}>
             <ApplyGlobalStyles />
             <MlflowThemeGlobalStyles />
-            <DarkThemeProvider isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme}>
+            <DarkThemeProvider setIsDarkTheme={setIsDarkTheme}>
               <QueryClientProvider client={queryClient}>
                 <MlflowRouter />
               </QueryClientProvider>

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -18,6 +18,7 @@ import { LegacySkeleton } from '@databricks/design-system';
 // eslint-disable-next-line no-useless-rename
 import { MlflowRouter as MlflowRouter } from './MlflowRouter';
 import { useMLflowDarkTheme } from './common/hooks/useMLflowDarkTheme';
+import { DarkThemeProvider } from './common/contexts/DarkThemeContext';
 
 export function MLFlowRoot() {
   // eslint-disable-next-line react-hooks/rules-of-hooks
@@ -45,9 +46,11 @@ export function MLFlowRoot() {
           <DesignSystemContainer isDarkTheme={isDarkTheme}>
             <ApplyGlobalStyles />
             <MlflowThemeGlobalStyles />
-            <QueryClientProvider client={queryClient}>
-              <MlflowRouter isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
-            </QueryClientProvider>
+            <DarkThemeProvider isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme}>
+              <QueryClientProvider client={queryClient}>
+                <MlflowRouter />
+              </QueryClientProvider>
+            </DarkThemeProvider>
           </DesignSystemContainer>
         </Provider>
       </RawIntlProvider>

--- a/mlflow/server/js/src/common/contexts/DarkThemeContext.tsx
+++ b/mlflow/server/js/src/common/contexts/DarkThemeContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext } from 'react';
+
+interface DarkThemeContextType {
+  isDarkTheme: boolean;
+  setIsDarkTheme: (isDarkTheme: boolean) => void;
+}
+
+const DarkThemeContext = createContext<DarkThemeContextType>({
+  isDarkTheme: false,
+  setIsDarkTheme: () => {},
+});
+
+export const DarkThemeProvider = ({
+  children,
+  isDarkTheme,
+  setIsDarkTheme,
+}: {
+  children: React.ReactNode;
+  isDarkTheme: boolean;
+  setIsDarkTheme: (isDarkTheme: boolean) => void;
+}) => {
+  return <DarkThemeContext.Provider value={{ isDarkTheme, setIsDarkTheme }}>{children}</DarkThemeContext.Provider>;
+};
+
+export const useDarkThemeContext = () => useContext(DarkThemeContext);

--- a/mlflow/server/js/src/common/contexts/DarkThemeContext.tsx
+++ b/mlflow/server/js/src/common/contexts/DarkThemeContext.tsx
@@ -1,25 +1,21 @@
 import React, { createContext, useContext } from 'react';
 
 interface DarkThemeContextType {
-  isDarkTheme: boolean;
   setIsDarkTheme: (isDarkTheme: boolean) => void;
 }
 
 const DarkThemeContext = createContext<DarkThemeContextType>({
-  isDarkTheme: false,
   setIsDarkTheme: () => {},
 });
 
 export const DarkThemeProvider = ({
   children,
-  isDarkTheme,
   setIsDarkTheme,
 }: {
   children: React.ReactNode;
-  isDarkTheme: boolean;
   setIsDarkTheme: (isDarkTheme: boolean) => void;
 }) => {
-  return <DarkThemeContext.Provider value={{ isDarkTheme, setIsDarkTheme }}>{children}</DarkThemeContext.Provider>;
+  return <DarkThemeContext.Provider value={{ setIsDarkTheme }}>{children}</DarkThemeContext.Provider>;
 };
 
 export const useDarkThemeContext = () => useContext(DarkThemeContext);


### PR DESCRIPTION
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

Fix router issue in TracesUI page when switching between dark theme and light theme

### What changes are proposed in this pull request?

Fix router issue in TracesUI page when switching between dark theme and light theme

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Before:

https://github.com/user-attachments/assets/828153c5-5f91-4da4-b0b4-476d0f6da360

After:
https://github.com/user-attachments/assets/1e6502cd-411c-494b-84a2-714355006462

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
