### PR TITLE
[UserFrustration] Add coloring for UserFrustration eval results in the AssessmentDisplayValue component

### DIFF
--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -2770,6 +2770,10 @@
     "defaultMessage": "False",
     "description": "False value in the evaluations table."
   },
+  "OcYzCN": {
+    "defaultMessage": "Unresolved",
+    "description": "Label for a user_frustration assessment with 'unresolved' value"
+  },
   "OeKIA4": {
     "defaultMessage": "Expectations added for a trace",
     "description": "Description for expectations variable"
@@ -3144,6 +3148,10 @@
   "SknPqh": {
     "defaultMessage": "Judge type",
     "description": "Label for judge type selection"
+  },
+  "Sm0bXt": {
+    "defaultMessage": "None",
+    "description": "Label for a user_frustration assessment with 'none' value"
   },
   "SnPghu": {
     "defaultMessage": "Delete sessions",
@@ -5766,6 +5774,10 @@
   "q8rYCQ": {
     "defaultMessage": "Data Type",
     "description": "Field label for assessment data type in a creation form"
+  },
+  "q90WPh": {
+    "defaultMessage": "Resolved",
+    "description": "Label for a user_frustration assessment with 'resolved' value"
   },
   "q90jVU": {
     "defaultMessage": "End:",

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackHistoryItem.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackHistoryItem.tsx
@@ -45,7 +45,7 @@ export const FeedbackHistoryItem = ({ feedback }: { feedback: FeedbackAssessment
               <FormattedMessage defaultMessage="Feedback" description="Label for the value of an feedback assessment" />
             </Typography.Text>
             <div>
-              <AssessmentDisplayValue jsonValue={JSON.stringify(value)} />
+              <AssessmentDisplayValue jsonValue={JSON.stringify(value)} assessmentName={feedback.assessment_name} />
             </div>
           </>
         )}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackItemContent.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackItemContent.tsx
@@ -74,7 +74,7 @@ export const FeedbackItemContent = ({ feedback }: { feedback: FeedbackAssessment
             <FormattedMessage defaultMessage="Feedback" description="Label for the value of an feedback assessment" />
           </Typography.Text>
           <div css={{ display: 'flex', gap: theme.spacing.xs }}>
-            <AssessmentDisplayValue jsonValue={JSON.stringify(value)} />
+            <AssessmentDisplayValue jsonValue={JSON.stringify(value)} assessmentName={feedback.assessment_name} />
             {feedback.overriddenAssessment && (
               <>
                 <span onClick={() => setIsHistoryModalVisible(true)}>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroup.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/FeedbackValueGroup.tsx
@@ -16,6 +16,7 @@ export const FeedbackValueGroup = ({
 }) => {
   const { theme } = useDesignSystemTheme();
   const [expanded, setExpanded] = useState(false);
+  const assessmentName = feedbacks[0]?.assessment_name;
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column' }}>
@@ -27,7 +28,7 @@ export const FeedbackValueGroup = ({
           icon={expanded ? <ChevronDownIcon /> : <ChevronRightIcon />}
           onClick={() => setExpanded(!expanded)}
         />
-        <AssessmentDisplayValue jsonValue={jsonValue} />
+        <AssessmentDisplayValue jsonValue={jsonValue} assessmentName={assessmentName} />
         <FeedbackValueGroupSourceCounts feedbacks={feedbacks} />
       </div>
       {expanded && (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/SimplifiedAssessmentView.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/right-pane/SimplifiedAssessmentView.tsx
@@ -93,7 +93,7 @@ const AssessmentCard = ({ assessment }: { assessment: FeedbackAssessment }) => {
       {/* Result value */}
       {!hasError && value !== undefined && (
         <div css={{ display: 'flex', alignItems: 'center' }}>
-          <AssessmentDisplayValue jsonValue={JSON.stringify(value)} />
+          <AssessmentDisplayValue jsonValue={JSON.stringify(value)} assessmentName={assessment.assessment_name} />
         </div>
       )}
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
@@ -57,10 +57,16 @@ export const SingleChatTurnAssessments = ({
                 css={{ maxWidth: 150 }}
                 skipIcons
                 overrideColor="default"
+                assessmentName={assessment.assessment_name}
               />
             ) : (
               <>
-                {title}: <AssessmentDisplayValue jsonValue={value} css={{ maxWidth: 150 }} />
+                {title}:{' '}
+                <AssessmentDisplayValue
+                  jsonValue={value}
+                  css={{ maxWidth: 150 }}
+                  assessmentName={assessment.assessment_name}
+                />
               </>
             )}
           </div>


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19388/files) to review incremental changes.
- [**stack/user-frustration-assessment-display-component-ui-polish**](https://github.com/mlflow/mlflow/pull/19388) [[Files changed](https://github.com/mlflow/mlflow/pull/19388/files)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### What changes are proposed in this pull request?

#### Context
One feedback from the multi-turn M1 bug bash was that the UI for `UserFrustration` judge is not highlighted and difficult to read ([ML-60165](https://databricks.atlassian.net/browse/ML-60165)). 

#### This PR
Add coloring for `UserFrustration` built-in judge results in AssessmentDisplayValue component used in the trace detail view and session view so that the result is highlighted and easier to read.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->
#### Manual Testing
| Before | After |
|-|-|
| <img width="389" height="203" alt="image" src="https://github.com/user-attachments/assets/73a6ab26-97d0-4310-954c-ea0646e92198" /> | <img width="389" height="203" alt="image" src="https://github.com/user-attachments/assets/aebfe195-8ab4-44a5-a330-6cd54dc89386" /> |
| <img width="389" height="203" alt="image" src="https://github.com/user-attachments/assets/0aa3d053-8216-4b99-8a2f-97e6412ff5cb" /> |  <img width="389" height="203" alt="image" src="https://github.com/user-attachments/assets/3c7f983e-a748-488a-9f78-fde25750e325" /> |
| <img width="389" height="203" alt="image" src="https://github.com/user-attachments/assets/5381432d-6d36-41d5-be18-88356703d71c" /> | <img width="389" height="203" alt="image" src="https://github.com/user-attachments/assets/8ce065c3-16d4-412f-9f66-709ba1949a2b" /> |
| <img width="392" height="431" alt="image" src="https://github.com/user-attachments/assets/098e568d-fff4-4ac3-9c10-d0aec88266aa" /> | <img width="392" height="431" alt="image" src="https://github.com/user-attachments/assets/ce83936a-b87e-45ef-80cb-de9f1cc0890b" /> |
| <img width="392" height="431" alt="image" src="https://github.com/user-attachments/assets/18da66d2-e549-4975-bfad-5c8ab42f646a" /> | <img width="392" height="431" alt="image" src="https://github.com/user-attachments/assets/3c68bda2-6674-4f69-a014-d8925d05c217" /> |
| <img width="392" height="431" alt="image" src="https://github.com/user-attachments/assets/9eba2d67-edcc-4158-816a-1703048dbd5d" /> |  <img width="392" height="431" alt="image" src="https://github.com/user-attachments/assets/b7b11f3e-a68c-4058-b55f-a3446544c2b2" /> | 


### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
