### PR TITLE
Job backend: Update job backend to use static names rather than function full names

### DIFF
--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -70,8 +70,8 @@ def submit_job(payload: SubmitJobPayload) -> Job:
     from mlflow.server.jobs import get_job_fn_fullname, submit_job
     from mlflow.server.jobs.utils import _load_function
 
-    fn_fullname = get_job_fn_fullname(payload.function_name)
     try:
+        fn_fullname = get_job_fn_fullname(payload.function_name)
         function = _load_function(fn_fullname)
         job = submit_job(function, payload.params, payload.timeout)
         return Job.from_job_entity(job)
@@ -101,9 +101,8 @@ def search_jobs(payload: SearchJobPayload) -> SearchJobsResponse:
     from mlflow.server.handlers import _get_job_store
     from mlflow.server.jobs import get_job_fn_fullname
 
-    fn_fullname = get_job_fn_fullname(payload.function_name)
-
     try:
+        fn_fullname = get_job_fn_fullname(payload.function_name)
         store = _get_job_store()
         job_results = [
             Job.from_job_entity(job)

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -102,7 +102,7 @@ def search_jobs(payload: SearchJobPayload) -> SearchJobsResponse:
     from mlflow.server.jobs import get_job_fn_fullname
 
     try:
-        fn_fullname = get_job_fn_fullname(payload.function_name)
+        fn_fullname = get_job_fn_fullname(payload.function_name) if payload.function_name else None
         store = _get_job_store()
         job_results = [
             Job.from_job_entity(job)

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -22,7 +22,7 @@ class Job(BaseModel):
 
     job_id: str
     creation_time: int
-    function_fullname: str
+    function_name: str
     params: dict[str, Any]
     timeout: float | None
     status: JobStatus
@@ -35,7 +35,7 @@ class Job(BaseModel):
         return cls(
             job_id=job.job_id,
             creation_time=job.creation_time,
-            function_fullname=job.function_fullname,
+            function_name=job.function_fullname.split(".")[-1],
             params=json.loads(job.params),
             timeout=job.timeout,
             status=job.status,

--- a/mlflow/server/jobs/__init__.py
+++ b/mlflow/server/jobs/__init__.py
@@ -36,16 +36,14 @@ def _build_job_function_fullname_map():
             case [*module_parts, func_name] if module_parts:
                 if exist_fullname := _job_function_fullname_map.get(func_name):
                     if exist_fullname != fn_fullname:
-                        raise MlflowException.invalid_parameter_value(
+                        _logger.warning(
                             f"The 2 job functions {fn_fullname} and {exist_fullname} have the same "
                             f"function name, this is not allowed."
                         )
                 else:
                     _job_function_fullname_map[func_name] = fn_fullname
             case _:
-                raise MlflowException.invalid_parameter_value(
-                    f"Invalid function fullname in the allowed list: {fn_fullname}"
-                )
+                _logger.warning(f"Invalid function fullname in the allowed list: {fn_fullname}")
 
 
 _build_job_function_fullname_map()

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -253,11 +253,12 @@ def test_job_endpoint_search(client: Client):
     )
     assert extract_job_ids(jobs) == [job1_id, job2_id]
 
-    jobs = client.search_job(
-        function_name="bad_fun_name",
-        params={"x": 7},
-    )
-    assert extract_job_ids(jobs) == []
+    with pytest.raises(requests.exceptions.HTTPError) as excinfo:  # noqa: PT011
+        client.search_job(
+            function_name="bad_fun_name",
+            params={"x": 7},
+        )
+    assert excinfo.value.response.status_code == 400
 
     jobs = client.search_job(
         function_name="simple_job_fun",

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -108,7 +108,8 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
             "PYTHONPATH": os.path.dirname(__file__),
             "MLFLOW_SERVER_ENABLE_JOB_EXECUTION": "true",
             "_MLFLOW_ALLOWED_JOB_FUNCTION_LIST": (
-                "test_endpoint.simple_job_fun,invalid_format_no_module,"
+                "test_endpoint.simple_job_fun,"
+                "invalid_format_no_module,"
                 "non_existent_module.some_function,os.non_existent_function,"
                 "test_endpoint.job_assert_tracking_uri"
             ),
@@ -164,12 +165,15 @@ def test_job_endpoint_invalid_function_format(client: Client):
     response = client.post("/ajax-api/3.0/jobs/", payload=payload)
     assert response.status_code == 400
     error_json = response.json()
-    assert "Invalid function fullname format" in error_json["detail"]
+    assert (
+        "The job function invalid_format_no_module does not exist or not in the allowed list"
+        in error_json["detail"]
+    )
 
 
 def test_job_endpoint_module_not_found(client: Client):
     payload = {
-        "function_name": "non_existent_module.some_function",
+        "function_name": "some_function",
         "params": {"x": 3, "y": 4},
     }
     response = client.post("/ajax-api/3.0/jobs/", payload=payload)

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -36,10 +36,10 @@ class Client:
         self.server_url = server_url
 
     def submit_job(
-        self, function_fullname: str, params: dict[str, Any], timeout: float | None = None
+        self, function_name: str, params: dict[str, Any], timeout: float | None = None
     ) -> dict[str, Any]:
         payload = {
-            "function_fullname": function_fullname,
+            "function_name": function_name,
             "params": params,
             "timeout": timeout,
         }
@@ -66,14 +66,14 @@ class Client:
 
     def search_job(
         self,
-        function_fullname: str | None = None,
+        function_name: str | None = None,
         params: dict[str, Any] | None = None,
         statuses: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         response = self.post(
             "/ajax-api/3.0/jobs/search",
             payload={
-                "function_fullname": function_fullname,
+                "function_name": function_name,
                 "params": params,
                 "statuses": statuses,
             },
@@ -139,7 +139,7 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
 
 def test_job_endpoint(client: Client):
     job_id = client.submit_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"x": 3, "y": 4},
     )["job_id"]
     job_json = client.wait_job(job_id)
@@ -158,7 +158,7 @@ def test_job_endpoint(client: Client):
 
 def test_job_endpoint_invalid_function_format(client: Client):
     payload = {
-        "function_fullname": "invalid_format_no_module",
+        "function_name": "invalid_format_no_module",
         "params": {"x": 3, "y": 4},
     }
     response = client.post("/ajax-api/3.0/jobs/", payload=payload)
@@ -169,7 +169,7 @@ def test_job_endpoint_invalid_function_format(client: Client):
 
 def test_job_endpoint_module_not_found(client: Client):
     payload = {
-        "function_fullname": "non_existent_module.some_function",
+        "function_name": "non_existent_module.some_function",
         "params": {"x": 3, "y": 4},
     }
     response = client.post("/ajax-api/3.0/jobs/", payload=payload)
@@ -180,7 +180,7 @@ def test_job_endpoint_module_not_found(client: Client):
 
 def test_job_endpoint_function_not_found(client: Client):
     payload = {
-        "function_fullname": "os.non_existent_function",
+        "function_name": "non_existent_function",
         "params": {"x": 3, "y": 4},
     }
     response = client.post("/ajax-api/3.0/jobs/", payload=payload)
@@ -191,7 +191,7 @@ def test_job_endpoint_function_not_found(client: Client):
 
 def test_job_endpoint_missing_parameters(client: Client):
     payload = {
-        "function_fullname": "test_endpoint.simple_job_fun",
+        "function_name": "simple_job_fun",
         "params": {"x": 3},  # Missing required parameter 'y'
     }
     response = client.post("/ajax-api/3.0/jobs/", payload=payload)
@@ -206,7 +206,7 @@ def test_job_endpoint_missing_parameters(client: Client):
 
 def test_job_tracking_uri(client: Client):
     job_id = client.submit_job(
-        function_fullname="test_endpoint.job_assert_tracking_uri",
+        function_name="job_assert_tracking_uri",
         params={"server_url": client.server_url},
     )["job_id"]
     job_json = client.wait_job(job_id)
@@ -215,22 +215,22 @@ def test_job_tracking_uri(client: Client):
 
 def test_job_endpoint_search(client: Client):
     job1_id = client.submit_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"x": 7, "y": 4},
     )["job_id"]
 
     job2_id = client.submit_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"x": 7, "y": 5},
     )["job_id"]
 
     job3_id = client.submit_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"x": 4, "y": 5},
     )["job_id"]
 
     job4_id = client.submit_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"x": 4, "y": 5, "sleep_secs": 5},
         timeout=2,
     )["job_id"]
@@ -244,51 +244,51 @@ def test_job_endpoint_search(client: Client):
         return [job_json["job_id"] for job_json in jobs]
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"x": 7},
     )
     assert extract_job_ids(jobs) == [job1_id, job2_id]
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.bad_fun_name",
+        function_name="bad_fun_name",
         params={"x": 7},
     )
     assert extract_job_ids(jobs) == []
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"x": 7, "y": 5},
     )
     assert extract_job_ids(jobs) == [job2_id]
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"y": 5},
     )
     assert extract_job_ids(jobs) == [job2_id, job3_id, job4_id]
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"y": 6},
     )
     assert extract_job_ids(jobs) == []
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"y": 5},
         statuses=["SUCCEEDED"],
     )
     assert extract_job_ids(jobs) == [job2_id, job3_id]
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"y": 5},
         statuses=["TIMEOUT"],
     )
     assert extract_job_ids(jobs) == [job4_id]
 
     jobs = client.search_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        function_name="simple_job_fun",
         params={"y": 5},
         statuses=["SUCCEEDED", "TIMEOUT"],
     )

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -148,7 +148,7 @@ def test_job_endpoint(client: Client):
     job_json.pop("last_update_time")
     assert job_json == {
         "job_id": job_id,
-        "function_fullname": "test_endpoint.simple_job_fun",
+        "function_name": "simple_job_fun",
         "params": {"x": 3, "y": 4},
         "timeout": None,
         "status": "SUCCEEDED",
@@ -302,7 +302,7 @@ def test_job_endpoint_search(client: Client):
     response = client.post(
         "/ajax-api/3.0/jobs/search",
         payload={
-            "function_fullname": "test_endpoint.simple_job_fun",
+            "function_name": "simple_job_fun",
             "statuses": ["BAD_STATUS"],
         },
     )


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/WeichenXu123/mlflow/pull/19405?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19405/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19405/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19405/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Motivation: The job backend uses function full name module.func_name as a unique identifier for the job function. This blocks us from moving function module in the future, because it will cause inconsistency between client and server in different versions. Each job function should have its own unique name and MLflow should maintain the mapping

In this PR, I set the "static name" as the function name regardless the module name, and maintain a map from the static name to the full function name.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
