### PR TITLE
docs: document Plotly tile map limitation in MLflow artifacts viewer

### DIFF
--- a/docs/api_reference/source/python_api/index.rst
+++ b/docs/api_reference/source/python_api/index.rst
@@ -31,3 +31,27 @@ log levels at the
 
     # Set log level to debugging
     logger.setLevel(logging.DEBUG)
+
+Known Limitations
+-----------------
+
+.. note::
+
+   Plotly map figures that rely on external tile sources (e.g. ``mapbox_style``, ``carto-positron``,
+   ``open-street-map``) may show a blank base map when viewed in the MLflow artifacts HTML viewer.
+   The viewer runs in a sandboxed iframe, which blocks external tile server requests (CORS).
+   Legends and choropleth colors still render correctly, but base tiles do not.
+
+   **Workaround:** use a non-tile choropleth that renders fully offline:
+
+   .. code-block:: python
+
+      fig = px.choropleth(
+          df,
+          geojson=counties,
+          locations="fips",
+          color="unemp",
+          scope="usa",
+      )
+      with mlflow.start_run():
+          mlflow.log_figure(fig, "map.html")


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/swetha028-git/mlflow/pull/19304?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19304/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19304/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19304/merge
```

</p>
</details>


Resolve #19298

### What changes are proposed in this pull request?

Documents a limitation where Plotly tile-based maps appear blank in the MLflow artifacts HTML viewer
due to iframe CORS sandbox restrictions. Adds workaround using non-tile choropleth rendering.

### How is this PR tested?

- [x] Manual tests

### Does this PR require documentation update?

- [x] Yes. I've updated:
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] Yes. A user-facing documentation clarification has been added.

#### What component(s), interfaces, languages, and integrations does this PR affect?

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes?

- [x] `rn/documentation`

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
