### PR TITLE
Automatically wrap async functions when passed to predict_fn

### DIFF
--- a/docs/docs/genai/eval-monitor/faq.mdx
+++ b/docs/docs/genai/eval-monitor/faq.mdx
@@ -31,6 +31,12 @@ Configure the timeout (in seconds) using the `MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT` e
 export MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT=600  # 10 minutes
 ```
 
+**For Jupyter Notebooks:** Install `nest_asyncio` to use async functions in notebook environments:
+
+```bash
+pip install nest_asyncio
+```
+
 Example with an async predict function:
 
 ```python

--- a/docs/docs/genai/eval-monitor/faq.mdx
+++ b/docs/docs/genai/eval-monitor/faq.mdx
@@ -21,6 +21,41 @@ MLflow uses a thread pool to run the predict function and scorers in parallel. C
 export MLFLOW_GENAI_EVAL_MAX_WORKERS=5
 ```
 
+## Can I use async functions as predict_fn?
+
+Yes! MLflow automatically detects and wraps async functions. The async function will be executed with a timeout to prevent indefinite hangs.
+
+Configure the timeout (in seconds) using the `MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT` environment variable (default: `300` seconds):
+
+```bash
+export MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT=600  # 10 minutes
+```
+
+Example with an async predict function:
+
+```python
+import asyncio
+from openai import AsyncOpenAI
+
+client = AsyncOpenAI()
+
+
+async def async_predict_fn(question: str) -> str:
+    """Async prediction function using OpenAI"""
+    response = await client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": question}],
+    )
+    return response.choices[0].message.content
+
+
+mlflow.genai.evaluate(
+    data=eval_dataset,
+    predict_fn=async_predict_fn,  # Async function automatically supported
+    scorers=[Correctness()],
+)
+```
+
 ## Why does MLflow make N+1 predictions during evaluation?
 
 MLflow requires the predict function passed through the `predict_fn` parameter to emit a single trace per call. To ensure the function produces a trace, MLflow first runs one additional prediction on a single input.

--- a/docs/docs/genai/eval-monitor/running-evaluation/agents.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/agents.mdx
@@ -114,6 +114,31 @@ def predict_fn(question: str) -> str:
     return Runner.run_sync(agent, question).final_output
 ```
 
+:::tip
+
+**Async Functions are Supported!**
+
+If your agent library provides an async API, you can use it directly without converting to sync. MLflow automatically detects and handles async functions:
+
+```python
+async def predict_fn(question: str) -> str:
+    result = await Runner.run(agent, question)
+    return result.final_output
+
+
+mlflow.genai.evaluate(
+    data=eval_dataset, predict_fn=predict_fn, scorers=[exact_match, uses_correct_tools]
+)
+```
+
+By default, async functions have a 5-minute timeout. Configure this using the `MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT` environment variable:
+
+```bash
+export MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT=600  # 10 minutes
+```
+
+:::
+
 ### Step 2: Create evaluation dataset
 
 Design test cases as a list of dictionaries, each with an `inputs`, `expectations`, and an optional `tags` field. We would like to evaluate the correctness of the output, but also the tool calls used by the agent.

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -690,6 +690,11 @@ MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING = _BooleanEnvironmentVariable(
     "MLFLOW_GENAI_EVAL_ENABLE_SCORER_TRACING", False
 )
 
+#: Timeout in seconds for async predict functions in mlflow.genai.evaluate. When an async
+#: function is passed as predict_fn, it will be wrapped with asyncio.run() with this timeout.
+#: (default: ``300``)
+MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT = _EnvironmentVariable("MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT", int, 300)
+
 #: Whether to warn (default) or raise (opt-in) for unresolvable requirements inference for
 #: a model's dependency inference. If set to True, an exception will be raised if requirements
 #: inference or the process of capturing imported modules encounters any errors.

--- a/mlflow/genai/evaluation/base.py
+++ b/mlflow/genai/evaluation/base.py
@@ -222,6 +222,11 @@ def evaluate(
             The function must emit a single trace per call. If it doesn't, decorate
             the function with @mlflow.trace decorator to ensure a trace to be emitted.
 
+            Both synchronous and asynchronous (async def) functions are supported. Async
+            functions are automatically detected and wrapped to run synchronously with a
+            configurable timeout (default: 300 seconds). Set the timeout using the
+            MLFLOW_GENAI_EVAL_ASYNC_TIMEOUT environment variable.
+
         model_id: Optional model identifier (e.g. "m-074689226d3b40bfbbdf4c3ff35832cd")
             to associate with the evaluation results. Can be also set globally via the
             :py:func:`mlflow.set_active_model` function.


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19249?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19249/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19249/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19249/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Automatically wrap async functions when they are passed to `predict_fn` in `mlflow.genai.evaluate`

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

```
import asyncio

import mlflow
import pandas as pd
from mlflow.genai.scorers import scorer


async def async_predict_fn(question: str) -> str:
    await asyncio.sleep(0.1)
    return f"Answer to: {question}"


@scorer
def length_scorer(inputs, outputs):
    return len(outputs)


data = pd.DataFrame([
    {"inputs": {"question": "What is MLflow?"}},
    {"inputs": {"question": "What is Python?"}},
])

result = mlflow.genai.evaluate(
    data=data,
    predict_fn=async_predict_fn,
    scorers=[length_scorer],
)

print(f"Metrics: {result.metrics}")

traces = mlflow.search_traces(run_id=result.run_id, return_type="list")
print(f"\nFirst trace assessments:")
for assessment in traces[0].info.assessments:
    print(f"  {assessment.name}: {assessment.feedback.value}")
```

outputs:
```
2025/12/05 10:09:14 INFO mlflow.genai.utils.data_validation: Testing model prediction with the first sample in the dataset. To disable this check, set the MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION environment variable to True.
2025/12/05 10:09:15 INFO mlflow.store.db.utils: Creating initial MLflow database tables...
2025/12/05 10:09:15 INFO mlflow.store.db.utils: Updating database tables
2025/12/05 10:09:15 INFO alembic.runtime.migration: Context impl SQLiteImpl.
2025/12/05 10:09:15 INFO alembic.runtime.migration: Will assume non-transactional DDL.
2025/12/05 10:09:15 INFO alembic.runtime.migration: Context impl SQLiteImpl.
2025/12/05 10:09:15 INFO alembic.runtime.migration: Will assume non-transactional DDL.

✨ Evaluation completed.

Metrics and evaluation results are logged to the MLflow run:
  Run name: sneaky-sow-347
  Run ID: 8b770a04ae284df9b6e343f3a9cc5aaa

To view the detailed evaluation results with sample-wise scores,
open the Traces tab in the Run page in the MLflow UI.

Metrics: {'length_scorer/mean': np.float64(26.0)}

First trace assessments:
  length_scorer: 26
```

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
Automatically wrap async functions when they are passed to `predict_fn` in `mlflow.genai.evaluate`

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
