### PR TITLE
[ML-59978] Add util to retrieve tools called from trace

### DIFF
--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -22,7 +22,12 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.genai.utils.data_validation import check_model_prediction
 from mlflow.models.evaluation.utils.trace import configure_autologging_for_evaluation
-from mlflow.tracing.constant import AssessmentMetadataKey, TraceMetadataKey, TraceTagKey
+from mlflow.tracing.constant import (
+    AssessmentMetadataKey,
+    SpanAttributeKey,
+    TraceMetadataKey,
+    TraceTagKey,
+)
 from mlflow.tracing.display import IPythonTraceDisplayHandler
 from mlflow.tracing.utils import TraceJSONEncoder
 from mlflow.tracing.utils.search import traces_to_df
@@ -33,6 +38,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from mlflow.genai.evaluation.entities import EvalItem, EvalResult
+    from mlflow.types.chat import ChatTool
 
 _logger = logging.getLogger(__name__)
 
@@ -758,3 +764,123 @@ def batch_link_traces_to_run(
                 return
 
             _logger.warning(f"Failed to link batch of traces to run: {e}")
+
+
+def extract_available_tools_from_trace(trace: Trace) -> list["ChatTool"]:
+    """
+    Extract available tools from a trace by checking all LLM spans.
+
+    This function mirrors the frontend's getChatToolsFromSpan logic in
+    ModelTraceExplorer.utils.tsx, which extracts tools per-span. It checks all
+    LLM and CHAT_MODEL spans for tools, and returns a deduplicated list
+    of all unique tools found across the trace.
+
+    For each span, it first checks the mlflow.chat.tools attribute, and if not
+    found, falls back to checking the inputs.tools field.
+
+    Args:
+        trace: MLflow trace object
+
+    Returns:
+        List of unique ChatTool objects, or an empty list if no valid tools are found.
+    """
+    if trace is None or trace.data is None:
+        return []
+
+    all_tools = []
+    seen_tool_signatures = set()
+
+    relevant_span_types = [SpanType.LLM, SpanType.CHAT_MODEL]
+
+    for span in trace.data.spans:
+        span_type = span.get_attribute(SpanAttributeKey.SPAN_TYPE)
+        if span_type not in relevant_span_types:
+            continue
+
+        span_tools = _extract_tools_from_span(span)
+
+        for tool in span_tools:
+            if tool.function:
+                tool_signature = _get_tool_signature(tool)
+                if tool_signature not in seen_tool_signatures:
+                    seen_tool_signatures.add(tool_signature)
+                    all_tools.append(tool)
+
+    return all_tools
+
+
+def _get_tool_signature(tool: "ChatTool") -> str:
+    if not tool.function:
+        return ""
+
+    try:
+        tool_dict = tool.function.model_dump()
+    except AttributeError:
+        tool_dict = tool.function.dict()
+
+    return json.dumps(tool_dict, sort_keys=True)
+
+
+def _extract_tools_from_span(span: Span) -> list["ChatTool"]:
+    """
+    Extract tools from a single LLM or CHAT_MODEL span, checking attribute first, then inputs.
+
+    This mirrors the frontend's getChatToolsFromSpan logic exactly, but returns
+    validated ChatTool objects using Pydantic validation.
+
+    Args:
+        span: MLflow span object
+
+    Returns:
+        List of ChatTool objects for this span
+    """
+    # First, try to get tools from the mlflow.chat.tools attribute
+    tools_attribute = span.get_attribute(SpanAttributeKey.CHAT_TOOLS)
+    if tools_attribute is not None:
+        try:
+            # Deserialize if it's a string
+            if isinstance(tools_attribute, str):
+                tools_attribute = json.loads(tools_attribute)
+
+            # Validate and convert to ChatTool objects using Pydantic
+            if isinstance(tools_attribute, list):
+                return _parse_tools_to_chat_tool(tools_attribute)
+        except (json.JSONDecodeError, ValueError, Exception) as e:
+            _logger.debug(f"Failed to parse tools from attribute in span {span.span_id}: {e}")
+
+    # Fall back to checking inputs.tools
+    if span.inputs is not None:
+        try:
+            inputs = _to_dict(span.inputs)
+            if isinstance(inputs, dict) and "tools" in inputs:
+                tools_from_inputs = inputs["tools"]
+                if isinstance(tools_from_inputs, list):
+                    return _parse_tools_to_chat_tool(tools_from_inputs)
+        except (ValueError, TypeError, Exception) as e:
+            _logger.debug(f"Failed to parse tools from inputs in span {span.span_id}: {e}")
+
+    return []
+
+
+def _parse_tools_to_chat_tool(tools_data: list[dict[str, Any]]) -> list["ChatTool"]:
+    """
+    Parse a list of tool dictionaries into ChatTool objects using Pydantic validation.
+
+    Args:
+        tools_data: List of tool dictionaries
+
+    Returns:
+        List of validated ChatTool objects. Invalid tools are skipped with debug logging.
+    """
+    from mlflow.types.chat import ChatTool
+
+    validated_tools = []
+    for data in tools_data:
+        try:
+            tool = ChatTool(**data)
+            validated_tools.append(tool)
+        except Exception as e:
+            _logger.debug(f"Skipping invalid tool {data}: {e}")
+            continue
+
+    return validated_tools

--- a/mlflow/types/chat.py
+++ b/mlflow/types/chat.py
@@ -68,6 +68,11 @@ class ToolCall(BaseModel):
     function: Function
 
 
+class ToolCallOutput(BaseModel):
+    tool_call: ToolCall
+    output: str
+
+
 class ChatMessage(BaseModel):
     """
     A chat request. ``content`` can be a string, or an array of content parts.


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19318/files/f6e361682e27681da5f0e48c026fccd295e39d48..b0beb6de18cbf8ffe39c6223da1525d6143ac585) to review incremental changes.
- [stack/ML-59978-add-util-to-retrieve-available-tools-from-trace](https://github.com/mlflow/mlflow/pull/19307) [[Files changed](https://github.com/mlflow/mlflow/pull/19307/files)]
  - [stack/ML-59978-add-fallback-for-available-tools-retrieval-using-llm](https://github.com/mlflow/mlflow/pull/19322) [[Files changed](https://github.com/mlflow/mlflow/pull/19322/files/f6e361682e27681da5f0e48c026fccd295e39d48..57c863f856032e8b6bd72af3a561cafe83a13576)]
  - [**stack/ML-59978-add-util-to-retrieve-tools-called-from-trace**](https://github.com/mlflow/mlflow/pull/19318) [[Files changed](https://github.com/mlflow/mlflow/pull/19318/files/f6e361682e27681da5f0e48c026fccd295e39d48..b0beb6de18cbf8ffe39c6223da1525d6143ac585)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Unit Testing
Added several new unit tests under `test_trace_utils.py`

#### Manual Testing
Built two simple agents with langchain and openai agent and verified that the parsing works for their traces

**Input**
```
    print("==================== Lanchain Agent ====================")    
    trace = mlflow.get_trace('tr-ea4cea45a3499c8e460509c88a65c5c3')

    available_tools = extract_available_tools_from_trace(trace)
    available_tools_list = list(available_tools)

    if len(available_tools_list) == 0:
        print("No tools were called in this trace")
    else:
        for i, tool in enumerate(available_tools_list):
            print(f"=====\nTool Available {i + 1}: {tool}")

    tools_called = extract_tools_called_from_trace(trace)
    tools_called_list = list(tools_called)

    if len(tools_called_list) == 0:
        print("No tools were called in this trace")
    else:
        for i, tool_call in enumerate(tools_called_list):
            print(f"=====\nTool Called {i + 1}: {tool_call}")


    print("==================== OpenAI Agent ====================")
    trace = mlflow.get_trace('tr-145e73fae5fa8f55a8c888c34658f7a4')

    available_tools = extract_available_tools_from_trace(trace)
    available_tools_list = list(available_tools)

    if len(available_tools_list) == 0:
        print("No tools were called in this trace")
    else:
        for i, tool in enumerate(available_tools_list):
            print(f"=====\nTool Available {i + 1}: {tool}")

    tools_called = extract_tools_called_from_trace(trace)
    tools_called_list = list(tools_called)

    if len(tools_called_list) == 0:
        print("No tools were called in this trace")
    else:
        for i, tool_call in enumerate(tools_called_list):
            print(f"=====\nTool Called {i + 1}: {tool_call}")
```

**Output**
```
==================== Lanchain Agent ====================
=====
Tool Available 1: type='function' function=FunctionToolDefinition(name='calculator', description="Performs basic mathematical operations. \n\n    Args:\n        operation: A mathematical expression like '5 + 3' or '10 * 2'", parameters=FunctionParams(properties={'operation': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['operation'], additionalProperties=None), strict=None)
=====
Tool Available 2: type='function' function=FunctionToolDefinition(name='get_word_length', description='Returns the length of a given word.\n\n    Args:\n        word: The word to count characters in', parameters=FunctionParams(properties={'word': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['word'], additionalProperties=None), strict=None)
=====
Tool Available 3: type='function' function=FunctionToolDefinition(name='reverse_string', description='Reverses the given text.\n\n    Args:\n        text: The text to reverse', parameters=FunctionParams(properties={'text': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['text'], additionalProperties=None), strict=None)
=====
Tool Called 1: tool_call=ToolCall(id='call_Q8vvmWJs72ll2VJahCw8uzUu', type='function', function=Function(name='calculator', arguments='{\n  "operation": "15 + 27"\n}')) output='The result is: 42'
=====
Tool Called 2: tool_call=ToolCall(id='call_EjX2UnIBW6WJokFMiCiqZB3W', type='function', function=Function(name='reverse_string', arguments='{\n  "text": "42"\n}')) output='Reversed: 24'
==================== OpenAI Agent ====================
=====
Tool Available 1: type='function' function=FunctionToolDefinition(name='_calculator', description='Performs basic mathematical operations.', parameters=FunctionParams(properties={'operation': ParamProperty(type='string', description="A mathematical expression like '5 + 3' or '10 * 2'", enum=None, items=None)}, type='object', required=['operation'], additionalProperties=False), strict=True)
=====
Tool Available 2: type='function' function=FunctionToolDefinition(name='_get_word_length', description='Returns the length of a given word.', parameters=FunctionParams(properties={'word': ParamProperty(type='string', description='The word to count characters in', enum=None, items=None)}, type='object', required=['word'], additionalProperties=False), strict=True)
=====
Tool Available 3: type='function' function=FunctionToolDefinition(name='_reverse_string', description='Reverses the given text.', parameters=FunctionParams(properties={'text': ParamProperty(type='string', description='The text to reverse', enum=None, items=None)}, type='object', required=['text'], additionalProperties=False), strict=True)
=====
Tool Called 1: tool_call=ToolCall(id='call_dNypwGI1VXliD3CjsfXIxarW', type='function', function=Function(name='_calculator', arguments='{"operation":"15 + 27"}')) output='The result is: 42'
=====
Tool Called 2: tool_call=ToolCall(id='call_6VNx5vaH05jvIg7W4IhsFbxX', type='function', function=Function(name='_reverse_string', arguments='{"text":"42"}')) output='Reversed: 24'
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
