### PR TITLE
Throw exception for session-level judge align API at the base judge level instead of built-in judge level

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -814,7 +814,6 @@ mlflow.genai.scorers.Completeness
 mlflow.genai.scorers.Completeness.get_input_fields
 mlflow.genai.scorers.Completeness.model_post_init
 mlflow.genai.scorers.ConversationCompleteness
-mlflow.genai.scorers.ConversationCompleteness.align
 mlflow.genai.scorers.ConversationCompleteness.get_input_fields
 mlflow.genai.scorers.ConversationCompleteness.model_post_init
 mlflow.genai.scorers.Correctness
@@ -850,7 +849,6 @@ mlflow.genai.scorers.Safety.get_input_fields
 mlflow.genai.scorers.Safety.model_post_init
 mlflow.genai.scorers.ScorerSamplingConfig
 mlflow.genai.scorers.UserFrustration
-mlflow.genai.scorers.UserFrustration.align
 mlflow.genai.scorers.UserFrustration.get_input_fields
 mlflow.genai.scorers.UserFrustration.model_post_init
 mlflow.genai.scorers.base.Scorer

--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -810,6 +810,9 @@ mlflow.genai.optimize_prompts
 mlflow.genai.register_prompt
 mlflow.genai.scheduled_scorers.ScorerScheduleConfig
 mlflow.genai.scorer
+mlflow.genai.scorers.Completeness
+mlflow.genai.scorers.Completeness.get_input_fields
+mlflow.genai.scorers.Completeness.model_post_init
 mlflow.genai.scorers.ConversationCompleteness
 mlflow.genai.scorers.ConversationCompleteness.align
 mlflow.genai.scorers.ConversationCompleteness.get_input_fields
@@ -852,6 +855,7 @@ mlflow.genai.scorers.UserFrustration.get_input_fields
 mlflow.genai.scorers.UserFrustration.model_post_init
 mlflow.genai.scorers.base.Scorer
 mlflow.genai.scorers.base.ScorerSamplingConfig
+mlflow.genai.scorers.builtin_scorers.Completeness
 mlflow.genai.scorers.builtin_scorers.ConversationCompleteness
 mlflow.genai.scorers.builtin_scorers.Correctness
 mlflow.genai.scorers.builtin_scorers.Equivalence

--- a/mlflow/genai/judges/base.py
+++ b/mlflow/genai/judges/base.py
@@ -109,6 +109,10 @@ class Judge(Scorer):
         Returns:
             A new Judge instance that is better aligned with the input traces.
 
+        Raises:
+            NotImplementedError: If called on a session-level scorer. Alignment is currently
+                only supported for single-turn scorers.
+
         Note on Logging:
             By default, alignment optimization shows minimal progress information.
             To see detailed optimization output, set the optimizer's logger to DEBUG::
@@ -118,6 +122,9 @@ class Judge(Scorer):
                 # For SIMBA optimizer (default)
                 logging.getLogger("mlflow.genai.judges.optimizers.simba").setLevel(logging.DEBUG)
         """
+        if self.is_session_level_scorer:
+            raise NotImplementedError("Alignment is not supported for session-level scorers.")
+
         if optimizer is None:
             optimizer = get_default_optimizer()
         return optimizer.align(self, traces)

--- a/mlflow/genai/judges/prompts/completeness.py
+++ b/mlflow/genai/judges/prompts/completeness.py
@@ -2,16 +2,16 @@
 COMPLETENESS_ASSESSMENT_NAME = "completeness"
 
 COMPLETENESS_PROMPT = """\
-Consider the following user prompt and AI response.
-You must decide whether the AI successfully addressed all explicit requests in the user's prompt.
-Output only "complete" or "incomplete" based on the criteria below.
+Consider the following user prompt and assistant response.
+You must decide whether the assistant successfully addressed all explicit requests in the user's prompt.
+Output only "yes" or "no" based on whether the conversation is complete or incomplete according to the criteria below.
 
 First, list all explicit user requests made in the user prompt.
-Second, for each request, determine whether it was addressed by the AI response.
+Second, for each request, determine whether it was addressed by the assistant response.
 Do not evaluate factual correctness, style, or usefulness beyond whether each request was directly handled.
-If the AI refuses but gives a clear and explicit explanation for the refusal, treat the response as complete;
+If the assistant refuses but gives a clear and explicit explanation for the refusal, treat the response as complete;
 if it refuses without providing any reasoning, treat it as incomplete.
-If the AI indicates it is missing information and asks the user for the necessary details instead of answering, treat this as complete.
+If the assistant indicates it is missing information and asks the user for the necessary details instead of answering, treat this as complete.
 If any explicit request in the user prompt is ignored, or handled in a way that does not match the user's instructions, treat the response as incomplete.
 Do not make assumptions or bring in external knowledge.
 

--- a/mlflow/genai/judges/prompts/completeness.py
+++ b/mlflow/genai/judges/prompts/completeness.py
@@ -2,45 +2,19 @@
 COMPLETENESS_ASSESSMENT_NAME = "completeness"
 
 COMPLETENESS_PROMPT = """\
-You are an expert evaluator of AI assistant responses.
-Your task is to determine whether the AI assistant has fully addressed all user questions in a single user prompt.
-Your judgment must rely only on evidence found directly in the user's question and the AI's response, not assumptions.
+Consider the following user prompt and AI response.
+You must decide whether the AI successfully addressed all explicit requests in the user's prompt.
+Output only "complete" or "incomplete" based on the criteria below.
 
-You will examine the interaction, identify whether the user's questions and requests were addressed, and then return a single label: "complete" or "incomplete".
+First, list all explicit user requests made in the user prompt.
+Second, for each request, determine whether it was addressed by the AI response.
+Do not evaluate factual correctness, style, or usefulness beyond whether each request was directly handled.
+If the AI refuses but gives a clear and explicit explanation for the refusal, treat the response as complete;
+if it refuses without providing any reasoning, treat it as incomplete.
+If the AI indicates it is missing information and asks the user for the necessary details instead of answering, treat this as complete.
+If any explicit request in the user prompt is ignored, or handled in a way that does not match the user's instructions, treat the response as incomplete.
+Do not make assumptions or bring in external knowledge.
 
-## Step-by-Step Instructions
-- First, identify and list all explicit user questions and requested items in the user's message.
-- For each one, apply the label criteria below to determine if the response is complete or incomplete.
-- Output **complete** or **incomplete** as the final answer.
-
-## Criteria
-Label the response **complete** if:
-- All explicit questions and requested items are addressed.
-    - No ignored or partially answered questions
-    - All requested information or deliverables are provided
-    - The assistant clearly refuses **and** explicitly provide the reason why it cannot answer or fulfill the request by quoting safety, legality, policy, or capability limits, etc. in its response,
-    and does not ignore any other parts of the prompt it could reasonably address.
-- Or the assistant explicitly requests the missing information that is genuinely necessary to answer the question or fulfill the request, and does not ignore any other parts it could already answer.
-
-Label the response **incomplete** if:
-- Any explicit user question or requested deliverable remains unanswered or unfulfilled, or is only "implied" but not clearly stated in the assistant's response.
-If you cannot locate a concrete sentence that answers it, you must treat it as unanswered.
-- The assistant misunderstood or failed to meet the user's underlying intent.
-- Important details or information explicitly requested by the user are missing.
-- The assistant simply refuses to answer and but does not explicitly provide the reason.
-
-## Important Notes
-- A short response can still be complete if it answers all questions.
-- A long response can still be incomplete if it misses any explicit question.
-- Do not judge whether the assistant's answer is factually correct or high-quality; only judge whether it has explicitly addressed all questions and requested items.
-- You **MUST NOT** infer missing answers from context or intent. If you cannot locate a concrete sentence that explicitly answers it, you must treat it as unanswered.
-
-## Output Instruction
-You must output **complete** or **incomplete** based on the criteria above.
-
-## User Prompt
-{{ inputs }}
-
-## AI Response
-{{ outputs }}
+<question>{{inputs}}</question>
+<answer>{{outputs}}</answer>
 """  # noqa: E501

--- a/mlflow/genai/judges/prompts/completeness.py
+++ b/mlflow/genai/judges/prompts/completeness.py
@@ -1,0 +1,46 @@
+# NB: User-facing name for the completeness assessment.
+COMPLETENESS_ASSESSMENT_NAME = "completeness"
+
+COMPLETENESS_PROMPT = """\
+You are an expert evaluator of AI assistant responses.
+Your task is to determine whether the AI assistant has fully addressed all user questions in a single user prompt.
+Your judgment must rely only on evidence found directly in the user's question and the AI's response, not assumptions.
+
+You will examine the interaction, identify whether the user's questions and requests were addressed, and then return a single label: "complete" or "incomplete".
+
+## Step-by-Step Instructions
+- First, identify and list all explicit user questions and requested items in the user's message.
+- For each one, apply the label criteria below to determine if the response is complete or incomplete.
+- Output **complete** or **incomplete** as the final answer.
+
+## Criteria
+Label the response **complete** if:
+- All explicit questions and requested items are addressed.
+    - No ignored or partially answered questions
+    - All requested information or deliverables are provided
+    - The assistant clearly refuses **and** explicitly provide the reason why it cannot answer or fulfill the request by quoting safety, legality, policy, or capability limits, etc. in its response,
+    and does not ignore any other parts of the prompt it could reasonably address.
+- Or the assistant explicitly requests the missing information that is genuinely necessary to answer the question or fulfill the request, and does not ignore any other parts it could already answer.
+
+Label the response **incomplete** if:
+- Any explicit user question or requested deliverable remains unanswered or unfulfilled, or is only "implied" but not clearly stated in the assistant's response.
+If you cannot locate a concrete sentence that answers it, you must treat it as unanswered.
+- The assistant misunderstood or failed to meet the user's underlying intent.
+- Important details or information explicitly requested by the user are missing.
+- The assistant simply refuses to answer and but does not explicitly provide the reason.
+
+## Important Notes
+- A short response can still be complete if it answers all questions.
+- A long response can still be incomplete if it misses any explicit question.
+- Do not judge whether the assistant's answer is factually correct or high-quality; only judge whether it has explicitly addressed all questions and requested items.
+- You **MUST NOT** infer missing answers from context or intent. If you cannot locate a concrete sentence that explicitly answers it, you must treat it as unanswered.
+
+## Output Instruction
+You must output **complete** or **incomplete** based on the criteria above.
+
+## User Prompt
+{{ inputs }}
+
+## AI Response
+{{ outputs }}
+"""  # noqa: E501

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -24,6 +24,7 @@ from mlflow.genai.scorers.registry import delete_scorer, get_scorer, list_scorer
 
 # Define the attributes that should be lazily loaded
 _LAZY_IMPORTS = {
+    "Completeness",
     "Correctness",
     "ExpectationsGuidelines",
     "Guidelines",
@@ -67,6 +68,7 @@ def __dir__():
 # This gives us the best of both worlds: type hints without circular imports.
 if TYPE_CHECKING:
     from mlflow.genai.scorers.builtin_scorers import (
+        Completeness,
         ConversationCompleteness,
         Correctness,
         Equivalence,
@@ -82,6 +84,7 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
+    "Completeness",
     "ConversationCompleteness",
     "Correctness",
     "ExpectationsGuidelines",

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -16,7 +16,7 @@ from mlflow.entities.assessment import Feedback
 from mlflow.entities.trace import Trace
 from mlflow.exceptions import MlflowException
 from mlflow.genai import judges
-from mlflow.genai.judges.base import AlignmentOptimizer, Judge, JudgeField
+from mlflow.genai.judges.base import Judge, JudgeField
 from mlflow.genai.judges.builtin import _MODEL_API_DOC
 from mlflow.genai.judges.constants import _AFFIRMATIVE_VALUES, _NEGATIVE_VALUES
 from mlflow.genai.judges.instructions_judge import InstructionsJudge
@@ -1680,9 +1680,6 @@ class UserFrustration(BuiltInScorer):
     ) -> Feedback:
         return self._get_judge()(session=session)
 
-    def align(self, traces: list[Trace], optimizer: AlignmentOptimizer | None = None) -> Judge:
-        raise NotImplementedError("Alignment is not supported for session-level scorers.")
-
 
 @experimental(version="3.7.0")
 @format_docstring(_MODEL_API_DOC)
@@ -1779,9 +1776,6 @@ class ConversationCompleteness(BuiltInScorer):
         session: list[Trace] | None = None,
     ) -> Feedback:
         return self._get_judge()(session=session)
-
-    def align(self, traces: list[Trace], optimizer: AlignmentOptimizer | None = None) -> Judge:
-        raise NotImplementedError("Alignment is not supported for session-level scorers.")
 
 
 @experimental(version="3.7.0")

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1431,10 +1431,9 @@ def test_conversation_completeness_with_session(name, model, expected_name):
     ],
 )
 def test_completeness_with_inputs_outputs(name, model, expected_name, rationale):
-    """Test Completeness scorer with direct inputs and outputs."""
     with patch(
         "mlflow.genai.judges.instructions_judge.invoke_judge_model",
-        return_value=Feedback(name=expected_name, value="complete", rationale=rationale),
+        return_value=Feedback(name=expected_name, value="yes", rationale=rationale),
     ) as mock_invoke_judge:
         kwargs = {}
         if name:
@@ -1448,22 +1447,21 @@ def test_completeness_with_inputs_outputs(name, model, expected_name, rationale)
         )
 
         assert result.name == expected_name
-        assert result.value == "complete"
+        assert result.value == "yes"
         assert result.rationale == rationale
         mock_invoke_judge.assert_called_once()
 
 
 def test_completeness_with_trace():
-    """Test Completeness scorer with trace."""
     with patch(
         "mlflow.genai.judges.instructions_judge.invoke_judge_model",
-        return_value=Feedback(name="completeness", value="complete", rationale="Fully addressed"),
+        return_value=Feedback(name="completeness", value="yes", rationale="Fully addressed"),
     ) as mock_invoke_judge:
         trace = create_simple_trace()
         scorer = Completeness()
         result = scorer(trace=trace)
 
         assert result.name == "completeness"
-        assert result.value == "complete"
+        assert result.value == "yes"
         assert result.rationale == "Fully addressed"
         mock_invoke_judge.assert_called_once()


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19045/files/c3d10bb447d44cdb2baf6b2d6271cdee592ad9bd..24ba45a93a80f06113b8bd76b8488059630a8852) to review incremental changes.
- [stack/P0_builtin_judges_stack_ML_59674](https://github.com/mlflow/mlflow/pull/18968) [[Files changed](https://github.com/mlflow/mlflow/pull/18968/files)]
  - [**stack/multi_turn_judge_align_handling_fix**](https://github.com/mlflow/mlflow/pull/19045) [[Files changed](https://github.com/mlflow/mlflow/pull/19045/files/c3d10bb447d44cdb2baf6b2d6271cdee592ad9bd..24ba45a93a80f06113b8bd76b8488059630a8852)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?
Currently the NotImplementedError for the align API for session-level judge is raised from the newly created `BuiltInScorer`s. But we also want to raise the exception for session_level judge created via `make_judge`. This PR moves the exception to the base judge class to cover both `BuiltInScorer` and `InstructionsJudge` created via `make_judge`.  

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
### Test Plan
Passed new unit test: test_session_level_scorer_alignment_raises_error

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
