### PR TITLE
Cache database in `tests/tracing/test_fluent.py` to speed up tests on Windows

### DIFF
--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -1,12 +1,14 @@
 import asyncio
 import json
 import os
+import shutil
 import threading
 import time
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import asdict
 from datetime import datetime
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -167,6 +169,32 @@ class ErroringStreamTestModel:
         if i >= 1:
             raise ValueError("Some error")
         return i
+
+
+@pytest.fixture(scope="module")
+def cached_db(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Creates and caches a SQLite database to avoid repeated migrations for each test run."""
+    from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+
+    tmp_path = tmp_path_factory.mktemp("sqlite_db")
+    db_path = tmp_path / "mlflow.db"
+    db_uri = f"sqlite:///{db_path}"
+    artifact_uri = tmp_path / "artifacts"
+    artifact_uri.mkdir(exist_ok=True)
+    store = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+    store.engine.dispose()
+    return db_path
+
+
+@pytest.fixture(autouse=True)
+def tracking_uri(tmp_path: Path, cached_db: Path):
+    """Copies the cached database and sets the tracking URI for each test."""
+    db_path = tmp_path / "mlflow.db"
+    shutil.copy(cached_db, db_path)
+    uri = f"sqlite:///{db_path}"
+    mlflow.set_tracking_uri(uri)
+    yield
+    mlflow.set_tracking_uri(None)
 
 
 @pytest.fixture


### PR DESCRIPTION
### What changes are proposed in this pull request?

Add `cached_db` fixture in `tests/tracing/test_fluent.py` to cache the SQLite database with migrations applied once per module, avoiding repeated migrations for each test.

On Windows, database migrations are very slow (~9 seconds per test on average), making `test_fluent.py` one of the slowest test files.

#### Before ([run](https://github.com/mlflow/mlflow/actions/runs/19851936191))

| Job | Duration | Tests | Min | Max | Avg |
| --- | -------- | ----- | --- | --- | --- |
| [windows (1)](https://github.com/mlflow/mlflow/actions/runs/19851936191/job/56880874871) | 130.38s | 28 | 0.011s | 8.601s | 4.657s |
| [windows (2)](https://github.com/mlflow/mlflow/actions/runs/19851936191/job/56880874882) | 252.29s | 28 | 0.011s | 14.078s | 9.010s |
| [windows (3)](https://github.com/mlflow/mlflow/actions/runs/19851936191/job/56880874881) | 147.19s | 28 | 0.010s | 10.447s | 5.257s |
| [windows (4)](https://github.com/mlflow/mlflow/actions/runs/19851936191/job/56880874887) | 137.71s | 28 | 0.009s | 9.137s | 4.918s |

#### After ([run](https://github.com/mlflow/mlflow/actions/runs/19853435561))

| Job | Duration | Tests | Min | Max | Avg |
| --- | -------- | ----- | --- | --- | --- |
| [windows (1)](https://github.com/mlflow/mlflow/actions/runs/19853435561/job/56885463174) | 33.31s | 28 | 0.012s | 11.843s | 1.190s |
| [windows (2)](https://github.com/mlflow/mlflow/actions/runs/19853435561/job/56885463169) | 13.81s | 28 | 0.012s | 3.754s | 0.493s |
| [windows (3)](https://github.com/mlflow/mlflow/actions/runs/19853435561/job/56885463150) | 28.38s | 28 | 0.012s | 10.419s | 1.014s |
| [windows (4)](https://github.com/mlflow/mlflow/actions/runs/19853435561/job/56885463160) | 17.64s | 28 | 0.010s | 4.692s | 0.630s |

#### Improvement

| Job | Before | After | Improvement |
| --- | ------ | ----- | ----------- |
| windows (1) | 130.38s | 33.31s | **74.4%** |
| windows (2) | 252.29s | 13.81s | **94.5%** |
| windows (3) | 147.19s | 28.38s | **80.7%** |
| windows (4) | 137.71s | 17.64s | **87.2%** |

About 10 min reduction in total, which is massive

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow



#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)