### PR TITLE
[Agentic Judges] Add util function to retrieve available tools from trace

### DIFF
--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -23,6 +23,7 @@ from mlflow.genai.utils.trace_utils import (
     _does_store_support_trace_linking,
     convert_predict_fn,
     create_minimal_trace,
+    extract_available_tools_from_trace,
     extract_expectations_from_trace,
     extract_inputs_from_trace,
     extract_outputs_from_trace,
@@ -34,6 +35,7 @@ from mlflow.genai.utils.trace_utils import (
     parse_tool_calls_from_trace,
     resolve_conversation_from_session,
 )
+from mlflow.tracing import set_span_chat_tools
 from mlflow.tracing.utils import build_otel_context
 
 from tests.tracing.helper import create_test_trace_info, get_traces, purge_traces
@@ -955,3 +957,212 @@ def test_convert_predict_fn_async_function_with_timeout(monkeypatch):
         converted_fn(request=sample_input)
 
     assert len(get_traces()) == 0
+
+
+@pytest.mark.parametrize(
+    ("span_type", "use_attribute", "tool_name", "tool_description"),
+    [
+        ("LLM", True, "get_weather", "Get current weather"),
+        ("CHAT_MODEL", False, "search", "Search the web"),
+    ],
+)
+def test_extract_available_tools_from_trace_basic(
+    span_type, use_attribute, tool_name, tool_description
+):
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": tool_name,
+                "description": tool_description,
+                "parameters": {"type": "object", "properties": {"param": {"type": "string"}}},
+            },
+        }
+    ]
+
+    with mlflow.start_span(name="test_span", span_type=span_type) as span:
+        if use_attribute:
+            set_span_chat_tools(span, tools)
+            span.set_inputs({"prompt": "test"})
+        else:
+            span.set_inputs({"messages": [{"role": "user", "content": "test"}], "tools": tools})
+        span.set_outputs({"response": "result"})
+
+    trace = mlflow.get_trace(span.trace_id)
+    extracted_tools = extract_available_tools_from_trace(trace)
+
+    assert len(extracted_tools) == 1
+    assert extracted_tools[0].function.name == tool_name
+    assert extracted_tools[0].function.description == tool_description
+
+
+def test_extract_available_tools_from_trace_with_multiple_spans():
+    tool1 = [
+        {
+            "type": "function",
+            "function": {
+                "name": "add",
+                "description": "Add two numbers",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "a": {"type": "number"},
+                        "b": {"type": "number"},
+                    },
+                },
+            },
+        }
+    ]
+
+    tool2 = [
+        {
+            "type": "function",
+            "function": {
+                "name": "multiply",
+                "description": "Multiply two numbers",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "x": {"type": "number"},
+                        "y": {"type": "number"},
+                    },
+                },
+            },
+        }
+    ]
+
+    with mlflow.start_span(name="parent") as parent:
+        with mlflow.start_span(name="llm1", span_type="LLM") as span1:
+            set_span_chat_tools(span1, tool1)
+
+        with mlflow.start_span(name="llm2", span_type="CHAT_MODEL") as span2:
+            set_span_chat_tools(span2, tool2)
+
+    trace = mlflow.get_trace(parent.trace_id)
+    extracted_tools = extract_available_tools_from_trace(trace)
+
+    assert len(extracted_tools) == 2
+    tool_names = [t.function.name for t in extracted_tools]
+    assert "add" in tool_names
+    assert "multiply" in tool_names
+
+
+def test_extract_available_tools_from_trace_deduplication():
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather info",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    with mlflow.start_span(name="parent") as parent:
+        with mlflow.start_span(name="llm1", span_type="LLM") as span1:
+            set_span_chat_tools(span1, tools)
+
+        with mlflow.start_span(name="llm2", span_type="LLM") as span2:
+            set_span_chat_tools(span2, tools)  # Same tool
+
+    trace = mlflow.get_trace(parent.trace_id)
+    extracted_tools = extract_available_tools_from_trace(trace)
+
+    # Should only return 1 tool despite being in 2 spans
+    assert len(extracted_tools) == 1
+    assert extracted_tools[0].function.name == "get_weather"
+
+
+def test_extract_available_tools_from_trace_different_descriptions():
+    tool1 = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search the web",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    tool2 = [
+        {
+            "type": "function",
+            "function": {
+                "name": "search",
+                "description": "Search the database",  # Different description
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+    with mlflow.start_span(name="parent") as parent:
+        with mlflow.start_span(name="llm1", span_type="LLM") as span1:
+            set_span_chat_tools(span1, tool1)
+
+        with mlflow.start_span(name="llm2", span_type="LLM") as span2:
+            set_span_chat_tools(span2, tool2)
+
+    trace = mlflow.get_trace(parent.trace_id)
+    extracted_tools = extract_available_tools_from_trace(trace)
+
+    # Should return 2 tools since descriptions are different
+    assert len(extracted_tools) == 2
+    descriptions = [t.function.description for t in extracted_tools]
+    assert "Search the web" in descriptions
+    assert "Search the database" in descriptions
+
+
+@pytest.mark.parametrize(
+    "trace_fixture",
+    [
+        None,
+        Trace(info=create_test_trace_info(trace_id="tr-123"), data=None),
+        Trace(info=create_test_trace_info(trace_id="tr-456"), data=TraceData(spans=[])),
+    ],
+)
+def test_extract_available_tools_from_trace_returns_empty(trace_fixture):
+    result = extract_available_tools_from_trace(trace_fixture)
+    assert result == []
+
+
+@pytest.mark.parametrize(
+    ("has_valid_tool", "expected_count"),
+    [
+        (False, 0),  # Only invalid tools
+        (True, 1),  # Mix of valid and invalid tools
+    ],
+)
+def test_extract_available_tools_from_trace_with_invalid_tools(has_valid_tool, expected_count):
+    with mlflow.start_span(name="parent") as parent:
+        if has_valid_tool:
+            valid_tool = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "valid_tool",
+                        "description": "A valid tool",
+                    },
+                }
+            ]
+            with mlflow.start_span(name="llm1", span_type="LLM") as span1:
+                set_span_chat_tools(span1, valid_tool)
+
+        with mlflow.start_span(name="llm2", span_type="LLM") as span2:
+            span2.set_inputs(
+                {
+                    "messages": [{"role": "user", "content": "test"}],
+                    "tools": [
+                        {"invalid": "tool"},  # Missing required fields
+                        {"type": "function"},  # Missing function field
+                    ],
+                }
+            )
+
+    trace = mlflow.get_trace(parent.trace_id)
+    extracted_tools = extract_available_tools_from_trace(trace)
+
+    assert len(extracted_tools) == expected_count
+    if has_valid_tool:
+        assert extracted_tools[0].function.name == "valid_tool"


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19307/files) to review incremental changes.
- [**stack/ML-59978-add-util-to-retrieve-available-tools-from-trace**](https://github.com/mlflow/mlflow/pull/19307) [[Files changed](https://github.com/mlflow/mlflow/pull/19307/files)]
  - [stack/ML-59978-add-fallback-for-available-tools-retrieval-using-llm](https://github.com/mlflow/mlflow/pull/19322) [[Files changed](https://github.com/mlflow/mlflow/pull/19322/files/5947b9eb67465496baa2f557957fa797b3ef5c77..60d87c0e25fb9a7c284f286882791f9e1b0ac3aa)]
    - [stack/ML-59978-introduce-tool-call-efficiency-builtin-judge](https://github.com/mlflow/mlflow/pull/19358) [[Files changed](https://github.com/mlflow/mlflow/pull/19358/files/60d87c0e25fb9a7c284f286882791f9e1b0ac3aa..cd095ba2a83df1e173d4bafdd795b1c2a41e2edd)]
      - [stack/agentic-judges-introduce-tool-call-correctness-builtin-judge](https://github.com/mlflow/mlflow/pull/19391) [[Files changed](https://github.com/mlflow/mlflow/pull/19391/files/cd095ba2a83df1e173d4bafdd795b1c2a41e2edd..8e5e8c1be23a8265219e4fa2632bec4743e87fe1)]
        - [stack/agentic-judges-support-expectation-comparison-for-tool-call-correctness](https://github.com/mlflow/mlflow/pull/19413) [[Files changed](https://github.com/mlflow/mlflow/pull/19413/files/8e5e8c1be23a8265219e4fa2632bec4743e87fe1..0c95c8fc9e4874648b34775e8ffe4db221af4003)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
#### Context
We would like to introduce a few new built-in agentic judges which will be able to evaluate the correctness and the efficiency of the tool use by the agent. These judges require us to be able to parse the tools available to the agent from the traces. Currently this information is captured by autolog, ie. in the "LLM" span types and we have existing logic from the frontend to parse the tool information from these spans.

#### This PR
Adds a python util function to parse `available_tools` from the trace by mirroring the logic from the frontend code.
The new util will take a trace as input and return a list of `ChatTool` objects which contains tool name, description, etc.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

#### Unit test
Added new unit tests in `tests/genai/utils/test_trace_utils.py`

#### Manual Testing
Tested with langchain and openai agents:
```
==================== Lanchain Agent ====================
Tool Available 1: type='function' function=FunctionToolDefinition(name='calculator', description="Performs basic mathematical operations. \n\n    Args:\n        operation: A mathematical expression like '5 + 3' or '10 * 2'", parameters=FunctionParams(properties={'operation': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['operation'], additionalProperties=None), strict=None)

Tool Available 2: type='function' function=FunctionToolDefinition(name='get_word_length', description='Returns the length of a given word.\n\n    Args:\n        word: The word to count characters in', parameters=FunctionParams(properties={'word': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['word'], additionalProperties=None), strict=None)

Tool Available 3: type='function' function=FunctionToolDefinition(name='reverse_string', description='Reverses the given text.\n\n    Args:\n        text: The text to reverse', parameters=FunctionParams(properties={'text': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['text'], additionalProperties=None), strict=None)

==================== OpenAI Agent ====================
Tool Available 1: type='function' function=FunctionToolDefinition(name='_calculator', description='Performs basic mathematical operations.', parameters=FunctionParams(properties={'operation': ParamProperty(type='string', description="A mathematical expression like '5 + 3' or '10 * 2'", enum=None, items=None)}, type='object', required=['operation'], additionalProperties=False), strict=True)

Tool Available 2: type='function' function=FunctionToolDefinition(name='_get_word_length', description='Returns the length of a given word.', parameters=FunctionParams(properties={'word': ParamProperty(type='string', description='The word to count characters in', enum=None, items=None)}, type='object', required=['word'], additionalProperties=False), strict=True)

Tool Available 3: type='function' function=FunctionToolDefinition(name='_reverse_string', description='Reverses the given text.', parameters=FunctionParams(properties={'text': ParamProperty(type='string', description='The text to reverse', enum=None, items=None)}, type='object', required=['text'], additionalProperties=False), strict=True)
```

Also tested with @dbczumar 's mlflow agent:
```
        response = litellm.completion(
            model=llm_config.model,
            messages=litellm_messages,
            tools=tools if tools else None,
            tool_choice="auto" if tools else None,
            **llm_config.litellm_params,
        )

        trace_id = mlflow.get_last_active_trace_id()

        if trace_id:
            trace = mlflow.get_trace(trace_id)

        for i, available_tool in enumerate(extract_available_tools_from_trace(trace)):
            print(f"=====\nAvailable Tool\n {i}: {available_tool}")
```

returns the following
```
=====
Available Tool 0 
: type='function' function=FunctionToolDefinition(name='get_team_info', description='Get information about MLflow teams, their JIRA projects, components, and sprint names. Use this tool to look up correct team names, JIRA component field values, ES component mappings, and sprint naming conventions. Essential for constructing accurate JIRA queries.', parameters=FunctionParams(properties={}, type='object', required=None, additionalProperties=None), strict=None)
=====
Available Tool 1 
: type='function' function=FunctionToolDefinition(name='doc_search', description='Search ingested documentation for relevant information. Use this to find specific details from MLflow documentation, guides, API references, and other ingested sources. Returns the most relevant documentation chunks with full page content.', parameters=FunctionParams(properties={'query': ParamProperty(type='string', description='The search query for finding relevant documentation', enum=None, items=None), 'top_k': ParamProperty(type='integer', description='Number of top results to return (default: 5)', enum=None, items=None)}, type='object', required=['query'], additionalProperties=None), strict=None)
=====
Available Tool 2 
: type='function' function=FunctionToolDefinition(name='open_url', description="Open a URL in the system's default browser or application. Use this to open JIRA tickets, documentation pages, GitHub links, or any other web URLs for the user to view.", parameters=FunctionParams(properties={'url': ParamProperty(type='string', description="The URL to open (e.g., 'https://databricks.atlassian.net/browse/ML-12345')", enum=None, items=None)}, type='object', required=['url'], additionalProperties=None), strict=None)
```

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
