### PR TITLE
Display experiment ID in the header

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.test.tsx
@@ -1,4 +1,4 @@
-import { jest, describe, beforeEach, it, expect } from '@jest/globals';
+import { jest, describe, beforeEach, it, expect, beforeAll } from '@jest/globals';
 import { ExperimentViewHeader, ExperimentViewHeaderSkeleton } from './ExperimentViewHeader';
 import { renderWithIntl, act, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
 import type { ExperimentEntity } from '@mlflow/mlflow/src/experiment-tracking/types';
@@ -34,6 +34,19 @@ describe('ExperimentViewHeader', () => {
   };
 
   const setEditing = jest.fn();
+  const clipboardWriteText = jest.fn();
+
+  beforeAll(() => {
+    Object.assign(global.navigator, {
+      clipboard: {
+        writeText: clipboardWriteText,
+      },
+    });
+  });
+
+  beforeEach(() => {
+    clipboardWriteText.mockClear();
+  });
 
   const renderComponent = (experiment = defaultExperiment) => {
     const mockStore = configureStore([thunk, promiseMiddleware()]);
@@ -67,6 +80,15 @@ describe('ExperimentViewHeader', () => {
 
     it('displays the last part of the experiment name', () => {
       expect(screen.getByText('name')).toBeInTheDocument();
+    });
+
+    it('shows the experiment id in the header', () => {
+      expect(screen.getByTestId('experiment-id-pill')).toHaveTextContent('Experiment ID: 123');
+    });
+
+    it('copies the experiment id when clicking the pill', async () => {
+      await userEvent.click(screen.getByTestId('experiment-id-pill'));
+      expect(clipboardWriteText).toHaveBeenCalledWith('123');
     });
 
     it('shows info tooltip with experiment details', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/header/ExperimentViewHeader.tsx
@@ -58,7 +58,7 @@ export const ExperimentViewHeader = React.memo(
     uiState?: ExperimentPageUIState;
     setEditing: (editing: boolean) => void;
     experimentKindSelector?: React.ReactNode;
-  refetchExperiment?: () => Promise<unknown>;
+    refetchExperiment?: () => Promise<unknown>;
   }) => {
     const { theme } = useDesignSystemTheme();
     const [experimentIdCopied, setExperimentIdCopied] = useState(false);
@@ -87,9 +87,7 @@ export const ExperimentViewHeader = React.memo(
 
     const getInfoTooltip = () => {
       return (
-        <div
-          style={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs, marginRight: theme.spacing.sm }}
-        >
+        <div style={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs, marginRight: theme.spacing.sm }}>
           <InfoPopover iconTitle="Info">
             <div
               css={{
@@ -156,18 +154,18 @@ export const ExperimentViewHeader = React.memo(
           }}
         >
           <div
-          css={{
-            display: 'flex',
-            gap: theme.spacing.sm,
-            alignItems: 'center',
-            overflow: 'hidden',
-            minWidth: 250,
-          }}
-        >
-          {shouldEnableExperimentPageSideTabs() && (
-            <>
-              <Link to={Routes.experimentsObservatoryRoute}>
-                <Button
+            css={{
+              display: 'flex',
+              gap: theme.spacing.sm,
+              alignItems: 'center',
+              overflow: 'hidden',
+              minWidth: 250,
+            }}
+          >
+            {shouldEnableExperimentPageSideTabs() && (
+              <>
+                <Link to={Routes.experimentsObservatoryRoute}>
+                  <Button
                     componentId="mlflow.experiment-page.header.back-icon-button"
                     type="tertiary"
                     icon={<ArrowLeftIcon />}
@@ -221,7 +219,10 @@ export const ExperimentViewHeader = React.memo(
               <Tooltip
                 content={
                   experimentIdCopied ? (
-                    <FormattedMessage defaultMessage="Experiment id copied" description="Tooltip when experiment id copied" />
+                    <FormattedMessage
+                      defaultMessage="Experiment id copied"
+                      description="Tooltip when experiment id copied"
+                    />
                   ) : (
                     <FormattedMessage
                       defaultMessage="Click to copy experiment id"
@@ -239,7 +240,16 @@ export const ExperimentViewHeader = React.memo(
                   data-testid="experiment-id-pill"
                   css={{ marginRight: 0, marginLeft: theme.spacing.xs }}
                 >
-                  <span css={{ display: 'flex', alignItems: 'center', color: theme.colors.indigo, marginRight: theme.spacing.xs, marginLeft: theme.spacing.xs, gap: 1 }}>
+                  <span
+                    css={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      color: theme.colors.indigo,
+                      marginRight: theme.spacing.xs,
+                      marginLeft: theme.spacing.xs,
+                      gap: 1,
+                    }}
+                  >
                     <FormattedMessage
                       defaultMessage="#"
                       description="Experiment page header subtitle showing experiment id"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19136?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19136/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19136/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19136/merge
```

</p>
</details>

### What changes are proposed in this pull request?

Today, to find the ID of an experiment, users need to either hover over the tiny info icon or extract it from the URL. Experiment ID is necessary for several places e.g. otel ingestion, so it is important to make it easy.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<img width="556" height="86" alt="Screenshot 2025-12-02 at 0 21 56" src="https://github.com/user-attachments/assets/10bd4953-5fca-486e-b1e3-19fc2b1f386a" />

Truncate for long experiment ID like file store:

<img width="436" height="64" alt="Screenshot 2025-12-02 at 0 22 03" src="https://github.com/user-attachments/assets/942144b7-87dd-439b-98dd-99b53951a76a" />


(Alternatively we can say "Experiment ID:" to make it very explicit. I picked "#" since it feels a bit noisy but open to switch)
<img width="537" height="59" alt="Screenshot 2025-12-02 at 0 06 38" src="https://github.com/user-attachments/assets/bc220fa8-7040-4631-8b4d-7a85426ffc5a" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
