### PR TITLE
Fix trace decorators usage for LangGraph async callers

### DIFF
--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -285,6 +285,15 @@ This way, the span for the `check_code` node will have child spans, which record
 
 ![LangGraph Child Span](/images/llms/tracing/langgraph-child-span.png)
 
+:::info Async Context Propagation
+When using async methods like `ainvoke()` with manual `@mlflow.trace` decorators, MLflow ensures proper context propagation by default. If you experience performance issues in high-throughput async scenarios and don't use manual tracing, you can disable this behavior:
+
+```python
+mlflow.langchain.autolog(run_tracer_inline=False)
+```
+
+:::
+
 ## Thread ID Tracking
 
 Since MLflow 3.6, MLflow will automatically record the thread (session) ID for the trace and let you view a group of traces as a session in the UI. To enable this feature, you need to pass the `thread_id` in the config when invoking the graph.

--- a/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
+++ b/docs/docs/genai/tracing/integrations/listing/langgraph.mdx
@@ -286,13 +286,20 @@ This way, the span for the `check_code` node will have child spans, which record
 ![LangGraph Child Span](/images/llms/tracing/langgraph-child-span.png)
 
 :::info Async Context Propagation
-When using async methods like `ainvoke()` with manual `@mlflow.trace` decorators, MLflow ensures proper context propagation by default. If you experience performance issues in high-throughput async scenarios and don't use manual tracing, you can disable this behavior:
+When using async methods like `ainvoke()` with manual `@mlflow.trace` decorators inside LangGraph nodes or tools, enable inline tracer execution to ensure proper context propagation:
 
 ```python
-mlflow.langchain.autolog(run_tracer_inline=False)
+mlflow.langchain.autolog(run_tracer_inline=True)
 ```
 
-:::
+This ensures that manually traced spans are properly nested within the autolog trace hierarchy. Without this setting, manual spans may appear as separate traces in async scenarios.
+
+:::warning
+When `run_tracer_inline=True` is enabled, avoid calling multiple graph invocations sequentially within the same async function, as this may cause traces to merge unexpectedly. If you need to make multiple sequential invocations, either:
+
+- Wrap each invocation in a separate async task
+- Use the default `run_tracer_inline=False` if you don't need manual tracing integration
+  :::
 
 ## Thread ID Tracking
 

--- a/mlflow/langchain/autolog.py
+++ b/mlflow/langchain/autolog.py
@@ -17,7 +17,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     log_traces=True,
-    run_tracer_inline=True,
+    run_tracer_inline=False,
 ):
     """
     Enables (or disables) and configures autologging from Langchain to MLflow.
@@ -37,12 +37,12 @@ def autolog(
         log_traces: If ``True``, traces are logged for Langchain models by using
             MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
             collected during inference. Default to ``True``.
-        run_tracer_inline: If ``True`` (default), the MLflow tracer callback runs in the main
-            async task rather than being offloaded to a thread pool. This ensures proper context
-            propagation when combining autolog traces with manual ``@mlflow.trace`` decorators
-            in async scenarios (e.g., LangGraph's ``ainvoke``). Set to ``False`` if you need
-            maximum async performance and don't use manual tracing within your LangChain/LangGraph
-            application.
+        run_tracer_inline: If ``True``, the MLflow tracer callback runs in the main async task
+            rather than being offloaded to a thread pool. This ensures proper context propagation
+            when combining autolog traces with manual ``@mlflow.trace`` decorators in async
+            scenarios (e.g., LangGraph's ``ainvoke``). Default is ``False`` for backward
+            compatibility. Set to ``True`` if you use manual ``@mlflow.trace`` decorators within
+            LangGraph nodes or tools and need them properly nested in the autolog trace.
     """
     try:
         from langchain_core.callbacks import BaseCallbackManager

--- a/mlflow/langchain/autolog.py
+++ b/mlflow/langchain/autolog.py
@@ -17,6 +17,7 @@ def autolog(
     disable_for_unsupported_versions=False,
     silent=False,
     log_traces=True,
+    run_tracer_inline=True,
 ):
     """
     Enables (or disables) and configures autologging from Langchain to MLflow.
@@ -36,6 +37,12 @@ def autolog(
         log_traces: If ``True``, traces are logged for Langchain models by using
             MlflowLangchainTracer as a callback during inference. If ``False``, no traces are
             collected during inference. Default to ``True``.
+        run_tracer_inline: If ``True`` (default), the MLflow tracer callback runs in the main
+            async task rather than being offloaded to a thread pool. This ensures proper context
+            propagation when combining autolog traces with manual ``@mlflow.trace`` decorators
+            in async scenarios (e.g., LangGraph's ``ainvoke``). Set to ``False`` if you need
+            maximum async performance and don't use manual tracing within your LangChain/LangGraph
+            application.
     """
     try:
         from langchain_core.callbacks import BaseCallbackManager
@@ -77,6 +84,7 @@ def autolog(
 
 def _patched_callback_manager_init(original, self, *args, **kwargs):
     from mlflow.langchain.langchain_tracer import MlflowLangchainTracer
+    from mlflow.utils.autologging_utils import get_autologging_config
 
     original(self, *args, **kwargs)
 
@@ -87,7 +95,8 @@ def _patched_callback_manager_init(original, self, *args, **kwargs):
         if isinstance(handler, MlflowLangchainTracer):
             return
 
-    _handler = MlflowLangchainTracer()
+    run_tracer_inline = get_autologging_config(FLAVOR_NAME, "run_tracer_inline", True)
+    _handler = MlflowLangchainTracer(run_inline=run_tracer_inline)
     self.add_handler(_handler, inherit=True)
 
 

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -68,6 +68,9 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
         # NB: The tracer can handle multiple traces in parallel under multi-threading scenarios.
         # DO NOT use instance variables to manage the state of single trace.
         super().__init__()
+        # NB: run_inline is an attribute defined in BaseCallbackHandler that controls whether
+        # the callback runs in the main async task or is offloaded to a thread pool.
+        # https://github.com/langchain-ai/langchain/blob/78c10f879077bc848d3d474ab202d49a6103727b/libs/core/langchain_core/callbacks/base.py#L438-L439
         self.run_inline = run_inline
         # run_id: (LiveSpan, OTel token)
         self._run_span_mapping: dict[str, SpanWithToken] = {}

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -53,16 +53,17 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             thread-local context. Occasionally this has to be passed manually because
             the callback may be invoked asynchronously and Langchain doesn't correctly
             propagate the thread-local context.
-        run_inline: If True (default), the callback runs in the main async task rather
-            than being offloaded to a thread pool. This ensures proper context propagation
-            when combining autolog traces with manual @mlflow.trace decorators in async
-            scenarios. Configurable via mlflow.langchain.autolog(run_tracer_inline=...).
+        run_inline: If True, the callback runs in the main async task rather than being
+            offloaded to a thread pool. This ensures proper context propagation when combining
+            autolog traces with manual @mlflow.trace decorators in async scenarios. Default is
+            False for backward compatibility. Configurable via
+            mlflow.langchain.autolog(run_tracer_inline=True).
     """
 
     def __init__(
         self,
         prediction_context: Optional["Context"] = None,
-        run_inline: bool = True,
+        run_inline: bool = False,
     ):
         # NB: The tracer can handle multiple traces in parallel under multi-threading scenarios.
         # DO NOT use instance variables to manage the state of single trace.

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -53,20 +53,21 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             thread-local context. Occasionally this has to be passed manually because
             the callback may be invoked asynchronously and Langchain doesn't correctly
             propagate the thread-local context.
+        run_inline: If True (default), the callback runs in the main async task rather
+            than being offloaded to a thread pool. This ensures proper context propagation
+            when combining autolog traces with manual @mlflow.trace decorators in async
+            scenarios. Configurable via mlflow.langchain.autolog(run_tracer_inline=...).
     """
-
-    # NB: run_inline=True ensures the callback runs in the main async task rather than
-    # being offloaded to a thread pool. This is critical for proper context propagation
-    # when mixing autolog traces with manual @mlflow.trace decorators in async scenarios.
-    run_inline = True
 
     def __init__(
         self,
         prediction_context: Optional["Context"] = None,
+        run_inline: bool = True,
     ):
         # NB: The tracer can handle multiple traces in parallel under multi-threading scenarios.
         # DO NOT use instance variables to manage the state of single trace.
         super().__init__()
+        self.run_inline = run_inline
         # run_id: (LiveSpan, OTel token)
         self._run_span_mapping: dict[str, SpanWithToken] = {}
         self._prediction_context = prediction_context

--- a/mlflow/langchain/langchain_tracer.py
+++ b/mlflow/langchain/langchain_tracer.py
@@ -55,6 +55,11 @@ class MlflowLangchainTracer(BaseCallbackHandler, metaclass=ExceptionSafeAbstract
             propagate the thread-local context.
     """
 
+    # NB: run_inline=True ensures the callback runs in the main async task rather than
+    # being offloaded to a thread pool. This is critical for proper context propagation
+    # when mixing autolog traces with manual @mlflow.trace decorators in async scenarios.
+    run_inline = True
+
     def __init__(
         self,
         prediction_context: Optional["Context"] = None,

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -686,7 +686,9 @@ async def test_tracer_with_manual_traces_async():
 
     @mlflow.trace(name="parent")
     async def run(message):
-        return await chain.ainvoke(message, config={"callbacks": [MlflowLangchainTracer()]})
+        # run_inline=True ensures proper context propagation in async scenarios
+        tracer = MlflowLangchainTracer(run_inline=True)
+        return await chain.ainvoke(message, config={"callbacks": [tracer]})
 
     response = await run("red")
     expected_response = '[{"role": "user", "content": "What is the complementary color of blue?"}]'

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -668,3 +668,37 @@ def test_serialize_invocation_params_none():
     callback = MlflowLangchainTracer()
     result = callback._serialize_invocation_params(None)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_tracer_with_manual_traces_async():
+    llm = ChatOpenAI()
+    prompt = PromptTemplate(
+        input_variables=["color"],
+        template="What is the complementary color of {color}?",
+    )
+
+    @mlflow.trace
+    def manual_transform(s: str):
+        return s.replace("red", "blue")
+
+    chain = RunnableLambda(manual_transform) | prompt | llm | StrOutputParser()
+
+    @mlflow.trace(name="parent")
+    async def run(message):
+        return await chain.ainvoke(message, config={"callbacks": [MlflowLangchainTracer()]})
+
+    response = await run("red")
+    expected_response = '[{"role": "user", "content": "What is the complementary color of blue?"}]'
+    assert response == expected_response
+
+    traces = get_traces()
+    assert len(traces) == 1
+
+    trace = traces[0]
+    spans = trace.data.spans
+    assert spans[0].name == "parent"
+    assert spans[1].name == "RunnableSequence"
+    assert spans[1].parent_id == spans[0].span_id
+    assert spans[2].name == "manual_transform"
+    assert spans[2].parent_id == spans[1].span_id

--- a/tests/langchain/test_langchain_tracer.py
+++ b/tests/langchain/test_langchain_tracer.py
@@ -702,3 +702,9 @@ async def test_tracer_with_manual_traces_async():
     assert spans[1].parent_id == spans[0].span_id
     assert spans[2].name == "manual_transform"
     assert spans[2].parent_id == spans[1].span_id
+
+
+@pytest.mark.parametrize("run_tracer_inline", [True, False])
+def test_tracer_run_inline_parameter(run_tracer_inline):
+    tracer = MlflowLangchainTracer(run_inline=run_tracer_inline)
+    assert tracer.run_inline == run_tracer_inline


### PR DESCRIPTION
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
Resolve #18216 

### What changes are proposed in this pull request?

Enables inline mode for async span management in LangGraph, eliminating the thread context reference issue that prevents. Added this config to the autologging config as an opt-out (disable for users who want the fastest possible performance if they choose to). Add note in the docs for why this is an option. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [X] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [X] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [X] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
