### PR TITLE
[UI Telemetry] Allow session_id and installation_id to be overridden in TelemetryRecord

### DIFF
--- a/mlflow/telemetry/schemas.py
+++ b/mlflow/telemetry/schemas.py
@@ -21,9 +21,13 @@ class Record:
     params: dict[str, Any] | None = None
     status: Status = Status.UNKNOWN
     duration_ms: int | None = None
+    # installation and session ID usually comes from the telemetry client,
+    # but callers can override with these fields (e.g. in UI telemetry records)
+    installation_id: str | None = None
+    session_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        result = {
             "timestamp_ns": self.timestamp_ns,
             "event_name": self.event_name,
             # dump params to string so we can parse them easily in ETL pipeline
@@ -31,6 +35,11 @@ class Record:
             "status": self.status.value,
             "duration_ms": self.duration_ms,
         }
+        if self.installation_id:
+            result["installation_id"] = self.installation_id
+        if self.session_id:
+            result["session_id"] = self.session_id
+        return result
 
 
 class SourceSDK(str, Enum):

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -67,6 +67,34 @@ def test_add_record_and_send(mock_telemetry_client: TelemetryClient, mock_reques
     assert data["status"] == "success"
 
 
+def test_record_with_session_and_installation_id(
+    mock_telemetry_client: TelemetryClient, mock_requests
+):
+    record = Record(
+        event_name="test_event",
+        timestamp_ns=time.time_ns(),
+        status=Status.SUCCESS,
+        session_id="session_id_override",
+        installation_id="installation_id_override",
+    )
+    mock_telemetry_client.add_record(record)
+    mock_telemetry_client.flush()
+    assert mock_requests[0]["data"]["session_id"] == "session_id_override"
+    assert mock_requests[0]["data"]["installation_id"] == "installation_id_override"
+
+    record = Record(
+        event_name="test_event",
+        timestamp_ns=time.time_ns(),
+        status=Status.SUCCESS,
+    )
+    mock_telemetry_client.add_record(record)
+    mock_telemetry_client.flush()
+    assert mock_requests[1]["data"]["session_id"] == mock_telemetry_client.info["session_id"]
+    assert (
+        mock_requests[1]["data"]["installation_id"] == mock_telemetry_client.info["installation_id"]
+    )
+
+
 def test_batch_processing(mock_telemetry_client: TelemetryClient, mock_requests):
     mock_telemetry_client._batch_size = 3  # Set small batch size for testing
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19240/files) to review incremental changes.
- [**stack/update-telemetry-config**](https://github.com/mlflow/mlflow/pull/19240) [[Files changed](https://github.com/mlflow/mlflow/pull/19240/files)]
  - [stack/server-handlers](https://github.com/mlflow/mlflow/pull/19291) [[Files changed](https://github.com/mlflow/mlflow/pull/19291/files/e086ee22e3b8d89ebb2bb9c7bc49e8ed402bd250..1417149a0033035c3cecc61ac088358c81114382)]
    - [stack/server-handlers-2](https://github.com/mlflow/mlflow/pull/19303) [[Files changed](https://github.com/mlflow/mlflow/pull/19303/files/1417149a0033035c3cecc61ac088358c81114382..5dd0c3fa455938708cc51c2cb57fc0d5b2c534fb)]
      - [stack/service-worker](https://github.com/mlflow/mlflow/pull/19292) [[Files changed](https://github.com/mlflow/mlflow/pull/19292/files/5dd0c3fa455938708cc51c2cb57fc0d5b2c534fb..f1800c39cf5a22b4dbcbf300879e191cdbcc3ed8)]
        - [stack/fe-client](https://github.com/mlflow/mlflow/pull/19312) [[Files changed](https://github.com/mlflow/mlflow/pull/19312/files/f1800c39cf5a22b4dbcbf300879e191cdbcc3ed8..774478c17ebdd157dd8cec5b15fd02a58ff7747b)]
          - [stack/settings](https://github.com/mlflow/mlflow/pull/19351) [[Files changed](https://github.com/mlflow/mlflow/pull/19351/files/774478c17ebdd157dd8cec5b15fd02a58ff7747b..6a5b2550db5e2b68e6fd904f8086d867ff6f9bdd)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds some optional fields to the telemetry `Record` dataclass. This is because with UI telemetry, we plan to reuse the existing telemetry client. However, the `session_id` and `installation_id` fields need to come from the browser, not from the python client. The UI will send these as part of the POST request payload, so we need to make sure they are respected.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

Manually tested end-to-end and made sure they show up correctly in the final table.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [x] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
