### PR TITLE
Fix InstructionsJudge using scorer description as assessment value

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -351,9 +351,11 @@ class InstructionsJudge(Judge):
 
     def get_output_fields(self) -> list[JudgeField]:
         """Get the output fields for this judge."""
+        # Use generic field description, not self.description, to avoid the LLM
+        # echoing the scorer's description as the assessment value
         result_field = JudgeField(
             name="result",
-            description=self.description or _RESULT_FIELD_DESCRIPTION,
+            description=_RESULT_FIELD_DESCRIPTION,
             value_type=self._feedback_value_type,
         )
         rationale_field = JudgeField(
@@ -547,17 +549,18 @@ class InstructionsJudge(Judge):
         )
 
     def _create_response_format_model(self) -> type[pydantic.BaseModel]:
-        result_field = (
-            self._feedback_value_type or str,
-            pydantic.Field(description=self.description or _RESULT_FIELD_DESCRIPTION),
-        )
-        rationale_field = (str, pydantic.Field(description=_RATIONALE_FIELD_DESCRIPTION))
+        # Use get_output_fields() as the single source of truth for field definitions
+        # This ensures field descriptions are consistent between the response format model
+        # and the system prompt instructions
+        output_fields = self.get_output_fields()
 
-        fields = (
-            {"rationale": rationale_field, "result": result_field}
-            if self._generate_rationale_first
-            else {"result": result_field, "rationale": rationale_field}
-        )
+        # Convert JudgeFields to Pydantic field definitions
+        fields = {}
+        for field in output_fields:
+            fields[field.name] = (
+                field.value_type,
+                pydantic.Field(description=field.description),
+            )
 
         return pydantic.create_model("ResponseFormat", **fields)
 

--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -549,12 +549,8 @@ class InstructionsJudge(Judge):
         )
 
     def _create_response_format_model(self) -> type[pydantic.BaseModel]:
-        # Use get_output_fields() as the single source of truth for field definitions
-        # This ensures field descriptions are consistent between the response format model
-        # and the system prompt instructions
         output_fields = self.get_output_fields()
 
-        # Convert JudgeFields to Pydantic field definitions
         fields = {}
         for field in output_fields:
             fields[field.name] = (

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -3420,17 +3420,6 @@ def test_instructions_judge_generate_rationale_first():
 
 
 def test_response_format_uses_generic_description_when_scorer_has_description():
-    """
-    Verify that response format uses generic field description even when scorer has
-    a custom description.
-
-    Bug: Previously the Pydantic Field description was set to self.description,
-    which caused the LLM to see the scorer's description in the JSON schema
-    and potentially echo it back as the value instead of generating an assessment.
-
-    Fix: The Field description should always be _RESULT_FIELD_DESCRIPTION
-    ("The evaluation rating/result") so the LLM understands what to return.
-    """
     scorer_description = "Evaluates the conciseness of the response"
     judge = InstructionsJudge(
         name="Conciseness",
@@ -3468,12 +3457,6 @@ def test_response_format_uses_generic_description_when_scorer_has_description():
 
 
 def test_response_format_uses_generic_description_when_scorer_has_no_description():
-    """
-    Verify that response format uses generic field description when scorer
-    has no custom description.
-
-    This ensures the fallback behavior is correct when self.description is None.
-    """
     judge = InstructionsJudge(
         name="TestJudge",
         instructions="Evaluate {{ outputs }}",
@@ -3484,6 +3467,7 @@ def test_response_format_uses_generic_description_when_scorer_has_no_description
     response_format_model = judge._create_response_format_model()
     schema = response_format_model.model_json_schema()
 
+    # The result field description should be the generic description
     result_description = schema["properties"]["result"]["description"]
     assert result_description == _RESULT_FIELD_DESCRIPTION, (
         f"Response format should use generic field description.\n"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/19121?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19121/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19121/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19121/merge
```

</p>
</details>

### Related Issues/PRs

N/A - Bug fix discovered during development

### What changes are proposed in this pull request?

This PR fixes a bug where `InstructionsJudge` scorers with custom descriptions would cause the LLM to echo back the scorer's description as the assessment value instead of generating an actual evaluation rating.

**Root Cause:**
The scorer's description (e.g., "Evaluates if the answer is concise") was being used in:
1. The JSON schema (`response_format`) sent to the LLM
2. The system prompt instructions

This caused the LLM to interpret the description as what the "result" field should contain, leading it to echo the description instead of generating an assessment.

**Solution:**
- Use generic field description (`_RESULT_FIELD_DESCRIPTION = "The evaluation rating/result"`) instead of the scorer's description
- Refactored `_create_response_format_model()` to use `get_output_fields()` as the single source of truth for field definitions
- Added explanatory comments to prevent future regressions

**Example Impact:**
- Before: `FeedbackValue(value="Evaluates if the answer is concise")` ❌
- After: `FeedbackValue(value=4)` ✅

**Files Changed:**
- `mlflow/genai/judges/instructions_judge/__init__.py`: Fixed field description logic in two methods
- `tests/genai/judges/test_make_judge.py`: Added comprehensive test coverage

### How is this PR tested?

- [x] Existing unit/integration tests (all pass)
- [x] New unit/integration tests
  - `test_response_format_uses_generic_description_when_scorer_has_description`
  - `test_response_format_uses_generic_description_when_scorer_has_no_description`
- [x] Manual tests (verified with Databricks integration - scorer now returns numeric ratings instead of description strings)

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

**Description:** Fixed a bug where LLM judge scorers (InstructionsJudge) with custom descriptions would return the description text as the assessment value instead of generating actual evaluation ratings. Scorers now correctly return numeric or categorical assessments as intended.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

**Rationale:** This is a bug fix that affects judge/scorer functionality. Users relying on custom-described judges are getting incorrect assessment values.