### PR TITLE
mlflow.genai.evaluate(): handle case where root span is unavailable

### DIFF
--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -198,9 +198,7 @@ def _extract_request_response_from_trace(df: "pd.DataFrame") -> "pd.DataFrame":
         )
 
     # Warn once if any traces have missing root spans
-    missing_root_span_mask = df["trace"].apply(
-        lambda trace: trace.data._get_root_span() is None
-    )
+    missing_root_span_mask = df["trace"].apply(lambda trace: trace.data._get_root_span() is None)
     if missing_root_span_mask.any():
         missing_count = missing_root_span_mask.sum()
         _logger.warning(

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -197,11 +197,11 @@ def _extract_request_response_from_trace(df: "pd.DataFrame") -> "pd.DataFrame":
             lambda trace: _safe_extract_from_root_span(trace, "outputs")
         )
 
-    # Warn about traces that don't have a root span (where inputs/outputs are None)
-    missing_count = df[["inputs", "outputs"]].isna().any(axis=1).sum()
-    if missing_count > 0:
+    # Warn once if any traces have missing root spans
+    if df["trace"].apply(lambda trace: trace.data._get_root_span() is None).any():
         _logger.warning(
-            f"Found {missing_count} trace(s) that do not have a root span with inputs/outputs."
+            "Some traces do not have a root span. "
+            "This may occur if traces were fetched with search_traces(..., include_spans=False)."
         )
 
     return df

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -201,7 +201,8 @@ def _extract_request_response_from_trace(df: "pd.DataFrame") -> "pd.DataFrame":
     missing_count = df[["inputs", "outputs"]].isna().any(axis=1).sum()
     if missing_count > 0:
         _logger.warning(
-            f"Found {missing_count} trace(s) that do not have a root span with inputs/outputs."
+            f"Found {missing_count} trace(s) that do not have a root span. "
+            "This may occur if traces were fetched with search_traces(..., include_spans=False)."
         )
 
     return df


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/dbczumar/mlflow/pull/19220?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19220/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19220/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19220/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

mlflow.genai.evaluate(): handle case where root span is unavailable. This can happen for partial third-party OTel traces or if the user calls `search_traces(include_spans=False)` and then tries to pass the resulting traces to eval. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [X] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
