### PR TITLE
Bump version to 2.22.4

### DIFF
--- a/mlflow/R/mlflow/DESCRIPTION
+++ b/mlflow/R/mlflow/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: mlflow
 Title: Interface to 'MLflow'
-Version: 2.22.3
+Version: 2.22.4
 Authors@R: 
     c(person(given = "Matei",
              family = "Zaharia",

--- a/mlflow/java/client/pom.xml
+++ b/mlflow/java/client/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>2.22.3</version>
+    <version>2.22.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mlflow/java/pom.xml
+++ b/mlflow/java/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.mlflow</groupId>
   <artifactId>mlflow-parent</artifactId>
-  <version>2.22.3</version>
+  <version>2.22.4</version>
   <packaging>pom</packaging>
   <name>MLflow Parent POM</name>
   <url>http://mlflow.org</url>
@@ -59,7 +59,7 @@
   </distributionManagement>
 
   <properties>
-    <mlflow-version>2.22.3</mlflow-version>
+    <mlflow-version>2.22.4</mlflow-version>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
     <scala.version>2.11.12</scala.version>

--- a/mlflow/java/scoring/pom.xml
+++ b/mlflow/java/scoring/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>2.22.3</version>
+    <version>2.22.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
+++ b/mlflow/java/scoring/src/main/java/org/mlflow/sagemaker/ScoringServer.java
@@ -172,7 +172,7 @@ public class ScoringServer {
     @Override
     public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
       response.setStatus(HttpServletResponse.SC_OK);
-      response.getWriter().print("2.22.3");
+      response.getWriter().print("2.22.4");
       response.getWriter().close();
     }
   }

--- a/mlflow/java/scoring/src/test/java/org/mlflow/ScoringServerTest.java
+++ b/mlflow/java/scoring/src/test/java/org/mlflow/ScoringServerTest.java
@@ -78,7 +78,7 @@ public class ScoringServerTest {
     HttpResponse response = httpClient.execute(getRequest);
     Assert.assertEquals(HttpServletResponse.SC_OK, response.getStatusLine().getStatusCode());
     String responseBody = getHttpResponseBody(response);
-    Assert.assertEquals("2.22.3", responseBody);
+    Assert.assertEquals("2.22.4", responseBody);
     server.stop();
   }
 

--- a/mlflow/java/spark/pom.xml
+++ b/mlflow/java/spark/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mlflow-spark_${scala.compat.version}</artifactId>
-  <version>2.22.3</version>
+  <version>2.22.4</version>
   <name>${project.artifactId}</name>
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.mlflow</groupId>
     <artifactId>mlflow-parent</artifactId>
-    <version>2.22.3</version>
+    <version>2.22.4</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/mlflow/server/js/src/common/constants.tsx
+++ b/mlflow/server/js/src/common/constants.tsx
@@ -9,7 +9,7 @@ export const ErrorCodes = {
   RESOURCE_CONFLICT: 'RESOURCE_CONFLICT',
 };
 
-export const Version = '2.22.3';
+export const Version = '2.22.4';
 
 const DOCS_VERSION = 'latest';
 

--- a/mlflow/version.py
+++ b/mlflow/version.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Databricks, Inc.
 import re
 
-VERSION = "2.22.3"
+VERSION = "2.22.4"
 
 
 def is_release_version():

--- a/pyproject.release.toml
+++ b/pyproject.release.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlflow"
-version = "2.22.3"
+version = "2.22.4"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README.md"
 keywords = ["mlflow", "ai", "databricks"]
@@ -27,7 +27,7 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-  "mlflow-skinny==2.22.3",
+  "mlflow-skinny==2.22.4",
   "Flask<4",
   "Jinja2<4,>=2.11; platform_system != 'Windows'",
   "Jinja2<4,>=3.0; platform_system == 'Windows'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlflow"
-version = "2.22.3"
+version = "2.22.4"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README.md"
 keywords = ["mlflow", "ai", "databricks"]

--- a/skinny/pyproject.toml
+++ b/skinny/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mlflow-skinny"
-version = "2.22.3"
+version = "2.22.4"
 description = "MLflow is an open source platform for the complete machine learning lifecycle"
 readme = "README_SKINNY.md"
 keywords = ["mlflow", "ai", "databricks"]


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19244?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19244/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19244/merge#subdirectory=skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s 19244
```

</p>
</details>

The previous release accidentally missed UI assets