### PR TITLE
Fix genai.evaluate column validation warning for session-level built in judges

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1587,7 +1587,7 @@ class BuiltInSessionLevelScorer(BuiltInScorer):
     Session-level scorers evaluate entire conversation sessions rather than individual traces.
     """
 
-    required_columns: set[str] = {"session"}
+    required_columns: set[str] = {"trace"}
     _judge: InstructionsJudge | None = pydantic.PrivateAttr(default=None)
 
     @abstractmethod


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xsh310/mlflow/pull/19067?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19067/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19067/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19067/merge
```

</p>
</details>

## 🥞 Stacked PR
Use this [link](#) to review incremental changes.

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Update `required_column` to "trace" for session level scorers to prevent the following warning when running with `genai.evaluate`:

```
INFO mlflow.genai.scorers.validation: The input data is missing following columns that are required by the specified scorers. The results will be null for those scorers.
 - `session` column is required by [conversation_completeness].
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
### Manual Test:

Tested with
```
  traces = mlflow.search_traces(
      experiment_ids=[experiment_id],
      filter_string=f"metadata.`mlflow.trace.session` = '{session_id}'",
      return_type="list",
  )

  result_df = mlflow.genai.evaluate(
      data = traces,
      scorers = [conversation_completeness_scorer],
  ).result_df

  print(result_df[['trace_id', 'conversation_completeness/value']])
```

**Before:**
```
INFO mlflow.genai.scorers.validation: The input data is missing following columns that are required by the specified scorers. The results will be null for those scorers.
 - `session` column is required by [conversation_completeness].
trace_id conversation_completeness/value
0  tr-2cd106b40e5cdfddffede040e34789a5                             NaN
1  tr-0a9f70b110b6f7045858228d6a2c74b1                             yes
2  tr-4c63218e359c30170fb7324f2177a035                             NaN
3  tr-e234aea83059823beadb90f0a7f0909f                             NaN
4  tr-2e2d728503c6f3de878c34c9d1b0f4dc                             NaN
5  tr-26d0ea33568b18301be944295fcc971a                             NaN
6  tr-f79ea6c663980841141961b6fac02f16                             NaN
7  tr-af8fb72cc9cd5d2f6637b416f7553289                             NaN
8  tr-713501bcb3c5b94211bec6d25a43b663                             NaN
9  tr-f319a35c635c3f308aee8257280b43ec                             NaN
```

**After:**
 ```                              
trace_id conversation_completeness/value
0  tr-843c1b545b861979e728a87d893878b3                             NaN
1  tr-d243d1f989fcea071b540173fbe655a7                             NaN
2  tr-f5e77a3d65d4174a96ca2374f9490b17                             NaN
3  tr-fd9e209b519417499b6397f9b2a1eab2                             NaN
4  tr-c125efb43121c5e40b247ddcfe806556                             NaN
5  tr-a70d40defd74b98a570dd50a2c8b8b55                             NaN
6  tr-2dcfdd2dde5863633b89c5de8ed87f86                             yes
7  tr-5ff410c5001376d5644a512890e59943                             NaN
8  tr-61365b536fc86e28c7d22c4fd38d7a9d                             NaN
9  tr-50dd9f34c727d17a3e79d94c9964e01b                             NaN
``` 

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
