### PR TITLE
Increase JS timeout for windows 

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -78,15 +78,9 @@ jobs:
       - name: Run type-check
         run: |
           yarn type-check
-      - name: Run tests (non-windows)
-        if: runner.os != 'Windows'
+      - name: Run tests
         run: |
-          yarn test --silent ${{ matrix.option }} src/experiment-tracking/components
-      - name: Run tests (windows)
-        if: runner.os == 'Windows'
-        # set a higher timeout for windows to avoid flaky tests
-        run: |
-          yarn test --testTimeout=10000 --silent ${{ matrix.option }} src/experiment-tracking/components
+          yarn test ${{ runner.os == 'Windows' && '--testTimeout=10000' || '' }} --silent ${{ matrix.option }} src/experiment-tracking/components
       - name: Run build
         if: runner.os == 'Linux'
         env:

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -78,9 +78,15 @@ jobs:
       - name: Run type-check
         run: |
           yarn type-check
-      - name: Run tests
+      - name: Run tests (non-windows)
+        if: runner.os != 'Windows'
         run: |
           yarn test --silent ${{ matrix.option }} src/experiment-tracking/components
+      - name: Run tests (windows)
+        if: runner.os == 'Windows'
+        # set a higher timeout for windows to avoid flaky tests
+        run: |
+          yarn test --testTimeout=10000 --silent ${{ matrix.option }} src/experiment-tracking/components
       - name: Run build
         if: runner.os == 'Linux'
         env:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/19102?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19102/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19102/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19102/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Sorry for the multiple PRs here, but this seems like the most stable option so far.

I've tried a [few](https://github.com/mlflow/mlflow/pull/19100) [different](https://github.com/mlflow/mlflow/pull/19087) [things](https://github.com/mlflow/mlflow/pull/18986) to deflake the JS tests, but it seems like in the end we can just increase the global timeout for windows. It's not ideal but better than letting PRs have noisy failures and force-merging.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

Ran JS CI 5 times on this PR, all passes: https://github.com/mlflow/mlflow/actions/runs/19753545456?pr=19102

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
