### PR TITLE
Improve error messages for multi-turn functionality

### DIFF
--- a/mlflow/genai/evaluation/session_utils.py
+++ b/mlflow/genai/evaluation/session_utils.py
@@ -157,5 +157,6 @@ def validate_session_level_evaluation_inputs(scorers: list[Scorer], predict_fn: 
             raise MlflowException.invalid_parameter_value(
                 f"Multi-turn scorers are not yet supported with predict_fn. "
                 f"The following scorers require session-level evaluation: {scorer_names}. "
-                f"Please pass traces instead."
+                f"Please pass existing traces containing session IDs to `data` "
+                f"(e.g., `data=mlflow.search_traces()`)."
             )

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1622,8 +1622,16 @@ class BuiltInSessionLevelScorer(BuiltInScorer):
         self,
         *,
         session: list[Trace] | None = None,
+        expectations: dict[str, Any] | None = None,
+        **kwargs,
     ) -> Feedback:
-        return self._get_judge()(session=session)
+        if kwargs:
+            invalid_args = ", ".join(f"'{k}'" for k in kwargs.keys())
+            raise TypeError(
+                f"Session level scorers can only accept the `session` and `expectations` "
+                f"parameters. Got unexpected keyword argument(s): {invalid_args}"
+            )
+        return self._get_judge()(session=session, expectations=expectations)
 
 
 @experimental(version="3.7.0")

--- a/tests/genai/evaluate/test_session_utils.py
+++ b/tests/genai/evaluate/test_session_utils.py
@@ -294,7 +294,8 @@ def test_validate_session_level_evaluation_inputs_with_predict_fn():
 
     with pytest.raises(
         MlflowException,
-        match="Multi-turn scorers are not yet supported with predict_fn",
+        match=r"Multi-turn scorers are not yet supported with predict_fn.*"
+        r"Please pass existing traces containing session IDs to `data`",
     ):
         validate_session_level_evaluation_inputs(
             scorers=scorers_list,

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1547,3 +1547,21 @@ def test_conversational_safety_instructions():
     assert "conversation" in instructions.lower()
     assert "assistant" in instructions.lower()
     assert "safety" in instructions.lower()
+
+
+def test_session_level_scorer_with_invalid_kwargs():
+    scorer = UserFrustration()
+
+    with pytest.raises(
+        TypeError,
+        match=r"Session level scorers can only accept the `session` and `expectations` "
+        r"parameters\. Got unexpected keyword argument\(s\): 'trace'",
+    ):
+        scorer(trace=create_simple_trace())
+
+    with pytest.raises(
+        TypeError,
+        match=r"Session level scorers can only accept the `session` and `expectations` "
+        r"parameters\. Got unexpected keyword argument\(s\): 'outputs'",
+    ):
+        scorer(outputs="some output")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19252?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19252/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19252/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19252/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - improves for calling multi-turn scorer with wrong args and for running `mlflow.genai.evaluate` with `predict_fn` and multi-turn scorers.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
