### PR TITLE
Parallelize multi-turn session evaluation

### DIFF
--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -29,7 +29,7 @@ from mlflow.environment_variables import (
 from mlflow.genai.evaluation import context
 from mlflow.genai.evaluation.entities import EvalItem, EvalResult, EvaluationResult
 from mlflow.genai.evaluation.session_utils import (
-    _evaluate_session_scorers,
+    evaluate_session_level_scorers,
     classify_scorers,
     group_traces_by_session,
 )
@@ -175,7 +175,7 @@ def run(
             if multi_turn_scorers and session_groups:
                 multi_turn_futures = [
                     executor.submit(
-                        _evaluate_session_scorers,
+                        evaluate_session_level_scorers,
                         session_id=session_id,
                         session_items=session_items,
                         multi_turn_scorers=multi_turn_scorers,

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -123,10 +123,8 @@ def run(
     # Classify scorers into single-turn and multi-turn
     single_turn_scorers, multi_turn_scorers = classify_scorers(scorers)
 
-    # Pre-compute session groups if multi-turn scorers exist
     session_groups = group_traces_by_session(eval_items) if multi_turn_scorers else {}
 
-    # Calculate total work units for progress bar
     total_tasks = len(eval_items) + len(session_groups)
 
     with ThreadPoolExecutor(
@@ -192,7 +190,6 @@ def run(
             if progress_bar:
                 progress_bar.close()
 
-    # Log multi-turn assessments to traces
     if multi_turn_assessments:
         _log_multi_turn_assessments_to_traces(
             multi_turn_assessments=multi_turn_assessments,

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -29,8 +29,8 @@ from mlflow.environment_variables import (
 from mlflow.genai.evaluation import context
 from mlflow.genai.evaluation.entities import EvalItem, EvalResult, EvaluationResult
 from mlflow.genai.evaluation.session_utils import (
-    evaluate_session_level_scorers,
     classify_scorers,
+    evaluate_session_level_scorers,
     group_traces_by_session,
 )
 from mlflow.genai.evaluation.telemetry import emit_custom_metric_event

--- a/mlflow/genai/evaluation/harness.py
+++ b/mlflow/genai/evaluation/harness.py
@@ -11,10 +11,10 @@ from typing import Any, Callable
 
 import pandas as pd
 
-# Add tqdm with fallback
 try:
     from tqdm.auto import tqdm
 except ImportError:
+    # If tqdm is not installed, we don't show a progress bar
     tqdm = None
 
 import mlflow
@@ -149,7 +149,7 @@ def run(
         eval_results = [None] * len(eval_items)
         multi_turn_assessments = {}
 
-        # Create progress bar for all tasks (tqdm imported at module level)
+        # Create progress bar for all tasks
         progress_bar = (
             tqdm(
                 total=total_tasks,
@@ -170,6 +170,8 @@ def run(
                     progress_bar.update(1)
 
             # Phase 2: Submit and complete multi-turn tasks (after single-turn)
+            # We run multi-turn scorers after single-turn, since single-turn scorers may create new
+            # traces that are needed by multi-turn scorers.
             if multi_turn_scorers and session_groups:
                 multi_turn_futures = [
                     executor.submit(

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -93,7 +93,7 @@ def evaluate_session_level_scorers(
     multi_turn_scorers: list[Scorer],
 ) -> dict[str, list[Feedback]]:
     """
-    Evaluate all multi-turn scorers for a single session in parallel.
+    Evaluate all multi-turn scorers for a single session.
 
     Args:
         session_id: The session identifier

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -57,12 +57,18 @@ def group_traces_by_session(
     session_groups = defaultdict(list)
 
     for item in eval_items:
-        if not getattr(item, "trace", None):
-            continue
+        session_id = None
 
-        trace_metadata = item.trace.info.trace_metadata
+        # First, try to get session_id from the trace metadata if trace exists
+        if getattr(item, "trace", None):
+            trace_metadata = item.trace.info.trace_metadata
+            session_id = trace_metadata.get(TraceMetadataKey.TRACE_SESSION)
 
-        if session_id := trace_metadata.get(TraceMetadataKey.TRACE_SESSION):
+        # If no session_id found in trace, check the source data (for dataset records)
+        if not session_id and item.source is not None:
+            session_id = item.source.source_data.get("session_id")
+
+        if session_id:
             session_groups[session_id].append(item)
 
     return dict(session_groups)

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -2,11 +2,16 @@
 
 import traceback
 from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import TYPE_CHECKING, Any
 
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_error import AssessmentError
 from mlflow.exceptions import MlflowException
+from mlflow.genai.evaluation.utils import (
+    make_code_type_assessment_source,
+    standardize_scorer_value,
+)
 from mlflow.genai.scorers import Scorer
 from mlflow.tracing.constant import TraceMetadataKey
 
@@ -76,68 +81,67 @@ def get_first_trace_in_session(session_items: list["EvalItem"]) -> "EvalItem":
     return min(session_items, key=lambda x: x.trace.info.request_time)
 
 
-def evaluate_session_level_scorers(
+def _evaluate_session_scorers(
+    session_id: str,
+    session_items: list["EvalItem"],
     multi_turn_scorers: list[Scorer],
-    session_groups: dict[str, list["EvalItem"]],
 ) -> dict[str, list[Feedback]]:
     """
-    Evaluate multi-turn scorers on grouped sessions.
+    Evaluate all multi-turn scorers for a single session in parallel.
 
     Args:
+        session_id: The session identifier
+        session_items: List of EvalItem objects from the same session
         multi_turn_scorers: List of multi-turn scorer instances
-        session_groups: Dict of {session_id: [eval_item, ...]}
 
     Returns:
-        dict: Dictionary mapping first trace ID of each session to its assessments list.
-              Structure: {first_trace_id: [feedback1, feedback2, ...], ...}
+        dict: {first_trace_id: [feedback1, feedback2, ...]}
     """
-    # Import here to avoid circular dependency
-    from mlflow.genai.evaluation.utils import (
-        make_code_type_assessment_source,
-        standardize_scorer_value,
-    )
+    first_item = get_first_trace_in_session(session_items)
+    first_trace_id = first_item.trace.info.trace_id
+    session_traces = [item.trace for item in session_items]
 
-    multi_turn_assessments = defaultdict(list)
+    def run_scorer(scorer: Scorer) -> list[Feedback]:
+        try:
+            value = scorer.run(session=session_traces)
+            feedbacks = standardize_scorer_value(scorer.name, value)
 
-    for session_id, session_items in session_groups.items():
-        # Get the first trace to store assessments
-        first_item = get_first_trace_in_session(session_items)
-        first_trace_id = first_item.trace.info.trace_id
+            # Add session_id to metadata for each feedback
+            for feedback in feedbacks:
+                if feedback.metadata is None:
+                    feedback.metadata = {}
+                feedback.metadata[TraceMetadataKey.TRACE_SESSION] = session_id
 
-        # Extract just the traces for scorer evaluation
-        session_traces = [item.trace for item in session_items]
-
-        # Evaluate each multi-turn scorer
-        for scorer in multi_turn_scorers:
-            try:
-                # Call scorer with session_traces parameter
-                value = scorer.run(session=session_traces)
-                feedbacks = standardize_scorer_value(scorer.name, value)
-
-                # Add session_id to metadata for each feedback
-                for feedback in feedbacks:
-                    if feedback.metadata is None:
-                        feedback.metadata = {}
-                    feedback.metadata[TraceMetadataKey.TRACE_SESSION] = session_id
-
-                # Extend the list with all feedbacks from this scorer
-                multi_turn_assessments[first_trace_id].extend(feedbacks)
-
-            except Exception as e:
-                # Use existing error handling mechanism
-                error_feedback = Feedback(
+            return feedbacks
+        except Exception as e:
+            return [
+                Feedback(
                     name=scorer.name,
                     source=make_code_type_assessment_source(scorer.name),
                     error=AssessmentError(
                         error_code="SCORER_ERROR",
-                        error_message=e,
+                        error_message=str(e),
                         stack_trace=traceback.format_exc(),
                     ),
                 )
+            ]
 
-                multi_turn_assessments[first_trace_id].append(error_feedback)
+    # Run scorers in parallel (similar to _compute_eval_scores for single-turn)
+    with ThreadPoolExecutor(
+        max_workers=len(multi_turn_scorers),
+        thread_name_prefix="MlflowGenAIEvalMultiTurnScorer",
+    ) as executor:
+        futures = [executor.submit(run_scorer, scorer) for scorer in multi_turn_scorers]
 
-    return multi_turn_assessments
+        try:
+            results = [future.result() for future in as_completed(futures)]
+        except KeyboardInterrupt:
+            executor.shutdown(cancel_futures=True)
+            raise
+
+    # Flatten results
+    all_feedbacks = [fb for sublist in results for fb in sublist]
+    return {first_trace_id: all_feedbacks}
 
 
 def validate_session_level_evaluation_inputs(scorers: list[Scorer], predict_fn: Any) -> None:

--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -87,7 +87,7 @@ def get_first_trace_in_session(session_items: list["EvalItem"]) -> "EvalItem":
     return min(session_items, key=lambda x: x.trace.info.request_time)
 
 
-def _evaluate_session_scorers(
+def evaluate_session_level_scorers(
     session_id: str,
     session_items: list["EvalItem"],
     multi_turn_scorers: list[Scorer],

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import math
-from concurrent.futures import Future, as_completed
 from typing import TYPE_CHECKING, Any, Collection
 
 from mlflow.entities import Assessment, Trace, TraceData
@@ -24,7 +23,6 @@ except ImportError:
 if TYPE_CHECKING:
     from mlflow.entities.evaluation_dataset import EvaluationDataset as EntityEvaluationDataset
     from mlflow.genai.datasets import EvaluationDataset as ManagedEvaluationDataset
-    from mlflow.genai.evaluation.entities import EvalResult
 
     try:
         import pyspark.sql.dataframe
@@ -387,25 +385,3 @@ def validate_tags(tags: Any) -> None:
 
     if errors:
         raise MlflowException.invalid_parameter_value("Invalid tags:\n  - " + "\n  - ".join(errors))
-
-
-def complete_eval_futures_with_progress_base(futures: list[Future]) -> list["EvalResult"]:
-    """Wraps the as_completed function with a progress bar."""
-    futures_as_completed = as_completed(futures)
-
-    try:
-        from tqdm.auto import tqdm
-
-        futures_as_completed = tqdm(
-            futures_as_completed,
-            total=len(futures),
-            disable=False,
-            desc="Evaluating",
-            smoothing=0,  # 0 means using average speed for remaining time estimates
-            bar_format=PGBAR_FORMAT,
-        )
-    except ImportError:
-        # If tqdm is not installed, we don't show a progress bar
-        pass
-
-    return [future.result() for future in futures_as_completed]

--- a/tests/genai/evaluate/test_session_utils.py
+++ b/tests/genai/evaluate/test_session_utils.py
@@ -125,6 +125,7 @@ def _create_mock_eval_item(trace):
     """Helper to create a mock EvalItem with a trace."""
     eval_item = Mock(spec=EvalItem)
     eval_item.trace = trace
+    eval_item.source = None  # Explicitly set to None so it doesn't return a Mock
     return eval_item
 
 
@@ -202,6 +203,7 @@ def test_group_traces_by_session_excludes_none_traces():
     eval_item1 = _create_mock_eval_item(trace1)
     eval_item2 = Mock()
     eval_item2.trace = None  # No trace
+    eval_item2.source = None  # No source
 
     eval_items = [eval_item1, eval_item2]
     session_groups = group_traces_by_session(eval_items)

--- a/tests/genai/evaluate/test_session_utils.py
+++ b/tests/genai/evaluate/test_session_utils.py
@@ -11,8 +11,8 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai import scorer
 from mlflow.genai.evaluation.entities import EvalItem
 from mlflow.genai.evaluation.session_utils import (
+    _evaluate_session_scorers,
     classify_scorers,
-    evaluate_session_level_scorers,
     get_first_trace_in_session,
     group_traces_by_session,
     validate_session_level_evaluation_inputs,
@@ -317,7 +317,7 @@ def test_validate_session_level_evaluation_inputs_mixed_scorers():
     )
 
 
-# ==================== Tests for evaluate_session_level_scorers ====================
+# ==================== Tests for _evaluate_session_scorers ====================
 
 
 def _create_test_trace(trace_id: str, request_time: int = 0) -> Trace:
@@ -348,21 +348,18 @@ def _create_eval_item(trace_id: str, request_time: int = 0) -> EvalItem:
     )
 
 
-def test_evaluate_session_level_scorers_success():
+def test_evaluate_session_scorers_success():
     mock_scorer = Mock(spec=mlflow.genai.Scorer)
     mock_scorer.name = "test_scorer"
     mock_scorer.run.return_value = 0.8
 
-    # Test with multiple sessions to verify scorer is called for each
-    session_groups = {
-        "session1": [
-            _create_eval_item("trace1", request_time=100),
-            _create_eval_item("trace2", request_time=200),
-        ],
-        "session2": [_create_eval_item("trace3", 150)],
-    }
+    # Test with a single session containing multiple traces
+    session_items = [
+        _create_eval_item("trace1", request_time=100),
+        _create_eval_item("trace2", request_time=200),
+    ]
 
-    with patch("mlflow.genai.evaluation.utils.standardize_scorer_value") as mock_standardize:
+    with patch("mlflow.genai.evaluation.session_utils.standardize_scorer_value") as mock_standardize:
         # Return a new Feedback object each time to avoid metadata overwriting
         def create_feedback(*args, **kwargs):
             return [
@@ -377,43 +374,35 @@ def test_evaluate_session_level_scorers_success():
 
         mock_standardize.side_effect = create_feedback
 
-        result = evaluate_session_level_scorers([mock_scorer], session_groups)
+        result = _evaluate_session_scorers("session1", session_items, [mock_scorer])
 
-        # Verify scorer was called for each session
-        assert mock_scorer.run.call_count == 2
+        # Verify scorer was called once (for the single session)
+        assert mock_scorer.run.call_count == 1
 
         # Verify scorer received session traces
-        call_args = mock_scorer.run.call_args_list
-        assert "session" in call_args[0].kwargs
-        assert len(call_args[0].kwargs["session"]) == 2  # session1 has 2 traces
-        assert len(call_args[1].kwargs["session"]) == 1  # session2 has 1 trace
+        call_args = mock_scorer.run.call_args
+        assert "session" in call_args.kwargs
+        assert len(call_args.kwargs["session"]) == 2  # session has 2 traces
 
-        # Verify results for both sessions (assessments on first trace of each)
-        assert "trace1" in result  # First trace of session1
-        assert "trace3" in result  # First trace of session2
+        # Verify result contains assessments for first trace
+        assert "trace1" in result  # First trace (earliest timestamp)
         assert len(result["trace1"]) == 1
-        assert len(result["trace3"]) == 1
         assert result["trace1"][0].name == "test_scorer"
         assert result["trace1"][0].value == 0.8
-        assert result["trace3"][0].name == "test_scorer"
-        assert result["trace3"][0].value == 0.8
 
         # Verify session_id was added to metadata
         assert result["trace1"][0].metadata is not None
         assert result["trace1"][0].metadata[TraceMetadataKey.TRACE_SESSION] == "session1"
-        assert result["trace3"][0].metadata[TraceMetadataKey.TRACE_SESSION] == "session2"
 
 
-def test_evaluate_session_level_scorers_handles_scorer_error():
+def test_evaluate_session_scorers_handles_scorer_error():
     mock_scorer = Mock(spec=mlflow.genai.Scorer)
     mock_scorer.name = "failing_scorer"
     mock_scorer.run.side_effect = ValueError("Scorer failed!")
 
-    session_groups = {
-        "session1": [_create_eval_item("trace1", 100)],
-    }
+    session_items = [_create_eval_item("trace1", 100)]
 
-    result = evaluate_session_level_scorers([mock_scorer], session_groups)
+    result = _evaluate_session_scorers("session1", session_items, [mock_scorer])
 
     # Verify error feedback was created
     assert "trace1" in result
@@ -426,16 +415,14 @@ def test_evaluate_session_level_scorers_handles_scorer_error():
     assert feedback.error.stack_trace is not None
 
 
-def test_evaluate_session_level_scorers_multiple_feedbacks_per_scorer():
+def test_evaluate_session_scorers_multiple_feedbacks_per_scorer():
     mock_scorer = Mock(spec=mlflow.genai.Scorer)
     mock_scorer.name = "multi_feedback_scorer"
     mock_scorer.run.return_value = {"metric1": 0.7, "metric2": 0.9}
 
-    session_groups = {
-        "session1": [_create_eval_item("trace1", 100)],
-    }
+    session_items = [_create_eval_item("trace1", 100)]
 
-    with patch("mlflow.genai.evaluation.utils.standardize_scorer_value") as mock_standardize:
+    with patch("mlflow.genai.evaluation.session_utils.standardize_scorer_value") as mock_standardize:
         feedbacks = [
             Feedback(
                 name="multi_feedback_scorer/metric1",
@@ -450,7 +437,7 @@ def test_evaluate_session_level_scorers_multiple_feedbacks_per_scorer():
         ]
         mock_standardize.return_value = feedbacks
 
-        result = evaluate_session_level_scorers([mock_scorer], session_groups)
+        result = _evaluate_session_scorers("session1", session_items, [mock_scorer])
 
         # Verify both feedbacks are stored
         assert "trace1" in result
@@ -463,21 +450,19 @@ def test_evaluate_session_level_scorers_multiple_feedbacks_per_scorer():
         assert feedback_by_name["multi_feedback_scorer/metric2"].value == 0.9
 
 
-def test_evaluate_session_level_scorers_first_trace_selection():
+def test_evaluate_session_scorers_first_trace_selection():
     mock_scorer = Mock(spec=mlflow.genai.Scorer)
     mock_scorer.name = "first_trace_scorer"
     mock_scorer.run.return_value = 1.0
 
     # Create session with traces in non-chronological order
-    session_groups = {
-        "session1": [
-            _create_eval_item("trace2", request_time=200),  # Second chronologically
-            _create_eval_item("trace1", request_time=100),  # First chronologically
-            _create_eval_item("trace3", request_time=300),  # Third chronologically
-        ]
-    }
+    session_items = [
+        _create_eval_item("trace2", request_time=200),  # Second chronologically
+        _create_eval_item("trace1", request_time=100),  # First chronologically
+        _create_eval_item("trace3", request_time=300),  # Third chronologically
+    ]
 
-    with patch("mlflow.genai.evaluation.utils.standardize_scorer_value") as mock_standardize:
+    with patch("mlflow.genai.evaluation.session_utils.standardize_scorer_value") as mock_standardize:
         feedback = Feedback(
             name="first_trace_scorer",
             source=AssessmentSource(source_type=AssessmentSourceType.CODE, source_id="test"),
@@ -485,7 +470,7 @@ def test_evaluate_session_level_scorers_first_trace_selection():
         )
         mock_standardize.return_value = [feedback]
 
-        result = evaluate_session_level_scorers([mock_scorer], session_groups)
+        result = _evaluate_session_scorers("session1", session_items, [mock_scorer])
 
         # Verify assessment is stored on trace1 (earliest request_time)
         assert "trace1" in result
@@ -496,7 +481,7 @@ def test_evaluate_session_level_scorers_first_trace_selection():
         assert result["trace1"][0].value == 1.0
 
 
-def test_evaluate_session_level_scorers_multiple_scorers():
+def test_evaluate_session_scorers_multiple_scorers():
     mock_scorer1 = Mock(spec=mlflow.genai.Scorer)
     mock_scorer1.name = "scorer1"
     mock_scorer1.run.return_value = 0.6
@@ -505,11 +490,9 @@ def test_evaluate_session_level_scorers_multiple_scorers():
     mock_scorer2.name = "scorer2"
     mock_scorer2.run.return_value = 0.8
 
-    session_groups = {
-        "session1": [_create_eval_item("trace1", 100)],
-    }
+    session_items = [_create_eval_item("trace1", 100)]
 
-    with patch("mlflow.genai.evaluation.utils.standardize_scorer_value") as mock_standardize:
+    with patch("mlflow.genai.evaluation.session_utils.standardize_scorer_value") as mock_standardize:
 
         def create_feedback(name, value):
             return [
@@ -527,9 +510,13 @@ def test_evaluate_session_level_scorers_multiple_scorers():
             create_feedback("scorer2", 0.8),
         ]
 
-        result = evaluate_session_level_scorers([mock_scorer1, mock_scorer2], session_groups)
+        result = _evaluate_session_scorers("session1", session_items, [mock_scorer1, mock_scorer2])
 
-        # Verify both scorers were evaluated
+        # Verify both scorers were evaluated (runs in parallel)
+        assert mock_scorer1.run.call_count == 1
+        assert mock_scorer2.run.call_count == 1
+
+        # Verify result contains assessments from both scorers
         assert "trace1" in result
         assert len(result["trace1"]) == 2
         # Find feedbacks by name
@@ -538,14 +525,3 @@ def test_evaluate_session_level_scorers_multiple_scorers():
         assert "scorer2" in feedback_by_name
         assert feedback_by_name["scorer1"].value == 0.6
         assert feedback_by_name["scorer2"].value == 0.8
-
-
-def test_evaluate_session_level_scorers_empty_session_groups():
-    mock_scorer = Mock(spec=mlflow.genai.Scorer)
-    mock_scorer.name = "test_scorer"
-
-    result = evaluate_session_level_scorers([mock_scorer], {})
-
-    # Should return empty result
-    assert result == {}
-    mock_scorer.run.assert_not_called()


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/AveshCSingh/mlflow/pull/19222?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19222/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19222/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19222/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->


### What changes are proposed in this pull request?

Updates `mlflow.genai.evaluate` to run multi-turn scorers in parallel, and to include their execution in the progress bar.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Manual validation: Ran [script](https://gist.github.com/AveshCSingh/dea752ec8366898bbbc860802b40151b), got output:

```
$ uv run python tmp/scripts/test_multi_turn_eval.py
warning: Failed to parse `pyproject.toml` during settings discovery:
  TOML parse error at line 232, column 1
      |
  232 | exclude-dependencies = ["databricks-connect"]
      | ^^^^^^^^^^^^^^^^^^^^
  unknown field `exclude-dependencies`, expected one of `required-version`, `native-tls`, `offline`, `no-cache`, `cache-dir`, `preview`, `python-preference`, `python-downloads`, `concurrent-downloads`, `concurrent-builds`, `concurrent-installs`, `index`, `index-url`, `extra-index-url`, `no-index`, `find-links`, `index-strategy`, `keyring-provider`, `allow-insecure-host`, `resolution`, `prerelease`, `fork-strategy`, `dependency-metadata`, `config-settings`, `config-settings-package`, `no-build-isolation`, `no-build-isolation-package`, `extra-build-dependencies`, `extra-build-variables`, `exclude-newer`, `exclude-newer-package`, `link-mode`, `compile-bytecode`, `no-sources`, `upgrade`, `upgrade-package`, `reinstall`, `reinstall-package`, `no-build`, `no-build-package`, `no-binary`, `no-binary-package`, `python-install-mirror`, `pypy-install-mirror`, `python-downloads-json-url`, `publish-url`, `trusted-publishing`, `check-url`, `add-bounds`, `pip`, `cache-keys`, `override-dependencies`, `constraint-dependencies`, `build-constraint-dependencies`, `environments`, `required-environments`, `conflicts`, `workspace`, `sources`, `managed`, `package`, `default-groups`, `dependency-groups`, `dev-dependencies`, `build-backend`

======================================================================
Multi-Turn Evaluation Demo
======================================================================
2025/12/04 23:08:39 INFO mlflow.store.db.utils: Creating initial MLflow database tables...
2025/12/04 23:08:39 INFO mlflow.store.db.utils: Updating database tables
2025-12-04 23:08:39 INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
2025-12-04 23:08:39 INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
2025-12-04 23:08:39 INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
2025-12-04 23:08:39 INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
Using tracking URI: sqlite:///mlflow.db


1. Creating traces with session metadata...
----------------------------------------------------------------------

  Session 1 (3 turns):
    - Turn 1: tr-ccef92cc0cd2751089dd35a893b8c1e7
    - Turn 2: tr-785902683fb01c268406e0dc299cffe2
    - Turn 3: tr-107bd59286c1f9f34d10fec772b1a4e9

  Session 2 (2 turns):
    - Turn 1: tr-f30435eff45eb6f3399f61145fdffc5a
    - Turn 2: tr-ceeb6a34ac999a8fb44a166467365d55

2. Creating evaluation dataset from traces...
----------------------------------------------------------------------
   Created dataset with 5 traces

3. Setting up scorers...
----------------------------------------------------------------------
   Single-turn scorers:
     - ResponseLengthScorer: Measures response length
   Multi-turn scorers:
     - ConversationLengthScorer: Counts turns per session
     - AverageResponseTimeScorer: Average response time per session

4. Running evaluation...
----------------------------------------------------------------------
Evaluating:  71%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████▏                                                    | 5/7 [Elapsed: 00:00, Remaining: 00:00]
Evaluating: 100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 7/7 [Elapsed: 00:05, Remaining: 00:00]

✨ Evaluation completed.

Metrics and evaluation results are logged to the MLflow run:
  Run name: merciful-mule-166
  Run ID: e10cb60391d44813b09239ef2f5008a0

To view the detailed evaluation results with sample-wise scores,
open the Traces tab in the Run page in the MLflow UI.


5. Results:
======================================================================

Aggregated Metrics:
----------------------------------------------------------------------
  response_length/mean: 31.00
  avg_response_time/mean: 0.00
  conversation_length/mean: 2.50

Per-Trace Results:
----------------------------------------------------------------------

  Multi-turn scores (one per session):
    tr-eaac9ffd5b81ca3b2... -> 3 turns, 0.0ms avg
    tr-420b8d8bed3e89b40... -> 2 turns, 0.0ms avg

  Single-turn scores (one per trace):
    tr-eaac9ffd5b81ca3b2... -> 38 chars
    tr-e790fe4eeadfe4d8a... -> 31 chars
    tr-de3e03ee4ecaecc55... -> 26 chars
    tr-420b8d8bed3e89b40... -> 29 chars
    tr-db8e31bad089fb52e... -> 31 chars

======================================================================
Demo completed successfully!
======================================================================

Key observations:
  - 5 traces total (3 in session_1, 2 in session_2)
  - 5 single-turn scores (one per trace)
  - 2 multi-turn scores (one per session)
  - Multi-turn scorers see all traces in each session

You can view detailed results in the MLflow UI:
  Run ID: e10cb60391d44813b09239ef2f5008a0
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Updates `mlflow.genai.evaluate` to run multi-turn scorers in parallel, and to include their execution in the progress bar.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
