### PR TITLE
[Workspace] Propagate workspace context through REST APIs

### DIFF
--- a/mlflow/cli/__init__.py
+++ b/mlflow/cli/__init__.py
@@ -46,6 +46,7 @@ from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.process import ShellCommandException
 from mlflow.utils.server_cli_utils import (
     artifacts_only_config_validation,
+    assert_server_workspace_env_unset,
     resolve_default_artifact_root,
 )
 
@@ -476,9 +477,8 @@ def _validate_static_prefix(ctx, param, value):
     ),
 )
 @click.option(
-    "--enable-workspaces",
+    "--enable-workspaces/--disable-workspaces",
     envvar=MLFLOW_ENABLE_WORKSPACES.name,
-    is_flag=True,
     default=False,
     show_default=True,
     help="Enable backwards compatible workspace-aware multi-tenancy mode.",
@@ -552,10 +552,13 @@ def server(
         disable_security_middleware=disable_security_middleware,
     )
 
-    if enable_workspaces:
-        os.environ[MLFLOW_ENABLE_WORKSPACES.name] = "true"
-        if workspace_store_uri:
-            os.environ[MLFLOW_WORKSPACE_STORE_URI.name] = workspace_store_uri
+    assert_server_workspace_env_unset()
+
+    # Keep environment flag in sync with the resolved boolean so server-side gating
+    # (which reads MLFLOW_ENABLE_WORKSPACES.get()) has a single source of truth.
+    os.environ[MLFLOW_ENABLE_WORKSPACES.name] = "true" if enable_workspaces else "false"
+    if enable_workspaces and workspace_store_uri:
+        os.environ[MLFLOW_WORKSPACE_STORE_URI.name] = workspace_store_uri
     elif workspace_store_uri:
         click.echo(
             "Ignoring --workspace-store-uri because workspaces are not enabled. "
@@ -597,10 +600,15 @@ def server(
     default_artifact_root = resolve_default_artifact_root(
         serve_artifacts, default_artifact_root, backend_store_uri
     )
-    artifacts_only_config_validation(artifacts_only, backend_store_uri)
+    artifacts_only_config_validation(artifacts_only, backend_store_uri, enable_workspaces)
 
     try:
-        initialize_backend_stores(backend_store_uri, registry_store_uri, default_artifact_root)
+        initialize_backend_stores(
+            backend_store_uri,
+            registry_store_uri,
+            default_artifact_root,
+            workspace_store_uri=workspace_store_uri,
+        )
     except Exception as e:
         _logger.error("Error initializing backend store")
         _logger.exception(e)

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -35,6 +35,10 @@ from mlflow.server.handlers import (
     get_trace_artifact_handler,
     upload_artifact_handler,
 )
+from mlflow.server.workspace_helpers import (
+    workspace_before_request_handler,
+    workspace_teardown_request_handler,
+)
 from mlflow.utils.os import is_windows
 from mlflow.utils.plugins import get_entry_points
 from mlflow.utils.process import _exec_cmd
@@ -69,6 +73,9 @@ if is_running_as_server:
     from mlflow.server import security
 
     security.init_security_middleware(app)
+
+app.before_request(workspace_before_request_handler)
+app.teardown_request(workspace_teardown_request_handler)
 
 for http_path, handler, methods in handlers.get_endpoints():
     app.add_url_rule(http_path, handler.__name__, handler, methods=methods)

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -6,15 +6,61 @@ using WSGIMiddleware to maintain 100% API compatibility while enabling future mi
 to FastAPI endpoints.
 """
 
-from fastapi import FastAPI
+import json
+
+from fastapi import FastAPI, Request
 from fastapi.middleware.wsgi import WSGIMiddleware
+from fastapi.responses import JSONResponse
 from flask import Flask
 
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.exceptions import MlflowException
 from mlflow.server import app as flask_app
 from mlflow.server.fastapi_security import init_fastapi_security
 from mlflow.server.job_api import job_api_router
 from mlflow.server.otel_api import otel_router
+from mlflow.server.workspace_helpers import WORKSPACE_HEADER_NAME, resolve_workspace_from_header
+from mlflow.tracing.utils.otlp import OTLP_TRACES_PATH
+from mlflow.utils.workspace_context import (
+    clear_server_request_workspace,
+    set_server_request_workspace,
+)
 from mlflow.version import VERSION
+
+# FastAPI routes that do not go through the Flask WSGI bridge (currently jobs + OTLP).
+FASTAPI_NATIVE_PREFIXES = (job_api_router.prefix, OTLP_TRACES_PATH)
+
+
+def add_fastapi_workspace_middleware(fastapi_app: FastAPI) -> None:
+    if getattr(fastapi_app.state, "workspace_middleware_added", False):
+        return
+
+    @fastapi_app.middleware("http")
+    async def workspace_context_middleware(request: Request, call_next):
+        if not MLFLOW_ENABLE_WORKSPACES.get():
+            return await call_next(request)
+
+        path = request.url.path
+        if not any(path.startswith(prefix) for prefix in FASTAPI_NATIVE_PREFIXES):
+            # Skip if it's a Flask route and let the Flask before request handler handle it.
+            return await call_next(request)
+
+        try:
+            workspace = resolve_workspace_from_header(request.headers.get(WORKSPACE_HEADER_NAME))
+        except MlflowException as e:
+            return JSONResponse(
+                status_code=e.get_http_status_code(),
+                content=json.loads(e.serialize_as_json()),
+            )
+
+        set_server_request_workspace(workspace.name if workspace else None)
+        try:
+            response = await call_next(request)
+        finally:
+            clear_server_request_workspace()
+        return response
+
+    fastapi_app.state.workspace_middleware_added = True
 
 
 def create_fastapi_app(flask_app: Flask = flask_app):
@@ -38,6 +84,8 @@ def create_fastapi_app(flask_app: Flask = flask_app):
 
     # Initialize security middleware BEFORE adding routes
     init_fastapi_security(fastapi_app)
+
+    add_fastapi_workspace_middleware(fastapi_app)
 
     # Include OpenTelemetry API router BEFORE mounting Flask app
     # This ensures FastAPI routes take precedence over the catch-all Flask mount

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -61,6 +61,7 @@ from mlflow.protos.databricks_pb2 import (
     BAD_REQUEST,
     FEATURE_DISABLED,
     INVALID_PARAMETER_VALUE,
+    INVALID_STATE,
     RESOURCE_DOES_NOT_EXIST,
 )
 from mlflow.protos.mlflow_artifacts_pb2 import (
@@ -211,6 +212,7 @@ from mlflow.tracking._model_registry.registry import ModelRegistryStoreRegistry
 from mlflow.tracking._tracking_service import utils
 from mlflow.tracking._tracking_service.registry import TrackingStoreRegistry
 from mlflow.tracking.registry import UnsupportedModelRegistryStoreURIException
+from mlflow.utils import workspace_context
 from mlflow.utils.databricks_utils import get_databricks_host_creds
 from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.utils.mime_type_utils import _guess_mime_type
@@ -223,6 +225,7 @@ from mlflow.utils.validation import (
     invalid_value,
     missing_value,
 )
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 from mlflow.webhooks.delivery import deliver_webhook, test_webhook
 from mlflow.webhooks.types import (
     ModelVersionAliasCreatedPayload,
@@ -532,12 +535,29 @@ def initialize_backend_stores(
     backend_store_uri: str | None = None,
     registry_store_uri: str | None = None,
     default_artifact_root: str | None = None,
+    workspace_store_uri: str | None = None,
 ) -> None:
-    _get_tracking_store(backend_store_uri, default_artifact_root)
+    tracking_store = _get_tracking_store(backend_store_uri, default_artifact_root)
+
+    if MLFLOW_ENABLE_WORKSPACES.get():
+        # Initialize the workspace store to verify it's correctly configured
+        _get_workspace_store(workspace_store_uri, tracking_uri=backend_store_uri)
+        _verify_tracking_store_workspace_support(tracking_store)
+
     try:
         _get_model_registry_store(registry_store_uri)
     except UnsupportedModelRegistryStoreURIException:
         pass
+
+
+def _verify_tracking_store_workspace_support(tracking_store: AbstractTrackingStore) -> None:
+    supports_fn = getattr(tracking_store, "supports_workspaces", None)
+    if not callable(supports_fn) or not supports_fn():
+        raise MlflowException(
+            "The configured tracking store does not support workspace-aware operations. "
+            "Remove the --enable-workspaces flag or configure a workspace-capable backend store.",
+            error_code=INVALID_STATE,
+        )
 
 
 def _assert_string(x):
@@ -818,6 +838,24 @@ def _workspace_not_supported(message: str) -> MlflowException:
 
 
 @catch_mlflow_exception
+def _server_features_handler():
+    """
+    Returns a dictionary containing the server features state.
+
+    This helps clients determine if workspaces are enabled.
+    """
+    response = Response(mimetype="application/json")
+    response.set_data(
+        json.dumps(
+            {
+                "workspaces_enabled": MLFLOW_ENABLE_WORKSPACES.get(),
+            }
+        )
+    )
+    return response
+
+
+@catch_mlflow_exception
 @_disable_if_workspaces_disabled
 def _list_workspaces_handler():
     _get_request_message(ListWorkspaces())
@@ -915,6 +953,7 @@ def get_artifact_handler():
             proxied_artifact_root=run.info.artifact_uri,
             relative_path=path,
         )
+        artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
     else:
         artifact_repo = _get_artifact_repo(run)
         artifact_path = path
@@ -1437,6 +1476,9 @@ def _list_artifacts_for_proxied_run_artifact_root(proxied_artifact_root, relativ
         proxied_artifact_root=proxied_artifact_root,
         relative_path=relative_path,
     )
+    artifact_destination_path = _get_workspace_scoped_repo_path_if_enabled(
+        artifact_destination_path
+    )
 
     artifact_entities = []
     for file_info in artifact_destination_repo.list_artifacts(artifact_destination_path):
@@ -1822,11 +1864,14 @@ def upload_artifact_handler():
     def _log_artifact_to_repo(file, run, dirname, artifact_dir):
         if _is_servable_proxied_run_artifact_root(run.info.artifact_uri):
             artifact_repo = _get_artifact_repo_mlflow_artifacts()
+            # Use posixpath.join since these are logical artifact paths (not local filesystem paths)
+            # that should always use forward slashes regardless of the platform.
             path_to_log = (
-                os.path.join(run.info.experiment_id, run.info.run_id, "artifacts", dirname)
+                posixpath.join(run.info.experiment_id, run.info.run_id, "artifacts", dirname)
                 if dirname
-                else os.path.join(run.info.experiment_id, run.info.run_id, "artifacts")
+                else posixpath.join(run.info.experiment_id, run.info.run_id, "artifacts")
             )
+            path_to_log = _get_workspace_scoped_repo_path_if_enabled(path_to_log)
         else:
             artifact_repo = get_artifact_repository(artifact_dir)
             path_to_log = dirname
@@ -2378,6 +2423,7 @@ def get_model_version_artifact_handler():
             proxied_artifact_root=artifact_uri,
             relative_path=path,
         )
+        artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
     else:
         artifact_repo = get_artifact_repository(artifact_uri)
         artifact_path = path
@@ -2811,6 +2857,63 @@ def _test_webhook(webhook_id: str):
 # MLflow Artifacts APIs
 
 
+def _get_workspace_scoped_repo_path_if_enabled(artifact_path: str | None) -> str | None:
+    """
+    Normalize artifact paths for proxied (served) artifacts so they remain workspace-isolated.
+
+    When ``mlflow-artifacts`` proxying is enabled and workspaces are on, every path under the HTTP
+    artifact endpoint must be rooted at ``workspaces/<workspace>/...``. Direct artifact repositories
+    (e.g., S3, GCS, local URIs) already encode their own isolation, so they bypass this logic by
+    calling the underlying store directly. Only the proxied repos need to be rewritten/validated
+    here.
+
+    Returns:
+        The workspace-scoped path. May return the original path in the following cases:
+        - Workspaces are disabled (returns ``artifact_path`` unchanged).
+        - Default workspace with no path (returns ``artifact_path`` unchanged to preserve legacy
+          root behavior, where artifacts live at the root rather than under ``workspaces/default``).
+        For non-default workspaces, always returns a string (``workspaces/<workspace>/...``).
+    """
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        return artifact_path
+
+    workspace = workspace_context.get_request_workspace()
+    if not workspace:
+        raise MlflowException.invalid_parameter_value(
+            "Active workspace is required for artifact operations. "
+            "Ensure X-MLFLOW-WORKSPACE is set or call mlflow.set_workspace()."
+        )
+
+    normalized = artifact_path.lstrip("/") if artifact_path else ""
+    base = posixpath.join("workspaces", workspace)
+
+    if not normalized:
+        # For the default workspace, preserve the legacy root behavior (no prefix),
+        # so root operations continue to see the existing layout.
+        return base if workspace != DEFAULT_WORKSPACE_NAME else artifact_path
+
+    if workspace == DEFAULT_WORKSPACE_NAME and not normalized.startswith("workspaces/"):
+        # Legacy default-workspace artifacts never had the workspace prefix; allow them to be served
+        # without rewriting as long as the path isn't trying to opt into the reserved namespace.
+        return artifact_path
+
+    leading_segments = normalized.split("/", 2)
+    if leading_segments and leading_segments[0] == "workspaces":
+        if len(leading_segments) == 1 or not leading_segments[1]:
+            raise MlflowException.invalid_parameter_value(
+                "Artifact paths prefixed with 'workspaces/' must include a workspace name."
+            )
+        requested_workspace = leading_segments[1]
+        if requested_workspace != workspace:
+            raise MlflowException.invalid_parameter_value(
+                f"Artifact path targets workspace '{requested_workspace}' "
+                f"but the workspace specified in the request is '{workspace}'."
+            )
+        return normalized
+
+    return posixpath.join(base, normalized)
+
+
 @catch_mlflow_exception
 @_disable_unless_serve_artifacts
 def _download_artifact(artifact_path):
@@ -2819,6 +2922,7 @@ def _download_artifact(artifact_path):
     from `artifact_path` (a relative path from the root artifact directory).
     """
     artifact_path = validate_path_is_safe(artifact_path)
+    artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
     tmp_dir = tempfile.TemporaryDirectory()
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
     dst = artifact_repo.download_artifacts(artifact_path, tmp_dir.name)
@@ -2844,6 +2948,7 @@ def _upload_artifact(artifact_path):
     to `artifact_path` (a relative path from the root artifact directory).
     """
     artifact_path = validate_path_is_safe(artifact_path)
+    artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
     head, tail = posixpath.split(artifact_path)
     with tempfile.TemporaryDirectory() as tmp_dir:
         tmp_path = os.path.join(tmp_dir, tail)
@@ -2870,6 +2975,7 @@ def _list_artifacts_mlflow_artifacts():
     """
     request_message = _get_request_message(ListArtifactsMlflowArtifacts())
     path = validate_path_is_safe(request_message.path) if request_message.HasField("path") else None
+    path = _get_workspace_scoped_repo_path_if_enabled(path)
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
     files = []
     for file_info in artifact_repo.list_artifacts(path):
@@ -2891,6 +2997,7 @@ def _delete_artifact_mlflow_artifacts(artifact_path):
     `path` (a relative path from the root artifact directory).
     """
     artifact_path = validate_path_is_safe(artifact_path)
+    artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
     _get_request_message(DeleteArtifact())
     artifact_repo = _get_artifact_repo_mlflow_artifacts()
     artifact_repo.delete_artifacts(artifact_path)
@@ -2943,6 +3050,7 @@ def _create_multipart_upload_artifact(artifact_path):
     to `artifact_path` (a relative path from the root artifact directory).
     """
     artifact_path = validate_path_is_safe(artifact_path)
+    artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
 
     request_message = _get_request_message(
         CreateMultipartUpload(),
@@ -2976,6 +3084,7 @@ def _complete_multipart_upload_artifact(artifact_path):
     to `artifact_path` (a relative path from the root artifact directory).
     """
     artifact_path = validate_path_is_safe(artifact_path)
+    artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
 
     request_message = _get_request_message(
         CompleteMultipartUpload(),
@@ -3009,6 +3118,7 @@ def _abort_multipart_upload_artifact(artifact_path):
     to `artifact_path` (a relative path from the root artifact directory).
     """
     artifact_path = validate_path_is_safe(artifact_path)
+    artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
 
     request_message = _get_request_message(
         AbortMultipartUpload(),
@@ -3613,6 +3723,7 @@ def get_logged_model_artifact_handler(model_id: str):
             proxied_artifact_root=logged_model.artifact_location,
             relative_path=artifact_file_path,
         )
+        artifact_path = _get_workspace_scoped_repo_path_if_enabled(artifact_path)
     else:
         artifact_repo = get_artifact_repository(logged_model.artifact_location)
         artifact_path = artifact_file_path
@@ -3997,11 +4108,16 @@ def get_endpoints(get_handler=get_handler):
     Returns:
         List of tuples (path, handler, methods)
     """
+    server_feature_paths = [
+        (_path, _server_features_handler, ["GET"])
+        for _path in _get_paths("/mlflow/server-features")
+    ]
     return (
         get_service_endpoints(MlflowService, get_handler)
         + get_service_endpoints(ModelRegistryService, get_handler)
         + get_service_endpoints(MlflowArtifactsService, get_handler)
         + get_service_endpoints(WebhookService, get_handler)
+        + server_feature_paths
         + [(_add_static_prefix("/graphql"), _graphql, ["GET", "POST"])]
     )
 

--- a/mlflow/server/workspace_helpers.py
+++ b/mlflow/server/workspace_helpers.py
@@ -3,15 +3,46 @@ from __future__ import annotations
 import logging
 import os
 
-from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES, MLFLOW_WORKSPACE_STORE_URI
+from flask import Response, request
+
+from mlflow.entities import Workspace
+from mlflow.environment_variables import (
+    MLFLOW_ENABLE_WORKSPACES,
+    MLFLOW_WORKSPACE_STORE_URI,
+)
 from mlflow.exceptions import MlflowException
 from mlflow.protos import databricks_pb2
+from mlflow.store.workspace.abstract_store import WorkspaceNameValidator
+from mlflow.store.workspace.utils import get_default_workspace_optional
 from mlflow.tracking._workspace.registry import get_workspace_store
-from mlflow.utils import workspace_utils
+from mlflow.utils import workspace_context, workspace_utils
+from mlflow.utils.workspace_utils import (
+    DEFAULT_WORKSPACE_NAME,
+    WORKSPACE_HEADER_NAME,
+    _normalize_workspace,
+)
 
 _logger = logging.getLogger(__name__)
 
 _workspace_store = None
+
+
+def resolve_workspace_from_header(header_workspace: str | None) -> Workspace | None:
+    """
+    Resolve (and validate) the active workspace given an optional header value.
+
+    When ``header_workspace`` is None or empty, the default workspace is used (if configured).
+    Returns None if no workspace can be resolved.
+    """
+    store = _get_workspace_store()
+
+    if header_workspace := _normalize_workspace(header_workspace):
+        if header_workspace != DEFAULT_WORKSPACE_NAME:
+            WorkspaceNameValidator.validate(header_workspace)
+        return store.get_workspace(header_workspace)
+
+    workspace, _ = get_default_workspace_optional(store)
+    return workspace
 
 
 def _get_workspace_store(workspace_uri: str | None = None, tracking_uri: str | None = None):
@@ -48,4 +79,55 @@ def _get_workspace_store(workspace_uri: str | None = None, tracking_uri: str | N
     return _workspace_store
 
 
-__all__ = ["_get_workspace_store"]
+def _workspace_error_response(exc: Exception) -> Response:
+    if isinstance(exc, MlflowException):
+        mlflow_exc = exc
+    else:
+        mlflow_exc = MlflowException(
+            str(exc),
+            error_code=databricks_pb2.INTERNAL_ERROR,
+        )
+        # Preserve the original stack for debugging by chaining the exception.
+        mlflow_exc.__cause__ = exc
+
+    response = Response(mimetype="application/json")
+    response.set_data(mlflow_exc.serialize_as_json())
+    response.status_code = mlflow_exc.get_http_status_code()
+    return response
+
+
+def workspace_before_request_handler():
+    if not MLFLOW_ENABLE_WORKSPACES.get():
+        if request.headers.get(WORKSPACE_HEADER_NAME, "").strip():
+            return _workspace_error_response(
+                MlflowException(
+                    "Workspace APIs are not available: multi-tenancy is not enabled on this server",
+                    error_code=databricks_pb2.FEATURE_DISABLED,
+                )
+            )
+        return None
+
+    header_value = request.headers.get(WORKSPACE_HEADER_NAME)
+    try:
+        workspace = resolve_workspace_from_header(header_value)
+    except MlflowException as exc:
+        return _workspace_error_response(exc)
+    except Exception as exc:
+        _logger.exception("Unexpected error while resolving workspace")
+        return _workspace_error_response(exc)
+
+    workspace_context.set_server_request_workspace(workspace.name if workspace else None)
+
+
+def workspace_teardown_request_handler(_exc):
+    if MLFLOW_ENABLE_WORKSPACES.get():
+        workspace_context.clear_server_request_workspace()
+
+
+__all__ = [
+    "WORKSPACE_HEADER_NAME",
+    "resolve_workspace_from_header",
+    "_get_workspace_store",
+    "workspace_before_request_handler",
+    "workspace_teardown_request_handler",
+]

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -2120,7 +2120,6 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         with self.ManagedSessionMaker() as session:
             query = self._get_query(session, SqlLoggedModel).filter(
                 SqlLoggedModel.model_id == model_id,
-                SqlLoggedModel.lifecycle_stage != LifecycleStage.DELETED,
             )
             if not allow_deleted:
                 query = query.filter(SqlLoggedModel.lifecycle_stage != LifecycleStage.DELETED)
@@ -3334,6 +3333,8 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
             return
 
         with self.ManagedSessionMaker() as session:
+            self._validate_trace_accessible(session, trace_id)
+
             # Build list of prompt version IDs (format: "name/version")
             prompt_ids = [f"{pv.name}/{pv.version}" for pv in prompt_versions]
 
@@ -4869,7 +4870,7 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
         Raises:
             MlflowException: If entity not found (RESOURCE_DOES_NOT_EXIST).
         """
-        obj = session.query(model_class).filter_by(**filters).first()
+        obj = self._get_query(session, model_class).filter_by(**filters).first()
         if not obj:
             filter_str = ", ".join(f"{k}='{v}'" for k, v in filters.items())
             raise MlflowException(

--- a/mlflow/store/workspace/rest_store.py
+++ b/mlflow/store/workspace/rest_store.py
@@ -4,6 +4,7 @@ from urllib.parse import quote
 
 from mlflow.entities import Workspace
 from mlflow.exceptions import MlflowException, RestException
+from mlflow.protos import databricks_pb2
 from mlflow.protos.databricks_pb2 import INVALID_STATE, RESOURCE_ALREADY_EXISTS
 from mlflow.protos.service_pb2 import (
     CreateWorkspace,
@@ -73,7 +74,7 @@ class RestWorkspaceStore(AbstractStore):
                 expected_status=201,
             )
         except RestException as exc:
-            if exc.error_code == "RESOURCE_ALREADY_EXISTS":
+            if exc.error_code == databricks_pb2.ErrorCode.Name(RESOURCE_ALREADY_EXISTS):
                 message = exc.message or f"Workspace '{workspace.name}' already exists."
                 raise MlflowException(message, RESOURCE_ALREADY_EXISTS) from exc
             raise
@@ -104,7 +105,7 @@ class RestWorkspaceStore(AbstractStore):
         )
 
     def get_default_workspace(self) -> Workspace:
-        raise MlflowException.invalid_parameter_value(
+        raise NotImplementedError(
             "REST workspace provider does not expose a default workspace; "
             "please specify a workspace explicitly or omit a workspace to leverage the server's "
             "configured default."

--- a/mlflow/utils/workspace_context.py
+++ b/mlflow/utils/workspace_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from contextvars import ContextVar, Token
 
+from mlflow.environment_variables import MLFLOW_WORKSPACE
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 _WORKSPACE: ContextVar[str | None] = ContextVar("mlflow_active_workspace", default=None)
@@ -9,43 +10,78 @@ _WORKSPACE: ContextVar[str | None] = ContextVar("mlflow_active_workspace", defau
 
 def get_request_workspace() -> str | None:
     """
-    Return the workspace currently bound to this execution context.
+    Return the active workspace for the current execution context.
 
-    This helper is request-scoped and should be used by code paths that need to
-    know which workspace initiated the current request.
+    Resolution order:
+    1) Request-scoped ContextVar (set by server middleware or explicit setters).
+    2) ``MLFLOW_WORKSPACE`` environment variable (client-side fallback, including threads).
     """
 
-    return _WORKSPACE.get()
+    if workspace := _WORKSPACE.get():
+        return workspace
+
+    return MLFLOW_WORKSPACE.get()
 
 
-def set_current_workspace(workspace: str | None) -> Token[str | None]:
-    """Bind the given workspace name to the current execution context."""
-
+def _validate_workspace(workspace: str | None) -> None:
     if workspace is not None and workspace != DEFAULT_WORKSPACE_NAME:
         from mlflow.store.workspace.abstract_store import WorkspaceNameValidator
 
         WorkspaceNameValidator.validate(workspace)
 
+
+def set_server_request_workspace(workspace: str | None) -> Token[str | None]:
+    """
+    Server-only setter: bind the workspace to the request ContextVar without touching env.
+    """
+
+    _validate_workspace(workspace)
     return _WORKSPACE.set(workspace)
 
 
-def clear_workspace() -> None:
-    """Explicitly clear the current workspace binding (set it to ``None``)."""
+def set_workspace(workspace: str | None) -> Token[str | None]:
+    """
+    Client setter: binds the workspace to the current thread and persists to env so child
+    threads inherit it.
+    """
+
+    _validate_workspace(workspace)
+    token = _WORKSPACE.set(workspace)
+    if workspace is None:
+        MLFLOW_WORKSPACE.unset()
+    else:
+        MLFLOW_WORKSPACE.set(workspace)
+    return token
+
+
+def clear_server_request_workspace() -> None:
+    """Clear the request-scoped ContextVar (does not touch the client env)."""
     _WORKSPACE.set(None)
 
 
 class WorkspaceContext:
-    """Context manager helper that temporarily sets the active workspace."""
+    """
+    Context manager that sets the client workspace (ContextVar + env) for the duration
+    of the block. Restores the previous env value on exit.
+    """
 
     def __init__(self, workspace: str | None):
         self._workspace = workspace
         self._token: Token[str | None] | None = None
+        self._prev_env_raw: str | None = None
 
     def __enter__(self) -> str | None:
-        self._token = set_current_workspace(self._workspace)
+        self._prev_env_raw = MLFLOW_WORKSPACE.get_raw()
+        self._token = set_workspace(self._workspace)
         return self._workspace
 
     def __exit__(self, exc_type, exc, tb) -> None:
         if self._token is not None:
             _WORKSPACE.reset(self._token)
             self._token = None
+
+        if self._prev_env_raw is None:
+            MLFLOW_WORKSPACE.unset()
+        else:
+            MLFLOW_WORKSPACE.set(self._prev_env_raw)
+        self._prev_env_raw = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -566,15 +566,25 @@ def disable_workspace_mode_by_default(monkeypatch):
         monkeypatch.delenv(env_var.name, raising=False)
 
     if workspace_context is not None:
-        workspace_context.clear_workspace()
+        workspace_context.clear_server_request_workspace()
 
     if workspace_utils is not None:
         workspace_utils.set_workspace_store_uri(None)
 
     yield
 
+    # Clear env vars at teardown to prevent leaking to subprocess servers.
+    # monkeypatch only tracks changes made through itself, so direct os.environ
+    # modifications (or those made by other code) would otherwise persist.
+    for env_var in (
+        MLFLOW_ENABLE_WORKSPACES,
+        MLFLOW_WORKSPACE,
+        MLFLOW_WORKSPACE_STORE_URI,
+    ):
+        os.environ.pop(env_var.name, None)
+
     if workspace_context is not None:
-        workspace_context.clear_workspace()
+        workspace_context.clear_server_request_workspace()
 
     if workspace_utils is not None:
         workspace_utils.set_workspace_store_uri(None)

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -16,6 +16,7 @@ from mlflow.entities.model_registry import (
 )
 from mlflow.entities.model_registry.prompt_version import IS_PROMPT_TAG_KEY, PROMPT_TEXT_TAG_KEY
 from mlflow.entities.trace_location import TraceLocation as EntityTraceLocation
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
 from mlflow.exceptions import MlflowException, MlflowNotImplementedException
 from mlflow.protos.databricks_pb2 import (
     INTERNAL_ERROR,
@@ -109,7 +110,9 @@ from mlflow.server.handlers import (
     _get_scorer,
     _get_trace,
     _get_trace_artifact_repo,
+    _get_workspace_scoped_repo_path_if_enabled,
     _link_prompts_to_trace,
+    _list_artifacts_for_proxied_run_artifact_root,
     _list_scorer_versions,
     _list_scorers,
     _list_webhooks,
@@ -135,8 +138,12 @@ from mlflow.server.handlers import (
     _upsert_dataset_records_handler,
     _validate_source_run,
     catch_mlflow_exception,
+    get_artifact_handler,
     get_endpoints,
+    get_logged_model_artifact_handler,
+    get_model_version_artifact_handler,
     get_trace_artifact_handler,
+    upload_artifact_handler,
 )
 from mlflow.store._unity_catalog.registry.rest_store import UcModelRegistryStore
 from mlflow.store.artifact.azure_blob_artifact_repo import AzureBlobArtifactRepository
@@ -154,6 +161,8 @@ from mlflow.tracing.utils import build_otel_context
 from mlflow.utils.mlflow_tags import MLFLOW_ARTIFACT_LOCATION
 from mlflow.utils.proto_json_utils import message_to_json
 from mlflow.utils.validation import MAX_BATCH_LOG_REQUEST_SIZE
+from mlflow.utils.workspace_context import WorkspaceContext
+from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 
 @pytest.fixture
@@ -2443,3 +2452,244 @@ def test_link_prompts_to_trace_handler(mock_get_request_message, mock_tracking_s
     # Verify response was created (200 status)
     assert response is not None
     assert response.status_code == 200
+
+
+def test_get_workspace_scoped_repo_path_if_enabled_allows_legacy_default_artifacts(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        assert (
+            _get_workspace_scoped_repo_path_if_enabled("1/legacy/artifact") == "1/legacy/artifact"
+        )
+
+
+def test_get_workspace_scoped_repo_path_if_enabled_still_scopes_non_default(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    with WorkspaceContext("team-blue"):
+        scoped = _get_workspace_scoped_repo_path_if_enabled("2/new/artifact")
+    assert scoped.startswith("workspaces/team-blue/2/new/artifact")
+
+
+def test_get_workspace_scoped_repo_path_if_enabled_prevents_cross_workspace_access(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+    with WorkspaceContext("team-a"):
+        with pytest.raises(MlflowException, match="targets workspace 'team-b'"):
+            _get_workspace_scoped_repo_path_if_enabled("workspaces/team-b/secret.txt")
+
+        with pytest.raises(MlflowException, match="targets workspace 'other'"):
+            _get_workspace_scoped_repo_path_if_enabled("workspaces/other/data/model.pkl")
+
+
+def test_get_workspace_scoped_repo_path_if_enabled_rejects_empty_workspace_in_path(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+    with WorkspaceContext("team-a"):
+        with pytest.raises(MlflowException, match="must include a workspace name"):
+            _get_workspace_scoped_repo_path_if_enabled("workspaces/")
+
+        with pytest.raises(MlflowException, match="must include a workspace name"):
+            _get_workspace_scoped_repo_path_if_enabled("workspaces//data.txt")
+
+
+def test_get_workspace_scoped_repo_path_if_enabled_allows_matching_workspace_prefix(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+    with WorkspaceContext("team-a"):
+        result = _get_workspace_scoped_repo_path_if_enabled("workspaces/team-a/data.txt")
+        assert result == "workspaces/team-a/data.txt"
+
+        result = _get_workspace_scoped_repo_path_if_enabled("/workspaces/team-a/nested/path")
+        assert result == "workspaces/team-a/nested/path"
+
+
+def test_get_workspace_scoped_repo_path_if_enabled_default_workspace_cross_access_blocked(
+    monkeypatch,
+):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+    with WorkspaceContext(DEFAULT_WORKSPACE_NAME):
+        result = _get_workspace_scoped_repo_path_if_enabled("legacy/artifact.txt")
+        assert result == "legacy/artifact.txt"
+
+        with pytest.raises(MlflowException, match="targets workspace 'team-b'"):
+            _get_workspace_scoped_repo_path_if_enabled("workspaces/team-b/data.txt")
+
+
+def test_get_workspace_scoped_repo_path_if_enabled_requires_active_workspace(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+
+    with pytest.raises(MlflowException, match="Active workspace is required"):
+        _get_workspace_scoped_repo_path_if_enabled("some/path")
+
+
+def test_get_artifact_handler_applies_workspace_scoping(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "s3://bucket")
+
+    mock_run = mock.MagicMock()
+    mock_run.info.artifact_uri = "mlflow-artifacts:/exp1/run1/artifacts"
+
+    mock_artifact_repo = mock.MagicMock()
+    mock_artifact_repo.download_artifacts.return_value = "/tmp/artifact.txt"
+
+    with (
+        mock.patch("mlflow.server.handlers._get_tracking_store") as mock_store,
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+        mock.patch("mlflow.server.handlers._send_artifact") as mock_send,
+    ):
+        mock_store.return_value.get_run.return_value = mock_run
+        mock_repo.return_value = mock_artifact_repo
+
+        with WorkspaceContext("team-blue"):
+            with app.test_request_context(
+                method="GET", query_string={"run_id": "run1", "path": "model/weights.bin"}
+            ):
+                get_artifact_handler()
+
+        mock_send.assert_called_once()
+        artifact_path = mock_send.call_args[0][1]
+        assert artifact_path.startswith("workspaces/team-blue/")
+
+
+def test_get_artifact_handler_no_scoping_when_workspaces_disabled(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "s3://bucket")
+
+    mock_run = mock.MagicMock()
+    mock_run.info.artifact_uri = "mlflow-artifacts:/exp1/run1/artifacts"
+
+    mock_artifact_repo = mock.MagicMock()
+
+    with (
+        mock.patch("mlflow.server.handlers._get_tracking_store") as mock_store,
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+        mock.patch("mlflow.server.handlers._send_artifact") as mock_send,
+    ):
+        mock_store.return_value.get_run.return_value = mock_run
+        mock_repo.return_value = mock_artifact_repo
+
+        with app.test_request_context(
+            method="GET", query_string={"run_id": "run1", "path": "model/weights.bin"}
+        ):
+            get_artifact_handler()
+
+        mock_send.assert_called_once()
+        artifact_path = mock_send.call_args[0][1]
+        assert not artifact_path.startswith("workspaces/")
+
+
+def test_get_model_version_artifact_handler_applies_workspace_scoping(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "s3://bucket")
+
+    mock_artifact_repo = mock.MagicMock()
+
+    with (
+        mock.patch("mlflow.server.handlers._get_model_registry_store") as mock_store,
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+        mock.patch("mlflow.server.handlers._send_artifact") as mock_send,
+    ):
+        mock_store.return_value.get_model_version_download_uri.return_value = (
+            "mlflow-artifacts:/models/MyModel/1"
+        )
+        mock_repo.return_value = mock_artifact_repo
+
+        with WorkspaceContext("team-red"):
+            with app.test_request_context(
+                method="GET", query_string={"name": "MyModel", "version": "1", "path": "model.pkl"}
+            ):
+                get_model_version_artifact_handler()
+
+        mock_send.assert_called_once()
+        artifact_path = mock_send.call_args[0][1]
+        assert artifact_path.startswith("workspaces/team-red/")
+
+
+def test_get_logged_model_artifact_handler_applies_workspace_scoping(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "s3://bucket")
+
+    mock_logged_model = mock.MagicMock()
+    mock_logged_model.artifact_location = "mlflow-artifacts:/exp1/run1/artifacts/model"
+
+    mock_artifact_repo = mock.MagicMock()
+
+    with (
+        mock.patch("mlflow.server.handlers._get_tracking_store") as mock_store,
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+        mock.patch("mlflow.server.handlers._send_artifact") as mock_send,
+    ):
+        mock_store.return_value.get_logged_model.return_value = mock_logged_model
+        mock_repo.return_value = mock_artifact_repo
+
+        with WorkspaceContext("team-green"):
+            with app.test_request_context(
+                method="GET", query_string={"artifact_file_path": "MLmodel"}
+            ):
+                get_logged_model_artifact_handler("model123")
+
+        mock_send.assert_called_once()
+        artifact_path = mock_send.call_args[0][1]
+        assert artifact_path.startswith("workspaces/team-green/")
+
+
+def test_upload_artifact_handler_applies_workspace_scoping(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "s3://bucket")
+
+    mock_run = mock.MagicMock()
+    mock_run.info.artifact_uri = "mlflow-artifacts:/exp1/run1/artifacts"
+    mock_run.info.experiment_id = "exp1"
+    mock_run.info.run_id = "run1"
+
+    mock_artifact_repo = mock.MagicMock()
+
+    with (
+        mock.patch("mlflow.server.handlers._get_tracking_store") as mock_store,
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+    ):
+        mock_store.return_value.get_run.return_value = mock_run
+        mock_repo.return_value = mock_artifact_repo
+
+        with WorkspaceContext("team-purple"):
+            with app.test_request_context(
+                method="POST",
+                query_string={"run_uuid": "run1", "path": "output.txt"},
+                data=b"test data",
+            ):
+                upload_artifact_handler()
+
+        mock_artifact_repo.log_artifact.assert_called_once()
+        logged_path = mock_artifact_repo.log_artifact.call_args[0][1]
+        assert logged_path.startswith("workspaces/team-purple/")
+
+
+def test_list_artifacts_for_proxied_run_artifact_root_applies_workspace_scoping(monkeypatch):
+    from mlflow.store.artifact.artifact_repo import ArtifactRepository
+
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    monkeypatch.setenv(SERVE_ARTIFACTS_ENV_VAR, "true")
+    monkeypatch.setenv(ARTIFACTS_DESTINATION_ENV_VAR, "s3://bucket")
+
+    mock_artifact_repo = mock.MagicMock(spec=ArtifactRepository)
+    mock_artifact_repo.list_artifacts.return_value = []
+
+    with (
+        mock.patch("mlflow.server.handlers._get_artifact_repo_mlflow_artifacts") as mock_repo,
+        WorkspaceContext("team-orange"),
+    ):
+        mock_repo.return_value = mock_artifact_repo
+
+        _list_artifacts_for_proxied_run_artifact_root(
+            proxied_artifact_root="mlflow-artifacts:/exp1/run1/artifacts",
+            relative_path="model",
+        )
+
+        mock_artifact_repo.list_artifacts.assert_called_once()
+        listed_path = mock_artifact_repo.list_artifacts.call_args[0][0]
+        assert listed_path.startswith("workspaces/team-orange/")

--- a/tests/server/test_workspace_middleware.py
+++ b/tests/server/test_workspace_middleware.py
@@ -1,0 +1,128 @@
+from __future__ import annotations
+
+import pytest
+import werkzeug
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from flask import Flask
+
+from mlflow.entities import Workspace
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES
+from mlflow.exceptions import MlflowException
+from mlflow.server import app as flask_app
+from mlflow.server.fastapi_app import add_fastapi_workspace_middleware
+from mlflow.server.job_api import job_api_router
+from mlflow.server.workspace_helpers import (
+    WORKSPACE_HEADER_NAME,
+    workspace_before_request_handler,
+    workspace_teardown_request_handler,
+)
+from mlflow.utils import workspace_context
+
+
+@pytest.fixture
+def flask_workspace_app(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    if not hasattr(werkzeug, "__version__"):
+        werkzeug.__version__ = "tests"
+
+    app = Flask(__name__)
+    app.before_request(workspace_before_request_handler)
+    app.teardown_request(workspace_teardown_request_handler)
+
+    @app.route("/ping")
+    def _ping():
+        return workspace_context.get_request_workspace() or "none"
+
+    return app
+
+
+def test_flask_workspace_middleware_sets_context(flask_workspace_app, monkeypatch):
+    class DummyWorkspaceStore:
+        def get_workspace(self, name):
+            return Workspace(name=name)
+
+    store = DummyWorkspaceStore()
+    monkeypatch.setattr(
+        "mlflow.server.workspace_helpers._get_workspace_store",
+        lambda workspace_uri=None, tracking_uri=None: store,
+    )
+
+    client = flask_workspace_app.test_client()
+    resp = client.get("/ping", headers={WORKSPACE_HEADER_NAME: "team-a"})
+    assert resp.data.decode() == "team-a"
+    assert workspace_context.get_request_workspace() is None
+
+
+def test_flask_workspace_middleware_requires_header(flask_workspace_app, monkeypatch):
+    class DefaultlessWorkspaceStore:
+        def get_default_workspace(self):
+            raise MlflowException.invalid_parameter_value("Active workspace is required.")
+
+    store = DefaultlessWorkspaceStore()
+    monkeypatch.setattr(
+        "mlflow.server.workspace_helpers._get_workspace_store",
+        lambda workspace_uri=None, tracking_uri=None: store,
+    )
+
+    client = flask_workspace_app.test_client()
+    resp = client.get("/ping")
+    assert resp.status_code == 400
+    assert "Active workspace is required" in resp.json["message"]
+    assert workspace_context.get_request_workspace() is None
+
+
+def _fastapi_workspace_app(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    app = FastAPI()
+    add_fastapi_workspace_middleware(app)
+
+    ping_path = f"{job_api_router.prefix}/ping"
+
+    @app.get(ping_path)
+    async def ping():
+        return {"workspace": workspace_context.get_request_workspace()}
+
+    return app, ping_path
+
+
+def test_fastapi_workspace_middleware_sets_context(monkeypatch):
+    app, ping_path = _fastapi_workspace_app(monkeypatch)
+    monkeypatch.setattr(
+        "mlflow.server.fastapi_app.resolve_workspace_from_header",
+        lambda header: Workspace(name=header),
+    )
+
+    client = TestClient(app)
+    resp = client.get(ping_path, headers={WORKSPACE_HEADER_NAME: "team-fast"})
+    assert resp.status_code == 200
+    assert resp.json() == {"workspace": "team-fast"}
+    assert workspace_context.get_request_workspace() is None
+
+
+def test_fastapi_workspace_middleware_handles_missing_header(monkeypatch):
+    app, ping_path = _fastapi_workspace_app(monkeypatch)
+    monkeypatch.setattr(
+        "mlflow.server.fastapi_app.resolve_workspace_from_header",
+        lambda header: None,
+    )
+
+    client = TestClient(app)
+    resp = client.get(ping_path)
+    assert resp.status_code == 200
+    assert resp.json() == {"workspace": None}
+    assert workspace_context.get_request_workspace() is None
+
+
+def test_server_features_endpoint(monkeypatch):
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "true")
+    client = flask_app.test_client()
+    resp = client.get("/api/2.0/mlflow/server-features")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"workspaces_enabled": True}
+
+    # Disable workspaces and ensure the endpoint reflects the change.
+    monkeypatch.setenv(MLFLOW_ENABLE_WORKSPACES.name, "false")
+    resp = client.get("/api/2.0/mlflow/server-features")
+    assert resp.status_code == 200
+    assert resp.get_json() == {"workspaces_enabled": False}

--- a/tests/store/tracking/test_sqlalchemy_store.py
+++ b/tests/store/tracking/test_sqlalchemy_store.py
@@ -134,7 +134,7 @@ from mlflow.utils.validation import (
     MAX_INPUT_TAG_VALUE_SIZE,
     MAX_TAG_VAL_LENGTH,
 )
-from mlflow.utils.workspace_context import WorkspaceContext
+from mlflow.utils.workspace_context import WorkspaceContext, set_workspace
 from mlflow.utils.workspace_utils import DEFAULT_WORKSPACE_NAME
 
 from tests.integration.utils import invoke_cli_runner
@@ -11747,6 +11747,9 @@ def test_log_spans_then_start_trace_preserves_tag(store: SqlAlchemyStore):
 def test_concurrent_log_spans_spans_location_tag(store: SqlAlchemyStore):
     experiment_id = store.create_experiment("test_concurrent_log_spans")
     trace_id = f"tr-{uuid.uuid4().hex}"
+
+    # Simulate client-side workspace selection and ensure it propagates to worker threads.
+    set_workspace(DEFAULT_WORKSPACE_NAME)
 
     def log_span_worker(span_id):
         span = create_test_span(

--- a/tests/store/workspace/test_rest_store.py
+++ b/tests/store/workspace/test_rest_store.py
@@ -100,22 +100,6 @@ def test_create_workspace_conflict_raises_resource_exists(store, monkeypatch):
     assert "already exists" in exc_info.value.message
 
 
-def test_create_workspace_handles_400_resource_exists(store, monkeypatch):
-    exc = RestException({"error_code": "RESOURCE_ALREADY_EXISTS", "message": "already exists"})
-    monkeypatch.setattr(
-        "mlflow.store.workspace.rest_store.call_endpoint",
-        mock.Mock(side_effect=exc),
-    )
-
-    with pytest.raises(
-        MlflowException,
-        match="already exists",
-    ) as exc_info:
-        store.create_workspace(Workspace(name="team-a"))
-
-    assert exc_info.value.error_code == "RESOURCE_ALREADY_EXISTS"
-
-
 def test_update_workspace_returns_new_description(store, host_creds):
     response = UpdateWorkspace.Response()
     response.workspace.name = "team-e"
@@ -150,11 +134,10 @@ def test_delete_workspace_returns_on_success(store, host_creds):
 
 def test_get_default_workspace_not_supported(store):
     with pytest.raises(
-        MlflowException,
+        NotImplementedError,
         match="REST workspace provider does not expose a default workspace",
-    ) as exc:
+    ):
         store.get_default_workspace()
-    assert exc.value.error_code == "INVALID_PARAMETER_VALUE"
 
 
 def test_rest_store_validates_workspace_names_before_http(monkeypatch, store):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,6 +10,7 @@ from unittest import mock
 from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
+import click
 import numpy as np
 import pandas as pd
 import pytest
@@ -22,6 +23,7 @@ from mlflow import pyfunc
 from mlflow.cli import cli, doctor, gc, server
 from mlflow.data import numpy_dataset
 from mlflow.entities import ViewType
+from mlflow.environment_variables import MLFLOW_ENABLE_WORKSPACES, MLFLOW_WORKSPACE_STORE_URI
 from mlflow.exceptions import MlflowException
 from mlflow.server import handlers
 from mlflow.store.artifact.artifact_repository_registry import get_artifact_repository
@@ -64,6 +66,22 @@ def test_server_static_prefix_validation():
         result = CliRunner().invoke(server, ["--static-prefix", "/mlflow/"])
         assert "--static-prefix should not end with a '/'." in result.output
         run_server_mock.assert_not_called()
+
+
+def test_server_cli_fails_when_workspace_env_set():
+    env = os.environ.copy()
+    # Trigger server-mode guard in mlflow.server.__init__
+    env["_MLFLOW_SERVER_SERVE_ARTIFACTS"] = "1"
+    env["MLFLOW_WORKSPACE"] = "team-a"
+
+    result = subprocess.run(
+        [sys.executable, "-m", "mlflow", "server", "--port", "0"],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode != 0
+    assert "MLFLOW_WORKSPACE=team-a is client-only" in result.stderr
 
 
 def test_server_uvicorn_options():
@@ -172,18 +190,83 @@ def test_server_gunicorn_options():
 def test_server_mlflow_artifacts_options():
     handlers._tracking_store = None
     handlers._model_registry_store = None
-    with mock.patch("mlflow.server._run_server") as run_server_mock:
-        CliRunner().invoke(server, ["--artifacts-only"])
+    with mock.patch(
+        "mlflow.tracking._tracking_service.utils._has_existing_mlruns_data", return_value=False
+    ):
+        runner = CliRunner()
+        with runner.isolated_filesystem():
+            with mock.patch("mlflow.server._run_server") as run_server_mock:
+                runner.invoke(server, ["--artifacts-only"])
+                run_server_mock.assert_called_once()
+            with mock.patch("mlflow.server._run_server") as run_server_mock:
+                runner.invoke(server, ["--serve-artifacts"])
+                run_server_mock.assert_called_once()
+            with mock.patch("mlflow.server._run_server") as run_server_mock:
+                runner.invoke(server, ["--no-serve-artifacts"])
+                run_server_mock.assert_called_once()
+            with mock.patch("mlflow.server._run_server") as run_server_mock:
+                runner.invoke(server, ["--artifacts-only"])
+                run_server_mock.assert_called_once()
+
+
+def test_server_artifacts_only_conflicts_with_enable_workspaces():
+    with pytest.raises(
+        click.UsageError, match="--enable-workspaces cannot be combined with --artifacts-only"
+    ):
+        CliRunner().invoke(
+            server,
+            ["--artifacts-only", "--enable-workspaces"],
+            catch_exceptions=False,
+            standalone_mode=False,
+        )
+
+
+def test_server_workspace_uri_sets_env_when_workspaces_enabled(tmp_path):
+    handlers._tracking_store = None
+    handlers._model_registry_store = None
+    workspace_uri = f"sqlite:///{tmp_path / 'workspace.db'}"
+    backend_uri = f"sqlite:///{tmp_path / 'backend.db'}"
+    artifact_root_path = tmp_path / "artifacts"
+    artifact_root_path.mkdir()
+    artifact_root = artifact_root_path.as_uri()
+
+    MLFLOW_WORKSPACE_STORE_URI.unset()
+    MLFLOW_ENABLE_WORKSPACES.unset()
+
+    try:
+        with (
+            mock.patch("mlflow.server._run_server") as run_server_mock,
+            mock.patch("mlflow.server.handlers.initialize_backend_stores") as init_backend,
+        ):
+            result = CliRunner().invoke(
+                server,
+                [
+                    "--enable-workspaces",
+                    "--workspace-store-uri",
+                    workspace_uri,
+                    "--backend-store-uri",
+                    backend_uri,
+                    "--registry-store-uri",
+                    backend_uri,
+                    "--default-artifact-root",
+                    artifact_root,
+                ],
+                catch_exceptions=False,
+                standalone_mode=False,
+            )
+        assert result.exit_code == 0
         run_server_mock.assert_called_once()
-    with mock.patch("mlflow.server._run_server") as run_server_mock:
-        CliRunner().invoke(server, ["--serve-artifacts"])
-        run_server_mock.assert_called_once()
-    with mock.patch("mlflow.server._run_server") as run_server_mock:
-        CliRunner().invoke(server, ["--no-serve-artifacts"])
-        run_server_mock.assert_called_once()
-    with mock.patch("mlflow.server._run_server") as run_server_mock:
-        CliRunner().invoke(server, ["--artifacts-only"])
-        run_server_mock.assert_called_once()
+        init_backend.assert_called_once_with(
+            backend_uri,
+            backend_uri,
+            artifact_root,
+            workspace_store_uri=workspace_uri,
+        )
+        assert MLFLOW_WORKSPACE_STORE_URI.get() == workspace_uri
+        assert MLFLOW_ENABLE_WORKSPACES.get() is True
+    finally:
+        MLFLOW_WORKSPACE_STORE_URI.unset()
+        MLFLOW_ENABLE_WORKSPACES.unset()
 
 
 @pytest.mark.parametrize("command", [server])

--- a/tests/test_runs.py
+++ b/tests/test_runs.py
@@ -354,6 +354,7 @@ def test_get_experiment_json():
         "tags": {"env": "test"},
         "creation_time": exp.creation_time,
         "last_update_time": exp.last_update_time,
+        "workspace": exp.workspace,
     }
     assert output == expected
 

--- a/tests/utils/test_workspace_utils.py
+++ b/tests/utils/test_workspace_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 
 from mlflow.environment_variables import MLFLOW_WORKSPACE
-from mlflow.utils.workspace_context import WorkspaceContext, clear_workspace
+from mlflow.utils.workspace_context import WorkspaceContext, clear_server_request_workspace
 from mlflow.utils.workspace_utils import (
     DEFAULT_WORKSPACE_NAME,
     resolve_entity_workspace_name,
@@ -12,7 +12,7 @@ from mlflow.utils.workspace_utils import (
 
 def teardown_function():
     # Ensure the ContextVar does not leak between tests
-    clear_workspace()
+    clear_server_request_workspace()
     os.environ.pop(MLFLOW_WORKSPACE.name, None)
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mprahl/mlflow/pull/19282?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19282/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19282/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19282/merge
```

</p>
</details>

### Related Issues/PRs

https://github.com/mlflow/mlflow/issues/1464
https://github.com/mlflow/mlflow/issues/5844
Design document: https://docs.google.com/document/d/1IbFfceCmWV3knJfc0ninn58EXLVbHUh1meV_pknOM40/edit

### What changes are proposed in this pull request?

Add Flask and FastAPI middleware to resolve the active workspace and set the workspace context. This allows workspace aware stores to directly leverage this without resolving it themselves. Artifact serving is also isolated by workspace when enabled.

Also enhance the server CLI with workspace configuration options.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
