### PR TITLE
[ML-59817] Address double scorer call events for wrapped builtin scorers

### DIFF
--- a/mlflow/genai/judges/instructions_judge/__init__.py
+++ b/mlflow/genai/judges/instructions_judge/__init__.py
@@ -455,7 +455,7 @@ class InstructionsJudge(Judge):
         except Exception:
             return str(value)
 
-    def __call__(
+    def _evaluate_impl(
         self,
         *,
         inputs: Any = None,
@@ -465,40 +465,25 @@ class InstructionsJudge(Judge):
         session: list[Trace] | None = None,
     ) -> Feedback:
         """
-        Evaluate the provided data using the judge's instructions.
+        Internal implementation of evaluation logic without telemetry tracking.
+
+        This method contains the core evaluation logic and is called by __call__.
+        It is intended for internal use by wrapper scorers (like Completeness)
+        to avoid double telemetry tracking when delegating to InstructionsJudge.
+
+        Users should call the scorer instance directly (e.g., scorer(...))
+        which invokes __call__ and ensures proper telemetry tracking.
 
         Args:
-            inputs: Input data to evaluate. If not provided and a trace is given,
-                will be extracted from the trace's root span inputs.
-            outputs: Output data to evaluate. If not provided and a trace is given,
-                will be extracted from the trace's root span outputs.
-            expectations: Expected outcomes or ground truth. If not provided and a trace is given,
-                will be extracted from the trace's expectation assessments.
-            trace: Trace object for evaluation. When the template uses {{ inputs }}, {{ outputs }},
-                or {{ expectations }}, the values will be extracted from the trace.
-            session: List of traces from the same session. When the template uses
-                {{ conversation }}, the conversation history will be extracted from these traces.
+            inputs: Input data to evaluate.
+            outputs: Output data to evaluate.
+            expectations: Expected outcomes or ground truth.
+            trace: Trace object for evaluation.
+            session: List of traces from the same session.
 
         Returns:
             Evaluation results
-
-        **Note on Trace Behavior**:
-        - If template uses {{ trace }}: The trace metadata is used by an agent-based judge that uses
-          tools to fetch aspects of the trace's span data. If inputs/outputs/expectations are also
-          provided, they can augment the agent's context if the template has corresponding
-          placeholders ({{ inputs }}/{{ outputs }}/{{ expectations }}). The agent will still use
-          tools to fetch span data but will have this additional context in the user prompt.
-        - If template uses {{ inputs }}/{{ outputs }}/{{ expectations }} without {{ trace }}:
-          Values are extracted from the trace, if specified, as follows:
-          - inputs/outputs: From the trace's root span
-          - expectations: From the trace's human-set expectation assessments (ground truth only)
-
-        **Note on Session Behavior**:
-        - Traces are expected to be in the same session and exception will be raised
-          if they are not.
-        - The conversation history will be extracted from the traces in chronological order.
         """
-
         self._validate_parameter_types(expectations, trace, session)
 
         original_inputs = inputs
@@ -555,6 +540,57 @@ class InstructionsJudge(Judge):
             trace=trace if is_trace_based else None,
             response_format=response_format,
             use_case=USE_CASE_AGENTIC_JUDGE,
+        )
+
+    def __call__(
+        self,
+        *,
+        inputs: Any = None,
+        outputs: Any = None,
+        expectations: dict[str, Any] | None = None,
+        trace: Trace | None = None,
+        session: list[Trace] | None = None,
+    ) -> Feedback:
+        """
+        Evaluate the provided data using the judge's instructions.
+
+        Args:
+            inputs: Input data to evaluate. If not provided and a trace is given,
+                will be extracted from the trace's root span inputs.
+            outputs: Output data to evaluate. If not provided and a trace is given,
+                will be extracted from the trace's root span outputs.
+            expectations: Expected outcomes or ground truth. If not provided and a trace is given,
+                will be extracted from the trace's expectation assessments.
+            trace: Trace object for evaluation. When the template uses {{ inputs }}, {{ outputs }},
+                or {{ expectations }}, the values will be extracted from the trace.
+            session: List of traces from the same session. When the template uses
+                {{ conversation }}, the conversation history will be extracted from these traces.
+
+        Returns:
+            Evaluation results
+
+        **Note on Trace Behavior**:
+        - If template uses {{ trace }}: The trace metadata is used by an agent-based judge that uses
+          tools to fetch aspects of the trace's span data. If inputs/outputs/expectations are also
+          provided, they can augment the agent's context if the template has corresponding
+          placeholders ({{ inputs }}/{{ outputs }}/{{ expectations }}). The agent will still use
+          tools to fetch span data but will have this additional context in the user prompt.
+        - If template uses {{ inputs }}/{{ outputs }}/{{ expectations }} without {{ trace }}:
+          Values are extracted from the trace, if specified, as follows:
+          - inputs/outputs: From the trace's root span
+          - expectations: From the trace's human-set expectation assessments (ground truth only)
+
+        **Note on Session Behavior**:
+        - Traces are expected to be in the same session and exception will be raised
+          if they are not.
+        - The conversation history will be extracted from the traces in chronological order.
+        """
+        return self._evaluate_impl(
+            inputs=inputs,
+            outputs=outputs,
+            expectations=expectations,
+            trace=trace,
+            session=session,
         )
 
     def _create_response_format_model(self) -> type[pydantic.BaseModel]:

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1639,7 +1639,7 @@ class BuiltInSessionLevelScorer(BuiltInScorer):
                 f"Session level scorers can only accept the `session` and `expectations` "
                 f"parameters. Got unexpected keyword argument(s): {invalid_args}"
             )
-        return self._get_judge()(session=session, expectations=expectations)
+        return self._get_judge()._evaluate_impl(session=session, expectations=expectations)
 
 
 @experimental(version="3.7.0")
@@ -2042,7 +2042,7 @@ class Completeness(BuiltInScorer):
         outputs: Any | None = None,
         trace: Trace | None = None,
     ) -> Feedback:
-        return self._get_judge()(
+        return self._get_judge()._evaluate_impl(
             inputs=inputs,
             outputs=outputs,
             trace=trace,

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1572,21 +1572,22 @@ def test_conversational_tool_call_efficiency_with_session():
 
         traces.append(mlflow.get_trace(span.trace_id))
 
-    with patch(
-        "mlflow.genai.judges.instructions_judge.InstructionsJudge.__call__"
-    ) as mock_judge_call:
-        mock_judge_call.return_value = Feedback(
-            name="conversational_tool_call_efficiency",
-            value=CategoricalRating.YES,
-            rationale="Efficient tool usage across session",
-        )
+    mock_feedback = Feedback(
+        name="conversational_tool_call_efficiency",
+        value=CategoricalRating.YES,
+        rationale="Efficient tool usage across session",
+    )
 
+    with patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=mock_feedback,
+    ) as mock_invoke:
         scorer = ConversationalToolCallEfficiency()
         result = scorer(session=traces)
 
         assert result.name == "conversational_tool_call_efficiency"
         assert result.value == CategoricalRating.YES
-        mock_judge_call.assert_called_once()
+        mock_invoke.assert_called_once()
 
 
 def test_conversational_tool_call_efficiency_get_input_fields():

--- a/tests/telemetry/test_tracked_events.py
+++ b/tests/telemetry/test_tracked_events.py
@@ -19,6 +19,7 @@ from mlflow.genai.judges.base import AlignmentOptimizer
 from mlflow.genai.scorers import scorer
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.builtin_scorers import (
+    Completeness,
     Guidelines,
     RelevanceToQuery,
     Safety,
@@ -1337,6 +1338,110 @@ def test_scorer_call_tracks_feedback_errors(mock_requests, mock_telemetry_client
             "scorer_kind": "decorator",
             "is_session_level_scorer": False,
             "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+
+def test_scorer_call_wrapped_builtin_scorer_direct(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    completeness_scorer = Completeness()
+
+    mock_feedback = Feedback(
+        name="completeness",
+        value="yes",
+        rationale="Test rationale",
+    )
+
+    with mock.patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=mock_feedback,
+    ):
+        completeness_scorer(inputs={"question": "What is MLflow?"}, outputs="MLflow is a platform")
+
+    mock_telemetry_client.flush()
+
+    # Verify exactly 1 scorer_call event was created
+    # (only top-level Completeness, not nested InstructionsJudge)
+    scorer_call_events = [
+        record for record in mock_requests if record["data"]["event_name"] == ScorerCallEvent.name
+    ]
+    assert len(scorer_call_events) == 1, (
+        f"Expected 1 scorer call event for Completeness scorer (nested calls should be skipped), "
+        f"got {len(scorer_call_events)}"
+    )
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "Completeness",
+            "scorer_kind": "builtin",
+            "is_session_level_scorer": False,
+            "callsite": "direct_scorer_call",
+            "has_feedback_error": False,
+        },
+    )
+
+
+def test_scorer_call_wrapped_builtin_scorer_from_genai_evaluate(
+    mock_requests, mock_telemetry_client: TelemetryClient
+):
+    user_frustration_scorer = UserFrustration()
+
+    @mlflow.trace(span_type=mlflow.entities.SpanType.CHAT_MODEL)
+    def model(question, session_id):
+        mlflow.update_current_trace(metadata={"mlflow.trace.session": session_id})
+        return f"Answer to: {question}"
+
+    model("What is MLflow?", session_id="test_session")
+    trace_1 = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    model("How does MLflow work?", session_id="test_session")
+    trace_2 = mlflow.get_trace(mlflow.get_last_active_trace_id())
+
+    test_data = pd.DataFrame(
+        [
+            {"trace": trace_1},
+            {"trace": trace_2},
+        ]
+    )
+
+    mock_feedback = Feedback(
+        name="user_frustration",
+        value="no",
+        rationale="Test rationale",
+    )
+
+    with mock.patch(
+        "mlflow.genai.judges.instructions_judge.invoke_judge_model",
+        return_value=mock_feedback,
+    ):
+        mlflow.genai.evaluate(data=test_data, scorers=[user_frustration_scorer])
+
+    mock_telemetry_client.flush()
+
+    # Verify exactly 1 scorer_call event was created for the session-level scorer
+    # (one call at the session level and no nested InstructionsJudge event)
+    scorer_call_events = [
+        record for record in mock_requests if record["data"]["event_name"] == ScorerCallEvent.name
+    ]
+    assert len(scorer_call_events) == 1, (
+        f"Expected 1 scorer call event for UserFrustration scorer "
+        f"(nested calls should be skipped), got {len(scorer_call_events)}"
+    )
+
+    validate_telemetry_record(
+        mock_telemetry_client,
+        mock_requests,
+        ScorerCallEvent.name,
+        {
+            "scorer_class": "UserFrustration",
+            "scorer_kind": "builtin",
+            "is_session_level_scorer": True,
+            "callsite": "genai.evaluate",
             "has_feedback_error": False,
         },
     )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19288/files) to review incremental changes.
- [**stack/ML-59817-address-double-call-events-for-wrapped-builtin-scorers**](https://github.com/mlflow/mlflow/pull/19288) [[Files changed](https://github.com/mlflow/mlflow/pull/19288/files)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
For our newly created built-in judges that wraps an `InstructionsJudge`, the scorer_called event will fire twice when evaluation runs, once for the built-in judge's __call__ and once for the `InstructionsJudge`'s __call__. To prevent this, I'm moving the __call__ logic for `InstructionsJudge` to a `_evaluate_impl` helper function instead and make the wrapped judges call `_evaluate_impl` to prevent duplicate events.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Manual Test
```
result = mlflow.genai.evaluate(
        data=_EVALUATION_TEST_CASES,
        predict_fn=predict_fn,
        scorers=[
                Completeness(), 
        ],
);
```

```
{'scorer_class': 'Completeness', 'scorer_kind': 'builtin', 'is_session_level_scorer': False, 'callsite': 'genai.evaluate', 'has_feedback_error': False}
x10
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
