### PR TITLE
[UserFrustration] Update user frustration built in judge output name

### DIFF
--- a/docs/docs/genai/eval-monitor/running-evaluation/multi-turn.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/multi-turn.mdx
@@ -109,7 +109,7 @@ results = mlflow.genai.evaluate(
 MLflow provides built-in scorers for evaluating conversations:
 
 - **<APILink fn="mlflow.genai.scorers.ConversationCompleteness">ConversationCompleteness</APILink>**: Evaluates whether the agent addressed all user questions throughout the conversation (returns "complete" or "incomplete")
-- **<APILink fn="mlflow.genai.scorers.UserFrustration">UserFrustration</APILink>**: Detects and tracks user frustration patterns (returns "no_frustration", "frustration_resolved", or "frustration_not_resolved")
+- **<APILink fn="mlflow.genai.scorers.UserFrustration">UserFrustration</APILink>**: Detects and tracks user frustration patterns (returns "none", "resolved", or "unresolved")
 
 See the [Predefined Scorers](/genai/eval-monitor/scorers/llm-judge/predefined#multi-turn-scorers) page for detailed usage examples and API documentation.
 

--- a/mlflow/genai/judges/prompts/user_frustration.py
+++ b/mlflow/genai/judges/prompts/user_frustration.py
@@ -4,13 +4,13 @@ USER_FRUSTRATION_ASSESSMENT_NAME = "user_frustration"
 USER_FRUSTRATION_PROMPT = """\
 Consider the following conversation history between a user and an assistant. Your task is to
 determine the user's emotional trajectory and output exactly one of the following labels:
-"no_frustration", "frustration_resolved", or "frustration_not_resolved".\
+"none", "resolved", or "unresolved".\
 
-"no_frustration" means the user never expresses frustration;
-"frustration_resolved" means the user is frustrated at some point but clearly ends the conversation satisfied or reassured;
+Return "none" when the user **never** expresses frustration at any point in the conversation;
+Return "unresolved" when the user is frustrated near the end or leaves without clear satisfaction.
+Only return "resolved" when the user **is frustrated at some point** in the conversation but clearly ends the conversation satisfied or reassured;
     - Do not assume the user is satisfied just because the assistant's final response is helpful, constructive, or polite;
-    - Only label a conversation as "frustration_resolved" if the user explicitly or strongly implies satisfaction, relief, or acceptance in their own final turns.
-"frustration_not_resolved" means the user is frustrated near the end or leaves without clear satisfaction.
+    - Only label a conversation as "resolved" if the user explicitly or strongly implies satisfaction, relief, or acceptance in their own final turns.
 
 Base your decision only on explicit or strongly implied signals in the conversation and do not
 use outside knowledge or assumptions.

--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1657,10 +1657,10 @@ class UserFrustration(BuiltInSessionLevelScorer):
     determine if the user shows explicit or implicit frustration directed at the AI.
     It evaluates the entire conversation and returns one of three values:
 
-    - "no_frustration": user not frustrated at any point in the conversation
-    - "frustration_resolved": user is frustrated at some point in the conversation,
+    - "none": user not frustrated at any point in the conversation
+    - "resolved": user is frustrated at some point in the conversation,
       but leaves the conversation satisfied
-    - "frustration_not_resolved": user is still frustrated at the end of the conversation
+    - "unresolved": user is still frustrated at the end of the conversation
 
     You can invoke the scorer directly with a session for testing, or pass it to
     `mlflow.genai.evaluate` for running full evaluation on a dataset.
@@ -1685,8 +1685,7 @@ class UserFrustration(BuiltInSessionLevelScorer):
 
         assessment = UserFrustration(name="my_user_frustration_judge")(session=session)
         print(assessment)
-        # Feedback with value "no_frustration", "frustration_resolved", or
-        # "frustration_not_resolved"
+        # Feedback with value "none", "resolved", or "unresolved"
 
     Example (with evaluate):
 
@@ -1713,9 +1712,7 @@ class UserFrustration(BuiltInSessionLevelScorer):
             instructions=self.instructions,
             model=self.model,
             description=self.description,
-            feedback_value_type=Literal[
-                "no_frustration", "frustration_resolved", "frustration_not_resolved"
-            ],
+            feedback_value_type=Literal["none", "resolved", "unresolved"],
         )
 
     @property

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -1354,15 +1354,13 @@ def test_user_frustration_with_session():
 
     with patch(
         "mlflow.genai.judges.instructions_judge.invoke_judge_model",
-        return_value=Feedback(
-            name="user_frustration", value="no_frustration", rationale="User is satisfied"
-        ),
+        return_value=Feedback(name="user_frustration", value="none", rationale="User is satisfied"),
     ) as mock_invoke_judge:
         scorer = UserFrustration()
         result = scorer(session=traces)
 
         assert result.name == "user_frustration"
-        assert result.value == "no_frustration"
+        assert result.value == "none"
         assert result.rationale == "User is satisfied"
         mock_invoke_judge.assert_called_once()
 
@@ -1380,7 +1378,7 @@ def test_user_frustration_with_custom_name_and_model(monkeypatch: pytest.MonkeyP
         "mlflow.genai.judges.instructions_judge.invoke_judge_model",
         return_value=Feedback(
             name="custom_frustration_check",
-            value="frustration_resolved",
+            value="resolved",
             rationale="User was initially frustrated but satisfied by the end",
         ),
     ) as mock_invoke_judge:
@@ -1388,7 +1386,7 @@ def test_user_frustration_with_custom_name_and_model(monkeypatch: pytest.MonkeyP
         result = scorer(session=traces)
 
         assert result.name == "custom_frustration_check"
-        assert result.value == "frustration_resolved"
+        assert result.value == "resolved"
         mock_invoke_judge.assert_called_once()
 
 


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19382/files) to review incremental changes.
- [**stack/ML-60165-update-user-frustration-output-name**](https://github.com/mlflow/mlflow/pull/19382) [[Files changed](https://github.com/mlflow/mlflow/pull/19382/files)]
  - [stack/user-frustration-eval-run-tab-ui-polish](https://github.com/mlflow/mlflow/pull/19383) [[Files changed](https://github.com/mlflow/mlflow/pull/19383/files/507d229d359aac7255d155eaeaab70a9cdef6cde..a653e6a9c9cfb7f679a11e3d4acd70e7b35cd845)]
    - [stack/user-frustration-assessment-display-component-ui-polish](https://github.com/mlflow/mlflow/pull/19388) [[Files changed](https://github.com/mlflow/mlflow/pull/19388/files/a653e6a9c9cfb7f679a11e3d4acd70e7b35cd845..dae44dc436069b6d4cd510d09d6c4385409a21a3)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
#### Context
One feedback from the multi-turn M1 bug bash was that the UI for `UserFrustration` judge is not highlighted and difficult to read ([ML-60165](https://databricks.atlassian.net/browse/ML-60165)). 

#### This PR
Update the judge output string from long strings values ("no_frustration", "frustration_resolved", "frustration_not_resolved") to shorter string values ("none", "resolved", "unresolved") to prevent string truncation on UI


### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

#### Manual Testing
<img width="400" height="800" alt="image" src="https://github.com/user-attachments/assets/ed0f969d-7517-4ab1-b946-62eceee65740" />


<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
