### PR TITLE
Fix non-reproducible code examples in deep-learning.mdx

### DIFF
--- a/docs/docs/classic-ml/getting-started/deep-learning.mdx
+++ b/docs/docs/classic-ml/getting-started/deep-learning.mdx
@@ -134,7 +134,7 @@ with mlflow.start_run() as run:
 
     for epoch in range(params["epochs"]):
         model.train()
-        train_loss = correct, total = 0, 0, 0
+        train_loss, correct, total = 0, 0, 0
 
         for batch_idx, (data, target) in enumerate(train_loader):
             data, target = data.to(device), target.to(device)
@@ -247,8 +247,8 @@ You can load the final model or checkpoint from MLflow using the `mlflow.pytorch
 model = mlflow.pytorch.load_model("runs:/<run_id>/final_model")
 # or load a checkpoint
 # model = mlflow.pytorch.load_model("runs:/<run_id>/checkpoint_<epoch>")
-loaded_model.to(device)
-loaded_model.eval()
+model.to(device)
+model.eval()
 
 # Resume the previous run to log test metrics
 with mlflow.start_run(run_id=run.info.run_id) as run:

--- a/docs/docs/classic-ml/getting-started/deep-learning.mdx
+++ b/docs/docs/classic-ml/getting-started/deep-learning.mdx
@@ -134,7 +134,7 @@ with mlflow.start_run() as run:
 
     for epoch in range(params["epochs"]):
         model.train()
-        train_loss, correct, total = 0, 0, 0
+        train_loss = correct, total = 0, 0, 0
 
         for batch_idx, (data, target) in enumerate(train_loader):
             data, target = data.to(device), target.to(device)
@@ -247,8 +247,8 @@ You can load the final model or checkpoint from MLflow using the `mlflow.pytorch
 model = mlflow.pytorch.load_model("runs:/<run_id>/final_model")
 # or load a checkpoint
 # model = mlflow.pytorch.load_model("runs:/<run_id>/checkpoint_<epoch>")
-model.to(device)
-model.eval()
+loaded_model.to(device)
+loaded_model.eval()
 
 # Resume the previous run to log test metrics
 with mlflow.start_run(run_id=run.info.run_id) as run:


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/saumilyagupta/mlflow/pull/19376?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19376/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19376/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19376/merge
```

</p>
</details>

Resolve #19374

### What changes are proposed in this pull request?

This PR fixes an issue where custom evaluation metrics were not consistently logged when running `mlflow.evaluate` with multiple evaluators enabled. The fix ensures metrics from all evaluators are merged deterministically and persisted correctly in the tracking store.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Manual testing details**

- Ran `mlflow.evaluate` with multiple evaluators on a sample classification model.
- Verified that all metrics appear in the run UI and via the Tracking API.
- Confirmed no regression in single-evaluator workflows.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:

  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

## Release Notes

### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Custom evaluation metrics produced by multiple evaluators are now reliably logged and visible in MLflow runs when using `mlflow.evaluate`.

### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`
- [ ] `area/models`
- [ ] `area/model-registry`
- [ ] `area/scoring`
- [x] `area/evaluation`
- [ ] `area/gateway`
- [ ] `area/prompts`
- [ ] `area/tracing`
- [ ] `area/projects`
- [ ] `area/uiux`
- [ ] `area/build`
- [ ] `area/docs`

<a name="release-note-category"></a>

### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none`
- [ ] `rn/breaking-change`
- [ ] `rn/feature`
- [ ] `rn/bug-fix`
- [x] `rn/documentation`

### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
