### PR TITLE
Enable autologging during optimization process

### DIFF
--- a/tests/genai/optimize/test_optimize.py
+++ b/tests/genai/optimize/test_optimize.py
@@ -11,6 +11,7 @@ from mlflow.genai.optimize.types import EvaluationResultRecord, PromptOptimizerO
 from mlflow.genai.prompts import register_prompt
 from mlflow.genai.scorers import scorer
 from mlflow.models.model import PromptVersion
+from mlflow.utils.import_hooks import _post_import_hooks
 
 
 class MockPromptOptimizer(BasePromptOptimizer):
@@ -90,8 +91,6 @@ def sample_summarization_dataset() -> list[dict[str, Any]]:
 
 
 def sample_predict_fn(input_text: str, language: str) -> str:
-    from mlflow.utils.import_hooks import _post_import_hooks
-
     mlflow.genai.load_prompt("prompts:/test_translation_prompt/1")
     translations = {
         ("Hello", "Spanish"): "Hola",

--- a/tests/genai/optimize/test_optimize.py
+++ b/tests/genai/optimize/test_optimize.py
@@ -90,12 +90,17 @@ def sample_summarization_dataset() -> list[dict[str, Any]]:
 
 
 def sample_predict_fn(input_text: str, language: str) -> str:
+    from mlflow.utils.import_hooks import _post_import_hooks
+
     mlflow.genai.load_prompt("prompts:/test_translation_prompt/1")
     translations = {
         ("Hello", "Spanish"): "Hola",
         ("World", "French"): "Monde",
         ("Goodbye", "Spanish"): "Adiós",
     }
+
+    # Verify that auto logging is enabled during the evaluation.
+    assert len(_post_import_hooks) > 0
     return translations.get((input_text, language), f"translated_{input_text}")
 
 


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/TomeHirata/mlflow/pull/19297?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19297/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19297/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19297/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Enable autologging during optimization process to capture more information

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
