### PR TITLE
[BUG FIX] Fix Managed Scorer Register Failure

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -625,7 +625,7 @@ class InstructionsJudge(Judge):
         """
         model = pydantic.create_model(
             "FeedbackValueSchema",
-            result=feedback_value_type,
+            result=(feedback_value_type, ...),
         )
         return model.model_json_schema()["properties"]["result"]
 

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -2759,6 +2759,32 @@ def test_make_judge_serialization_with_feedback_value_type():
     assert typing.get_args(restored_list._feedback_value_type) == (str,)
 
 
+def test_judge_with_literal_type_serialization():
+    literal_type = Literal["good", "bad"]
+    judge = make_judge(
+        name="test_judge",
+        instructions="Rate the response as {{ inputs }}",
+        feedback_value_type=literal_type,
+        model="databricks:/databricks-meta-llama-3-1-70b-instruct",
+    )
+
+    # Test serialization
+    serialized = InstructionsJudge._serialize_feedback_value_type(literal_type)
+    assert "enum" in serialized
+    assert serialized["enum"] == ["good", "bad"]
+
+    # Test model validate
+    dumped = judge.model_dump()
+    restored = Scorer.model_validate(dumped)
+    assert restored.name == "test_judge"
+    assert restored._feedback_value_type is not None
+
+    # Test register
+    registered = judge.register()
+    assert registered.name == "test_judge"
+    assert registered._feedback_value_type is not None
+
+
 def test_make_judge_validates_feedback_value_type():
     # Valid types should work
     make_judge(


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19146/files) to review incremental changes.
- [**stack/ML-59988-Managed-Scorer-Register-Fails**](https://github.com/mlflow/mlflow/pull/19146) [[Files changed](https://github.com/mlflow/mlflow/pull/19146/files)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?
Currently registering `InstructionsJudge` in databricks managed environment throws the following exception:
```
ValueError: Scorer 'conversation_politeness_bbb' is not valid: A non-annotated attribute was detected: `result = typing.Literal['consistently_polite', 'mostly_polite', 'impolite']`. All model fields require a type annotation; if `result` is not meant to be a field, you may be able to resolve this error by annotating it as a `ClassVar` or updating `model_config['ignored_types']`.

For further information visit https://errors.pydantic.dev/2.10/u/model-field-missing-annotation.

Common reasons your scorer may not be valid:
- Non self-contained code (packages used within scorer function body should be imported inline)
- Type hints requiring imports in scorer function signature
- Invalid code environment (e.g. missing dependencies)
[Trace ID: 00-7a309bdd04091586e39d459606b82dde-e756bfc23b651113-00]
File /local_disk0/.ephemeral_nfs/envs/pythonEnv-7e9fe0a6-8eaf-4282-9ff4-f865e11a6acd/lib/python3.12/site-packages/databricks/rag_eval/monitoring/scheduled_scorers.py:33, in _validate_scorer(scorer)
     32 try:
---> 33     Scorer.model_validate(scorer.model_dump())
     34 except Exception as e:
File /local_disk0/.ephemeral_nfs/envs/pythonEnv-7e9fe0a6-8eaf-4282-9ff4-f865e11a6acd/lib/python3.12/site-packages/databricks/rag_eval/monitoring/scheduled_scorers.py:35, in _validate_scorer(scorer)
     33     Scorer.model_validate(scorer.model_dump())
     34 except Exception as e:
---> 35     raise ValueError(f"Scorer '{scorer.name}' is not valid: {e}.\n\n{invalid_scorer_explanation}")
```

This error happens because line 628 on  mlflow/genai/judges/instructions_judge/__init__.py
```
model = pydantic.create_model(
    "FeedbackValueSchema",
    result=feedback_value_type, 
)
```
uses Pydantic v1 syntax (field=type), but MLflow uses Pydantic v2, which requires fields to be defined as tuples: field=(type, default). Without the tuple syntax, Pydantic v2 treats result as a class attribute rather than a field definition, triggering the "non-annotated attribute" error.

This PR updated the code to use the tuple format (type, ...) which explicitly tells Pydantic v2:
- The field name is result
- The field type is feedback_value_type (e.g., Literal["a", "b", "c"])
- The ... (Ellipsis) indicates it's a required field with no default value

This change:
- Aligns with Pydantic v2 requirements (MLflow uses pydantic >= 2.0.0)
- Matches the existing pattern used elsewhere in the codebase (see line 556-558 in the same file)
- Enables judges with Literal feedback_value_type to be registered on managed Databricks
<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual Test Test Plan:
Tested with the fully Databricks Notebook:
https://e2-dogfood.staging.cloud.databricks.com/editor/notebooks/3548418520551959?o=6051921418418893

The error goes away when pip install from this PR:
<img width="836" height="563" alt="image" src="https://github.com/user-attachments/assets/0b9de2da-915e-4f49-a35e-6aa46c6e74f6" />

Verified OSS register still works:
<img width="710" height="434" alt="image" src="https://github.com/user-attachments/assets/f95a32d6-fe81-483e-aaf3-88e332aeeaae" />

#### New Unit Test
Testing with `pydantic 2.10.6`

**Before:**
```
============================================ short test summary info ============================================
FAILED | MEM 31.9/64.0 GB | DISK 10.5/926.4 GB tests/genai/judges/test_make_judge.py::test_judge_with_literal_type_serialization - pydantic.errors.PydanticUserError: A non-annotated attribute was detected: `result = typing.Literal['good', ...
=============================================== 1 failed in 1.62s ===============================================
```

**After:**
```
tests/genai/judges/test_make_judge.py::test_judge_with_literal_type_serialization PASSED | MEM 32.1/64.0 GB | DISK 10.5/926.4 GB [100%]
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
