### PR TITLE
[ML-59817] Add scorer call event telemetry

### DIFF
--- a/mlflow/telemetry/events.py
+++ b/mlflow/telemetry/events.py
@@ -1,7 +1,9 @@
+import inspect
 import sys
 from enum import Enum
 from typing import Any
 
+from mlflow.entities import Feedback
 from mlflow.telemetry.constant import GENAI_MODULES, MODULES_TO_CHECK_IMPORT
 
 
@@ -369,3 +371,47 @@ class TraceSource(str, Enum):
 
 class TracesReceivedByServerEvent(Event):
     name: str = "traces_received_by_server"
+
+
+class ScorerCallEvent(Event):
+    name: str = "scorer_call"
+
+    @classmethod
+    def parse(cls, arguments: dict[str, Any]) -> dict[str, Any] | None:
+        from mlflow.genai.scorers.base import Scorer
+        from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
+
+        scorer_instance = arguments.get("self")
+        if not isinstance(scorer_instance, Scorer):
+            return None
+
+        callsite = "direct_scorer_call"
+        for frame_info in inspect.stack()[:10]:
+            frame_filename = frame_info.filename
+            frame_function = frame_info.function
+
+            if "mlflow/genai/scorers/base" in frame_filename.replace("\\", "/"):
+                if frame_function == "run":
+                    callsite = "genai.evaluate"
+                    break
+
+        return {
+            "scorer_class": (
+                type(scorer_instance).__name__
+                if isinstance(scorer_instance, BuiltInScorer)
+                else "UserDefinedScorer"
+            ),
+            "scorer_kind": scorer_instance.kind.value,
+            "is_session_level_scorer": scorer_instance.is_session_level_scorer,
+            "callsite": callsite,
+        }
+
+    @classmethod
+    def parse_result(cls, result: Any) -> dict[str, Any] | None:
+        if isinstance(result, Feedback):
+            return {"has_feedback_error": result.error is not None}
+
+        if isinstance(result, list) and result and all(isinstance(f, Feedback) for f in result):
+            return {"has_feedback_error": any(f.error is not None for f in result)}
+
+        return {"has_feedback_error": False}

--- a/mlflow/telemetry/track.py
+++ b/mlflow/telemetry/track.py
@@ -60,12 +60,6 @@ def _add_telemetry_record(
             bound_args.apply_defaults()
 
             arguments = dict(bound_args.arguments)
-            arguments.pop("self", None)
-
-            params = list(arguments.keys())
-            if params and params[0] == "cls" and isinstance(arguments["cls"], type):
-                del arguments["cls"]
-
             record_params = event.parse(arguments) or {}
             if hasattr(event, "parse_result"):
                 record_params.update(event.parse_result(result))

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -10,12 +10,20 @@ from click.testing import CliRunner
 import mlflow
 from mlflow import MlflowClient
 from mlflow.entities import EvaluationDataset, Expectation, Feedback, Metric, Param, RunTag
+from mlflow.entities.assessment_source import AssessmentSource, AssessmentSourceType
 from mlflow.entities.trace import Trace
 from mlflow.entities.webhook import WebhookAction, WebhookEntity, WebhookEvent
 from mlflow.genai.datasets import create_dataset
 from mlflow.genai.judges import make_judge
 from mlflow.genai.judges.base import AlignmentOptimizer
-from mlflow.genai.scorers.builtin_scorers import Guidelines, RelevanceToQuery, UserFrustration
+from mlflow.genai.scorers import scorer
+from mlflow.genai.scorers.base import Scorer
+from mlflow.genai.scorers.builtin_scorers import (
+    Guidelines,
+    RelevanceToQuery,
+    Safety,
+    UserFrustration,
+)
 from mlflow.pyfunc.model import ResponsesAgent, ResponsesAgentRequest, ResponsesAgentResponse
 from mlflow.telemetry.client import TelemetryClient
 from mlflow.telemetry.events import (
@@ -45,6 +53,7 @@ from mlflow.telemetry.events import (
     McpRunEvent,
     MergeRecordsEvent,
     PromptOptimizationEvent,
+    ScorerCallEvent,
     StartTraceEvent,
 )
 from mlflow.tracking.fluent import _create_dataset_input, _initialize_logged_model
@@ -1066,4 +1075,268 @@ def test_load_prompt(mock_requests, mock_telemetry_client: TelemetryClient):
     mlflow.genai.load_prompt(name_or_uri="prompts:/test_prompt@latest")
     validate_telemetry_record(
         mock_telemetry_client, mock_requests, LoadPromptEvent.name, {"uses_alias": True}
+    )
+
+
+def test_scorer_call_direct(mock_requests, mock_telemetry_client: TelemetryClient):
+    @scorer
+    def custom_scorer(outputs) -> bool:
+        return len(outputs) > 0
+
+    result = custom_scorer(outputs="test output")
+    assert result is True
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "UserDefinedScorer",
+            "scorer_kind": "decorator",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+    safety_scorer = Safety()
+
+    mock_feedback = Feedback(
+        name="test_feedback",
+        value="yes",
+        rationale="Test rationale",
+    )
+
+    with mock.patch(
+        "mlflow.genai.judges.builtin.invoke_judge_model",
+        return_value=mock_feedback,
+    ):
+        safety_scorer(outputs="test output")
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "Safety",
+            "scorer_kind": "builtin",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+    mock_requests.clear()
+
+    guidelines_scorer = Guidelines(guidelines="The response must be in English")
+    with mock.patch(
+        "mlflow.genai.judges.builtin.invoke_judge_model",
+        return_value=mock_feedback,
+    ):
+        guidelines_scorer(
+            inputs={"question": "What is MLflow?"}, outputs="MLflow is an ML platform"
+        )
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "Guidelines",
+            "scorer_kind": "guidelines",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+    mock_requests.clear()
+
+    class CustomClassScorer(Scorer):
+        name: str = "custom_class"
+
+        def __call__(self, *, outputs) -> bool:
+            return len(outputs) > 0
+
+    custom_class_scorer = CustomClassScorer()
+    result = custom_class_scorer(outputs="test output")
+    assert result is True
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "UserDefinedScorer",
+            "scorer_kind": "class",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+
+def test_scorer_call_from_genai_evaluate(mock_requests, mock_telemetry_client: TelemetryClient):
+    @scorer
+    def simple_length_checker(outputs) -> bool:
+        return len(outputs) > 0
+
+    session_judge = make_judge(
+        name="conversation_quality",
+        instructions="Evaluate if the {{ conversation }} is engaging and coherent",
+        model="openai:/gpt-4",
+    )
+
+    # Create traces with session metadata for session-level scorer testing
+    @mlflow.trace(span_type=mlflow.entities.SpanType.CHAT_MODEL)
+    def model(question, session_id):
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+        return f"Answer to: {question}"
+
+    model("What is MLflow?", session_id="test_session")
+    trace_1 = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    model("How does MLflow work?", session_id="test_session")
+    trace_2 = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    test_data = pd.DataFrame(
+        [
+            {
+                "trace": trace_1,
+            },
+            {
+                "trace": trace_2,
+            },
+        ]
+    )
+
+    mock_feedback = Feedback(
+        name="test_feedback",
+        value="yes",
+        rationale="Test",
+    )
+
+    with mock.patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=mock_feedback,
+    ):
+        mlflow.genai.evaluate(data=test_data, scorers=[simple_length_checker, session_judge])
+
+    mock_telemetry_client.flush()
+
+    scorer_call_events = [
+        record for record in mock_requests if record["data"]["event_name"] == ScorerCallEvent.name
+    ]
+
+    # Should have 3 events: 2 response-level calls (one per trace)
+    # + 1 session-level call (one per session)
+    assert len(scorer_call_events) == 3
+
+    event_params = [json.loads(event["data"]["params"]) for event in scorer_call_events]
+
+    # Validate response-level scorer was called twice (once per trace)
+    response_level_events = [
+        params
+        for params in event_params
+        if params["scorer_class"] == "UserDefinedScorer"
+        and params["scorer_kind"] == "decorator"
+        and params["is_session_level_scorer"] is False
+        and params["callsite"] == "genai.evaluate"
+        and params["has_feedback_error"] is False
+    ]
+    assert len(response_level_events) == 2
+
+    # Validate session-level scorer was called once (once per session)
+    session_level_events = [
+        params
+        for params in event_params
+        if params["scorer_class"] == "UserDefinedScorer"
+        and params["scorer_kind"] == "instructions"
+        and params["is_session_level_scorer"] is True
+        and params["callsite"] == "genai.evaluate"
+        and params["has_feedback_error"] is False
+    ]
+    assert len(session_level_events) == 1
+
+    mock_requests.clear()
+
+
+def test_scorer_call_tracks_feedback_errors(mock_requests, mock_telemetry_client: TelemetryClient):
+    error_judge = make_judge(
+        name="quality_judge",
+        instructions="Evaluate if {{ outputs }} is high quality",
+        model="openai:/gpt-4",
+    )
+
+    error_feedback = Feedback(
+        name="quality_judge",
+        error="Model invocation failed",
+        source=AssessmentSource(
+            source_type=AssessmentSourceType.LLM_JUDGE, source_id="openai:/gpt-4"
+        ),
+    )
+    with mock.patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=error_feedback,
+    ):
+        result = error_judge(outputs="test output")
+        assert result.error is not None
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "UserDefinedScorer",
+            "scorer_kind": "instructions",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": True,
+        },
+    )
+
+    mock_requests.clear()
+
+    # Test Scorer returns list of Feedback with mixed errors
+    @scorer
+    def multi_feedback_scorer(outputs) -> list[Feedback]:
+        return [
+            Feedback(name="feedback1", value=1.0),
+            Feedback(name="feedback2", error=ValueError("Error in feedback 2")),
+            Feedback(name="feedback3", value=0.5),
+        ]
+
+    multi_feedback_scorer(outputs="test")
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "UserDefinedScorer",
+            "scorer_kind": "decorator",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": True,
+        },
+    )
+
+    mock_requests.clear()
+
+    # Test Scorer returns primitive type (no Feedback error possible)
+    @scorer
+    def primitive_scorer(outputs) -> bool:
+        return True
+
+    primitive_scorer(outputs="test")
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "UserDefinedScorer",
+            "scorer_kind": "decorator",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
     )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19287/files) to review incremental changes.
- [**stack/ML-59817-add-scorer-call-telemetry-event**](https://github.com/mlflow/mlflow/pull/19287) [[Files changed](https://github.com/mlflow/mlflow/pull/19287/files)]
  - [stack/ML-59817-address-double-call-events-for-wrapped-builtin-scorers](https://github.com/mlflow/mlflow/pull/19288) [[Files changed](https://github.com/mlflow/mlflow/pull/19288/files/5d839b52bbd1a584200f69d7b49d50173bad73c3..26f0c83d49d004535cf906a67c94ea038ccb2a89)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

### What changes are proposed in this pull request?
We want to add a new telemetry event scorer_call so that we can have a better understand of questions like, "how many scorer calls come directly from scorer() vs genai.evaluate?" and "what percentage of scorer calls are successful"

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Manual Test
```
result = mlflow.genai.evaluate(
        data=_EVALUATION_TEST_CASES,
        predict_fn=predict_fn,
        scorers=[
                Safety(name="my_safety_scorer"), 
        ],
);
```

```
{'scorer_class': 'Safety', 'scorer_kind': 'builtin', 'is_session_level_scorer': False, 'callsite': 'genai.evaluate', 'has_feedback_error': False}
x10
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
