### PR TITLE
Support assessment values metrics for boolean and numeric values

### DIFF
--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -207,7 +207,8 @@ def _get_assessment_numeric_value_column(json_column: Column) -> Column:
     return case(
         (json_column == "true", 1.0),
         (json_column == "false", 0.0),
-        # Skip strings, lists, and dicts (JSON objects/arrays)
+        # Skip null, strings, lists, and dicts (JSON null/objects/arrays)
+        (json_column == "null", None),
         (func.substring(json_column, 1, 1).in_(['"', "[", "{"]), None),
         # For numbers, cast to float
         else_=func.cast(json_column, sqlalchemy.Float),

--- a/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
+++ b/mlflow/store/tracking/utils/sql_trace_metrics_utils.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import Column, and_, exists, func, literal_column
+import sqlalchemy
+from sqlalchemy import Column, and_, case, exists, func, literal_column
 from sqlalchemy.orm.query import Query
 
 from mlflow.entities.trace_metrics import (
@@ -72,6 +73,10 @@ ASSESSMENTS_METRICS_CONFIGS: dict[str, TraceMetricsConfig] = {
     AssessmentMetricKey.ASSESSMENT_COUNT: TraceMetricsConfig(
         aggregation_types={AggregationType.COUNT},
         dimensions={"assessment_name", "assessment_value"},
+    ),
+    AssessmentMetricKey.ASSESSMENT_VALUE: TraceMetricsConfig(
+        aggregation_types={AggregationType.AVG, AggregationType.PERCENTILE},
+        dimensions={"assessment_name"},
     ),
 }
 
@@ -184,6 +189,31 @@ def _get_aggregation_expression(aggregation: MetricAggregation, db_type: str, co
             )
 
 
+def _get_assessment_numeric_value_column(json_column: Column) -> Column:
+    """
+    Extract numeric value from JSON-encoded assessment value.
+
+    Handles conversion of JSON primitives to numeric values:
+    - JSON true/false -> 1/0
+    - JSON numbers -> numeric value
+    - other JSON-encoded values -> NULL
+
+    Args:
+        json_column: Column containing JSON-encoded value
+
+    Returns:
+        Column expression that extracts numeric value or NULL for non-numeric values
+    """
+    return case(
+        (json_column == "true", 1.0),
+        (json_column == "false", 0.0),
+        # Skip strings, lists, and dicts (JSON objects/arrays)
+        (func.substring(json_column, 1, 1).in_(['"', "[", "{"]), None),
+        # For numbers, cast to float
+        else_=func.cast(json_column, sqlalchemy.Float),
+    )
+
+
 def _get_column_to_aggregate(view_type: MetricViewType, metric_name: str) -> Column:
     """
     Get the SQL column for the given metric name and view type.
@@ -212,6 +242,8 @@ def _get_column_to_aggregate(view_type: MetricViewType, metric_name: str) -> Col
             match metric_name:
                 case AssessmentMetricKey.ASSESSMENT_COUNT:
                     return SqlAssessments.assessment_id
+                case "assessment_value":
+                    return _get_assessment_numeric_value_column(SqlAssessments.value)
 
     raise MlflowException.invalid_parameter_value(
         f"Unsupported metric name: {metric_name} for view type {view_type}",

--- a/mlflow/tracing/constant.py
+++ b/mlflow/tracing/constant.py
@@ -177,3 +177,4 @@ class AssessmentMetricKey:
     """
 
     ASSESSMENT_COUNT = "assessment_count"
+    ASSESSMENT_VALUE = "assessment_value"

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -2368,7 +2368,7 @@ def test_query_assessment_value_with_null_value(store: SqlAlchemyStore):
     assessment = Feedback(
         trace_id=trace_id,
         name="score",
-        value=12.34,
+        value=12,
         source=AssessmentSource(source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"),
     )
     store.create_assessment(assessment)
@@ -2385,5 +2385,5 @@ def test_query_assessment_value_with_null_value(store: SqlAlchemyStore):
     assert asdict(result[0]) == {
         "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
         "dimensions": {"assessment_name": "score"},
-        "values": {"AVG": 12.34},
+        "values": {"AVG": 12},
     }

--- a/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
+++ b/tests/store/tracking/test_sqlalchemy_store_query_trace_metrics.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 import pytest
 
 from mlflow.entities import (
+    Assessment,
     AssessmentSource,
     AssessmentSourceType,
     Expectation,
@@ -259,19 +260,19 @@ def test_query_trace_metrics_latency_avg(store: SqlAlchemyStore):
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="latency",
+        metric_name=TraceMetricKey.LATENCY,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
         dimensions=["name"],
     )
 
     assert len(result) == 2
     assert asdict(result[0]) == {
-        "metric_name": "latency",
+        "metric_name": TraceMetricKey.LATENCY,
         "dimensions": {"name": "workflow_a"},
         "values": {"AVG": 200.0},
     }
     assert asdict(result[1]) == {
-        "metric_name": "latency",
+        "metric_name": TraceMetricKey.LATENCY,
         "dimensions": {"name": "workflow_b"},
         "values": {"AVG": 200.0},
     }
@@ -309,7 +310,7 @@ def test_query_trace_metrics_latency_percentiles(
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="latency",
+        metric_name=TraceMetricKey.LATENCY,
         aggregations=[
             MetricAggregation(
                 aggregation_type=AggregationType.PERCENTILE, percentile_value=percentile_value
@@ -328,12 +329,12 @@ def test_query_trace_metrics_latency_percentiles(
 
     assert len(result) == 2
     assert asdict(result[0]) == {
-        "metric_name": "latency",
+        "metric_name": TraceMetricKey.LATENCY,
         "dimensions": {"name": "workflow_a"},
         "values": {f"P{percentile_value}": expected_workflow_a},
     }
     assert asdict(result[1]) == {
-        "metric_name": "latency",
+        "metric_name": TraceMetricKey.LATENCY,
         "dimensions": {"name": "workflow_b"},
         "values": {f"P{percentile_value}": expected_workflow_b},
     }
@@ -364,7 +365,7 @@ def test_query_trace_metrics_latency_multiple_aggregations(store: SqlAlchemyStor
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="latency",
+        metric_name=TraceMetricKey.LATENCY,
         aggregations=[
             MetricAggregation(aggregation_type=AggregationType.AVG),
             MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=95),
@@ -379,7 +380,7 @@ def test_query_trace_metrics_latency_multiple_aggregations(store: SqlAlchemyStor
     expected_p99 = _get_expected_percentile_value(store, 99.0, 100.0, 500.0, values)
 
     assert asdict(result[0]) == {
-        "metric_name": "latency",
+        "metric_name": TraceMetricKey.LATENCY,
         "dimensions": {"name": "workflow_a"},
         "values": {"AVG": 300.0, "P95": expected_p95, "P99": expected_p99},
     }
@@ -808,19 +809,19 @@ def test_query_trace_metrics_total_tokens_sum(traces_with_token_usage_setup):
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="total_tokens",
+        metric_name=TraceMetricKey.TOTAL_TOKENS,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
         dimensions=["name"],
     )
 
     assert len(result) == 2
     assert asdict(result[0]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {"name": "workflow_a"},
         "values": {"SUM": 675},
     }
     assert asdict(result[1]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {"name": "workflow_b"},
         "values": {"SUM": 825},
     }
@@ -832,19 +833,19 @@ def test_query_trace_metrics_total_tokens_avg(traces_with_token_usage_setup):
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="total_tokens",
+        metric_name=TraceMetricKey.TOTAL_TOKENS,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
         dimensions=["name"],
     )
 
     assert len(result) == 2
     assert asdict(result[0]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {"name": "workflow_a"},
         "values": {"AVG": 225.0},
     }
     assert asdict(result[1]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {"name": "workflow_b"},
         "values": {"AVG": 412.5},
     }
@@ -857,7 +858,7 @@ def test_query_trace_metrics_total_tokens_percentiles(traces_with_token_usage_se
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="total_tokens",
+        metric_name=TraceMetricKey.TOTAL_TOKENS,
         aggregations=[
             MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=p)
             for p in percentiles
@@ -884,12 +885,12 @@ def test_query_trace_metrics_total_tokens_percentiles(traces_with_token_usage_se
 
     assert len(result) == 2
     assert asdict(result[0]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {"name": "workflow_a"},
         "values": expected_workflow_a_values,
     }
     assert asdict(result[1]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {"name": "workflow_b"},
         "values": expected_workflow_b_values,
     }
@@ -901,7 +902,7 @@ def test_query_trace_metrics_total_tokens_no_dimensions(traces_with_token_usage_
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="total_tokens",
+        metric_name=TraceMetricKey.TOTAL_TOKENS,
         aggregations=[
             MetricAggregation(aggregation_type=AggregationType.SUM),
             MetricAggregation(aggregation_type=AggregationType.AVG),
@@ -910,7 +911,7 @@ def test_query_trace_metrics_total_tokens_no_dimensions(traces_with_token_usage_
 
     assert len(result) == 1
     assert asdict(result[0]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {},
         "values": {"SUM": 1500, "AVG": 300.0},
     }
@@ -933,13 +934,13 @@ def test_query_trace_metrics_total_tokens_without_token_usage(store: SqlAlchemyS
     result = store.query_trace_metrics(
         experiment_ids=[exp_id],
         view_type=MetricViewType.TRACES,
-        metric_name="total_tokens",
+        metric_name=TraceMetricKey.TOTAL_TOKENS,
         aggregations=[MetricAggregation(aggregation_type=AggregationType.SUM)],
     )
 
     assert len(result) == 1
     assert asdict(result[0]) == {
-        "metric_name": "total_tokens",
+        "metric_name": TraceMetricKey.TOTAL_TOKENS,
         "dimensions": {},
         "values": {"SUM": None},
     }
@@ -1823,4 +1824,516 @@ def test_query_assessment_metrics_across_multiple_traces(store: SqlAlchemyStore)
         "metric_name": AssessmentMetricKey.ASSESSMENT_COUNT,
         "dimensions": {"assessment_name": "relevance"},
         "values": {"COUNT": 3},
+    }
+
+
+def test_query_assessment_value_avg_by_name(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_assessment_value_avg_by_name")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    assessments_data = [
+        ("accuracy", 0.8),
+        ("accuracy", 0.9),
+        ("accuracy", 0.85),
+        ("precision", 0.7),
+        ("precision", 0.75),
+        ("quality", "high"),
+    ]
+
+    for name, value in assessments_data:
+        assessment = Feedback(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
+        dimensions=["assessment_name"],
+    )
+
+    assert len(result) == 3
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "accuracy"},
+        "values": {"AVG": pytest.approx(0.85, abs=0.01)},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "precision"},
+        "values": {"AVG": pytest.approx(0.725, abs=0.01)},
+    }
+    # non-numeric value result should be None
+    assert asdict(result[2]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "quality"},
+        "values": {"AVG": None},
+    }
+
+
+def test_query_assessment_value_with_boolean_values(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_assessment_value_with_boolean")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    assessments_data = [
+        ("correctness", True),
+        ("correctness", True),
+        ("correctness", False),
+        ("correctness", True),
+    ]
+
+    for name, value in assessments_data:
+        assessment = Feedback(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
+        dimensions=["assessment_name"],
+    )
+
+    assert len(result) == 1
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "correctness"},
+        "values": {"AVG": pytest.approx(3 / 4, abs=0.01)},
+    }
+
+
+@pytest.mark.parametrize(
+    "percentile_value",
+    [50.0, 75.0, 90.0, 95.0, 99.0],
+)
+def test_query_assessment_value_percentiles(
+    store: SqlAlchemyStore,
+    percentile_value: float,
+):
+    exp_id = store.create_experiment(f"test_assessment_value_p{percentile_value}")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    assessments_data_accuracy = [
+        ("accuracy", 0.1),
+        ("accuracy", 0.2),
+        ("accuracy", 0.3),
+        ("accuracy", 0.4),
+        ("accuracy", 0.5),
+    ]
+    assessments_data_score = [
+        ("score", 10.0),
+        ("score", 20.0),
+        ("score", 30.0),
+    ]
+
+    for name, value in assessments_data_accuracy + assessments_data_score:
+        assessment = Feedback(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[
+            MetricAggregation(
+                aggregation_type=AggregationType.PERCENTILE, percentile_value=percentile_value
+            )
+        ],
+        dimensions=["assessment_name"],
+    )
+
+    accuracy_values = [0.1, 0.2, 0.3, 0.4, 0.5]
+    score_values = [10.0, 20.0, 30.0]
+
+    expected_accuracy = pytest.approx(
+        _get_expected_percentile_value(
+            store, percentile_value, min(accuracy_values), max(accuracy_values), accuracy_values
+        ),
+        abs=0.01,
+    )
+    expected_score = pytest.approx(
+        _get_expected_percentile_value(
+            store, percentile_value, min(score_values), max(score_values), score_values
+        ),
+        abs=0.01,
+    )
+
+    assert len(result) == 2
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "accuracy"},
+        "values": {f"P{percentile_value}": expected_accuracy},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "score"},
+        "values": {f"P{percentile_value}": expected_score},
+    }
+
+
+def test_query_assessment_value_mixed_types(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_assessment_value_mixed_types")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    assessments_data = [
+        ("rating", 5.0),
+        ("rating", 4.5),
+        ("rating", 3.0),
+        ("status", "good"),
+        ("status", "bad"),
+        ("passed", True),
+        ("passed", False),
+        ("passed", True),
+    ]
+
+    for name, value in assessments_data:
+        assessment = Feedback(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
+        dimensions=["assessment_name"],
+    )
+
+    assert len(result) == 3
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "passed"},
+        "values": {"AVG": pytest.approx(2.0 / 3.0, abs=0.01)},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "rating"},
+        "values": {"AVG": pytest.approx(12.5 / 3.0, abs=0.01)},
+    }
+    assert asdict(result[2]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "status"},
+        "values": {"AVG": None},
+    }
+
+
+def test_query_assessment_value_multiple_aggregations(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_assessment_value_multiple_aggs")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    assessments_data = [
+        ("score", 10.0),
+        ("score", 20.0),
+        ("score", 30.0),
+        ("score", 40.0),
+        ("score", 50.0),
+    ]
+
+    for name, value in assessments_data:
+        assessment = Feedback(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[
+            MetricAggregation(aggregation_type=AggregationType.AVG),
+            MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=50),
+            MetricAggregation(aggregation_type=AggregationType.PERCENTILE, percentile_value=95),
+        ],
+        dimensions=["assessment_name"],
+    )
+
+    values = [10.0, 20.0, 30.0, 40.0, 50.0]
+    expected_p50 = pytest.approx(
+        _get_expected_percentile_value(store, 50.0, 10.0, 50.0, values), abs=0.01
+    )
+    expected_p95 = pytest.approx(
+        _get_expected_percentile_value(store, 95.0, 10.0, 50.0, values), abs=0.01
+    )
+
+    assert len(result) == 1
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "score"},
+        "values": {"AVG": 30.0, "P50": expected_p50, "P95": expected_p95},
+    }
+
+
+@pytest.mark.parametrize(
+    "assessment_type",
+    [Feedback, Expectation],
+)
+def test_query_assessment_value_no_dimensions(
+    store: SqlAlchemyStore, assessment_type: type[Assessment]
+):
+    exp_id = store.create_experiment("test_assessment_value_no_dimensions")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    assessments_data = [
+        ("accuracy", 0.8),
+        ("accuracy", 0.9),
+        ("precision", 0.7),
+        ("recall", 0.85),
+    ]
+
+    for name, value in assessments_data:
+        assessment = assessment_type(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
+    )
+
+    assert len(result) == 1
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {},
+        "values": {"AVG": pytest.approx(3.25 / 4, abs=0.01)},
+    }
+
+
+def test_query_assessment_value_with_time_bucket(store: SqlAlchemyStore):
+    exp_id = store.create_experiment("test_assessment_value_time_bucket")
+
+    # Base time in milliseconds (2020-01-01 00:00:00 UTC)
+    base_time_ms = 1577836800000
+    hour_ms = 60 * 60 * 1000
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=base_time_ms,
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    # Create assessments with numeric values at different times
+    assessment_data = [
+        # Hour 0: avg should be (0.8 + 0.9) / 2 = 0.85
+        (base_time_ms, "accuracy", 0.8),
+        (base_time_ms + 10 * 60 * 1000, "accuracy", 0.9),
+        # Hour 1: avg should be (0.7 + 0.75) / 2 = 0.725
+        (base_time_ms + hour_ms, "precision", 0.7),
+        (base_time_ms + hour_ms + 30 * 60 * 1000, "precision", 0.75),
+        # Hour 2: avg should be 0.95
+        (base_time_ms + 2 * hour_ms, "recall", 0.95),
+    ]
+
+    for timestamp, name, value in assessment_data:
+        assessment = Feedback(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            create_time_ms=timestamp,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
+        time_interval_seconds=3600,
+        start_time_ms=base_time_ms,
+        end_time_ms=base_time_ms + 3 * hour_ms,
+    )
+
+    assert len(result) == 3
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {
+            "time_bucket": datetime.fromtimestamp(base_time_ms / 1000, tz=timezone.utc).isoformat()
+        },
+        "values": {"AVG": pytest.approx(0.85, abs=0.01)},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {
+            "time_bucket": datetime.fromtimestamp(
+                (base_time_ms + hour_ms) / 1000, tz=timezone.utc
+            ).isoformat()
+        },
+        "values": {"AVG": pytest.approx(0.725, abs=0.01)},
+    }
+    assert asdict(result[2]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {
+            "time_bucket": datetime.fromtimestamp(
+                (base_time_ms + 2 * hour_ms) / 1000, tz=timezone.utc
+            ).isoformat()
+        },
+        "values": {"AVG": pytest.approx(0.95, abs=0.01)},
+    }
+
+
+@pytest.mark.parametrize(
+    "assessment_type",
+    [Feedback, Expectation],
+)
+def test_query_assessment_invalid_values(store: SqlAlchemyStore, assessment_type: type[Assessment]):
+    exp_id = store.create_experiment("test_assessment_invalid_values")
+
+    trace_id = f"tr-{uuid.uuid4().hex}"
+    trace_info = TraceInfo(
+        trace_id=trace_id,
+        trace_location=trace_location.TraceLocation.from_experiment_id(exp_id),
+        request_time=get_current_time_millis(),
+        execution_duration=100,
+        state=TraceStatus.OK,
+        tags={TraceTagKey.TRACE_NAME: "test_trace"},
+    )
+    store.start_trace(trace_info)
+
+    assessments_data = [
+        ("string_score", json.dumps("test")),
+        ("list_score", json.dumps([1, 2, 3])),
+        ("dict_score", json.dumps({"a": 1, "b": 2})),
+    ]
+
+    for name, value in assessments_data:
+        assessment = assessment_type(
+            trace_id=trace_id,
+            name=name,
+            value=value,
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.HUMAN, source_id="user@test.com"
+            ),
+        )
+        store.create_assessment(assessment)
+
+    result = store.query_trace_metrics(
+        experiment_ids=[exp_id],
+        view_type=MetricViewType.ASSESSMENTS,
+        metric_name=AssessmentMetricKey.ASSESSMENT_VALUE,
+        aggregations=[MetricAggregation(aggregation_type=AggregationType.AVG)],
+        dimensions=["assessment_name"],
+    )
+
+    assert len(result) == 3
+    assert asdict(result[0]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "dict_score"},
+        "values": {"AVG": None},
+    }
+    assert asdict(result[1]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "list_score"},
+        "values": {"AVG": None},
+    }
+    assert asdict(result[2]) == {
+        "metric_name": AssessmentMetricKey.ASSESSMENT_VALUE,
+        "dimensions": {"assessment_name": "string_score"},
+        "values": {"AVG": None},
     }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/serena-ruan/mlflow/pull/19315?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19315/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19315/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19315/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?
Support metrics for assessment values if the value is one of: int, float, boolean.
For other types (string, list[...], dict[...]) this doesn't apply and will return None.

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
