### PR TITLE
Add ON DELETE CASCADE to foreign key constraints from logged_model_* tables, trace_info, and spans to experiments table

### DIFF
--- a/mlflow/store/db_migrations/versions/c3a777925173_add_cascade_deletion_to_logged_model_.py
+++ b/mlflow/store/db_migrations/versions/c3a777925173_add_cascade_deletion_to_logged_model_.py
@@ -76,28 +76,29 @@ def upgrade():
         conn = op.get_bind()
 
         # 1. Create new table with updated FK constraint (ON DELETE CASCADE)
-        # fmt: off
-        conn.execute(sa.text(
-            "CREATE TABLE _alembic_tmp_spans ("
-            "trace_id VARCHAR(50) NOT NULL, "
-            "experiment_id INTEGER NOT NULL, "
-            "span_id VARCHAR(50) NOT NULL, "
-            "parent_span_id VARCHAR(50), "
-            "name TEXT, "
-            "type VARCHAR(500), "
-            "status VARCHAR(50) NOT NULL, "
-            "start_time_unix_nano BIGINT NOT NULL, "
-            "end_time_unix_nano BIGINT, "
-            "duration_ns BIGINT GENERATED ALWAYS AS "
-            "(end_time_unix_nano - start_time_unix_nano) STORED, "
-            "content TEXT NOT NULL, "
-            "CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id), "
-            "CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) "
-            "REFERENCES trace_info (request_id) ON DELETE CASCADE, "
-            "CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) "
-            "REFERENCES experiments (experiment_id) ON DELETE CASCADE)"
-        ))
-        # fmt: on
+        conn.execute(
+            sa.text(
+                "CREATE TABLE _alembic_tmp_spans (\n"
+                "    trace_id VARCHAR(50) NOT NULL,\n"
+                "    experiment_id INTEGER NOT NULL,\n"
+                "    span_id VARCHAR(50) NOT NULL,\n"
+                "    parent_span_id VARCHAR(50),\n"
+                "    name TEXT,\n"
+                "    type VARCHAR(500),\n"
+                "    status VARCHAR(50) NOT NULL,\n"
+                "    start_time_unix_nano BIGINT NOT NULL,\n"
+                "    end_time_unix_nano BIGINT,\n"
+                "    duration_ns BIGINT GENERATED ALWAYS AS "
+                "(end_time_unix_nano - start_time_unix_nano) STORED,\n"
+                "    content TEXT NOT NULL,\n"
+                "    CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),\n"
+                "    CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) "
+                "REFERENCES trace_info (request_id) ON DELETE CASCADE,\n"
+                "    CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) "
+                "REFERENCES experiments (experiment_id) ON DELETE CASCADE\n"
+                ")"
+            )
+        )
 
         # 2. Copy data (excluding computed column - it will be auto-calculated)
         conn.execute(

--- a/mlflow/store/db_migrations/versions/c3a777925173_add_cascade_deletion_to_logged_model_.py
+++ b/mlflow/store/db_migrations/versions/c3a777925173_add_cascade_deletion_to_logged_model_.py
@@ -1,0 +1,154 @@
+"""add cascade deletion to logged model and span foreign keys
+
+Create Date: 2025-11-26 18:36:56.930151
+
+"""
+
+from alembic import op
+
+from mlflow.store.tracking.dbmodels.models import (
+    SqlExperiment,
+    SqlLoggedModelMetric,
+    SqlLoggedModelParam,
+    SqlLoggedModelTag,
+    SqlSpan,
+    SqlTraceInfo,
+)
+
+# revision identifiers, used by Alembic.
+revision = "c3a777925173"
+down_revision = "bf29a5ff90ea"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """
+    Add ON DELETE CASCADE to foreign key constraints from logged_model_* tables,
+    trace_info, and spans to experiments table. This ensures child records are
+    automatically deleted when an experiment is deleted.
+    """
+    import sqlalchemy as sa
+
+    # Tables and their foreign key constraint names (excluding spans for now)
+    tables_and_constraints = [
+        (
+            SqlLoggedModelMetric.__tablename__,
+            "fk_logged_model_metrics_experiment_id",
+        ),
+        (
+            SqlLoggedModelParam.__tablename__,
+            "fk_logged_model_params_experiment_id",
+        ),
+        (
+            SqlLoggedModelTag.__tablename__,
+            "fk_logged_model_tags_experiment_id",
+        ),
+        (
+            SqlTraceInfo.__tablename__,
+            "fk_trace_info_experiment_id",
+        ),
+    ]
+
+    # Update all tables (except spans) to add CASCADE deletion
+    for table_name, fk_constraint_name in tables_and_constraints:
+        # Use batch_alter_table for SQLite compatibility
+        with op.batch_alter_table(table_name, schema=None) as batch_op:
+            batch_op.drop_constraint(fk_constraint_name, type_="foreignkey")
+            batch_op.create_foreign_key(
+                fk_constraint_name,
+                SqlExperiment.__tablename__,
+                ["experiment_id"],
+                ["experiment_id"],
+                ondelete="CASCADE",
+            )
+
+    # Handle spans table separately because it has a computed column (duration_ns).
+    # SQLite's batch_alter_table recreates the table by copying data (see
+    # alembic.ddl.sqlite.SQLiteImpl.requires_recreate_in_batch), which fails for
+    # computed columns (SQLite error: "cannot INSERT into generated column").
+    # MySQL/PostgreSQL use native ALTER TABLE (see alembic.ddl.impl.DefaultImpl.
+    # requires_recreate_in_batch returns False) and don't need this workaround.
+    dialect_name = op.get_context().dialect.name
+    if dialect_name == "sqlite":
+        # SQLite requires table recreation to modify FK constraints.
+        # We must handle the computed column (duration_ns) manually.
+        conn = op.get_bind()
+
+        # 1. Create new table with updated FK constraint (ON DELETE CASCADE)
+        # fmt: off
+        conn.execute(sa.text(
+            "CREATE TABLE _alembic_tmp_spans ("
+            "trace_id VARCHAR(50) NOT NULL, "
+            "experiment_id INTEGER NOT NULL, "
+            "span_id VARCHAR(50) NOT NULL, "
+            "parent_span_id VARCHAR(50), "
+            "name TEXT, "
+            "type VARCHAR(500), "
+            "status VARCHAR(50) NOT NULL, "
+            "start_time_unix_nano BIGINT NOT NULL, "
+            "end_time_unix_nano BIGINT, "
+            "duration_ns BIGINT GENERATED ALWAYS AS "
+            "(end_time_unix_nano - start_time_unix_nano) STORED, "
+            "content TEXT NOT NULL, "
+            "CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id), "
+            "CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) "
+            "REFERENCES trace_info (request_id) ON DELETE CASCADE, "
+            "CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) "
+            "REFERENCES experiments (experiment_id) ON DELETE CASCADE)"
+        ))
+        # fmt: on
+
+        # 2. Copy data (excluding computed column - it will be auto-calculated)
+        conn.execute(
+            sa.text("""
+            INSERT INTO _alembic_tmp_spans (
+                trace_id, experiment_id, span_id, parent_span_id, name, type,
+                status, start_time_unix_nano, end_time_unix_nano, content
+            )
+            SELECT
+                trace_id, experiment_id, span_id, parent_span_id, name, type,
+                status, start_time_unix_nano, end_time_unix_nano, content
+            FROM spans
+            """)
+        )
+
+        # 3. Drop old table and rename new one
+        conn.execute(sa.text("DROP TABLE spans"))
+        conn.execute(sa.text("ALTER TABLE _alembic_tmp_spans RENAME TO spans"))
+
+        # 4. Recreate indexes
+        conn.execute(sa.text("CREATE INDEX index_spans_experiment_id ON spans (experiment_id)"))
+        conn.execute(
+            sa.text(
+                "CREATE INDEX index_spans_experiment_id_status_type "
+                "ON spans (experiment_id, status, type)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "CREATE INDEX index_spans_experiment_id_type_status "
+                "ON spans (experiment_id, type, status)"
+            )
+        )
+        conn.execute(
+            sa.text(
+                "CREATE INDEX index_spans_experiment_id_duration "
+                "ON spans (experiment_id, duration_ns)"
+            )
+        )
+    else:
+        # MySQL/PostgreSQL use native ALTER TABLE - no table recreation, no computed column issue
+        with op.batch_alter_table(SqlSpan.__tablename__, schema=None) as batch_op:
+            batch_op.drop_constraint("fk_spans_experiment_id", type_="foreignkey")
+            batch_op.create_foreign_key(
+                "fk_spans_experiment_id",
+                SqlExperiment.__tablename__,
+                ["experiment_id"],
+                ["experiment_id"],
+                ondelete="CASCADE",
+            )
+
+
+def downgrade():
+    pass

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -680,7 +680,9 @@ class SqlTraceInfo(Base):
     Trace ID: `String` (limit 50 characters). *Primary Key* for ``trace_info`` table.
     Named as "trace_id" in V3 format.
     """
-    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"), nullable=False)
+    experiment_id = Column(
+        Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"), nullable=False
+    )
     """
     Experiment ID to which this trace belongs: *Foreign Key* into ``experiments`` table.
     """
@@ -1172,6 +1174,7 @@ class SqlLoggedModelMetric(Base):
         ForeignKeyConstraint(
             ["experiment_id"],
             ["experiments.experiment_id"],
+            ondelete="CASCADE",
             name="fk_logged_model_metrics_experiment_id",
         ),
         ForeignKeyConstraint(
@@ -1234,6 +1237,7 @@ class SqlLoggedModelParam(Base):
         ForeignKeyConstraint(
             ["experiment_id"],
             ["experiments.experiment_id"],
+            ondelete="CASCADE",
             name="fk_logged_model_params_experiment_id",
         ),
     )
@@ -1280,6 +1284,7 @@ class SqlLoggedModelTag(Base):
         ForeignKeyConstraint(
             ["experiment_id"],
             ["experiments.experiment_id"],
+            ondelete="CASCADE",
             name="fk_logged_model_tags_experiment_id",
         ),
     )
@@ -1691,7 +1696,9 @@ class SqlSpan(Base):
     Foreign key to trace_info table.
     """
 
-    experiment_id = Column(Integer, ForeignKey("experiments.experiment_id"), nullable=False)
+    experiment_id = Column(
+        Integer, ForeignKey("experiments.experiment_id", ondelete="CASCADE"), nullable=False
+    )
     """
     Experiment ID: `Integer`. Foreign key to experiments table.
     """

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -242,7 +242,7 @@ CREATE TABLE trace_info (
 	request_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	response_preview VARCHAR(1000) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
-	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -301,7 +301,7 @@ CREATE TABLE logged_model_metrics (
 	dataset_name VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	dataset_digest VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS",
 	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
-	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
 )
@@ -313,7 +313,7 @@ CREATE TABLE logged_model_params (
 	param_key VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	param_value VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
-	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
@@ -324,7 +324,7 @@ CREATE TABLE logged_model_tags (
 	tag_key VARCHAR(255) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	tag_value VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
-	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
@@ -383,7 +383,7 @@ CREATE TABLE spans (
 	duration_ns BIGINT GENERATED ALWAYS AS (([end_time_unix_nano]-[start_time_unix_nano])) STORED,
 	content VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -247,7 +247,7 @@ CREATE TABLE trace_info (
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
 	PRIMARY KEY (request_id),
-	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -307,7 +307,7 @@ CREATE TABLE logged_model_metrics (
 	dataset_name VARCHAR(500),
 	dataset_digest VARCHAR(36),
 	PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
-	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
 )
@@ -319,7 +319,7 @@ CREATE TABLE logged_model_params (
 	param_key VARCHAR(255) NOT NULL,
 	param_value TEXT NOT NULL,
 	PRIMARY KEY (model_id, param_key),
-	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
@@ -330,7 +330,7 @@ CREATE TABLE logged_model_tags (
 	tag_key VARCHAR(255) NOT NULL,
 	tag_value TEXT NOT NULL,
 	PRIMARY KEY (model_id, tag_key),
-	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
@@ -391,7 +391,7 @@ CREATE TABLE spans (
 	duration_ns BIGINT GENERATED ALWAYS AS (((`end_time_unix_nano` - `start_time_unix_nano`))) STORED,
 	content LONGTEXT NOT NULL,
 	PRIMARY KEY (trace_id, span_id),
-	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -249,7 +249,7 @@ CREATE TABLE trace_info (
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
-	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -308,7 +308,7 @@ CREATE TABLE logged_model_metrics (
 	dataset_name VARCHAR(500),
 	dataset_digest VARCHAR(36),
 	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
-	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
 )
@@ -320,7 +320,7 @@ CREATE TABLE logged_model_params (
 	param_key VARCHAR(255) NOT NULL,
 	param_value TEXT NOT NULL,
 	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
-	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
@@ -331,7 +331,7 @@ CREATE TABLE logged_model_tags (
 	tag_key VARCHAR(255) NOT NULL,
 	tag_value TEXT NOT NULL,
 	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
-	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
 )
 
@@ -390,7 +390,7 @@ CREATE TABLE spans (
 	duration_ns BIGINT GENERATED ALWAYS AS ((end_time_unix_nano - start_time_unix_nano)) STORED,
 	content TEXT NOT NULL,
 	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
-	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE,
 	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE
 )
 

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -250,7 +250,7 @@ CREATE TABLE trace_info (
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
-	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -310,9 +310,9 @@ CREATE TABLE logged_model_metrics (
 	dataset_name VARCHAR(500),
 	dataset_digest VARCHAR(36),
 	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
-	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
 	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
-	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
+	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -322,8 +322,8 @@ CREATE TABLE logged_model_params (
 	param_key VARCHAR(255) NOT NULL,
 	param_value TEXT NOT NULL,
 	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
-	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -333,8 +333,8 @@ CREATE TABLE logged_model_tags (
 	tag_key VARCHAR(255) NOT NULL,
 	tag_value TEXT NOT NULL,
 	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
-	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -394,7 +394,7 @@ CREATE TABLE spans (
 	content TEXT NOT NULL,
 	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
 	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE,
-	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -250,7 +250,7 @@ CREATE TABLE trace_info (
 	request_preview VARCHAR(1000),
 	response_preview VARCHAR(1000),
 	CONSTRAINT trace_info_pk PRIMARY KEY (request_id),
-	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_trace_info_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -310,9 +310,9 @@ CREATE TABLE logged_model_metrics (
 	dataset_name VARCHAR(500),
 	dataset_digest VARCHAR(36),
 	CONSTRAINT logged_model_metrics_pk PRIMARY KEY (model_id, metric_name, metric_timestamp_ms, metric_step, run_id),
-	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
+	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE,
 	CONSTRAINT fk_logged_model_metrics_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
-	CONSTRAINT fk_logged_model_metrics_run_id FOREIGN KEY(run_id) REFERENCES runs (run_uuid) ON DELETE CASCADE
+	CONSTRAINT fk_logged_model_metrics_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -322,8 +322,8 @@ CREATE TABLE logged_model_params (
 	param_key VARCHAR(255) NOT NULL,
 	param_value TEXT NOT NULL,
 	CONSTRAINT logged_model_params_pk PRIMARY KEY (model_id, param_key),
-	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+	CONSTRAINT fk_logged_model_params_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_params_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -333,8 +333,8 @@ CREATE TABLE logged_model_tags (
 	tag_key VARCHAR(255) NOT NULL,
 	tag_value TEXT NOT NULL,
 	CONSTRAINT logged_model_tags_pk PRIMARY KEY (model_id, tag_key),
-	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id),
-	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE
+	CONSTRAINT fk_logged_model_tags_model_id FOREIGN KEY(model_id) REFERENCES logged_models (model_id) ON DELETE CASCADE,
+	CONSTRAINT fk_logged_model_tags_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 
@@ -390,11 +390,11 @@ CREATE TABLE spans (
 	status VARCHAR(50) NOT NULL,
 	start_time_unix_nano BIGINT NOT NULL,
 	end_time_unix_nano BIGINT,
-	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED,
+	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED, content TEXT NOT NULL, CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id), CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE, CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) STORED,
 	content TEXT NOT NULL,
 	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
 	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE,
-	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id)
+	CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) ON DELETE CASCADE
 )
 
 

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -390,7 +390,7 @@ CREATE TABLE spans (
 	status VARCHAR(50) NOT NULL,
 	start_time_unix_nano BIGINT NOT NULL,
 	end_time_unix_nano BIGINT,
-	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED, content TEXT NOT NULL, CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id), CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE, CONSTRAINT fk_spans_experiment_id FOREIGN KEY(experiment_id) REFERENCES experiments (experiment_id) STORED,
+	duration_ns BIGINT GENERATED ALWAYS AS (end_time_unix_nano - start_time_unix_nano) STORED,
 	content TEXT NOT NULL,
 	CONSTRAINT spans_pk PRIMARY KEY (trace_id, span_id),
 	CONSTRAINT fk_spans_trace_id FOREIGN KEY(trace_id) REFERENCES trace_info (request_id) ON DELETE CASCADE,


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/joelrobin18/mlflow/pull/19051?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19051/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19051/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19051/merge
```

</p>
</details>

### Related Issues/PRs

Fix #18781 

### What changes are proposed in this pull request?

Add ON DELETE CASCADE to foreign key constraints from logged_model_* tables, trace_info, and spans to experiments table.
Added a migration script

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests


### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Add ON DELETE CASCADE to foreign key constraints from logged_model_* tables, trace_info, and spans to experiments table. Added a migration script

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [x] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
