### PR TITLE
Refactor test to use pytest.mark.parametrize

### DIFF
--- a/tests/entities/test_assessment.py
+++ b/tests/entities/test_assessment.py
@@ -607,21 +607,13 @@ def test_feedback_passes_through_assessment_error():
     assert proto.feedback.error.error_code == "CUSTOM_ERROR_CODE"
 
 
-def test_feedback_rejects_invalid_error_types():
-    # Test with integer
+@pytest.mark.parametrize(
+    "invalid_error",
+    [123, ["error"], {"error": "message"}],
+    ids=["int", "list", "dict"],
+)
+def test_feedback_rejects_invalid_error_types(invalid_error):
     with pytest.raises(
         MlflowException, match="'error' must be an Exception, AssessmentError, or string"
     ):
-        Feedback(name="test", error=123)
-
-    # Test with list
-    with pytest.raises(
-        MlflowException, match="'error' must be an Exception, AssessmentError, or string"
-    ):
-        Feedback(name="test", error=["error"])
-
-    # Test with dict
-    with pytest.raises(
-        MlflowException, match="'error' must be an Exception, AssessmentError, or string"
-    ):
-        Feedback(name="test", error={"error": "message"})
+        Feedback(name="test", error=invalid_error)


### PR DESCRIPTION
### Related Issues/PRs

Addresses review comment: https://github.com/mlflow/mlflow/pull/19340/changes#r2616202724

### What changes are proposed in this pull request?

This PR refactors `test_feedback_rejects_invalid_error_types()` in `tests/entities/test_assessment.py` to use `@pytest.mark.parametrize` instead of three repetitive test blocks.

**Changes:**
- Converts three separate test blocks into a single parametrized test
- Adds descriptive test IDs (`int`, `list`, `dict`) for better test output
- Reduces test code from 18 lines to 9 lines while preserving behavior

**Benefits:**
- Reduces code duplication
- Makes it easier to add new test cases in the future
- Improves test readability and maintainability
- Follows existing patterns in the test file

### How is this PR tested?

- [x] Existing unit/integration tests

Verified parametrized test runs three times with correct IDs:

```bash
uv run pytest tests/entities/test_assessment.py::test_feedback_rejects_invalid_error_types -v
```

Output shows three test runs:
- `test_feedback_rejects_invalid_error_types[int]` ✓
- `test_feedback_rejects_invalid_error_types[list]` ✓
- `test_feedback_rejects_invalid_error_types[dict]` ✓

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/build`: Build and test infrastructure for MLflow

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)