### PR TITLE
[ML-59918] Add input data fields to genai_evaluate telemetry event

### DIFF
--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -14,7 +14,10 @@ from mlflow.exceptions import MlflowException
 from mlflow.genai.datasets.evaluation_dataset import EvaluationDataset
 from mlflow.genai.evaluation.constant import InputDatasetColumn
 from mlflow.genai.evaluation.session_utils import validate_session_level_evaluation_inputs
-from mlflow.genai.evaluation.utils import _convert_to_eval_set
+from mlflow.genai.evaluation.utils import (
+    _convert_to_eval_set,
+    _get_eval_data_size_and_fields,
+)
 from mlflow.genai.scorers import Scorer
 from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 from mlflow.genai.scorers.validation import valid_data_for_builtin_scorers, validate_scorers
@@ -28,6 +31,7 @@ from mlflow.models.evaluation.base import (
 from mlflow.models.evaluation.utils.trace import configure_autologging_for_evaluation
 from mlflow.telemetry.events import GenAIEvaluateEvent
 from mlflow.telemetry.track import record_usage_event
+from mlflow.telemetry.utils import _log_error
 from mlflow.tracing.constant import (
     DATABRICKS_OPTIONS_KEY,
     DATABRICKS_OUTPUT_KEY,
@@ -243,6 +247,23 @@ def evaluate(
         This function is not thread-safe. Please do not use it in multi-threaded
         environments.
     """
+    result, _ = _run_harness(data, scorers, predict_fn, model_id)
+    return result
+
+
+@record_usage_event(GenAIEvaluateEvent)
+def _run_harness(data, scorers, predict_fn, model_id) -> tuple[EvaluationResult, dict[str, Any]]:
+    """
+    Internal harness for running evaluation.
+
+    Returns:
+        A tuple containing:
+            - EvaluationResult: The evaluation result object with metrics and assessments
+            - dict: Telemetry data dictionary containing evaluation metadata (data size, fields,
+              etc.). This is used by the @record_usage_event decorator.
+    """
+    from mlflow.genai.evaluation import harness
+
     is_managed_dataset = isinstance(data, (EvaluationDataset, EntityEvaluationDataset))
 
     scorers = validate_scorers(scorers)
@@ -271,13 +292,6 @@ def evaluate(
     if predict_fn:
         predict_fn = convert_predict_fn(predict_fn=predict_fn, sample_input=sample_input)
 
-    return _run_harness(data, scorers, predict_fn, model_id)
-
-
-@record_usage_event(GenAIEvaluateEvent)
-def _run_harness(data, scorers, predict_fn, model_id):
-    from mlflow.genai.evaluation import harness
-
     # NB: The "RAG_EVAL_MAX_WORKERS" env var is used in the DBX agent harness, but is
     # deprecated in favor of the new "MLFLOW_GENAI_EVAL_MAX_WORKERS" env var. The old
     # one is not publicly documented, but we keep it for backward compatibility.
@@ -295,6 +309,12 @@ def _run_harness(data, scorers, predict_fn, model_id):
         # Use default name for evaluation dataset when converting from DataFrame
         mlflow_dataset = mlflow.data.from_pandas(df=data, name="dataset")
         df = data
+
+    try:
+        telemetry_data = _get_eval_data_size_and_fields(df)
+    except Exception:
+        _log_error("Failed to get evaluation data size and fields for GenAIEvaluateEvent")
+        telemetry_data = {}
 
     with (
         _start_run_or_reuse_active_run() as run_id,
@@ -319,7 +339,7 @@ def _run_harness(data, scorers, predict_fn, model_id):
     except Exception:
         logger.debug("Failed to display summary and usage instructions", exc_info=True)
 
-    return result
+    return result, telemetry_data
 
 
 def _log_dataset_input(

--- a/mlflow/genai/evaluation/utils.py
+++ b/mlflow/genai/evaluation/utils.py
@@ -7,7 +7,9 @@ from typing import TYPE_CHECKING, Any, Collection
 from mlflow.entities import Assessment, Trace, TraceData
 from mlflow.entities.assessment import DEFAULT_FEEDBACK_NAME, Feedback
 from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
+from mlflow.entities.evaluation_dataset import EvaluationDataset as EntityEvaluationDataset
 from mlflow.exceptions import MlflowException
+from mlflow.genai.datasets import EvaluationDataset as ManagedEvaluationDataset
 from mlflow.genai.evaluation.constant import (
     AgentEvaluationReserverKey,
 )
@@ -55,14 +57,45 @@ PGBAR_FORMAT = (
 )
 
 
+def _get_eval_data_type(data: "EvaluationDatasetTypes") -> dict[str, Any]:
+    data_type = type(data)
+
+    if data_type is list:
+        if len(data) > 0 and all(isinstance(item, Trace) for item in data):
+            return {"eval_data_type": "list[Trace]"}
+        return {"eval_data_type": "list[dict]"}
+
+    if data_type is EntityEvaluationDataset:
+        return {"eval_data_type": "EntityEvaluationDataset"}
+    if data_type is ManagedEvaluationDataset:
+        return {"eval_data_type": "EvaluationDataset"}
+
+    module = data_type.__module__
+    qualname = data_type.__qualname__
+
+    if qualname == "DataFrame":
+        if module.startswith("pandas"):
+            return {"eval_data_type": "pd.DataFrame"}
+        if module.startswith("pyspark"):
+            return {"eval_data_type": "pyspark.sql.DataFrame"}
+
+    return "unknown"
+
+
+def _get_eval_data_size_and_fields(df: "pd.DataFrame") -> dict[str, Any]:
+    input_columns = set(df.columns.tolist())
+    relevant_fields = {"inputs", "outputs", "trace", "expectations"}
+    return {
+        "eval_data_size": len(df),
+        "eval_data_provided_fields": sorted(input_columns & relevant_fields),
+    }
+
+
 def _convert_eval_set_to_df(data: "EvaluationDatasetTypes") -> "pd.DataFrame":
     """
     Takes in a dataset in the format that `mlflow.genai.evaluate()` expects and
     converts it into a pandas DataFrame.
     """
-    from mlflow.entities.evaluation_dataset import EvaluationDataset as EntityEvaluationDataset
-    from mlflow.genai.datasets import EvaluationDataset as ManagedEvaluationDataset
-
     if isinstance(data, list):
         if all(isinstance(item, Trace) for item in data):
             data = traces_to_df(data)

--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -84,6 +84,13 @@ class GenAIEvaluateEvent(Event):
         # Track if predict_fn is provided
         record_params["predict_fn_provided"] = arguments.get("predict_fn") is not None
 
+        # Track eval data type
+        eval_data = arguments.get("data")
+        if eval_data is not None:
+            from mlflow.genai.evaluation.utils import _get_eval_data_type
+
+            record_params.update(_get_eval_data_type(eval_data))
+
         # Track scorer information
         scorers = arguments.get("scorers") or []
         scorer_info = [
@@ -102,6 +109,15 @@ class GenAIEvaluateEvent(Event):
         record_params["scorer_info"] = scorer_info
 
         return record_params
+
+    @classmethod
+    def parse_result(cls, result: Any) -> dict[str, Any] | None:
+        _, telemetry_data = result
+
+        if not isinstance(telemetry_data, dict):
+            return None
+
+        return telemetry_data
 
 
 class CreateLoggedModelEvent(Event):

--- a/tests/genai/evaluate/test_evaluation.py
+++ b/tests/genai/evaluate/test_evaluation.py
@@ -624,7 +624,7 @@ def test_empty_scorers_allowed():
     data = [{"inputs": {"question": "What is MLflow?"}, "outputs": "MLflow is an ML platform"}]
 
     with mock.patch("mlflow.genai.evaluation.base._run_harness") as mock_evaluate_oss:
-        mock_evaluate_oss.return_value = mock_result
+        mock_evaluate_oss.return_value = (mock_result, {})
         result = mlflow.genai.evaluate(data=data, scorers=[])
 
     assert result is mock_result

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -387,8 +387,6 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
     model = TestModel()
 
     with (
-        mock.patch("mlflow.genai.judges.is_context_relevant"),
-        mock.patch("mlflow.genai.judges.meets_guidelines"),
         mock.patch("mlflow.genai.judges.utils.invocation_utils.invoke_judge_model"),
     ):
         # Test with all scorer kinds and scopes, without predict_fn
@@ -414,6 +412,9 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
                 {"class": "RelevanceToQuery", "kind": "builtin", "scope": "response"},
                 {"class": "UserFrustration", "kind": "builtin", "scope": "session"},
             ],
+            "eval_data_type": "list[dict]",
+            "eval_data_size": 1,
+            "eval_data_provided_fields": ["inputs", "outputs"],
         }
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
@@ -431,6 +432,121 @@ def test_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
                 {"class": "RelevanceToQuery", "kind": "builtin", "scope": "response"},
                 {"class": "Guidelines", "kind": "guidelines", "scope": "response"},
             ],
+            "eval_data_type": "list[dict]",
+            "eval_data_size": 1,
+            "eval_data_provided_fields": ["inputs", "outputs"],
+        }
+        validate_telemetry_record(
+            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+        )
+
+
+def test_genai_evaluate_telemetry_data_fields(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    @mlflow.genai.scorer
+    def sample_scorer():
+        return 1.0
+
+    with mock.patch("mlflow.genai.judges.utils.invocation_utils.invoke_judge_model"):
+        # Test with list of dicts
+        data_list = [
+            {
+                "inputs": {"question": "Q1"},
+                "outputs": "A1",
+                "expectations": {"answer": "Expected1"},
+            },
+            {
+                "inputs": {"question": "Q2"},
+                "outputs": "A2",
+                "expectations": {"answer": "Expected2"},
+            },
+        ]
+        mlflow.genai.evaluate(data=data_list, scorers=[sample_scorer])
+        expected_params = {
+            "predict_fn_provided": False,
+            "scorer_info": [
+                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+            ],
+            "eval_data_type": "list[dict]",
+            "eval_data_size": 2,
+            "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
+        }
+        validate_telemetry_record(
+            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+        )
+
+        # Test with pandas DataFrame
+        df_data = pd.DataFrame(
+            [
+                {"inputs": {"question": "Q1"}, "outputs": "A1"},
+                {"inputs": {"question": "Q2"}, "outputs": "A2"},
+                {"inputs": {"question": "Q3"}, "outputs": "A3"},
+            ]
+        )
+        mlflow.genai.evaluate(data=df_data, scorers=[sample_scorer])
+        expected_params = {
+            "predict_fn_provided": False,
+            "scorer_info": [
+                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+            ],
+            "eval_data_type": "pd.DataFrame",
+            "eval_data_size": 3,
+            "eval_data_provided_fields": ["inputs", "outputs"],
+        }
+        validate_telemetry_record(
+            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+        )
+
+        # Test with list of Traces
+        trace_ids = []
+        for i in range(2):
+            with mlflow.start_span(name=f"test_span_{i}") as span:
+                span.set_inputs({"question": f"Q{i}"})
+                span.set_outputs({"answer": f"A{i}"})
+                trace_ids.append(span.trace_id)
+
+        traces = [mlflow.get_trace(trace_id) for trace_id in trace_ids]
+        mlflow.genai.evaluate(data=traces, scorers=[sample_scorer])
+        expected_params = {
+            "predict_fn_provided": False,
+            "scorer_info": [
+                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+            ],
+            "eval_data_type": "list[Trace]",
+            "eval_data_size": 2,
+            "eval_data_provided_fields": ["inputs", "outputs", "trace"],
+        }
+        validate_telemetry_record(
+            mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params
+        )
+
+        # Test with EvaluationDataset
+        from mlflow.genai.datasets import create_dataset
+
+        dataset = create_dataset("test_dataset")
+        dataset_data = [
+            {
+                "inputs": {"question": "Q1"},
+                "outputs": "A1",
+                "expectations": {"answer": "Expected1"},
+            },
+            {
+                "inputs": {"question": "Q2"},
+                "outputs": "A2",
+                "expectations": {"answer": "Expected2"},
+            },
+        ]
+        dataset.merge_records(dataset_data)
+        mlflow.genai.evaluate(data=dataset, scorers=[sample_scorer])
+        expected_params = {
+            "predict_fn_provided": False,
+            "scorer_info": [
+                {"class": "UserDefinedScorer", "kind": "decorator", "scope": "response"},
+            ],
+            "eval_data_type": "EvaluationDataset",
+            "eval_data_size": 2,
+            "eval_data_provided_fields": ["expectations", "inputs", "outputs"],
         }
         validate_telemetry_record(
             mock_telemetry_client, mock_requests, GenAIEvaluateEvent.name, expected_params


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19230/files) to review incremental changes.
- [**stack/ML-59918-add-oss-telemetry-input-data-fields**](https://github.com/mlflow/mlflow/pull/19230) [[Files changed](https://github.com/mlflow/mlflow/pull/19230/files)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs
Previous discussions: https://github.com/mlflow/mlflow/pull/19040

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Adding 3 new fields to `genai_evaluate` event:
- `eval_data_size: int`
- `eval_data_type: str, "list[Trace]" | "list[dict]" | "pd.DataFrame" | "EntityEvaluationDataset" | "EvaluationDataset" | "pyspark.sql.DataFrame" | "unknown"`
- `eval_data_provided_field: set(str, "inputs" | "outputs" | "trace" | "expectations")`

These fields will help us understand the size of the evaluation runs and how users are passing in input data for evaluation runs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual Test
Running the following code snippet:
```
_EVALUATION_TEST_CASES = [
    {
        "inputs": {
            "question": "What are the top 10 trending anime this season?",
        },
    },
    ...
]

from mlflow.genai.scorers import Safety, RelevanceToQuery, Guidelines

@mlflow.genai.scorer(name="custom_scorer_2")
def custom_scorer_2():
        return 2.0

result = mlflow.genai.evaluate(
        data=_EVALUATION_TEST_CASES,
        predict_fn=predict_fn,
        scorers=[Safety(name="my_secret_app's_safety_scorer"), RelevanceToQuery(), Guidelines(
                name="test_guidelines",
                guidelines=["The response must be helpful and accurate"],
        ),
        custom_scorer_2
        ],
);
```

**Before**
```
{
    "predict_fn_provided": true,
    "scorer_info": [
      {
        "class": "Safety",
        "kind": "builtin",
        "scope": "response"
      },
      {
        "class": "RelevanceToQuery",
        "kind": "builtin",
        "scope": "response"
      },
      {
        "class": "Guidelines",
        "kind": "guidelines",
        "scope": "response"
      },
      {
        "class": "UserDefinedScorer",
        "kind": "decorator",
        "scope": "response"
      }
    ]
 }
```

**After**
```
{
  "predict_fn_provided": true,
  "scorer_info": [
    {
      "class": "Safety",
      "kind": "builtin",
      "scope": "response"
    },
    {
      "class": "RelevanceToQuery",
      "kind": "builtin",
      "scope": "response"
    },
    {
      "class": "Guidelines",
      "kind": "guidelines",
      "scope": "response"
    },
    {
      "class": "UserDefinedScorer",
      "kind": "decorator",
      "scope": "response"
    }
  ],
  "eval_data_type": "list[dict]",
  "eval_data_size": 10,
  "eval_data_provided_fields": [
    "inputs"
  ]
}
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
