### PR TITLE
Handle trace with 3p generaic root span

### DIFF
--- a/mlflow/tracing/utils/__init__.py
+++ b/mlflow/tracing/utils/__init__.py
@@ -549,7 +549,12 @@ def update_trace_state_from_span_conditionally(trace, root_span):
     # If the trace state is anything else, it means the user explicitly set it
     # and we should preserve it
     if trace.info.state == TraceState.IN_PROGRESS:
-        trace.info.state = TraceState.from_otel_status(root_span.status)
+        state = TraceState.from_otel_status(root_span.status)
+        # If the root span is created by the native OpenTelemetry SDK, the status code can be UNSET
+        # (default value when an otel span is ended). Override it to OK here to avoid backend error.
+        if state == TraceState.STATE_UNSPECIFIED:
+            state = TraceState.OK
+        trace.info.state = state
 
 
 def get_experiment_id_for_trace(span: OTelReadableSpan) -> str:

--- a/tests/tracing/opentelemetry/test_integration.py
+++ b/tests/tracing/opentelemetry/test_integration.py
@@ -37,8 +37,6 @@ def test_mlflow_and_opentelemetry_unified_tracing_with_otel_root_span(monkeypatc
 
             mlflow_span.set_outputs({"text": "world"})
 
-        root_span.set_status(otel_trace.Status(otel_trace.StatusCode.OK))
-
     traces = get_traces()
     assert len(traces) == 1
     trace = traces[0]
@@ -59,7 +57,7 @@ def test_mlflow_and_opentelemetry_unified_tracing_with_otel_root_span(monkeypatc
     assert spans[0].events[0].name == "event1"
     assert spans[0].events[0].attributes["key2"] == "value2"
     assert spans[0].parent_id is None
-    assert spans[0].status.status_code == SpanStatusCode.OK
+    assert spans[0].status.status_code == SpanStatusCode.UNSET
     assert spans[1].name == "mlflow_span"
     assert spans[1].attributes["key3"] == "value3"
     assert spans[1].events == []


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19217?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19217/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19217/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19217/merge
```

</p>
</details>

### What changes are proposed in this pull request?

OpenTelemetry span by default have "UNSET" status when the span is exported without any status set manually. This is not ideal, so in MLflow SDK, we override this to OK.

https://github.com/mlflow/mlflow/blob/176c901e3de42afb5dda0ed7618299ff807a1341/mlflow/entities/span.py#L646-L651

However, if users combine native OTel SDK and MLflow like this example, https://mlflow.org/docs/latest/genai/tracing/app-instrumentation/opentelemetry/#using-other-opentelemetry-libraries, the override does not happen. Since root span has unset status, MLflow tries to log TraceInfo with unset status, which is considered as invalid request in Databricks.

This PR add a override for trace info status to bypass this issue.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
