### PR TITLE
Update adapter routing for DBX to not require string

### DIFF
--- a/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
@@ -106,7 +106,7 @@ def _parse_databricks_model_response(
 def _invoke_databricks_serving_endpoint(
     *,
     model_name: str,
-    prompt: str,
+    prompt: str | list["ChatMessage"],
     num_retries: int,
     response_format: type[pydantic.BaseModel] | None = None,
     inference_params: dict[str, Any] | None = None,
@@ -122,14 +122,12 @@ def _invoke_databricks_serving_endpoint(
     for attempt in range(num_retries + 1):
         try:
             # Build request payload
-            payload = {
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": prompt,
-                    }
-                ],
-            }
+            if isinstance(prompt, str):
+                messages = [{"role": "user", "content": prompt}]
+            else:
+                messages = [{"role": msg.role, "content": msg.content} for msg in prompt]
+
+            payload = {"messages": messages}
 
             # Add response_schema if provided
             if response_format is not None:
@@ -276,7 +274,7 @@ class InvokeJudgeModelHelperOutput:
 def _invoke_databricks_serving_endpoint_judge(
     *,
     model_name: str,
-    prompt: str,
+    prompt: str | list["ChatMessage"],
     assessment_name: str,
     num_retries: int = 10,
     response_format: type[pydantic.BaseModel] | None = None,
@@ -332,7 +330,7 @@ class DatabricksServingEndpointAdapter(BaseJudgeAdapter):
             return False
 
         model_provider, _ = _parse_model_uri(model_uri)
-        return model_provider in {"databricks", "endpoints"} and isinstance(prompt, str)
+        return model_provider in {"databricks", "endpoints"}
 
     def invoke(self, input_params: AdapterInvocationInput) -> AdapterInvocationOutput:
         # Show deprecation warning for legacy 'endpoints' provider

--- a/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
+++ b/mlflow/genai/judges/adapters/databricks_serving_endpoint_adapter.py
@@ -125,6 +125,17 @@ def _invoke_databricks_serving_endpoint(
             if isinstance(prompt, str):
                 messages = [{"role": "user", "content": prompt}]
             else:
+                from mlflow.types.llm import ChatMessage
+
+                if not isinstance(prompt, list) or (
+                    prompt and not all(isinstance(msg, ChatMessage) for msg in prompt)
+                ):
+                    prompt_type = type(prompt).__name__
+                    raise MlflowException(
+                        f"Invalid prompt type: expected str or list[ChatMessage], "
+                        f"got {prompt_type}",
+                        error_code=INVALID_PARAMETER_VALUE,
+                    )
                 messages = [{"role": msg.role, "content": msg.content} for msg in prompt]
 
             payload = {"messages": messages}

--- a/tests/genai/judges/adapters/test_databricks_adapter.py
+++ b/tests/genai/judges/adapters/test_databricks_adapter.py
@@ -368,6 +368,33 @@ def test_invoke_databricks_serving_endpoint_with_inference_params() -> None:
     assert result.response == "Test response"
 
 
+@pytest.mark.parametrize(
+    "invalid_prompt",
+    [
+        123,  # Not a string or list
+        ["not a ChatMessage", "also invalid"],  # List but not ChatMessage instances
+    ],
+)
+def test_invoke_databricks_serving_endpoint_invalid_prompt_type(invalid_prompt) -> None:
+    mock_creds = mock.Mock()
+    mock_creds.host = "https://test.databricks.com"
+    mock_creds.token = "test-token"
+
+    with (
+        mock.patch(
+            "mlflow.utils.databricks_utils.get_databricks_host_creds",
+            return_value=mock_creds,
+        ),
+    ):
+        with pytest.raises(
+            MlflowException,
+            match="Invalid prompt type: expected str or list\\[ChatMessage\\]",
+        ):
+            _invoke_databricks_serving_endpoint(
+                model_name="test-model", prompt=invalid_prompt, num_retries=0
+            )
+
+
 def test_record_success_telemetry_with_databricks_agents() -> None:
     # Mock the telemetry function separately
     mock_telemetry_module = mock.MagicMock()

--- a/tests/genai/judges/adapters/test_utils.py
+++ b/tests/genai/judges/adapters/test_utils.py
@@ -1,0 +1,105 @@
+from unittest import mock
+
+import pytest
+
+from mlflow.exceptions import MlflowException
+from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
+    DatabricksManagedJudgeAdapter,
+)
+from mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter import (
+    DatabricksServingEndpointAdapter,
+)
+from mlflow.genai.judges.adapters.gateway_adapter import GatewayAdapter
+from mlflow.genai.judges.adapters.litellm_adapter import LiteLLMAdapter
+from mlflow.genai.judges.adapters.utils import get_adapter
+from mlflow.genai.judges.constants import _DATABRICKS_DEFAULT_JUDGE_MODEL
+from mlflow.types.llm import ChatMessage
+
+
+@pytest.fixture
+def string_prompt():
+    return "This is a test prompt"
+
+
+@pytest.fixture
+def list_prompt():
+    return [
+        ChatMessage(role="system", content="You are a helpful assistant"),
+        ChatMessage(role="user", content="Please evaluate this"),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "prompt_type", "expected_adapter"),
+    [
+        # Databricks adapters
+        (_DATABRICKS_DEFAULT_JUDGE_MODEL, "string", DatabricksManagedJudgeAdapter),
+        (_DATABRICKS_DEFAULT_JUDGE_MODEL, "list", DatabricksManagedJudgeAdapter),
+        ("databricks:/my-endpoint", "string", DatabricksServingEndpointAdapter),
+        ("databricks:/my-endpoint", "list", DatabricksServingEndpointAdapter),
+        ("endpoints:/my-endpoint", "string", DatabricksServingEndpointAdapter),
+        ("endpoints:/my-endpoint", "list", DatabricksServingEndpointAdapter),
+        # Gateway adapter
+        ("openai:/gpt-4", "string", GatewayAdapter),
+        ("anthropic:/claude-3-5-sonnet-20241022", "string", GatewayAdapter),
+        ("bedrock:/anthropic.claude-3-5-sonnet-20241022-v2:0", "string", GatewayAdapter),
+    ],
+)
+def test_get_adapter_without_litellm(
+    model_uri, prompt_type, expected_adapter, string_prompt, list_prompt
+):
+    prompt = string_prompt if prompt_type == "string" else list_prompt
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
+        return_value=False,
+    ):
+        adapter = get_adapter(model_uri, prompt)
+        assert isinstance(adapter, expected_adapter)
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "prompt_type", "expected_adapter"),
+    [
+        # Databricks adapters (take priority over litellm)
+        (_DATABRICKS_DEFAULT_JUDGE_MODEL, "string", DatabricksManagedJudgeAdapter),
+        (_DATABRICKS_DEFAULT_JUDGE_MODEL, "list", DatabricksManagedJudgeAdapter),
+        ("databricks:/my-endpoint", "string", DatabricksServingEndpointAdapter),
+        ("databricks:/my-endpoint", "list", DatabricksServingEndpointAdapter),
+        ("endpoints:/my-endpoint", "string", DatabricksServingEndpointAdapter),
+        ("endpoints:/my-endpoint", "list", DatabricksServingEndpointAdapter),
+        # LiteLLM adapter
+        ("openai:/gpt-4", "string", LiteLLMAdapter),
+        ("openai:/gpt-4", "list", LiteLLMAdapter),
+        ("anthropic:/claude-3-5-sonnet-20241022", "string", LiteLLMAdapter),
+        ("anthropic:/claude-3-5-sonnet-20241022", "list", LiteLLMAdapter),
+    ],
+)
+def test_get_adapter_with_litellm(
+    model_uri, prompt_type, expected_adapter, string_prompt, list_prompt
+):
+    prompt = string_prompt if prompt_type == "string" else list_prompt
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
+        return_value=True,
+    ):
+        adapter = get_adapter(model_uri, prompt)
+        assert isinstance(adapter, expected_adapter)
+
+
+@pytest.mark.parametrize(
+    ("model_uri", "expected_error"),
+    [
+        ("openai:/gpt-4", "No suitable adapter found for model_uri='openai:/gpt-4'"),
+        (
+            "vertex_ai:/gemini-pro",
+            "No suitable adapter found for model_uri='vertex_ai:/gemini-pro'",
+        ),
+    ],
+)
+def test_get_adapter_unsupported_with_list(model_uri, expected_error, list_prompt):
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
+        return_value=False,
+    ):
+        with pytest.raises(MlflowException, match=expected_error):
+            get_adapter(model_uri, list_prompt)


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19339?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19339/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19339/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19339/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Update adapter routing for DBX to not require string

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
```python
from unittest import mock

from mlflow.genai.judges.adapters.databricks_managed_judge_adapter import (
    DatabricksManagedJudgeAdapter,
)
from mlflow.genai.judges.adapters.databricks_serving_endpoint_adapter import (
    DatabricksServingEndpointAdapter,
)
from mlflow.genai.judges.adapters.gateway_adapter import GatewayAdapter
from mlflow.genai.judges.adapters.litellm_adapter import LiteLLMAdapter
from mlflow.types.llm import ChatMessage

# Test cases: (model_uri, prompt_type, expected_without_litellm, expected_with_litellm)
TEST_CASES = [
    ("databricks", "string", DatabricksManagedJudgeAdapter, DatabricksManagedJudgeAdapter),
    ("databricks", "list", DatabricksManagedJudgeAdapter, DatabricksManagedJudgeAdapter),
    ("databricks:/my-endpoint", "string", DatabricksServingEndpointAdapter, DatabricksServingEndpointAdapter),
    ("databricks:/my-endpoint", "list", DatabricksServingEndpointAdapter, DatabricksServingEndpointAdapter),
    ("endpoints:/my-endpoint", "string", DatabricksServingEndpointAdapter, DatabricksServingEndpointAdapter),
    ("endpoints:/my-endpoint", "list", DatabricksServingEndpointAdapter, DatabricksServingEndpointAdapter),
    ("openai:/gpt-4", "string", GatewayAdapter, LiteLLMAdapter),
    ("openai:/gpt-4", "list", None, LiteLLMAdapter),
    ("anthropic:/claude-3-5-sonnet-20241022", "string", GatewayAdapter, LiteLLMAdapter),
    ("anthropic:/claude-3-5-sonnet-20241022", "list", None, LiteLLMAdapter),
]


def get_applicable_adapter(model_uri: str, prompt):
    adapters = [
        DatabricksManagedJudgeAdapter,
        DatabricksServingEndpointAdapter,
        LiteLLMAdapter,  # Checked BEFORE GatewayAdapter
        GatewayAdapter,
    ]

    for adapter in adapters:
        if adapter.is_applicable(model_uri, prompt):
            return adapter
    return None


def test_scenario(scenario_name: str, litellm_available: bool):
    print(f"\n{'='*70}")
    print(f"{scenario_name}")
    print(f"{'='*70}\n")

    string_prompt = "test input"
    list_prompt = [ChatMessage(role="user", content="test")]

    passed = 0
    failed = 0

    for model_uri, prompt_type, expected_without, expected_with in TEST_CASES:
        expected_adapter = expected_with if litellm_available else expected_without
        prompt = string_prompt if prompt_type == "string" else list_prompt

        with mock.patch(
            "mlflow.genai.judges.adapters.litellm_adapter._is_litellm_available",
            return_value=litellm_available,
        ):
            actual_adapter = get_applicable_adapter(model_uri, prompt)

        status = "✓" if actual_adapter == expected_adapter else "✗"
        expected_name = expected_adapter.__name__ if expected_adapter else "None"
        actual_name = actual_adapter.__name__ if actual_adapter else "None"

        if actual_adapter == expected_adapter:
            passed += 1
            print(f"{status} {model_uri:40} {prompt_type:6} -> {actual_name}")
        else:
            failed += 1
            print(
                f"{status} {model_uri:40} {prompt_type:6} -> Expected: {expected_name}, Got: {actual_name}"
            )

    print(f"\nResults: {passed} passed, {failed} failed")
    return failed == 0

success1 = test_scenario("Scenario 1: WITHOUT LiteLLM (fallback to GatewayAdapter)", False)
success2 = test_scenario("Scenario 2: WITH LiteLLM (LiteLLMAdapter handles all)", True)

print(f"\n{'='*70}")
if success1 and success2:
    print("✅ All adapter selection tests passed!")
    return 0
else:
    print("⚠️  Some tests failed!")
    return 1
```


<img width="748" height="687" alt="Screenshot 2025-12-15 at 9 17 08 PM" src="https://github.com/user-attachments/assets/7453ab27-865a-4702-939f-7c4ccc81baa4" />


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
