### PR TITLE
Add mlflow experiments get command

### DIFF
--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -78,26 +78,26 @@ def search_experiments(view):
 @EXPERIMENT_ID
 @click.option(
     "--output",
-    type=click.Choice(["json"]),
-    default="json",
-    help="Output format. Only 'json' is currently supported (default: json).",
+    type=click.Choice(["json", "table"]),
+    default="table",
+    help="Output format: 'table' (default) or 'json'.",
 )
 def get_experiment(experiment_id, output):
     """
     Get details of an experiment by ID.
 
     Displays experiment information including name, artifact location, lifecycle stage,
-    tags, creation time, and last update time in JSON format.
+    tags, creation time, and last update time.
 
     \b
     Examples:
 
     .. code-block:: bash
 
-        # Get experiment in JSON format (default)
+        # Get experiment in table format (default)
         mlflow experiments get --experiment-id 1
 
-        # Explicit JSON output
+        # Get experiment in JSON format
         mlflow experiments get --experiment-id 1 --output json
 
         # Using short option
@@ -106,9 +106,28 @@ def get_experiment(experiment_id, output):
     store = _get_store()
     experiment = store.get_experiment(experiment_id)
 
-    # Convert experiment to dictionary using the __iter__ method from _MlflowObject
-    experiment_dict = dict(experiment)
-    click.echo(json.dumps(experiment_dict, indent=2))
+    if output == "json":
+        experiment_dict = dict(experiment)
+        click.echo(json.dumps(experiment_dict, indent=2))
+    elif output == "table":
+        table_data = [
+            ["Experiment ID", experiment.experiment_id],
+            ["Name", experiment.name],
+            ["Artifact Location", experiment.artifact_location],
+            ["Lifecycle Stage", experiment.lifecycle_stage],
+            ["Creation Time", experiment.creation_time or "N/A"],
+            ["Last Update Time", experiment.last_update_time or "N/A"],
+        ]
+
+        if experiment.tags:
+            tags_str = ", ".join([f"{k}={v}" for k, v in experiment.tags.items()])
+            table_data.append(["Tags", tags_str])
+        else:
+            table_data.append(["Tags", ""])
+
+        max_field_width = max(len(row[0]) for row in table_data)
+        for field, value in table_data:
+            click.echo(f"{field.ljust(max_field_width + 2)}: {value}")
 
 
 @commands.command("delete")

--- a/mlflow/experiments.py
+++ b/mlflow/experiments.py
@@ -1,3 +1,4 @@
+import json
 import os
 
 import click
@@ -71,6 +72,43 @@ def search_experiments(view):
         for exp in experiments
     ]
     click.echo(_create_table(sorted(table), headers=["Experiment Id", "Name", "Artifact Location"]))
+
+
+@commands.command("get")
+@EXPERIMENT_ID
+@click.option(
+    "--output",
+    type=click.Choice(["json"]),
+    default="json",
+    help="Output format. Only 'json' is currently supported (default: json).",
+)
+def get_experiment(experiment_id, output):
+    """
+    Get details of an experiment by ID.
+
+    Displays experiment information including name, artifact location, lifecycle stage,
+    tags, creation time, and last update time in JSON format.
+
+    \b
+    Examples:
+
+    .. code-block:: bash
+
+        # Get experiment in JSON format (default)
+        mlflow experiments get --experiment-id 1
+
+        # Explicit JSON output
+        mlflow experiments get --experiment-id 1 --output json
+
+        # Using short option
+        mlflow experiments get -x 0
+    """
+    store = _get_store()
+    experiment = store.get_experiment(experiment_id)
+
+    # Convert experiment to dictionary using the __iter__ method from _MlflowObject
+    experiment_dict = dict(experiment)
+    click.echo(json.dumps(experiment_dict, indent=2))
 
 
 @commands.command("delete")

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -328,16 +328,17 @@ def test_get_experiment_default():
     result = CliRunner().invoke(experiments.get_experiment, ["--experiment-id", "0"])
     assert result.exit_code == 0
 
-    output = json.loads(result.output)
-    assert output["experiment_id"] == "0"
-    assert "name" in output
-    assert "artifact_location" in output
-    assert "lifecycle_stage" in output
-    assert "tags" in output
+    # Default output is table format
+    assert "Experiment ID" in result.output
+    assert "Name" in result.output
+    assert "Artifact Location" in result.output
+    assert "Lifecycle Stage" in result.output
+    assert ":" in result.output
 
 
-def test_get_experiment_explicit_json():
-    exp_id = mlflow.create_experiment("test_get_exp_explicit")
+def test_get_experiment_json():
+    exp_id = mlflow.create_experiment("test_get_exp_json", tags={"env": "test"})
+    exp = mlflow.get_experiment(exp_id)
 
     result = CliRunner().invoke(
         experiments.get_experiment, ["--experiment-id", exp_id, "--output", "json"]
@@ -345,49 +346,47 @@ def test_get_experiment_explicit_json():
     assert result.exit_code == 0
 
     output = json.loads(result.output)
-    assert output["experiment_id"] == exp_id
-    assert output["name"] == "test_get_exp_explicit"
-    assert output["lifecycle_stage"] == "active"
+    expected = {
+        "experiment_id": exp_id,
+        "name": "test_get_exp_json",
+        "artifact_location": exp.artifact_location,
+        "lifecycle_stage": "active",
+        "tags": {"env": "test"},
+        "creation_time": exp.creation_time,
+        "last_update_time": exp.last_update_time,
+    }
+    assert output == expected
 
 
-def test_get_experiment_short_option():
-    exp_id = mlflow.create_experiment("test_get_exp_short")
+def test_get_experiment_table():
+    exp_id = mlflow.create_experiment("test_get_exp_table", tags={"env": "test", "team": "ml"})
 
-    result = CliRunner().invoke(experiments.get_experiment, ["-x", exp_id])
+    result = CliRunner().invoke(
+        experiments.get_experiment, ["--experiment-id", exp_id, "--output", "table"]
+    )
     assert result.exit_code == 0
 
-    output = json.loads(result.output)
-    assert output["experiment_id"] == exp_id
-    assert output["name"] == "test_get_exp_short"
+    # Verify table format
+    assert "Experiment ID" in result.output
+    assert exp_id in result.output
+    assert "Name" in result.output
+    assert "test_get_exp_table" in result.output
+    assert "Lifecycle Stage" in result.output
+    assert "active" in result.output
+    assert "Tags" in result.output
+    assert "env=test" in result.output
+    assert "team=ml" in result.output
 
 
-def test_get_experiment_with_tags():
-    exp_id = mlflow.create_experiment("test_get_exp_tags", tags={"env": "test", "team": "ml"})
+def test_get_experiment_table_no_tags():
+    exp_id = mlflow.create_experiment("test_get_exp_no_tags")
 
-    result = CliRunner().invoke(experiments.get_experiment, ["-x", exp_id])
+    result = CliRunner().invoke(experiments.get_experiment, ["-x", exp_id, "--output", "table"])
     assert result.exit_code == 0
 
-    output = json.loads(result.output)
-    assert output["tags"] == {"env": "test", "team": "ml"}
-    assert output["experiment_id"] == exp_id
-    assert output["lifecycle_stage"] == "active"
-
-
-def test_get_experiment_json_structure():
-    exp_id = mlflow.create_experiment("test_json_structure")
-
-    result = CliRunner().invoke(experiments.get_experiment, ["--experiment-id", exp_id])
-    assert result.exit_code == 0
-
-    output = json.loads(result.output)
-    # Verify all expected fields
-    assert "experiment_id" in output
-    assert "name" in output
-    assert "artifact_location" in output
-    assert "lifecycle_stage" in output
-    assert "tags" in output
-    assert "creation_time" in output
-    assert "last_update_time" in output
+    assert "Experiment ID" in result.output
+    assert exp_id in result.output
+    assert "Tags" in result.output
 
 
 def test_get_experiment_missing_id():
@@ -405,7 +404,7 @@ def test_get_experiment_deleted():
     exp_id = mlflow.create_experiment("test_deleted")
     mlflow.delete_experiment(exp_id)
 
-    result = CliRunner().invoke(experiments.get_experiment, ["-x", exp_id])
+    result = CliRunner().invoke(experiments.get_experiment, ["-x", exp_id, "--output", "json"])
     assert result.exit_code == 0
 
     output = json.loads(result.output)


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR adds a new CLI command `mlflow experiments get` that retrieves and displays experiment details by ID. The command supports both table and JSON output formats.

**Key features:**
- Required `--experiment-id` / `-x` flag to specify the experiment
- Optional `--output` flag supporting `table` (default) and `json` formats
- **Table format** (default): Vertical layout showing all experiment fields in human-readable format
- **JSON format**: Complete experiment data in JSON structure for programmatic use
- Displays all experiment fields: experiment_id, name, artifact_location, lifecycle_stage, tags, creation_time, last_update_time

**Output examples:**

Table format (default):
```bash
$ mlflow experiments get --experiment-id 0
Experiment ID      : 0
Name               : Default
Artifact Location  : /path/to/mlruns/0
Lifecycle Stage    : active
Creation Time      : 1764288610669
Last Update Time   : 1764288610669
Tags               :
```

JSON format:
```bash
$ mlflow experiments get --experiment-id 0 --output json
{
  "experiment_id": "0",
  "name": "Default",
  "artifact_location": "/path/to/mlruns/0",
  "lifecycle_stage": "active",
  "tags": {},
  "creation_time": 1764288610669,
  "last_update_time": 1764288610669
}
```

**Implementation details:**
- Follows existing MLflow CLI patterns (consistent with `runs describe` command)
- Uses Click's `click.Choice` for output format validation
- Table format uses vertical layout (field: value) for better single-entity readability
- Uses `dict(experiment)` for serialization via `_MlflowObject.__iter__`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**New tests added (7 total):**
1. `test_get_experiment_default` - Default table output
2. `test_get_experiment_json` - Complete JSON validation with expected output comparison
3. `test_get_experiment_table` - Table format with tags
4. `test_get_experiment_table_no_tags` - Table format without tags
5. `test_get_experiment_missing_id` - Missing required parameter
6. `test_get_experiment_invalid_id` - Invalid experiment ID
7. `test_get_experiment_deleted` - Deleted experiments (lifecycle stage)

**Test coverage:**
- ✅ Default behavior (table format)
- ✅ Both output formats (table and JSON)
- ✅ Short option (`-x`)
- ✅ Experiments with and without tags
- ✅ Complete JSON structure validation
- ✅ Error cases (missing/invalid ID)
- ✅ All lifecycle stages (active and deleted)

**Manual testing:**
```bash
# Default table format
$ mlflow experiments get --experiment-id 0

# JSON format
$ mlflow experiments get --experiment-id 0 --output json

# Short option
$ mlflow experiments get -x 0

# Help command
$ mlflow experiments get --help
```

**Quality checks:**
- ✅ All 7 tests pass
- ✅ Ruff linting passes
- ✅ Ruff formatting passes
- ✅ Clint custom linter passes
- ✅ All pre-commit hooks pass

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

The command is self-documenting through its docstring and `--help` output. No additional documentation is needed at this time.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added new CLI command `mlflow experiments get --experiment-id <ID>` to retrieve and display experiment details. The command supports two output formats:
- **Table format** (default): Human-readable vertical layout showing all experiment fields
- **JSON format** (via `--output json`): Complete experiment data in JSON structure for programmatic use

The command provides easy access to experiment metadata including name, artifact location, lifecycle stage, tags, and timestamps.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

**Commits:**
1. `2469e5115` - Initial implementation with JSON output only
2. `4d14803ed` - Add table output format and set as default

🤖 Generated with [Claude Code](https://claude.com/claude-code)