### PR TITLE
Add prompt model config to the prompt registry UI

### DIFF
--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -11,6 +11,7 @@ from mlflow.entities.model_registry.model_version_tag import ModelVersionTag
 from mlflow.exceptions import MlflowException
 from mlflow.prompt.constants import (
     IS_PROMPT_TAG_KEY,
+    PROMPT_MODEL_CONFIG_TAG_KEY,
     PROMPT_TEMPLATE_VARIABLE_PATTERN,
     PROMPT_TEXT_DISPLAY_LIMIT,
     PROMPT_TEXT_TAG_KEY,
@@ -19,7 +20,6 @@ from mlflow.prompt.constants import (
     PROMPT_TYPE_TEXT,
     RESPONSE_FORMAT_TAG_KEY,
 )
-from mlflow.utils.mlflow_tags import MLFLOW_PROMPT_MODEL_CONFIG
 
 # Alias type
 PromptVersionTag = ModelVersionTag
@@ -139,7 +139,7 @@ def _is_reserved_tag(key: str) -> bool:
         PROMPT_TEXT_TAG_KEY,
         PROMPT_TYPE_TAG_KEY,
         RESPONSE_FORMAT_TAG_KEY,
-        MLFLOW_PROMPT_MODEL_CONFIG,
+        PROMPT_MODEL_CONFIG_TAG_KEY,
     }
 
 
@@ -233,7 +233,7 @@ class PromptVersion(_ModelRegistryEntity):
             else:
                 # Validate dict by converting through PromptModelConfig
                 config_dict = PromptModelConfig.from_dict(model_config).to_dict()
-            tags[MLFLOW_PROMPT_MODEL_CONFIG] = json.dumps(config_dict)
+            tags[PROMPT_MODEL_CONFIG_TAG_KEY] = json.dumps(config_dict)
 
         # Store the tags dict
         self._tags: dict[str, str] = tags
@@ -310,9 +310,9 @@ class PromptVersion(_ModelRegistryEntity):
             and settings like temperature, top_p, max_tokens, etc., or None if no
             model config is specified.
         """
-        if MLFLOW_PROMPT_MODEL_CONFIG not in self._tags:
+        if PROMPT_MODEL_CONFIG_TAG_KEY not in self._tags:
             return None
-        return json.loads(self._tags[MLFLOW_PROMPT_MODEL_CONFIG])
+        return json.loads(self._tags[PROMPT_MODEL_CONFIG_TAG_KEY])
 
     def to_single_brace_format(self) -> str | list[dict[str, Any]]:
         """

--- a/mlflow/entities/model_registry/prompt_version.py
+++ b/mlflow/entities/model_registry/prompt_version.py
@@ -34,6 +34,7 @@ class PromptModelConfig(BaseModel):
     particular prompt version.
 
     Args:
+        provider: The model provider (e.g., "openai", "anthropic", "google").
         model_name: The name or identifier of the model (e.g., "gpt-4", "claude-3-opus").
         temperature: Sampling temperature for controlling randomness (typically 0.0-2.0).
             Lower values make output more deterministic, higher values more random.
@@ -81,6 +82,7 @@ class PromptModelConfig(BaseModel):
         )
     """
 
+    provider: str | None = None
     model_name: str | None = None
     temperature: float | None = Field(None, ge=0)
     max_tokens: int | None = Field(None, gt=0)

--- a/mlflow/genai/prompts/__init__.py
+++ b/mlflow/genai/prompts/__init__.py
@@ -11,12 +11,12 @@ from mlflow.entities.model_registry.prompt_version import (
     PromptModelConfig,
     PromptVersion,
 )
+from mlflow.prompt.constants import PROMPT_MODEL_CONFIG_TAG_KEY
 from mlflow.prompt.registry_utils import PromptCache as PromptCache
 from mlflow.prompt.registry_utils import require_prompt_registry
 from mlflow.store.entities.paged_list import PagedList
 from mlflow.tracking.client import MlflowClient
 from mlflow.utils.annotations import experimental
-from mlflow.utils.mlflow_tags import MLFLOW_PROMPT_MODEL_CONFIG
 
 
 @contextmanager
@@ -395,7 +395,7 @@ def set_prompt_model_config(
 
     with suppress_genai_migration_warning():
         MlflowClient().set_prompt_version_tag(
-            name=name, version=version, key=MLFLOW_PROMPT_MODEL_CONFIG, value=config_json
+            name=name, version=version, key=PROMPT_MODEL_CONFIG_TAG_KEY, value=config_json
         )
 
 
@@ -423,5 +423,5 @@ def delete_prompt_model_config(name: str, version: str | int) -> None:
     """
     with suppress_genai_migration_warning():
         MlflowClient().delete_prompt_version_tag(
-            name=name, version=version, key=MLFLOW_PROMPT_MODEL_CONFIG
+            name=name, version=version, key=PROMPT_MODEL_CONFIG_TAG_KEY
         )

--- a/mlflow/prompt/constants.py
+++ b/mlflow/prompt/constants.py
@@ -8,6 +8,7 @@ PROMPT_TEXT_TAG_KEY = "mlflow.prompt.text"
 # Unity Catalog tags cannot contain dots
 PROMPT_TYPE_TAG_KEY = "_mlflow_prompt_type"
 RESPONSE_FORMAT_TAG_KEY = "_mlflow_prompt_response_format"
+PROMPT_MODEL_CONFIG_TAG_KEY = "_mlflow_prompt_model_config"
 
 # Prompt types
 PROMPT_TYPE_TEXT = "text"

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.tsx
@@ -36,6 +36,7 @@ import { first, isEmpty } from 'lodash';
 import { PromptsListTableTagsBox } from './components/PromptDetailsTagsBox';
 import { PromptNotFoundView } from './components/PromptNotFoundView';
 import { useUpdatePromptVersionMetadataModal } from './hooks/useUpdatePromptVersionMetadataModal';
+import { useEditModelConfigModal } from './hooks/useEditModelConfigModal';
 import type { ThunkDispatch } from '../../../redux-types';
 import { setModelVersionAliasesApi } from '../../../model-registry/actions';
 import { ExperimentPageTabName } from '../../constants';
@@ -83,6 +84,10 @@ const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) =>
   });
 
   const { EditPromptVersionMetadataModal, showEditPromptVersionMetadataModal } = useUpdatePromptVersionMetadataModal({
+    onSuccess: refetch,
+  });
+
+  const { EditModelConfigModal, openEditModelConfigModal } = useEditModelConfigModal({
     onSuccess: refetch,
   });
 
@@ -260,6 +265,7 @@ const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) =>
                   showEditAliasesModal={showEditAliasesModal}
                   registeredPrompt={promptDetailsData?.prompt}
                   showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
+                  showEditModelConfigModal={openEditModelConfigModal}
                 />
               )}
               {mode === PromptVersionsTableMode.COMPARE && (
@@ -282,6 +288,7 @@ const PromptsDetailsPage = ({ experimentId }: { experimentId?: string } = {}) =>
       {CreatePromptModal}
       {DeletePromptModal}
       {EditPromptVersionMetadataModal}
+      {EditModelConfigModal}
     </ScrollablePageWrapper>
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
@@ -1,0 +1,201 @@
+import { FormUI, RHFControlledComponents, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useFormContext } from 'react-hook-form';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+interface ModelConfigFormProps {
+  namePrefix?: string; // For nested forms, e.g., "modelConfig."
+}
+
+export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext();
+
+  // Helper to get field name with prefix
+  const fieldName = (name: string) => `${namePrefix}${name}`;
+
+  // Helper to get nested error
+  const getError = (name: string) => {
+    const parts = fieldName(name).split('.');
+    let error: any = errors;
+    for (const part of parts) {
+      error = error?.[part];
+    }
+    return error;
+  };
+
+  return (
+    <div
+      css={{
+        border: `1px solid ${theme.colors.border}`,
+        borderRadius: theme.general.borderRadiusBase,
+        padding: theme.spacing.md,
+      }}
+    >
+      {/* Section Header */}
+      <Typography.Title level={4} css={{ marginBottom: theme.spacing.sm }}>
+        <FormattedMessage
+          defaultMessage="Model Configuration"
+          description="Section header for model configuration in prompt creation"
+        />
+      </Typography.Title>
+
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+        {/* Model Name - Full Width */}
+        <div>
+          <FormUI.Label htmlFor={fieldName('modelName')}>
+            <FormattedMessage defaultMessage="Model" description="Label for model name input in model config form" />
+          </FormUI.Label>
+          <RHFControlledComponents.Input
+            control={control}
+            id={fieldName('modelName')}
+            componentId={`mlflow.prompts.model_config.${fieldName('modelName')}`}
+            name={fieldName('modelName')}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'e.g., gpt-4, claude-3-opus',
+              description: 'Placeholder for model name input',
+            })}
+          />
+        </div>
+
+        {/* Sampling Parameters - 2 Column Grid */}
+        <div>
+          <Typography.Text
+            bold
+            css={{
+              display: 'block',
+              marginBottom: theme.spacing.xs,
+              fontSize: theme.typography.fontSizeSm,
+              color: theme.colors.textSecondary,
+            }}
+          >
+            <FormattedMessage
+              defaultMessage="Sampling Parameters"
+              description="Subsection for sampling parameters in model config"
+            />
+          </Typography.Text>
+          <div css={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: theme.spacing.sm }}>
+            {/* Temperature */}
+            <div>
+              <FormUI.Label htmlFor={fieldName('temperature')}>
+                <FormattedMessage defaultMessage="Temperature" description="Label for temperature input" />
+              </FormUI.Label>
+              <RHFControlledComponents.Input
+                control={control}
+                id={fieldName('temperature')}
+                componentId={`mlflow.prompts.model_config.${fieldName('temperature')}`}
+                name={fieldName('temperature')}
+                validationState={getError('temperature') ? 'error' : undefined}
+              />
+              {getError('temperature') && <FormUI.Message type="error" message={getError('temperature')?.message} />}
+            </div>
+
+            {/* Max Tokens */}
+            <div>
+              <FormUI.Label htmlFor={fieldName('maxTokens')}>
+                <FormattedMessage defaultMessage="Max Tokens" description="Label for max tokens input" />
+              </FormUI.Label>
+              <RHFControlledComponents.Input
+                control={control}
+                id={fieldName('maxTokens')}
+                componentId={`mlflow.prompts.model_config.${fieldName('maxTokens')}`}
+                name={fieldName('maxTokens')}
+                validationState={getError('maxTokens') ? 'error' : undefined}
+              />
+              {getError('maxTokens') && <FormUI.Message type="error" message={getError('maxTokens')?.message} />}
+            </div>
+
+            {/* Top P */}
+            <div>
+              <FormUI.Label htmlFor={fieldName('topP')}>
+                <FormattedMessage defaultMessage="Top P" description="Label for top P input" />
+              </FormUI.Label>
+              <RHFControlledComponents.Input
+                control={control}
+                id={fieldName('topP')}
+                componentId={`mlflow.prompts.model_config.${fieldName('topP')}`}
+                name={fieldName('topP')}
+                validationState={getError('topP') ? 'error' : undefined}
+              />
+              {getError('topP') && <FormUI.Message type="error" message={getError('topP')?.message} />}
+            </div>
+
+            {/* Top K */}
+            <div>
+              <FormUI.Label htmlFor={fieldName('topK')}>
+                <FormattedMessage defaultMessage="Top K" description="Label for top K input" />
+              </FormUI.Label>
+              <RHFControlledComponents.Input
+                control={control}
+                id={fieldName('topK')}
+                componentId={`mlflow.prompts.model_config.${fieldName('topK')}`}
+                name={fieldName('topK')}
+                validationState={getError('topK') ? 'error' : undefined}
+              />
+              {getError('topK') && <FormUI.Message type="error" message={getError('topK')?.message} />}
+            </div>
+
+            {/* Frequency Penalty */}
+            <div>
+              <FormUI.Label htmlFor={fieldName('frequencyPenalty')}>
+                <FormattedMessage defaultMessage="Frequency Penalty" description="Label for frequency penalty input" />
+              </FormUI.Label>
+              <RHFControlledComponents.Input
+                control={control}
+                id={fieldName('frequencyPenalty')}
+                componentId={`mlflow.prompts.model_config.${fieldName('frequencyPenalty')}`}
+                name={fieldName('frequencyPenalty')}
+                validationState={getError('frequencyPenalty') ? 'error' : undefined}
+              />
+              {getError('frequencyPenalty') && (
+                <FormUI.Message type="error" message={getError('frequencyPenalty')?.message} />
+              )}
+            </div>
+
+            {/* Presence Penalty */}
+            <div>
+              <FormUI.Label htmlFor={fieldName('presencePenalty')}>
+                <FormattedMessage defaultMessage="Presence Penalty" description="Label for presence penalty input" />
+              </FormUI.Label>
+              <RHFControlledComponents.Input
+                control={control}
+                id={fieldName('presencePenalty')}
+                componentId={`mlflow.prompts.model_config.${fieldName('presencePenalty')}`}
+                name={fieldName('presencePenalty')}
+                validationState={getError('presencePenalty') ? 'error' : undefined}
+              />
+              {getError('presencePenalty') && (
+                <FormUI.Message type="error" message={getError('presencePenalty')?.message} />
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* Stop Sequences - Full Width */}
+        <div>
+          <FormUI.Label htmlFor={fieldName('stopSequences')}>
+            <FormattedMessage
+              defaultMessage="Stop Sequences (comma-separated)"
+              description="Label for stop sequences input"
+            />
+          </FormUI.Label>
+          <RHFControlledComponents.Input
+            control={control}
+            id={fieldName('stopSequences')}
+            componentId={`mlflow.prompts.model_config.${fieldName('stopSequences')}`}
+            name={fieldName('stopSequences')}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'e.g., \\n\\n, END, ###',
+              description: 'Placeholder for stop sequences input',
+            })}
+            validationState={getError('stopSequences') ? 'error' : undefined}
+          />
+          {getError('stopSequences') && <FormUI.Message type="error" message={getError('stopSequences')?.message} />}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
@@ -184,7 +184,7 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
             componentId={`mlflow.prompts.model_config.${fieldName('stopSequences')}`}
             name={fieldName('stopSequences')}
             placeholder={intl.formatMessage({
-              defaultMessage: 'e.g., \\n\\n, END, ###',
+              defaultMessage: 'e.g., END, ###, STOP',
               description: 'Placeholder for stop sequences input',
             })}
             validationState={getError('stopSequences') ? 'error' : undefined}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
@@ -1,12 +1,15 @@
-import { FormUI, RHFControlledComponents, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  FormUI,
+  InfoSmallIcon,
+  Popover,
+  RHFControlledComponents,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import { useFormContext } from 'react-hook-form';
 import { FormattedMessage, useIntl } from 'react-intl';
 
-interface ModelConfigFormProps {
-  namePrefix?: string; // For nested forms, e.g., "modelConfig."
-}
-
-export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
+export const ModelConfigForm = () => {
   const { theme } = useDesignSystemTheme();
   const intl = useIntl();
   const {
@@ -14,15 +17,14 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
     formState: { errors },
   } = useFormContext();
 
-  const fieldName = (name: string) => `${namePrefix}${name}`;
+  const getFieldName = (name: string) => `modelConfig.${name}`;
 
+  /**
+   * Gets validation error for a model config field.
+   * Errors are stored as errors.modelConfig.fieldName by the parent form validation.
+   */
   const getError = (name: string) => {
-    const parts = fieldName(name).split('.');
-    let error: any = errors;
-    for (const part of parts) {
-      error = error?.[part];
-    }
-    return error;
+    return (errors?.['modelConfig'] as any)?.[name];
   };
 
   return (
@@ -33,23 +35,56 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
         padding: theme.spacing.md,
       }}
     >
-      <Typography.Title level={4} css={{ marginBottom: theme.spacing.sm }}>
-        <FormattedMessage
-          defaultMessage="Model Configuration"
-          description="Section header for model configuration in prompt creation"
-        />
-      </Typography.Title>
+      <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs, marginBottom: theme.spacing.sm }}>
+        <Typography.Title level={4} css={{ marginBottom: 0 }}>
+          <FormattedMessage
+            defaultMessage="Model Configuration"
+            description="Section header for model configuration in prompt creation"
+          />
+        </Typography.Title>
+        <Popover.Root componentId="mlflow.prompts.model_config.help">
+          <Popover.Trigger aria-label="Model configuration help" css={{ border: 0, background: 'none', padding: 0 }}>
+            <InfoSmallIcon />
+          </Popover.Trigger>
+          <Popover.Content align="start">
+            <FormattedMessage
+              defaultMessage="Model configuration stores the LLM settings associated with this prompt."
+              description="Help text explaining model configuration purpose"
+            />
+            <Popover.Arrow />
+          </Popover.Content>
+        </Popover.Root>
+      </div>
 
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
         <div>
-          <FormUI.Label htmlFor={fieldName('modelName')}>
-            <FormattedMessage defaultMessage="Model" description="Label for model name input in model config form" />
+          <FormUI.Label htmlFor="mlflow.prompts.model_config.provider">
+            <FormattedMessage defaultMessage="Provider" description="Label for model provider input" />
           </FormUI.Label>
           <RHFControlledComponents.Input
             control={control}
-            id={fieldName('modelName')}
-            componentId={`mlflow.prompts.model_config.${fieldName('modelName')}`}
-            name={fieldName('modelName')}
+            id="mlflow.prompts.model_config.provider"
+            componentId="mlflow.prompts.model_config.provider"
+            name={getFieldName('provider')}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'e.g., openai, anthropic, google',
+              description: 'Placeholder for provider input',
+            })}
+          />
+        </div>
+
+        <div>
+          <FormUI.Label htmlFor="mlflow.prompts.model_config.modelName">
+            <FormattedMessage
+              defaultMessage="Model Name"
+              description="Label for model name input in model config form"
+            />
+          </FormUI.Label>
+          <RHFControlledComponents.Input
+            control={control}
+            id="mlflow.prompts.model_config.modelName"
+            componentId="mlflow.prompts.model_config.modelName"
+            name={getFieldName('modelName')}
             placeholder={intl.formatMessage({
               defaultMessage: 'e.g., gpt-4, claude-3-opus',
               description: 'Placeholder for model name input',
@@ -57,122 +92,106 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
           />
         </div>
 
-        {/* Sampling Parameters - 2 Column Grid */}
-        <div>
-          <Typography.Text
-            bold
-            css={{
-              display: 'block',
-              marginBottom: theme.spacing.xs,
-              fontSize: theme.typography.fontSizeSm,
-              color: theme.colors.textSecondary,
-            }}
-          >
-            <FormattedMessage
-              defaultMessage="Sampling Parameters"
-              description="Subsection for sampling parameters in model config"
+        {/* 2 Column Grid for Parameters */}
+        <div css={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: theme.spacing.sm }}>
+          {/* Temperature */}
+          <div>
+            <FormUI.Label htmlFor="mlflow.prompts.model_config.temperature">
+              <FormattedMessage defaultMessage="Temperature" description="Label for temperature input" />
+            </FormUI.Label>
+            <RHFControlledComponents.Input
+              control={control}
+              id="mlflow.prompts.model_config.temperature"
+              componentId="mlflow.prompts.model_config.temperature"
+              name={getFieldName('temperature')}
+              validationState={getError('temperature') ? 'error' : undefined}
             />
-          </Typography.Text>
-          <div css={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: theme.spacing.sm }}>
-            {/* Temperature */}
-            <div>
-              <FormUI.Label htmlFor={fieldName('temperature')}>
-                <FormattedMessage defaultMessage="Temperature" description="Label for temperature input" />
-              </FormUI.Label>
-              <RHFControlledComponents.Input
-                control={control}
-                id={fieldName('temperature')}
-                componentId={`mlflow.prompts.model_config.${fieldName('temperature')}`}
-                name={fieldName('temperature')}
-                validationState={getError('temperature') ? 'error' : undefined}
-              />
-              {getError('temperature') && <FormUI.Message type="error" message={getError('temperature')?.message} />}
-            </div>
+            {getError('temperature') && <FormUI.Message type="error" message={getError('temperature')?.message} />}
+          </div>
 
-            {/* Max Tokens */}
-            <div>
-              <FormUI.Label htmlFor={fieldName('maxTokens')}>
-                <FormattedMessage defaultMessage="Max Tokens" description="Label for max tokens input" />
-              </FormUI.Label>
-              <RHFControlledComponents.Input
-                control={control}
-                id={fieldName('maxTokens')}
-                componentId={`mlflow.prompts.model_config.${fieldName('maxTokens')}`}
-                name={fieldName('maxTokens')}
-                validationState={getError('maxTokens') ? 'error' : undefined}
-              />
-              {getError('maxTokens') && <FormUI.Message type="error" message={getError('maxTokens')?.message} />}
-            </div>
+          {/* Max Tokens */}
+          <div>
+            <FormUI.Label htmlFor="mlflow.prompts.model_config.maxTokens">
+              <FormattedMessage defaultMessage="Max Tokens" description="Label for max tokens input" />
+            </FormUI.Label>
+            <RHFControlledComponents.Input
+              control={control}
+              id="mlflow.prompts.model_config.maxTokens"
+              componentId="mlflow.prompts.model_config.maxTokens"
+              name={getFieldName('maxTokens')}
+              validationState={getError('maxTokens') ? 'error' : undefined}
+            />
+            {getError('maxTokens') && <FormUI.Message type="error" message={getError('maxTokens')?.message} />}
+          </div>
 
-            {/* Top P */}
-            <div>
-              <FormUI.Label htmlFor={fieldName('topP')}>
-                <FormattedMessage defaultMessage="Top P" description="Label for top P input" />
-              </FormUI.Label>
-              <RHFControlledComponents.Input
-                control={control}
-                id={fieldName('topP')}
-                componentId={`mlflow.prompts.model_config.${fieldName('topP')}`}
-                name={fieldName('topP')}
-                validationState={getError('topP') ? 'error' : undefined}
-              />
-              {getError('topP') && <FormUI.Message type="error" message={getError('topP')?.message} />}
-            </div>
+          {/* Top P */}
+          <div>
+            <FormUI.Label htmlFor="mlflow.prompts.model_config.topP">
+              <FormattedMessage defaultMessage="Top P" description="Label for top P input" />
+            </FormUI.Label>
+            <RHFControlledComponents.Input
+              control={control}
+              id="mlflow.prompts.model_config.topP"
+              componentId="mlflow.prompts.model_config.topP"
+              name={getFieldName('topP')}
+              validationState={getError('topP') ? 'error' : undefined}
+            />
+            {getError('topP') && <FormUI.Message type="error" message={getError('topP')?.message} />}
+          </div>
 
-            {/* Top K */}
-            <div>
-              <FormUI.Label htmlFor={fieldName('topK')}>
-                <FormattedMessage defaultMessage="Top K" description="Label for top K input" />
-              </FormUI.Label>
-              <RHFControlledComponents.Input
-                control={control}
-                id={fieldName('topK')}
-                componentId={`mlflow.prompts.model_config.${fieldName('topK')}`}
-                name={fieldName('topK')}
-                validationState={getError('topK') ? 'error' : undefined}
-              />
-              {getError('topK') && <FormUI.Message type="error" message={getError('topK')?.message} />}
-            </div>
+          {/* Top K */}
+          <div>
+            <FormUI.Label htmlFor="mlflow.prompts.model_config.topK">
+              <FormattedMessage defaultMessage="Top K" description="Label for top K input" />
+            </FormUI.Label>
+            <RHFControlledComponents.Input
+              control={control}
+              id="mlflow.prompts.model_config.topK"
+              componentId="mlflow.prompts.model_config.topK"
+              name={getFieldName('topK')}
+              validationState={getError('topK') ? 'error' : undefined}
+            />
+            {getError('topK') && <FormUI.Message type="error" message={getError('topK')?.message} />}
+          </div>
 
-            {/* Frequency Penalty */}
-            <div>
-              <FormUI.Label htmlFor={fieldName('frequencyPenalty')}>
-                <FormattedMessage defaultMessage="Frequency Penalty" description="Label for frequency penalty input" />
-              </FormUI.Label>
-              <RHFControlledComponents.Input
-                control={control}
-                id={fieldName('frequencyPenalty')}
-                componentId={`mlflow.prompts.model_config.${fieldName('frequencyPenalty')}`}
-                name={fieldName('frequencyPenalty')}
-                validationState={getError('frequencyPenalty') ? 'error' : undefined}
-              />
-              {getError('frequencyPenalty') && (
-                <FormUI.Message type="error" message={getError('frequencyPenalty')?.message} />
-              )}
-            </div>
+          {/* Frequency Penalty */}
+          <div>
+            <FormUI.Label htmlFor="mlflow.prompts.model_config.frequencyPenalty">
+              <FormattedMessage defaultMessage="Frequency Penalty" description="Label for frequency penalty input" />
+            </FormUI.Label>
+            <RHFControlledComponents.Input
+              control={control}
+              id="mlflow.prompts.model_config.frequencyPenalty"
+              componentId="mlflow.prompts.model_config.frequencyPenalty"
+              name={getFieldName('frequencyPenalty')}
+              validationState={getError('frequencyPenalty') ? 'error' : undefined}
+            />
+            {getError('frequencyPenalty') && (
+              <FormUI.Message type="error" message={getError('frequencyPenalty')?.message} />
+            )}
+          </div>
 
-            {/* Presence Penalty */}
-            <div>
-              <FormUI.Label htmlFor={fieldName('presencePenalty')}>
-                <FormattedMessage defaultMessage="Presence Penalty" description="Label for presence penalty input" />
-              </FormUI.Label>
-              <RHFControlledComponents.Input
-                control={control}
-                id={fieldName('presencePenalty')}
-                componentId={`mlflow.prompts.model_config.${fieldName('presencePenalty')}`}
-                name={fieldName('presencePenalty')}
-                validationState={getError('presencePenalty') ? 'error' : undefined}
-              />
-              {getError('presencePenalty') && (
-                <FormUI.Message type="error" message={getError('presencePenalty')?.message} />
-              )}
-            </div>
+          {/* Presence Penalty */}
+          <div>
+            <FormUI.Label htmlFor="mlflow.prompts.model_config.presencePenalty">
+              <FormattedMessage defaultMessage="Presence Penalty" description="Label for presence penalty input" />
+            </FormUI.Label>
+            <RHFControlledComponents.Input
+              control={control}
+              id="mlflow.prompts.model_config.presencePenalty"
+              componentId="mlflow.prompts.model_config.presencePenalty"
+              name={getFieldName('presencePenalty')}
+              validationState={getError('presencePenalty') ? 'error' : undefined}
+            />
+            {getError('presencePenalty') && (
+              <FormUI.Message type="error" message={getError('presencePenalty')?.message} />
+            )}
           </div>
         </div>
 
         {/* Stop Sequences */}
         <div>
-          <FormUI.Label htmlFor={fieldName('stopSequences')}>
+          <FormUI.Label htmlFor="mlflow.prompts.model_config.stopSequences">
             <FormattedMessage
               defaultMessage="Stop Sequences (comma-separated)"
               description="Label for stop sequences input"
@@ -180,9 +199,9 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
           </FormUI.Label>
           <RHFControlledComponents.Input
             control={control}
-            id={fieldName('stopSequences')}
-            componentId={`mlflow.prompts.model_config.${fieldName('stopSequences')}`}
-            name={fieldName('stopSequences')}
+            id="mlflow.prompts.model_config.stopSequences"
+            componentId="mlflow.prompts.model_config.stopSequences"
+            name={getFieldName('stopSequences')}
             placeholder={intl.formatMessage({
               defaultMessage: 'e.g., END, ###, STOP',
               description: 'Placeholder for stop sequences input',

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/ModelConfigForm.tsx
@@ -14,10 +14,8 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
     formState: { errors },
   } = useFormContext();
 
-  // Helper to get field name with prefix
   const fieldName = (name: string) => `${namePrefix}${name}`;
 
-  // Helper to get nested error
   const getError = (name: string) => {
     const parts = fieldName(name).split('.');
     let error: any = errors;
@@ -35,7 +33,6 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
         padding: theme.spacing.md,
       }}
     >
-      {/* Section Header */}
       <Typography.Title level={4} css={{ marginBottom: theme.spacing.sm }}>
         <FormattedMessage
           defaultMessage="Model Configuration"
@@ -44,7 +41,6 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
       </Typography.Title>
 
       <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
-        {/* Model Name - Full Width */}
         <div>
           <FormUI.Label htmlFor={fieldName('modelName')}>
             <FormattedMessage defaultMessage="Model" description="Label for model name input in model config form" />
@@ -174,7 +170,7 @@ export const ModelConfigForm = ({ namePrefix = '' }: ModelConfigFormProps) => {
           </div>
         </div>
 
-        {/* Stop Sequences - Full Width */}
+        {/* Stop Sequences */}
         <div>
           <FormUI.Label htmlFor={fieldName('stopSequences')}>
             <FormattedMessage

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentPreview.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptContentPreview.tsx
@@ -36,6 +36,7 @@ export const PromptContentPreview = ({
   registeredPrompt,
   showEditAliasesModal,
   showEditPromptVersionMetadataModal,
+  showEditModelConfigModal,
 }: {
   promptVersion?: RegisteredPromptVersion;
   onUpdatedContent?: () => Promise<any>;
@@ -44,6 +45,7 @@ export const PromptContentPreview = ({
   registeredPrompt?: RegisteredPrompt;
   showEditAliasesModal?: (versionNumber: string) => void;
   showEditPromptVersionMetadataModal: (promptVersion: RegisteredPromptVersion) => void;
+  showEditModelConfigModal?: (promptVersion: RegisteredPromptVersion) => void;
 }) => {
   const value = useMemo(() => (promptVersion ? getPromptContentTagValue(promptVersion) : ''), [promptVersion]);
   const isChatPromptType = useMemo(() => isChatPrompt(promptVersion), [promptVersion]);
@@ -145,6 +147,7 @@ export const PromptContentPreview = ({
         registeredPromptVersion={promptVersion}
         showEditAliasesModal={showEditAliasesModal}
         showEditPromptVersionMetadataModal={showEditPromptVersionMetadataModal}
+        showEditModelConfigModal={showEditModelConfigModal}
       />
       <Spacer shrinks={false} />
       <div

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from '../../../../common/utils/RoutingUtils';
 import Routes from '../../../routes';
 import { usePromptRunsInfo } from '../hooks/usePromptRunsInfo';
-import { getModelConfigFromTags, REGISTERED_PROMPT_SOURCE_RUN_IDS } from '../utils';
+import { getModelConfigFromTags, MODEL_CONFIG_FIELD_LABELS, REGISTERED_PROMPT_SOURCE_RUN_IDS } from '../utils';
 import { useCallback, useMemo } from 'react';
 import { PromptVersionRuns } from './PromptVersionRuns';
 import { isUserFacingTag } from '@mlflow/mlflow/src/common/utils/TagUtils';
@@ -151,54 +151,21 @@ export const PromptVersionMetadata = ({
             <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm }}>
               {hasModelConfig ? (
                 <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, flex: 1 }}>
-                  {modelConfig.model_name && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Model: </Typography.Text>
-                      <Typography.Text>{modelConfig.model_name}</Typography.Text>
-                    </div>
-                  )}
-                  {modelConfig.temperature !== undefined && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Temperature: </Typography.Text>
-                      <Typography.Text>{modelConfig.temperature}</Typography.Text>
-                    </div>
-                  )}
-                  {modelConfig.max_tokens !== undefined && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Max Tokens: </Typography.Text>
-                      <Typography.Text>{modelConfig.max_tokens}</Typography.Text>
-                    </div>
-                  )}
-                  {modelConfig.top_p !== undefined && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Top P: </Typography.Text>
-                      <Typography.Text>{modelConfig.top_p}</Typography.Text>
-                    </div>
-                  )}
-                  {modelConfig.top_k !== undefined && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Top K: </Typography.Text>
-                      <Typography.Text>{modelConfig.top_k}</Typography.Text>
-                    </div>
-                  )}
-                  {modelConfig.frequency_penalty !== undefined && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Frequency Penalty: </Typography.Text>
-                      <Typography.Text>{modelConfig.frequency_penalty}</Typography.Text>
-                    </div>
-                  )}
-                  {modelConfig.presence_penalty !== undefined && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Presence Penalty: </Typography.Text>
-                      <Typography.Text>{modelConfig.presence_penalty}</Typography.Text>
-                    </div>
-                  )}
-                  {modelConfig.stop_sequences && modelConfig.stop_sequences.length > 0 && (
-                    <div>
-                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Stop Sequences: </Typography.Text>
-                      <Typography.Text>{modelConfig.stop_sequences.join(', ')}</Typography.Text>
-                    </div>
-                  )}
+                  {Object.entries(modelConfig).map(([key, value]) => {
+                    if (value === undefined || value === null) return null;
+                    if (key === 'extra_params') return null;
+                    if (Array.isArray(value) && value.length === 0) return null;
+
+                    const label = MODEL_CONFIG_FIELD_LABELS[key as keyof typeof MODEL_CONFIG_FIELD_LABELS];
+                    const displayValue = Array.isArray(value) ? value.join(', ') : String(value);
+
+                    return (
+                      <div key={key}>
+                        <Typography.Text css={{ color: theme.colors.textSecondary }}>{label}: </Typography.Text>
+                        <Typography.Text>{displayValue}</Typography.Text>
+                      </div>
+                    );
+                  })}
                 </div>
               ) : (
                 <Typography.Hint>—</Typography.Hint>

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
@@ -153,8 +153,34 @@ export const PromptVersionMetadata = ({
                 <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, flex: 1 }}>
                   {Object.entries(modelConfig).map(([key, value]) => {
                     if (value === undefined || value === null) return null;
-                    if (key === 'extra_params') return null;
                     if (Array.isArray(value) && value.length === 0) return null;
+
+                    // Handle extra_params separately - display as nested section
+                    if (key === 'extra_params' && typeof value === 'object' && !Array.isArray(value)) {
+                      const extraParams = value as Record<string, any>;
+                      if (Object.keys(extraParams).length === 0) return null;
+
+                      return (
+                        <div key={key}>
+                          <Typography.Text css={{ color: theme.colors.textSecondary }}>extra_params:</Typography.Text>
+                          <div css={{ marginLeft: theme.spacing.md }}>
+                            {Object.entries(extraParams).map(([extraKey, extraValue]) => {
+                              if (extraValue === undefined || extraValue === null) return null;
+                              const extraDisplayValue =
+                                typeof extraValue === 'object' ? JSON.stringify(extraValue) : String(extraValue);
+                              return (
+                                <div key={`${key}.${extraKey}`}>
+                                  <Typography.Text css={{ color: theme.colors.textSecondary }}>
+                                    {extraKey}:{' '}
+                                  </Typography.Text>
+                                  <Typography.Text>{extraDisplayValue}</Typography.Text>
+                                </div>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      );
+                    }
 
                     const label = MODEL_CONFIG_FIELD_LABELS[key as keyof typeof MODEL_CONFIG_FIELD_LABELS];
                     const displayValue = Array.isArray(value) ? value.join(', ') : String(value);

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/components/PromptVersionMetadata.tsx
@@ -1,4 +1,4 @@
-import { ParagraphSkeleton, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { Button, ParagraphSkeleton, PencilIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { ModelVersionTableAliasesCell } from '../../../../model-registry/components/aliases/ModelVersionTableAliasesCell';
 import type { RegisteredPrompt, RegisteredPromptVersion } from '../types';
 import Utils from '../../../../common/utils/Utils';
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 import { Link } from '../../../../common/utils/RoutingUtils';
 import Routes from '../../../routes';
 import { usePromptRunsInfo } from '../hooks/usePromptRunsInfo';
-import { REGISTERED_PROMPT_SOURCE_RUN_IDS } from '../utils';
+import { getModelConfigFromTags, REGISTERED_PROMPT_SOURCE_RUN_IDS } from '../utils';
 import { useCallback, useMemo } from 'react';
 import { PromptVersionRuns } from './PromptVersionRuns';
 import { isUserFacingTag } from '@mlflow/mlflow/src/common/utils/TagUtils';
@@ -21,6 +21,7 @@ export const PromptVersionMetadata = ({
   showEditAliasesModal,
   onEditVersion,
   showEditPromptVersionMetadataModal,
+  showEditModelConfigModal,
   aliasesByVersion,
   isBaseline,
 }: {
@@ -29,6 +30,7 @@ export const PromptVersionMetadata = ({
   showEditAliasesModal?: (versionNumber: string) => void;
   onEditVersion?: (vesrion: RegisteredPromptVersion) => void;
   showEditPromptVersionMetadataModal?: (version: RegisteredPromptVersion) => void;
+  showEditModelConfigModal?: (version: RegisteredPromptVersion) => void;
   aliasesByVersion: Record<string, string[]>;
   isBaseline?: boolean;
 }) => {
@@ -130,6 +132,89 @@ export const PromptVersionMetadata = ({
         </>
       )}
       <PromptVersionTags onEditVersionMetadata={onEditVersionMetadata} tags={visibleTagList} />
+      {/* Model Config Section */}
+      {(() => {
+        const modelConfig = getModelConfigFromTags(registeredPromptVersion?.tags);
+        const hasModelConfig = !!modelConfig;
+
+        // Only show section if there's config or ability to edit
+        if (!hasModelConfig && !showEditModelConfigModal) return null;
+
+        return (
+          <>
+            <Typography.Text bold>
+              <FormattedMessage
+                defaultMessage="Model Config:"
+                description="Label for model configuration in the prompt details page"
+              />
+            </Typography.Text>
+            <div css={{ display: 'flex', alignItems: 'flex-start', gap: theme.spacing.sm }}>
+              {hasModelConfig ? (
+                <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs, flex: 1 }}>
+                  {modelConfig.model_name && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Model: </Typography.Text>
+                      <Typography.Text>{modelConfig.model_name}</Typography.Text>
+                    </div>
+                  )}
+                  {modelConfig.temperature !== undefined && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Temperature: </Typography.Text>
+                      <Typography.Text>{modelConfig.temperature}</Typography.Text>
+                    </div>
+                  )}
+                  {modelConfig.max_tokens !== undefined && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Max Tokens: </Typography.Text>
+                      <Typography.Text>{modelConfig.max_tokens}</Typography.Text>
+                    </div>
+                  )}
+                  {modelConfig.top_p !== undefined && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Top P: </Typography.Text>
+                      <Typography.Text>{modelConfig.top_p}</Typography.Text>
+                    </div>
+                  )}
+                  {modelConfig.top_k !== undefined && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Top K: </Typography.Text>
+                      <Typography.Text>{modelConfig.top_k}</Typography.Text>
+                    </div>
+                  )}
+                  {modelConfig.frequency_penalty !== undefined && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Frequency Penalty: </Typography.Text>
+                      <Typography.Text>{modelConfig.frequency_penalty}</Typography.Text>
+                    </div>
+                  )}
+                  {modelConfig.presence_penalty !== undefined && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Presence Penalty: </Typography.Text>
+                      <Typography.Text>{modelConfig.presence_penalty}</Typography.Text>
+                    </div>
+                  )}
+                  {modelConfig.stop_sequences && modelConfig.stop_sequences.length > 0 && (
+                    <div>
+                      <Typography.Text css={{ color: theme.colors.textSecondary }}>Stop Sequences: </Typography.Text>
+                      <Typography.Text>{modelConfig.stop_sequences.join(', ')}</Typography.Text>
+                    </div>
+                  )}
+                </div>
+              ) : (
+                <Typography.Hint>—</Typography.Hint>
+              )}
+              {showEditModelConfigModal && (
+                <Button
+                  componentId="mlflow.prompts.details.version.edit_model_config"
+                  size="small"
+                  icon={<PencilIcon />}
+                  onClick={() => showEditModelConfigModal(registeredPromptVersion)}
+                />
+              )}
+            </div>
+          </>
+        );
+      })()}
       {(isLoadingRuns || runIds.length > 0) && (
         <PromptVersionRuns isLoadingRuns={isLoadingRuns} runIds={runIds} runInfoMap={runInfoMap} />
       )}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -9,7 +9,6 @@ import {
   Spacer,
   SegmentedControlGroup,
   SegmentedControlButton,
-  useDesignSystemTheme,
 } from '@databricks/design-system';
 import { useState } from 'react';
 import { useForm, Controller, FormProvider } from 'react-hook-form';
@@ -51,7 +50,6 @@ export const useCreatePromptModal = ({
   const [open, setOpen] = useState(false);
   const [showAdvancedSettings, setShowAdvancedSettings] = useState(false);
   const intl = useIntl();
-  const { theme } = useDesignSystemTheme();
 
   const form = useForm<{
     draftName: string;
@@ -316,6 +314,11 @@ export const useCreatePromptModal = ({
     const promptType = isChatPrompt(latestVersion) ? PROMPT_TYPE_CHAT : PROMPT_TYPE_TEXT;
     const parsedMessages = getChatPromptMessagesFromValue(tagValue);
 
+    // Check if latest version has model config to auto-expand advanced settings
+    const hasModelConfig =
+      mode === CreatePromptModalMode.CreatePromptVersion &&
+      latestVersion?.tags?.some((tag) => tag.key === MLFLOW_PROMPT_MODEL_CONFIG && tag.value);
+
     form.reset({
       commitMessage: '',
       draftName: '',
@@ -327,7 +330,7 @@ export const useCreatePromptModal = ({
       promptType,
       modelConfig: {},
     });
-    setShowAdvancedSettings(false);
+    setShowAdvancedSettings(!!hasModelConfig);
     setOpen(true);
   };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -20,8 +20,8 @@ import {
   getChatPromptMessagesFromValue,
   getPromptContentTagValue,
   isChatPrompt,
-  MLFLOW_PROMPT_MODEL_CONFIG,
   PROMPT_EXPERIMENT_IDS_TAG_KEY,
+  PROMPT_MODEL_CONFIG_TAG_KEY,
   PROMPT_TYPE_CHAT,
   PROMPT_TYPE_TEXT,
   validateModelConfig,
@@ -140,7 +140,7 @@ export const useCreatePromptModal = ({
           // Convert model config form data to backend format
           const modelConfig = formDataToModelConfig(values.modelConfig);
           const modelConfigTags = modelConfig
-            ? [{ key: MLFLOW_PROMPT_MODEL_CONFIG, value: JSON.stringify(modelConfig) }]
+            ? [{ key: PROMPT_MODEL_CONFIG_TAG_KEY, value: JSON.stringify(modelConfig) }]
             : [];
 
           mutateCreateVersion(
@@ -317,7 +317,7 @@ export const useCreatePromptModal = ({
     // Check if latest version has model config to auto-expand advanced settings
     const hasModelConfig =
       mode === CreatePromptModalMode.CreatePromptVersion &&
-      latestVersion?.tags?.some((tag) => tag.key === MLFLOW_PROMPT_MODEL_CONFIG && tag.value);
+      latestVersion?.tags?.some((tag) => tag.key === PROMPT_MODEL_CONFIG_TAG_KEY && tag.value);
 
     form.reset({
       commitMessage: '',

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useCreatePromptModal.tsx
@@ -298,7 +298,7 @@ export const useCreatePromptModal = ({
         {showAdvancedSettings && (
           <>
             <Spacer size="sm" />
-            <ModelConfigForm namePrefix="modelConfig." />
+            <ModelConfigForm />
           </>
         )}
       </Modal>

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
@@ -1,0 +1,132 @@
+import { useState, useCallback } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { Modal, Button, Spacer, Alert } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useMutation } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { RegisteredPromptsApi } from '../api';
+import { ModelConfigForm } from '../components/ModelConfigForm';
+import {
+  formDataToModelConfig,
+  getModelConfigFromTags,
+  MLFLOW_PROMPT_MODEL_CONFIG,
+  modelConfigToFormData,
+  validateModelConfig,
+} from '../utils';
+import type { PromptModelConfigFormData, RegisteredPromptVersion } from '../types';
+
+export const useEditModelConfigModal = ({ onSuccess }: { onSuccess?: () => void }) => {
+  const [open, setOpen] = useState(false);
+  const [editingVersion, setEditingVersion] = useState<RegisteredPromptVersion | null>(null);
+  const intl = useIntl();
+
+  const form = useForm<{ modelConfig: PromptModelConfigFormData }>({
+    defaultValues: { modelConfig: {} },
+  });
+
+  const updateMutation = useMutation({
+    mutationFn: async ({
+      promptName,
+      promptVersion,
+      modelConfigJson,
+    }: {
+      promptName: string;
+      promptVersion: string;
+      modelConfigJson: string;
+    }) => {
+      // Update or delete the model config tag
+      if (modelConfigJson) {
+        return RegisteredPromptsApi.setRegisteredPromptVersionTag(
+          promptName,
+          promptVersion,
+          MLFLOW_PROMPT_MODEL_CONFIG,
+          modelConfigJson,
+        );
+      } else {
+        return RegisteredPromptsApi.deleteRegisteredPromptVersionTag(
+          promptName,
+          promptVersion,
+          MLFLOW_PROMPT_MODEL_CONFIG,
+        );
+      }
+    },
+  });
+
+  const openModal = useCallback(
+    (version: RegisteredPromptVersion) => {
+      setEditingVersion(version);
+      const currentConfig = getModelConfigFromTags(version.tags);
+      form.reset({ modelConfig: modelConfigToFormData(currentConfig) });
+      setOpen(true);
+    },
+    [form],
+  );
+
+  const handleSave = form.handleSubmit(async (values) => {
+    if (!editingVersion) return;
+
+    // Validate
+    const errors = validateModelConfig(values.modelConfig);
+    if (Object.keys(errors).length > 0) {
+      Object.entries(errors).forEach(([field, message]) => {
+        form.setError(`modelConfig.${field}` as any, { type: 'validation', message });
+      });
+      return;
+    }
+
+    // Convert to backend format
+    const modelConfig = formDataToModelConfig(values.modelConfig);
+    const modelConfigJson = modelConfig ? JSON.stringify(modelConfig) : '';
+
+    updateMutation.mutate(
+      {
+        promptName: editingVersion.name,
+        promptVersion: editingVersion.version,
+        modelConfigJson,
+      },
+      {
+        onSuccess: () => {
+          setOpen(false);
+          onSuccess?.();
+        },
+      },
+    );
+  });
+
+  const EditModelConfigModal = (
+    <FormProvider {...form}>
+      <Modal
+        componentId="mlflow.prompts.edit_model_config.modal"
+        visible={open}
+        onCancel={() => setOpen(false)}
+        title={
+          <FormattedMessage
+            defaultMessage="Edit Model Configuration"
+            description="Title for the edit model config modal"
+          />
+        }
+        okText={<FormattedMessage defaultMessage="Save" description="Save button for the edit model config modal" />}
+        okButtonProps={{ loading: updateMutation.isLoading }}
+        onOk={handleSave}
+        cancelText={
+          <FormattedMessage defaultMessage="Cancel" description="Cancel button for the edit model config modal" />
+        }
+        size="normal"
+      >
+        {updateMutation.error && (
+          <>
+            <Alert
+              componentId="mlflow.prompts.edit_model_config.error"
+              closable={false}
+              message={(updateMutation.error as Error).message}
+              type="error"
+            />
+            <Spacer />
+          </>
+        )}
+        <ModelConfigForm namePrefix="modelConfig." />
+      </Modal>
+    </FormProvider>
+  );
+
+  return { EditModelConfigModal, openEditModelConfigModal: openModal };
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
@@ -1,17 +1,3 @@
-/**
- * Hook for editing model configuration of an existing prompt version.
- *
- * Returns a modal component and a function to open it. When opened for a prompt version:
- * - Pre-fills the form with current model config values (if any exist)
- * - Validates user input before saving
- * - Updates the "mlflow.prompt.modelConfig" tag via API on save
- *
- * Usage:
- *   const { EditModelConfigModal, openEditModelConfigModal } = useEditModelConfigModal({ onSuccess: refetch });
- *   // ...
- *   <Button onClick={() => openEditModelConfigModal(promptVersion)}>Edit</Button>
- *   {EditModelConfigModal}
- */
 import { useState, useCallback } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { Modal, Button, Spacer, Alert } from '@databricks/design-system';
@@ -132,7 +118,7 @@ export const useEditModelConfigModal = ({ onSuccess }: { onSuccess?: () => void 
             <Spacer />
           </>
         )}
-        <ModelConfigForm namePrefix="modelConfig." />
+        <ModelConfigForm />
       </Modal>
     </FormProvider>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
@@ -58,12 +58,13 @@ export const useEditModelConfigModal = ({ onSuccess }: { onSuccess?: () => void 
 
   const openModal = useCallback(
     (version: RegisteredPromptVersion) => {
+      updateMutation.reset();
       setEditingVersion(version);
       const currentConfig = getModelConfigFromTags(version.tags);
       form.reset({ modelConfig: modelConfigToFormData(currentConfig) });
       setOpen(true);
     },
-    [form],
+    [form, updateMutation],
   );
 
   const handleSave = form.handleSubmit(async (values) => {
@@ -102,7 +103,10 @@ export const useEditModelConfigModal = ({ onSuccess }: { onSuccess?: () => void 
       <Modal
         componentId="mlflow.prompts.edit_model_config.modal"
         visible={open}
-        onCancel={() => setOpen(false)}
+        onCancel={() => {
+          setOpen(false);
+          form.clearErrors();
+        }}
         title={
           <FormattedMessage
             defaultMessage="Edit Model Configuration"

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
@@ -1,3 +1,17 @@
+/**
+ * Hook for editing model configuration of an existing prompt version.
+ *
+ * Returns a modal component and a function to open it. When opened for a prompt version:
+ * - Pre-fills the form with current model config values (if any exist)
+ * - Validates user input before saving
+ * - Updates the "mlflow.prompt.modelConfig" tag via API on save
+ *
+ * Usage:
+ *   const { EditModelConfigModal, openEditModelConfigModal } = useEditModelConfigModal({ onSuccess: refetch });
+ *   // ...
+ *   <Button onClick={() => openEditModelConfigModal(promptVersion)}>Edit</Button>
+ *   {EditModelConfigModal}
+ */
 import { useState, useCallback } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { Modal, Button, Spacer, Alert } from '@databricks/design-system';
@@ -33,21 +47,12 @@ export const useEditModelConfigModal = ({ onSuccess }: { onSuccess?: () => void 
       promptVersion: string;
       modelConfigJson: string;
     }) => {
-      // Update or delete the model config tag
-      if (modelConfigJson) {
-        return RegisteredPromptsApi.setRegisteredPromptVersionTag(
-          promptName,
-          promptVersion,
-          MLFLOW_PROMPT_MODEL_CONFIG,
-          modelConfigJson,
-        );
-      } else {
-        return RegisteredPromptsApi.deleteRegisteredPromptVersionTag(
-          promptName,
-          promptVersion,
-          MLFLOW_PROMPT_MODEL_CONFIG,
-        );
-      }
+      return RegisteredPromptsApi.setRegisteredPromptVersionTag(
+        promptName,
+        promptVersion,
+        MLFLOW_PROMPT_MODEL_CONFIG,
+        modelConfigJson,
+      );
     },
   });
 
@@ -75,7 +80,7 @@ export const useEditModelConfigModal = ({ onSuccess }: { onSuccess?: () => void 
 
     // Convert to backend format
     const modelConfig = formDataToModelConfig(values.modelConfig);
-    const modelConfigJson = modelConfig ? JSON.stringify(modelConfig) : '';
+    const modelConfigJson = modelConfig ? JSON.stringify(modelConfig) : '{}';
 
     updateMutation.mutate(
       {

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/hooks/useEditModelConfigModal.tsx
@@ -8,8 +8,8 @@ import { ModelConfigForm } from '../components/ModelConfigForm';
 import {
   formDataToModelConfig,
   getModelConfigFromTags,
-  MLFLOW_PROMPT_MODEL_CONFIG,
   modelConfigToFormData,
+  PROMPT_MODEL_CONFIG_TAG_KEY,
   validateModelConfig,
 } from '../utils';
 import type { PromptModelConfigFormData, RegisteredPromptVersion } from '../types';
@@ -36,7 +36,7 @@ export const useEditModelConfigModal = ({ onSuccess }: { onSuccess?: () => void 
       return RegisteredPromptsApi.setRegisteredPromptVersionTag(
         promptName,
         promptVersion,
-        MLFLOW_PROMPT_MODEL_CONFIG,
+        PROMPT_MODEL_CONFIG_TAG_KEY,
         modelConfigJson,
       );
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
@@ -32,8 +32,7 @@ export interface ChatPromptMessage {
 }
 
 /**
- * Backend format for prompt model configuration (snake_case).
- * Matches the PromptModelConfig class in mlflow/entities/model_registry/prompt_version.py
+ * Represents a prompt model configuration, in the backend format (snake_case).
  */
 export interface PromptModelConfig {
   model_name?: string;
@@ -48,16 +47,15 @@ export interface PromptModelConfig {
 }
 
 /**
- * Form format for prompt model configuration (camelCase with string inputs).
- * Used for form state management with react-hook-form.
+ * Represents a prompt model configuration, in the UI form format (camelCase with string inputs).
  */
 export interface PromptModelConfigFormData {
   modelName?: string;
-  temperature?: string; // String for form input, will be parsed to number
-  maxTokens?: string; // String for form input, will be parsed to number
-  topP?: string; // String for form input, will be parsed to number
-  topK?: string; // String for form input, will be parsed to number
-  frequencyPenalty?: string; // String for form input, will be parsed to number
-  presencePenalty?: string; // String for form input, will be parsed to number
-  stopSequences?: string; // Comma-separated string for form input, will be parsed to array
+  temperature?: string;
+  maxTokens?: string;
+  topP?: string;
+  topK?: string;
+  frequencyPenalty?: string;
+  presencePenalty?: string;
+  stopSequences?: string;
 }

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
@@ -35,6 +35,7 @@ export interface ChatPromptMessage {
  * Represents a prompt model configuration, in the backend format (snake_case).
  */
 export interface PromptModelConfig {
+  provider?: string;
   model_name?: string;
   temperature?: number;
   max_tokens?: number;
@@ -50,6 +51,7 @@ export interface PromptModelConfig {
  * Represents a prompt model configuration, in the UI form format (camelCase with string inputs).
  */
 export interface PromptModelConfigFormData {
+  provider?: string;
   modelName?: string;
   temperature?: string;
   maxTokens?: string;

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/types.ts
@@ -30,3 +30,34 @@ export interface ChatPromptMessage {
   role: string;
   content: string;
 }
+
+/**
+ * Backend format for prompt model configuration (snake_case).
+ * Matches the PromptModelConfig class in mlflow/entities/model_registry/prompt_version.py
+ */
+export interface PromptModelConfig {
+  model_name?: string;
+  temperature?: number;
+  max_tokens?: number;
+  top_p?: number;
+  top_k?: number;
+  frequency_penalty?: number;
+  presence_penalty?: number;
+  stop_sequences?: string[];
+  extra_params?: Record<string, any>;
+}
+
+/**
+ * Form format for prompt model configuration (camelCase with string inputs).
+ * Used for form state management with react-hook-form.
+ */
+export interface PromptModelConfigFormData {
+  modelName?: string;
+  temperature?: string; // String for form input, will be parsed to number
+  maxTokens?: string; // String for form input, will be parsed to number
+  topP?: string; // String for form input, will be parsed to number
+  topK?: string; // String for form input, will be parsed to number
+  frequencyPenalty?: string; // String for form input, will be parsed to number
+  presencePenalty?: string; // String for form input, will be parsed to number
+  stopSequences?: string; // Comma-separated string for form input, will be parsed to array
+}

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.test.ts
@@ -1,0 +1,206 @@
+import { describe, test, expect } from '@jest/globals';
+import { formDataToModelConfig, modelConfigToFormData, validateModelConfig, getModelConfigFromTags } from './utils';
+import type { PromptModelConfig, PromptModelConfigFormData } from './types';
+
+describe('Model Config Utils', () => {
+  describe('formDataToModelConfig', () => {
+    test('converts all fields correctly', () => {
+      const formData: PromptModelConfigFormData = {
+        modelName: 'gpt-4',
+        temperature: '0.7',
+        maxTokens: '2048',
+        topP: '0.9',
+        topK: '40',
+        frequencyPenalty: '0.5',
+        presencePenalty: '0.3',
+        stopSequences: '\\n\\n, END, ###',
+      };
+
+      const result = formDataToModelConfig(formData);
+
+      expect(result).toEqual({
+        model_name: 'gpt-4',
+        temperature: 0.7,
+        max_tokens: 2048,
+        top_p: 0.9,
+        top_k: 40,
+        frequency_penalty: 0.5,
+        presence_penalty: 0.3,
+        stop_sequences: ['\\n\\n', 'END', '###'],
+      });
+    });
+
+    test('returns undefined for empty form data', () => {
+      const formData: PromptModelConfigFormData = {};
+      expect(formDataToModelConfig(formData)).toBeUndefined();
+    });
+
+    test('handles partial data', () => {
+      const formData: PromptModelConfigFormData = {
+        modelName: 'claude-3',
+        temperature: '1.0',
+      };
+
+      const result = formDataToModelConfig(formData);
+
+      expect(result).toEqual({
+        model_name: 'claude-3',
+        temperature: 1.0,
+      });
+    });
+
+    test('filters out invalid number strings', () => {
+      const formData: PromptModelConfigFormData = {
+        temperature: 'abc',
+        maxTokens: 'xyz',
+      };
+
+      expect(formDataToModelConfig(formData)).toBeUndefined();
+    });
+
+    test('trims whitespace from strings', () => {
+      const formData: PromptModelConfigFormData = {
+        modelName: '  gpt-4  ',
+        stopSequences: '  \\n\\n  ,  END  ',
+      };
+
+      const result = formDataToModelConfig(formData);
+
+      expect(result).toEqual({
+        model_name: 'gpt-4',
+        stop_sequences: ['\\n\\n', 'END'],
+      });
+    });
+  });
+
+  describe('modelConfigToFormData', () => {
+    test('converts all fields correctly', () => {
+      const config: PromptModelConfig = {
+        model_name: 'gpt-4',
+        temperature: 0.7,
+        max_tokens: 2048,
+        top_p: 0.9,
+        top_k: 40,
+        frequency_penalty: 0.5,
+        presence_penalty: 0.3,
+        stop_sequences: ['\\n\\n', 'END', '###'],
+      };
+
+      const result = modelConfigToFormData(config);
+
+      expect(result).toEqual({
+        modelName: 'gpt-4',
+        temperature: '0.7',
+        maxTokens: '2048',
+        topP: '0.9',
+        topK: '40',
+        frequencyPenalty: '0.5',
+        presencePenalty: '0.3',
+        stopSequences: '\\n\\n, END, ###',
+      });
+    });
+
+    test('returns empty object for undefined config', () => {
+      expect(modelConfigToFormData(undefined)).toEqual({});
+    });
+
+    test('handles partial data', () => {
+      const config: PromptModelConfig = {
+        model_name: 'claude-3',
+        temperature: 1.0,
+      };
+
+      const result = modelConfigToFormData(config);
+
+      expect(result).toEqual({
+        modelName: 'claude-3',
+        temperature: '1',
+        maxTokens: '',
+        topP: '',
+        topK: '',
+        frequencyPenalty: '',
+        presencePenalty: '',
+        stopSequences: '',
+      });
+    });
+  });
+
+  describe('validateModelConfig', () => {
+    test('returns no errors for valid data', () => {
+      const formData: PromptModelConfigFormData = {
+        temperature: '0.7',
+        maxTokens: '2048',
+        topP: '0.9',
+        topK: '40',
+        frequencyPenalty: '0.5',
+        presencePenalty: '0.3',
+      };
+
+      expect(validateModelConfig(formData)).toEqual({});
+    });
+
+    test('validates temperature range', () => {
+      expect(validateModelConfig({ temperature: '-1' })).toHaveProperty('temperature');
+      expect(validateModelConfig({ temperature: 'abc' })).toHaveProperty('temperature');
+      expect(validateModelConfig({ temperature: '0' })).toEqual({});
+    });
+
+    test('validates maxTokens range', () => {
+      expect(validateModelConfig({ maxTokens: '0' })).toHaveProperty('maxTokens');
+      expect(validateModelConfig({ maxTokens: '-1' })).toHaveProperty('maxTokens');
+      expect(validateModelConfig({ maxTokens: 'abc' })).toHaveProperty('maxTokens');
+      expect(validateModelConfig({ maxTokens: '1' })).toEqual({});
+    });
+
+    test('validates topP range', () => {
+      expect(validateModelConfig({ topP: '-0.1' })).toHaveProperty('topP');
+      expect(validateModelConfig({ topP: '1.1' })).toHaveProperty('topP');
+      expect(validateModelConfig({ topP: '0.5' })).toEqual({});
+    });
+
+    test('validates topK range', () => {
+      expect(validateModelConfig({ topK: '0' })).toHaveProperty('topK');
+      expect(validateModelConfig({ topK: '-1' })).toHaveProperty('topK');
+      expect(validateModelConfig({ topK: '1' })).toEqual({});
+    });
+
+    test('validates frequency and presence penalty range', () => {
+      expect(validateModelConfig({ frequencyPenalty: '-2.1' })).toHaveProperty('frequencyPenalty');
+      expect(validateModelConfig({ frequencyPenalty: '2.1' })).toHaveProperty('frequencyPenalty');
+      expect(validateModelConfig({ presencePenalty: '-2.1' })).toHaveProperty('presencePenalty');
+      expect(validateModelConfig({ presencePenalty: '2.1' })).toHaveProperty('presencePenalty');
+      expect(validateModelConfig({ frequencyPenalty: '0' })).toEqual({});
+    });
+  });
+
+  describe('getModelConfigFromTags', () => {
+    test('parses valid JSON tag', () => {
+      const tags = [{ key: 'mlflow.prompt.modelConfig', value: '{"model_name":"gpt-4","temperature":0.7}' }];
+
+      const result = getModelConfigFromTags(tags);
+
+      expect(result).toEqual({
+        model_name: 'gpt-4',
+        temperature: 0.7,
+      });
+    });
+
+    test('returns undefined for missing tag', () => {
+      const tags = [{ key: 'other.tag', value: 'value' }];
+      expect(getModelConfigFromTags(tags)).toBeUndefined();
+    });
+
+    test('returns undefined for invalid JSON', () => {
+      const tags = [{ key: 'mlflow.prompt.modelConfig', value: 'not-json' }];
+      expect(getModelConfigFromTags(tags)).toBeUndefined();
+    });
+
+    test('returns undefined for empty tags array', () => {
+      expect(getModelConfigFromTags([])).toBeUndefined();
+    });
+
+    test('returns undefined for undefined tags', () => {
+      expect(getModelConfigFromTags(undefined)).toBeUndefined();
+    });
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.test.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.test.ts
@@ -6,6 +6,7 @@ describe('Model Config Utils', () => {
   describe('formDataToModelConfig', () => {
     test('converts all fields correctly', () => {
       const formData: PromptModelConfigFormData = {
+        provider: 'openai',
         modelName: 'gpt-4',
         temperature: '0.7',
         maxTokens: '2048',
@@ -19,6 +20,7 @@ describe('Model Config Utils', () => {
       const result = formDataToModelConfig(formData);
 
       expect(result).toEqual({
+        provider: 'openai',
         model_name: 'gpt-4',
         temperature: 0.7,
         max_tokens: 2048,
@@ -76,6 +78,7 @@ describe('Model Config Utils', () => {
   describe('modelConfigToFormData', () => {
     test('converts all fields correctly', () => {
       const config: PromptModelConfig = {
+        provider: 'openai',
         model_name: 'gpt-4',
         temperature: 0.7,
         max_tokens: 2048,
@@ -89,6 +92,7 @@ describe('Model Config Utils', () => {
       const result = modelConfigToFormData(config);
 
       expect(result).toEqual({
+        provider: 'openai',
         modelName: 'gpt-4',
         temperature: '0.7',
         maxTokens: '2048',
@@ -113,6 +117,7 @@ describe('Model Config Utils', () => {
       const result = modelConfigToFormData(config);
 
       expect(result).toEqual({
+        provider: '',
         modelName: 'claude-3',
         temperature: '1',
         maxTokens: '',
@@ -175,7 +180,7 @@ describe('Model Config Utils', () => {
 
   describe('getModelConfigFromTags', () => {
     test('parses valid JSON tag', () => {
-      const tags = [{ key: 'mlflow.prompt.modelConfig', value: '{"model_name":"gpt-4","temperature":0.7}' }];
+      const tags = [{ key: '_mlflow_prompt_model_config', value: '{"model_name":"gpt-4","temperature":0.7}' }];
 
       const result = getModelConfigFromTags(tags);
 
@@ -191,7 +196,7 @@ describe('Model Config Utils', () => {
     });
 
     test('returns undefined for invalid JSON', () => {
-      const tags = [{ key: 'mlflow.prompt.modelConfig', value: 'not-json' }];
+      const tags = [{ key: '_mlflow_prompt_model_config', value: 'not-json' }];
       expect(getModelConfigFromTags(tags)).toBeUndefined();
     });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -1,6 +1,12 @@
 import type { KeyValueEntity } from '@mlflow/mlflow/src/common/types';
 import { parseJSONSafe } from '@mlflow/mlflow/src/common/utils/TagUtils';
-import type { ChatPromptMessage, RegisteredPrompt, RegisteredPromptVersion } from './types';
+import type {
+  ChatPromptMessage,
+  PromptModelConfig,
+  PromptModelConfigFormData,
+  RegisteredPrompt,
+  RegisteredPromptVersion,
+} from './types';
 import { MLFLOW_LINKED_PROMPTS_TAG } from '../../constants';
 
 export const REGISTERED_PROMPT_CONTENT_TAG_KEY = 'mlflow.prompt.text';
@@ -15,6 +21,8 @@ export const PROMPT_TYPE_CHAT = 'chat' as const;
 export const PROMPT_TYPE_TAG_KEY = '_mlflow_prompt_type';
 // Tag key used to store comma-separated experiment IDs associated with a prompt
 export const PROMPT_EXPERIMENT_IDS_TAG_KEY = '_mlflow_experiment_ids';
+// Tag key used to store model config as JSON string (must match backend)
+export const MLFLOW_PROMPT_MODEL_CONFIG = 'mlflow.prompt.modelConfig';
 
 // Query parameter name for specifying prompt version in URLs
 export const PROMPT_VERSION_QUERY_PARAM = 'promptVersion';
@@ -111,4 +119,149 @@ export const buildSearchFilterClause = (searchFilter?: string): string => {
     // Simple name search
     return `name ILIKE '%${searchFilter}%'`;
   }
+};
+
+/**
+ * Parse model config from tag value (JSON string).
+ * Returns undefined if tag doesn't exist or JSON parsing fails.
+ */
+export const getModelConfigFromTags = (tags?: KeyValueEntity[]): PromptModelConfig | undefined => {
+  const configTag = tags?.find((tag) => tag.key === MLFLOW_PROMPT_MODEL_CONFIG);
+  if (!configTag?.value) {
+    return undefined;
+  }
+
+  try {
+    return JSON.parse(configTag.value) as PromptModelConfig;
+  } catch (error) {
+    console.error('Failed to parse model config:', error);
+    return undefined;
+  }
+};
+
+/**
+ * Convert form data to backend model config format.
+ * Returns undefined if no fields have values.
+ */
+export const formDataToModelConfig = (formData: PromptModelConfigFormData): PromptModelConfig | undefined => {
+  const hasAnyValue = Object.values(formData).some((v) => v !== undefined && v !== '');
+  if (!hasAnyValue) {
+    return undefined;
+  }
+
+  const config: PromptModelConfig = {};
+
+  if (formData.modelName?.trim()) {
+    config.model_name = formData.modelName.trim();
+  }
+  if (formData.temperature?.trim()) {
+    const temp = parseFloat(formData.temperature);
+    if (!isNaN(temp)) config.temperature = temp;
+  }
+  if (formData.maxTokens?.trim()) {
+    const tokens = parseInt(formData.maxTokens, 10);
+    if (!isNaN(tokens)) config.max_tokens = tokens;
+  }
+  if (formData.topP?.trim()) {
+    const topP = parseFloat(formData.topP);
+    if (!isNaN(topP)) config.top_p = topP;
+  }
+  if (formData.topK?.trim()) {
+    const topK = parseInt(formData.topK, 10);
+    if (!isNaN(topK)) config.top_k = topK;
+  }
+  if (formData.frequencyPenalty?.trim()) {
+    const freqPenalty = parseFloat(formData.frequencyPenalty);
+    if (!isNaN(freqPenalty)) config.frequency_penalty = freqPenalty;
+  }
+  if (formData.presencePenalty?.trim()) {
+    const presPenalty = parseFloat(formData.presencePenalty);
+    if (!isNaN(presPenalty)) config.presence_penalty = presPenalty;
+  }
+  if (formData.stopSequences?.trim()) {
+    // Split by comma and trim each value
+    const sequences = formData.stopSequences
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+    if (sequences.length > 0) config.stop_sequences = sequences;
+  }
+
+  return Object.keys(config).length > 0 ? config : undefined;
+};
+
+/**
+ * Convert backend model config to form data format.
+ * Returns empty object if config is undefined.
+ */
+export const modelConfigToFormData = (config?: PromptModelConfig): PromptModelConfigFormData => {
+  if (!config) {
+    return {};
+  }
+
+  return {
+    modelName: config.model_name ?? '',
+    temperature: config.temperature !== undefined ? String(config.temperature) : '',
+    maxTokens: config.max_tokens !== undefined ? String(config.max_tokens) : '',
+    topP: config.top_p !== undefined ? String(config.top_p) : '',
+    topK: config.top_k !== undefined ? String(config.top_k) : '',
+    frequencyPenalty: config.frequency_penalty !== undefined ? String(config.frequency_penalty) : '',
+    presencePenalty: config.presence_penalty !== undefined ? String(config.presence_penalty) : '',
+    stopSequences: config.stop_sequences ? config.stop_sequences.join(', ') : '',
+  };
+};
+
+/**
+ * Validate model config form values.
+ * Returns an object with field names as keys and error messages as values.
+ */
+export const validateModelConfig = (formData: PromptModelConfigFormData): Record<string, string> => {
+  const errors: Record<string, string> = {};
+
+  if (formData['temperature']?.trim()) {
+    const temp = parseFloat(formData['temperature']);
+    if (isNaN(temp) || temp < 0) {
+      errors['temperature'] = 'Temperature must be a number >= 0';
+    }
+  }
+
+  if (formData['maxTokens']?.trim()) {
+    const tokens = parseInt(formData['maxTokens'], 10);
+    if (isNaN(tokens) || tokens <= 0) {
+      errors['maxTokens'] = 'Max tokens must be an integer > 0';
+    }
+  }
+
+  if (formData['topP']?.trim()) {
+    const topP = parseFloat(formData['topP']);
+    if (isNaN(topP) || topP < 0 || topP > 1) {
+      errors['topP'] = 'Top P must be a number between 0 and 1';
+    }
+  }
+
+  if (formData['topK']?.trim()) {
+    const topK = parseInt(formData['topK'], 10);
+    if (isNaN(topK) || topK <= 0) {
+      errors['topK'] = 'Top K must be an integer > 0';
+    }
+  }
+
+  if (formData['frequencyPenalty']?.trim()) {
+    const freqPenalty = parseFloat(formData['frequencyPenalty']);
+    if (isNaN(freqPenalty) || freqPenalty < -2 || freqPenalty > 2) {
+      errors['frequencyPenalty'] = 'Frequency penalty must be a number between -2 and 2';
+    }
+  }
+
+  if (formData['presencePenalty']?.trim()) {
+    const presPenalty = parseFloat(formData['presencePenalty']);
+    if (isNaN(presPenalty) || presPenalty < -2 || presPenalty > 2) {
+      errors['presencePenalty'] = 'Presence penalty must be a number between -2 and 2';
+    }
+  }
+
+  // Stop sequences validation - just check it's a valid comma-separated string
+  // No specific validation needed as any string is valid
+
+  return errors;
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -24,6 +24,17 @@ export const PROMPT_EXPERIMENT_IDS_TAG_KEY = '_mlflow_experiment_ids';
 // Tag key used to store model config as JSON string (must match backend)
 export const MLFLOW_PROMPT_MODEL_CONFIG = 'mlflow.prompt.modelConfig';
 
+export const MODEL_CONFIG_FIELD_LABELS = {
+  model_name: 'Model',
+  temperature: 'Temperature',
+  max_tokens: 'Max Tokens',
+  top_p: 'Top P',
+  top_k: 'Top K',
+  frequency_penalty: 'Frequency Penalty',
+  presence_penalty: 'Presence Penalty',
+  stop_sequences: 'Stop Sequences',
+} as const;
+
 // Query parameter name for specifying prompt version in URLs
 export const PROMPT_VERSION_QUERY_PARAM = 'promptVersion';
 

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -22,9 +22,9 @@ export const PROMPT_TYPE_TAG_KEY = '_mlflow_prompt_type';
 // Tag key used to store comma-separated experiment IDs associated with a prompt
 export const PROMPT_EXPERIMENT_IDS_TAG_KEY = '_mlflow_experiment_ids';
 // Tag key used to store model config as JSON string (must match backend)
-export const MLFLOW_PROMPT_MODEL_CONFIG = 'mlflow.prompt.modelConfig';
+export const PROMPT_MODEL_CONFIG_TAG_KEY = '_mlflow_prompt_model_config';
 
-export const MODEL_CONFIG_FIELD_LABELS = {
+export const MODEL_CONFIG_FIELD_LABELS: Record<Exclude<keyof PromptModelConfig, 'extra_params'>, string> = {
   provider: 'Provider',
   model_name: 'Model',
   temperature: 'Temperature',
@@ -138,7 +138,7 @@ export const buildSearchFilterClause = (searchFilter?: string): string => {
  * Returns undefined if tag doesn't exist or JSON parsing fails.
  */
 export const getModelConfigFromTags = (tags?: KeyValueEntity[]): PromptModelConfig | undefined => {
-  const configTag = tags?.find((tag) => tag.key === MLFLOW_PROMPT_MODEL_CONFIG);
+  const configTag = tags?.find((tag) => tag.key === PROMPT_MODEL_CONFIG_TAG_KEY);
   if (!configTag?.value) {
     return undefined;
   }
@@ -156,7 +156,7 @@ export const getModelConfigFromTags = (tags?: KeyValueEntity[]): PromptModelConf
  * Returns undefined if no fields have values.
  */
 export const formDataToModelConfig = (formData: PromptModelConfigFormData): PromptModelConfig | undefined => {
-  const hasAnyValue = Object.values(formData).some((v) => v !== undefined && v !== '');
+  const hasAnyValue = Object.values(formData).some((v) => !!v);
   if (!hasAnyValue) {
     return undefined;
   }
@@ -275,9 +275,6 @@ export const validateModelConfig = (formData: PromptModelConfigFormData): Record
       errors['presencePenalty'] = 'Presence penalty must be a number between -2 and 2';
     }
   }
-
-  // Stop sequences validation - just check it's a valid comma-separated string
-  // No specific validation needed as any string is valid
 
   return errors;
 };

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -163,11 +163,13 @@ export const formDataToModelConfig = (formData: PromptModelConfigFormData): Prom
 
   const config: PromptModelConfig = {};
 
-  if (formData.provider?.trim()) {
-    config.provider = formData.provider.trim();
+  const provider = formData.provider?.trim();
+  if (provider) {
+    config.provider = provider;
   }
-  if (formData.modelName?.trim()) {
-    config.model_name = formData.modelName.trim();
+  const modelName = formData.modelName?.trim();
+  if (modelName) {
+    config.model_name = modelName;
   }
   if (formData.temperature?.trim()) {
     const temp = parseFloat(formData.temperature);

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/utils.ts
@@ -25,6 +25,7 @@ export const PROMPT_EXPERIMENT_IDS_TAG_KEY = '_mlflow_experiment_ids';
 export const MLFLOW_PROMPT_MODEL_CONFIG = 'mlflow.prompt.modelConfig';
 
 export const MODEL_CONFIG_FIELD_LABELS = {
+  provider: 'Provider',
   model_name: 'Model',
   temperature: 'Temperature',
   max_tokens: 'Max Tokens',
@@ -162,6 +163,9 @@ export const formDataToModelConfig = (formData: PromptModelConfigFormData): Prom
 
   const config: PromptModelConfig = {};
 
+  if (formData.provider?.trim()) {
+    config.provider = formData.provider.trim();
+  }
   if (formData.modelName?.trim()) {
     config.model_name = formData.modelName.trim();
   }
@@ -211,6 +215,7 @@ export const modelConfigToFormData = (config?: PromptModelConfig): PromptModelCo
   }
 
   return {
+    provider: config.provider ?? '',
     modelName: config.model_name ?? '',
     temperature: config.temperature !== undefined ? String(config.temperature) : '',
     maxTokens: config.max_tokens !== undefined ? String(config.max_tokens) : '',

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -3097,6 +3097,10 @@
     "defaultMessage": "Copy S3 URI to clipboard",
     "description": "Text for the HTTP/HF location link in the experiment run dataset drawer"
   },
+  "Sb+wLa": {
+    "defaultMessage": "Model configuration stores the LLM settings associated with this prompt.",
+    "description": "Help text explaining model configuration purpose"
+  },
   "Sb0Z4Z": {
     "defaultMessage": ", . : / - = and blank spaces are not allowed",
     "description": "Add new key-value tag modal > Invalid characters error"
@@ -3463,6 +3467,10 @@
   "W8bOkn": {
     "defaultMessage": "250",
     "description": "Label for 250 first runs visible in run count selector within runs compare configuration modal"
+  },
+  "W99FRU": {
+    "defaultMessage": "Model Name",
+    "description": "Label for model name input in model config form"
   },
   "WDqWWa": {
     "defaultMessage": "Show all runs",
@@ -4403,6 +4411,10 @@
     "defaultMessage": "Source",
     "description": "Experiment page > traces table > source column header"
   },
+  "eMbUhX": {
+    "defaultMessage": "e.g., openai, anthropic, google",
+    "description": "Placeholder for provider input"
+  },
   "eNUbaN": {
     "defaultMessage": "Y-axis:",
     "description": "Label text for y-axis in scatter plot comparison in MLflow"
@@ -4818,10 +4830,6 @@
   "hnhCDT": {
     "defaultMessage": "Error occurred",
     "description": "Run page > artifact view > logged table view > generic error empty state title"
-  },
-  "hp4zLf": {
-    "defaultMessage": "Sampling Parameters",
-    "description": "Subsection for sampling parameters in model config"
   },
   "hxMEqi": {
     "defaultMessage": "The model version will be copied to {selectedModel} as a new version.",
@@ -5871,10 +5879,6 @@
     "defaultMessage": "just now",
     "description": "Evaluation review > assessments > tooltip > just now"
   },
-  "rmAmIt": {
-    "defaultMessage": "Model",
-    "description": "Label for model name input in model config form"
-  },
   "rpqN8U": {
     "defaultMessage": "Dataset",
     "description": "Header title for the dataset column in the logged model list table"
@@ -6306,6 +6310,10 @@
   "wFvyI1": {
     "defaultMessage": "Registered at:",
     "description": "A label for the registration timestamp in the prompt details page"
+  },
+  "wJX0a/": {
+    "defaultMessage": "Provider",
+    "description": "Label for model provider input"
   },
   "wKXJ6U": {
     "defaultMessage": "Toggle visibility of evaluation runs",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -7,6 +7,10 @@
     "defaultMessage": "Assessments",
     "description": "Label for the assessments pane"
   },
+  "+/Zrmm": {
+    "defaultMessage": "Temperature",
+    "description": "Label for temperature input"
+  },
   "+1d2x/": {
     "defaultMessage": "Run judge on traces",
     "description": "Title for running judge on traces"
@@ -527,6 +531,10 @@
     "defaultMessage": "Edit",
     "description": "Text for the edit button next to the description section title on\n             the model view page"
   },
+  "3Cwqj9": {
+    "defaultMessage": "e.g., gpt-4, claude-3-opus",
+    "description": "Placeholder for model name input"
+  },
   "3D2Znf": {
     "defaultMessage": "Filter by {columnNames}",
     "description": "Experiment page > artifact compare view > search input placeholder"
@@ -765,6 +773,10 @@
   "5jXYY4": {
     "defaultMessage": "Detailed assessments",
     "description": "Evaluation review > assessments > detailed assessments > title"
+  },
+  "5lsHqm": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button for the edit model config modal"
   },
   "5m2VPy": {
     "defaultMessage": "Image grid",
@@ -1245,6 +1257,10 @@
   "9mAGv0": {
     "defaultMessage": "Model name",
     "description": "Text for form title on creating model in the model registry"
+  },
+  "9oh44C": {
+    "defaultMessage": "Stop Sequences (comma-separated)",
+    "description": "Label for stop sequences input"
   },
   "9pJlQd": {
     "defaultMessage": "No prompt versions created",
@@ -2510,6 +2526,10 @@
     "defaultMessage": "Created at",
     "description": "Label for the creation timestamp of a logged model on the logged model details page"
   },
+  "MX4ypf": {
+    "defaultMessage": "Save",
+    "description": "Save button for the edit model config modal"
+  },
   "MZNjYJ": {
     "defaultMessage": "Actions ({count})",
     "description": "Actions dropdown button label with count of selected sessions"
@@ -2901,6 +2921,10 @@
     "defaultMessage": "Error",
     "description": "Title for error fallback component in the MLflow experiment chat sessions page"
   },
+  "QZXOSm": {
+    "defaultMessage": "Frequency Penalty",
+    "description": "Label for frequency penalty input"
+  },
   "QcEYpD": {
     "defaultMessage": "Add to evaluation dataset",
     "description": "Add traces to evaluation dataset action"
@@ -2936,6 +2960,10 @@
   "R/4/8G": {
     "defaultMessage": "Metric",
     "description": "Label for the metric column in the logged model details metrics table"
+  },
+  "R1FeSE": {
+    "defaultMessage": "Advanced settings (optional)",
+    "description": "Toggle button for advanced settings in prompt creation modal"
   },
   "R3Lb6z": {
     "defaultMessage": "The requested resource was not found.",
@@ -2992,6 +3020,10 @@
   "Rlwm5V": {
     "defaultMessage": "Name is required",
     "description": "A validation state for the prompt name in the prompt creation modal"
+  },
+  "RmmAwm": {
+    "defaultMessage": "Top P",
+    "description": "Label for top P input"
   },
   "Rs+SVS": {
     "defaultMessage": "Ready",
@@ -3351,6 +3383,10 @@
   "VPU43C": {
     "defaultMessage": "Compare parameter importance",
     "description": "Experiment page > compare runs > parallel coordinates chart > chart not configured warning > title"
+  },
+  "VSitCY": {
+    "defaultMessage": "Top K",
+    "description": "Label for top K input"
   },
   "VTePPP": {
     "defaultMessage": "Create your first experiment",
@@ -4783,6 +4819,10 @@
     "defaultMessage": "Error occurred",
     "description": "Run page > artifact view > logged table view > generic error empty state title"
   },
+  "hp4zLf": {
+    "defaultMessage": "Sampling Parameters",
+    "description": "Subsection for sampling parameters in model config"
+  },
   "hxMEqi": {
     "defaultMessage": "The model version will be copied to {selectedModel} as a new version.",
     "description": "Model registry > OSS Promote model modal > copy explanatory text"
@@ -5687,6 +5727,10 @@
     "defaultMessage": "Value",
     "description": "Run page > Overview > Parameters table > Value column header"
   },
+  "qKGnLV": {
+    "defaultMessage": "Model Config:",
+    "description": "Label for model configuration in the prompt details page"
+  },
   "qMwRy3": {
     "defaultMessage": "Registered Models",
     "description": "Header for displaying models in the model registry"
@@ -5827,6 +5871,10 @@
     "defaultMessage": "just now",
     "description": "Evaluation review > assessments > tooltip > just now"
   },
+  "rmAmIt": {
+    "defaultMessage": "Model",
+    "description": "Label for model name input in model config form"
+  },
   "rpqN8U": {
     "defaultMessage": "Dataset",
     "description": "Header title for the dataset column in the logged model list table"
@@ -5834,6 +5882,10 @@
   "rs7Iic": {
     "defaultMessage": "Tags",
     "description": "Run page > Overview > Run tags section label"
+  },
+  "rstugP": {
+    "defaultMessage": "Max Tokens",
+    "description": "Label for max tokens input"
   },
   "rxMHgr": {
     "defaultMessage": "Stage transition",
@@ -5926,6 +5978,10 @@
   "sXqvoN": {
     "defaultMessage": "Ignore column ordering",
     "description": "Toggle text that determines whether to ignore column order in the\n                      model comparison page"
+  },
+  "sXyBDU": {
+    "defaultMessage": "Model Configuration",
+    "description": "Section header for model configuration in prompt creation"
   },
   "sbHChH": {
     "defaultMessage": "Dataset name is required",
@@ -6046,6 +6102,10 @@
   "uSVfB9": {
     "defaultMessage": "Not grounded",
     "description": "Evaluation results > retrieval grounded assessment > negative value label. Displayed if evaluation result is considered as not grounded."
+  },
+  "uX2XCM": {
+    "defaultMessage": "Edit Model Configuration",
+    "description": "Title for the edit model config modal"
   },
   "uXW7SK": {
     "defaultMessage": "Iterate on quality with offline evaluations and comparisons.",
@@ -6323,6 +6383,10 @@
     "defaultMessage": "MLflow MCP server",
     "description": "Home page news card title one"
   },
+  "x03ytD": {
+    "defaultMessage": "e.g., END, ###, STOP",
+    "description": "Placeholder for stop sequences input"
+  },
   "x0K27S": {
     "defaultMessage": "Nothing to compare!",
     "description": "Header displayed in the metrics and params compare plot when no values are selected"
@@ -6410,6 +6474,10 @@
   "xnr5KT": {
     "defaultMessage": "No events found",
     "description": "Empty state for the events tab in the model trace explorer. Events are logs of arbitrary things (e.g. exceptions) that occur during the execution of a span, and can be user-defined."
+  },
+  "xpwj4T": {
+    "defaultMessage": "Presence Penalty",
+    "description": "Label for presence penalty input"
   },
   "xq0Rde": {
     "defaultMessage": "New",

--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -22,6 +22,7 @@ from mlflow.entities.model_registry.prompt_version import (
 )
 from mlflow.exceptions import MlflowException, RestException
 from mlflow.prompt.constants import (
+    PROMPT_MODEL_CONFIG_TAG_KEY,
     PROMPT_TYPE_CHAT,
     PROMPT_TYPE_TAG_KEY,
     PROMPT_TYPE_TEXT,
@@ -159,7 +160,6 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_DATABRICKS_JOB_ID,
     MLFLOW_DATABRICKS_JOB_RUN_ID,
     MLFLOW_DATABRICKS_NOTEBOOK_ID,
-    MLFLOW_PROMPT_MODEL_CONFIG,
 )
 from mlflow.utils.proto_json_utils import message_to_json, parse_dict
 from mlflow.utils.rest_utils import (
@@ -1519,7 +1519,7 @@ class UcModelRegistryStore(BaseRestStore):
             else:
                 config_dict = model_config
 
-            final_tags[MLFLOW_PROMPT_MODEL_CONFIG] = json.dumps(config_dict)
+            final_tags[PROMPT_MODEL_CONFIG_TAG_KEY] = json.dumps(config_dict)
         if isinstance(template, str):
             final_tags[PROMPT_TYPE_TAG_KEY] = PROMPT_TYPE_TEXT
         else:

--- a/mlflow/store/model_registry/abstract_store.py
+++ b/mlflow/store/model_registry/abstract_store.py
@@ -22,6 +22,7 @@ from mlflow.exceptions import MlflowException
 from mlflow.prompt.constants import (
     IS_PROMPT_TAG_KEY,
     PROMPT_EXPERIMENT_IDS_TAG_KEY,
+    PROMPT_MODEL_CONFIG_TAG_KEY,
     PROMPT_TEXT_TAG_KEY,
     PROMPT_TYPE_CHAT,
     PROMPT_TYPE_TAG_KEY,
@@ -40,7 +41,6 @@ from mlflow.tracing.constant import TraceTagKey
 from mlflow.tracing.utils.prompt import update_linked_prompts_tag
 from mlflow.utils.annotations import developer_stable
 from mlflow.utils.logging_utils import eprint
-from mlflow.utils.mlflow_tags import MLFLOW_PROMPT_MODEL_CONFIG
 
 _logger = logging.getLogger(__name__)
 
@@ -806,7 +806,7 @@ class AbstractStore:
                 config_dict = PromptModelConfig.from_dict(model_config).to_dict()
 
             version_tags.append(
-                ModelVersionTag(key=MLFLOW_PROMPT_MODEL_CONFIG, value=json.dumps(config_dict))
+                ModelVersionTag(key=PROMPT_MODEL_CONFIG_TAG_KEY, value=json.dumps(config_dict))
             )
 
         if tags:

--- a/mlflow/tracking/client.py
+++ b/mlflow/tracking/client.py
@@ -67,6 +67,7 @@ from mlflow.prompt.constants import (
     IS_PROMPT_TAG_KEY,
     PROMPT_ASSOCIATED_RUN_IDS_TAG_KEY,
     PROMPT_EXPERIMENT_IDS_TAG_KEY,
+    PROMPT_MODEL_CONFIG_TAG_KEY,
     PROMPT_TEXT_TAG_KEY,
     PROMPT_TYPE_CHAT,
     PROMPT_TYPE_TAG_KEY,
@@ -131,7 +132,6 @@ from mlflow.utils.mlflow_tags import (
     MLFLOW_LOGGED_ARTIFACTS,
     MLFLOW_LOGGED_IMAGES,
     MLFLOW_PARENT_RUN_ID,
-    MLFLOW_PROMPT_MODEL_CONFIG,
 )
 from mlflow.utils.time import get_current_time_millis
 from mlflow.utils.uri import is_databricks_unity_catalog_uri, is_databricks_uri
@@ -671,7 +671,7 @@ class MlflowClient:
                 # Validate dict by converting through PromptModelConfig
                 config_dict = PromptModelConfig.from_dict(model_config).to_dict()
 
-            tags.update({MLFLOW_PROMPT_MODEL_CONFIG: json.dumps(config_dict)})
+            tags.update({PROMPT_MODEL_CONFIG_TAG_KEY: json.dumps(config_dict)})
 
         try:
             mv: ModelVersion = registry_client.create_model_version(

--- a/mlflow/utils/mlflow_tags.py
+++ b/mlflow/utils/mlflow_tags.py
@@ -87,9 +87,6 @@ MLFLOW_EXPERIMENT_PRIMARY_METRIC_GREATER_IS_BETTER = (
 # For automatic model checkpointing
 LATEST_CHECKPOINT_ARTIFACT_TAG_KEY = "mlflow.latest_checkpoint_artifact"
 
-# For prompt model configuration
-MLFLOW_PROMPT_MODEL_CONFIG = "mlflow.prompt.modelConfig"
-
 
 # A set of tags that cannot be updated by the user
 IMMUTABLE_TAGS = {MLFLOW_USER, MLFLOW_ARTIFACT_LOCATION}

--- a/tests/entities/test_prompt.py
+++ b/tests/entities/test_prompt.py
@@ -11,9 +11,9 @@ from mlflow.entities.model_registry.prompt_version import (
     PromptVersion,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.prompt.constants import PROMPT_MODEL_CONFIG_TAG_KEY
 from mlflow.prompt.registry_utils import model_version_to_prompt_version
 from mlflow.protos.model_registry_pb2 import ModelVersionTag
-from mlflow.utils.mlflow_tags import MLFLOW_PROMPT_MODEL_CONFIG
 
 
 def test_prompt_initialization():
@@ -143,7 +143,7 @@ def test_prompt_from_model_version():
         tags=[
             ModelVersionTag(key=IS_PROMPT_TAG_KEY, value="true"),
             ModelVersionTag(key=PROMPT_TEXT_TAG_KEY, value="Hello, {{name}}!"),
-            ModelVersionTag(key=MLFLOW_PROMPT_MODEL_CONFIG, value=model_config_json),
+            ModelVersionTag(key=PROMPT_MODEL_CONFIG_TAG_KEY, value=model_config_json),
         ],
         aliases=["alias"],
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/chenmoneygithub/mlflow/pull/19279?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19279/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19279/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19279/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Add prompt model config to the prompt registry UI:

- Allow specifying the model config when creating the prompt
- Displaying the model config on the registry UI
- Edit the model config on the prompt page.

Earlier we added client and backend support in PR https://github.com/mlflow/mlflow/pull/19174, and this one handles the frontend. See below for demo:

![chrome-capture-2025-12-9](https://github.com/user-attachments/assets/aa039332-e8f4-446f-912c-822c6a3558cc)




### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
