### PR TITLE
Include environment variable fallback for SGC run resumption

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -1132,3 +1132,10 @@ MLFLOW_JUDGE_MAX_ITERATIONS = _EnvironmentVariable("MLFLOW_JUDGE_MAX_ITERATIONS"
 _MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS = _BooleanEnvironmentVariable(
     "MLFLOW_ENABLE_SGC_RUN_RESUMPTION_FOR_DATABRICKS_JOBS", True
 )
+
+#: Serverless GPU Compute (SGC) job run ID for automatic run resumption on Databricks.
+#: This is used as a fallback when the dbutils widget parameter is not available.
+#: (default: ``None``)
+_SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID = _EnvironmentVariable(
+    "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", str, None
+)

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -1061,12 +1061,9 @@ def get_sgc_job_run_id() -> str | None:
         str or None: The SGC job run ID if available, otherwise None. Returns None
         when neither the widget nor environment variable is set.
     """
-    job_run_id = None
-
     try:
         dbutils = _get_dbutils()
-        job_run_id = dbutils.widgets.get("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID")
-        if job_run_id:
+        if job_run_id := dbutils.widgets.get("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"):
             _logger.debug(f"SGC job run ID from dbutils widget: {job_run_id}")
             return job_run_id
     except _NoDbutilsError:
@@ -1074,8 +1071,7 @@ def get_sgc_job_run_id() -> str | None:
     except Exception as e:
         _logger.debug(f"Failed to retrieve SGC job run ID from dbutils widget: {e}", exc_info=True)
 
-    job_run_id = _SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID.get()
-    if job_run_id:
+    if job_run_id := _SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID.get():
         _logger.debug(f"SGC job run ID from environment variable: {job_run_id}")
         return job_run_id
 

--- a/mlflow/utils/databricks_utils.py
+++ b/mlflow/utils/databricks_utils.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
 
 import mlflow.utils
 from mlflow.environment_variables import (
+    _SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID,
     MLFLOW_ENABLE_DB_SDK,
     MLFLOW_TRACKING_URI,
 )
@@ -1050,28 +1051,35 @@ def check_databricks_secret_scope_access(scope_name):
 
 def get_sgc_job_run_id() -> str | None:
     """
-    Retrieves the Serverless GPU Compute (SGC) job run ID from Databricks task values.
+    Retrieves the Serverless GPU Compute (SGC) job run ID from Databricks.
 
     This function is used to enable automatic run resumption for SGC jobs by fetching
-    the job run ID from the Databricks task context. The job run ID is set by the
-    Databricks platform when running SGC jobs.
+    the job run ID. It first checks the Databricks widget parameter, then falls back
+    to checking the environment variable if the widget is not found.
 
     Returns:
-        str or None: The SGC job run ID if available, otherwise None. Returns None in
-        non-Databricks environments or when the task value is not set.
+        str or None: The SGC job run ID if available, otherwise None. Returns None
+        when neither the widget nor environment variable is set.
     """
-    try:
-        dbutils = _get_dbutils()
-    except _NoDbutilsError:
-        return None
+    job_run_id = None
 
     try:
+        dbutils = _get_dbutils()
         job_run_id = dbutils.widgets.get("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID")
-        _logger.debug(f"SGC job run ID: {job_run_id}")
-        return job_run_id
+        if job_run_id:
+            _logger.debug(f"SGC job run ID from dbutils widget: {job_run_id}")
+            return job_run_id
+    except _NoDbutilsError:
+        _logger.debug("dbutils not available, checking environment variable")
     except Exception as e:
-        _logger.debug(f"Failed to retrieve SGC job run ID from task values: {e}", exc_info=True)
-        return None
+        _logger.debug(f"Failed to retrieve SGC job run ID from dbutils widget: {e}", exc_info=True)
+
+    job_run_id = _SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID.get()
+    if job_run_id:
+        _logger.debug(f"SGC job run ID from environment variable: {job_run_id}")
+        return job_run_id
+
+    return None
 
 
 def _construct_databricks_run_url(

--- a/tests/utils/test_databricks_utils.py
+++ b/tests/utils/test_databricks_utils.py
@@ -869,7 +869,8 @@ def test_get_databricks_workspace_client_config_client_creation_error():
             get_databricks_workspace_client_config("databricks://profile")
 
 
-def test_get_sgc_job_run_id_success():
+def test_get_sgc_job_run_id_success(monkeypatch):
+    monkeypatch.delenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", raising=False)
     mock_dbutils = mock.MagicMock()
     mock_dbutils.widgets.get.return_value = "test_job_run_id_12345"
 
@@ -881,19 +882,80 @@ def test_get_sgc_job_run_id_success():
         )
 
 
-def test_get_sgc_job_run_id_no_dbutils():
+def test_get_sgc_job_run_id_no_dbutils(monkeypatch):
+    monkeypatch.delenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", raising=False)
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", side_effect=_NoDbutilsError()):
         result = get_sgc_job_run_id()
         assert result is None
 
 
-def test_get_sgc_job_run_id_value_error():
+def test_get_sgc_job_run_id_no_dbutils_with_env_var(monkeypatch):
+    monkeypatch.setenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", "env_job_run_id_456")
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", side_effect=_NoDbutilsError()):
+        result = get_sgc_job_run_id()
+        assert result == "env_job_run_id_456"
+
+
+def test_get_sgc_job_run_id_value_error(monkeypatch):
+    monkeypatch.delenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", raising=False)
     mock_dbutils = mock.MagicMock()
     mock_dbutils.widgets.get.side_effect = ValueError("Widget not found")
 
     with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
         result = get_sgc_job_run_id()
         assert result is None
+        mock_dbutils.widgets.get.assert_called_once_with(
+            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
+        )
+
+
+def test_get_sgc_job_run_id_value_error_with_env_var(monkeypatch):
+    monkeypatch.setenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", "env_job_run_id_789")
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.widgets.get.side_effect = ValueError("Widget not found")
+
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        result = get_sgc_job_run_id()
+        assert result == "env_job_run_id_789"
+        mock_dbutils.widgets.get.assert_called_once_with(
+            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
+        )
+
+
+def test_get_sgc_job_run_id_empty_widget_with_env_var(monkeypatch):
+    monkeypatch.setenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", "env_job_run_id_999")
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.widgets.get.return_value = ""
+
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        result = get_sgc_job_run_id()
+        assert result == "env_job_run_id_999"
+        mock_dbutils.widgets.get.assert_called_once_with(
+            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
+        )
+
+
+def test_get_sgc_job_run_id_none_widget_with_env_var(monkeypatch):
+    monkeypatch.setenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", "env_job_run_id_111")
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.widgets.get.return_value = None
+
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        result = get_sgc_job_run_id()
+        assert result == "env_job_run_id_111"
+        mock_dbutils.widgets.get.assert_called_once_with(
+            "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
+        )
+
+
+def test_get_sgc_job_run_id_widget_takes_precedence_over_env_var(monkeypatch):
+    monkeypatch.setenv("SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID", "env_job_run_id_222")
+    mock_dbutils = mock.MagicMock()
+    mock_dbutils.widgets.get.return_value = "widget_job_run_id_333"
+
+    with mock.patch("mlflow.utils.databricks_utils._get_dbutils", return_value=mock_dbutils):
+        result = get_sgc_job_run_id()
+        assert result == "widget_job_run_id_333"
         mock_dbutils.widgets.get.assert_called_once_with(
             "SERVERLESS_GPU_COMPUTE_ASSOCIATED_JOB_RUN_ID"
         )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/artjen/mlflow/pull/19143?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19143/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19143/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19143/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs
https://github.com/mlflow/mlflow/pull/19015

### What changes are proposed in this pull request?
Add a fallback mechanism to resolve the SGC run resumption id using an environment variable. 
Short term, SGC (aka SkyRun) will not support dbutils and requires another way to resolve the run resumption id.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests: [notebook](https://e2-spog.staging.cloud.databricks.com/editor/notebooks/3548418520573043?o=6051921418418893)

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
