### PR TITLE
Fix Tensorflow Cross Version tests

### DIFF
--- a/mlflow/ml-package-versions.yml
+++ b/mlflow/ml-package-versions.yml
@@ -117,12 +117,11 @@ tensorflow:
       pip install --pre tf-nightly
 
   models:
-    minimum: "2.15.0.post1"
+    minimum: "2.16.0"
     maximum: "2.20.0"
     requirements:
       # Requirements to run tests for keras
       ">= 0.0.0": ["scikit-learn", "pyspark", "pyarrow", "transformers!=4.38.0,!=4.38.1"]
-      "== 2.15.1": ["transformers<4.39.0"]
     run: |
       pytest \
         tests/tensorflow/test_tensorflow2_core_model_export.py \
@@ -131,7 +130,7 @@ tensorflow:
         tests/tensorflow/test_keras_pyfunc_model_works_with_all_input_types.py
 
   autologging:
-    minimum: "2.15.0.post1"
+    minimum: "2.16.0"
     maximum: "2.20.0"
     requirements:
       "== dev": ["scikit-learn"]

--- a/mlflow/ml_package_versions.py
+++ b/mlflow/ml_package_versions.py
@@ -263,11 +263,11 @@ _ML_PACKAGE_VERSIONS = {
             "pip_release": "tensorflow"
         },
         "models": {
-            "minimum": "2.15.0.post1",
+            "minimum": "2.16.0",
             "maximum": "2.20.0"
         },
         "autologging": {
-            "minimum": "2.15.0.post1",
+            "minimum": "2.16.0",
             "maximum": "2.20.0"
         }
     },

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -7,6 +7,7 @@ import pickle
 import sys
 from pathlib import Path
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import numpy as np
 import pytest
@@ -1107,9 +1108,18 @@ def test_import_tensorflow_with_fluent_autolog_enables_tensorflow_autologging():
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
 
+def _uri_to_path(uri):
+    """Convert a file:// URI to a local path."""
+    parsed = urlparse(uri)
+    if parsed.scheme == "file":
+        return parsed.path
+    return uri
+
+
 def _assert_autolog_infers_model_signature_correctly(input_sig_spec, output_sig_spec):
     logged_model = mlflow.last_logged_model()
-    ml_model_path = os.path.join(logged_model.artifact_location, "MLmodel")
+    artifact_path = _uri_to_path(logged_model.artifact_location)
+    ml_model_path = os.path.join(artifact_path, "MLmodel")
     with open(ml_model_path) as f:
         data = yaml.safe_load(f)
         assert data is not None
@@ -1248,7 +1258,8 @@ def test_keras_autolog_load_saved_hdf5_model(keras_data_gen_sequence):
     with mlflow.start_run():
         model.fit(keras_data_gen_sequence)
         logged_model = mlflow.last_logged_model()
-        assert Path(logged_model.artifact_location, "data", "model.h5").exists()
+        artifact_path = _uri_to_path(logged_model.artifact_location)
+        assert Path(artifact_path, "data", "model.h5").exists()
 
 
 def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):
@@ -1257,7 +1268,8 @@ def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):
     initial_model.fit(keras_data_gen_sequence)
 
     logged_model = mlflow.last_logged_model()
-    mlmodel_path = f"{logged_model.artifact_location}/MLmodel"
+    artifact_path = _uri_to_path(logged_model.artifact_location)
+    mlmodel_path = os.path.join(artifact_path, "MLmodel")
     with open(mlmodel_path) as f:
         mlmodel_contents = yaml.safe_load(f)
     assert "signature" in mlmodel_contents.keys()

--- a/tests/tensorflow/test_tensorflow2_autolog.py
+++ b/tests/tensorflow/test_tensorflow2_autolog.py
@@ -7,7 +7,6 @@ import pickle
 import sys
 from pathlib import Path
 from unittest.mock import patch
-from urllib.parse import urlparse
 
 import numpy as np
 import pytest
@@ -30,6 +29,7 @@ from mlflow.utils.autologging_utils import (
     AUTOLOGGING_INTEGRATIONS,
     autologging_is_disabled,
 )
+from mlflow.utils.file_utils import local_file_uri_to_path
 from mlflow.utils.process import _exec_cmd
 
 np.random.seed(1337)
@@ -1108,17 +1108,9 @@ def test_import_tensorflow_with_fluent_autolog_enables_tensorflow_autologging():
     assert not autologging_is_disabled(mlflow.tensorflow.FLAVOR_NAME)
 
 
-def _uri_to_path(uri):
-    """Convert a file:// URI to a local path."""
-    parsed = urlparse(uri)
-    if parsed.scheme == "file":
-        return parsed.path
-    return uri
-
-
 def _assert_autolog_infers_model_signature_correctly(input_sig_spec, output_sig_spec):
     logged_model = mlflow.last_logged_model()
-    artifact_path = _uri_to_path(logged_model.artifact_location)
+    artifact_path = local_file_uri_to_path(logged_model.artifact_location)
     ml_model_path = os.path.join(artifact_path, "MLmodel")
     with open(ml_model_path) as f:
         data = yaml.safe_load(f)
@@ -1258,7 +1250,7 @@ def test_keras_autolog_load_saved_hdf5_model(keras_data_gen_sequence):
     with mlflow.start_run():
         model.fit(keras_data_gen_sequence)
         logged_model = mlflow.last_logged_model()
-        artifact_path = _uri_to_path(logged_model.artifact_location)
+        artifact_path = local_file_uri_to_path(logged_model.artifact_location)
         assert Path(artifact_path, "data", "model.h5").exists()
 
 
@@ -1268,7 +1260,7 @@ def test_keras_autolog_logs_model_signature_by_default(keras_data_gen_sequence):
     initial_model.fit(keras_data_gen_sequence)
 
     logged_model = mlflow.last_logged_model()
-    artifact_path = _uri_to_path(logged_model.artifact_location)
+    artifact_path = local_file_uri_to_path(logged_model.artifact_location)
     mlmodel_path = os.path.join(artifact_path, "MLmodel")
     with open(mlmodel_path) as f:
         mlmodel_contents = yaml.safe_load(f)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/19335?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19335/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19335/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19335/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

PR 19258 changed the way that artifacts are handled for tests through the use of `db_uri` fixture, returning a `file:///` URI instead of a local path. This PR provides a conversion helper function to translate the uri to a local path for TF tests to function correctly. 

This also bumps the minimum tested version off of the 2.15.0.post1 build - this source build is causing timeouts in CI and is unstable. 

### How is this PR tested?

- [X] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [X] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [X] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [X] No (this PR will be included in the next minor release)
