### PR TITLE
Fix component IDs in UI code

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageSubTabSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageSubTabSelector.tsx
@@ -15,7 +15,11 @@ export const ExperimentPageSubTabSelector = ({
 
   if (activeTab === ExperimentPageTabName.EvaluationRuns || activeTab === ExperimentPageTabName.Datasets) {
     return (
-      <Tabs.Root componentId={experimentId} value={activeTab} css={{ '& > div': { marginBottom: 0 } }}>
+      <Tabs.Root
+        componentId="mlflow.experiment.details.sub-tab-selector"
+        value={activeTab}
+        css={{ '& > div': { marginBottom: 0 } }}
+      >
         <Tabs.List>
           <Tabs.Trigger value={ExperimentPageTabName.EvaluationRuns}>
             <Link

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroupSourceCounts.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroupSourceCounts.tsx
@@ -35,7 +35,7 @@ export const FeedbackValueGroupSourceCounts = ({ feedbacks }: { feedbacks: Feedb
     <div css={{ display: 'flex', gap: theme.spacing.xs, alignItems: 'center', marginLeft: theme.spacing.xs }}>
       {Object.entries(sourceCounts).map(([sourceType, count]) => (
         <Tag
-          componentId={`shared.model-trace-explorer.feedback-source-count-${sourceType}`}
+          componentId="shared.model-trace-explorer.feedback-source-count"
           css={{
             margin: 0,
           }}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessageHeader.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/ModelTraceExplorerChatMessageHeader.tsx
@@ -127,7 +127,7 @@ export const ModelTraceExplorerChatMessageHeader = ({
                 </Typography.Text>
               ),
               toolCallId: (
-                <Tooltip componentId="test" content={message.tool_call_id}>
+                <Tooltip componentId="shared.model-trace-explorer.tool-call-id-tooltip" content={message.tool_call_id}>
                   <div
                     css={{ display: 'inline-flex', flexShrink: 1, overflow: 'hidden', marginLeft: theme.spacing.xs }}
                   >

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeFilterButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/timeline-tree/TimelineTreeFilterButton.tsx
@@ -52,7 +52,7 @@ export const TimelineTreeFilterButton = ({
             return (
               <Checkbox
                 key={spanType}
-                componentId={`shared.model-trace-explorer.toggle-span-filter_${spanType}-${!shouldDisplay}`}
+                componentId="shared.model-trace-explorer.toggle-span-filter"
                 style={{ width: '100%' }}
                 isChecked={shouldDisplay}
                 onChange={() =>


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/daniellok-db/mlflow/pull/19267?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19267/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19267/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19267/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

I ran a manual audit to check if any of our component IDs are currently containing any user-generated content, and in the process i found a couple that are potentially doing so + a couple more that were just "test" or something useless.

This PR fixes some of the minor cases. There remains a lot of codegen IDs but those can be cleaned up in the future. The most important fix in this PR is simply the exclusion of `spanType` and `sourceType` (which can be set by the user). If we implement UI telemetry it will be important not to have these.

Eventually we are migrating to all component IDs being static (it is already a lint rule upstream), so this is pre-work for that anyway.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

ran this script (claude generated but seems more or less legit): https://gist.github.com/daniellok-db/5336913d13ea2ecac9f37ffcb1bb100a

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
