### PR TITLE
Improve documentation for 'prompt_template'

### DIFF
--- a/mlflow/utils/docstring_utils.py
+++ b/mlflow/utils/docstring_utils.py
@@ -266,6 +266,39 @@ Currently, only the following pipeline types are supported:
 - `summarization <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.SummarizationPipeline>`_
 - `text2text-generation <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.Text2TextGenerationPipeline>`_
 - `text-generation <https://huggingface.co/transformers/main_classes/pipelines.html#transformers.TextGenerationPipeline>`_
+
+The following example shows how to log a text-generation pipeline with a prompt template and
+use it via the ``python_function`` (pyfunc) flavor:
+
+.. code-block:: python
+
+    import mlflow
+    from transformers import pipeline
+
+    # Initialize a text-generation pipeline
+    generator = pipeline("text-generation", model="gpt2")
+
+    # Define a prompt template. The ``{prompt}`` placeholder will be replaced
+    # with the raw user input at inference time.
+    prompt_template = "Answer the following question concisely.\\n\\nQ: {prompt}\\nA:"
+
+    example_prompt = "What is MLflow?"
+
+    # Log the model with the prompt template and an input example
+    with mlflow.start_run():
+        model_info = mlflow.transformers.log_model(
+            transformers_model=generator,
+            name="qa_text_generator",
+            prompt_template=prompt_template,
+            input_example=example_prompt,
+        )
+
+    # Load the model back as a pyfunc model
+    loaded_model = mlflow.pyfunc.load_model(model_info.model_uri)
+
+    # The input to ``predict`` is the raw question string; the prompt template
+    # is applied internally before calling the underlying transformers pipeline.
+    loaded_model.predict("What is experiment tracking?")
 """
         ),
         "code_paths": (


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/ingo-stallknecht/mlflow/pull/19105?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19105/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19105/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19105/merge
```

</p>
</details>

### Related Issues/PRs

None.

### What changes are proposed in this pull request?

This PR improves the documentation for the `prompt_template` parameter in
`LOG_MODEL_PARAM_DOCS` (`mlflow/mlflow/utils/docstring_utils.py`).

The original description already explained the `{prompt}` placeholder and listed
the supported pipeline types. This update keeps the existing content intact and
adds a concise Python example demonstrating:

- how to define a prompt template,
- how to log a text-generation pipeline using `mlflow.transformers.log_model`,
- how the pyfunc flavor applies the template automatically at inference time.

This example makes the intended usage clearer and improves the usability of the
`prompt_template` feature without changing any behavior.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

This is a documentation-only change.  
Manual verification was performed to ensure that the added example integrates
correctly into the shared docstring, and CI will validate that the documentation
builds without issues.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [x] Examples
  - [x] API references
  - [ ] Instructions

This update enhances the API reference documentation for the `prompt_template`
parameter by adding a practical example.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Improved documentation for the `prompt_template` parameter in the transformers
flavor, including a short usage example.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [ ] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [x] `area/docs`

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [x] `rn/documentation`

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
