### PR TITLE
Cache database in `tests/tracking/fluent/test_fluent.py` to speed up tests on Windows

### DIFF
--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -3,6 +3,7 @@ import multiprocessing
 import os
 import random
 import re
+import shutil
 import subprocess
 import sys
 import threading
@@ -12,6 +13,7 @@ from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from importlib import reload
 from itertools import zip_longest
+from pathlib import Path
 from unittest import mock
 
 import pandas as pd
@@ -171,6 +173,32 @@ def create_experiment(
     tags=None,
 ):
     return mlflow.entities.Experiment(experiment_id, name, artifact_location, lifecycle_stage, tags)
+
+
+@pytest.fixture(scope="module")
+def cached_db(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Creates and caches a SQLite database to avoid repeated migrations for each test run."""
+    from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+
+    tmp_path = tmp_path_factory.mktemp("sqlite_db")
+    db_path = tmp_path / "mlflow.db"
+    db_uri = f"sqlite:///{db_path}"
+    artifact_uri = tmp_path / "artifacts"
+    artifact_uri.mkdir(exist_ok=True)
+    store = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+    store.engine.dispose()
+    return db_path
+
+
+@pytest.fixture(autouse=True)
+def tracking_uri(tmp_path: Path, cached_db: Path):
+    """Copies the cached database and sets the tracking URI for each test."""
+    db_path = tmp_path / "mlflow.db"
+    shutil.copy(cached_db, db_path)
+    uri = f"sqlite:///{db_path}"
+    mlflow.set_tracking_uri(uri)
+    yield
+    mlflow.set_tracking_uri(None)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Related Issues/PRs

#19158

### What changes are proposed in this pull request?

On Windows, db migration is very slow (~8 seconds per test). This change caches the SQLite database at the module level and copies it for each test, reducing the migration overhead and speeding up test execution.

This is the same optimization applied in #19158 for `tests/tracing/test_fluent.py`.

### Results

#### Before (without caching)

| Job         | Duration | Tests | Min    | Max      | Avg    |
| ----------- | -------- | ----- | ------ | -------- | ------ |
| windows (1) | 267.82s  | 32    | 0.035s | 107.684s | 8.369s |
| windows (2) | 84.75s   | 32    | 0.040s | 6.995s   | 2.649s |
| windows (3) | 81.51s   | 31    | 0.037s | 6.448s   | 2.629s |
| windows (4) | 137.69s  | 32    | 0.037s | 10.071s  | 4.303s |

#### After (with caching)

| Job         | Duration | Tests | Min    | Max     | Avg    |
| ----------- | -------- | ----- | ------ | ------- | ------ |
| windows (1) | 103.06s  | 32    | 0.039s | 70.199s | 3.221s |
| windows (2) | 37.02s   | 28    | 0.011s | 16.911s | 1.322s |
| windows (3) | 26.83s   | 31    | 0.039s | 7.581s  | 0.865s |
| windows (4) | 25.32s   | 28    | 0.010s | 9.764s  | 0.904s |

#### Summary

| Job         | Before  | After   | Improvement |
| ----------- | ------- | ------- | ----------- |
| windows (1) | 267.82s | 103.06s | 61.5%       |
| windows (2) | 84.75s  | 37.02s  | 56.3%       |
| windows (3) | 81.51s  | 26.83s  | 67.1%       |
| windows (4) | 137.69s | 25.32s  | 81.6%       |

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)