### PR TITLE
Implement unified chat completion endpoint

### DIFF
--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -246,13 +246,6 @@ async def chat_completions(request: Request):
 
     _validate_store(store)
 
-    # Validate this is a chat request
-    if "messages" not in body:
-        raise HTTPException(
-            status_code=400,
-            detail="Invalid chat request: missing 'messages' field",
-        )
-
     endpoint_type = EndpointType.LLM_V1_CHAT
     try:
         payload = chat.RequestPayload(**body)

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -230,7 +230,7 @@ async def chat_completions(request: Request):
         raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {e!s}")
 
     # Extract endpoint name from "model" parameter
-    endpoint_name = body.get("model")
+    endpoint_name = body.pop("model", None)
     if not endpoint_name:
         raise HTTPException(
             status_code=400,

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -783,7 +783,7 @@ async def test_chat_completions_endpoint_missing_messages(store: SqlAlchemyStore
         }
     )
 
-    with pytest.raises(HTTPException, match="missing 'messages' field") as exc_info:
+    with pytest.raises(HTTPException, match="Invalid chat payload") as exc_info:
         await chat_completions(mock_request)
 
     assert exc_info.value.status_code == 400

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -24,6 +24,7 @@ from mlflow.gateway.providers.openai import OpenAIProvider
 from mlflow.gateway.schemas import chat, embeddings
 from mlflow.server.gateway_api import (
     _create_provider_from_endpoint_name,
+    chat_completions,
     gateway_router,
     invocations,
 )
@@ -636,3 +637,164 @@ def test_create_provider_from_endpoint_name_no_models(store: SqlAlchemyStore):
     ):
         with pytest.raises(MlflowException, match="has no models configured"):
             _create_provider_from_endpoint_name(store, endpoint.name, EndpointType.LLM_V1_CHAT)
+
+
+# =============================================================================
+# OpenAI-compatible chat completions endpoint tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_endpoint(store: SqlAlchemyStore):
+    secret = store.create_gateway_secret(
+        secret_name="openai-compat-key",
+        secret_value={"api_key": "sk-test"},
+        provider="openai",
+    )
+    model_def = store.create_gateway_model_definition(
+        name="openai-compat-model",
+        secret_id=secret.secret_id,
+        provider="openai",
+        model_name="gpt-4",
+    )
+    store.create_gateway_endpoint(
+        name="my-chat-endpoint", model_definition_ids=[model_def.model_definition_id]
+    )
+
+    # Mock the provider's chat method
+    mock_response = chat.ResponsePayload(
+        id="test-id",
+        object="chat.completion",
+        created=1234567890,
+        model="gpt-4",
+        choices=[
+            chat.Choice(
+                index=0,
+                message=chat.ResponseMessage(role="assistant", content="Hello from OpenAI!"),
+                finish_reason="stop",
+            )
+        ],
+        usage=chat.ChatUsage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+    # Create a mock request with OpenAI-compatible format
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(
+        return_value={
+            "model": "my-chat-endpoint",  # Endpoint name via model parameter
+            "messages": [{"role": "user", "content": "Hi"}],
+            "temperature": 0.7,
+            "stream": False,
+        }
+    )
+
+    # Patch the provider creation to return a mocked provider
+    with patch(
+        "mlflow.server.gateway_api._create_provider_from_endpoint_name"
+    ) as mock_create_provider:
+        mock_provider = MagicMock()
+        mock_provider.chat = AsyncMock(return_value=mock_response)
+        mock_create_provider.return_value = mock_provider
+
+        # Call the handler
+        response = await chat_completions(mock_request)
+
+        # Verify
+        assert response.id == "test-id"
+        assert response.choices[0].message.content == "Hello from OpenAI!"
+        assert mock_provider.chat.called
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_endpoint_streaming(store: SqlAlchemyStore):
+    secret = store.create_gateway_secret(
+        secret_name="stream-key",
+        secret_value={"api_key": "sk-test"},
+        provider="openai",
+    )
+    model_def = store.create_gateway_model_definition(
+        name="stream-model",
+        secret_id=secret.secret_id,
+        provider="openai",
+        model_name="gpt-4",
+    )
+    store.create_gateway_endpoint(
+        name="stream-endpoint", model_definition_ids=[model_def.model_definition_id]
+    )
+
+    # Create streaming request
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(
+        return_value={
+            "model": "stream-endpoint",
+            "messages": [{"role": "user", "content": "Hi"}],
+            "stream": True,
+        }
+    )
+
+    # Mock streaming response
+    mock_streaming_response = MagicMock()
+
+    with (
+        patch(
+            "mlflow.server.gateway_api._create_provider_from_endpoint_name"
+        ) as mock_create_provider,
+        patch(
+            "mlflow.server.gateway_api.make_streaming_response",
+            return_value=mock_streaming_response,
+        ) as mock_make_streaming,
+    ):
+        mock_provider = MagicMock()
+        mock_provider.chat_stream = MagicMock(return_value="mock_stream")
+        mock_create_provider.return_value = mock_provider
+
+        response = await chat_completions(mock_request)
+
+        # Verify streaming was called
+        assert mock_provider.chat_stream.called
+        assert mock_make_streaming.called
+        assert response == mock_streaming_response
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_endpoint_missing_model_parameter(store: SqlAlchemyStore):
+    # Create request without model parameter
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(
+        return_value={
+            "messages": [{"role": "user", "content": "Hi"}],
+        }
+    )
+
+    with pytest.raises(HTTPException, match="Missing required 'model' parameter") as exc_info:
+        await chat_completions(mock_request)
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_endpoint_missing_messages(store: SqlAlchemyStore):
+    # Create request without messages
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(
+        return_value={
+            "model": "my-endpoint",
+            "temperature": 0.7,
+        }
+    )
+
+    with pytest.raises(HTTPException, match="missing 'messages' field") as exc_info:
+        await chat_completions(mock_request)
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_endpoint_invalid_json(store: SqlAlchemyStore):
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(side_effect=ValueError("Invalid JSON"))
+
+    with pytest.raises(HTTPException, match="Invalid JSON payload: Invalid JSON") as exc_info:
+        await chat_completions(mock_request)
+
+    assert exc_info.value.status_code == 400


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19390/files) to review incremental changes.
- [**stack/gateway/unified-endpoint-2**](https://github.com/mlflow/mlflow/pull/19390) [[Files changed](https://github.com/mlflow/mlflow/pull/19390/files)]
  - [stack/gateway/litellm-provider](https://github.com/mlflow/mlflow/pull/19394) [[Files changed](https://github.com/mlflow/mlflow/pull/19394/files/1490ceeb1db88852b5ef04864a4880ec045c80b7..f4d0b5526ce0c37ec0e7a49178929fb1a1617da4)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Added unified chat-completion endpoint which is compatible to OpenAI chat completion interface. 

```python
import mlflow
from openai import OpenAI

mlflow.set_tracking_uri("http://localhost:5000")
mlflow.set_experiment("Gateway")
from mlflow.tracking._tracking_service.utils import _get_store

store = _get_store()

secret = store.create_gateway_secret(
    secret_name="openai_api",
    secret_value={"api_key": "<secret>"},
    provider="openai",
)
model_def = store.create_gateway_model_definition(
    name="gpt-5-mini",
    secret_id=secret.secret_id,
    provider="openai",
    model_name="gpt-5-mini",
)
endpoint = store.create_gateway_endpoint(
    name="openai-v1", model_definition_ids=[model_def.model_definition_id]
)

client = OpenAI(
   base_url="http://localhost:5000/gateway/mlflow/v1",
   api_key="dummy",
)

messages = [{"role": "user", "content": "How are you ?"}]

response = client.chat.completions.create(
   model="openai-v1",
   messages=messages,
   temperature=1,
)
print(response.choices[0].message)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
