### PR TITLE
Add diagnostic assertions to investigate Windows test failure

### DIFF
--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -249,8 +249,8 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     SqlAlchemyStore._db_uri_sql_alchemy_engine_map[db_uri] = (
                         mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(db_uri)
                     )
-        print("🚗 Engine 🚗")  # noqa: T201
-        print(self.engine)  # noqa: T201
+        print("🚗 Engine map 🚗")  # noqa: T201
+        print(SqlAlchemyStore._db_uri_sql_alchemy_engine_map)  # noqa: T201
         self.engine = SqlAlchemyStore._db_uri_sql_alchemy_engine_map[db_uri]
         # On a completely fresh MLflow installation against an empty database (verify database
         # emptiness by checking that 'experiments' etc aren't in the list of table names), run all

--- a/mlflow/store/tracking/sqlalchemy_store.py
+++ b/mlflow/store/tracking/sqlalchemy_store.py
@@ -249,6 +249,8 @@ class SqlAlchemyStore(SqlAlchemyGatewayStoreMixin, AbstractStore):
                     SqlAlchemyStore._db_uri_sql_alchemy_engine_map[db_uri] = (
                         mlflow.store.db.utils.create_sqlalchemy_engine_with_retry(db_uri)
                     )
+        print("🚗 Engine 🚗")  # noqa: T201
+        print(self.engine)  # noqa: T201
         self.engine = SqlAlchemyStore._db_uri_sql_alchemy_engine_map[db_uri]
         # On a completely fresh MLflow installation against an empty database (verify database
         # emptiness by checking that 'experiments' etc aren't in the list of table names), run all

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -61,6 +61,7 @@ def test_tracking_scheme_without_existing_mlruns(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     items_in_tmp = list(tmp_path.iterdir())
     assert items_in_tmp == []
+    assert False, (os.environ["MLFLOW_TRACKING_TOKEN"], mlflow.get_tracking_uri())
     (tmp_path / "some_file.txt").touch()
     store = _get_store()
     assert isinstance(store, SqlAlchemyStore)

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -61,6 +61,7 @@ def test_tracking_scheme_without_existing_mlruns(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     items_in_tmp = list(tmp_path.iterdir())
     assert items_in_tmp == []
+    (tmp_path / "some_file.txt").touch()
     store = _get_store()
     assert isinstance(store, SqlAlchemyStore)
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -61,7 +61,8 @@ def test_tracking_scheme_without_existing_mlruns(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     items_in_tmp = list(tmp_path.iterdir())
     assert items_in_tmp == []
-    assert False, (os.environ.get("MLFLOW_TRACKING_URI"), mlflow.get_tracking_uri())
+    print("🚗 MLFLOW_TRACKING_URI 🚗")  # noqa: T201
+    print(os.environ.get("MLFLOW_TRACKING_URI"), mlflow.get_tracking_uri())  # noqa: T201
     (tmp_path / "some_file.txt").touch()
     store = _get_store()
     assert isinstance(store, SqlAlchemyStore)

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -57,7 +57,10 @@ def test_tracking_scheme_with_existing_mlruns(tmp_path, monkeypatch):
 
 
 def test_tracking_scheme_without_existing_mlruns(tmp_path, monkeypatch):
+    assert tmp_path.exists()
     monkeypatch.chdir(tmp_path)
+    items_in_tmp = list(tmp_path.iterdir())
+    assert items_in_tmp == []
     store = _get_store()
     assert isinstance(store, SqlAlchemyStore)
 

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -61,7 +61,7 @@ def test_tracking_scheme_without_existing_mlruns(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     items_in_tmp = list(tmp_path.iterdir())
     assert items_in_tmp == []
-    assert False, (os.environ["MLFLOW_TRACKING_URI"], mlflow.get_tracking_uri())
+    assert False, (os.environ.get("MLFLOW_TRACKING_URI"), mlflow.get_tracking_uri())
     (tmp_path / "some_file.txt").touch()
     store = _get_store()
     assert isinstance(store, SqlAlchemyStore)

--- a/tests/tracking/_tracking_service/test_utils.py
+++ b/tests/tracking/_tracking_service/test_utils.py
@@ -61,7 +61,7 @@ def test_tracking_scheme_without_existing_mlruns(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     items_in_tmp = list(tmp_path.iterdir())
     assert items_in_tmp == []
-    assert False, (os.environ["MLFLOW_TRACKING_TOKEN"], mlflow.get_tracking_uri())
+    assert False, (os.environ["MLFLOW_TRACKING_URI"], mlflow.get_tracking_uri())
     (tmp_path / "some_file.txt").touch()
     store = _get_store()
     assert isinstance(store, SqlAlchemyStore)


### PR DESCRIPTION
### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

Add diagnostic assertions to `test_tracking_scheme_without_existing_mlruns` to investigate a Windows CI test failure where SQLite fails with "unable to open database file" error.

The assertions check:
1. Whether `tmp_path` exists
2. Whether `tmp_path` is empty before the test runs

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)