### PR TITLE
Ensure server-provided artifact root is reused on MLflowClient calls

### DIFF
--- a/mlflow/tracking/_tracking_service/utils.py
+++ b/mlflow/tracking/_tracking_service/utils.py
@@ -25,6 +25,7 @@ from mlflow.utils.uri import (
 
 _logger = logging.getLogger(__name__)
 _tracking_uri = None
+_SERVER_ARTIFACT_ROOT_ENV_VAR = "_MLFLOW_SERVER_ARTIFACT_ROOT"
 
 
 def _has_existing_mlruns_data() -> bool:
@@ -181,8 +182,14 @@ def _get_file_store(store_uri, **_):
 def _get_sqlalchemy_store(store_uri, artifact_uri):
     from mlflow.store.tracking.sqlalchemy_store import SqlAlchemyStore
 
+    # When running inside the server process (e.g., Model.log() triggered by a job/API),
+    # inherit the server's configured artifact root from the environment rather than
+    # falling back to the local default. This ensures artifacts are stored in the
+    # correct location (e.g., S3) regardless of which code path creates the store.
     if artifact_uri is None:
-        artifact_uri = DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+        artifact_uri = os.environ.get(
+            _SERVER_ARTIFACT_ROOT_ENV_VAR, DEFAULT_LOCAL_FILE_AND_ARTIFACT_PATH
+        )
     return SqlAlchemyStore(store_uri, artifact_uri)
 
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -18,6 +18,7 @@ from mlflow.environment_variables import (
     MLFLOW_TRACKING_USERNAME,
 )
 from mlflow.exceptions import MlflowException
+from mlflow.server import ARTIFACT_ROOT_ENV_VAR
 from mlflow.store.db.db_types import DATABASE_ENGINES
 from mlflow.store.tracking.databricks_rest_store import DatabricksTracingRestStore
 from mlflow.store.tracking.file_store import FileStore
@@ -238,6 +239,22 @@ def test_get_store_sqlalchemy_store_with_artifact_uri(tmp_path, monkeypatch, db_
             )
 
     mock_create_engine.assert_called_once_with(uri, pool_pre_ping=True)
+
+
+def test_get_sqlalchemy_store_uses_server_artifact_root(tmp_path, monkeypatch):
+    store_uri = f"sqlite:///{tmp_path.joinpath('backend_store.db')}"
+    artifact_path = tmp_path / "server-artifacts"
+    artifact_uri = path_to_local_file_uri(artifact_path)
+    monkeypatch.setenv(ARTIFACT_ROOT_ENV_VAR, artifact_uri)
+
+    with mock.patch("mlflow.store.tracking.sqlalchemy_store.SqlAlchemyStore") as mock_store:
+        mlflow.tracking._tracking_service.utils._get_sqlalchemy_store(
+            store_uri=store_uri, artifact_uri=None
+        )
+
+    mock_store.assert_called_once()
+    assert mock_store.call_args.args[1] == artifact_uri
+    monkeypatch.delenv(ARTIFACT_ROOT_ENV_VAR, raising=False)
 
 
 def test_get_store_databricks(monkeypatch):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/mprahl/mlflow/pull/19336?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19336/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19336/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19336/merge
```

</p>
</details>


### Related Issues/PRs

### What changes are proposed in this pull request?

When `Model.log()` (or similar) runs within the server process, it creates its own `MlflowClient` which triggers store creation via a different code path than the server handlers use. Here's the flow:

Flow Without This Fix

1. **Server starts** with `--default-artifact-root s3://bucket/artifacts`
2. Server sets `_MLFLOW_SERVER_ARTIFACT_ROOT=s3://bucket/artifacts` in the environment
3. **Model logging triggers** → `Model.log()` creates `MlflowClient(tracking_uri)`
4. `MlflowClient` → `TrackingServiceClient.store` → `utils._get_store(tracking_uri)` (no `artifact_uri`)
5. `_tracking_store_registry.get_store(store_uri, artifact_uri=None)`
6. `_get_sqlalchemy_store(store_uri, artifact_uri=None)`
7. **Before fix:** `artifact_uri = "./mlruns"` (hardcoded default)
8. Model artifacts incorrectly saved to local `./mlruns` instead of `s3://bucket/artifacts`

Flow With This Fix

Steps 1-6 are the same, but:

7. **After fix:** `artifact_uri = os.environ.get("_MLFLOW_SERVER_ARTIFACT_ROOT", "./mlruns")`
8. Model artifacts correctly saved to `s3://bucket/artifacts`

This ensures both store creation paths (`handlers._get_tracking_store` and `utils._get_sqlalchemy_store`) read from the same environment variable that the server sets at startup.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Fixed an issue where logging a model would ignore the default artifact root and default to storing it at ./mlruns.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [x] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
