### PR TITLE
Add note about documentation branches to doc fix issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/doc_fix_template.yaml
+++ b/.github/ISSUE_TEMPLATE/doc_fix_template.yaml
@@ -13,6 +13,9 @@ body:
         - ✅ **Documentation pages** under https://mlflow.org/docs (API reference, tutorials, how-to guides) — you're in the right place!
         - ❌ **Main website content** (blog posts, marketing pages, other site content) — please file at https://github.com/mlflow/mlflow-website/issues instead
 
+        **Important note about documentation branches:**
+        The production documentation at https://mlflow.org/docs/latest/ is built from the **release branch** (e.g., `branch-3.7`), not `master`. If you notice a discrepancy between the live docs and the source code on `master`, the fix may already exist on `master`. You can verify this by checking the preview site at https://dev--mlflow-docs-preview.netlify.app/docs/latest which is built from `master`.
+
         **Please fill in this documentation issue template to ensure a timely and thorough response.**
   - type: dropdown
     id: contribution


### PR DESCRIPTION
### Related Issues/PRs

#19256

### What changes are proposed in this pull request?

Add a note to the documentation fix issue template clarifying that:
- Production docs at https://mlflow.org/docs/latest/ are built from release branches (e.g., `branch-3.7`), not `master`
- Users can verify discrepancies by checking the preview site at https://dev--mlflow-docs-preview.netlify.app/docs/latest which is built from `master`

This helps reporters and maintainers quickly identify whether an issue is a missing backport vs. a genuine bug.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)