### PR TITLE
Remove redundant tracking_uri fixtures from test files

### DIFF
--- a/tests/artifacts/test_artifacts.py
+++ b/tests/artifacts/test_artifacts.py
@@ -7,7 +7,6 @@ import pytest
 
 import mlflow
 from mlflow.exceptions import MlflowException
-from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 from mlflow.utils.file_utils import mkdir, path_to_local_file_uri
 from mlflow.utils.os import is_windows
 
@@ -15,12 +14,6 @@ from mlflow.utils.os import is_windows
 class Artifact(NamedTuple):
     uri: str
     content: str
-
-
-@pytest.fixture(autouse=True)
-def tracking_uri(db_uri: str):
-    with _use_tracking_uri(db_uri):
-        yield
 
 
 @pytest.fixture

--- a/tests/tracing/test_fluent.py
+++ b/tests/tracing/test_fluent.py
@@ -169,18 +169,6 @@ class ErroringStreamTestModel:
         return i
 
 
-@pytest.fixture(autouse=True)
-def tracking_uri(db_uri: str):
-    """Sets the tracking URI for each test."""
-    if IS_TRACING_SDK_ONLY:
-        yield
-        return
-
-    mlflow.set_tracking_uri(db_uri)
-    yield
-    mlflow.set_tracking_uri(None)
-
-
 @pytest.fixture
 def mock_client():
     client = mock.MagicMock()

--- a/tests/tracking/fluent/test_fluent.py
+++ b/tests/tracking/fluent/test_fluent.py
@@ -174,14 +174,6 @@ def create_experiment(
 
 
 @pytest.fixture(autouse=True)
-def tracking_uri(db_uri: str):
-    """Sets the tracking URI for each test."""
-    mlflow.set_tracking_uri(db_uri)
-    yield
-    mlflow.set_tracking_uri(None)
-
-
-@pytest.fixture(autouse=True)
 def reset_experiment_id():
     """
     This fixture resets the active experiment id *after* the execution of the test case in which

--- a/tests/tracking/test_log_image.py
+++ b/tests/tracking/test_log_image.py
@@ -5,15 +5,8 @@ import posixpath
 import pytest
 
 import mlflow
-from mlflow.tracking._tracking_service.utils import _use_tracking_uri
 from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.utils.time import get_current_time_millis
-
-
-@pytest.fixture(autouse=True)
-def tracking_uri(db_uri: str):
-    with _use_tracking_uri(db_uri):
-        yield
 
 
 @pytest.mark.parametrize("subdir", [None, ".", "dir", "dir1/dir2", "dir/.."])

--- a/tests/tracking/test_tracking.py
+++ b/tests/tracking/test_tracking.py
@@ -44,14 +44,6 @@ from mlflow.utils.validation import (
 )
 
 
-@pytest.fixture(autouse=True)
-def tracking_uri(db_uri: str):
-    """Sets the tracking URI for each test."""
-    mlflow.set_tracking_uri(db_uri)
-    yield
-    mlflow.set_tracking_uri(None)
-
-
 class MockExperiment(NamedTuple):
     experiment_id: str
     lifecycle_stage: str


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/harupy/mlflow/pull/19294?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19294/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19294/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19294/merge
```

</p>
</details>

### Related Issues/PRs

#19258

### What changes are proposed in this pull request?

After #19258, `tracking_uri_mock` in `tests/conftest.py` now uses `db_uri` and is `autouse` by default. This makes per-file `tracking_uri` fixtures redundant, so this PR removes them.

### How is this PR tested?

- [x] Existing unit/integration tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)