### PR TITLE
[Agentic Judges] Introduce tool call efficiency builtin judge

### DIFF
--- a/docs/api_reference/api_inventory.txt
+++ b/docs/api_reference/api_inventory.txt
@@ -798,6 +798,7 @@ mlflow.genai.judges.is_context_sufficient
 mlflow.genai.judges.is_correct
 mlflow.genai.judges.is_grounded
 mlflow.genai.judges.is_safe
+mlflow.genai.judges.is_tool_call_efficient
 mlflow.genai.judges.make_judge
 mlflow.genai.judges.meets_guidelines
 mlflow.genai.judges.utils.CategoricalRating
@@ -893,6 +894,9 @@ mlflow.genai.scorers.ScorerSamplingConfig
 mlflow.genai.scorers.Summarization
 mlflow.genai.scorers.Summarization.get_input_fields
 mlflow.genai.scorers.Summarization.model_post_init
+mlflow.genai.scorers.ToolCallEfficiency
+mlflow.genai.scorers.ToolCallEfficiency.get_input_fields
+mlflow.genai.scorers.ToolCallEfficiency.model_post_init
 mlflow.genai.scorers.UserFrustration
 mlflow.genai.scorers.UserFrustration.model_post_init
 mlflow.genai.scorers.base.Scorer
@@ -913,6 +917,7 @@ mlflow.genai.scorers.builtin_scorers.RetrievalRelevance
 mlflow.genai.scorers.builtin_scorers.RetrievalSufficiency
 mlflow.genai.scorers.builtin_scorers.Safety
 mlflow.genai.scorers.builtin_scorers.Summarization
+mlflow.genai.scorers.builtin_scorers.ToolCallEfficiency
 mlflow.genai.scorers.builtin_scorers.UserFrustration
 mlflow.genai.scorers.delete_scorer
 mlflow.genai.scorers.get_all_scorers

--- a/mlflow/genai/judges/__init__.py
+++ b/mlflow/genai/judges/__init__.py
@@ -7,6 +7,7 @@ from mlflow.genai.judges.builtin import (
     is_correct,
     is_grounded,
     is_safe,
+    is_tool_call_efficient,
     meets_guidelines,
 )
 from mlflow.genai.judges.custom_prompt_judge import custom_prompt_judge
@@ -26,6 +27,7 @@ __all__ = [
     "is_correct",
     "is_context_relevant",
     "is_context_sufficient",
+    "is_tool_call_efficient",
     "meets_guidelines",
     "custom_prompt_judge",
 ]

--- a/mlflow/genai/judges/prompts/tool_call_efficiency.py
+++ b/mlflow/genai/judges/prompts/tool_call_efficiency.py
@@ -1,0 +1,170 @@
+import logging
+from typing import TYPE_CHECKING
+
+from mlflow.genai.prompts.utils import format_prompt
+
+_logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from mlflow.genai.utils.type import FunctionCall
+    from mlflow.types.chat import ChatTool
+
+# NB: User-facing name for the is_tool_call_efficient assessment.
+TOOL_CALL_EFFICIENCY_FEEDBACK_NAME = "tool_call_efficiency"
+
+TOOL_CALL_EFFICIENCY_PROMPT_INSTRUCTIONS = """\
+Consider the agent's tool usage for redundancy and inefficiency.
+
+Given the user's request, the available tools, and the sequence of tools called by the agent, \
+determine whether any tool calls were unnecessary or could have been made more efficient. In your \
+analysis, treat retries caused by temporary tool failures (e.g., timeouts, transient errors) as \
+efficient and not redundant.
+
+Consider in particular:
+
+Calls to the same tool with identical or very similar arguments
+
+Repeated calls to the same tool with the same parameters
+
+Multiple calls that could reasonably have been consolidated into a single call
+
+<request>
+{{request}}
+</request>
+
+<available_tools>
+{{available_tools}}
+</available_tools>
+
+<tools_called>
+{{tools_called}}
+</tools_called>"""
+
+TOOL_CALL_EFFICIENCY_PROMPT_OUTPUT = """
+
+Please evaluate whether the agent's tool usage is efficient and free of redundancy using only the following json format. Return "yes" if the tool usage is efficient and free of redundancy, otherwise return "no".
+Do not use any markdown formatting or output additional lines.
+{
+  "rationale": "Reason for the assessment. If redundant tool calls are found, identify which specific calls are redundant and explain why. If no redundancy is found, explain why the tool usage is efficient. Start each rationale with `Let's think step by step`",
+  "result": "yes|no"
+}\
+"""  # noqa: E501
+
+TOOL_CALL_EFFICIENCY_PROMPT = (
+    TOOL_CALL_EFFICIENCY_PROMPT_INSTRUCTIONS + TOOL_CALL_EFFICIENCY_PROMPT_OUTPUT
+)
+
+
+def _format_available_tools(available_tools: list["ChatTool"]) -> str:
+    """Format available tools with descriptions and parameters.
+
+    Args:
+        available_tools: The set of available tools
+
+    Returns:
+        Formatted string representation of available tools
+
+    Example:
+        >>> # Output format:
+        >>> # - search: Search for information on the web
+        >>> #     - query (required): string - The search query to execute
+        >>> #     - max_results (optional): integer - Maximum number of results
+        >>> # - translate: Translate text to another language
+        >>> #     - text (required): string - The text to translate
+        >>> #     - target (required): string - Target language code
+    """
+    available_tools_parts = []
+    for tool in available_tools:
+        if not tool.function:
+            _logger.warning(f"Skipping tool with missing function definition: {tool}")
+            continue
+
+        tool_str = f"- {tool.function.name}"
+        if tool.function.description:
+            tool_str += f": {tool.function.description}"
+
+        if tool.function.parameters and tool.function.parameters.properties:
+            params = tool.function.parameters
+            required_params = set(params.required or [])
+            param_lines = []
+
+            for param_name, param_prop in params.properties.items():
+                is_required = param_name in required_params
+                required_marker = " (required)" if is_required else " (optional)"
+                param_line = f"    - {param_name}{required_marker}"
+
+                if hasattr(param_prop, "type") and param_prop.type:
+                    param_line += f": {param_prop.type}"
+
+                if param_prop.description:
+                    param_line += f" - {param_prop.description}"
+
+                param_lines.append(param_line)
+
+            if param_lines:
+                tool_str += "\n" + "\n".join(param_lines)
+
+        available_tools_parts.append(tool_str)
+    return "\n\n".join(available_tools_parts) if available_tools_parts else "No tools available"
+
+
+def _format_tools_called(tools_called: list["FunctionCall"]) -> str:
+    """Format tools called with step numbers, arguments, and outputs.
+
+    Args:
+        tools_called: The sequence of tools that were called by the agent.
+            Each element should be a FunctionCall object.
+
+    Returns:
+        Formatted string representation of tools called
+
+    Example:
+        >>> # Output format:
+        >>> # Tool Call 1: search
+        >>> #   Input Arguments: {"query": "capital of France"}
+        >>> #   Output: Paris
+        >>> #
+        >>> # Tool Call 2: translate
+        >>> #   Input Arguments: {"text": "Paris", "target": "es"}
+        >>> #   Output: París
+    """
+    tools_called_parts = []
+    for idx, tool in enumerate(tools_called, start=1):
+        tool_name = tool.name
+        tool_args = tool.arguments or {}
+        tool_output = tool.outputs or "(no output)"
+
+        tool_str = f"Tool Call {idx}: {tool_name}\n"
+        tool_str += f"  Input Arguments: {tool_args}\n"
+        tool_str += f"  Output: {tool_output}\n"
+        if tool.exception:
+            tool_str += f"  Exception: {tool.exception}"
+        tools_called_parts.append(tool_str)
+    return "\n\n".join(tools_called_parts) if tools_called_parts else "No tools called"
+
+
+def get_prompt(
+    request: str,
+    tools_called: list["FunctionCall"],
+    available_tools: list["ChatTool"],
+) -> str:
+    """Generate tool call efficiency evaluation prompt.
+
+    Args:
+        request: The original user request that the agent is trying to fulfill
+        tools_called: The sequence of tools that were called by the agent.
+            Each element should be a FunctionCall object.
+        available_tools: The set of available tools
+
+    Returns:
+        Formatted prompt string
+    """
+    available_tools_str = _format_available_tools(available_tools)
+    tools_called_str = _format_tools_called(tools_called)
+
+    return format_prompt(
+        TOOL_CALL_EFFICIENCY_PROMPT,
+        request=request,
+        available_tools=available_tools_str,
+        tools_called=tools_called_str,
+    )

--- a/mlflow/genai/scorers/__init__.py
+++ b/mlflow/genai/scorers/__init__.py
@@ -43,6 +43,7 @@ _LAZY_IMPORTS = {
     "RetrievalSufficiency",
     "Safety",
     "Summarization",
+    "ToolCallEfficiency",
     "UserFrustration",
     "get_all_scorers",
 }
@@ -92,6 +93,7 @@ if TYPE_CHECKING:
         RetrievalSufficiency,
         Safety,
         Summarization,
+        ToolCallEfficiency,
         UserFrustration,
         get_all_scorers,
     )
@@ -113,6 +115,7 @@ __all__ = [
     "RetrievalSufficiency",
     "Safety",
     "Summarization",
+    "ToolCallEfficiency",
     "UserFrustration",
     "Scorer",
     "scorer",

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -52,6 +52,9 @@ from mlflow.genai.judges.prompts.summarization import (
     SUMMARIZATION_ASSESSMENT_NAME,
     SUMMARIZATION_PROMPT,
 )
+from mlflow.genai.judges.prompts.tool_call_efficiency import (
+    TOOL_CALL_EFFICIENCY_PROMPT_INSTRUCTIONS,
+)
 from mlflow.genai.judges.prompts.user_frustration import (
     USER_FRUSTRATION_ASSESSMENT_NAME,
     USER_FRUSTRATION_PROMPT,
@@ -68,9 +71,11 @@ from mlflow.genai.scorers.base import (
     SerializedScorer,
 )
 from mlflow.genai.utils.trace_utils import (
+    extract_available_tools_from_trace,
     extract_request_from_trace,
     extract_response_from_trace,
     extract_retrieval_context_from_trace,
+    extract_tools_called_from_trace,
     parse_inputs_to_str,
     parse_outputs_to_str,
     resolve_expectations_from_trace,
@@ -706,6 +711,83 @@ class RetrievalGroundedness(BuiltInScorer):
             feedback.span_id = span_id
             feedbacks.append(feedback)
         return feedbacks
+
+
+@experimental(version="3.8.0")
+@format_docstring(_MODEL_API_DOC)
+class ToolCallEfficiency(BuiltInScorer):
+    """
+    ToolCallEfficiency evaluates the agent's trajectory for redundancy in tool usage,
+    such as tool calls with the same or similar arguments.
+
+    This scorer analyzes whether the agent makes redundant tool calls during execution.
+    It checks for duplicate or near-duplicate tool invocations that could be avoided
+    for more efficient task completion.
+
+    You can invoke the scorer directly with a single input for testing, or pass it to
+    `mlflow.genai.evaluate` for running full evaluation on a dataset.
+
+    Args:
+        name: The name of the scorer. Defaults to "tool_call_efficiency".
+        model: {{ model }}
+
+    Example (direct usage):
+
+    .. code-block:: python
+
+        import mlflow
+        from mlflow.genai.scorers import ToolCallEfficiency
+
+        trace = mlflow.get_trace("<your-trace-id>")
+        feedback = ToolCallEfficiency(name="my_tool_call_efficiency")(trace=trace)
+        print(feedback)
+
+    Example (with evaluate):
+
+    .. code-block:: python
+
+        import mlflow
+
+        data = mlflow.search_traces(...)
+        result = mlflow.genai.evaluate(data=data, scorers=[ToolCallEfficiency()])
+    """
+
+    name: str = "tool_call_efficiency"
+    model: str | None = None
+    required_columns: set[str] = {"trace"}
+    description: str = (
+        "Evaluate the agent's trajectory for redundancy in tool usage, "
+        "such as tool calls with the same or similar arguments."
+    )
+
+    @property
+    def instructions(self) -> str:
+        return TOOL_CALL_EFFICIENCY_PROMPT_INSTRUCTIONS
+
+    def get_input_fields(self) -> list[JudgeField]:
+        return [
+            JudgeField(
+                name="trace",
+                description=(
+                    "The trace of the model's execution. The trace should contain tool call "
+                    "information across the agent's trajectory. MLflow will analyze the tool calls "
+                    "to identify any redundancy, such as duplicate or similar tool invocations."
+                ),
+            ),
+        ]
+
+    def __call__(self, *, trace: Trace) -> Feedback:
+        request = extract_request_from_trace(trace)
+        available_tools = extract_available_tools_from_trace(trace)
+        tools_called = extract_tools_called_from_trace(trace)
+
+        return judges.is_tool_call_efficient(
+            request=request,
+            tools_called=tools_called,
+            available_tools=available_tools,
+            name=self.name,
+            model=self.model,
+        )
 
 
 @format_docstring(_MODEL_API_DOC)

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -184,7 +184,7 @@ def _get_exception_from_span(span: Span) -> str | None:
 
     exception_type = attrs.get("exception.type", "Exception")
 
-    if exception_message := attrs.get("exception.message", ""):
+    if exception_message := attrs.get("exception.message"):
         return f"{exception_type}: {exception_message}"
     return exception_type
 

--- a/mlflow/genai/utils/trace_utils.py
+++ b/mlflow/genai/utils/trace_utils.py
@@ -42,6 +42,7 @@ if TYPE_CHECKING:
     import pandas as pd
 
     from mlflow.genai.evaluation.entities import EvalItem, EvalResult
+    from mlflow.genai.utils.type import FunctionCall
     from mlflow.types.chat import ChatTool
 
 _logger = logging.getLogger(__name__)
@@ -164,7 +165,68 @@ def resolve_outputs_from_trace(
     return outputs
 
 
-def parse_tool_calls_from_trace(trace: Trace) -> list[dict[str, str]]:
+def _get_exception_from_span(span: Span) -> str | None:
+    """
+    Extract exception information from span events.
+
+    Args:
+        span: The span to check for exception events.
+
+    Returns:
+        A formatted string containing exception information if found, None otherwise.
+    """
+    exception_events = [event for event in span.events if event.name == "exception"]
+    if not exception_events:
+        return None
+
+    exception_event = exception_events[0]
+    attrs = exception_event.attributes
+
+    exception_type = attrs.get("exception.type", "Exception")
+
+    if exception_message := attrs.get("exception.message", ""):
+        return f"{exception_type}: {exception_message}"
+    return exception_type
+
+
+def extract_tools_called_from_trace(trace: Trace) -> list["FunctionCall"]:
+    """
+    Extract tool call information from TOOL type spans in a trace.
+
+    This function extracts tool spans (spans with span_type==SpanType.TOOL) from a trace
+    and returns them as a list of FunctionCall objects containing the tool name, inputs,
+    and outputs.
+
+    Args:
+        trace: A single Trace object to extract tool calls from.
+
+    Returns:
+        List of FunctionCall objects.
+        Returns empty list if no tool spans are found.
+
+    Example:
+        >>> trace = mlflow.get_trace(trace_id)
+        >>> tools = extract_tools_called_from_trace(trace)
+        >>> # Returns: [FunctionCall(name="tool_name", arguments={...}, outputs={...})]
+    """
+    from mlflow.genai.utils.type import FunctionCall
+
+    tools_called = []
+    tool_spans = trace.search_spans(span_type=SpanType.TOOL)
+
+    for tool_span in sorted(tool_spans, key=lambda s: s.start_time_ns or 0):
+        tool_info = FunctionCall(
+            name=tool_span.name,
+            arguments=tool_span.inputs or None,
+            outputs=tool_span.outputs or None,
+            exception=_get_exception_from_span(tool_span),
+        )
+        tools_called.append(tool_info)
+
+    return tools_called
+
+
+def parse_tool_call_messages_from_trace(trace: Trace) -> list[dict[str, str]]:
     """
     Extract and format tool call information from TOOL type spans in a trace.
 
@@ -182,19 +244,20 @@ def parse_tool_calls_from_trace(trace: Trace) -> list[dict[str, str]]:
 
     Example:
         >>> trace = mlflow.get_trace(trace_id)
-        >>> tool_messages = parse_tool_calls_from_trace(trace)
+        >>> tool_messages = parse_tool_call_messages_from_trace(trace)
         >>> # Returns: [{"role": "tool", "content": "Tool: name\\nInputs: ...\\nOutputs: ..."}]
     """
+    tools_called = extract_tools_called_from_trace(trace)
 
     tool_messages = []
-    tool_spans = trace.search_spans(span_type=SpanType.TOOL)
-
-    for tool_span in sorted(tool_spans, key=lambda s: s.start_time_ns or 0):
-        tool_info = f"Tool: {tool_span.name}"
-        if tool_span.inputs:
-            tool_info += f"\nInputs: {tool_span.inputs}"
-        if tool_span.outputs:
-            tool_info += f"\nOutputs: {tool_span.outputs}"
+    for tool in tools_called:
+        tool_info = f"Tool: {tool.name}"
+        if tool.arguments is not None:
+            tool_info += f"\nInputs: {tool.arguments}"
+        if tool.outputs is not None:
+            tool_info += f"\nOutputs: {tool.outputs}"
+        if tool.exception is not None:
+            tool_info += f"\nException: {tool.exception}"
         tool_messages.append({"role": "tool", "content": tool_info})
 
     return tool_messages
@@ -233,7 +296,7 @@ def resolve_conversation_from_session(
 
         # Extract tool calls from TOOL type spans (if requested)
         if include_tool_calls:
-            tool_messages = parse_tool_calls_from_trace(trace)
+            tool_messages = parse_tool_call_messages_from_trace(trace)
             conversation.extend(tool_messages)
 
         # Extract and parse output (assistant message)

--- a/mlflow/genai/utils/type.py
+++ b/mlflow/genai/utils/type.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from typing import Any
+
+from mlflow.types.chat import Function
+
+
+class FunctionCall(Function):
+    arguments: str | dict[str, Any] | None = None
+    outputs: Any | None = None
+    exception: str | None = None

--- a/tests/genai/judges/test_builtin.py
+++ b/tests/genai/judges/test_builtin.py
@@ -18,6 +18,8 @@ from mlflow.genai.scorers import RelevanceToQuery, Safety, Scorer, UserFrustrati
 from mlflow.genai.scorers.aggregation import compute_aggregated_metrics
 from mlflow.genai.scorers.base import SerializedScorer
 from mlflow.genai.scorers.builtin_scorers import _sanitize_scorer_feedback
+from mlflow.genai.utils.type import FunctionCall
+from mlflow.types.chat import ChatTool, FunctionToolDefinition
 
 from tests.genai.conftest import databricks_only
 
@@ -580,3 +582,46 @@ def test_ser_deser_session_level_scorer():
     deserialized2 = Scorer.model_validate(serialized_obj)
     assert isinstance(deserialized2, UserFrustration)
     assert deserialized2.is_session_level_scorer is True
+
+
+def test_is_tool_call_efficient_with_custom_name_and_model():
+    with mock.patch(
+        "mlflow.genai.judges.builtin.invoke_judge_model",
+        return_value=Feedback(
+            name="custom_efficiency_check",
+            value=CategoricalRating.YES,
+            rationale="Let's think step by step. Tool usage is optimal.",
+            source=AssessmentSource(
+                source_type=AssessmentSourceType.LLM_JUDGE,
+                source_id="anthropic:/claude-3-sonnet",
+            ),
+        ),
+    ) as mock_invoke:
+        feedback = judges.is_tool_call_efficient(
+            request="Get weather for Paris",
+            tools_called=[
+                FunctionCall(
+                    name="get_weather",
+                    arguments={"city": "Paris"},
+                    outputs="Sunny, 22°C",
+                    exception=None,
+                )
+            ],
+            available_tools=[
+                ChatTool(
+                    type="function",
+                    function=FunctionToolDefinition(name="get_weather", description="Get weather"),
+                )
+            ],
+            name="custom_efficiency_check",
+            model="anthropic:/claude-3-sonnet",
+        )
+
+    assert feedback.name == "custom_efficiency_check"
+    assert feedback.value == CategoricalRating.YES
+    assert feedback.source.source_id == "anthropic:/claude-3-sonnet"
+
+    mock_invoke.assert_called_once()
+    args, kwargs = mock_invoke.call_args
+    assert args[0] == "anthropic:/claude-3-sonnet"
+    assert kwargs["assessment_name"] == "custom_efficiency_check"

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -29,6 +29,7 @@ from mlflow.genai.scorers import (
     RetrievalSufficiency,
     Safety,
     Summarization,
+    ToolCallEfficiency,
     UserFrustration,
 )
 from mlflow.genai.scorers.base import Scorer, ScorerKind
@@ -1665,6 +1666,44 @@ def test_conversational_tool_call_efficiency_instructions():
     instructions = scorer.instructions
     assert "tool" in instructions.lower()
     assert "efficient" in instructions.lower() or "redundant" in instructions.lower()
+
+
+def test_tool_call_efficiency():
+    with mlflow.start_span(name="agent") as span:
+        span.set_inputs({"question": "What is the weather in Paris?"})
+        with mlflow.start_span(name="get_weather", span_type=SpanType.TOOL) as tool_span:
+            tool_span.set_inputs({"city": "Paris"})
+            tool_span.set_outputs("Sunny, 22°C")
+        span.set_outputs("The weather in Paris is sunny and 22°C")
+
+    efficient_trace = mlflow.get_trace(span.trace_id)
+
+    with mlflow.start_span(name="agent") as span:
+        span.set_inputs({"question": "Get weather for InvalidCity"})
+        with mlflow.start_span(name="get_weather", span_type=SpanType.TOOL) as tool_span:
+            tool_span.set_inputs({"city": "InvalidCity123"})
+            tool_span.record_exception(ValueError("City not found"))
+        span.set_outputs("Sorry, I couldn't find that city")
+
+    exception_trace = mlflow.get_trace(span.trace_id)
+
+    with patch("mlflow.genai.judges.builtin.invoke_judge_model") as mock_invoke:
+        mock_invoke.return_value = Feedback(
+            name="tool_call_efficiency",
+            value=CategoricalRating.YES,
+            rationale="Tool usage is efficient",
+        )
+
+        scorer = ToolCallEfficiency()
+        result = scorer(trace=efficient_trace)
+
+        assert result.name == "tool_call_efficiency"
+        assert result.value == CategoricalRating.YES
+        mock_invoke.assert_called()
+
+        result = scorer(trace=exception_trace)
+        assert result.name == "tool_call_efficiency"
+        mock_invoke.assert_called()
 
 
 def test_conversational_role_adherence_with_session():

--- a/tests/genai/utils/test_trace_utils.py
+++ b/tests/genai/utils/test_trace_utils.py
@@ -33,7 +33,7 @@ from mlflow.genai.utils.trace_utils import (
     extract_retrieval_context_from_trace,
     parse_inputs_to_str,
     parse_outputs_to_str,
-    parse_tool_calls_from_trace,
+    parse_tool_call_messages_from_trace,
     resolve_conversation_from_session,
 )
 from mlflow.tracing import set_span_chat_tools
@@ -787,7 +787,7 @@ def test_create_minimal_trace_with_source_but_no_session():
     assert trace.data._get_root_span().outputs == "answer"
 
 
-def test_parse_tool_calls_from_trace():
+def test_parse_tool_call_messages_from_trace():
     with mlflow.start_span(name="root") as root_span:
         root_span.set_inputs({"question": "What is the stock price?"})
 
@@ -802,7 +802,7 @@ def test_parse_tool_calls_from_trace():
         root_span.set_outputs("AAPL price is $150.")
 
     trace = mlflow.get_trace(root_span.trace_id)
-    tool_messages = parse_tool_calls_from_trace(trace)
+    tool_messages = parse_tool_call_messages_from_trace(trace)
 
     assert len(tool_messages) == 2
     assert tool_messages[0] == {
@@ -817,18 +817,18 @@ def test_parse_tool_calls_from_trace():
     }
 
 
-def test_parse_tool_calls_from_trace_no_tools():
+def test_parse_tool_call_messages_from_trace_no_tools():
     with mlflow.start_span(name="root") as span:
         span.set_inputs({"question": "Hello"})
         span.set_outputs("Hi there")
 
     trace = mlflow.get_trace(span.trace_id)
-    tool_messages = parse_tool_calls_from_trace(trace)
+    tool_messages = parse_tool_call_messages_from_trace(trace)
 
     assert tool_messages == []
 
 
-def test_parse_tool_calls_from_trace_tool_without_outputs():
+def test_parse_tool_call_messages_from_trace_tool_without_outputs():
     with mlflow.start_span(name="root") as root_span:
         root_span.set_inputs({"query": "test"})
 
@@ -838,7 +838,7 @@ def test_parse_tool_calls_from_trace_tool_without_outputs():
         root_span.set_outputs("result")
 
     trace = mlflow.get_trace(root_span.trace_id)
-    tool_messages = parse_tool_calls_from_trace(trace)
+    tool_messages = parse_tool_call_messages_from_trace(trace)
 
     assert len(tool_messages) == 1
     assert tool_messages[0] == {


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19358/files) to review incremental changes.
- [**stack/ML-59978-introduce-tool-call-efficiency-builtin-judge**](https://github.com/mlflow/mlflow/pull/19358) [[Files changed](https://github.com/mlflow/mlflow/pull/19358/files)]
  - [stack/agentic-judges-introduce-tool-call-correctness-builtin-judge](https://github.com/mlflow/mlflow/pull/19391) [[Files changed](https://github.com/mlflow/mlflow/pull/19391/files/da297894cc37c2a62389a880be87bdf4d8b0adba..097c5e068efa02fec1552f5d671da8cfe4f0713e)]
    - [stack/agentic-judges-support-expectation-comparison-for-tool-call-correctness](https://github.com/mlflow/mlflow/pull/19413) [[Files changed](https://github.com/mlflow/mlflow/pull/19413/files/097c5e068efa02fec1552f5d671da8cfe4f0713e..a1122935276e763aa919dd073c36b849c0330b77)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
This PR introduces a new P0 agentic judge `ToolCallEfficiency` for measuring whether the tool call pattern is efficient given the user query and detects the agent makes redundant/ineffcient tool calls.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

#### Manual Testing
Tested with 5 inefficient patterns
```
========== Inefficient Test Case 1: Inefficient Pagination ==========
User Query: 
{'query': 'Show me items with IDs 1, 2, and 3.'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 1}
  Output: {'content': 'ID: 1, Name: Apple, Price: $1.5', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_M7rWzRvWYacmQGo78B4d6iaR', 'artifact': None, 'status': 'success'}

Tool Call 2: get_items
  Input Arguments: {'start_id': 2}
  Output: {'content': 'ID: 2, Name: Banana, Price: $0.8', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_i8bvWsW8cY7HXErEolAFmemo', 'artifact': None, 'status': 'success'}

Tool Call 3: get_items
  Input Arguments: {'start_id': 3}
  Output: {'content': 'ID: 3, Name: Orange, Price: $1.2', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_AuSHkEykAXvCQB60wnV7vG2u', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: no
Rationale: The user requested items with IDs 1, 2, and 3. The available tool 'get_items' supports fetching multiple items efficiently by specifying a start_id and an end_id covering a range. However, the agent called 'get_items' three separate times each with a single ID (start_id 1, 2, then 3). Instead of making three separate calls, the agent could have made a single call to 'get_items' with start_id 1 and end_id 3 to fetch all requested items at once. This approach reduces the number of calls and improves efficiency. Therefore, the agent's tool usage is redundant and not efficient.




========== Inefficient Test Case 2: Redundant Verification ==========
User Query: 
{'query': 'What is item 2?'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 2}
  Output: {'content': 'ID: 2, Name: Banana, Price: $0.8', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_bLBfETEqZirZdQywV1BLpovA', 'artifact': None, 'status': 'success'}

Tool Call 2: get_items
  Input Arguments: {'start_id': 2}
  Output: {'content': 'ID: 2, Name: Banana, Price: $0.8', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_nKwOLIUdsCPh3IK6H08g3sWW', 'artifact': None, 'status': 'success'}

Tool Call 3: get_items
  Input Arguments: {'start_id': 2}
  Output: {'content': 'ID: 2, Name: Banana, Price: $0.8', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_38fdEtQ6iiPdwa8ZYEkw0M2l', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: no
Rationale: The user's query is to find information about item 2. The agent called the 'get_items' tool three times with the exact same argument {'start_id': 2}, and each call returned the same information about item 2: 'ID: 2, Name: Banana, Price: $0.8'. There is no indication any call failed and needed to be retried due to transient errors. Furthermore, since the tool allows retrieving multiple items efficiently, but here the query was about a single item, a single call with 'start_id': 2 would have sufficed. Therefore, the second and third calls to 'get_items' with identical arguments are redundant and unnecessary. The agent's tool usage includes redundant calls that could have been avoided by calling the tool once, making the usage inefficient.




========== Inefficient Test Case 3: Overlapping Ranges ==========
User Query: 
{'query': 'Get items in the range 1 to 3.'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 1, 'end_id': 2}
  Output: {'content': 'ID: 1, Name: Apple, Price: $1.5\nID: 2, Name: Banana, Price: $0.8', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_Hujezi8qDM6GkvtG7zGi6GI3', 'artifact': None, 'status': 'success'}

Tool Call 2: get_items
  Input Arguments: {'start_id': 2, 'end_id': 3}
  Output: {'content': 'ID: 2, Name: Banana, Price: $0.8\nID: 3, Name: Orange, Price: $1.2', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_NM1RVIP8tixQTkjN6TlIUXTs', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: no
Rationale: The user requested items in the range 1 to 3. The agent made two get_items calls: first for range 1 to 2, then for range 2 to 3. Both calls include item with ID 2, so there is redundancy in retrieving the item with ID 2 twice. Moreover, the get_items tool supports retrieving multiple items efficiently in a single call by specifying the start and end IDs. Therefore, the agent could have made a single call get_items with start_id=1 and end_id=3, which would be more efficient and not redundant. Hence, the tool usage is not efficient and includes redundant calls.




========== Inefficient Test Case 4: Manual Counting ==========
User Query: 
{'query': 'How many items are in the database?'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 1}
  Output: {'content': 'ID: 1, Name: Apple, Price: $1.5', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_pNGduBXYnu68F14tbOjLvxFG', 'artifact': None, 'status': 'success'}

Tool Call 2: get_items
  Input Arguments: {'start_id': 2}
  Output: {'content': 'ID: 2, Name: Banana, Price: $0.8', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_HdIUtp7L2gZU4smjuJgJxZED', 'artifact': None, 'status': 'success'}

Tool Call 3: get_items
  Input Arguments: {'start_id': 3}
  Output: {'content': 'ID: 3, Name: Orange, Price: $1.2', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_9rvmf3ULcqDUDBv3ATUTMXDQ', 'artifact': None, 'status': 'success'}

Tool Call 4: get_items
  Input Arguments: {'start_id': 4}
  Output: {'content': 'ID: 4, Name: Grape, Price: $2.5', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_xXZx8zOLoWbJy1xo6V8KgvE5', 'artifact': None, 'status': 'success'}

Tool Call 5: get_items
  Input Arguments: {'start_id': 5}
  Output: {'content': 'ID: 5, Name: Mango, Price: $3.0', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_GfL8Qx4HYvb1zBaMZtLyPEbP', 'artifact': None, 'status': 'success'}

Tool Call 6: get_items
  Input Arguments: {'start_id': 6}
  Output: {'content': 'ERROR 404: No items found', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_NfXdl899Z84BTJTemnBZpoZX', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: no
Rationale: The user query is to find out how many items are in the database. There is a tool called count_items available that directly provides the total count of items, which would be the most efficient and straightforward approach. However, the agent instead made multiple calls to get_items with start_id ranging from 1 through 6, retrieving items one at a time by specifying a single start_id and no end_id. This approach is inefficient because get_items can retrieve multiple items efficiently if a range (start_id and end_id) is specified, but the agent did not consolidate these calls into a single call. Additionally, calling get_items six times for individual item IDs instead of one call to count_items or one call to get_items with a range results in redundancy and inefficiency. Therefore, the tool usage is not efficient and exhibits redundancy.




========== Inefficient Test Case 5: Retrying Non-Transient Errors ==========
User Query: 
{'query': 'What is item 99?'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 99}
  Output: {'content': 'ERROR 404: No items found', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_Z63Wr7p44R0A7ka9MNJYEfuJ', 'artifact': None, 'status': 'success'}

Tool Call 2: get_items
  Input Arguments: {'start_id': 99}
  Output: {'content': 'ERROR 404: No items found', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_6xNbNQmqxvmCjSrCfWkZXCf6', 'artifact': None, 'status': 'success'}

Tool Call 3: get_items
  Input Arguments: {'start_id': 99}
  Output: {'content': 'ERROR 404: No items found', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_EXRCGwqJ4RqJFMqkZ3AkGLq5', 'artifact': None, 'status': 'success'}

Tool Call 4: get_items
  Input Arguments: {'start_id': 99}
  Output: {'content': 'ERROR 404: No items found', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_15Xjcwt4LA2WH77ZiYrCOV4B', 'artifact': None, 'status': 'success'}

Tool Call 5: get_items
  Input Arguments: {'start_id': 99}
  Output: {'content': 'ERROR 404: No items found', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_H7EX8AIunwj5C4UCjeF55mTw', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: no
Rationale: The agent made five calls to the get_items tool, each with the exact same argument {'start_id': 99}. Each call returned an identical error message indicating no item 99 was found. Since the parameters and responses were the same each time, it is clear that these repeated calls are redundant and unnecessary. None of these calls appear to be retries due to transient failures, as the status is 'success' and the error is consistent, suggesting the item simply doesn't exist. Therefore, the agent could have avoided multiple identical calls and instead stopped after the first failed attempt, making the process more efficient. Hence, the tool usage is not efficient and contains redundancy.
```

And then tested with 5 efficient patterns:
```
========== Efficient Test Case 1: Efficient Pagination ==========
User Query: 
{'query': 'Show me items with IDs 1, 2, and 3.'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 1, 'end_id': 3}
  Output: {'content': 'ID: 1, Name: Apple, Price: $1.5\nID: 2, Name: Banana, Price: $0.8\nID: 3, Name: Orange, Price: $1.2', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_3csb1jvhA18HYZmXUWRI8wyN', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: yes
Rationale: The user's request is to show items with IDs 1, 2, and 3. The agent made a single call to the get_items tool with start_id=1 and end_id=3, which retrieves all requested items in one efficient call. There were no repeated or similar calls, and no redundant or consolidatable calls. Therefore, the agent's tool usage is efficient and free of redundancy.




========== Efficient Test Case 2: No Redundant Verification ==========
User Query: 
{'query': 'What is item 2?'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 2}
  Output: {'content': 'ID: 2, Name: Banana, Price: $0.8', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_junTVuvvp8YUu7QsMetxpuCD', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: yes
Rationale: The user requested the description of item 2. The agent called the tool get_items once with start_id 2 and no end_id, correctly retrieving the information for item 2 only. There were no repeated calls, no calls with overlapping or similar arguments, and no unnecessary consolidation because only one item was requested. The call was efficient and without redundancy.




========== Efficient Test Case 3: Single Range Call ==========
User Query: 
{'query': 'Get items in the range 1 to 3.'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: get_items
  Input Arguments: {'start_id': 1, 'end_id': 3}
  Output: {'content': 'ID: 1, Name: Apple, Price: $1.5\nID: 2, Name: Banana, Price: $0.8\nID: 3, Name: Orange, Price: $1.2', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'get_items', 'id': None, 'tool_call_id': 'call_QT6Z9TRmR1NpMjSXioDZlCuQ', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: yes
Rationale: The user's query was to get items in the range 1 to 3. The agent made a single call to the get_items tool with start_id 1 and end_id 3, which directly satisfies the user's request. There were no repeated calls to the same tool with identical or similar arguments, nor multiple calls that could have been consolidated. No retries due to errors were present. Therefore, the tool usage is efficient and free of redundancy.




========== Efficient Test Case 4: Use Direct Count Tool ==========
User Query: 
{'query': 'How many items are in the database?'}


Available Tools: 
- get_items: Get items by ID range. Can retrieve multiple items efficiently.

    Args:
        start_id: Starting item ID (inclusive)
        end_id: Ending item ID (inclusive). If None, returns only the item with start_id

    Returns:
        Item information as a string
    - start_id (required): integer
    - end_id (optional): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: count_items
  Input Arguments: {}
  Output: {'content': 'Total items: 5', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'count_items', 'id': None, 'tool_call_id': 'call_4dXBGuI8hS73iHnpYk16t97y', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: yes
Rationale: The user's request is to find out how many items are in the database. There are two tools available: count_items, which directly returns the total count, and get_items, which fetches items by ID range. The agent called count_items once, which is the most efficient way to answer the query since it directly returns the total count without needing to retrieve any items. No redundant or unnecessary tool calls were made, and no retries or inefficiencies were introduced. Thus, the tool usage is efficient and free of redundancy.




========== Efficient Test Case 5: Efficient Transient Error Retry ==========
User Query: 
{'query': 'What is item 3?'}


Available Tools: 
- try_get_item: Try to get an item by its ID.
    Args:
        item_id: The ID of the item to retrieve

    Returns:
        Item information or transient error
    - item_id (required): integer

- count_items: Get the total count of items directly.

    Returns:
        Total number of items


Tools Called: 
Tool Call 1: try_get_item
  Input Arguments: {'item_id': 3}
  Output: {'content': 'ERROR 503: Service temporarily unavailable. Please retry.', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'try_get_item', 'id': None, 'tool_call_id': 'call_ai99CKJmYsokP4NW8fJD2oib', 'artifact': None, 'status': 'success'}

Tool Call 2: try_get_item
  Input Arguments: {'item_id': 3}
  Output: {'content': 'ID: 3, Name: Orange, Price: $1.2', 'additional_kwargs': {}, 'response_metadata': {}, 'type': 'tool', 'name': 'try_get_item', 'id': None, 'tool_call_id': 'call_fhnV08iiSsvPi7thP9qQfJ00', 'artifact': None, 'status': 'success'}


____________Evaluation Result_________
Efficiency Prediction: yes
Rationale: The user requested information about item 3, so the agent correctly used the try_get_item tool with item_id 3. The first call resulted in a transient error (ERROR 503), which is recognized as a temporary failure and is not considered inefficient or redundant. The agent retried the same call, which then succeeded in returning the item details. Since retries due to transient errors are explicitly allowed and are not considered redundant, the two calls are justified. No other unnecessary calls or consolidations were possible given the user's request and available tools. Therefore, the tool usage is efficient and free of redundancy.
```

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
