### PR TITLE
[UI Telemetry] Add settings page and info banner to control user opt-out

### DIFF
--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   DatabaseIcon,
   DropdownMenu,
+  GearIcon,
   HomeIcon,
   ModelsIcon,
   PlusIcon,
@@ -26,12 +27,12 @@ import Routes from '../../experiment-tracking/routes';
 import { FormattedMessage } from 'react-intl';
 
 const isHomeActive = (location: Location) => matchPath({ path: '/', end: true }, location.pathname);
-
 const isExperimentsActive = (location: Location) =>
   matchPath('/experiments/*', location.pathname) || matchPath('/compare-experiments/*', location.pathname);
 const isModelsActive = (location: Location) => matchPath('/models/*', location.pathname);
 const isPromptsActive = (location: Location) => matchPath('/prompts/*', location.pathname);
 const isGatewayActive = (location: Location) => matchPath('/gateway/*', location.pathname);
+const isSettingsActive = (location: Location) => matchPath('/settings/*', location.pathname);
 
 export function MlflowSidebar() {
   const location = useLocation();
@@ -157,7 +158,7 @@ export function MlflowSidebar() {
         </DropdownMenu.Content>
       </DropdownMenu.Root>
 
-      <nav>
+      <nav css={{ display: 'flex', flexDirection: 'column', justifyContent: 'space-between', height: '100%' }}>
         <ul
           css={{
             listStyleType: 'none',
@@ -194,6 +195,31 @@ export function MlflowSidebar() {
             </li>
           ))}
         </ul>
+        <Link
+          to={ExperimentTrackingRoutes.settingsPageRoute}
+          aria-current={isSettingsActive(location) ? 'page' : undefined}
+          css={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: theme.spacing.sm,
+            color: theme.colors.textPrimary,
+            paddingInline: theme.spacing.md,
+            paddingBlock: theme.spacing.sm,
+            borderRadius: theme.borders.borderRadiusSm,
+            '&:hover': {
+              color: theme.colors.actionLinkHover,
+              backgroundColor: theme.colors.actionDefaultBackgroundHover,
+            },
+            '&[aria-current="page"]': {
+              backgroundColor: theme.colors.actionDefaultBackgroundPress,
+              color: theme.isDarkMode ? theme.colors.blue300 : theme.colors.blue700,
+              fontWeight: theme.typography.typographyBoldFontWeight,
+            },
+          }}
+        >
+          <GearIcon />
+          <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />
+        </Link>
       </nav>
 
       <CreateExperimentModal

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -181,6 +181,7 @@ export function MlflowSidebar() {
                   borderRadius: theme.borders.borderRadiusSm,
                   '&:hover': {
                     color: theme.colors.actionLinkHover,
+                    backgroundColor: theme.colors.actionDefaultBackgroundHover,
                   },
                   '&[aria-current="page"]': {
                     backgroundColor: theme.colors.actionDefaultBackgroundPress,

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -102,6 +102,11 @@ export const getRouteDefs = () => [
     element: createLazyRouteElement(() => import('../home/HomePage')),
     pageId: PageId.home,
   },
+  {
+    path: RoutePaths.settingsPage,
+    element: createLazyRouteElement(() => import('../settings/SettingsPage')),
+    pageId: PageId.settingsPage,
+  },
   ...getExperimentPageRouteDefs(),
   {
     path: RoutePaths.experimentLoggedModelDetailsPageTab,

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -7,6 +7,7 @@ import type { ExperimentPageTabName } from './constants';
  */
 export enum PageId {
   home = 'mlflow.home',
+  settingsPage = 'mlflow.settings',
   promptsPage = 'mlflow.prompts',
   promptDetailsPage = 'mlflow.prompts.details',
   experimentPageTabbed = 'mlflow.experiment.details.tab',
@@ -126,6 +127,9 @@ export class RoutePaths {
   static get promptDetailsPage() {
     return createMLflowRoutePath('/prompts/:promptName');
   }
+  static get settingsPage() {
+    return createMLflowRoutePath('/settings');
+  }
 }
 
 // Concrete routes and functions for generating parametrized paths
@@ -145,6 +149,10 @@ class Routes {
 
   static get experimentPageSearchRoute() {
     return RoutePaths.experimentPageSearch;
+  }
+
+  static get settingsPageRoute() {
+    return RoutePaths.settingsPage;
   }
 
   static getExperimentPageRoute(experimentId: string, isComparingRuns = false, shareState?: string) {

--- a/mlflow/server/js/src/home/HomePage.tsx
+++ b/mlflow/server/js/src/home/HomePage.tsx
@@ -11,10 +11,7 @@ import { GetStarted } from './components/GetStarted';
 import { ExperimentsHomeView } from './components/ExperimentsHomeView';
 import { DiscoverNews } from './components/DiscoverNews';
 import { LogTracesDrawer } from './components/LogTracesDrawer';
-import { Link } from '../common/utils/RoutingUtils';
-import Routes from '../experiment-tracking/routes';
-import { TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY } from '../telemetry/utils';
-import { useLocalStorage } from '../shared/web-shared/hooks';
+import { TelemetryInfoAlert } from '../telemetry/TelemetryInfoAlert';
 
 type ExperimentQueryKey = ['home', 'recent-experiments'];
 
@@ -24,11 +21,6 @@ const HomePage = () => {
   const { theme } = useDesignSystemTheme();
   const invalidateExperiments = useInvalidateExperimentList();
   const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
-  const [isTelemetryAlertDismissed, setIsTelemetryAlertDismissed] = useLocalStorage({
-    key: TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY,
-    version: 1,
-    initialValue: false,
-  });
 
   const { data, error, isLoading, refetch } = useQuery<
     SearchExperimentsApiResponse,
@@ -65,40 +57,7 @@ const HomePage = () => {
       }}
     >
       <Header title={<FormattedMessage defaultMessage="Welcome to MLflow" description="Home page hero title" />} />
-      {!isTelemetryAlertDismissed && (
-        <Alert
-          componentId="mlflow.home.telemetry-alert"
-          message="Information about UI telemetry"
-          type="info"
-          onClose={() => setIsTelemetryAlertDismissed(true)}
-          description={
-            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
-              <span>
-                <FormattedMessage
-                  defaultMessage="MLflow collects usage data to improve the product. To confirm your settings, please visit the <settings>settings</settings> page. To learn more about what data is collected, please visit the <documentation>documentation</documentation>."
-                  description="Telemetry alert description"
-                  values={{
-                    settings: (chunks: any) => (
-                      <Link to={Routes.settingsPageRoute} onClick={() => setIsTelemetryAlertDismissed(true)}>
-                        {chunks}
-                      </Link>
-                    ),
-                    documentation: (chunks: any) => (
-                      <Link
-                        to="https://mlflow.org/docs/latest/community/usage-tracking.html"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {chunks}
-                      </Link>
-                    ),
-                  }}
-                />
-              </span>
-            </div>
-          }
-        />
-      )}
+      <TelemetryInfoAlert />
       <GetStarted />
       <ExperimentsHomeView
         experiments={experiments}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -23,6 +23,10 @@
     "defaultMessage": "Cancel",
     "description": "Button label for cancelling the creation of an assessment"
   },
+  "+CGMk6": {
+    "defaultMessage": "On",
+    "description": "Telemetry enabled label"
+  },
   "+Cr7Gu": {
     "defaultMessage": "Search metrics",
     "description": "Placeholder text for the search input in the logged model details metrics table"
@@ -2474,6 +2478,10 @@
     "defaultMessage": "No traces found with the current filter query. <button>Reset filters</button> to see all traces.",
     "description": "Experiment page > traces table > no traces recorded"
   },
+  "LXz6c5": {
+    "defaultMessage": "This setting enables UI telemetry data collection. Learn more about what types of data are collected in our {documentation}.",
+    "description": "Enable telemetry settings description"
+  },
   "LajLDb": {
     "defaultMessage": "Move to top",
     "description": "Experiment page > compare runs tab > chart header > move to top option"
@@ -3983,6 +3991,10 @@
     "defaultMessage": "Outputs",
     "description": "Table subtitle for schema outputs in the model comparison page"
   },
+  "aCzpU3": {
+    "defaultMessage": "Off",
+    "description": "Telemetry disabled label"
+  },
   "aE6zVg": {
     "defaultMessage": "Configure predefined judges, create guidelines-based LLM judges, or build custom judge functions to track your unique metrics. {link}",
     "description": "Description for the empty state of the judges page"
@@ -4795,6 +4807,10 @@
     "defaultMessage": "Automatically log traces for DSPy executions by calling the {code} function. For example:",
     "description": "Description of how to log traces for the DSPy package using MLflow autologging. This message is followed by a code example."
   },
+  "h2398a": {
+    "defaultMessage": "documentation",
+    "description": "Documentation link text"
+  },
   "h2Ejm7": {
     "defaultMessage": "Learn more",
     "description": "Link to the documentation page for user and session tracking"
@@ -4858,6 +4874,10 @@
   "hcDB9U": {
     "defaultMessage": "+∞",
     "description": "Label displaying positive infinity symbol displayed on a plot UI element"
+  },
+  "hg+bcy": {
+    "defaultMessage": "Enable telemetry",
+    "description": "Enable telemetry settings title"
   },
   "hkXDZn": {
     "defaultMessage": "MLflow allows you associate traces with users and chat sessions. This is useful for analyzing multi-turn conversations, enabling you to inspect what happened at each step. Copy the code snippet below to generate a sample trace, or visit the documentation for a more in-depth example.",
@@ -5074,6 +5094,10 @@
   "jhjCgW": {
     "defaultMessage": "Agent versions",
     "description": "Label for the agent versions tab in the MLflow experiment navbar"
+  },
+  "jiIft9": {
+    "defaultMessage": "Settings",
+    "description": "Sidebar link for settings page"
   },
   "jjidVr": {
     "defaultMessage": "{numValue}/{numEvals} for run \"{runName}\"",
@@ -5855,6 +5879,10 @@
     "defaultMessage": "Create version",
     "description": "Button for creating a new genai model version"
   },
+  "qvEOHi": {
+    "defaultMessage": "MLflow collects usage data to improve the product. To confirm your preferences, please visit the settings page in the navigation sidebar. To learn more about what data is collected, please visit the <documentation>documentation</documentation>.",
+    "description": "Telemetry alert description"
+  },
   "qzahRD": {
     "defaultMessage": "Name",
     "description": "Section header for optional judge name"
@@ -6394,6 +6422,10 @@
   "wNHR0W": {
     "defaultMessage": "Aliases",
     "description": "Column title text for model version aliases in model version table"
+  },
+  "wRV8PN": {
+    "defaultMessage": "Settings",
+    "description": "Settings page title"
   },
   "wY58OE": {
     "defaultMessage": "Retrieval groundedness",

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -2,6 +2,8 @@ import { Switch, Typography, useDesignSystemTheme } from '@databricks/design-sys
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 import { useLocalStorage } from '../shared/web-shared/hooks';
 import { TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from '../telemetry/utils';
+import { telemetryClient } from '../telemetry';
+import { useCallback } from 'react';
 
 const SettingsPage = () => {
   const { theme } = useDesignSystemTheme();
@@ -12,6 +14,18 @@ const SettingsPage = () => {
     version: TELEMETRY_ENABLED_STORAGE_VERSION,
     initialValue: true,
   });
+
+  const handleTelemetryToggle = useCallback(
+    (checked: boolean) => {
+      setIsTelemetryEnabled(checked);
+      if (checked) {
+        telemetryClient.start();
+      } else {
+        telemetryClient.shutdown();
+      }
+    },
+    [setIsTelemetryEnabled],
+  );
 
   return (
     <div css={{ padding: theme.spacing.md }}>
@@ -45,7 +59,7 @@ const SettingsPage = () => {
         <Switch
           componentId="mlflow.settings.telemetry.toggle-switch"
           checked={isTelemetryEnabled}
-          onChange={setIsTelemetryEnabled}
+          onChange={handleTelemetryToggle}
           label=" "
           activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })}
           inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })}

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from '@databricks/i18n';
 import { useLocalStorage } from '../shared/web-shared/hooks';
-import { TELEMETRY_ENABLED_STORAGE_KEY } from '../telemetry/utils';
+import { TELEMETRY_ENABLED_STORAGE_KEY, TELEMETRY_ENABLED_STORAGE_VERSION } from '../telemetry/utils';
 
 const SettingsPage = () => {
   const { theme } = useDesignSystemTheme();
@@ -9,7 +9,7 @@ const SettingsPage = () => {
 
   const [isTelemetryEnabled, setIsTelemetryEnabled] = useLocalStorage({
     key: TELEMETRY_ENABLED_STORAGE_KEY,
-    version: 1,
+    version: TELEMETRY_ENABLED_STORAGE_VERSION,
     initialValue: true,
   });
 

--- a/mlflow/server/js/src/settings/SettingsPage.tsx
+++ b/mlflow/server/js/src/settings/SettingsPage.tsx
@@ -1,0 +1,59 @@
+import { Switch, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from '@databricks/i18n';
+import { useLocalStorage } from '../shared/web-shared/hooks';
+import { TELEMETRY_ENABLED_STORAGE_KEY } from '../telemetry/utils';
+
+const SettingsPage = () => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const [isTelemetryEnabled, setIsTelemetryEnabled] = useLocalStorage({
+    key: TELEMETRY_ENABLED_STORAGE_KEY,
+    version: 1,
+    initialValue: true,
+  });
+
+  return (
+    <div css={{ padding: theme.spacing.md }}>
+      <Typography.Title level={2}>
+        <FormattedMessage defaultMessage="Settings" description="Settings page title" />
+      </Typography.Title>
+
+      <div css={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', maxWidth: 600 }}>
+        <div css={{ display: 'flex', flexDirection: 'column', marginRight: theme.spacing.lg }}>
+          <Typography.Title level={4}>
+            <FormattedMessage defaultMessage="Enable telemetry" description="Enable telemetry settings title" />
+          </Typography.Title>
+          <Typography.Text>
+            <FormattedMessage
+              defaultMessage="This setting enables UI telemetry data collection. Learn more about what types of data are collected in our {documentation}."
+              description="Enable telemetry settings description"
+              values={{
+                documentation: (
+                  <Typography.Link
+                    componentId="mlflow.settings.telemetry.documentation-link"
+                    href="https://mlflow.org/docs/latest/community/usage-tracking.html"
+                    openInNewTab
+                  >
+                    <FormattedMessage defaultMessage="documentation" description="Documentation link text" />
+                  </Typography.Link>
+                ),
+              }}
+            />
+          </Typography.Text>
+        </div>
+        <Switch
+          componentId="mlflow.settings.telemetry.toggle-switch"
+          checked={isTelemetryEnabled}
+          onChange={setIsTelemetryEnabled}
+          label=" "
+          activeLabel={intl.formatMessage({ defaultMessage: 'On', description: 'Telemetry enabled label' })}
+          inactiveLabel={intl.formatMessage({ defaultMessage: 'Off', description: 'Telemetry disabled label' })}
+          disabledLabel=" "
+        />
+      </div>
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
+++ b/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
@@ -3,7 +3,6 @@ import { useLocalStorage } from '../shared/web-shared/hooks';
 import { Alert, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
 import { Link } from '../common/utils/RoutingUtils';
-import Routes from '../experiment-tracking/routes';
 
 export const TelemetryInfoAlert = () => {
   const { theme } = useDesignSystemTheme();
@@ -31,11 +30,6 @@ export const TelemetryInfoAlert = () => {
               defaultMessage="MLflow collects usage data to improve the product. To confirm your preferences, please visit the settings page in the navigation sidebar. To learn more about what data is collected, please visit the <documentation>documentation</documentation>."
               description="Telemetry alert description"
               values={{
-                settings: (chunks: any) => (
-                  <Link to={Routes.settingsPageRoute} onClick={() => setIsTelemetryAlertDismissed(true)}>
-                    {chunks}
-                  </Link>
-                ),
                 documentation: (chunks: any) => (
                   <Link
                     to="https://mlflow.org/docs/latest/community/usage-tracking.html"

--- a/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
+++ b/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
@@ -1,0 +1,55 @@
+import { TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY } from '../telemetry/utils';
+import { useLocalStorage } from '../shared/web-shared/hooks';
+import { Alert, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from '@databricks/i18n';
+import { Link } from '../common/utils/RoutingUtils';
+import Routes from '../experiment-tracking/routes';
+
+export const TelemetryInfoAlert = () => {
+  const { theme } = useDesignSystemTheme();
+
+  const [isTelemetryAlertDismissed, setIsTelemetryAlertDismissed] = useLocalStorage({
+    key: TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY,
+    version: 1,
+    initialValue: false,
+  });
+
+  if (isTelemetryAlertDismissed) {
+    return null;
+  }
+
+  return (
+    <Alert
+      componentId="mlflow.home.telemetry-alert"
+      message="Information about UI telemetry"
+      type="info"
+      onClose={() => setIsTelemetryAlertDismissed(true)}
+      description={
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+          <span>
+            <FormattedMessage
+              defaultMessage="MLflow collects usage data to improve the product. To confirm your preferences, please visit the settings page in the navigation sidebar. To learn more about what data is collected, please visit the <documentation>documentation</documentation>."
+              description="Telemetry alert description"
+              values={{
+                settings: (chunks: any) => (
+                  <Link to={Routes.settingsPageRoute} onClick={() => setIsTelemetryAlertDismissed(true)}>
+                    {chunks}
+                  </Link>
+                ),
+                documentation: (chunks: any) => (
+                  <Link
+                    to="https://mlflow.org/docs/latest/community/usage-tracking.html"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {chunks}
+                  </Link>
+                ),
+              }}
+            />
+          </span>
+        </div>
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
+++ b/mlflow/server/js/src/telemetry/TelemetryInfoAlert.tsx
@@ -1,4 +1,7 @@
-import { TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY } from '../telemetry/utils';
+import {
+  TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY,
+  TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_VERSION,
+} from '../telemetry/utils';
 import { useLocalStorage } from '../shared/web-shared/hooks';
 import { Alert, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from '@databricks/i18n';
@@ -9,7 +12,7 @@ export const TelemetryInfoAlert = () => {
 
   const [isTelemetryAlertDismissed, setIsTelemetryAlertDismissed] = useLocalStorage({
     key: TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY,
-    version: 1,
+    version: TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_VERSION,
     initialValue: false,
   });
 

--- a/mlflow/server/js/src/telemetry/utils.ts
+++ b/mlflow/server/js/src/telemetry/utils.ts
@@ -7,6 +7,8 @@ export const TELEMETRY_ENABLED_STORAGE_KEY = 'mlflow.settings.telemetry.enabled'
 
 export const TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_KEY = 'mlflow.telemetry.info.alert.dismissed';
 
+export const TELEMETRY_INFO_ALERT_DISMISSED_STORAGE_VERSION = 1;
+
 export const isDesignSystemEvent = (event: any): event is DesignSystemObservabilityEvent => {
   if (!event || !isObject(event) || Array.isArray(event)) {
     return false;


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19351/files) to review incremental changes.
- [**stack/settings**](https://github.com/mlflow/mlflow/pull/19351) [[Files changed](https://github.com/mlflow/mlflow/pull/19351/files)]
  - [stack/documentation](https://github.com/mlflow/mlflow/pull/19427) [[Files changed](https://github.com/mlflow/mlflow/pull/19427/files/9ae28c6d7e750862bc27268c5c58d8d2c413f6f3..b2e82e63dfb91f4ba217b8cb5254e3952ef1851a)]
    - [stack/logging-for-tabs](https://github.com/mlflow/mlflow/pull/19480) [[Files changed](https://github.com/mlflow/mlflow/pull/19480/files/b2e82e63dfb91f4ba217b8cb5254e3952ef1851a..5021f8b39405245f4fd22c76c8a9e02d53cd1ca4)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds a few things to allow users to opt out and notify them about telemetry:

1. Settings page in bottom left of navbar
2. UI banner

The previous PR in the stack has been updated to respect this preference. The worker will not be spun up if the preference is set.

Furthermore, the worker is killed/restarted when the toggle is switched, so the user does not have to refresh when updating preferences.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Demo of worker shutting down / restarting when toggle is switched (changed batch rate to 5 sec for demo purposes):


https://github.com/user-attachments/assets/844f1f41-bfe9-4483-b196-6d470575f631


Demo of information banner:

https://github.com/user-attachments/assets/c83bfa17-9d1d-41c6-ae07-c1f48cd773e9


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
