### PR TITLE
Deflake jest tests

### DIFF
--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -5,7 +5,7 @@
     "start": "craco start",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
-    "test": "NODE_OPTIONS=\"--expose-gc\" craco --max_old_space_size=8192 test --env=jsdom --colors --watchAll=false --logHeapUsage --silent",
+    "test": "NODE_OPTIONS=\"--expose-gc\" craco --max_old_space_size=8192 test --env=jsdom --colors --watchAll=false --silent",
     "test:watch": "yarn test --watch",
     "test:ci": "CI=true craco test --env=jsdom --colors --forceExit --ci --coverage",
     "lint": "eslint --ext js,jsx,ts,tsx src",

--- a/mlflow/server/js/package.json
+++ b/mlflow/server/js/package.json
@@ -5,7 +5,7 @@
     "start": "craco start",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public",
-    "test": "craco --max_old_space_size=8192 test --env=jsdom --colors --watchAll=false",
+    "test": "NODE_OPTIONS=\"--expose-gc\" craco --max_old_space_size=8192 test --env=jsdom --colors --watchAll=false --logHeapUsage --silent",
     "test:watch": "yarn test --watch",
     "test:ci": "CI=true craco test --env=jsdom --colors --forceExit --ci --coverage",
     "lint": "eslint --ext js,jsx,ts,tsx src",

--- a/mlflow/server/js/src/setupTests.js
+++ b/mlflow/server/js/src/setupTests.js
@@ -95,5 +95,5 @@ beforeEach(() => {
 });
 
 afterAll(() => {
-  global.gc();
+  jest.restoreAllMocks();
 });

--- a/mlflow/server/js/src/setupTests.js
+++ b/mlflow/server/js/src/setupTests.js
@@ -93,3 +93,7 @@ beforeEach(() => {
     }
   };
 });
+
+afterAll(() => {
+  global.gc();
+});


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/19087?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19087/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19087/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19087/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

I'm not sure why this works but in local testing, running jest with the `--expose-gc` node option seems to greatly improve memory usage, even if we do not call `global.gc()` ourselves.

In this PR, I add this env var, and I also call `restoreAllMocks` after each test suite as it also seem to help reduce some memory leaks.



### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

ran jest with `--logHeapUsage` and analyzed the logs (one run per so maybe it's not so reliable but difference seems huge):

```
// without `--expose-gc`, with `restoreAllMocks`
$ cat logs-no-gc-with-cleanup.txt | ./heap-stats.sh
Tests:   174
Min:     298 MB
Max:     1814 MB
Average: 1140 MB

// with `--expose-gc`, without `restoreAllMocks`
$ cat logs-gc-no-changes.txt | ./heap-stats.sh
Tests:   174
Min:     349 MB
Max:     1134 MB
Average: 731 MB

// with `--expose-gc`, with `restoreAllMocks`
$ cat logs-gc-with-cleanup.txt | ./heap-stats.sh
Tests:   174
Min:     289 MB
Max:     1044 MB
Average: 685 MB
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
