### PR TITLE
Add experiment prompts functionality

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
@@ -17,7 +17,7 @@ const ExperimentPageRoutePathToTabNameMap = map(
     [RoutePaths.experimentPageTabScorers]: ExperimentPageTabName.Judges,
     // OSS experiment prompt page routes
     [RoutePaths.experimentPageTabPrompts]: ExperimentPageTabName.Prompts,
-    [RoutePaths.experimentPromptDetails]: ExperimentPageTabName.Prompts,
+    [RoutePaths.experimentPageTabPromptDetails]: ExperimentPageTabName.Prompts,
   },
   (tabName, routePath) => ({ routePath, tabName }),
 );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
@@ -15,8 +15,9 @@ const ExperimentPageRoutePathToTabNameMap = map(
     [RoutePaths.experimentPageTabChatSessions]: ExperimentPageTabName.ChatSessions,
     [RoutePaths.experimentPageTabSingleChatSession]: ExperimentPageTabName.SingleChatSession,
     [RoutePaths.experimentPageTabScorers]: ExperimentPageTabName.Judges,
-    [RoutePaths.experimentPromptsList]: ExperimentPageTabName.Prompts,
-    [RoutePaths.experimentPrompt]: ExperimentPageTabName.Prompts,
+    // OSS experiment prompt page routes
+    [RoutePaths.experimentPageTabPrompts]: ExperimentPageTabName.Prompts,
+    [RoutePaths.experimentPromptDetails]: ExperimentPageTabName.Prompts,
   },
   (tabName, routePath) => ({ routePath, tabName }),
 );

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
@@ -15,6 +15,8 @@ const ExperimentPageRoutePathToTabNameMap = map(
     [RoutePaths.experimentPageTabChatSessions]: ExperimentPageTabName.ChatSessions,
     [RoutePaths.experimentPageTabSingleChatSession]: ExperimentPageTabName.SingleChatSession,
     [RoutePaths.experimentPageTabScorers]: ExperimentPageTabName.Judges,
+    [RoutePaths.experimentPromptsList]: ExperimentPageTabName.Prompts,
+    [RoutePaths.experimentPrompt]: ExperimentPageTabName.Prompts,
   },
   (tabName, routePath) => ({ routePath, tabName }),
 );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.test.tsx
@@ -56,7 +56,7 @@ describe('ExperimentPageSideNav', () => {
       expect(screen.getByText('Datasets')).toBeInTheDocument();
 
       // Check prompts & versions section
-      const versionsSectionHeader = 'Versions';
+      const versionsSectionHeader = 'Prompts & versions';
       expect(screen.getByText(versionsSectionHeader)).toBeInTheDocument();
       expect(screen.getByText('Agent versions')).toBeInTheDocument();
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/constants.tsx
@@ -69,6 +69,16 @@ const ExperimentPageSideNavGenAIConfig = {
     {
       label: (
         <FormattedMessage
+          defaultMessage="Prompts"
+          description="Label for the prompts tab in the MLflow experiment navbar"
+        />
+      ),
+      icon: <TextBoxIcon />,
+      tabName: ExperimentPageTabName.Prompts,
+    },
+    {
+      label: (
+        <FormattedMessage
           defaultMessage="Agent versions"
           description="Label for the agent versions tab in the MLflow experiment navbar"
         />
@@ -132,7 +142,7 @@ export const getExperimentPageSideNavSectionLabel = (
     case 'prompts-versions':
       return (
         <FormattedMessage
-          defaultMessage="Versions"
+          defaultMessage="Prompts & versions"
           description="Label for the versions section in the MLflow experiment navbar"
         />
       );

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/ExperimentPromptDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/ExperimentPromptDetailsPage.tsx
@@ -1,0 +1,12 @@
+import invariant from 'invariant';
+import { useParams } from '../../../common/utils/RoutingUtils';
+import PromptsDetailsPage from './PromptsDetailsPage';
+
+const ExperimentPromptDetailsPage = () => {
+  const { experimentId } = useParams();
+  invariant(experimentId, 'Experiment ID must be defined');
+
+  return <PromptsDetailsPage experimentId={experimentId} />;
+};
+
+export default ExperimentPromptDetailsPage;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/ExperimentPromptsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/ExperimentPromptsPage.tsx
@@ -1,0 +1,12 @@
+import invariant from 'invariant';
+import { useParams } from '../../../common/utils/RoutingUtils';
+import PromptsPage from './PromptsPage';
+
+const ExperimentPromptsPage = () => {
+  const { experimentId } = useParams();
+  invariant(experimentId, 'Experiment ID must be defined');
+
+  return <PromptsPage experimentId={experimentId} />;
+};
+
+export default ExperimentPromptsPage;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -38,6 +38,7 @@ import { PromptNotFoundView } from './components/PromptNotFoundView';
 import { useUpdatePromptVersionMetadataModal } from './hooks/useUpdatePromptVersionMetadataModal';
 import type { ThunkDispatch } from '../../../redux-types';
 import { setModelVersionAliasesApi } from '../../../model-registry/actions';
+import { ExperimentPageTabName } from '../../constants';
 
 const getAliasesModalTitle = (version: string) => (
   <FormattedMessage
@@ -75,7 +76,9 @@ const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) =>
     registeredPrompt: promptDetailsData?.prompt,
     onSuccess: () =>
       navigate(
-        experimentId ? Routes.getExperimentPageTabRoute(experimentId, 'prompts' as any) : Routes.promptsPageRoute,
+        experimentId
+          ? Routes.getExperimentPageTabRoute(experimentId, ExperimentPageTabName.Prompts)
+          : Routes.promptsPageRoute,
       ),
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -47,7 +47,7 @@ const getAliasesModalTitle = (version: string) => (
   />
 );
 
-const PromptsDetailsPage = () => {
+const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) => {
   const { promptName } = useParams<{ promptName: string }>();
   const { theme } = useDesignSystemTheme();
   const navigate = useNavigate();
@@ -62,6 +62,7 @@ const PromptsDetailsPage = () => {
     mode: CreatePromptModalMode.CreatePromptVersion,
     registeredPrompt: promptDetailsData?.prompt,
     latestVersion: first(promptDetailsData?.versions),
+    experimentId,
     onSuccess: async ({ promptVersion }) => {
       await refetch();
       if (promptVersion) {
@@ -72,7 +73,10 @@ const PromptsDetailsPage = () => {
 
   const { DeletePromptModal, openModal: openDeleteModal } = useDeletePromptModal({
     registeredPrompt: promptDetailsData?.prompt,
-    onSuccess: () => navigate(Routes.promptsPageRoute),
+    onSuccess: () =>
+      navigate(
+        experimentId ? Routes.getExperimentPageTabRoute(experimentId, 'prompts' as any) : Routes.promptsPageRoute,
+      ),
   });
 
   const { EditPromptVersionMetadataModal, showEditPromptVersionMetadataModal } = useUpdatePromptVersionMetadataModal({
@@ -135,13 +139,13 @@ const PromptsDetailsPage = () => {
     return <PromptNotFoundView promptName={promptName} />;
   }
 
-  const breadcrumbs = (
+  const breadcrumbs = !experimentId ? (
     <Breadcrumb>
       <Breadcrumb.Item>
         <Link to={Routes.promptsPageRoute}>Prompts</Link>
       </Breadcrumb.Item>
     </Breadcrumb>
-  );
+  ) : undefined;
 
   if (isLoading) {
     return (

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
@@ -14,19 +14,20 @@ import ErrorUtils from '../../../common/utils/ErrorUtils';
 import { PromptPageErrorHandler } from './components/PromptPageErrorHandler';
 import { useDebounce } from 'use-debounce';
 
-const PromptsPage = () => {
+const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
   const [searchFilter, setSearchFilter] = useState('');
   const navigate = useNavigate();
 
   const [debouncedSearchFilter] = useDebounce(searchFilter, 500);
 
   const { data, error, refetch, hasNextPage, hasPreviousPage, isLoading, onNextPage, onPreviousPage } =
-    usePromptsListQuery({ searchFilter: debouncedSearchFilter });
+    usePromptsListQuery({ experimentId, searchFilter: debouncedSearchFilter });
 
   const { EditTagsModal, showEditPromptTagsModal } = useUpdateRegisteredPromptTags({ onSuccess: refetch });
   const { CreatePromptModal, openModal: openCreateVersionModal } = useCreatePromptModal({
     mode: CreatePromptModalMode.CreatePrompt,
-    onSuccess: ({ promptName }) => navigate(Routes.getPromptDetailsPageRoute(promptName)),
+    experimentId,
+    onSuccess: ({ promptName }) => navigate(Routes.getPromptDetailsPageRoute(promptName, experimentId)),
   });
 
   return (
@@ -62,6 +63,7 @@ const PromptsPage = () => {
           onNextPage={onNextPage}
           onPreviousPage={onPreviousPage}
           onEditTags={showEditPromptTagsModal}
+          experimentId={experimentId}
         />
       </div>
       {EditTagsModal}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/api.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/api.test.ts
@@ -77,3 +77,114 @@ describe('buildSearchFilterClause', () => {
     expect(buildSearchFilterClause(complexFilter)).toBe(complexFilter);
   });
 });
+
+describe('RegisteredPromptsApi.listRegisteredPrompts with experimentId', () => {
+  const server = setupServer();
+
+  it('should include experiment ID filter when experimentId is provided', async () => {
+    const experimentId = '123';
+    let capturedFilter = '';
+
+    server.use(
+      rest.get('/ajax-api/2.0/mlflow/registered-models/search', (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter') || '';
+        return res(
+          ctx.json({
+            registered_models: [],
+          }),
+        );
+      }),
+    );
+
+    await RegisteredPromptsApi.listRegisteredPrompts(undefined, undefined, experimentId);
+
+    expect(capturedFilter).toContain("tags.`mlflow.prompt.is_prompt` = 'true'");
+    expect(capturedFilter).toContain(`tags.\`_mlflow_experiment_ids\` ILIKE '%,${experimentId},%'`);
+    expect(capturedFilter).toContain(' AND ');
+  });
+
+  it('should combine experiment ID filter with search filter', async () => {
+    const experimentId = '456';
+    const searchFilter = 'my-prompt';
+    let capturedFilter = '';
+
+    server.use(
+      rest.get('/ajax-api/2.0/mlflow/registered-models/search', (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter') || '';
+        return res(
+          ctx.json({
+            registered_models: [],
+          }),
+        );
+      }),
+    );
+
+    await RegisteredPromptsApi.listRegisteredPrompts(searchFilter, undefined, experimentId);
+
+    expect(capturedFilter).toContain("tags.`mlflow.prompt.is_prompt` = 'true'");
+    expect(capturedFilter).toContain(`tags.\`_mlflow_experiment_ids\` ILIKE '%,${experimentId},%'`);
+    expect(capturedFilter).toContain("name ILIKE '%my-prompt%'");
+  });
+
+  it('should not include experiment ID filter when experimentId is not provided', async () => {
+    let capturedFilter = '';
+
+    server.use(
+      rest.get('/ajax-api/2.0/mlflow/registered-models/search', (req, res, ctx) => {
+        capturedFilter = req.url.searchParams.get('filter') || '';
+        return res(
+          ctx.json({
+            registered_models: [],
+          }),
+        );
+      }),
+    );
+
+    await RegisteredPromptsApi.listRegisteredPrompts();
+
+    expect(capturedFilter).toContain("tags.`mlflow.prompt.is_prompt` = 'true'");
+    expect(capturedFilter).not.toContain('_mlflow_experiment_ids');
+  });
+});
+
+describe('RegisteredPromptsApi.createRegisteredPrompt with additionalTags', () => {
+  const server = setupServer();
+
+  it('should include additional tags when creating a prompt', async () => {
+    let capturedBody: any = null;
+
+    server.use(
+      rest.post('/ajax-api/2.0/mlflow/registered-models/create', async (req, res, ctx) => {
+        capturedBody = await req.json();
+        return res(ctx.json({}));
+      }),
+    );
+
+    const additionalTags = [{ key: '_mlflow_experiment_ids', value: ',789,' }];
+    await RegisteredPromptsApi.createRegisteredPrompt('test-prompt', additionalTags);
+
+    expect(capturedBody.name).toBe('test-prompt');
+    expect(capturedBody.tags).toEqual(
+      expect.arrayContaining([
+        { key: 'mlflow.prompt.is_prompt', value: 'true' },
+        { key: '_mlflow_experiment_ids', value: ',789,' },
+      ]),
+    );
+  });
+
+  it('should only include default tag when no additional tags provided', async () => {
+    let capturedBody: any = null;
+
+    server.use(
+      rest.post('/ajax-api/2.0/mlflow/registered-models/create', async (req, res, ctx) => {
+        capturedBody = await req.json();
+        return res(ctx.json({}));
+      }),
+    );
+
+    await RegisteredPromptsApi.createRegisteredPrompt('test-prompt');
+
+    expect(capturedBody.name).toBe('test-prompt');
+    expect(capturedBody.tags).toEqual([{ key: 'mlflow.prompt.is_prompt', value: 'true' }]);
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTable.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTable.tsx
@@ -78,6 +78,7 @@ export const PromptsListTable = ({
   onNextPage,
   onPreviousPage,
   onEditTags,
+  experimentId,
 }: {
   prompts?: RegisteredPrompt[];
   error?: Error;
@@ -88,6 +89,7 @@ export const PromptsListTable = ({
   onNextPage: () => void;
   onPreviousPage: () => void;
   onEditTags: (editedEntity: RegisteredPrompt) => void;
+  experimentId?: string;
 }) => {
   const { theme } = useDesignSystemTheme();
   const columns = usePromptsTableColumns();
@@ -99,7 +101,7 @@ export const PromptsListTable = ({
       columns,
       getCoreRowModel: getCoreRowModel(),
       getRowId: (row, index) => row.name ?? index.toString(),
-      meta: { onEditTags } satisfies PromptsTableMetadata,
+      meta: { onEditTags, experimentId } satisfies PromptsTableMetadata,
     },
   );
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTableNameCell.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptsListTableNameCell.tsx
@@ -2,12 +2,20 @@ import type { ColumnDef } from '@tanstack/react-table';
 import { Link } from '../../../../common/utils/RoutingUtils';
 import Routes from '../../../routes';
 import type { RegisteredPrompt } from '../types';
+import type { PromptsTableMetadata } from '../utils';
 
-export const PromptsListTableNameCell: ColumnDef<RegisteredPrompt>['cell'] = ({ row: { original }, getValue }) => {
+export const PromptsListTableNameCell: ColumnDef<RegisteredPrompt>['cell'] = ({
+  row: { original },
+  getValue,
+  table: {
+    options: { meta },
+  },
+}) => {
   const name = getValue<string>();
+  const { experimentId } = (meta || {}) as PromptsTableMetadata;
 
   if (!original.name) {
     return name;
   }
-  return <Link to={Routes.getPromptDetailsPageRoute(encodeURIComponent(original.name))}>{name}</Link>;
+  return <Link to={Routes.getPromptDetailsPageRoute(encodeURIComponent(original.name), experimentId)}>{name}</Link>;
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -18,6 +18,7 @@ import {
   isChatPrompt,
   PROMPT_TYPE_CHAT,
   PROMPT_TYPE_TEXT,
+  PROMPT_EXPERIMENT_IDS_TAG_KEY,
 } from '../utils';
 import type { ChatPromptMessage } from '../types';
 import { ChatMessageCreator } from '../components/ChatMessageCreator';
@@ -31,11 +32,13 @@ export const useCreatePromptModal = ({
   mode = CreatePromptModalMode.CreatePromptVersion,
   registeredPrompt,
   latestVersion,
+  experimentId,
   onSuccess,
 }: {
   mode: CreatePromptModalMode;
   registeredPrompt?: RegisteredPrompt;
   latestVersion?: RegisteredPromptVersion;
+  experimentId?: string;
   onSuccess?: (result: { promptName: string; promptVersion?: string }) => void | Promise<any>;
 }) => {
   const [open, setOpen] = useState(false);
@@ -113,6 +116,9 @@ export const useCreatePromptModal = ({
             content: message.content.trim(),
           }));
 
+          // Prepare experiment ID tag which has `,${experimentId},` format
+          const promptTags = experimentId ? [{ key: PROMPT_EXPERIMENT_IDS_TAG_KEY, value: `,${experimentId},` }] : [];
+
           mutateCreateVersion(
             {
               createPromptEntity: isCreatingNewPrompt,
@@ -120,6 +126,7 @@ export const useCreatePromptModal = ({
               commitMessage: values.commitMessage,
               promptName,
               tags: values.tags,
+              promptTags,
               promptType: values.promptType,
             },
             {

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreateRegisteredPromptMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreateRegisteredPromptMutation.tsx
@@ -10,13 +10,22 @@ type UpdateContentPayload = {
   content: string;
   commitMessage?: string;
   tags: { key: string; value: string }[];
+  promptTags?: { key: string; value: string }[];
 };
 
 export const useCreateRegisteredPromptMutation = () => {
   const updateMutation = useMutation<{ version: string }, Error, UpdateContentPayload>({
-    mutationFn: async ({ promptName, promptType, createPromptEntity, content, commitMessage, tags }) => {
+    mutationFn: async ({
+      promptName,
+      promptType,
+      createPromptEntity,
+      content,
+      commitMessage,
+      tags,
+      promptTags = [],
+    }) => {
       if (createPromptEntity) {
-        await RegisteredPromptsApi.createRegisteredPrompt(promptName);
+        await RegisteredPromptsApi.createRegisteredPrompt(promptName, promptTags);
       }
 
       const version = await RegisteredPromptsApi.createRegisteredPromptVersion(

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/usePromptsListQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/usePromptsListQuery.tsx
@@ -5,16 +5,18 @@ import type { RegisteredPromptsListResponse } from '../types';
 import { RegisteredPromptsApi } from '../api';
 
 const queryFn = ({ queryKey }: QueryFunctionContext<PromptsListQueryKey>) => {
-  const [, { searchFilter, pageToken }] = queryKey;
-  return RegisteredPromptsApi.listRegisteredPrompts(searchFilter, pageToken);
+  const [, { searchFilter, pageToken, experimentId }] = queryKey;
+  return RegisteredPromptsApi.listRegisteredPrompts(searchFilter, pageToken, experimentId);
 };
 
-type PromptsListQueryKey = ['prompts_list', { searchFilter?: string; pageToken?: string }];
+type PromptsListQueryKey = ['prompts_list', { searchFilter?: string; pageToken?: string; experimentId?: string }];
 
 export const usePromptsListQuery = ({
   searchFilter,
+  experimentId,
 }: {
   searchFilter?: string;
+  experimentId?: string;
 } = {}) => {
   const previousPageTokens = useRef<(string | undefined)[]>([]);
 
@@ -25,7 +27,7 @@ export const usePromptsListQuery = ({
     Error,
     RegisteredPromptsListResponse,
     PromptsListQueryKey
-  >(['prompts_list', { searchFilter, pageToken: currentPageToken }], {
+  >(['prompts_list', { searchFilter, pageToken: currentPageToken, experimentId }], {
     queryFn,
     retry: false,
   });

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -13,11 +13,16 @@ export const IS_PROMPT_TAG_VALUE = 'true';
 export const PROMPT_TYPE_TEXT = 'text' as const;
 export const PROMPT_TYPE_CHAT = 'chat' as const;
 export const PROMPT_TYPE_TAG_KEY = '_mlflow_prompt_type';
+// Tag key used to store comma-separated experiment IDs associated with a prompt
+export const PROMPT_EXPERIMENT_IDS_TAG_KEY = '_mlflow_experiment_ids';
 
 // Query parameter name for specifying prompt version in URLs
 export const PROMPT_VERSION_QUERY_PARAM = 'promptVersion';
 
-export type PromptsTableMetadata = { onEditTags: (editedEntity: RegisteredPrompt) => void };
+export type PromptsTableMetadata = {
+  onEditTags: (editedEntity: RegisteredPrompt) => void;
+  experimentId?: string;
+};
 export type PromptsVersionsTableMetadata = {
   showEditAliasesModal: (versionNumber: string) => void;
   aliasesByVersion: Record<string, string[]>;

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -81,6 +81,16 @@ const getExperimentPageRouteDefs = () => {
             return import('./pages/experiment-evaluation-datasets/ExperimentEvaluationDatasetsPage');
           }),
         },
+        {
+          path: RoutePaths.experimentPromptsList,
+          pageId: PageId.experimentPromptsList,
+          element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptsPage')),
+        },
+        {
+          path: RoutePaths.experimentPrompt,
+          pageId: PageId.experimentPromptDetails,
+          element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptDetailsPage')),
+        },
       ],
     },
   ];

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -87,8 +87,8 @@ const getExperimentPageRouteDefs = () => {
           element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptsPage')),
         },
         {
-          path: RoutePaths.experimentPromptDetails,
-          pageId: PageId.experimentPromptDetails,
+          path: RoutePaths.experimentPageTabPromptDetails,
+          pageId: PageId.experimentPageTabPromptDetails,
           element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptDetailsPage')),
         },
       ],

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -82,12 +82,12 @@ const getExperimentPageRouteDefs = () => {
           }),
         },
         {
-          path: RoutePaths.experimentPromptsList,
-          pageId: PageId.experimentPromptsList,
+          path: RoutePaths.experimentPageTabPrompts,
+          pageId: PageId.experimentPageTabPrompts,
           element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptsPage')),
         },
         {
-          path: RoutePaths.experimentPrompt,
+          path: RoutePaths.experimentPromptDetails,
           pageId: PageId.experimentPromptDetails,
           element: createLazyRouteElement(() => import('./pages/prompts/ExperimentPromptDetailsPage')),
         },

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -23,7 +23,7 @@ export enum PageId {
   experimentPageTabSingleChatSession = 'mlflow.experiment.tab.single-chat-session',
   experimentPageTabScorers = 'mlflow.experiment.tab.scorers',
   experimentPageTabPrompts = 'mlflow.experiment.prompts.list',
-  experimentPromptDetails = 'mlflow.experiment.prompt.details',
+  experimentPageTabPromptDetails = 'mlflow.experiment.prompt.details',
   // Child routes for experiment page - end
   experimentPageSearch = 'mlflow.experiment.details.search',
   compareExperimentsSearch = 'mlflow.experiment.compare',
@@ -98,7 +98,7 @@ export class RoutePaths {
   static get experimentPageTabPrompts() {
     return createMLflowRoutePath('/experiments/:experimentId/prompts');
   }
-  static get experimentPromptDetails() {
+  static get experimentPageTabPromptDetails() {
     return createMLflowRoutePath('/experiments/:experimentId/prompts/:promptName');
   }
   static get runPageDirect() {
@@ -298,7 +298,7 @@ class Routes {
 
   static getPromptDetailsPageRoute(promptName: string, experimentId?: string) {
     if (experimentId) {
-      return generatePath(RoutePaths.experimentPromptDetails, { experimentId, promptName });
+      return generatePath(RoutePaths.experimentPageTabPromptDetails, { experimentId, promptName });
     }
     return generatePath(RoutePaths.promptDetailsPage, { promptName });
   }

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -22,7 +22,7 @@ export enum PageId {
   experimentPageTabChatSessions = 'mlflow.experiment.tab.chat-sessions',
   experimentPageTabSingleChatSession = 'mlflow.experiment.tab.single-chat-session',
   experimentPageTabScorers = 'mlflow.experiment.tab.scorers',
-  experimentPromptsList = 'mlflow.experiment.prompts.list',
+  experimentPageTabPrompts = 'mlflow.experiment.prompts.list',
   experimentPromptDetails = 'mlflow.experiment.prompt.details',
   // Child routes for experiment page - end
   experimentPageSearch = 'mlflow.experiment.details.search',
@@ -94,10 +94,11 @@ export class RoutePaths {
   static get runPageWithArtifact() {
     return createMLflowRoutePath('/experiments/:experimentId/runs/:runUuid/artifactPath/*');
   }
-  static get experimentPromptsList() {
+  // OSS experiment prompt page routes
+  static get experimentPageTabPrompts() {
     return createMLflowRoutePath('/experiments/:experimentId/prompts');
   }
-  static get experimentPrompt() {
+  static get experimentPromptDetails() {
     return createMLflowRoutePath('/experiments/:experimentId/prompts/:promptName');
   }
   static get runPageDirect() {
@@ -297,7 +298,7 @@ class Routes {
 
   static getPromptDetailsPageRoute(promptName: string, experimentId?: string) {
     if (experimentId) {
-      return generatePath(RoutePaths.experimentPrompt, { experimentId, promptName });
+      return generatePath(RoutePaths.experimentPromptDetails, { experimentId, promptName });
     }
     return generatePath(RoutePaths.promptDetailsPage, { promptName });
   }

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -22,6 +22,8 @@ export enum PageId {
   experimentPageTabChatSessions = 'mlflow.experiment.tab.chat-sessions',
   experimentPageTabSingleChatSession = 'mlflow.experiment.tab.single-chat-session',
   experimentPageTabScorers = 'mlflow.experiment.tab.scorers',
+  experimentPromptsList = 'mlflow.experiment.prompts.list',
+  experimentPromptDetails = 'mlflow.experiment.prompt.details',
   // Child routes for experiment page - end
   experimentPageSearch = 'mlflow.experiment.details.search',
   compareExperimentsSearch = 'mlflow.experiment.compare',
@@ -29,7 +31,6 @@ export enum PageId {
   runPageDirect = 'mlflow.experiment.run.details.direct',
   compareRuns = 'mlflow.experiment.run.compare',
   metricPage = 'mlflow.metric.details',
-  experimentPrompt = 'mlflow.experiment.prompt',
 }
 
 // Route path definitions (used in defining route elements)
@@ -294,7 +295,10 @@ class Routes {
     return RoutePaths.promptsPage;
   }
 
-  static getPromptDetailsPageRoute(promptName: string) {
+  static getPromptDetailsPageRoute(promptName: string, experimentId?: string) {
+    if (experimentId) {
+      return generatePath(RoutePaths.experimentPrompt, { experimentId, promptName });
+    }
     return generatePath(RoutePaths.promptDetailsPage, { promptName });
   }
 }

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -1162,6 +1162,10 @@
     "defaultMessage": "Train models",
     "description": "Home page quick action title for training models"
   },
+  "9/KT56": {
+    "defaultMessage": "Prompts",
+    "description": "Label for the prompts tab in the MLflow experiment navbar"
+  },
   "93BFzC": {
     "defaultMessage": "Outputs",
     "description": "Label for outputs variable option"
@@ -1710,6 +1714,10 @@
     "defaultMessage": "Delete",
     "description": "Delete evaluation runs modal button text"
   },
+  "ED1+Xu": {
+    "defaultMessage": "Prompts & versions",
+    "description": "Label for the versions section in the MLflow experiment navbar"
+  },
   "EI7moF": {
     "defaultMessage": "Last year",
     "description": "Option for the start select dropdown to filter runs since the last 1 year"
@@ -1849,10 +1857,6 @@
   "Fg/zU/": {
     "defaultMessage": "GenAI apps & agents",
     "description": "A short label for custom experiments focused on generative AI app and agent development"
-  },
-  "Fhrgrc": {
-    "defaultMessage": "Versions",
-    "description": "Label for the versions section in the MLflow experiment navbar"
   },
   "FiKsFK": {
     "defaultMessage": "Last modified",


### PR DESCRIPTION
### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add experiment-scoped prompt pages for better organization of features and consistency with Databricks. Kept existing global prompt tab in order to allow users to view unscoped prompts.

- Introduced new routes for experiment prompts and prompt details.
- Updated the Prompts API to support filtering by experiment ID.
- Enhanced the PromptsPage and PromptsDetailsPage components to handle experiment context.
- Added tests for experiment-scoped prompts and prompt creation with experiment tags.
- Updated side navigation to include a Prompts tab.


https://github.com/user-attachments/assets/211ab3a8-051c-4427-8fc3-8173eda54591


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
