### PR TITLE
Fix shared cluster Py4j statefulness issue

### DIFF
--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -722,7 +722,7 @@ def test_capture_imported_modules_excludes_pyspark_gateway_env_vars(monkeypatch,
     Test that PYSPARK_GATEWAY_PORT and PYSPARK_GATEWAY_SECRET are excluded from the
     subprocess environment when capturing imported modules.
 
-    These env vars, if inherited by the subprocess, can cause the subprocess to connect
+    These env vars, if inherited by a subprocess, can cause the subprocess to connect
     to the parent's py4j gateway. Libraries like databricks-sdk may then corrupt the
     parent's gateway state, causing delayed py4j errors like
     "Error while obtaining a new communication channel".
@@ -751,11 +751,5 @@ def test_capture_imported_modules_excludes_pyspark_gateway_env_vars(monkeypatch,
         except MlflowException:
             pass
 
-    assert "PYSPARK_GATEWAY_PORT" not in captured_env, (
-        "PYSPARK_GATEWAY_PORT should not be passed to subprocess - "
-        "it can cause the subprocess to interfere with the parent's py4j gateway"
-    )
-    assert "PYSPARK_GATEWAY_SECRET" not in captured_env, (
-        "PYSPARK_GATEWAY_SECRET should not be passed to subprocess - "
-        "it can cause the subprocess to interfere with the parent's py4j gateway"
-    )
+    assert "PYSPARK_GATEWAY_PORT" not in captured_env
+    assert "PYSPARK_GATEWAY_SECRET" not in captured_env

--- a/tests/utils/test_requirements_utils.py
+++ b/tests/utils/test_requirements_utils.py
@@ -740,16 +740,16 @@ def test_capture_imported_modules_excludes_pyspark_gateway_env_vars(monkeypatch,
         mock.patch(
             "mlflow.utils.requirements_utils._run_command",
             side_effect=mock_run_command,
-        ),
+        ) as mock_run,
         mock.patch(
             "mlflow.utils.requirements_utils._download_artifact_from_uri",
             return_value=str(tmp_path),
-        ),
+        ) as mock_download,
     ):
-        try:
+        with pytest.raises(MlflowException, match="Mocked"):
             _capture_imported_modules("fake/model/path", "pyfunc")
-        except MlflowException:
-            pass
 
+    mock_download.assert_called_once()
+    mock_run.assert_called_once()
     assert "PYSPARK_GATEWAY_PORT" not in captured_env
     assert "PYSPARK_GATEWAY_SECRET" not in captured_env


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/19139?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19139/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19139/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19139/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fix for shared clusters issue with py4j rejected connection timeouts when saving / logging models.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [X] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [X] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
