### PR TITLE
Fix error when registering a model with env_pack multiple times

### DIFF
--- a/mlflow/utils/env_pack.py
+++ b/mlflow/utils/env_pack.py
@@ -173,6 +173,11 @@ def pack_env_for_databricks_model_serving(
         temp_artifacts_dir.mkdir(exist_ok=False)
         _tar(local_artifacts_dir, temp_artifacts_dir / _MODEL_VERSION_TAR)
         _tar(Path(sys.prefix), temp_artifacts_dir / _MODEL_ENVIRONMENT_TAR)
+        
+        # Remove existing _databricks directory if present (e.g., from previous registration)
+        target_path = local_artifacts_dir / _ARTIFACT_PATH
+        if target_path.exists():
+            shutil.rmtree(target_path)
         shutil.move(str(temp_artifacts_dir), local_artifacts_dir)
 
         yield str(local_artifacts_dir)

--- a/mlflow/utils/env_pack.py
+++ b/mlflow/utils/env_pack.py
@@ -173,7 +173,7 @@ def pack_env_for_databricks_model_serving(
         temp_artifacts_dir.mkdir(exist_ok=False)
         _tar(local_artifacts_dir, temp_artifacts_dir / _MODEL_VERSION_TAR)
         _tar(Path(sys.prefix), temp_artifacts_dir / _MODEL_ENVIRONMENT_TAR)
-        
+
         # Remove existing _databricks directory if present (e.g., from previous registration)
         target_path = local_artifacts_dir / _ARTIFACT_PATH
         if target_path.exists():

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -312,7 +312,6 @@ def test_pack_env_for_databricks_model_serving_missing_runtime_version(tmp_path,
 def test_pack_env_for_databricks_model_serving_handles_existing_databricks_dir(
     tmp_path, mock_dbr_version
 ):
-    """Test that pack_env_for_databricks_model_serving handles existing _databricks directory."""
     # Mock download_artifacts to return a path
     mock_artifacts_dir = tmp_path / "artifacts"
     mock_artifacts_dir.mkdir()

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -355,6 +355,6 @@ def test_pack_env_for_databricks_model_serving_handles_existing_databricks_dir(
             assert databricks_path.exists()
             assert (databricks_path / env_pack._MODEL_VERSION_TAR).exists()
             assert (databricks_path / env_pack._MODEL_ENVIRONMENT_TAR).exists()
-            
+
             # Verify old file is gone (directory was replaced, not merged)
             assert not (databricks_path / "old_file.txt").exists()

--- a/tests/utils/test_env_pack.py
+++ b/tests/utils/test_env_pack.py
@@ -307,3 +307,55 @@ def test_pack_env_for_databricks_model_serving_missing_runtime_version(tmp_path,
         ):
             with env_pack.pack_env_for_databricks_model_serving("models:/test-model/1"):
                 pass
+
+
+def test_pack_env_for_databricks_model_serving_handles_existing_databricks_dir(
+    tmp_path, mock_dbr_version
+):
+    """Test that pack_env_for_databricks_model_serving handles existing _databricks directory."""
+    # Mock download_artifacts to return a path
+    mock_artifacts_dir = tmp_path / "artifacts"
+    mock_artifacts_dir.mkdir()
+    (mock_artifacts_dir / "requirements.txt").write_text("numpy==1.21.0")
+
+    # Create MLmodel file with correct runtime version
+    mlmodel_path = mock_artifacts_dir / "MLmodel"
+    mlmodel_path.write_text(
+        yaml.dump(
+            {
+                "databricks_runtime": "client.2.0",
+                "flavors": {"python_function": {"model_path": "model.pkl"}},
+            }
+        )
+    )
+
+    # Simulate existing _databricks directory from previous registration
+    existing_databricks_dir = mock_artifacts_dir / env_pack._ARTIFACT_PATH
+    existing_databricks_dir.mkdir()
+    (existing_databricks_dir / "old_file.txt").write_text("old content")
+
+    # Create a mock environment directory
+    mock_env_dir = tmp_path / "mock_env"
+    venv.create(mock_env_dir, with_pip=True)
+
+    with (
+        mock.patch(
+            "mlflow.utils.env_pack.download_artifacts",
+            return_value=str(mock_artifacts_dir),
+        ),
+        mock.patch("sys.prefix", str(mock_env_dir)),
+    ):
+        # This should succeed even though _databricks directory already exists
+        with env_pack.pack_env_for_databricks_model_serving(
+            "models:/test-model/1", enforce_pip_requirements=False
+        ) as artifacts_dir:
+            # Verify artifacts directory exists and contains expected files
+            artifacts_path = Path(artifacts_dir)
+            assert artifacts_path.exists()
+            databricks_path = artifacts_path / env_pack._ARTIFACT_PATH
+            assert databricks_path.exists()
+            assert (databricks_path / env_pack._MODEL_VERSION_TAR).exists()
+            assert (databricks_path / env_pack._MODEL_ENVIRONMENT_TAR).exists()
+            
+            # Verify old file is gone (directory was replaced, not merged)
+            assert not (databricks_path / "old_file.txt").exists()


### PR DESCRIPTION
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
https://github.com/mlflow/mlflow/pull/15783 which introduced env_pack

### What changes are proposed in this pull request?

Currently if you have an mlflow model that you register using the env_pack argument, you cannot re-register the same model to a different name as you will get an error saying "Destination path already exists":

<img width="1070" height="367" alt="image" src="https://github.com/user-attachments/assets/307cdccc-cf41-4061-a4c5-3b4229f42af1" />


### How is this PR tested?

- [X] New unit/integration tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
