### PR TITLE
[BUG FIX] Add is_session_level-scorer flag to scorer serialization

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -725,6 +725,7 @@ class InstructionsJudge(Judge):
             name=self.name,
             description=self.description,
             aggregations=self.aggregations,
+            is_session_level_scorer=self.is_session_level_scorer,
             mlflow_version=mlflow.__version__,
             serialization_version=_SERIALIZATION_VERSION,
             instructions_judge_pydantic_data=pydantic_data,

--- a/mlflow/genai/scorers/base.py
+++ b/mlflow/genai/scorers/base.py
@@ -75,6 +75,7 @@ class SerializedScorer:
     name: str
     aggregations: list[str] | None = None
     description: str | None = None
+    is_session_level_scorer: bool = False
 
     # Version metadata
     mlflow_version: str = mlflow.__version__
@@ -190,6 +191,7 @@ class Scorer(BaseModel):
             name=self.name,
             description=self.description,
             aggregations=self.aggregations,
+            is_session_level_scorer=self.is_session_level_scorer,
             mlflow_version=mlflow.__version__,
             serialization_version=_SERIALIZATION_VERSION,
             call_source=source_info.get("call_source"),

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -294,6 +294,7 @@ class BuiltInScorer(Judge):
             name=self.name,
             description=self.description,
             aggregations=self.aggregations,
+            is_session_level_scorer=self.is_session_level_scorer,
             mlflow_version=mlflow.__version__,
             serialization_version=_SERIALIZATION_VERSION,
             builtin_scorer_class=self.__class__.__name__,

--- a/tests/genai/judges/test_builtin.py
+++ b/tests/genai/judges/test_builtin.py
@@ -14,7 +14,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai import judges
 from mlflow.genai.evaluation.entities import EvalItem, EvalResult
 from mlflow.genai.judges.utils import CategoricalRating
-from mlflow.genai.scorers import RelevanceToQuery, Safety, Scorer
+from mlflow.genai.scorers import RelevanceToQuery, Safety, Scorer, UserFrustration
 from mlflow.genai.scorers.aggregation import compute_aggregated_metrics
 from mlflow.genai.scorers.base import SerializedScorer
 from mlflow.genai.scorers.builtin_scorers import _sanitize_scorer_feedback
@@ -553,3 +553,28 @@ def test_ser_deser():
         assert isinstance(deserialized, Safety)
         assert deserialized.name == "safety"
         assert deserialized.required_columns == {"inputs", "outputs"}
+
+
+def test_ser_deser_session_level_scorer():
+    scorer = UserFrustration()
+
+    # Verify the scorer is session-level
+    assert scorer.is_session_level_scorer is True
+
+    # Test serialization
+    serialized_dict = scorer.model_dump()
+    assert serialized_dict["is_session_level_scorer"] is True
+    assert serialized_dict["name"] == "user_frustration"
+    assert serialized_dict["builtin_scorer_class"] == "UserFrustration"
+
+    # Test deserialization from dict
+    deserialized = Scorer.model_validate(serialized_dict)
+    assert isinstance(deserialized, UserFrustration)
+    assert deserialized.name == "user_frustration"
+    assert deserialized.is_session_level_scorer is True
+
+    # Test deserialization from SerializedScorer object
+    serialized_obj = SerializedScorer(**serialized_dict)
+    deserialized2 = Scorer.model_validate(serialized_obj)
+    assert isinstance(deserialized2, UserFrustration)
+    assert deserialized2.is_session_level_scorer is True

--- a/tests/genai/judges/test_make_judge.py
+++ b/tests/genai/judges/test_make_judge.py
@@ -1322,6 +1322,7 @@ def test_model_dump_uses_serialized_scorer_dataclass():
     expected_scorer = SerializedScorer(
         name="test_dataclass_judge",
         aggregations=[],
+        is_session_level_scorer=False,
         mlflow_version=mlflow.__version__,
         serialization_version=1,
         instructions_judge_pydantic_data={
@@ -1344,6 +1345,53 @@ def test_model_dump_uses_serialized_scorer_dataclass():
     assert serialized == expected_dict
 
     assert set(serialized.keys()) == set(expected_dict.keys())
+
+
+def test_model_dump_session_level_scorer():
+    judge = make_judge(
+        name="conversation_judge",
+        instructions="Evaluate the {{ conversation }} for coherence",
+        feedback_value_type=str,
+        model="openai:/gpt-4",
+    )
+
+    # Verify it's a session-level scorer
+    assert judge.is_session_level_scorer is True
+
+    serialized = judge.model_dump()
+
+    # Verify is_session_level_scorer is properly serialized
+    assert serialized["is_session_level_scorer"] is True
+    assert serialized["name"] == "conversation_judge"
+
+    expected_scorer = SerializedScorer(
+        name="conversation_judge",
+        aggregations=[],
+        is_session_level_scorer=True,
+        mlflow_version=mlflow.__version__,
+        serialization_version=1,
+        instructions_judge_pydantic_data={
+            "feedback_value_type": {
+                "type": "string",
+                "title": "Result",
+            },
+            "instructions": "Evaluate the {{ conversation }} for coherence",
+            "model": "openai:/gpt-4",
+        },
+        builtin_scorer_class=None,
+        builtin_scorer_pydantic_data=None,
+        call_source=None,
+        call_signature=None,
+        original_func_name=None,
+    )
+
+    expected_dict = asdict(expected_scorer)
+    assert serialized == expected_dict
+
+    # Test deserialization preserves is_session_level_scorer
+    deserialized = Scorer.model_validate(serialized)
+    assert deserialized.is_session_level_scorer is True
+    assert deserialized.name == "conversation_judge"
 
 
 def test_instructions_judge_works_with_evaluate(mock_invoke_judge_model):

--- a/tests/genai/scorers/test_scorer.py
+++ b/tests/genai/scorers/test_scorer.py
@@ -354,6 +354,7 @@ def test_custom_scorer_registration_blocked_for_non_databricks_uri():
 def test_custom_scorer_loading_blocked_for_non_databricks_uri():
     serialized = SerializedScorer(
         name="malicious_scorer",
+        is_session_level_scorer=False,
         call_source="import os\nos.system('echo hacked')\nreturn True",
         call_signature="(outputs)",
         original_func_name="malicious_scorer",
@@ -368,6 +369,7 @@ def test_custom_scorer_loading_blocked_for_non_databricks_uri():
 def test_custom_scorer_loading_blocked_for_databricks_remote_access():
     serialized = SerializedScorer(
         name="malicious_scorer",
+        is_session_level_scorer=False,
         call_source="import os\nos.system('echo hacked')\nreturn True",
         call_signature="(outputs)",
         original_func_name="malicious_scorer",
@@ -386,6 +388,7 @@ def test_custom_scorer_loading_blocked_for_databricks_remote_access():
 def test_custom_scorer_error_message_renders_code_snippet_legibly():
     serialized = SerializedScorer(
         name="complex_scorer",
+        is_session_level_scorer=False,
         call_source=(
             "if not outputs:\n"
             "    return 0\n"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/xsh310/mlflow/pull/19171?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19171/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19171/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19171/merge
```

</p>
</details>

## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19171/files) to review incremental changes.
- [**stack/add-session-level-flag-to-scorer-serialization**](https://github.com/mlflow/mlflow/pull/19171) [[Files changed](https://github.com/mlflow/mlflow/pull/19171/files)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

Adding `is_session_level_scorer` property to scorer serialization so that this can be parsed by the UI client.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
All of the following passes:
```
python -m pytest tests/genai/judges/test_make_judge.py -v
```
```
python -m pytest tests/genai/scorers/test_scorer.py -v
```
```
python -m pytest tests/genai/judges/test_builtin.py -v
```


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
