### PR TITLE
Investigate: SQLite database file open error during MLflow `atexit` flush

### DIFF
--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1108,6 +1108,7 @@ def autolog(
             extra_tags=extra_tags,
         )
 
+        raise Exception("Dummy exception to trigger finally block for atexit registration")
         atexit.register(flush_metrics_queue)
 
 

--- a/mlflow/pytorch/__init__.py
+++ b/mlflow/pytorch/__init__.py
@@ -1108,7 +1108,7 @@ def autolog(
             extra_tags=extra_tags,
         )
 
-        raise Exception("Dummy exception to trigger finally block for atexit registration")
+        # raise Exception("Dummy exception to trigger finally block for atexit registration")
         atexit.register(flush_metrics_queue)
 
 

--- a/mlflow/store/db/utils.py
+++ b/mlflow/store/db/utils.py
@@ -302,7 +302,8 @@ def create_sqlalchemy_engine_with_retry(db_uri):
             if attempts < MAX_RETRY_COUNT:
                 sleep_duration = 0.1 * ((2**attempts) - 1)
                 _logger.warning(
-                    "SQLAlchemy engine could not be created. The following exception is caught.\n"
+                    f"SQLAlchemy engine could not be created with {db_uri}. "
+                    "The following exception is caught.\n"
                     "%s\nOperation will be retried in %.1f seconds",
                     e,
                     sleep_duration,

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -228,6 +228,7 @@ class SqlAlchemyStore(AbstractStore):
             default_artifact_root: Path/URI to location suitable for large data (such as a blob
                 store object, DBFS path, or shared NFS file system).
         """
+        print(f"DB URI: {db_uri}")  # noqa: T201
         super().__init__()
         self.db_uri = db_uri
         self.db_type = extract_db_type_from_uri(db_uri)

--- a/mlflow/utils/autologging_utils/metrics_queue.py
+++ b/mlflow/utils/autologging_utils/metrics_queue.py
@@ -35,7 +35,6 @@ def flush_metrics_queue():
         # flush operation should proceed; all others are redundant and should be dropped
         acquired_lock = _metrics_queue_lock.acquire(blocking=False)
         if acquired_lock:
-            client = MlflowClient()
             # For thread safety and to avoid modifying a list while iterating over it, we record a
             # separate list of the items being flushed and remove each one from the metric queue,
             # rather than clearing the metric queue or reassigning it (clearing / reassigning is
@@ -46,6 +45,10 @@ def flush_metrics_queue():
                 _metrics_queue.remove(item)
 
             metrics_by_run = _assoc_list_to_map(snapshot)
+            if not metrics_by_run:
+                return
+
+            client = MlflowClient()
             for run_id, metrics in metrics_by_run.items():
                 client.log_batch(run_id, metrics=metrics, params=[], tags=[])
     finally:

--- a/mlflow/utils/autologging_utils/metrics_queue.py
+++ b/mlflow/utils/autologging_utils/metrics_queue.py
@@ -35,6 +35,7 @@ def flush_metrics_queue():
         # flush operation should proceed; all others are redundant and should be dropped
         acquired_lock = _metrics_queue_lock.acquire(blocking=False)
         if acquired_lock:
+            client = MlflowClient()
             # For thread safety and to avoid modifying a list while iterating over it, we record a
             # separate list of the items being flushed and remove each one from the metric queue,
             # rather than clearing the metric queue or reassigning it (clearing / reassigning is
@@ -45,10 +46,6 @@ def flush_metrics_queue():
                 _metrics_queue.remove(item)
 
             metrics_by_run = _assoc_list_to_map(snapshot)
-            if not metrics_by_run:
-                return
-
-            client = MlflowClient()
             for run_id, metrics in metrics_by_run.items():
                 client.log_batch(run_id, metrics=metrics, params=[], tags=[])
     finally:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/19193?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19193/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19193/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19193/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

https://github.com/mlflow/mlflow/actions/runs/19889721078/job/57005606478#step:12:1211

```
2025/12/03 10:34:06 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 0.1 seconds
2025/12/03 10:34:06 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 0.3 seconds
2025/12/03 10:34:06 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 0.7 seconds
2025/12/03 10:34:07 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 1.5 seconds
2025/12/03 10:34:08 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 3.1 seconds
2025/12/03 10:34:11 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 6.3 seconds
2025/12/03 10:34:18 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 12.7 seconds
2025/12/03 10:34:30 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 25.5 seconds
2025/12/03 10:34:56 WARNING mlflow.store.db.utils: SQLAlchemy engine could not be created. The following exception is caught.
(sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
Operation will be retried in 51.1 seconds
Exception ignored in atexit callback: <function flush_metrics_queue at 0x7f0b82efb880>
Traceback (most recent call last):
  File "/home/runner/work/mlflow/mlflow/mlflow/utils/autologging_utils/metrics_queue.py", line 38, in flush_metrics_queue
    client = MlflowClient()
  File "/home/runner/work/mlflow/mlflow/mlflow/tracking/client.py", line 224, in __init__
    self._tracking_client = TrackingServiceClient(final_tracking_uri)
  File "/home/runner/work/mlflow/mlflow/mlflow/tracking/_tracking_service/client.py", line 96, in __init__
    self.store
  File "/home/runner/work/mlflow/mlflow/mlflow/tracking/_tracking_service/client.py", line 100, in store
    return utils._get_store(self.tracking_uri)
  File "/home/runner/work/mlflow/mlflow/mlflow/tracking/_tracking_service/utils.py", line 253, in _get_store
    return _tracking_store_registry.get_store(store_uri, artifact_uri)
  File "/home/runner/work/mlflow/mlflow/mlflow/tracking/_tracking_service/registry.py", line 45, in get_store
    return self._get_store_with_resolved_uri(resolved_store_uri, artifact_uri)
  File "/home/runner/work/mlflow/mlflow/mlflow/tracking/_tracking_service/registry.py", line 56, in _get_store_with_resolved_uri
    return builder(store_uri=resolved_store_uri, artifact_uri=artifact_uri)
  File "/home/runner/work/mlflow/mlflow/mlflow/tracking/_tracking_service/utils.py", line 185, in _get_sqlalchemy_store
    return SqlAlchemyStore(store_uri, artifact_uri)
  File "/home/runner/work/mlflow/mlflow/mlflow/store/tracking/sqlalchemy_store.py", line 246, in __init__
    mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(db_uri)
  File "/home/runner/work/mlflow/mlflow/mlflow/store/db/utils.py", line 299, in create_sqlalchemy_engine_with_retry
    sqlalchemy.inspect(engine)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/inspection.py", line 140, in inspect
    ret = reg(subject)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 313, in _engine_insp
    return Inspector._construct(Inspector._init_engine, bind)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 246, in _construct
    init(self, bind)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/reflection.py", line 257, in _init_engine
    engine.connect().close()
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3277, in connect
    return self._connection_cls(self)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 145, in __init__
    Connection._handle_dbapi_exception_noconnection(
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2440, in _handle_dbapi_exception_noconnection
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 143, in __init__
    self._dbapi_connection = engine.raw_connection()
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 3301, in raw_connection
    return self.pool.connect()
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 447, in connect
    return _ConnectionFairy._checkout(self)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 1264, in _checkout
    fairy = _ConnectionRecord.checkout(pool)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 711, in checkout
    rec = pool._do_get()
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/impl.py", line 177, in _do_get
    with util.safe_reraise():
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 224, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/impl.py", line 175, in _do_get
    return self._create_connection()
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 388, in _create_connection
    return _ConnectionRecord(self)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 673, in __init__
    self.__connect()
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 899, in __connect
    with util.safe_reraise():
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/util/langhelpers.py", line 224, in __exit__
    raise exc_value.with_traceback(exc_tb)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/pool/base.py", line 895, in __connect
    self.dbapi_connection = connection = pool._invoke_creator(self)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/create.py", line 661, in connect
    return dialect.connect(*cargs, **cparams)
  File "/home/runner/work/mlflow/mlflow/.venv/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 629, in connect
    return self.loaded_dbapi.connect(*cargs, **cparams)  # type: ignore[no-any-return]  # NOQA: E501
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) unable to open database file
(Background on this error at: https://sqlalche.me/e/20/e3q8)
```

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
