### PR TITLE
[Agentic Judges] Add fallback retrieval for available tools using LLM

### DIFF
--- a/mlflow/genai/utils/prompts/available_tools_extraction.py
+++ b/mlflow/genai/utils/prompts/available_tools_extraction.py
@@ -1,0 +1,104 @@
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from mlflow.types.llm import ChatMessage
+
+AVAILABLE_TOOLS_EXTRACTION_SYSTEM_PROMPT = """You are an expert in analyzing agent execution traces.
+Your task is to examine an MLflow trace and identify all tools or functions that were
+available to the LLM, not which tools were actually called.
+
+CRITICAL: You MUST return ONLY valid JSON matching the schema below.
+Do NOT return explanations, comments, or natural language. Return ONLY the JSON object.
+
+## How You Should Analyze the Trace
+Use the tools available to you to thoroughly inspect the trace:
+1. Use list_spans
+Retrieve the list of spans in the trace. Each span may contain tool definitions in
+attributes or inputs.
+
+2. Use GetSpanTool
+For any span returned by list_spans, inspect its content—especially:
+- inputs
+- attributes
+- metadata
+These may include tool definitions or schemas given to the LLM.
+
+3. Use SearchTraceRegexTool
+Search the trace for keywords commonly associated with tool definitions, such as:
+- "definition"
+- "schema"
+- "tool"
+- "parameters"
+- "functions"
+Use these results to locate spans likely to contain tool schemas.
+
+You must base your findings only on information contained in the trace.
+Do not rely on or confuse the tools that you can use (like list_spans or GetSpanTool)
+with the tools that were available to the LLM inside the trace. Only identify tools that
+the trace itself shows were provided to the LLM.
+
+## What to Look For
+Search the trace for tool definitions or schemas that were provided to the LLM,
+regardless of where they appear (span attributes, inputs, metadata, etc.).
+
+A "tool definition" includes:
+- The tool/function name
+- An optional description
+- An optional JSON schema for parameters
+
+## Required Output Format
+You MUST return a valid JSON object in exactly this format:
+
+{output_example}
+
+For every tool definition found, extract and return:
+- type — Always "function"
+- function.name — The tool's name (required)
+- function.description — A description of the tool (use empty string "" if not available)
+- function.parameters — The JSON parameter schema (use empty object {{}} if not available)
+
+## Rules
+- Return ONLY valid JSON. No explanations, no markdown, no comments.
+- Return only unique tools. Two tool definitions should be treated as duplicates if
+  any of the following are true: Their tool names/descriptions/parameter schemas are
+  identical or nearly identical.
+- If no tool definitions are present in the trace, return: {{"tools": []}}
+- Only identify tools that the trace explicitly provides; do not infer or invent tools.
+"""
+
+AVAILABLE_TOOLS_EXTRACTION_USER_PROMPT = """
+Please analyze the trace with the tools available to you and return the tools that were
+available to the LLM in the trace.
+
+Remember: respond with ONLY valid JSON matching the schema provided.
+- Use double quotes for all property names and string values.
+- Do not include comments, trailing commas, or explanatory text.
+- Do not wrap the JSON in markdown (no ``` blocks).
+- Do not include any text before or after the JSON.
+- The response must be directly parseable by json.loads().
+
+If no tools are found, return {"tools": []}.
+"""
+
+
+def get_available_tools_extraction_prompts(
+    output_example: str,
+) -> list["ChatMessage"]:
+    """
+    Generate system and user prompts for extracting available tools from a trace.
+
+    Args:
+        output_example: JSON string example of the expected output format.
+
+    Returns:
+        A list of chat messages [system_message, user_message] for tool extraction.
+    """
+    from mlflow.types.llm import ChatMessage
+
+    system_prompt = AVAILABLE_TOOLS_EXTRACTION_SYSTEM_PROMPT.format(output_example=output_example)
+    user_prompt = AVAILABLE_TOOLS_EXTRACTION_USER_PROMPT
+
+    system_message = ChatMessage(role="system", content=system_prompt)
+    user_message = ChatMessage(role="user", content=user_prompt)
+
+    return [system_message, user_message]

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any, Callable
 
 from cachetools.func import cached
 from opentelemetry.trace import NoOpTracer
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 import mlflow
 from mlflow.entities.assessment_source import AssessmentSourceType
@@ -20,7 +20,11 @@ from mlflow.environment_variables import (
     MLFLOW_GENAI_EVAL_SKIP_TRACE_VALIDATION,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.utils import get_chat_completions_with_structured_output
 from mlflow.genai.utils.data_validation import check_model_prediction
+from mlflow.genai.utils.prompts.available_tools_extraction import (
+    get_available_tools_extraction_prompts,
+)
 from mlflow.models.evaluation.utils.trace import configure_autologging_for_evaluation
 from mlflow.tracing.constant import (
     AssessmentMetadataKey,
@@ -771,27 +775,38 @@ def batch_link_traces_to_run(
             _logger.warning(f"Failed to link batch of traces to run: {e}")
 
 
-def extract_available_tools_from_trace(trace: Trace) -> list["ChatTool"]:
+class ExtractedToolsFromTrace(BaseModel):
+    tools: list["ChatTool"] = Field(
+        default_factory=list,
+        description="List of all available tools found in the trace",
+    )
+
+    model_config = {"extra": "forbid"}
+
+
+def extract_available_tools_from_trace(trace: Trace, model: str | None = None) -> list["ChatTool"]:
     """
     Extract available tools from a trace by checking all LLM spans.
 
-    This function mirrors the frontend's getChatToolsFromSpan logic in
-    ModelTraceExplorer.utils.tsx, which extracts tools per-span. It checks all
-    LLM and CHAT_MODEL spans for tools, and returns a deduplicated list
-    of all unique tools found across the trace.
+    This function uses a two-stage approach:
+    1. Programmatic extraction: Checks all LLM and CHAT_MODEL spans for tools in
+       attributes (mlflow.chat.tools) and inputs (inputs.tools field).
+    2. LLM fallback: If no tools are found programmatically, uses an LLM to analyze
+       the trace and identify tool definitions.
 
-    For each span, it first checks the mlflow.chat.tools attribute, and if not
-    found, falls back to checking the inputs.tools field.
+    The programmatic approach mirrors the frontend's getChatToolsFromSpan logic in
+    ModelTraceExplorer.utils.tsx, which extracts tools per-span and returns a
+    deduplicated list of all unique tools found across the trace.
 
     Args:
         trace: MLflow trace object
+        model: Optional model URI to use for LLM-based fallback extraction
+               (e.g., "openai:/gpt-4"). If None, uses a default model.
 
     Returns:
         List of unique ChatTool objects, or an empty list if no valid tools are found.
     """
-    if trace is None or trace.data is None:
-        return []
-
+    # Stage 1: Programmatic extraction from span attributes and inputs
     all_tools = []
     seen_tool_signatures = set()
 
@@ -811,7 +826,11 @@ def extract_available_tools_from_trace(trace: Trace) -> list["ChatTool"]:
                     seen_tool_signatures.add(tool_signature)
                     all_tools.append(tool)
 
-    return all_tools
+    if all_tools:
+        return all_tools
+
+    # Stage 2: LLM fallback when programmatic extraction yields no results
+    return _try_extract_available_tools_with_llm(trace, model)
 
 
 def _get_tool_signature(tool: "ChatTool") -> str:
@@ -839,29 +858,21 @@ def _extract_tools_from_span(span: Span) -> list["ChatTool"]:
     Returns:
         List of ChatTool objects for this span
     """
-    # First, try to get tools from the mlflow.chat.tools attribute
     tools_attribute = span.get_attribute(SpanAttributeKey.CHAT_TOOLS)
     if tools_attribute is not None:
         try:
-            # Deserialize if it's a string
             if isinstance(tools_attribute, str):
                 tools_attribute = json.loads(tools_attribute)
-
-            # Validate and convert to ChatTool objects using Pydantic
-            if isinstance(tools_attribute, list):
-                return _parse_tools_to_chat_tool(tools_attribute)
-        except (json.JSONDecodeError, ValueError, Exception) as e:
+            return _parse_tools_to_chat_tool(tools_attribute)
+        except Exception as e:
             _logger.debug(f"Failed to parse tools from attribute in span {span.span_id}: {e}")
 
-    # Fall back to checking inputs.tools
     if span.inputs is not None:
         try:
             inputs = _to_dict(span.inputs)
-            if isinstance(inputs, dict) and "tools" in inputs:
-                tools_from_inputs = inputs["tools"]
-                if isinstance(tools_from_inputs, list):
-                    return _parse_tools_to_chat_tool(tools_from_inputs)
-        except (ValueError, TypeError, Exception) as e:
+            if "tools" in inputs:
+                return _parse_tools_to_chat_tool(inputs["tools"])
+        except Exception as e:
             _logger.debug(f"Failed to parse tools from inputs in span {span.span_id}: {e}")
 
     return []
@@ -886,6 +897,81 @@ def _parse_tools_to_chat_tool(tools_data: list[dict[str, Any]]) -> list["ChatToo
             validated_tools.append(tool)
         except Exception as e:
             _logger.debug(f"Skipping invalid tool {data}: {e}")
-            continue
 
     return validated_tools
+
+
+def _try_extract_available_tools_with_llm(
+    trace: Trace, model: str | None = None
+) -> list["ChatTool"]:
+    """
+    Attempt to extract available tools from trace using LLM with structured output.
+
+    This is a fallback method when programmatic extraction fails. It uses an LLM to
+    analyze the trace and identify tool definitions that were available to the agent.
+
+    Args:
+        trace: MLflow trace object to analyze
+        model: Optional model URI to use for extraction (e.g., "openai:/gpt-4").
+               If None, uses a default model.
+
+    Returns:
+        List of ChatTool objects extracted by the LLM, or empty list if extraction fails.
+    """
+    if model is None:
+        if is_databricks_uri(mlflow.get_tracking_uri()):
+            # TODO: Add support for Databricks tool extraction with LLM fallback.
+            _logger.warning("Databricks is not supported for tool extraction with LLM fallback.")
+            return []
+        else:
+            model = "openai:/gpt-4.1-mini"
+
+    try:
+        from mlflow.types.chat import (
+            ChatTool,
+            FunctionParams,
+            FunctionToolDefinition,
+            ParamProperty,
+        )
+
+        output_example = json.dumps(
+            ExtractedToolsFromTrace(
+                tools=[
+                    ChatTool(
+                        type="function",
+                        function=FunctionToolDefinition(
+                            name="example_tool",
+                            description="Description of what the tool does",
+                            parameters=FunctionParams(
+                                type="object",
+                                properties={
+                                    "param1": ParamProperty(
+                                        type="string",
+                                        description="A parameter",
+                                    )
+                                },
+                                required=["param1"],
+                            ),
+                        ),
+                    )
+                ]
+            ).model_dump(),
+            indent=2,
+        )
+
+        messages = get_available_tools_extraction_prompts(output_example)
+
+        result = get_chat_completions_with_structured_output(
+            model_uri=model,
+            messages=messages,
+            output_schema=ExtractedToolsFromTrace,
+            trace=trace,
+        )
+
+        return result.tools
+
+    except Exception as e:
+        _logger.warning(
+            f"Failed to extract tools from trace using LLM. Returning empty list. Error: {e!r}"
+        )
+        return []

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -21,6 +21,7 @@ from mlflow.genai.evaluation.utils import is_none_or_nan
 from mlflow.genai.scorers.base import scorer
 from mlflow.genai.utils.trace_utils import (
     _does_store_support_trace_linking,
+    _try_extract_available_tools_with_llm,
     convert_predict_fn,
     create_minimal_trace,
     extract_available_tools_from_trace,
@@ -37,6 +38,7 @@ from mlflow.genai.utils.trace_utils import (
 )
 from mlflow.tracing import set_span_chat_tools
 from mlflow.tracing.utils import build_otel_context
+from mlflow.types.chat import ChatTool, FunctionToolDefinition
 
 from tests.tracing.helper import create_test_trace_info, get_traces, purge_traces
 
@@ -992,8 +994,14 @@ def test_extract_available_tools_from_trace_basic(
     extracted_tools = extract_available_tools_from_trace(trace)
 
     assert len(extracted_tools) == 1
-    assert extracted_tools[0].function.name == tool_name
-    assert extracted_tools[0].function.description == tool_description
+    assert extracted_tools[0].model_dump(exclude_none=True) == {
+        "type": "function",
+        "function": {
+            "name": tool_name,
+            "description": tool_description,
+            "parameters": {"type": "object", "properties": {"param": {"type": "string"}}},
+        },
+    }
 
 
 def test_extract_available_tools_from_trace_with_multiple_spans():
@@ -1042,9 +1050,38 @@ def test_extract_available_tools_from_trace_with_multiple_spans():
     extracted_tools = extract_available_tools_from_trace(trace)
 
     assert len(extracted_tools) == 2
-    tool_names = [t.function.name for t in extracted_tools]
-    assert "add" in tool_names
-    assert "multiply" in tool_names
+
+    extracted_tools_sorted = sorted(extracted_tools, key=lambda t: t.function.name)
+
+    assert extracted_tools_sorted[0].model_dump(exclude_none=True) == {
+        "type": "function",
+        "function": {
+            "name": "add",
+            "description": "Add two numbers",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"type": "number"},
+                    "b": {"type": "number"},
+                },
+            },
+        },
+    }
+
+    assert extracted_tools_sorted[1].model_dump(exclude_none=True) == {
+        "type": "function",
+        "function": {
+            "name": "multiply",
+            "description": "Multiply two numbers",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "x": {"type": "number"},
+                    "y": {"type": "number"},
+                },
+            },
+        },
+    }
 
 
 def test_extract_available_tools_from_trace_deduplication():
@@ -1064,14 +1101,20 @@ def test_extract_available_tools_from_trace_deduplication():
             set_span_chat_tools(span1, tools)
 
         with mlflow.start_span(name="llm2", span_type="LLM") as span2:
-            set_span_chat_tools(span2, tools)  # Same tool
+            set_span_chat_tools(span2, tools)
 
     trace = mlflow.get_trace(parent.trace_id)
     extracted_tools = extract_available_tools_from_trace(trace)
 
-    # Should only return 1 tool despite being in 2 spans
     assert len(extracted_tools) == 1
-    assert extracted_tools[0].function.name == "get_weather"
+    assert extracted_tools[0].model_dump(exclude_none=True) == {
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "description": "Get weather info",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
 
 
 def test_extract_available_tools_from_trace_different_descriptions():
@@ -1091,7 +1134,7 @@ def test_extract_available_tools_from_trace_different_descriptions():
             "type": "function",
             "function": {
                 "name": "search",
-                "description": "Search the database",  # Different description
+                "description": "Search the database",
                 "parameters": {"type": "object", "properties": {}},
             },
         }
@@ -1107,22 +1150,31 @@ def test_extract_available_tools_from_trace_different_descriptions():
     trace = mlflow.get_trace(parent.trace_id)
     extracted_tools = extract_available_tools_from_trace(trace)
 
-    # Should return 2 tools since descriptions are different
     assert len(extracted_tools) == 2
-    descriptions = [t.function.description for t in extracted_tools]
-    assert "Search the web" in descriptions
-    assert "Search the database" in descriptions
+
+    extracted_tools_sorted = sorted(extracted_tools, key=lambda t: t.function.description)
+
+    assert extracted_tools_sorted[0].model_dump(exclude_none=True) == {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "Search the database",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    assert extracted_tools_sorted[1].model_dump(exclude_none=True) == {
+        "type": "function",
+        "function": {
+            "name": "search",
+            "description": "Search the web",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
 
 
-@pytest.mark.parametrize(
-    "trace_fixture",
-    [
-        None,
-        Trace(info=create_test_trace_info(trace_id="tr-123"), data=None),
-        Trace(info=create_test_trace_info(trace_id="tr-456"), data=TraceData(spans=[])),
-    ],
-)
-def test_extract_available_tools_from_trace_returns_empty(trace_fixture):
+def test_extract_available_tools_from_trace_returns_empty():
+    trace_fixture = Trace(info=create_test_trace_info(trace_id="tr-456"), data=TraceData(spans=[]))
     result = extract_available_tools_from_trace(trace_fixture)
     assert result == []
 
@@ -1165,4 +1217,84 @@ def test_extract_available_tools_from_trace_with_invalid_tools(has_valid_tool, e
 
     assert len(extracted_tools) == expected_count
     if has_valid_tool:
-        assert extracted_tools[0].function.name == "valid_tool"
+        assert extracted_tools[0].model_dump(exclude_none=True) == {
+            "type": "function",
+            "function": {
+                "name": "valid_tool",
+                "description": "A valid tool",
+            },
+        }
+
+
+def test_extract_available_tools_llm_fallback_triggered_when_no_tools_found(monkeypatch):
+    with mlflow.start_span(name="llm_span", span_type=SpanType.LLM) as span:
+        span.set_inputs(
+            {
+                "messages": [{"role": "user", "content": "test"}],
+                "tools": [
+                    {
+                        "tool_name": "hard_to_extract_tool",
+                        "description": "A tool that is hard to extract",
+                    }
+                ],
+            }
+        )
+        span.set_outputs({"response": "result"})
+
+    trace = mlflow.get_trace(span.trace_id)
+
+    mock_tools = [
+        ChatTool(
+            type="function",
+            function=FunctionToolDefinition(
+                name="hard_to_extract_tool",
+                description="A tool that is hard to extract",
+                parameters={"type": "object", "properties": {"x": {"type": "string"}}},
+            ),
+        )
+    ]
+
+    mock_llm_fallback_called = []
+
+    def mock_llm_fallback(trace_arg, model_arg):
+        mock_llm_fallback_called.append({"trace": trace_arg, "model": model_arg})
+        return mock_tools
+
+    monkeypatch.setattr(
+        "mlflow.genai.utils.trace_utils._try_extract_available_tools_with_llm",
+        mock_llm_fallback,
+    )
+
+    extracted_tools = extract_available_tools_from_trace(trace, model="openai:/gpt-4")
+
+    assert len(mock_llm_fallback_called) == 1
+    assert mock_llm_fallback_called[0]["trace"] == trace
+    assert mock_llm_fallback_called[0]["model"] == "openai:/gpt-4"
+    assert len(extracted_tools) == 1
+    assert extracted_tools[0].model_dump(exclude_none=True) == {
+        "type": "function",
+        "function": {
+            "name": "hard_to_extract_tool",
+            "description": "A tool that is hard to extract",
+            "parameters": {"type": "object", "properties": {"x": {"type": "string"}}},
+        },
+    }
+
+
+def test_try_extract_available_tools_with_llm_returns_empty_on_error(monkeypatch):
+    with mlflow.start_span(name="llm_span", span_type=SpanType.LLM) as span:
+        span.set_inputs({"messages": [{"role": "user", "content": "test"}]})
+        span.set_outputs({"response": "result"})
+
+    trace = mlflow.get_trace(span.trace_id)
+
+    def mock_raise_error(*args, **kwargs):
+        raise RuntimeError("LLM API error")
+
+    monkeypatch.setattr(
+        "mlflow.genai.utils.trace_utils.get_chat_completions_with_structured_output",
+        mock_raise_error,
+    )
+
+    result = _try_extract_available_tools_with_llm(trace, model="openai:/gpt-4")
+    assert result == []


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19322/files) to review incremental changes.
- [**stack/ML-59978-add-fallback-for-available-tools-retrieval-using-llm**](https://github.com/mlflow/mlflow/pull/19322) [[Files changed](https://github.com/mlflow/mlflow/pull/19322/files)]
  - [stack/ML-59978-introduce-tool-call-efficiency-builtin-judge](https://github.com/mlflow/mlflow/pull/19358) [[Files changed](https://github.com/mlflow/mlflow/pull/19358/files/11452fea38c1e1aade52dc81151773526f3196e9..2b95efce281ac7b1108c670b6207ee2309d4e0b9)]
    - [stack/agentic-judges-introduce-tool-call-correctness-builtin-judge](https://github.com/mlflow/mlflow/pull/19391) [[Files changed](https://github.com/mlflow/mlflow/pull/19391/files/2b95efce281ac7b1108c670b6207ee2309d4e0b9..47c64b929e7d18e8627c8d8eeccb765528cb275a)]
      - [stack/agentic-judges-support-expectation-comparison-for-tool-call-correctness](https://github.com/mlflow/mlflow/pull/19413) [[Files changed](https://github.com/mlflow/mlflow/pull/19413/files/47c64b929e7d18e8627c8d8eeccb765528cb275a..f6290f83cbd1586422d8cdec919584ac5a1a0757)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Adding a fallback solution for parsing `available_tools` by using a tracing parsing agent.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Manual Testing
Tested on Langchain and OpenAI agent:

Response from `gpt-4o-mini` (sometimes won't return all the tools available):
```
==================== Lanchain Agent ====================
Tool Available 1: type='function' function=FunctionToolDefinition(name='calculator', description=None, parameters=None, strict=None)

Tool Available 2: type='function' function=FunctionToolDefinition(name='reverse_string', description=None, parameters=None, strict=None)

==================== OpenAI Agent ====================
Tool Available 1: type='function' function=FunctionToolDefinition(name='_calculator', description=None, parameters=FunctionParams(properties={'operation': ParamProperty(type='string', description='The mathematical operation to perform', enum=None, items=None)}, type='object', required=['operation'], additionalProperties=None), strict=None)

Tool Available 2: type='function' function=FunctionToolDefinition(name='_reverse_string', description=None, parameters=FunctionParams(properties={'text': ParamProperty(type='string', description='The text to reverse', enum=None, items=None)}, type='object', required=['text'], additionalProperties=None), strict=None)
```

Response form `gpt-4.1-mini` (returns all the tools available with my example trace):
```
==================== Lanchain Agent ====================
Tool Available 1: type='function' function=FunctionToolDefinition(name='calculator', description="Performs basic mathematical operations. \n\n    Args:\n        operation: A mathematical expression like '5 + 3' or '10 * 2'", parameters=FunctionParams(properties={'operation': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['operation'], additionalProperties=None), strict=None)

Tool Available 2: type='function' function=FunctionToolDefinition(name='get_word_length', description='Returns the length of a given word.\n\n    Args:\n        word: The word to count characters in', parameters=FunctionParams(properties={'word': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['word'], additionalProperties=None), strict=None)

Tool Available 3: type='function' function=FunctionToolDefinition(name='reverse_string', description='Reverses the given text.\n\n    Args:\n        text: The text to reverse', parameters=FunctionParams(properties={'text': ParamProperty(type='string', description=None, enum=None, items=None)}, type='object', required=['text'], additionalProperties=None), strict=None)

==================== OpenAI Agent ====================
Tool Available 1: type='function' function=FunctionToolDefinition(name='_calculator', description='Performs basic mathematical operations.', parameters=FunctionParams(properties={'operation': ParamProperty(type='string', description="A mathematical expression like '5 + 3' or '10 * 2'", enum=None, items=None)}, type='object', required=['operation'], additionalProperties=False), strict=None)

Tool Available 2: type='function' function=FunctionToolDefinition(name='_get_word_length', description='Returns the length of a given word.', parameters=FunctionParams(properties={'word': ParamProperty(type='string', description='The word to count characters in', enum=None, items=None)}, type='object', required=['word'], additionalProperties=False), strict=None)

Tool Available 3: type='function' function=FunctionToolDefinition(name='_reverse_string', description='Reverses the given text.', parameters=FunctionParams(properties={'text': ParamProperty(type='string', description='The text to reverse', enum=None, items=None)}, type='object', required=['text'], additionalProperties=False), strict=None)
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
