### PR TITLE
Support batch span export to UC Table

### DIFF
--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -920,16 +920,20 @@ MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE = _EnvironmentVariable(
 )
 
 #: Maximum number of spans to export in a single batch. When set to larger than 1, MLflow will
-# export spans in batches. This must be used together with `MLFLOW_ENABLE_ASYNC_TRACE_LOGGING`
-# set to true (default).
-#: (default: ``1`` = no batching)
+#: export spans in batches. This must be used together with `MLFLOW_ENABLE_ASYNC_TRACE_LOGGING`
+#: set to true (default).
+#: Note: Currently only Unity Catalog table exporter supports batching. Other exporters will export
+#: spans immediately.
+#: (default: ``10``)
 MLFLOW_ASYNC_TRACE_LOGGING_MAX_SPAN_BATCH_SIZE = _EnvironmentVariable(
-    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_BATCH_SIZE", int, 1
+    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_SPAN_BATCH_SIZE", int, 10
 )
 
 #: Maximum interval in milliseconds between two batches. When the interval is reached,
 #: MLflow will export the spans in the current batch regardless of the batch size.
 #: This interval only applies when the max batch size is set to larger than 1.
+#: Note: Currently only Unity Catalog table exporter supports batching. Other exporters will export
+#: spans immediately.
 #: (default: ``5000`` = 5 seconds)
 MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS = _EnvironmentVariable(
     "MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS", int, 5000

--- a/mlflow/environment_variables.py
+++ b/mlflow/environment_variables.py
@@ -919,6 +919,21 @@ MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE = _EnvironmentVariable(
     "MLFLOW_ASYNC_TRACE_LOGGING_MAX_QUEUE_SIZE", int, 1000
 )
 
+#: Maximum number of spans to export in a single batch. When set to larger than 1, MLflow will
+# export spans in batches. This must be used together with `MLFLOW_ENABLE_ASYNC_TRACE_LOGGING`
+# set to true (default).
+#: (default: ``1`` = no batching)
+MLFLOW_ASYNC_TRACE_LOGGING_MAX_SPAN_BATCH_SIZE = _EnvironmentVariable(
+    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_BATCH_SIZE", int, 1
+)
+
+#: Maximum interval in milliseconds between two batches. When the interval is reached,
+#: MLflow will export the spans in the current batch regardless of the batch size.
+#: This interval only applies when the max batch size is set to larger than 1.
+#: (default: ``5000`` = 5 seconds)
+MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS = _EnvironmentVariable(
+    "MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS", int, 5000
+)
 
 #: Timeout seconds for retrying trace logging.
 #: (default: ``500``)

--- a/mlflow/store/tracking/databricks_rest_store.py
+++ b/mlflow/store/tracking/databricks_rest_store.py
@@ -476,6 +476,8 @@ class DatabricksTracingRestStore(RestStore):
         _logger.debug(f"Unlinked experiment {experiment_id} from trace location: {location}")
 
     def log_spans(self, location: str, spans: list[Span], tracking_uri=None) -> list[Span]:
+        _logger.debug(f"Logging {len(spans)} spans to {location}")
+
         if not spans:
             return []
 

--- a/mlflow/tracing/export/span_batcher.py
+++ b/mlflow/tracing/export/span_batcher.py
@@ -1,0 +1,117 @@
+import atexit
+import logging
+import threading
+from collections import defaultdict
+from queue import Queue
+from typing import Callable
+
+from mlflow.entities.span import Span
+from mlflow.environment_variables import (
+    MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS,
+    MLFLOW_ASYNC_TRACE_LOGGING_MAX_SPAN_BATCH_SIZE,
+)
+from mlflow.tracing.export.async_export_queue import AsyncTraceExportQueue, Task
+
+_logger = logging.getLogger(__name__)
+
+
+class SpanBatcher:
+    """
+    Queue based batching processor for span export to Databricks Unity Catalog table.
+
+    Exposes two configuration knobs
+    - Max span batch size: The maximum number of spans to export in a single batch.
+    - Max interval: The maximum interval in milliseconds between two batches.
+    When one of two conditions is met, the batch is exported.
+    """
+
+    def __init__(
+        self, async_task_queue: AsyncTraceExportQueue, log_spans_func: Callable[[list[Span]], None]
+    ):
+        self._max_span_batch_size = MLFLOW_ASYNC_TRACE_LOGGING_MAX_SPAN_BATCH_SIZE.get()
+        self._max_interval_ms = MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS.get()
+
+        self._span_queue = Queue()
+        self._async_task_handler = async_task_queue
+        self._log_spans_func = log_spans_func
+        self._lock = threading.RLock()
+        self._stop_event = threading.Event()
+
+        self._worker = threading.Thread(
+            name="MLflowSpanBatcherWorker",
+            daemon=True,
+            target=self._worker_loop,
+        )
+        self._worker_awaken = threading.Event()
+        self._worker.start()
+
+        atexit.register(self.shutdown)
+
+        _logger.debug(
+            "Async trace logging is configured with batch size "
+            f"{self._max_span_batch_size} and max interval {self._max_interval_ms}ms"
+        )
+
+    def add_span(self, location: str, span: Span):
+        if self._stop_event.is_set():
+            return
+
+        self._span_queue.put((location, span))
+        if self._span_queue.qsize() >= self._max_span_batch_size:
+            # Trigger the immediate export when the batch is full
+            self._worker_awaken.set()
+
+    def _worker_loop(self):
+        while not self._stop_event.is_set():
+            # sleep_interrupted is True when the export is triggered by the batch size limit.
+            # If this is False, the interval has expired so we should export the current batch
+            # even if the batch size is not reached.
+            sleep_interrupted = self._worker_awaken.wait(self._max_interval_ms / 1000)
+            if self._stop_event.is_set():
+                break
+            self._consume_batch(flush_all=not sleep_interrupted)
+            self._worker_awaken.clear()
+
+        self._consume_batch(flush_all=True)
+
+    def _consume_batch(self, flush_all: bool = False):
+        with self._lock:
+            while (
+                self._span_queue.qsize() >= self._max_span_batch_size
+                # Export all remaining spans in the queue if necessary
+                or (flush_all and not self._span_queue.empty())
+            ):
+                # Spans in the queue can have multiple locations. Since the backend API only support
+                # logging spans to a single location, we need to group spans by location and export
+                # them separately.
+                location_to_spans = defaultdict(list)
+                for location, span in [
+                    self._span_queue.get()
+                    for _ in range(min(self._max_span_batch_size, self._span_queue.qsize()))
+                ]:
+                    location_to_spans[location].append(span)
+
+                for location, spans in location_to_spans.items():
+                    self._export(location, spans)
+
+    def _export(self, location: str, spans: list[Span]):
+        _logger.debug(f"Exporting a span batch with {len(spans)} spans to {location}")
+
+        self._async_task_handler.put(
+            Task(
+                handler=self._log_spans_func,
+                args=(location, spans),
+                error_msg="Failed to export batch of spans.",
+            )
+        )
+
+    def shutdown(self):
+        if self._stop_event.is_set():
+            return
+
+        try:
+            self._stop_event.set()
+            self._worker_awaken.set()
+            self._worker.join()
+        except Exception as e:
+            _logger.debug(f"Error while shutting down span batcher: {e}")

--- a/mlflow/tracing/export/uc_table.py
+++ b/mlflow/tracing/export/uc_table.py
@@ -71,6 +71,5 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
         return False
 
     def flush(self) -> None:
-        # self._async_queue.activate()
         self._span_batcher.shutdown()
         self._async_queue.flush(terminate=True)

--- a/mlflow/tracing/export/uc_table.py
+++ b/mlflow/tracing/export/uc_table.py
@@ -6,8 +6,8 @@ from opentelemetry.sdk.trace import ReadableSpan
 from mlflow.entities.span import Span
 from mlflow.entities.trace_info import TraceInfo
 from mlflow.environment_variables import MLFLOW_ENABLE_ASYNC_TRACE_LOGGING
-from mlflow.tracing.export.async_export_queue import Task
 from mlflow.tracing.export.mlflow_v3 import MlflowV3SpanExporter
+from mlflow.tracing.export.span_batcher import SpanBatcher
 from mlflow.tracing.utils import get_active_spans_table_name
 
 _logger = logging.getLogger(__name__)
@@ -24,6 +24,12 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
         # Track if we've raised an error for span export to avoid raising it multiple times.
         self._has_raised_span_export_error = False
 
+        if hasattr(self, "_async_queue"):
+            self._span_batcher = SpanBatcher(
+                async_task_queue=self._async_queue,
+                log_spans_func=self._log_spans,
+            )
+
     def _export_spans_incrementally(self, spans: Sequence[ReadableSpan]) -> None:
         """
         Export spans incrementally as they complete.
@@ -39,27 +45,23 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
             _logger.debug("No active spans table name found. Skipping span export.")
             return
 
-        _logger.debug(f"exporting spans to uc table: {location}")
-
         # Wrapping with MLflow span interface for easier downstream handling
         spans = [Span(span) for span in spans]
         if self._should_log_async():
-            self._async_queue.put(
-                task=Task(
-                    handler=self._client.log_spans,
-                    args=(location, spans),
-                    error_msg="Failed to log spans to the trace server.",
-                )
-            )
+            for span in spans:
+                self._span_batcher.add_span(location=location, span=span)
         else:
-            try:
-                self._client.log_spans(location, spans)
-            except Exception as e:
-                if self._has_raised_span_export_error:
-                    _logger.debug(f"Failed to log spans to the trace server: {e}", exc_info=True)
-                else:
-                    _logger.warning(f"Failed to log spans to the trace server: {e}")
-                    self._has_raised_span_export_error = True
+            self._log_spans(location, spans)
+
+    def _log_spans(self, location: str, spans: list[Span]) -> None:
+        try:
+            self._client.log_spans(location, spans)
+        except Exception as e:
+            if self._has_raised_span_export_error:
+                _logger.debug(f"Failed to log spans to the trace server: {e}", exc_info=True)
+            else:
+                _logger.warning(f"Failed to log spans to the trace server: {e}")
+                self._has_raised_span_export_error = True
 
     def _should_enable_async_logging(self) -> bool:
         return MLFLOW_ENABLE_ASYNC_TRACE_LOGGING.get()
@@ -67,3 +69,8 @@ class DatabricksUCTableSpanExporter(MlflowV3SpanExporter):
     # Override this to False since spans are logged to UC table instead of artifacts.
     def _should_log_spans_to_artifacts(self, trace_info: TraceInfo) -> bool:
         return False
+
+    def flush(self) -> None:
+        # self._async_queue.activate()
+        self._span_batcher.shutdown()
+        self._async_queue.flush(terminate=True)

--- a/tests/tracing/export/test_uc_table_exporter.py
+++ b/tests/tracing/export/test_uc_table_exporter.py
@@ -1,3 +1,5 @@
+import time
+from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
 import pytest
@@ -98,3 +100,157 @@ def test_log_trace_no_log_spans_if_no_uc_schema():
         # Verify both start_trace and _upload_trace_data were called
         mock_client.start_trace.assert_called_once_with(mock_trace.info)
         mock_client.log_spans.assert_not_called()
+
+
+def test_export_spans_batch_max_size(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_BATCH_SIZE", "5")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS", "10000")
+
+    exporter = DatabricksUCTableSpanExporter()
+    exporter._client = mock.MagicMock()
+    with mock.patch(
+        "mlflow.tracing.export.uc_table.get_active_spans_table_name",
+        return_value="catalog.schema.spans",
+    ):
+        exporter._export_spans_incrementally(
+            [
+                create_mock_otel_span(trace_id=12345, span_id=1),
+                create_mock_otel_span(trace_id=12345, span_id=2),
+                create_mock_otel_span(trace_id=12345, span_id=3),
+                create_mock_otel_span(trace_id=12345, span_id=4),
+            ]
+        )
+        exporter._client.log_spans.assert_not_called()
+
+        exporter._export_spans_incrementally([create_mock_otel_span(trace_id=12345, span_id=5)])
+        # NB: There can be a tiny delay once the batch becomes full and the worker thread
+        # is interrupted by the threading event and activate the async queue. Flush has to
+        # happen after the activation.
+        time.sleep(1)
+        exporter._async_queue.flush()
+        exporter._client.log_spans.assert_called_once()
+        location, spans = exporter._client.log_spans.call_args[0]
+        assert location == "catalog.schema.spans"
+        assert len(spans) == 5
+        assert all(isinstance(span, Span) for span in spans)
+
+
+def test_export_spans_batch_flush_on_interval(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_BATCH_SIZE", "10")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS", "1000")
+
+    exporter = DatabricksUCTableSpanExporter()
+    exporter._client = mock.MagicMock()
+
+    otel_span = create_mock_otel_span(trace_id=12345, span_id=1)
+
+    with mock.patch(
+        "mlflow.tracing.export.uc_table.get_active_spans_table_name",
+        return_value="catalog.schema.spans",
+    ):
+        exporter._export_spans_incrementally([otel_span])
+
+    # Allow the batcher's interval timer to fire
+    time.sleep(1.5)
+
+    exporter._client.log_spans.assert_called_once()
+    location, spans = exporter._client.log_spans.call_args[0]
+    assert location == "catalog.schema.spans"
+    assert len(spans) == 1
+
+
+def test_export_spans_batch_shutdown(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_BATCH_SIZE", "10")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS", "1000")
+
+    exporter = DatabricksUCTableSpanExporter()
+    exporter._client = mock.MagicMock()
+
+    with mock.patch(
+        "mlflow.tracing.export.uc_table.get_active_spans_table_name",
+        return_value="catalog.schema.spans",
+    ):
+        exporter._export_spans_incrementally(
+            [
+                create_mock_otel_span(trace_id=12345, span_id=1),
+                create_mock_otel_span(trace_id=12345, span_id=2),
+                create_mock_otel_span(trace_id=12345, span_id=3),
+            ]
+        )
+
+    exporter.flush()
+    exporter._client.log_spans.assert_called_once()
+    location, spans = exporter._client.log_spans.call_args[0]
+    assert location == "catalog.schema.spans"
+    assert len(spans) == 3
+
+
+def test_export_spans_batch_thread_safety(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_BATCH_SIZE", "16")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS", "1000")
+
+    exporter = DatabricksUCTableSpanExporter()
+    exporter._client = mock.MagicMock()
+
+    def _generate_spans():
+        exporter._export_spans_incrementally(
+            [create_mock_otel_span(trace_id=12345, span_id=i) for i in range(5)]
+        )
+
+    with mock.patch(
+        "mlflow.tracing.export.uc_table.get_active_spans_table_name",
+        return_value="catalog.schema.spans",
+    ):
+        with ThreadPoolExecutor(max_workers=5) as executor:
+            futures = [executor.submit(_generate_spans) for _ in range(10)]
+            for future in futures:
+                future.result()
+
+        exporter.flush()
+
+        assert exporter._client.log_spans.call_count == 4
+        for i in range(4):
+            location, spans = exporter._client.log_spans.call_args_list[i][0]
+            assert location == "catalog.schema.spans"
+            assert len(spans) == 16 if i < 3 else 2
+
+
+def test_export_spans_batch_split_spans_by_location(monkeypatch):
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_BATCH_SIZE", "10")
+    monkeypatch.setenv("MLFLOW_ASYNC_TRACE_LOGGING_MAX_INTERVAL_MILLIS", "1000")
+
+    exporter = DatabricksUCTableSpanExporter()
+    exporter._client = mock.MagicMock()
+
+    with mock.patch(
+        "mlflow.tracing.export.uc_table.get_active_spans_table_name",
+        return_value="catalog.schema.table_1",
+    ):
+        exporter._export_spans_incrementally(
+            [
+                create_mock_otel_span(trace_id=12345, span_id=1),
+                create_mock_otel_span(trace_id=12345, span_id=2),
+            ]
+        )
+
+    with mock.patch(
+        "mlflow.tracing.export.uc_table.get_active_spans_table_name",
+        return_value="catalog.schema.table_2",
+    ):
+        exporter._export_spans_incrementally(
+            [
+                create_mock_otel_span(trace_id=12345, span_id=3),
+                create_mock_otel_span(trace_id=12345, span_id=4),
+                create_mock_otel_span(trace_id=12345, span_id=5),
+            ]
+        )
+
+    exporter.flush()
+
+    assert exporter._client.log_spans.call_count == 2
+    location, spans = exporter._client.log_spans.call_args_list[0][0]
+    assert location == "catalog.schema.table_1"
+    assert len(spans) == 2
+    location, spans = exporter._client.log_spans.call_args_list[1][0]
+    assert location == "catalog.schema.table_2"
+    assert len(spans) == 3


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19324?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19324/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19324/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19324/merge
```

</p>
</details>

### What changes are proposed in this pull request?

For Zerobus traces, the `TraceExport` endpoint handle batch of spans. However, we are not making use of it since the spans passed to the exporter is exported immediately (via async queue), namely, every span creates a new export request. This is highly inefficient and limit scalability.

This PR introduces a queue-based batching to the UC exporter. It is built as a pluggable component to the current async queue, rather than updating the existing queue directly, since it is used for handling multiple types of requests e.g. StartTrace request and other exporters.

The default is no-batch to reduce blast radius, but actually it might be ok to change given the product is private preview (easier to change now than after public release). Will revisit it with the team before merging.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests


<img width="1212" height="389" alt="Screenshot 2025-12-11 at 9 56 19" src="https://github.com/user-attachments/assets/c03fbcbf-4673-4c82-b626-7a8ed49492d0" />


### Does this PR require documentation update?

Def need to be in documentation once the feature becomes public.

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Support span batching when exporting spans to Databricks UC tables.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
