### PR TITLE
[UI Telemetry] Add server handlers

### DIFF
--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -159,12 +159,12 @@ def serve_get_logged_model_artifact(model_id: str):
 
 
 @app.route(_add_static_prefix("/ajax-api/2.0/mlflow/ui-telemetry"), methods=["GET"])
-def serve_get_telemetry():
+def serve_get_ui_telemetry():
     return get_ui_telemetry_handler()
 
 
 @app.route(_add_static_prefix("/ajax-api/2.0/mlflow/ui-telemetry"), methods=["POST"])
-def serve_post_telemetry():
+def serve_post_ui_telemetry():
     return post_ui_telemetry_handler()
 
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -158,12 +158,12 @@ def serve_get_logged_model_artifact(model_id: str):
     return get_logged_model_artifact_handler(model_id)
 
 
-@app.route(_add_static_prefix("/ajax-api/2.0/mlflow/ui-telemetry"), methods=["GET"])
+@app.route(_add_static_prefix("/ajax-api/3.0/mlflow/ui-telemetry"), methods=["GET"])
 def serve_get_ui_telemetry():
     return get_ui_telemetry_handler()
 
 
-@app.route(_add_static_prefix("/ajax-api/2.0/mlflow/ui-telemetry"), methods=["POST"])
+@app.route(_add_static_prefix("/ajax-api/3.0/mlflow/ui-telemetry"), methods=["POST"])
 def serve_post_ui_telemetry():
     return post_ui_telemetry_handler()
 

--- a/mlflow/server/__init__.py
+++ b/mlflow/server/__init__.py
@@ -45,6 +45,8 @@ from mlflow.server.handlers import (
     get_metric_history_bulk_interval_handler,
     get_model_version_artifact_handler,
     get_trace_artifact_handler,
+    get_ui_telemetry_handler,
+    post_ui_telemetry_handler,
     upload_artifact_handler,
 )
 from mlflow.utils.os import is_windows
@@ -154,6 +156,16 @@ def serve_get_trace_artifact():
 )
 def serve_get_logged_model_artifact(model_id: str):
     return get_logged_model_artifact_handler(model_id)
+
+
+@app.route(_add_static_prefix("/ajax-api/2.0/mlflow/ui-telemetry"), methods=["GET"])
+def serve_get_telemetry():
+    return get_ui_telemetry_handler()
+
+
+@app.route(_add_static_prefix("/ajax-api/2.0/mlflow/ui-telemetry"), methods=["POST"])
+def serve_post_telemetry():
+    return post_ui_telemetry_handler()
 
 
 # We expect the react app to be built assuming it is hosted at /static-files, so that requests for

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4678,8 +4678,8 @@ def _get_dataset_records_handler(dataset_id):
     return _wrap_response(response_message)
 
 
-# Cache for telemetry config with 24 hour TTL
-_telemetry_config_cache = TTLCache(maxsize=1, ttl=86400)
+# Cache for telemetry config with 3 hour TTL
+_telemetry_config_cache = TTLCache(maxsize=1, ttl=10800)
 
 
 def _get_or_fetch_ui_telemetry_config():

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4678,8 +4678,8 @@ def _get_dataset_records_handler(dataset_id):
     return _wrap_response(response_message)
 
 
-# Cache for telemetry config with 1 hour TTL
-_telemetry_config_cache = TTLCache(maxsize=1, ttl=3600)
+# Cache for telemetry config with 24 hour TTL
+_telemetry_config_cache = TTLCache(maxsize=1, ttl=86400)
 
 
 def _get_or_fetch_ui_telemetry_config():

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -4727,6 +4727,9 @@ def post_ui_telemetry_handler():
         if not data:
             return jsonify({"status": "success"})
 
+        if (client := get_telemetry_client()) is None:
+            return jsonify({"status": "disabled"})
+
         # check cached config to see if telemetry is disabled
         # if so, don't process the records. we don't rely on the
         # config from the telemetry client because it is only fetched
@@ -4750,9 +4753,7 @@ def post_ui_telemetry_handler():
             for event in data
         ]
 
-        # Add record to telemetry client
-        if client := get_telemetry_client():
-            client.add_records(records)
+        client.add_records(records)
 
         return jsonify({"status": "success"})
     except Exception as e:

--- a/mlflow/server/handlers.py
+++ b/mlflow/server/handlers.py
@@ -13,6 +13,7 @@ from functools import partial, wraps
 from typing import Any
 
 import requests
+from cachetools import TTLCache
 from flask import Response, current_app, jsonify, request, send_file
 from google.protobuf import descriptor
 from google.protobuf.json_format import ParseError
@@ -151,6 +152,7 @@ from mlflow.protos.service_pb2 import (
     GetTrace,
     GetTraceInfo,
     GetTraceInfoV3,
+    GetUITelemetryConfig,
     LinkPromptsToTrace,
     LinkTracesToRun,
     ListArtifacts,
@@ -195,6 +197,7 @@ from mlflow.protos.service_pb2 import (
     UpdateGatewayModelDefinition,
     UpdateGatewaySecret,
     UpdateRun,
+    UploadUITelemetryRecords,
     UpsertDatasetRecords,
 )
 from mlflow.protos.service_pb2 import Trace as ProtoTrace
@@ -4670,6 +4673,98 @@ def _get_dataset_records_handler(dataset_id):
     return _wrap_response(response_message)
 
 
+# Cache for telemetry config with 1 hour TTL
+_telemetry_config_cache = TTLCache(maxsize=1, ttl=3600)
+
+
+@catch_mlflow_exception
+def get_ui_telemetry_handler():
+    """
+    GET handler for /telemetry endpoint.
+    Returns the telemetry client configuration by fetching it directly.
+    """
+    from mlflow.telemetry.utils import fetch_ui_telemetry_config
+
+    if "config" in _telemetry_config_cache:
+        config = _telemetry_config_cache["config"]
+    else:
+        config = fetch_ui_telemetry_config()
+        _telemetry_config_cache["config"] = config
+
+    response_message = GetUITelemetryConfig.Response()
+    # UI telemetry should be also disabled if overall telemetry is disabled
+    response_message.disable_ui_telemetry = config.get("disable_ui_telemetry", True) or config.get(
+        "disable_telemetry", True
+    )
+    response_message.disable_ui_events.extend(config.get("disable_ui_events", []))
+    response_message.ui_rollout_percentage = config.get("ui_rollout_percentage", 0)
+    return _wrap_response(response_message)
+
+
+@catch_mlflow_exception
+def post_ui_telemetry_handler():
+    """
+    POST handler for /telemetry endpoint.
+    Accepts telemetry records and adds them to the telemetry client.
+    """
+    from mlflow.telemetry import get_telemetry_client
+    from mlflow.telemetry.schemas import Record, Status
+    from mlflow.telemetry.utils import fetch_ui_telemetry_config
+
+    request_message = _get_request_message(
+        UploadUITelemetryRecords(),
+        schema={
+            "records": [_assert_array],
+        },
+    )
+
+    data = request_message.records
+    if not data:
+        raise MlflowException(
+            message="Request body must contain records.",
+            error_code=INVALID_PARAMETER_VALUE,
+        )
+
+    # check cached config to see if telemetry is disabled
+    # if so, don't process the records. we don't rely on the
+    # config from the telemetry client because it is only fetched
+    # once, so it won't be updated unless the server is restarted.
+    if "config" in _telemetry_config_cache:
+        config = _telemetry_config_cache["config"]
+    else:
+        config = fetch_ui_telemetry_config()
+        _telemetry_config_cache["config"] = config
+
+    response_message = UploadUITelemetryRecords.Response()
+
+    # if updated telemetry config is disabled, tell the UI to stop sending records
+    if config.get("disable_telemetry") or config.get("disable_ui_telemetry"):
+        response_message.status = "disabled"
+        return _wrap_response(response_message)
+
+    records = [
+        Record(
+            event_name=event.event_name,
+            timestamp_ns=event.timestamp_ns,
+            params=dict(event.params),
+            status=Status.SUCCESS,
+            installation_id=event.installation_id,
+            session_id=event.session_id,
+            duration_ms=0,
+        )
+        for event in data
+    ]
+
+    # Add record to telemetry client
+    client = get_telemetry_client()
+    if client is not None:
+        for record in records:
+            client.add_record(record)
+
+    response_message.status = "success"
+    return _wrap_response(response_message)
+
+
 HANDLERS = {
     # Tracking Server APIs
     CreateExperiment: _create_experiment,
@@ -4816,4 +4911,7 @@ HANDLERS = {
     # Endpoint Tags APIs
     SetGatewayEndpointTag: _set_gateway_endpoint_tag,
     DeleteGatewayEndpointTag: _delete_gateway_endpoint_tag,
+    # UI Telemetry APIs
+    GetUITelemetryConfig: get_ui_telemetry_handler,
+    UploadUITelemetryRecords: post_ui_telemetry_handler,
 }

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -140,9 +140,20 @@ class TelemetryClient:
             return
 
         with self._batch_lock:
-            self._pending_records.extend(records)
-            if len(self._pending_records) >= self._batch_size:
-                self._send_batch()
+            # Add records in chunks to ensure we never exceed batch_size
+            offset = 0
+            while offset < len(records):
+                # Calculate how many records we can add to reach batch_size
+                space_left = self._batch_size - len(self._pending_records)
+                chunk_size = min(space_left, len(records) - offset)
+
+                # Add only enough records to reach batch_size
+                self._pending_records.extend(records[offset : offset + chunk_size])
+                offset += chunk_size
+
+                # Send batch if we've reached the limit
+                if len(self._pending_records) >= self._batch_size:
+                    self._send_batch()
 
     def _send_batch(self):
         """Send the current batch of records."""

--- a/mlflow/telemetry/client.py
+++ b/mlflow/telemetry/client.py
@@ -132,6 +132,18 @@ class TelemetryClient:
             if len(self._pending_records) >= self._batch_size:
                 self._send_batch()
 
+    def add_records(self, records: list[Record]):
+        if not self.is_active:
+            self.activate()
+
+        if self._is_stopped:
+            return
+
+        with self._batch_lock:
+            self._pending_records.extend(records)
+            if len(self._pending_records) >= self._batch_size:
+                self._send_batch()
+
     def _send_batch(self):
         """Send the current batch of records."""
         if not self._pending_records:

--- a/tests/server/conftest.py
+++ b/tests/server/conftest.py
@@ -28,6 +28,12 @@ def test_app():
 
 
 @pytest.fixture
+def test_app_context(test_app):
+    with test_app.app_context():
+        yield
+
+
+@pytest.fixture
 def mlflow_app_client():
     """Test client for the MLflow Flask application with security middleware."""
     from flask import Flask

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -2608,9 +2608,10 @@ def test_get_ui_telemetry_handler_disabled_by_config(
         assert mock_fetch.call_count == 1
 
 
-def test_get_ui_telemetry_handler_disabled_by_env(test_app_context, mock_telemetry_config_cache):
-    # by default, telemetry is disabled in tests, so we just
-    # don't use the bypass_telemetry_env_check fixture
+def test_get_ui_telemetry_handler_disabled_by_env(
+    test_app_context, mock_telemetry_config_cache, monkeypatch
+):
+    monkeypatch.setenv("DO_NOT_TRACK", "true")
     with mock.patch("mlflow.telemetry.utils.fetch_ui_telemetry_config") as mock_fetch:
         response = get_ui_telemetry_handler()
         assert response is not None
@@ -2733,7 +2734,10 @@ def test_post_ui_telemetry_handler_telemetry_disabled_by_config(
         mock_client.add_record.assert_not_called()
 
 
-def test_post_ui_telemetry_handler_telemetry_disabled_by_env(test_app, mock_telemetry_config_cache):
+def test_post_ui_telemetry_handler_telemetry_disabled_by_env(
+    test_app, mock_telemetry_config_cache, monkeypatch
+):
+    monkeypatch.setenv("DO_NOT_TRACK", "true")
     request = json.dumps({"records": []})
     with (
         test_app.test_request_context(

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -2609,7 +2609,7 @@ def test_get_ui_telemetry_handler_disabled_by_config(
 
 
 def test_get_ui_telemetry_handler_disabled_by_env(
-    test_app_context, mock_telemetry_config_cache, monkeypatch
+    test_app_context, mock_telemetry_config_cache, bypass_telemetry_env_check, monkeypatch
 ):
     monkeypatch.setenv("DO_NOT_TRACK", "true")
     with mock.patch("mlflow.telemetry.utils.fetch_ui_telemetry_config") as mock_fetch:
@@ -2735,7 +2735,7 @@ def test_post_ui_telemetry_handler_telemetry_disabled_by_config(
 
 
 def test_post_ui_telemetry_handler_telemetry_disabled_by_env(
-    test_app, mock_telemetry_config_cache, monkeypatch
+    test_app, mock_telemetry_config_cache, bypass_telemetry_env_check, monkeypatch
 ):
     monkeypatch.setenv("DO_NOT_TRACK", "true")
     request = json.dumps({"records": []})

--- a/tests/server/test_handlers.py
+++ b/tests/server/test_handlers.py
@@ -236,6 +236,12 @@ def mock_telemetry_config_cache():
         yield m
 
 
+@pytest.fixture
+def bypass_telemetry_disabled(monkeypatch):
+    with mock.patch("mlflow.telemetry.utils.is_telemetry_disabled", return_value=False) as m:
+        yield m
+
+
 def test_health():
     with app.test_client() as c:
         response = c.get("/health")
@@ -2540,7 +2546,7 @@ def test_litellm_not_available():
             assert "LiteLLM is not installed" in data["message"]
 
 
-def test_get_ui_telemetry_handler(mock_telemetry_config_cache):
+def test_get_ui_telemetry_handler(mock_telemetry_config_cache, bypass_telemetry_disabled):
     config = {
         "disable_telemetry": False,
         "disable_ui_telemetry": False,
@@ -2574,7 +2580,9 @@ def test_get_ui_telemetry_handler(mock_telemetry_config_cache):
         assert response_data["ui_rollout_percentage"] == 50.0
 
 
-def test_get_ui_telemetry_handler_disabled(mock_telemetry_config_cache):
+def test_get_ui_telemetry_handler_disabled_by_config(
+    mock_telemetry_config_cache, bypass_telemetry_disabled
+):
     config = {
         "disable_telemetry": True,
         "disable_ui_telemetry": False,
@@ -2582,7 +2590,9 @@ def test_get_ui_telemetry_handler_disabled(mock_telemetry_config_cache):
         "ui_rollout_percentage": 0,
     }
 
-    with mock.patch("mlflow.telemetry.utils.fetch_ui_telemetry_config", return_value=config):
+    with mock.patch(
+        "mlflow.telemetry.utils.fetch_ui_telemetry_config", return_value=config
+    ) as mock_fetch:
         response = get_ui_telemetry_handler()
         assert response is not None
         assert response.status_code == 200
@@ -2594,9 +2604,28 @@ def test_get_ui_telemetry_handler_disabled(mock_telemetry_config_cache):
         assert response_data["ui_rollout_percentage"] == 0.0
         # empty arrays are excluded from the response
         assert "disable_ui_events" not in response_data
+        assert mock_fetch.call_count == 1
 
 
-def test_get_ui_telemetry_handler_fallback_values(mock_telemetry_config_cache):
+def test_get_ui_telemetry_handler_disabled_by_env(mock_telemetry_config_cache):
+    with mock.patch("mlflow.telemetry.utils.fetch_ui_telemetry_config") as mock_fetch:
+        response = get_ui_telemetry_handler()
+        assert response is not None
+        assert response.status_code == 200
+        response_data = json.loads(response.get_data())
+
+        # if telemetry is disabled by env var, the server should always report
+        # that UI telemetry is disabled, and no config fetch should happen
+        mock_fetch.assert_not_called()
+        assert response_data["disable_ui_telemetry"] is True
+        assert response_data["ui_rollout_percentage"] == 0.0
+        # empty arrays are excluded from the response
+        assert "disable_ui_events" not in response_data
+
+
+def test_get_ui_telemetry_handler_fallback_values(
+    mock_telemetry_config_cache, bypass_telemetry_disabled
+):
     config_without_ui_fields = {
         "disable_telemetry": False,
         "rollout_percentage": 100,
@@ -2625,7 +2654,9 @@ def test_get_ui_telemetry_handler_fallback_values(mock_telemetry_config_cache):
         assert response_data["ui_rollout_percentage"] == 0
 
 
-def test_post_ui_telemetry_handler_success(mock_get_request_message, mock_telemetry_config_cache):
+def test_post_ui_telemetry_handler_success(
+    mock_get_request_message, mock_telemetry_config_cache, bypass_telemetry_disabled
+):
     request_msg = UploadUITelemetryRecords()
 
     event1 = request_msg.records.add()
@@ -2663,8 +2694,8 @@ def test_post_ui_telemetry_handler_success(mock_get_request_message, mock_teleme
         assert mock_client.add_record.call_count == 2
 
 
-def test_post_ui_telemetry_handler_telemetry_disabled(
-    mock_get_request_message, mock_telemetry_config_cache
+def test_post_ui_telemetry_handler_telemetry_disabled_by_config(
+    mock_get_request_message, mock_telemetry_config_cache, bypass_telemetry_disabled
 ):
     request_msg = UploadUITelemetryRecords()
 
@@ -2694,3 +2725,26 @@ def test_post_ui_telemetry_handler_telemetry_disabled(
 
         assert response_data["status"] == "disabled"
         mock_client.add_record.assert_not_called()
+
+
+def test_post_ui_telemetry_handler_telemetry_disabled_by_env(
+    mock_get_request_message, mock_telemetry_config_cache
+):
+    # by default, telemetry is disabled in tests, so we just
+    # don't use the bypass_telemetry_disabled fixture
+    with (
+        mock.patch("mlflow.telemetry.utils.fetch_ui_telemetry_config") as mock_fetch,
+        mock.patch("mlflow.telemetry.get_telemetry_client") as mock_get_client,
+    ):
+        response = post_ui_telemetry_handler()
+
+        assert response is not None
+        assert response.status_code == 200
+
+        response_data = json.loads(response.get_data())
+
+        assert response_data["status"] == "disabled"
+
+        # assert that no fetch happens and no client is retrieved
+        mock_fetch.assert_not_called()
+        mock_get_client.assert_not_called()

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -68,25 +68,50 @@ def test_add_record_and_send(mock_telemetry_client: TelemetryClient, mock_reques
 
 
 def test_add_records_and_send(mock_telemetry_client: TelemetryClient, mock_requests):
-    record1 = Record(
-        event_name="test_event_1",
-        timestamp_ns=time.time_ns(),
-        status=Status.SUCCESS,
-    )
+    # Pre-populate pending_records with 200 records
+    initial_records = [
+        Record(
+            event_name=f"initial_{i}",
+            timestamp_ns=time.time_ns(),
+            status=Status.SUCCESS,
+        )
+        for i in range(200)
+    ]
+    mock_telemetry_client.add_records(initial_records)
 
-    record2 = Record(
-        event_name="test_event_2",
-        timestamp_ns=time.time_ns(),
-        status=Status.SUCCESS,
-    )
+    # We haven't hit the batch size limit yet, so expect no records to be sent
+    assert len(mock_telemetry_client._pending_records) == 200
+    assert len(mock_requests) == 0
 
-    mock_telemetry_client.add_records([record1, record2])
+    # Add 1000 more records
+    # Expected behavior:
+    # - First 300 records fill to 500 -> send batch (200 + 300) to queue
+    # - Next 500 records -> send batch to queue
+    # - Last 200 records remain in pending (200 < 500)
+    additional_records = [
+        Record(
+            event_name=f"additional_{i}",
+            timestamp_ns=time.time_ns(),
+            status=Status.SUCCESS,
+        )
+        for i in range(1000)
+    ]
+    mock_telemetry_client.add_records(additional_records)
+
+    # Verify batching logic:
+    # - 2 batches should be in the queue
+    # - 200 records should remain in pending
+    assert mock_telemetry_client._queue.qsize() == 2
+    assert len(mock_telemetry_client._pending_records) == 200
+
+    # Flush to process queue and send the remaining partial batch
     mock_telemetry_client.flush()
-    received_records = mock_requests
 
-    assert len(received_records) == 2
-    assert received_records[0]["data"]["event_name"] == "test_event_1"
-    assert received_records[1]["data"]["event_name"] == "test_event_2"
+    # Verify all 1200 records were sent
+    assert len(mock_requests) == 1200
+    event_names = {req["data"]["event_name"] for req in mock_requests}
+    assert all(f"initial_{i}" in event_names for i in range(200))
+    assert all(f"additional_{i}" in event_names for i in range(1000))
 
 
 def test_record_with_session_and_installation_id(

--- a/tests/telemetry/test_client.py
+++ b/tests/telemetry/test_client.py
@@ -67,6 +67,28 @@ def test_add_record_and_send(mock_telemetry_client: TelemetryClient, mock_reques
     assert data["status"] == "success"
 
 
+def test_add_records_and_send(mock_telemetry_client: TelemetryClient, mock_requests):
+    record1 = Record(
+        event_name="test_event_1",
+        timestamp_ns=time.time_ns(),
+        status=Status.SUCCESS,
+    )
+
+    record2 = Record(
+        event_name="test_event_2",
+        timestamp_ns=time.time_ns(),
+        status=Status.SUCCESS,
+    )
+
+    mock_telemetry_client.add_records([record1, record2])
+    mock_telemetry_client.flush()
+    received_records = mock_requests
+
+    assert len(received_records) == 2
+    assert received_records[0]["data"]["event_name"] == "test_event_1"
+    assert received_records[1]["data"]["event_name"] == "test_event_2"
+
+
 def test_record_with_session_and_installation_id(
     mock_telemetry_client: TelemetryClient, mock_requests
 ):


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19303/files) to review incremental changes.
- [**stack/server-handlers-2**](https://github.com/mlflow/mlflow/pull/19303) [[Files changed](https://github.com/mlflow/mlflow/pull/19303/files)]
  - [stack/service-worker](https://github.com/mlflow/mlflow/pull/19292) [[Files changed](https://github.com/mlflow/mlflow/pull/19292/files/3839eec1bd6eef2e29f18bdfc7ccb413efe79d59..d06c4550cc30389e0ad53f0f195c9188a9853953)]
    - [stack/fe-client](https://github.com/mlflow/mlflow/pull/19312) [[Files changed](https://github.com/mlflow/mlflow/pull/19312/files/d06c4550cc30389e0ad53f0f195c9188a9853953..5deb59ff52d58bdea24c7af33af9e506a290df25)]
      - [stack/settings](https://github.com/mlflow/mlflow/pull/19351) [[Files changed](https://github.com/mlflow/mlflow/pull/19351/files/5deb59ff52d58bdea24c7af33af9e506a290df25..20c89185b4db2687ef239619a61bda1d0d2c9250)]
        - [stack/documentation](https://github.com/mlflow/mlflow/pull/19427) [[Files changed](https://github.com/mlflow/mlflow/pull/19427/files/20c89185b4db2687ef239619a61bda1d0d2c9250..2f0a68fcbc074be49d9362f9c9d01fbd9504fa5c)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR implements the actual handlers that will serve the `/ui-telemetry` GET and POST endpoints.

They are relatively simple, but a few guiding principles:
1. If telemetry is disabled via env vars, these handers must make no fetches and must tell the UI that telemetry is disabled
2. The config is checked in both the GET and POST in case it has been updated between the two requests (e.g. UI fetches the config -> we disable telemetry via config -> UI POSTs logs as it does not know config got updated). In case telemetry is disabled by config, we should not upload logs.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Bug bashed + unit tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
