### PR TITLE
[ML-59952] Add telemetry field on genai_evaluate event to track multi-turn scorer usages

### DIFF
--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -98,6 +98,10 @@ class GenAIEvaluateEvent(Event):
         )
         record_params["scorer_kind_count"] = dict[str, int](sorted(scorer_kind_count.items()))
 
+        # Track session-level scorer counts
+        session_level_scorers = [scorer for scorer in scorers if scorer.is_session_level_scorer]
+        record_params["session_level_scorer_count"] = len(session_level_scorers)
+
         return record_params
 
 

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,5 +1,4 @@
 import sys
-from collections import Counter
 from enum import Enum
 from typing import Any
 
@@ -85,22 +84,22 @@ class GenAIEvaluateEvent(Event):
         # Track if predict_fn is provided
         record_params["predict_fn_provided"] = arguments.get("predict_fn") is not None
 
-        # Track builtin scorers
+        # Track scorer information
         scorers = arguments.get("scorers") or []
-        builtin_scorers = {
-            type(scorer).__name__ for scorer in scorers if isinstance(scorer, BuiltInScorer)
-        }
-        record_params["builtin_scorers"] = sorted(builtin_scorers)
-
-        # Track scorer kind counts
-        scorer_kind_count = Counter[str](
-            scorer.kind.value for scorer in scorers if isinstance(scorer, Scorer)
-        )
-        record_params["scorer_kind_count"] = dict[str, int](sorted(scorer_kind_count.items()))
-
-        # Track session-level scorer counts
-        session_level_scorers = [scorer for scorer in scorers if scorer.is_session_level_scorer]
-        record_params["session_level_scorer_count"] = len(session_level_scorers)
+        scorer_info = [
+            {
+                "class": (
+                    type(scorer).__name__
+                    if isinstance(scorer, BuiltInScorer)
+                    else "UserDefinedScorer"
+                ),
+                "kind": scorer.kind.value,
+                "scope": "session" if scorer.is_session_level_scorer else "response",
+            }
+            for scorer in scorers
+            if isinstance(scorer, Scorer)
+        ]
+        record_params["scorer_info"] = scorer_info
 
         return record_params
 

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -353,121 +353,84 @@ def test_create_webhook(mock_requests, mock_telemetry_client: TelemetryClient):
 
 def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
     @mlflow.genai.scorer
-    def sample_scorer():
+    def decorator_scorer():
         return 1.0
 
-    model = TestModel()
-    data = [
-        {
-            "inputs": {"model_input": ["What is the capital of France?"]},
-            "outputs": "The capital of France is Paris.",
-        }
-    ]
-    with mock.patch("mlflow.genai.judges.is_context_relevant"):
-        mlflow.genai.evaluate(
-            data=data,
-            scorers=[sample_scorer, RelevanceToQuery(name="my_judge")],
-            predict_fn=model.predict,
-        )
-        expected_params = {
-            "builtin_scorers": ["RelevanceToQuery"],
-            "predict_fn_provided": True,
-            "scorer_kind_count": {"decorator": 1, "builtin": 1},
-            "session_level_scorer_count": 0,
-        }
-        validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
-        )
-
-        # Test without predict_fn
-        mlflow.genai.evaluate(
-            data=data,
-            scorers=[sample_scorer],
-        )
-        expected_params = {
-            "builtin_scorers": [],
-            "predict_fn_provided": False,
-            "scorer_kind_count": {"decorator": 1},
-            "session_level_scorer_count": 0,
-        }
-        validate_telemetry_record(
-            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
-        )
-
-
-def test_genai_evaluate_scorer_kind_count(mock_requests, mock_telemetry_client: TelemetryClient):
-    # Create scorers of different kinds
-    @mlflow.genai.scorer
-    def custom_scorer_1():
-        return 1.0
-
-    @mlflow.genai.scorer
-    def custom_scorer_2():
-        return 2.0
-
-    # Create an InstructionsJudge
     instructions_judge = make_judge(
         name="quality_judge",
         instructions="Evaluate if {{ outputs }} is high quality",
         model="openai:/gpt-4",
     )
 
-    # Create a session-level instructions judge
     session_level_instruction_judge = make_judge(
         name="conversation_quality",
         instructions="Evaluate if the {{ conversation }} is engaging and coherent",
         model="openai:/gpt-4",
     )
 
-    # Create a Guidelines scorer
     guidelines_scorer = Guidelines(
         name="politeness",
         guidelines=["Be polite", "Be respectful"],
     )
 
-    # Create builtin scorers
-    builtin_scorer_1 = RelevanceToQuery(name="relevance1")
-    builtin_scorer_2 = RelevanceToQuery(name="relevance2")
+    builtin_scorer = RelevanceToQuery(name="relevance_check")
 
-    # Create a session-level builtin scorer
     session_level_builtin_scorer = UserFrustration(name="frustration_check")
 
     data = [
         {
-            "inputs": {"question": "What is MLflow?"},
+            "inputs": {"model_input": ["What is MLflow?"]},
             "outputs": "MLflow is an open source platform.",
         }
     ]
+
+    model = TestModel()
 
     with (
         mock.patch("mlflow.genai.judges.is_context_relevant"),
         mock.patch("mlflow.genai.judges.meets_guidelines"),
         mock.patch("mlflow.genai.judges.utils.invocation_utils.invoke_judge_model"),
     ):
+        # Test with all scorer kinds and scopes, without predict_fn
         mlflow.genai.evaluate(
             data=data,
             scorers=[
-                custom_scorer_1,
-                custom_scorer_2,
+                decorator_scorer,
                 instructions_judge,
                 session_level_instruction_judge,
                 guidelines_scorer,
-                builtin_scorer_1,
-                builtin_scorer_2,
+                builtin_scorer,
                 session_level_builtin_scorer,
             ],
         )
 
         expected_params = {
-            "builtin_scorers": ["Guidelines", "RelevanceToQuery", "UserFrustration"],
             "predict_fn_provided": False,
-            "scorer_kind_count": {
-                "builtin": 3,
-                "decorator": 2,
-                "guidelines": 1,
-                "instructions": 2,
-            },
-            "session_level_scorer_count": 2,
+            "scorer_info": [
+                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+                {"class": "UserDefinedScorer", "kind": "instructions", "scope": "response"},
+                {"class": "UserDefinedScorer", "kind": "instructions", "scope": "session"},
+                {"class": "Guidelines", "kind": "guidelines", "scope": "response"},
+                {"class": "RelevanceToQuery", "kind": "builtin", "scope": "response"},
+                {"class": "UserFrustration", "kind": "builtin", "scope": "session"},
+            ],
+        }
+        validate_telemetry_record(
+            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+        )
+
+        # Test with predict_fn
+        mlflow.genai.evaluate(
+            data=data,
+            scorers=[builtin_scorer, guidelines_scorer],
+            predict_fn=model.predict,
+        )
+        expected_params = {
+            "predict_fn_provided": True,
+            "scorer_info": [
+                {"class": "RelevanceToQuery", "kind": "builtin", "scope": "response"},
+                {"class": "Guidelines", "kind": "guidelines", "scope": "response"},
+            ],
         }
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19138/files) to review incremental changes.
- [**stack/ML-59952-multi-turn-scorer-telemetry**](https://github.com/mlflow/mlflow/pull/19138) [[Files changed](https://github.com/mlflow/mlflow/pull/19138/files)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
#### Context
Currently we have the `builtin-scorers` field in `genai_evaluate` event which helps us measure the count of the multi-turn built-in judges, but we also want to measure the count of multi-turn scorers created by `make_judge` as well which is not captured in the current telemetry.

#### This PR
Add a new field `session_level_scorer_count` to keep track of the number of multi-turn  scorers provided in `genai_evaluate`.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual Test Test Plan
Run the following code snippet in notebook
```
import mlflow
from mlflow.genai.judges import make_judge
from typing import Literal
from mlflow.genai.scorers import Safety, Guidelines, UserFrustration, ConversationCompleteness

traces_from_my_session = mlflow.search_traces(
    experiment_ids=[experiment_id],
    filter_string=f"metadata.`mlflow.trace.session` = '{GOOD_SESSION_ID}'",
    return_type="list",
)

@mlflow.genai.scorer(name="custom_scorer_2")
def custom_scorer_2():
        return 2.0

my_own_multi_turn_scorer = make_judge(
    name="my_own_multi_turn_scorer",
    instructions=(
        "## Instructions:\n"
        "Evaluate the conversation between the user and the agent and determine if the agent is able to make the user happy.\n"
        "## Conversation History: {{ conversation }}\n"
    ),
    feedback_value_type=Literal["happy", "not happy"],
)

result = mlflow.genai.evaluate(
        data=traces_from_my_session,
        scorers=[Safety(name="my_secret_apps_safety_scorer"), Guidelines(
                name="test_guidelines",
                guidelines=["The response must be helpful and accurate"],
        ),
        custom_scorer_2,
        my_own_multi_turn_scorer,
        UserFrustration(),
        ConversationCompleteness()
        ],
);
```

Printed the following record_param value:
```
{
    "predict_fn_provided": false,
    "builtin_scorers": [
      "ConversationCompleteness",
      "Guidelines",
      "Safety",
      "UserFrustration"
    ],
    "scorer_kind_count": {
      "builtin": 3,
      "decorator": 1,
      "guidelines": 1,
      "instructions": 1
    },
    "session_level_scorer_count": 3,
    "mlflow_experiment_id": "21"
  }
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
