### PR TITLE
Add unified invocation endpoint

### DIFF
--- a/mlflow/gateway/providers/bedrock.py
+++ b/mlflow/gateway/providers/bedrock.py
@@ -242,6 +242,7 @@ class AmazonBedrockProvider(BaseProvider):
                 "aws_session_token": aws_config.aws_session_token,
             }
         else:
+            # TODO: handle session token authentication
             return {}
 
     @property

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -51,8 +51,7 @@ def create_fastapi_app(flask_app: Flask = flask_app):
     # Include Gateway API router for database-backed endpoints
     # This provides /gateway/{endpoint_name}/mlflow/invocations routes
     try:
-        gateway_router = get_gateway_router()
-        fastapi_app.include_router(gateway_router)
+        fastapi_app.include_router(get_gateway_router())
     except Exception as e:
         # Log warning but don't fail server startup if gateway endpoints can't be loaded
         logging.getLogger(__name__).warning(

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -6,15 +6,13 @@ using WSGIMiddleware to maintain 100% API compatibility while enabling future mi
 to FastAPI endpoints.
 """
 
-import logging
-
 from fastapi import FastAPI
 from fastapi.middleware.wsgi import WSGIMiddleware
 from flask import Flask
 
 from mlflow.server import app as flask_app
 from mlflow.server.fastapi_security import init_fastapi_security
-from mlflow.server.gateway_api import get_gateway_router
+from mlflow.server.gateway_api import gateway_router
 from mlflow.server.job_api import job_api_router
 from mlflow.server.otel_api import otel_router
 from mlflow.version import VERSION
@@ -50,13 +48,7 @@ def create_fastapi_app(flask_app: Flask = flask_app):
 
     # Include Gateway API router for database-backed endpoints
     # This provides /gateway/{endpoint_name}/mlflow/invocations routes
-    try:
-        fastapi_app.include_router(get_gateway_router())
-    except Exception as e:
-        # Log warning but don't fail server startup if gateway endpoints can't be loaded
-        logging.getLogger(__name__).warning(
-            f"Failed to register gateway endpoints: {e}", exc_info=True
-        )
+    fastapi_app.include_router(gateway_router)
 
     # Mount the entire Flask application at the root path
     # This ensures compatibility with existing APIs

--- a/mlflow/server/fastapi_app.py
+++ b/mlflow/server/fastapi_app.py
@@ -6,6 +6,8 @@ using WSGIMiddleware to maintain 100% API compatibility while enabling future mi
 to FastAPI endpoints.
 """
 
+import logging
+
 from fastapi import FastAPI
 from fastapi.middleware.wsgi import WSGIMiddleware
 from flask import Flask
@@ -53,8 +55,6 @@ def create_fastapi_app(flask_app: Flask = flask_app):
         fastapi_app.include_router(gateway_router)
     except Exception as e:
         # Log warning but don't fail server startup if gateway endpoints can't be loaded
-        import logging
-
         logging.getLogger(__name__).warning(
             f"Failed to register gateway endpoints: {e}", exc_info=True
         )

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -159,11 +159,9 @@ def _create_provider_from_endpoint_config(
         )
     else:
         # TODO: Support long-tail providers with LiteLLM
-        raise MlflowException(
-            f"Provider '{model_config.provider}' is not yet supported for database-backed endpoints"
-        )
+        pass
 
-    # Create a temporary EndpointConfig for the provider
+    # Create an EndpointConfig for the provider
     # This mimics what the gateway does with yaml-based configs
     gateway_endpoint_config = EndpointConfig(
         name=endpoint_config.endpoint_name,
@@ -234,7 +232,7 @@ def _create_invocations_handler(endpoint_id: str, store: SqlAlchemyStore):
     return _invocations
 
 
-def register_gateway_endpoints(store: SqlAlchemyStore) -> APIRouter:
+def _register_gateway_endpoints(store: SqlAlchemyStore) -> APIRouter:
     """
     Register dynamic gateway endpoints from the database.
 
@@ -292,4 +290,4 @@ def get_gateway_router() -> APIRouter:
         )
         return gateway_router
 
-    return register_gateway_endpoints(store)
+    return _register_gateway_endpoints(store)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -11,7 +11,6 @@ import logging
 from fastapi import APIRouter, HTTPException, Request
 
 from mlflow.exceptions import MlflowException
-from mlflow.gateway.app import _translate_http_exception
 from mlflow.gateway.config import (
     AmazonBedrockConfig,
     AnthropicConfig,
@@ -28,7 +27,7 @@ from mlflow.gateway.config import (
 from mlflow.gateway.providers import get_provider
 from mlflow.gateway.providers.base import BaseProvider
 from mlflow.gateway.schemas import chat, embeddings
-from mlflow.gateway.utils import make_streaming_response
+from mlflow.gateway.utils import make_streaming_response, translate_http_exception
 from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST
 from mlflow.store.tracking.gateway.config_resolver import get_endpoint_config
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
@@ -157,7 +156,7 @@ def _create_provider_from_endpoint_name(
 
 
 @gateway_router.post("/{endpoint_name}/mlflow/invocations")
-@_translate_http_exception
+@translate_http_exception
 async def invocations(endpoint_name: str, request: Request):
     """
     Create a unified invocations endpoint handler that supports both chat and embeddings.

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -137,7 +137,7 @@ def _create_provider_from_endpoint_config(
         )
     else:
         # TODO: Support long-tail providers with LiteLLM
-        pass
+        raise NotImplementedError(f"Provider {provider_enum} is not supported")
 
     # Create an EndpointConfig for the provider
     # This mimics what the gateway does with yaml-based configs

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -39,15 +39,15 @@ _logger = logging.getLogger(__name__)
 gateway_router = APIRouter(prefix="/gateway", tags=["gateway"])
 
 
-def _create_provider_from_endpoint_config(
-    endpoint_name: str, store: SqlAlchemyStore, endpoint_type: EndpointType
+def _create_provider_from_endpoint_name(
+    store: SqlAlchemyStore, endpoint_name: str, endpoint_type: EndpointType
 ) -> BaseProvider:
     """
     Create a provider instance from database endpoint configuration.
 
     Args:
-        endpoint_name: The endpoint name to retrieve configuration for.
         store: The SQLAlchemy store instance.
+        endpoint_name: The endpoint name to retrieve configuration for.
         endpoint_type: Endpoint type (chat or embeddings).
 
     Returns:
@@ -189,7 +189,7 @@ async def invocations(endpoint_name: str, request: Request):
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid chat payload: {e!s}")
 
-        provider = _create_provider_from_endpoint_config(endpoint_name, store, endpoint_type)
+        provider = _create_provider_from_endpoint_name(store, endpoint_name, endpoint_type)
 
         if payload.stream:
             return await make_streaming_response(provider.chat_stream(payload))
@@ -204,7 +204,7 @@ async def invocations(endpoint_name: str, request: Request):
         except Exception as e:
             raise HTTPException(status_code=400, detail=f"Invalid embeddings payload: {e!s}")
 
-        provider = _create_provider_from_endpoint_config(endpoint_name, store, endpoint_type)
+        provider = _create_provider_from_endpoint_name(store, endpoint_name, endpoint_type)
 
         return await provider.embeddings(payload)
 

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -1,0 +1,247 @@
+"""
+Database-backed Gateway API endpoints for MLflow Server.
+
+This module provides dynamic gateway endpoints that are configured from the database
+rather than from a static YAML configuration file. It integrates the AI Gateway
+functionality directly into the MLflow tracking server.
+"""
+
+import functools
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+
+from mlflow.exceptions import MlflowException
+from mlflow.gateway.config import EndpointType
+from mlflow.gateway.providers import get_provider
+from mlflow.gateway.providers.base import BaseProvider
+from mlflow.gateway.schemas import chat, embeddings
+from mlflow.gateway.utils import make_streaming_response
+from mlflow.protos.databricks_pb2 import RESOURCE_DOES_NOT_EXIST, ErrorCode
+from mlflow.store.tracking.gateway.config_resolver import get_endpoint_config
+from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+from mlflow.tracking._tracking_service.utils import _get_store
+
+_logger = logging.getLogger(__name__)
+
+# Create router for gateway endpoints
+gateway_router = APIRouter(prefix="/gateway", tags=["gateway"])
+
+
+def _translate_http_exception(func):
+    """
+    Decorator for translating MLflow exceptions to HTTP exceptions.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        try:
+            return await func(*args, **kwargs)
+        except MlflowException as e:
+            if e.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST):
+                raise HTTPException(status_code=404, detail=str(e))
+            raise HTTPException(status_code=400, detail=str(e))
+        except Exception as e:
+            _logger.exception(f"Unexpected error in gateway endpoint: {e}")
+            raise HTTPException(status_code=500, detail=f"Internal server error: {str(e)}")
+
+    return wrapper
+
+
+def _create_provider_from_endpoint_config(
+    endpoint_id: str, store: SqlAlchemyStore
+) -> tuple[BaseProvider, EndpointType]:
+    """
+    Create a provider instance from database endpoint configuration.
+
+    Args:
+        endpoint_id: The endpoint ID to retrieve configuration for.
+        store: The SQLAlchemy store instance.
+
+    Returns:
+        Tuple of (Provider instance, EndpointType)
+
+    Raises:
+        MlflowException: If endpoint not found or configuration is invalid.
+    """
+    from mlflow.gateway.config import (
+        AmazonBedrockConfig,
+        AnthropicConfig,
+        AWSBaseConfig,
+        EndpointConfig,
+        EndpointType,
+        Model as ModelConfig,
+        OpenAIConfig,
+        Provider,
+    )
+
+    # Get endpoint config with decrypted secrets
+    endpoint_config = get_endpoint_config(endpoint_id=endpoint_id, store=store)
+
+    if not endpoint_config.models:
+        raise MlflowException(
+            f"Endpoint '{endpoint_id}' has no models configured",
+            error_code=RESOURCE_DOES_NOT_EXIST,
+        )
+
+    # For now, use the first model (later we can support traffic routing)
+    model_config = endpoint_config.models[0]
+
+    # Determine endpoint type based on provider capabilities
+    # Default to chat for most providers
+    endpoint_type = EndpointType.LLM_V1_CHAT
+
+    # Build provider-specific configuration
+    provider_enum = Provider(model_config.provider)
+
+    if provider_enum == Provider.OPENAI:
+        provider_config = OpenAIConfig(
+            openai_api_key=model_config.secret_value,
+            openai_api_base=model_config.auth_config.get("api_base")
+            if model_config.auth_config
+            else None,
+        )
+    elif provider_enum == Provider.ANTHROPIC:
+        provider_config = AnthropicConfig(anthropic_api_key=model_config.secret_value)
+    elif provider_enum in (Provider.BEDROCK, Provider.AMAZON_BEDROCK):
+        auth_config = model_config.auth_config or {}
+        provider_config = AmazonBedrockConfig(
+            aws_config=AWSBaseConfig(**auth_config) if auth_config else AWSBaseConfig(),
+        )
+    else:
+        raise MlflowException(
+            f"Provider '{model_config.provider}' is not yet supported for database-backed endpoints"
+        )
+
+    # Create a temporary EndpointConfig for the provider
+    # This mimics what the gateway does with file-based configs
+    # Note: EndpointConfig expects a dict for the model field, not a Model instance
+    gateway_endpoint_config = EndpointConfig(
+        name=endpoint_config.endpoint_name,
+        endpoint_type=endpoint_type,
+        model={
+            "name": model_config.model_name,
+            "provider": provider_enum.value,
+            "config": provider_config.model_dump(),
+        },
+    )
+
+    # Get and instantiate the provider
+    provider_class = get_provider(provider_enum)
+    provider_instance = provider_class(gateway_endpoint_config)
+
+    return provider_instance, endpoint_type
+
+
+def _create_invocations_handler(endpoint_id: str, store: SqlAlchemyStore):
+    """
+    Create a unified invocations endpoint handler that supports both chat and embeddings.
+
+    The handler automatically detects the request type based on the payload structure:
+    - If payload has "messages" field -> chat endpoint
+    - If payload has "input" field -> embeddings endpoint
+    """
+
+    @_translate_http_exception
+    async def _invocations(request: Request):
+        # Get raw JSON to determine request type
+        try:
+            body = await request.json()
+        except Exception as e:
+            raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {str(e)}")
+
+        provider, endpoint_type = _create_provider_from_endpoint_config(endpoint_id, store)
+
+        # Detect request type based on payload structure
+        if "messages" in body:
+            # Chat request
+            try:
+                payload = chat.RequestPayload(**body)
+            except Exception as e:
+                raise HTTPException(status_code=400, detail=f"Invalid chat payload: {str(e)}")
+
+            if payload.stream:
+                return await make_streaming_response(provider.chat_stream(payload))
+            else:
+                return await provider.chat(payload)
+
+        elif "input" in body:
+            # Embeddings request
+            try:
+                payload = embeddings.RequestPayload(**body)
+            except Exception as e:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid embeddings payload: {str(e)}"
+                )
+
+            return await provider.embeddings(payload)
+
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid request: payload must contain either 'messages' (for chat) or 'input' (for embeddings)",
+            )
+
+    return _invocations
+
+
+def register_gateway_endpoints(store: SqlAlchemyStore) -> APIRouter:
+    """
+    Register dynamic gateway endpoints from the database.
+
+    This function queries the database for all configured endpoints and dynamically
+    registers FastAPI routes for each one.
+
+    Args:
+        store: The SQLAlchemy store instance to query for endpoints.
+
+    Returns:
+        The configured APIRouter with all gateway endpoints registered.
+    """
+    # Get all endpoints from the database
+    try:
+        endpoints = store.list_endpoints()
+    except Exception as e:
+        _logger.warning(f"Failed to load gateway endpoints from database: {e}")
+        endpoints = []
+
+    _logger.info(f"Registering {len(endpoints)} gateway endpoints from database")
+
+    for endpoint in endpoints:
+        endpoint_name = endpoint.name
+        endpoint_id = endpoint.endpoint_id
+
+        # Register unified invocations endpoint (supports both chat and embeddings)
+        invocations_path = f"/{endpoint_name}/mlflow/invocations"
+        gateway_router.add_api_route(
+            path=invocations_path,
+            endpoint=_create_invocations_handler(endpoint_id, store),
+            methods=["POST"],
+            response_model=None,  # Dynamic response based on request type
+            name=f"invocations_{endpoint_name}",
+            summary=f"Invocations endpoint for {endpoint_name} (supports chat and embeddings)",
+        )
+        _logger.info(f"Registered invocations endpoint: /gateway{invocations_path}")
+
+    return gateway_router
+
+
+def get_gateway_router() -> APIRouter:
+    """
+    Get the configured gateway router.
+
+    This is the main entry point for integrating the gateway API into the MLflow server.
+
+    Returns:
+        APIRouter configured with all database-backed gateway endpoints.
+    """
+    store = _get_store()
+    if not isinstance(store, SqlAlchemyStore):
+        _logger.warning(
+            f"Gateway endpoints require SqlAlchemyStore, got {type(store).__name__}. "
+            "Gateway endpoints will not be available."
+        )
+        return gateway_router
+
+    return register_gateway_endpoints(store)

--- a/mlflow/store/tracking/gateway/config_resolver.py
+++ b/mlflow/store/tracking/gateway/config_resolver.py
@@ -136,7 +136,7 @@ def get_resource_endpoint_configs(
 
 
 def get_endpoint_config(
-    endpoint_id: str,
+    endpoint_name: str,
     store: SqlAlchemyStore | None = None,
 ) -> GatewayEndpointConfig:
     """
@@ -151,7 +151,7 @@ def get_endpoint_config(
     backends.
 
     Args:
-        endpoint_id: Unique identifier for the endpoint.
+        endpoint_name: Unique identifier for the endpoint.
         store: Optional SqlAlchemyStore instance. If not provided, the current
             tracking store is used.
 
@@ -175,7 +175,7 @@ def get_endpoint_config(
         sql_endpoint = store._get_entity_or_raise(
             session,
             SqlGatewayEndpoint,
-            {"endpoint_id": endpoint_id},
+            {"name": endpoint_name},
             "GatewayEndpoint",
         )
 

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -24,8 +24,8 @@ from mlflow.gateway.schemas import chat, embeddings
 from mlflow.server.gateway_api import (
     _create_invocations_handler,
     _create_provider_from_endpoint_config,
-    gateway_router,
     _register_gateway_endpoints,
+    gateway_router,
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -45,16 +45,11 @@ def set_kek_passphrase(monkeypatch):
 def store(tmp_path: Path):
     artifact_uri = tmp_path / "artifacts"
     artifact_uri.mkdir(exist_ok=True)
-    if db_uri_env := MLFLOW_TRACKING_URI.get():
-        s = SqlAlchemyStore(db_uri_env, artifact_uri.as_uri())
-        mlflow.set_tracking_uri(db_uri_env)
-        yield s
-    else:
-        db_path = tmp_path / "mlflow.db"
-        db_uri = f"sqlite:///{db_path}"
-        mlflow.set_tracking_uri(db_uri)
-        s = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
-        yield s
+    db_path = tmp_path / "mlflow.db"
+    db_uri = f"sqlite:///{db_path}"
+    mlflow.set_tracking_uri(db_uri)
+    yield SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+    mlflow.set_tracking_uri(None)
 
 
 def test_create_provider_from_endpoint_name_openai(store: SqlAlchemyStore):

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -1,0 +1,243 @@
+"""
+Tests for database-backed Gateway API endpoints.
+"""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from mlflow.environment_variables import MLFLOW_TRACKING_URI
+from mlflow.gateway.config import EndpointType
+from mlflow.gateway.schemas import chat, embeddings
+from mlflow.server.gateway_api import (
+    _create_invocations_handler,
+    _create_provider_from_endpoint_config,
+    gateway_router,
+    register_gateway_endpoints,
+)
+from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
+
+pytestmark = pytest.mark.notrackingurimock
+
+TEST_PASSPHRASE = "test-passphrase-for-gateway-api-tests"
+
+
+@pytest.fixture(autouse=True)
+def set_kek_passphrase(monkeypatch):
+    monkeypatch.setenv("MLFLOW_CRYPTO_KEK_PASSPHRASE", TEST_PASSPHRASE)
+
+
+@pytest.fixture
+def store(tmp_path: Path):
+    artifact_uri = tmp_path / "artifacts"
+    artifact_uri.mkdir(exist_ok=True)
+    if db_uri_env := MLFLOW_TRACKING_URI.get():
+        s = SqlAlchemyStore(db_uri_env, artifact_uri.as_uri())
+        yield s
+    else:
+        db_path = tmp_path / "mlflow.db"
+        db_uri = f"sqlite:///{db_path}"
+        s = SqlAlchemyStore(db_uri, artifact_uri.as_uri())
+        yield s
+
+
+def test_create_provider_from_endpoint_config_openai(store: SqlAlchemyStore):
+    # Create test data
+    secret = store.create_secret(
+        secret_name="openai-key",
+        secret_value="sk-test-123",
+        provider="openai",
+        credential_name="OPENAI_API_KEY",
+    )
+    model_def = store.create_model_definition(
+        name="gpt-model",
+        secret_id=secret.secret_id,
+        provider="openai",
+        model_name="gpt-4o",
+    )
+    endpoint = store.create_endpoint(
+        name="test-openai-endpoint", model_definition_ids=[model_def.model_definition_id]
+    )
+
+    # Create provider
+    provider, endpoint_type = _create_provider_from_endpoint_config(endpoint.endpoint_id, store)
+
+    assert provider is not None
+    assert endpoint_type == EndpointType.LLM_V1_CHAT
+
+
+def test_create_provider_from_endpoint_config_anthropic(store: SqlAlchemyStore):
+    secret = store.create_secret(
+        secret_name="anthropic-key",
+        secret_value="sk-ant-test",
+        provider="anthropic",
+    )
+    model_def = store.create_model_definition(
+        name="claude-model",
+        secret_id=secret.secret_id,
+        provider="anthropic",
+        model_name="claude-3-sonnet",
+    )
+    endpoint = store.create_endpoint(
+        name="test-anthropic-endpoint", model_definition_ids=[model_def.model_definition_id]
+    )
+
+    provider, endpoint_type = _create_provider_from_endpoint_config(endpoint.endpoint_id, store)
+
+    assert provider is not None
+    assert endpoint_type == EndpointType.LLM_V1_CHAT
+
+
+def test_create_provider_from_endpoint_config_nonexistent_endpoint(store: SqlAlchemyStore):
+    from mlflow.exceptions import MlflowException
+
+    with pytest.raises(MlflowException, match="not found"):
+        _create_provider_from_endpoint_config("nonexistent-id", store)
+
+
+def test_register_gateway_endpoints(store: SqlAlchemyStore):
+    # Create test endpoints
+    secret = store.create_secret(
+        secret_name="test-key",
+        secret_value="sk-test",
+        provider="openai",
+    )
+    model_def = store.create_model_definition(
+        name="test-model",
+        secret_id=secret.secret_id,
+        provider="openai",
+        model_name="gpt-4",
+    )
+    endpoint = store.create_endpoint(
+        name="test-endpoint", model_definition_ids=[model_def.model_definition_id]
+    )
+
+    # Register endpoints
+    router = register_gateway_endpoints(store)
+
+    # Check that routes were registered
+    route_paths = [route.path for route in router.routes]
+    assert "/gateway/test-endpoint/mlflow/invocations" in route_paths
+    # Should NOT have separate embeddings endpoint
+    assert "/gateway/test-endpoint/mlflow/embeddings" not in route_paths
+
+
+@pytest.mark.asyncio
+async def test_invocations_handler_chat(store: SqlAlchemyStore):
+    # Create test data
+    secret = store.create_secret(
+        secret_name="chat-key",
+        secret_value="sk-test-chat",
+        provider="openai",
+    )
+    model_def = store.create_model_definition(
+        name="chat-model",
+        secret_id=secret.secret_id,
+        provider="openai",
+        model_name="gpt-4",
+    )
+    endpoint = store.create_endpoint(
+        name="chat-endpoint", model_definition_ids=[model_def.model_definition_id]
+    )
+
+    # Create handler
+    handler = _create_invocations_handler(endpoint.endpoint_id, store)
+
+    # Mock the provider's chat method
+    mock_response = chat.ResponsePayload(
+        id="test-id",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            chat.Choice(
+                index=0,
+                message=chat.ResponseMessage(role="assistant", content="Hello!"),
+                finish_reason="stop",
+            )
+        ],
+        usage=chat.ChatUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+    # Create a mock request with chat payload
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(
+        return_value={
+            "messages": [{"role": "user", "content": "Hi"}],
+            "temperature": 0.7,
+            "stream": False,
+        }
+    )
+
+    # Patch the provider creation to return a mocked provider
+    with patch(
+        "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+    ) as mock_create_provider:
+        mock_provider = MagicMock()
+        mock_provider.chat = AsyncMock(return_value=mock_response)
+        mock_create_provider.return_value = (mock_provider, EndpointType.LLM_V1_CHAT)
+
+        # Call the handler
+        response = await handler(mock_request)
+
+        # Verify
+        assert response.id == "test-id"
+        assert response.choices[0].message.content == "Hello!"
+        assert mock_provider.chat.called
+
+
+@pytest.mark.asyncio
+async def test_invocations_handler_embeddings(store: SqlAlchemyStore):
+    # Create test data
+    secret = store.create_secret(
+        secret_name="embed-key",
+        secret_value="sk-test-embed",
+        provider="openai",
+    )
+    model_def = store.create_model_definition(
+        name="embed-model",
+        secret_id=secret.secret_id,
+        provider="openai",
+        model_name="text-embedding-ada-002",
+    )
+    endpoint = store.create_endpoint(
+        name="embed-endpoint", model_definition_ids=[model_def.model_definition_id]
+    )
+
+    # Create handler
+    handler = _create_invocations_handler(endpoint.endpoint_id, store)
+
+    # Mock the provider's embeddings method
+    mock_response = embeddings.ResponsePayload(
+        object="list",
+        data=[embeddings.EmbeddingObject(embedding=[0.1, 0.2, 0.3], index=0)],
+        model="text-embedding-ada-002",
+        usage=embeddings.EmbeddingsUsage(prompt_tokens=5, total_tokens=5),
+    )
+
+    # Create a mock request with embeddings payload
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(return_value={"input": "test text"})
+
+    # Patch the provider creation to return a mocked provider
+    with patch(
+        "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+    ) as mock_create_provider:
+        mock_provider = MagicMock()
+        mock_provider.embeddings = AsyncMock(return_value=mock_response)
+        mock_create_provider.return_value = (mock_provider, EndpointType.LLM_V1_EMBEDDINGS)
+
+        # Call the handler
+        response = await handler(mock_request)
+
+        # Verify
+        assert response.object == "list"
+        assert len(response.data) == 1
+        assert response.data[0].embedding == [0.1, 0.2, 0.3]
+        assert mock_provider.embeddings.called
+
+
+def test_gateway_router_initialization():
+    assert gateway_router is not None
+    assert gateway_router.prefix == "/gateway"

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -24,7 +24,7 @@ from mlflow.gateway.providers.mistral import MistralProvider
 from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.server.gateway_api import (
-    _create_provider_from_endpoint_config,
+    _create_provider_from_endpoint_name,
     gateway_router,
     invocations,
 )
@@ -57,7 +57,7 @@ def store(tmp_path: Path):
         yield s
 
 
-def test_create_provider_from_endpoint_config_openai(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_openai(store: SqlAlchemyStore):
     # Create test data
     secret = store.create_gateway_secret(
         secret_name="openai-key",
@@ -74,14 +74,14 @@ def test_create_provider_from_endpoint_config_openai(store: SqlAlchemyStore):
         name="test-openai-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, OpenAIProvider)
     assert isinstance(provider.config.model.config, OpenAIConfig)
     assert provider.config.model.config.openai_api_key == "sk-test-123"
 
 
-def test_create_provider_from_endpoint_config_azure_openai(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_azure_openai(store: SqlAlchemyStore):
     # Test Azure OpenAI configuration
     secret = store.create_gateway_secret(
         secret_name="azure-openai-key",
@@ -104,7 +104,7 @@ def test_create_provider_from_endpoint_config_azure_openai(store: SqlAlchemyStor
         name="test-azure-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, OpenAIProvider)
     assert isinstance(provider.config.model.config, OpenAIConfig)
@@ -115,7 +115,7 @@ def test_create_provider_from_endpoint_config_azure_openai(store: SqlAlchemyStor
     assert provider.config.model.config.openai_api_key == "azure-api-key-test"
 
 
-def test_create_provider_from_endpoint_config_azure_openai_with_azuread(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_azure_openai_with_azuread(store: SqlAlchemyStore):
     # Test Azure OpenAI with AzureAD authentication
     secret = store.create_gateway_secret(
         secret_name="azuread-openai-key",
@@ -138,7 +138,7 @@ def test_create_provider_from_endpoint_config_azure_openai_with_azuread(store: S
         name="test-azuread-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, OpenAIProvider)
     assert isinstance(provider.config.model.config, OpenAIConfig)
@@ -149,7 +149,7 @@ def test_create_provider_from_endpoint_config_azure_openai_with_azuread(store: S
     assert provider.config.model.config.openai_api_key == "azuread-api-key-test"
 
 
-def test_create_provider_from_endpoint_config_anthropic(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_anthropic(store: SqlAlchemyStore):
     secret = store.create_gateway_secret(
         secret_name="anthropic-key",
         secret_value={"api_key": "sk-ant-test"},
@@ -165,13 +165,13 @@ def test_create_provider_from_endpoint_config_anthropic(store: SqlAlchemyStore):
         name="test-anthropic-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, AnthropicProvider)
     assert provider.config.model.config.anthropic_api_key == "sk-ant-test"
 
 
-def test_create_provider_from_endpoint_config_bedrock_base_config(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_bedrock_base_config(store: SqlAlchemyStore):
     # Test Bedrock with base config (default credentials chain)
     secret = store.create_gateway_secret(
         secret_name="bedrock-base-key",
@@ -189,14 +189,14 @@ def test_create_provider_from_endpoint_config_bedrock_base_config(store: SqlAlch
         name="test-bedrock-base-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, AmazonBedrockProvider)
     assert isinstance(provider.config.model.config.aws_config, AWSBaseConfig)
     assert provider.config.model.config.aws_config.aws_region == "us-east-1"
 
 
-def test_create_provider_from_endpoint_config_bedrock_access_keys(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_bedrock_access_keys(store: SqlAlchemyStore):
     # Test Bedrock with access key authentication
     secret = store.create_gateway_secret(
         secret_name="bedrock-keys",
@@ -218,7 +218,7 @@ def test_create_provider_from_endpoint_config_bedrock_access_keys(store: SqlAlch
         name="test-bedrock-keys-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, AmazonBedrockProvider)
     assert isinstance(provider.config.model.config.aws_config, AWSIdAndKey)
@@ -228,7 +228,7 @@ def test_create_provider_from_endpoint_config_bedrock_access_keys(store: SqlAlch
     assert provider.config.model.config.aws_config.aws_region == "us-west-2"
 
 
-def test_create_provider_from_endpoint_config_bedrock_role(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_bedrock_role(store: SqlAlchemyStore):
     # Test Bedrock with role-based authentication
     secret = store.create_gateway_secret(
         secret_name="bedrock-role-key",
@@ -250,7 +250,7 @@ def test_create_provider_from_endpoint_config_bedrock_role(store: SqlAlchemyStor
         name="test-bedrock-role-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, AmazonBedrockProvider)
     assert isinstance(provider.config.model.config.aws_config, AWSRole)
@@ -262,7 +262,7 @@ def test_create_provider_from_endpoint_config_bedrock_role(store: SqlAlchemyStor
     assert provider.config.model.config.aws_config.aws_region == "eu-west-1"
 
 
-def test_create_provider_from_endpoint_config_mistral(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_mistral(store: SqlAlchemyStore):
     # Test Mistral provider
     secret = store.create_gateway_secret(
         secret_name="mistral-key",
@@ -279,14 +279,14 @@ def test_create_provider_from_endpoint_config_mistral(store: SqlAlchemyStore):
         name="test-mistral-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, MistralProvider)
     assert isinstance(provider.config.model.config, MistralConfig)
     assert provider.config.model.config.mistral_api_key == "mistral-test-key"
 
 
-def test_create_provider_from_endpoint_config_gemini(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_gemini(store: SqlAlchemyStore):
     # Test Gemini provider
     secret = store.create_gateway_secret(
         secret_name="gemini-key",
@@ -303,16 +303,16 @@ def test_create_provider_from_endpoint_config_gemini(store: SqlAlchemyStore):
         name="test-gemini-endpoint", model_definition_ids=[model_def.model_definition_id]
     )
 
-    provider = _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+    provider = _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
 
     assert isinstance(provider, GeminiProvider)
     assert isinstance(provider.config.model.config, GeminiConfig)
     assert provider.config.model.config.gemini_api_key == "gemini-test-key"
 
 
-def test_create_provider_from_endpoint_config_nonexistent_endpoint(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_nonexistent_endpoint(store: SqlAlchemyStore):
     with pytest.raises(MlflowException, match="not found"):
-        _create_provider_from_endpoint_config("nonexistent-id", store, EndpointType.LLM_V1_CHAT)
+        _create_provider_from_endpoint_name(store, "nonexistent-id", EndpointType.LLM_V1_CHAT)
 
 
 @pytest.mark.asyncio
@@ -361,7 +361,7 @@ async def test_invocations_handler_chat(store: SqlAlchemyStore):
 
     # Patch the provider creation to return a mocked provider
     with patch(
-        "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+        "mlflow.server.gateway_api._create_provider_from_endpoint_name"
     ) as mock_create_provider:
         mock_provider = MagicMock()
         mock_provider.chat = AsyncMock(return_value=mock_response)
@@ -408,7 +408,7 @@ async def test_invocations_handler_embeddings(store: SqlAlchemyStore):
 
     # Patch the provider creation to return a mocked provider
     with patch(
-        "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+        "mlflow.server.gateway_api._create_provider_from_endpoint_name"
     ) as mock_create_provider:
         mock_provider = MagicMock()
         mock_provider.embeddings = AsyncMock(return_value=mock_response)
@@ -478,7 +478,7 @@ async def test_invocations_handler_missing_fields(store: SqlAlchemyStore):
     mock_request.json = AsyncMock(return_value={"temperature": 0.7})
 
     with patch(
-        "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+        "mlflow.server.gateway_api._create_provider_from_endpoint_name"
     ) as mock_create_provider:
         mock_provider = MagicMock()
         mock_create_provider.return_value = mock_provider
@@ -518,7 +518,7 @@ async def test_invocations_handler_invalid_chat_payload(store: SqlAlchemyStore):
     )
 
     with patch(
-        "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+        "mlflow.server.gateway_api._create_provider_from_endpoint_name"
     ) as mock_create_provider:
         mock_provider = MagicMock()
         mock_create_provider.return_value = mock_provider
@@ -555,7 +555,7 @@ async def test_invocations_handler_invalid_embeddings_payload(store: SqlAlchemyS
     )
 
     with patch(
-        "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+        "mlflow.server.gateway_api._create_provider_from_endpoint_name"
     ) as mock_create_provider:
         mock_provider = MagicMock()
         mock_create_provider.return_value = mock_provider
@@ -597,7 +597,7 @@ async def test_invocations_handler_streaming(store: SqlAlchemyStore):
 
     with (
         patch(
-            "mlflow.server.gateway_api._create_provider_from_endpoint_config"
+            "mlflow.server.gateway_api._create_provider_from_endpoint_name"
         ) as mock_create_provider,
         patch(
             "mlflow.server.gateway_api.make_streaming_response",
@@ -616,7 +616,7 @@ async def test_invocations_handler_streaming(store: SqlAlchemyStore):
         assert response == mock_streaming_response
 
 
-def test_create_provider_from_endpoint_config_no_models(store: SqlAlchemyStore):
+def test_create_provider_from_endpoint_name_no_models(store: SqlAlchemyStore):
     # Create a minimal endpoint to get an endpoint_name
     secret = store.create_gateway_secret(
         secret_name="test-key",
@@ -641,4 +641,4 @@ def test_create_provider_from_endpoint_config_no_models(store: SqlAlchemyStore):
         ),
     ):
         with pytest.raises(MlflowException, match="has no models configured"):
-            _create_provider_from_endpoint_config(endpoint.name, store, EndpointType.LLM_V1_CHAT)
+            _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -5,7 +5,6 @@ import pytest
 from fastapi import HTTPException
 
 import mlflow
-from mlflow.environment_variables import MLFLOW_TRACKING_URI
 from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import (
     AWSBaseConfig,

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -25,7 +25,7 @@ from mlflow.server.gateway_api import (
     _create_invocations_handler,
     _create_provider_from_endpoint_config,
     gateway_router,
-    register_gateway_endpoints,
+    _register_gateway_endpoints,
 )
 from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
@@ -349,7 +349,7 @@ def test_register_gateway_endpoints(store: SqlAlchemyStore):
     )
 
     # Register endpoints
-    router = register_gateway_endpoints(store)
+    router = _register_gateway_endpoints(store)
 
     # Check that routes were registered
     route_paths = [route.path for route in router.routes]

--- a/tests/store/tracking/test_gateway_sql_store.py
+++ b/tests/store/tracking/test_gateway_sql_store.py
@@ -971,7 +971,7 @@ def test_get_gateway_endpoint_config(store: SqlAlchemyStore):
     )
 
     config = get_endpoint_config(
-        endpoint_id=endpoint.endpoint_id,
+        endpoint_name=endpoint.name,
         store=store,
     )
 
@@ -1004,7 +1004,7 @@ def test_get_gateway_endpoint_config_with_auth_config(store: SqlAlchemyStore):
     )
 
     config = get_endpoint_config(
-        endpoint_id=endpoint.endpoint_id,
+        endpoint_name=endpoint.name,
         store=store,
     )
 
@@ -1039,7 +1039,7 @@ def test_get_gateway_endpoint_config_multiple_models(store: SqlAlchemyStore):
     )
 
     config = get_endpoint_config(
-        endpoint_id=endpoint.endpoint_id,
+        endpoint_name=endpoint.name,
         store=store,
     )
 
@@ -1053,7 +1053,7 @@ def test_get_gateway_endpoint_config_multiple_models(store: SqlAlchemyStore):
 def test_get_gateway_endpoint_config_nonexistent_endpoint_raises(store: SqlAlchemyStore):
     with pytest.raises(MlflowException, match="not found") as exc:
         get_endpoint_config(
-            endpoint_id="nonexistent-endpoint-id",
+            endpoint_name="nonexistent-endpoint",
             store=store,
         )
     assert exc.value.error_code == ErrorCode.Name(RESOURCE_DOES_NOT_EXIST)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/19290?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19290/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19290/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19290/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add unified invocation endpoint (`/gateway/{endpoint_name}/mlflow/invocations/`) from the endpoints in DB. This PR supports first-class providers (OpenAI, Anthropic, Gemini, Mistral, Bedrock) that are supported in the existing gateway feature and a PR for long-tail providers will be filed as a follow-up.

Verified that following flow works correctly
```python
import mlflow

mlflow.set_tracking_uri("http://localhost:5000")
mlflow.set_experiment("Gateway")
from mlflow.tracking._tracking_service.utils import _get_store

store = _get_store()

secret = store.create_gateway_secret(
    secret_name="openai_api",
    secret_value={"api_key": "<secret>"},
    provider="openai",
)
model_def = store.create_gateway_model_definition(
    name="gpt-5-mini",
    secret_id=secret.secret_id,
    provider="openai",
    model_name="gpt-5-mini",
)
endpoint = store.create_gateway_endpoint(
    name="openai-v1", model_definition_ids=[model_def.model_definition_id]
)
```

```bash
curl -X POST http://localhost:5000/gateway/openai-v1/mlflow/invocations \
 -H "Content-Type: application/json" \
 -d '{
   "messages": [
     {"role": "user", "content": "Hello, how are you?"}
   ],
   "temperature": 1
 }'
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
