### PR TITLE
[FR] Add the tools of CrewAI to the mlflow UI

### DIFF
--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -25,10 +25,7 @@ def patched_standalone_call(original, *args, **kwargs):
 
     fullname, span_type = _resolve_standalone_span(original, kwargs)
     if fullname is None or span_type is None:
-        _logger.debug(
-            "CrewAI Autolog misconfiguration: could not resolve span name or type for %s",
-            original.__name__,
-        )
+        _logger.debug(f"Could not resolve span name or type for {original}")
         return original(*args, **kwargs)
 
     with mlflow.start_span(name=fullname, span_type=span_type) as span:

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -17,35 +17,64 @@ from mlflow.utils.autologging_utils.config import AutoLoggingConfig
 _logger = logging.getLogger(__name__)
 
 
+def patched_standalone_call(original, *args, **kwargs):
+    config = AutoLoggingConfig.init(flavor_name=mlflow.crewai.FLAVOR_NAME)
+
+    if not config.log_traces:
+        return original(*args, **kwargs)
+
+    fullname, span_type = _resolve_standalone_span(original, kwargs)
+    if fullname is None or span_type is None:
+        _logger.debug(
+            "CrewAI Autolog misconfiguration: could not resolve span name or type for %s",
+            original.__name__,
+        )
+        return original(*args, **kwargs)
+
+    with mlflow.start_span(name=fullname, span_type=span_type) as span:
+        inputs = _construct_full_inputs(original, *args, **kwargs)
+        span.set_inputs(inputs)
+
+        result = original(*args, **kwargs)
+
+        # Need to convert the response of generate_content for better visualization
+        outputs = result.__dict__ if hasattr(result, "__dict__") else result
+        span.set_outputs(outputs)
+
+        return result
+
+
 def patched_class_call(original, self, *args, **kwargs):
     config = AutoLoggingConfig.init(flavor_name=mlflow.crewai.FLAVOR_NAME)
 
-    if config.log_traces:
-        default_name = f"{self.__class__.__name__}.{original.__name__}"
-        fullname = _get_span_name(self) or default_name
-        span_type = _get_span_type(self)
-        with mlflow.start_span(name=fullname, span_type=span_type) as span:
-            inputs = _construct_full_inputs(original, self, *args, **kwargs)
-            span.set_inputs(inputs)
-            _set_span_attributes(span=span, instance=self)
+    if not config.log_traces:
+        return original(self, *args, **kwargs)
 
-            # CrewAI reports only crew-level usage totals.
-            # This patch hooks LiteLLM's `completion` to capture each response
-            # so per-call LLM usage can be logged.
-            capture_context = (
-                _capture_llm_response(self) if span_type == SpanType.LLM else nullcontext()
-            )
-            with capture_context:
-                result = original(self, *args, **kwargs)
+    default_name = f"{self.__class__.__name__}.{original.__name__}"
+    fullname = _get_span_name(self) or default_name
+    span_type = _get_span_type(self)
+    with mlflow.start_span(name=fullname, span_type=span_type) as span:
+        inputs = _construct_full_inputs(original, self, *args, **kwargs)
+        span.set_inputs(inputs)
+        _set_span_attributes(span=span, instance=self)
 
-            # Need to convert the response of generate_content for better visualization
-            outputs = result.__dict__ if hasattr(result, "__dict__") else result
+        # CrewAI reports only crew-level usage totals.
+        # This patch hooks LiteLLM's `completion` to capture each response
+        # so per-call LLM usage can be logged.
+        capture_context = (
+            _capture_llm_response(self) if span_type == SpanType.LLM else nullcontext()
+        )
+        with capture_context:
+            result = original(self, *args, **kwargs)
 
-            if span_type == SpanType.LLM and (usage_dict := _parse_usage(self)):
-                span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
-            span.set_outputs(outputs)
+        # Need to convert the response of generate_content for better visualization
+        outputs = result.__dict__ if hasattr(result, "__dict__") else result
 
-            return result
+        if span_type == SpanType.LLM and (usage_dict := _parse_usage(self)):
+            span.set_attribute(SpanAttributeKey.CHAT_USAGE, usage_dict)
+        span.set_outputs(outputs)
+
+        return result
 
 
 def _capture_llm_response(instance):
@@ -81,6 +110,18 @@ def _parse_usage(instance: Any) -> dict[str, int] | None:
     }
 
 
+def _resolve_standalone_span(original, kwargs):
+    name = original.__name__
+    if name == "execute_tool_and_check_finality":
+        # default_tool_name should not be hit in normal runs; may append if crewai bugs
+        default_tool_name = "ToolExecution"
+        fullname = kwargs["agent_action"].tool if "agent_action" in kwargs else None
+        fullname = fullname or default_tool_name
+        return fullname, SpanType.TOOL
+
+    return None, None
+
+
 def _get_span_type(instance) -> str:
     import crewai
     from crewai import LLM, Agent, Crew, Task
@@ -89,13 +130,11 @@ def _get_span_type(instance) -> str:
     try:
         if isinstance(instance, (Flow, Crew, Task)):
             return SpanType.CHAIN
-        elif isinstance(instance, Agent):
+        if isinstance(instance, Agent):
             return SpanType.AGENT
-        elif isinstance(instance, LLM):
+        if isinstance(instance, LLM):
             return SpanType.LLM
-        elif isinstance(instance, Flow):
-            return SpanType.CHAIN
-        elif isinstance(
+        if isinstance(
             instance, crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin
         ):
             return SpanType.MEMORY

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -107,7 +107,7 @@ def _parse_usage(instance: Any) -> dict[str, int] | None:
     }
 
 
-def _resolve_standalone_span(original, kwargs):
+def _resolve_standalone_span(original, kwargs) -> tuple[str, SpanType]:
     name = original.__name__
     if name == "execute_tool_and_check_finality":
         # default_tool_name should not be hit in normal runs; may append if crewai bugs

--- a/mlflow/crewai/autolog.py
+++ b/mlflow/crewai/autolog.py
@@ -127,11 +127,13 @@ def _get_span_type(instance) -> str:
     try:
         if isinstance(instance, (Flow, Crew, Task)):
             return SpanType.CHAIN
-        if isinstance(instance, Agent):
+        elif isinstance(instance, Agent):
             return SpanType.AGENT
-        if isinstance(instance, LLM):
+        elif isinstance(instance, LLM):
             return SpanType.LLM
-        if isinstance(
+        elif isinstance(instance, Flow):
+            return SpanType.CHAIN
+        elif isinstance(
             instance, crewai.agents.agent_builder.base_agent_executor_mixin.CrewAgentExecutorMixin
         ):
             return SpanType.MEMORY

--- a/tests/crewai/test_crewai_autolog.py
+++ b/tests/crewai/test_crewai_autolog.py
@@ -1,4 +1,3 @@
-from types import SimpleNamespace
 from unittest.mock import ANY, Mock, patch
 
 import crewai
@@ -218,10 +217,6 @@ def task_named(simple_agent_1):
         description="noop",
         expected_output="noop",
     )
-
-
-def _fake_disabled_config(**_):
-    return SimpleNamespace(log_traces=False)
 
 
 def global_autolog():
@@ -974,10 +969,7 @@ def test_crew_task_named(simple_agent_1, task_named, autolog):
 
 
 def test_patched_class_call_original_when_traces_disabled(monkeypatch):
-    monkeypatch.setattr(
-        "mlflow.utils.autologging_utils.config.AutoLoggingConfig.init",
-        _fake_disabled_config,
-    )
+    mlflow.crewai.autolog(log_traces=False)
     original = Mock(return_value="ok")
     obj = object()
 
@@ -988,10 +980,7 @@ def test_patched_class_call_original_when_traces_disabled(monkeypatch):
 
 
 def test_patched_standalone_call_original_when_traces_disabled(monkeypatch):
-    monkeypatch.setattr(
-        "mlflow.utils.autologging_utils.config.AutoLoggingConfig.init",
-        _fake_disabled_config,
-    )
+    mlflow.crewai.autolog(log_traces=False)
     original = Mock(return_value="ok")
 
     result = patched_standalone_call(original, "arg", kw="val")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/Killian-fal/mlflow/pull/19160?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19160/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19160/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19160/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
 Resolve #19159

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
Here a result of the feature :
<img width="422" height="321" alt="first" src="https://github.com/user-attachments/assets/3bf4d0ef-d55e-48a9-ab70-08e6b4f7394d" />
<img width="1458" height="571" alt="inputs" src="https://github.com/user-attachments/assets/7fd33a85-77e9-43b8-a2b7-adcd24196a4d" />
<img width="1005" height="384" alt="output" src="https://github.com/user-attachments/assets/e3712e96-14b0-4761-878e-e95607878f84" />
<img width="480" height="312" alt="timeline" src="https://github.com/user-attachments/assets/4083dff5-e5c2-4565-a218-9350faab9a40" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Now, when using CrewAI, the tools are displayed in the steps of the tracing section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
