### PR TITLE
Fix UC to UC copying regression

### DIFF
--- a/mlflow/store/_unity_catalog/registry/rest_store.py
+++ b/mlflow/store/_unity_catalog/registry/rest_store.py
@@ -896,10 +896,20 @@ class UcModelRegistryStore(BaseRestStore):
                     shutil.rmtree(local_model_dir)
 
     def _get_logged_model_from_model_id(self, model_id) -> LoggedModel | None:
-        # load the MLflow LoggedModel by model_id and
         if model_id is None:
             return None
-        return mlflow.get_logged_model(model_id)
+        try:
+            return mlflow.get_logged_model(model_id)
+        except MlflowException as e:
+            # model_id may be from a different workspace that's not accessible,
+            # e.g., during cross-workspace model copying
+            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                _logger.debug(
+                    f"Could not find logged model with ID {model_id}. "
+                    "This may occur during cross-workspace model copying."
+                )
+                return None
+            raise
 
     def _create_model_version_with_optional_signature_validation(
         self,

--- a/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
+++ b/tests/store/_unity_catalog/model_registry/test_unity_catalog_rest_store.py
@@ -35,7 +35,7 @@ from mlflow.prompt.constants import (
     PROMPT_TYPE_TEXT,
     RESPONSE_FORMAT_TAG_KEY,
 )
-from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
+from mlflow.protos.databricks_pb2 import INTERNAL_ERROR, RESOURCE_DOES_NOT_EXIST
 from mlflow.protos.databricks_uc_registry_messages_pb2 import (
     MODEL_VERSION_OPERATION_READ_WRITE,
     AwsCredentials,
@@ -972,6 +972,15 @@ def test_get_logged_model_from_model_id_returns_logged_model_on_success(store):
 def test_get_logged_model_from_model_id_returns_none_for_none_input(store):
     result = store._get_logged_model_from_model_id(None)
     assert result is None
+
+
+def test_get_logged_model_from_model_id_reraises_other_exceptions(store):
+    with mock.patch(
+        "mlflow.get_logged_model",
+        side_effect=MlflowException("Some other error", error_code=INTERNAL_ERROR),
+    ):
+        with pytest.raises(MlflowException, match="Some other error"):
+            store._get_logged_model_from_model_id("model123")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/19280?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19280/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19280/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19280/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Fixes a regression accidentally introduced in https://github.com/mlflow/mlflow/pull/17458 that made `model_id` required in the abstract implementation, forcing the UC registry store to fail for the previously working path of copying models across workspaces (which was entirely functional prior to 3.4.0). 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [X] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
