### PR TITLE
Introduce MLFLOW_CREATE_MODEL_VERSION_SOURCE_REGEX to validate source parameter of /model-versions/create request

### DIFF
--- a/docs/docs/tracking/server/index.mdx
+++ b/docs/docs/tracking/server/index.mdx
@@ -263,6 +263,79 @@ response = requests.get("http://<mlflow-host>:<mlflow-port>/version")
 assert response.text == mlflow.__version__  # Checking for a strict version match
 ```
 
+## Model Version Source Validation
+
+The tracking server can be configured to validate model version sources using a regular expression pattern. This security feature helps ensure that only model versions from approved sources are registered in your model registry.
+
+### Configuration
+
+Set the `MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX` environment variable when starting the tracking server:
+
+```bash
+export MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX="^mlflow-artifacts:/.*$"
+mlflow server --host 0.0.0.0 --port 5000
+```
+
+### Usage
+
+When this environment variable is set, the tracking server will validate the `source` parameter in model version creation requests against the specified regular expression pattern. If the source doesn't match the pattern, the request will be rejected with an error.
+
+#### Example: Restricting to MLflow Artifacts
+
+To only allow model versions from MLflow artifacts storage:
+
+```bash
+export MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX="^mlflow-artifacts:/.*$"
+mlflow server --host 0.0.0.0 --port 5000
+```
+
+With this configuration:
+
+```python
+import mlflow
+from mlflow import MlflowClient
+
+client = MlflowClient("http://localhost:5000")
+
+# This will work - source matches the pattern
+client.create_model_version(
+    name="my-model",
+    source="mlflow-artifacts://1/artifacts/model",
+    run_id="abc123",
+)
+
+# This will fail - source doesn't match the pattern
+client.create_model_version(
+    name="my-model",
+    source="s3://my-bucket/model",
+    run_id="def456",
+)  # Raises MlflowException: Invalid model version source
+```
+
+#### Example: Restricting to Specific S3 Buckets
+
+To only allow model versions from specific S3 buckets:
+
+```bash
+export MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX="^s3://(production-models|staging-models)/.*$"
+mlflow server --host 0.0.0.0 --port 5000
+```
+
+This pattern would allow sources like:
+- `s3://production-models/model-v1/`
+- `s3://staging-models/experiment-123/model/`
+
+But reject sources like:
+- `s3://untrusted-bucket/model/`
+- `file:///local/path/model`
+
+:::note
+- If the environment variable is not set, no source validation is performed.
+- The validation only applies to the `/mlflow/model-versions/create` API endpoint.
+- The regular expression is applied using Python's `re.search()` function.
+- Use standard regular expression syntax for pattern matching.
+:::
+
 ## Handling timeout when uploading/downloading large artifacts
 
 When uploading or downloading large artifacts through the tracking server with the artifact proxy enabled, the server may take a long time to process the request. If it exceeds the timeout limit (30 seconds by default), the server will restart the worker process, resulting in a request failure on the client side.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -781,3 +781,10 @@ MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE = _EnvironmentVariable(
 MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT = _EnvironmentVariable(
     "MLFLOW_ASYNC_TRACE_LOGGING_RETRY_TIMEOUT", int, 60
 )
+
+#: If specified, tracking server rejects model `/mlflow/model-versions/create` requests with
+#: a source that does not match the specified regular expression.
+#: (default: ``None``).
+MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX = _EnvironmentVariable(
+    "MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX", str, None
+)

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -9,9 +9,12 @@ import math
 import os
 import pathlib
 import posixpath
+import subprocess
 import sys
 import time
 import urllib.parse
+from io import StringIO
+from pathlib import Path
 from unittest import mock
 
 import flask
@@ -57,6 +60,7 @@ from mlflow.utils.os import is_windows
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.time import get_current_time_millis
 
+from tests.helper_functions import get_safe_port
 from tests.integration.utils import invoke_cli_runner
 from tests.tracking.integration_test_utils import (
     _init_server,
@@ -1575,6 +1579,57 @@ def test_create_model_version_with_file_uri(mlflow_client):
     assert "is not a valid remote uri" in response.json()["message"]
 
 
+def test_create_model_version_with_validation_regex(tmp_path: Path):
+    port = get_safe_port()
+    with subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "mlflow",
+            "server",
+            "--port",
+            str(port),
+            "--backend-store-uri",
+            f"sqlite:///{tmp_path / 'mlflow.db'}",
+        ],
+        env=(
+            os.environ.copy()
+            | {
+                "MLFLOW_CREATE_MODEL_VERSION_SOURCE_VALIDATION_REGEX": r"^mlflow-artifacts:/.*$",
+            }
+        ),
+    ) as proc:
+        try:
+            # Wait for the server to start
+            for _ in range(10):
+                try:
+                    if requests.get(f"http://localhost:{port}/health").ok:
+                        break
+                except requests.ConnectionError:
+                    time.sleep(1)
+            else:
+                raise RuntimeError("Failed to connect to the MLflow server")
+
+            # Test that the validation regex works as expected
+            client = MlflowClient(f"http://localhost:{port}")
+            name = "test"
+            client.create_registered_model(name)
+            # Invalid source
+            with pytest.raises(MlflowException, match="Invalid model version source"):
+                client.create_model_version(name, source="s3://path/to/model")
+            # Valid source
+            experiment_id = client.create_experiment("test")
+            run = client.create_run(experiment_id=experiment_id)
+            assert run.info.artifact_uri.startswith("mlflow-artifacts:/")
+            client.create_model_version(
+                name, source=f"{run.info.artifact_uri}/model", run_id=run.info.run_id
+            )
+        finally:
+            proc.terminate()
+            proc.wait()
+
+
+@pytest.mark.xfail(reason="Tracking server does not support logged-model endpoints yet")
 def test_logging_model_with_local_artifact_uri(mlflow_client):
     from sklearn.linear_model import LogisticRegression
 

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -13,7 +13,6 @@ import subprocess
 import sys
 import time
 import urllib.parse
-from io import StringIO
 from pathlib import Path
 from unittest import mock
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19135?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19135/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19135/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 19135
```

</p>
</details>

### What changes are proposed in this pull request?

https://github.com/mlflow/mlflow/pull/16081 addresses a security issue with CVE 8.1. The fix was added to 3.0 but there are users who cannot upgrade to 3.x immediately (e.g. https://github.com/mlflow/mlflow/issues/19122). Therefore, this PR backport the fix to 2.22.x.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Introduce MLFLOW_CREATE_MODEL_VERSION_SOURCE_REGEX to validate source parameter of /model-versions/create request

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [x] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
