### PR TITLE
Convert auto assign to cron job to check all PRs

### DIFF
--- a/.github/workflows/auto-assign.js
+++ b/.github/workflows/auto-assign.js
@@ -1,0 +1,80 @@
+async function getMaintainers({ github, context }) {
+  const collaborators = await github.paginate(github.rest.repos.listCollaborators, {
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+  });
+  return collaborators
+    .filter(({ role_name }) => ["admin", "maintain"].includes(role_name))
+    .map(({ login }) => login)
+    .sort();
+}
+
+module.exports = async ({ github, context }) => {
+  const { owner, repo } = context.repo;
+  const maintainers = await getMaintainers({ github, context });
+
+  // Get current time minus 200 minutes to look for recent comments and PRs
+  const lookbackTime = new Date(Date.now() - 200 * 60 * 1000);
+
+  // Use search API to find recently updated open PRs
+  const searchQuery = `repo:${owner}/${repo} is:pr is:open updated:>=${lookbackTime.toISOString()}`;
+  const searchResults = await github.paginate(github.rest.search.issuesAndPullRequests, {
+    q: searchQuery,
+    sort: "updated",
+    order: "desc",
+  });
+
+  console.log(`Scanning ${searchResults.length} recently updated PRs`);
+
+  for (const pr of searchResults) {
+    const prAuthor = pr.user.login;
+    const currentAssignees = pr.assignees.map((a) => a.login);
+
+    // Get recent comments and reviews
+    const [issueComments, reviews] = await Promise.all([
+      github.rest.issues.listComments({
+        owner,
+        repo,
+        issue_number: pr.number,
+        since: lookbackTime.toISOString(),
+      }),
+      github.rest.pulls.listReviews({
+        owner,
+        repo,
+        pull_number: pr.number,
+      }),
+    ]);
+
+    // Filter reviews by lookback time
+    const recentReviews = reviews.data.filter((r) => new Date(r.submitted_at) > lookbackTime);
+
+    // Extract and filter maintainer authors directly
+    const allAuthors = [
+      ...issueComments.data.map((c) => c.user.login),
+      ...recentReviews.map((r) => r.user.login),
+    ];
+    const maintainersToAssign = [
+      ...new Set(
+        allAuthors.filter(
+          (login) =>
+            maintainers.includes(login) && login !== prAuthor && !currentAssignees.includes(login)
+        )
+      ),
+    ];
+
+    if (maintainersToAssign.length === 0) {
+      continue;
+    }
+
+    // Assign maintainers
+    await github.rest.issues.addAssignees({
+      owner,
+      repo,
+      issue_number: pr.number,
+      assignees: maintainersToAssign,
+    });
+    console.log(`Assigned [${maintainersToAssign.join(", ")}] to PR #${pr.number}`);
+  }
+
+  console.log("Scan completed");
+};

--- a/.github/workflows/auto-assign.js
+++ b/.github/workflows/auto-assign.js
@@ -9,7 +9,7 @@ async function getMaintainers({ github, context }) {
     .sort();
 }
 
-module.exports = async ({ github, context }) => {
+module.exports = async ({ github, context, skipAssignment = false }) => {
   const { owner, repo } = context.repo;
   const maintainers = new Set(await getMaintainers({ github, context }));
 
@@ -62,13 +62,19 @@ module.exports = async ({ github, context }) => {
     }
 
     // Assign maintainers
-    await github.rest.issues.addAssignees({
-      owner,
-      repo,
-      issue_number: pr.number,
-      assignees: maintainersToAssign,
-    });
-    console.log(`Assigned [${maintainersToAssign.join(", ")}] to PR #${pr.number}`);
+    if (!skipAssignment) {
+      await github.rest.issues.addAssignees({
+        owner,
+        repo,
+        issue_number: pr.number,
+        assignees: maintainersToAssign,
+      });
+    }
+    console.log(
+      `${skipAssignment ? "[DRY RUN] Would assign" : "Assigned"} [${maintainersToAssign.join(
+        ", "
+      )}] to PR #${pr.number}`
+    );
   }
 
   console.log("Scan completed");

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -5,6 +5,10 @@ on:
     # Run every 3 hours to check for new maintainer comments
     - cron: "0 */3 * * *"
   workflow_dispatch: # Allow manual triggering
+  pull_request:
+    paths:
+      - .github/workflows/auto-assign.yml
+      - .github/workflows/auto-assign.js
 
 defaults:
   run:
@@ -21,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        if: github.event_name != 'pull_request'
         with:
           script: |
             const script = require('./.github/workflows/auto-assign.js');

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -24,6 +24,9 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          sparse-checkout: |
+            .github/workflows/auto-assign.js
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           sparse-checkout: |
-            .github/workflows/auto-assign.js
+            .github
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -25,8 +25,8 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        if: github.event_name != 'pull_request'
         with:
           script: |
             const script = require('./.github/workflows/auto-assign.js');
-            await script({ github, context });
+            const skipAssignment = context.eventName === 'pull_request';
+            await script({ github, context, skipAssignment });

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -19,81 +19,9 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
-            const { owner, repo } = context.repo;
-            const maintainers = ["B-Step62", "BenWilson2", "daniellok-db", "harupy", "serena-ruan", "TomeHirata", "WeichenXu123"];
-
-            // Get current time minus 200 minutes to look for recent comments and PRs (provides buffer beyond 3-hour cron schedule to avoid missing comments during execution overlap)
-            const lookbackTime = new Date(Date.now() - 200 * 60 * 1000);
-
-            // Get recent PRs (stop pagination when we hit PRs older than 200 minutes)
-            const prs = [];
-
-            outer: for await (const response of github.paginate.iterator(github.rest.pulls.list, {
-              owner,
-              repo,
-              state: 'open',
-              sort: 'updated',
-              direction: 'desc'
-            })) {
-              for (const pr of response.data) {
-                const updatedAt = new Date(pr.updated_at);
-                if (updatedAt > lookbackTime) {
-                  prs.push(pr);
-                } else {
-                  break outer;
-                }
-              }
-            }
-
-            console.log(`Scanning ${prs.length} recently updated PRs`);
-
-            for (const pr of prs) {
-              const prAuthor = pr.user.login;
-              const currentAssignees = pr.assignees.map(a => a.login);
-
-              // Get recent comments (both issue and review comments)
-              const [issueComments, reviewComments] = await Promise.all([
-                github.rest.issues.listComments({
-                  owner,
-                  repo,
-                  issue_number: pr.number,
-                  since: lookbackTime.toISOString()
-                }),
-                github.rest.pulls.listReviewComments({
-                  owner,
-                  repo,
-                  pull_number: pr.number,
-                  since: lookbackTime.toISOString()
-                })
-              ]);
-
-              const allComments = [...issueComments.data, ...reviewComments.data];
-
-              // Process maintainer comments
-              const maintainerComments = allComments.filter(c =>
-                maintainers.includes(c.user.login) &&
-                c.user.login !== prAuthor &&
-                !currentAssignees.includes(c.user.login)
-              );
-
-              if (maintainerComments.length === 0) {
-                continue;
-              }
-
-              // Get unique maintainers to assign
-              const maintainersToAssign = [...new Set(maintainerComments.map(c => c.user.login))];
-
-              // Assign maintainers
-              await github.rest.issues.addAssignees({
-                owner,
-                repo,
-                issue_number: pr.number,
-                assignees: maintainersToAssign,
-              });
-              console.log(`Assigned [${maintainersToAssign.join(', ')}] to PR #${pr.number}`);
-            }
-
-            console.log('Scan completed');
+            const script = require('./.github/workflows/auto-assign.js');
+            await script({ github, context });

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,52 +1,101 @@
 name: Auto-assign maintainer
 
 on:
-  issue_comment:
-    types:
-      - created
-  pull_request_review_comment:
-    types:
-      - created
+  schedule:
+    # Run every 3 hours to check for new maintainer comments
+    - cron: "0 */3 * * *"
+  workflow_dispatch: # Allow manual triggering
 
 defaults:
   run:
     shell: bash
 
 jobs:
-  assign:
-    # Only run on open PR comments from maintainers who are not already assigned and not the PR owner
-    if: >
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        github.event.issue.state == 'open' &&
-        contains(fromJSON('["B-Step62", "BenWilson2", "daniellok-db", "harupy", "serena-ruan", "TomeHirata", "WeichenXu123"]'), github.event.comment.user.login) &&
-        !contains(github.event.issue.assignees.*.login, github.event.comment.user.login) &&
-        github.event.comment.user.login != github.event.issue.user.login
-      ) || (
-        github.event_name == 'pull_request_review_comment' &&
-        github.event.pull_request.state == 'open' &&
-        contains(fromJSON('["B-Step62", "BenWilson2", "daniellok-db", "harupy", "serena-ruan", "TomeHirata", "WeichenXu123"]'), github.event.comment.user.login) &&
-        !contains(github.event.pull_request.assignees.*.login, github.event.comment.user.login) &&
-        github.event.comment.user.login != github.event.pull_request.user.login
-      )
+  scan-and-assign:
     runs-on: ubuntu-slim
-    timeout-minutes: 5
+    timeout-minutes: 10
     permissions:
+      contents: read
+      issues: write
       pull-requests: write
     steps:
       - uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         with:
           script: |
             const { owner, repo } = context.repo;
-            const issue_number = context.payload.issue?.number || context.payload.pull_request?.number;
-            const commenter = context.payload.comment.user.login;
+            const maintainers = ["B-Step62", "BenWilson2", "daniellok-db", "harupy", "serena-ruan", "TomeHirata", "WeichenXu123"];
 
-            console.log(`Adding ${commenter} as assignee`);
-            await github.rest.issues.addAssignees({
+            // Get current time minus 4 hours to look for recent comments and PRs (with buffer since we run every 3 hours)
+            const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
+
+            // Get recent PRs (stop pagination when we hit PRs older than 4 hours)
+            const prs = [];
+
+            outer: for await (const response of github.paginate.iterator(github.rest.pulls.list, {
               owner,
               repo,
-              issue_number,
-              assignees: [commenter],
-            });
-            console.log(`Successfully added ${commenter} as assignee`);
+              state: 'open',
+              sort: 'updated',
+              direction: 'desc'
+            })) {
+              for (const pr of response.data) {
+                const updatedAt = new Date(pr.updated_at);
+                if (updatedAt > fourHoursAgo) {
+                  prs.push(pr);
+                } else {
+                  break outer;
+                }
+              }
+            }
+
+            console.log(`Scanning ${prs.length} recently updated PRs`);
+
+            for (const pr of prs) {
+              const prAuthor = pr.user.login;
+              const currentAssignees = pr.assignees.map(a => a.login);
+
+              // Get recent comments (both issue and review comments)
+              const [issueComments, reviewComments] = await Promise.all([
+                github.rest.issues.listComments({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  since: fourHoursAgo.toISOString()
+                }),
+                github.rest.pulls.listReviewComments({
+                  owner,
+                  repo,
+                  pull_number: pr.number,
+                  since: fourHoursAgo.toISOString()
+                })
+              ]);
+
+              const allComments = [...issueComments.data, ...reviewComments.data];
+
+              // Process maintainer comments
+              const maintainerComments = allComments.filter(c =>
+                maintainers.includes(c.user.login) &&
+                c.user.login !== prAuthor &&
+                !currentAssignees.includes(c.user.login)
+              );
+
+              if (maintainerComments.length === 0) {
+                continue;
+              }
+
+              // Get unique maintainers to assign
+              const maintainersToAssign = [...new Set(maintainerComments.map(c => c.user.login))];
+
+              // Assign maintainers
+              if (maintainersToAssign.length > 0) {
+                await github.rest.issues.addAssignees({
+                  owner,
+                  repo,
+                  issue_number: pr.number,
+                  assignees: maintainersToAssign,
+                });
+                console.log(`Assigned [${maintainersToAssign.join(', ')}] to PR #${pr.number}`);
+              }
+            }
+
+            console.log('Scan completed');

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -25,10 +25,10 @@ jobs:
             const { owner, repo } = context.repo;
             const maintainers = ["B-Step62", "BenWilson2", "daniellok-db", "harupy", "serena-ruan", "TomeHirata", "WeichenXu123"];
 
-            // Get current time minus 4 hours to look for recent comments and PRs (with buffer since we run every 3 hours)
-            const fourHoursAgo = new Date(Date.now() - 4 * 60 * 60 * 1000);
+            // Get current time minus 200 minutes to look for recent comments and PRs (provides buffer beyond 3-hour cron schedule to avoid missing comments during execution overlap)
+            const lookbackTime = new Date(Date.now() - 200 * 60 * 1000);
 
-            // Get recent PRs (stop pagination when we hit PRs older than 4 hours)
+            // Get recent PRs (stop pagination when we hit PRs older than 200 minutes)
             const prs = [];
 
             outer: for await (const response of github.paginate.iterator(github.rest.pulls.list, {
@@ -40,7 +40,7 @@ jobs:
             })) {
               for (const pr of response.data) {
                 const updatedAt = new Date(pr.updated_at);
-                if (updatedAt > fourHoursAgo) {
+                if (updatedAt > lookbackTime) {
                   prs.push(pr);
                 } else {
                   break outer;
@@ -60,13 +60,13 @@ jobs:
                   owner,
                   repo,
                   issue_number: pr.number,
-                  since: fourHoursAgo.toISOString()
+                  since: lookbackTime.toISOString()
                 }),
                 github.rest.pulls.listReviewComments({
                   owner,
                   repo,
                   pull_number: pr.number,
-                  since: fourHoursAgo.toISOString()
+                  since: lookbackTime.toISOString()
                 })
               ]);
 
@@ -87,15 +87,13 @@ jobs:
               const maintainersToAssign = [...new Set(maintainerComments.map(c => c.user.login))];
 
               // Assign maintainers
-              if (maintainersToAssign.length > 0) {
-                await github.rest.issues.addAssignees({
-                  owner,
-                  repo,
-                  issue_number: pr.number,
-                  assignees: maintainersToAssign,
-                });
-                console.log(`Assigned [${maintainersToAssign.join(', ')}] to PR #${pr.number}`);
-              }
+              await github.rest.issues.addAssignees({
+                owner,
+                repo,
+                issue_number: pr.number,
+                assignees: maintainersToAssign,
+              });
+              console.log(`Assigned [${maintainersToAssign.join(', ')}] to PR #${pr.number}`);
             }
 
             console.log('Scan completed');


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/19270?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19270/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19270/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19270/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs
Previous implementation of the auto-assign job doesn't work on PRs filed from forked repos due to secrets permission issue (e.g. https://github.com/mlflow/mlflow/actions/runs/20017852341/job/57398826571#step:2:24) As a result, convert it to a cron job runs automatically to check the PRs updated in the last 4 hours and add assignees.
<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
