### PR TITLE
Add sidebar for session-level assessments in sessions view

### DIFF
--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatConversation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatConversation.tsx
@@ -106,6 +106,7 @@ export const ExperimentSingleChatConversation = ({
                 />
               </Button>
             </div>
+            {/* TODO: add turn-level metrics */}
             <SingleChatTurnMessages key={traceId} trace={trace} />
             {shouldEnableAssessmentsInSessions() && (
               <>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
@@ -19,7 +19,7 @@ export const ExperimentSingleChatSessionMetrics = ({
         gap: theme.spacing.sm,
       }}
     >
-      {chatSessionMetrics.sessionTokens.total_tokens && (
+      {chatSessionMetrics.sessionTokens['total_tokens'] && (
         <div
           css={{
             display: 'flex',
@@ -33,7 +33,7 @@ export const ExperimentSingleChatSessionMetrics = ({
             />
           </Typography.Text>
           <Tag componentId="mlflow.experiment.chat-session.metrics.tokens-tag" icon={<TokenIcon />}>
-            {chatSessionMetrics.sessionTokens.total_tokens}
+            {chatSessionMetrics.sessionTokens['total_tokens']}
           </Tag>
         </div>
       )}

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
@@ -19,7 +19,7 @@ export const ExperimentSingleChatSessionMetrics = ({
         gap: theme.spacing.sm,
       }}
     >
-      {chatSessionMetrics.sessionTokens['total_tokens'] && (
+      {chatSessionMetrics.sessionTokens?.['total_tokens'] && (
         <div
           css={{
             display: 'flex',

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
@@ -1,0 +1,67 @@
+import { Tag, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import type { ExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
+import { FormattedMessage } from 'react-intl';
+
+export const ExperimentSingleChatSessionMetrics = ({
+  chatSessionMetrics,
+}: {
+  chatSessionMetrics: ExperimentSingleChatMetrics;
+}) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      css={{
+        borderBottom: `1px solid ${theme.colors.grey100}`,
+        paddingBottom: theme.spacing.sm,
+        paddingLeft: theme.spacing.md,
+        paddingRight: theme.spacing.md,
+        display: 'flex',
+        gap: theme.spacing.sm,
+      }}
+    >
+      {chatSessionMetrics.sessionTokens.total_tokens > 0 && (
+        <div
+          css={{
+            display: 'flex',
+            gap: theme.spacing.xs,
+            alignItems: 'center',
+          }}
+        >
+          <Typography.Text color="secondary">
+            <FormattedMessage
+              defaultMessage="Tokens:"
+              description="Label for the total token count metric in chat session metrics"
+            />
+          </Typography.Text>
+          <Tag componentId="mlflow.experiment.chat-session.metrics.tokens-tag">
+            {chatSessionMetrics.sessionTokens.total_tokens}
+          </Tag>
+        </div>
+      )}
+      {chatSessionMetrics.sessionLatency && (
+        <div
+          css={{
+            display: 'flex',
+            gap: theme.spacing.xs,
+            alignItems: 'center',
+          }}
+        >
+          <Typography.Text color="secondary">
+            <FormattedMessage
+              defaultMessage="Latency:"
+              description="Label for the total latency metric in chat session metrics"
+            />
+          </Typography.Text>
+          <Tag componentId="mlflow.experiment.chat-session.metrics.latency-tag">
+            <FormattedMessage
+              defaultMessage="{latency} sec"
+              description="Display format for latency value in seconds in chat session metrics"
+              values={{ latency: chatSessionMetrics.sessionLatency?.toFixed(4) }}
+            />
+          </Tag>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionMetrics.tsx
@@ -1,6 +1,7 @@
-import { Tag, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { ClockIcon, Tag, TokenIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import type { ExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
-import { FormattedMessage } from 'react-intl';
+
+import { FormattedMessage } from '@databricks/i18n';
 
 export const ExperimentSingleChatSessionMetrics = ({
   chatSessionMetrics,
@@ -14,27 +15,24 @@ export const ExperimentSingleChatSessionMetrics = ({
       css={{
         borderBottom: `1px solid ${theme.colors.grey100}`,
         paddingBottom: theme.spacing.sm,
-        paddingLeft: theme.spacing.md,
-        paddingRight: theme.spacing.md,
         display: 'flex',
         gap: theme.spacing.sm,
       }}
     >
-      {chatSessionMetrics.sessionTokens.total_tokens > 0 && (
+      {chatSessionMetrics.sessionTokens.total_tokens && (
         <div
           css={{
             display: 'flex',
             gap: theme.spacing.xs,
-            alignItems: 'center',
           }}
         >
           <Typography.Text color="secondary">
             <FormattedMessage
-              defaultMessage="Tokens:"
+              defaultMessage="Tokens"
               description="Label for the total token count metric in chat session metrics"
             />
           </Typography.Text>
-          <Tag componentId="mlflow.experiment.chat-session.metrics.tokens-tag">
+          <Tag componentId="mlflow.experiment.chat-session.metrics.tokens-tag" icon={<TokenIcon />}>
             {chatSessionMetrics.sessionTokens.total_tokens}
           </Tag>
         </div>
@@ -44,16 +42,15 @@ export const ExperimentSingleChatSessionMetrics = ({
           css={{
             display: 'flex',
             gap: theme.spacing.xs,
-            alignItems: 'center',
           }}
         >
           <Typography.Text color="secondary">
             <FormattedMessage
-              defaultMessage="Latency:"
+              defaultMessage="Latency"
               description="Label for the total latency metric in chat session metrics"
             />
           </Typography.Text>
-          <Tag componentId="mlflow.experiment.chat-session.metrics.latency-tag">
+          <Tag componentId="mlflow.experiment.chat-session.metrics.latency-tag" icon={<ClockIcon />}>
             <FormattedMessage
               defaultMessage="{latency} sec"
               description="Display format for latency value in seconds in chat session metrics"

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -15,10 +15,10 @@ import invariant from 'invariant';
 import { useGetExperimentQuery } from '../../../hooks/useExperimentQuery';
 import { useCallback, useMemo, useRef, useState } from 'react';
 // BEGIN-EDGE
-import { useFetchTraceV4LazyQuery } from '@databricks/web-shared/genai-traces-table';
-import { useMonitoringSqlWarehouseId } from '../../experiment-evaluation-monitoring/hooks/useMonitoringSqlWarehouseId';
-import { useUpdateExperimentUCSchemaStorage } from '../../../components/experiment-page/components/traces-v3/hooks/useUpdateExperimentUCSchemaStorage';
 // Commented out because these don't exist in OSS:
+// import { useFetchTraceV4LazyQuery } from '@databricks/web-shared/genai-traces-table';
+// import { useMonitoringSqlWarehouseId } from '../../experiment-evaluation-monitoring/hooks/useMonitoringSqlWarehouseId';
+// import { useUpdateExperimentUCSchemaStorage } from '../../../components/experiment-page/components/traces-v3/hooks/useUpdateExperimentUCSchemaStorage';
 // import { LabelingSchemaContextProvider } from '@databricks/web-shared/model-trace-explorer';
 // import { useExperimentLabelingSchemas } from '../../../hooks/useExperimentLabelingSchemas';
 // END-EDGE
@@ -37,6 +37,7 @@ import {
   ExperimentSingleChatSessionSidebar,
   ExperimentSingleChatSessionSidebarSkeleton,
 } from './ExperimentSingleChatSessionSidebar';
+import { shouldEnableChatSessionsTab } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
 import { getTrace as getTraceV3 } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils';
 import { getChatSessionsFilter } from '../utils';
 import {
@@ -81,7 +82,7 @@ import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessio
 // };
 // END-EDGE
 
-const OssContextProviders = ({
+const oss_ContextProviders = ({
   children,
   modelTraceInfo,
   invalidateTraceQuery,
@@ -114,22 +115,50 @@ const ExperimentSingleChatSessionPageImpl = () => {
     experimentId,
   });
 
+  // BEGIN-EDGE
+  // Commented out because useUpdateExperimentUCSchemaStorage doesn't exist in OSS:
+  // const { storageUCSchema, setStorageUCSchema, isUpdatingStorageUCSchema } = useUpdateExperimentUCSchemaStorage({
+  //   experimentId,
+  // });
+  // END-EDGE
   const traceSearchLocations = useMemo(
     () => {
+      // BEGIN-EDGE
+      // Commented out because UC schema doesn't exist in OSS:
+      // // If the experiment is still loading, wait with determining the trace location
+      // if (isLoadingExperiment && shouldUseTracesV4API()) {
+      //   return [];
+      // }
+      // if (storageUCSchema && shouldUseTracesV4API()) {
+      //   return [createTraceLocationForUCSchema(storageUCSchema)];
+      // }
+      // END-EDGE
       return [createTraceLocationForExperiment(experimentId)];
     },
     // prettier-ignore
     [
       experimentId,
+      // BEGIN-EDGE
+      // storageUCSchema,
+      // isLoadingExperiment,
+      // END-EDGE
     ],
   );
 
   const filters = useMemo(() => getChatSessionsFilter({ sessionId }), [sessionId]);
 
+  // BEGIN-EDGE
+  // Commented out because useMonitoringSqlWarehouseId doesn't exist in OSS:
+  // const [selectedWarehouseId, setSelectedWarehouseId] = useMonitoringSqlWarehouseId();
+  // const [warehousesLoading, setWarehousesLoading] = useState(false);
+  // END-EDGE
   const { data: traceInfos, isLoading: isLoadingTraceInfos } = useSearchMlflowTraces({
     locations: traceSearchLocations,
     filters,
     disabled: false,
+    // BEGIN-EDGE
+    // sqlWarehouseId: selectedWarehouseId || undefined,
+    // END-EDGE
   });
 
   const sortedTraceInfos = useMemo(() => {
@@ -138,6 +167,35 @@ const ExperimentSingleChatSessionPageImpl = () => {
 
   const chatSessionMetrics = useExperimentSingleChatMetrics({ traceInfos: sortedTraceInfos });
 
+  // BEGIN-EDGE
+  // Commented out because useFetchTraceV4LazyQuery and useExperimentLabelingSchemas don't exist in OSS:
+  // // A function used to fetch trace using V4 API
+  // const getTraceV4 = useFetchTraceV4LazyQuery({ selectedSqlWarehouseId: selectedWarehouseId || undefined });
+  //
+  // // A wrapper function that decides whether to use V4 API or original API to fetch trace
+  // const getTrace = useCallback<GetTraceFunction>(
+  //   (traceId, traceInfo) => {
+  //     if (shouldUseTracesV4API() && traceInfo && isV3ModelTraceInfo(traceInfo) && doesTraceSupportV4API(traceInfo)) {
+  //       return getTraceV4(traceInfo);
+  //     }
+  //     return getTraceV3(traceId, traceInfo);
+  //   },
+  //   [getTraceV4],
+  // );
+  //
+  // const labelingSchemasConfig = useExperimentLabelingSchemas(experimentId);
+  //
+  // const getAssessmentTitle = useCallback(
+  //   (assessmentName: string) => {
+  //     const matchingSchema = labelingSchemasConfig.schemas?.find((schema) => schema?.name === assessmentName);
+  //     if (matchingSchema) {
+  //       return matchingSchema.title ?? assessmentName;
+  //     }
+  //     return assessmentName;
+  //   },
+  //   [labelingSchemasConfig.schemas],
+  // );
+  // END-EDGE
   const getTrace = getTraceV3;
   const getAssessmentTitle = useCallback((assessmentName: string) => assessmentName, []);
   const {
@@ -149,7 +207,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
   const firstTraceInfo = traces?.[0]?.info;
 
   return (
-    <OssContextProviders modelTraceInfo={firstTraceInfo} invalidateTraceQuery={invalidateSingleTraceQuery}>
+    <oss_ContextProviders modelTraceInfo={firstTraceInfo} invalidateTraceQuery={invalidateSingleTraceQuery}>
       <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
         <div
           css={
@@ -166,6 +224,19 @@ const ExperimentSingleChatSessionPageImpl = () => {
             // prettier-ignore
             viewState="single-chat-session"
             sessionId={sessionId}
+            // BEGIN-EDGE
+            // Commented out EDGE-only props:
+            // experimentId={experimentId}
+            // selectedWarehouseId={selectedWarehouseId || undefined}
+            // setSelectedWarehouseId={setSelectedWarehouseId}
+            // setWarehousesLoading={setWarehousesLoading}
+            // isListMonitorsLoading={false}
+            // isShinkansenEnabled
+            // shinkansenTraceArchiveTableName={undefined}
+            // selectedStorageUCSchema={storageUCSchema}
+            // setSelectedStorageUCSchema={setStorageUCSchema}
+            // isUpdatingStorageUCSchema={isUpdatingStorageUCSchema}
+            // END-EDGE
           />
         </div>
 
@@ -221,17 +292,17 @@ const ExperimentSingleChatSessionPageImpl = () => {
                 marginBottom: -theme.spacing.lg,
               }}
             >
-              <OssContextProviders
+              <oss_ContextProviders
                 modelTraceInfo={selectedTrace?.info}
                 invalidateTraceQuery={invalidateSingleTraceQuery}
               >
                 {selectedTrace && <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />}
-              </OssContextProviders>
+              </oss_ContextProviders>
             </div>
           </Drawer.Content>
         </Drawer.Root>
       </div>
-    </OssContextProviders>
+    </oss_ContextProviders>
   );
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -37,7 +37,6 @@ import {
   ExperimentSingleChatSessionSidebar,
   ExperimentSingleChatSessionSidebarSkeleton,
 } from './ExperimentSingleChatSessionSidebar';
-import { shouldEnableChatSessionsTab } from '@mlflow/mlflow/src/common/utils/FeatureUtils';
 import { getTrace as getTraceV3 } from '@mlflow/mlflow/src/experiment-tracking/utils/TraceUtils';
 import { getChatSessionsFilter } from '../utils';
 import {
@@ -82,7 +81,7 @@ import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessio
 // };
 // END-EDGE
 
-const oss_ContextProviders = ({
+const OssContextProviders = ({
   children,
   modelTraceInfo,
   invalidateTraceQuery,
@@ -207,7 +206,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
   const firstTraceInfo = traces?.[0]?.info;
 
   return (
-    <oss_ContextProviders modelTraceInfo={firstTraceInfo} invalidateTraceQuery={invalidateSingleTraceQuery}>
+    <OssContextProviders modelTraceInfo={firstTraceInfo} invalidateTraceQuery={invalidateSingleTraceQuery}>
       <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
         <div
           css={
@@ -292,17 +291,17 @@ const ExperimentSingleChatSessionPageImpl = () => {
                 marginBottom: -theme.spacing.lg,
               }}
             >
-              <oss_ContextProviders
+              <OssContextProviders
                 modelTraceInfo={selectedTrace?.info}
                 invalidateTraceQuery={invalidateSingleTraceQuery}
               >
                 {selectedTrace && <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />}
-              </oss_ContextProviders>
+              </OssContextProviders>
             </div>
           </Drawer.Content>
         </Drawer.Root>
       </div>
-    </oss_ContextProviders>
+    </OssContextProviders>
   );
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -18,8 +18,9 @@ import { useCallback, useMemo, useRef, useState } from 'react';
 import { useFetchTraceV4LazyQuery } from '@databricks/web-shared/genai-traces-table';
 import { useMonitoringSqlWarehouseId } from '../../experiment-evaluation-monitoring/hooks/useMonitoringSqlWarehouseId';
 import { useUpdateExperimentUCSchemaStorage } from '../../../components/experiment-page/components/traces-v3/hooks/useUpdateExperimentUCSchemaStorage';
-import { LabelingSchemaContextProvider } from '@databricks/web-shared/model-trace-explorer';
-import { useExperimentLabelingSchemas } from '../../../hooks/useExperimentLabelingSchemas';
+// Commented out because these don't exist in OSS:
+// import { LabelingSchemaContextProvider } from '@databricks/web-shared/model-trace-explorer';
+// import { useExperimentLabelingSchemas } from '../../../hooks/useExperimentLabelingSchemas';
 // END-EDGE
 import { ExperimentSingleChatSessionScoreResults } from './ExperimentSingleChatSessionScoreResults';
 import { TracesV3Toolbar } from '../../../components/experiment-page/components/traces-v3/TracesV3Toolbar';
@@ -46,40 +47,41 @@ import { Drawer, useDesignSystemTheme } from '@databricks/design-system';
 import { useExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
 import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessionMetrics';
 // BEGIN-EDGE
-const ContextProviders = ({
-  sqlWarehouseId,
-  modelTraceInfo,
-  children,
-  labelingSchemasConfig,
-  invalidateTraceQuery,
-}: {
-  sqlWarehouseId?: string;
-  modelTraceInfo?: ModelTrace['info'];
-  children: React.ReactNode;
-  labelingSchemasConfig: ReturnType<typeof useExperimentLabelingSchemas>;
-  invalidateTraceQuery?: (traceId?: string) => void;
-}) => {
-  return (
-    <ModelTraceExplorerUpdateTraceContextProvider
-      sqlWarehouseId={sqlWarehouseId}
-      modelTraceInfo={modelTraceInfo}
-      invalidateTraceQuery={invalidateTraceQuery}
-    >
-      <LabelingSchemaContextProvider
-        schemas={labelingSchemasConfig.schemas}
-        allAvailableSchemas={labelingSchemasConfig.allAvailableSchemas}
-        isLoading={labelingSchemasConfig.isLoading}
-        onAddSchema={labelingSchemasConfig.addSchema}
-        onRemoveSchema={labelingSchemasConfig.removeSchema}
-      >
-        {children}
-      </LabelingSchemaContextProvider>
-    </ModelTraceExplorerUpdateTraceContextProvider>
-  );
-};
+// Commented out because LabelingSchemaContextProvider and useExperimentLabelingSchemas don't exist in OSS:
+// const ContextProviders = ({
+//   sqlWarehouseId,
+//   modelTraceInfo,
+//   children,
+//   labelingSchemasConfig,
+//   invalidateTraceQuery,
+// }: {
+//   sqlWarehouseId?: string;
+//   modelTraceInfo?: ModelTrace['info'];
+//   children: React.ReactNode;
+//   labelingSchemasConfig: ReturnType<typeof useExperimentLabelingSchemas>;
+//   invalidateTraceQuery?: (traceId?: string) => void;
+// }) => {
+//   return (
+//     <ModelTraceExplorerUpdateTraceContextProvider
+//       sqlWarehouseId={sqlWarehouseId}
+//       modelTraceInfo={modelTraceInfo}
+//       invalidateTraceQuery={invalidateTraceQuery}
+//     >
+//       <LabelingSchemaContextProvider
+//         schemas={labelingSchemasConfig.schemas}
+//         allAvailableSchemas={labelingSchemasConfig.allAvailableSchemas}
+//         isLoading={labelingSchemasConfig.isLoading}
+//         onAddSchema={labelingSchemasConfig.addSchema}
+//         onRemoveSchema={labelingSchemasConfig.removeSchema}
+//       >
+//         {children}
+//       </LabelingSchemaContextProvider>
+//     </ModelTraceExplorerUpdateTraceContextProvider>
+//   );
+// };
 // END-EDGE
 
-const oss_ContextProviders = ({
+const OssContextProviders = ({
   children,
   modelTraceInfo,
   invalidateTraceQuery,
@@ -147,7 +149,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
   const firstTraceInfo = traces?.[0]?.info;
 
   return (
-    <oss_ContextProviders modelTraceInfo={firstTraceInfo} invalidateTraceQuery={invalidateSingleTraceQuery}>
+    <OssContextProviders modelTraceInfo={firstTraceInfo} invalidateTraceQuery={invalidateSingleTraceQuery}>
       <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
         <div
           css={
@@ -219,17 +221,17 @@ const ExperimentSingleChatSessionPageImpl = () => {
                 marginBottom: -theme.spacing.lg,
               }}
             >
-              <oss_ContextProviders
+              <OssContextProviders
                 modelTraceInfo={selectedTrace?.info}
                 invalidateTraceQuery={invalidateSingleTraceQuery}
               >
                 {selectedTrace && <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />}
-              </oss_ContextProviders>
+              </OssContextProviders>
             </div>
           </Drawer.Content>
         </Drawer.Root>
       </div>
-    </oss_ContextProviders>
+    </OssContextProviders>
   );
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -40,8 +40,23 @@ import { ExperimentSingleChatSessionScoreResults } from './ExperimentSingleChatS
 import { useExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
 import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessionMetrics';
 
-const ContextProviders = ({ children }: { children: React.ReactNode }) => {
-  return <>{children}</>;
+const ContextProviders = ({
+  children,
+  modelTraceInfo,
+  invalidateTraceQuery,
+}: {
+  children: React.ReactNode;
+  modelTraceInfo?: ModelTrace['info'];
+  invalidateTraceQuery?: (traceId?: string) => void;
+}) => {
+  return (
+    <ModelTraceExplorerUpdateTraceContextProvider
+      modelTraceInfo={modelTraceInfo}
+      invalidateTraceQuery={invalidateTraceQuery}
+    >
+      {children}
+    </ModelTraceExplorerUpdateTraceContextProvider>
+  );
 };
 
 const ExperimentSingleChatSessionPageImpl = () => {
@@ -112,9 +127,15 @@ const ExperimentSingleChatSessionPageImpl = () => {
     }
   }, [selectedTraceIdFromUrl, traces, isLoadingTraceDatas]);
 
+  const firstTraceInfo = traces?.[0]?.info;
+
   return (
-    <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-      <div
+    <ContextProviders
+      modelTraceInfo={firstTraceInfo}
+      invalidateTraceQuery={invalidateSingleTraceQuery}
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
+        <div
         css={
           shouldEnableAssessmentsInSessions()
             ? {
@@ -157,7 +178,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
             chatRefs={chatRefs}
             getAssessmentTitle={getAssessmentTitle}
           />
-          {shouldEnableAssessmentsInSessions() && <ExperimentSingleChatSessionScoreResults traces={traces ?? []} />}
+          {shouldEnableAssessmentsInSessions() && <ExperimentSingleChatSessionScoreResults traces={traces ?? []} sessionId={sessionId} />}
         </div>
       )}
       <Drawer.Root
@@ -182,7 +203,9 @@ const ExperimentSingleChatSessionPageImpl = () => {
               marginBottom: -theme.spacing.lg,
             }}
           >
-            <ContextProviders // prettier-ignore
+            <ContextProviders
+              modelTraceInfo={selectedTrace?.info}
+              invalidateTraceQuery={invalidateSingleTraceQuery}
             >
               {selectedTrace && <ModelTraceExplorer modelTrace={selectedTrace} collapseAssessmentPane="force-open" />}
             </ContextProviders>
@@ -190,6 +213,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
         </Drawer.Content>
       </Drawer.Root>
     </div>
+    </ContextProviders>
   );
 };
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionPage.tsx
@@ -21,6 +21,7 @@ import {
   isV3ModelTraceInfo,
   ModelTraceExplorer,
   ModelTraceExplorerUpdateTraceContextProvider,
+  shouldEnableAssessmentsInSessions,
   shouldUseTracesV4API,
 } from '@databricks/web-shared/model-trace-explorer';
 import {
@@ -35,6 +36,9 @@ import {
 } from './ExperimentSingleChatConversation';
 import { Drawer, useDesignSystemTheme } from '@databricks/design-system';
 import { SELECTED_TRACE_ID_QUERY_PARAM } from '../../../constants';
+import { ExperimentSingleChatSessionScoreResults } from './ExperimentSingleChatSessionScoreResults';
+import { useExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
+import { ExperimentSingleChatSessionMetrics } from './ExperimentSingleChatSessionMetrics';
 
 const ContextProviders = ({ children }: { children: React.ReactNode }) => {
   return <>{children}</>;
@@ -85,6 +89,8 @@ const ExperimentSingleChatSessionPageImpl = () => {
     return traceInfos?.sort((a, b) => new Date(a.request_time).getTime() - new Date(b.request_time).getTime());
   }, [traceInfos]);
 
+  const chatSessionMetrics = useExperimentSingleChatMetrics({ traceInfos: sortedTraceInfos });
+
   const getTrace = getTraceV3;
   const getAssessmentTitle = useCallback((assessmentName: string) => assessmentName, []);
   const {
@@ -108,11 +114,27 @@ const ExperimentSingleChatSessionPageImpl = () => {
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
-      <TracesV3Toolbar
-        // prettier-ignore
-        viewState="single-chat-session"
-        sessionId={sessionId}
-      />
+      <div
+        css={
+          shouldEnableAssessmentsInSessions()
+            ? {
+                '& > div': {
+                  borderBottom: 'none',
+                },
+              }
+            : undefined
+        }
+      >
+        <TracesV3Toolbar
+          // prettier-ignore
+          viewState="single-chat-session"
+          sessionId={sessionId}
+        />
+      </div>
+
+      {shouldEnableAssessmentsInSessions() && (
+        <ExperimentSingleChatSessionMetrics chatSessionMetrics={chatSessionMetrics} />
+      )}
       {isLoadingTraceDatas || isLoadingTraceInfos ? (
         <div css={{ display: 'flex', flex: 1, minHeight: 0 }}>
           <ExperimentSingleChatSessionSidebarSkeleton />
@@ -135,6 +157,7 @@ const ExperimentSingleChatSessionPageImpl = () => {
             chatRefs={chatRefs}
             getAssessmentTitle={getAssessmentTitle}
           />
+          {shouldEnableAssessmentsInSessions() && <ExperimentSingleChatSessionScoreResults traces={traces ?? []} />}
         </div>
       )}
       <Drawer.Root

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
@@ -1,7 +1,4 @@
 import { useDesignSystemTheme } from '@databricks/design-system';
-// BEGIN-EDGE
-// import { AssessmentsPaneV2, shouldEnableTracesTabLabelingSchemas } from '@databricks/web-shared/model-trace-explorer';
-// END-EDGE
 import {
   isSessionLevelAssessment,
   ModelTraceExplorerUpdateTraceContextProvider,
@@ -11,26 +8,12 @@ import {
   AssessmentsPane,
   ASSESSMENT_SESSION_METADATA_KEY,
 } from '@databricks/web-shared/model-trace-explorer';
-import { first, last } from 'lodash';
+import { first } from 'lodash';
 import { useMemo } from 'react';
-import { FormattedMessage } from 'react-intl';
 import { ResizableBox } from 'react-resizable';
 
 const initialWidth = 300;
 const maxWidth = 600;
-
-// BEGIN-EDGE
-// const getAssessmentsPaneComponent = () => {
-//   if (shouldEnableTracesTabLabelingSchemas()) {
-//     return AssessmentsPaneV2;
-//   }
-//   return AssessmentsPane;
-// };
-// END-EDGE
-
-const getAssessmentsPaneComponent = () => {
-  return AssessmentsPane;
-};
 
 export const ExperimentSingleChatSessionScoreResults = ({
   traces,
@@ -55,8 +38,6 @@ export const ExperimentSingleChatSessionScoreResults = ({
   );
 
   const defaultMetadata = useMemo(() => ({ [ASSESSMENT_SESSION_METADATA_KEY]: sessionId }), [sessionId]);
-
-  const AssessmentsPaneComponent = getAssessmentsPaneComponent();
 
   const traceUpdateContext = useModelTraceExplorerUpdateTraceContext();
 
@@ -118,7 +99,7 @@ export const ExperimentSingleChatSessionScoreResults = ({
               border: 0,
             }}
           >
-            <AssessmentsPaneComponent
+            <AssessmentsPane
               assessments={sessionAssessments}
               traceId={firstTraceInfoInSession.trace_id}
               defaultMetadata={defaultMetadata}
@@ -129,11 +110,3 @@ export const ExperimentSingleChatSessionScoreResults = ({
     </div>
   );
 };
-
-const AssessmentsTitleOverride = (count?: number) => (
-  <FormattedMessage
-    defaultMessage="Session scorers{count, plural, =0 {} other { (#)}}"
-    values={{ count: count ?? 0 }}
-    description="Section title in a side panel that displays session-level scorers"
-  />
-);

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
@@ -1,9 +1,11 @@
 import { useDesignSystemTheme } from '@databricks/design-system';
 // BEGIN-EDGE
-import { AssessmentsPaneV2, shouldEnableTracesTabLabelingSchemas } from '@databricks/web-shared/model-trace-explorer';
+// import { AssessmentsPaneV2, shouldEnableTracesTabLabelingSchemas } from '@databricks/web-shared/model-trace-explorer';
 // END-EDGE
 import {
   isSessionLevelAssessment,
+  ModelTraceExplorerUpdateTraceContextProvider,
+  useModelTraceExplorerUpdateTraceContext,
   isV3ModelTraceInfo,
   type ModelTrace,
   AssessmentsPane,
@@ -17,12 +19,16 @@ import { ResizableBox } from 'react-resizable';
 const initialWidth = 300;
 const maxWidth = 600;
 
+// BEGIN-EDGE
+// const getAssessmentsPaneComponent = () => {
+//   if (shouldEnableTracesTabLabelingSchemas()) {
+//     return AssessmentsPaneV2;
+//   }
+//   return AssessmentsPane;
+// };
+// END-EDGE
+
 const getAssessmentsPaneComponent = () => {
-  // BEGIN-EDGE
-  if (shouldEnableTracesTabLabelingSchemas()) {
-    return AssessmentsPaneV2;
-  }
-  // END-EDGE
   return AssessmentsPane;
 };
 
@@ -51,6 +57,8 @@ export const ExperimentSingleChatSessionScoreResults = ({
   const defaultMetadata = useMemo(() => ({ [ASSESSMENT_SESSION_METADATA_KEY]: sessionId }), [sessionId]);
 
   const AssessmentsPaneComponent = getAssessmentsPaneComponent();
+
+  const traceUpdateContext = useModelTraceExplorerUpdateTraceContext();
 
   if (!firstTraceInfoInSession) {
     return null;
@@ -98,16 +106,23 @@ export const ExperimentSingleChatSessionScoreResults = ({
           flex: 1,
         }}
       >
-        <AssessmentsPaneComponent
-          assessments={sessionAssessments}
-          traceId={firstTraceInfoInSession.trace_id}
-          defaultMetadata={defaultMetadata}
-          css={{
-            paddingLeft: 0,
-            border: 0,
-          }}
-          assessmentsTitleOverride={AssessmentsTitleOverride}
-        />
+        {/* Repeat the context from the level above, additionally adding proper trace info and chat session ID */}
+        <ModelTraceExplorerUpdateTraceContextProvider
+          {...traceUpdateContext}
+          modelTraceInfo={firstTraceInfoInSession}
+          chatSessionId={sessionId}
+        >
+          <AssessmentsPaneComponent
+            assessments={sessionAssessments}
+            traceId={firstTraceInfoInSession.trace_id}
+            defaultMetadata={defaultMetadata}
+            css={{
+              paddingLeft: 0,
+              border: 0,
+            }}
+            assessmentsTitleOverride={AssessmentsTitleOverride}
+          />
+        </ModelTraceExplorerUpdateTraceContextProvider>
       </ResizableBox>
     </div>
   );

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
@@ -26,7 +26,13 @@ const getAssessmentsPaneComponent = () => {
   return AssessmentsPane;
 };
 
-export const ExperimentSingleChatSessionScoreResults = ({ traces, sessionId }: { traces: ModelTrace[]; sessionId: string }) => {
+export const ExperimentSingleChatSessionScoreResults = ({
+  traces,
+  sessionId,
+}: {
+  traces: ModelTrace[];
+  sessionId: string;
+}) => {
   const { theme } = useDesignSystemTheme();
 
   const firstTraceInfoInSession = useMemo(() => {
@@ -42,10 +48,7 @@ export const ExperimentSingleChatSessionScoreResults = ({ traces, sessionId }: {
     [firstTraceInfoInSession],
   );
 
-  const defaultMetadata = useMemo(
-    () => ({ [ASSESSMENT_SESSION_METADATA_KEY]: sessionId }),
-    [sessionId],
-  );
+  const defaultMetadata = useMemo(() => ({ [ASSESSMENT_SESSION_METADATA_KEY]: sessionId }), [sessionId]);
 
   const AssessmentsPaneComponent = getAssessmentsPaneComponent();
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
@@ -112,16 +112,18 @@ export const ExperimentSingleChatSessionScoreResults = ({
           modelTraceInfo={firstTraceInfoInSession}
           chatSessionId={sessionId}
         >
-          <AssessmentsPaneComponent
-            assessments={sessionAssessments}
-            traceId={firstTraceInfoInSession.trace_id}
-            defaultMetadata={defaultMetadata}
+          <div
             css={{
               paddingLeft: 0,
               border: 0,
             }}
-            assessmentsTitleOverride={AssessmentsTitleOverride}
-          />
+          >
+            <AssessmentsPaneComponent
+              assessments={sessionAssessments}
+              traceId={firstTraceInfoInSession.trace_id}
+              defaultMetadata={defaultMetadata}
+            />
+          </div>
         </ModelTraceExplorerUpdateTraceContextProvider>
       </ResizableBox>
     </div>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/ExperimentSingleChatSessionScoreResults.tsx
@@ -1,0 +1,91 @@
+import { useDesignSystemTheme } from '@databricks/design-system';
+import {
+  isSessionLevelAssessment,
+  isV3ModelTraceInfo,
+  type ModelTrace,
+  AssessmentsPane,
+} from '@databricks/web-shared/model-trace-explorer';
+import { first } from 'lodash';
+import { useMemo } from 'react';
+import { FormattedMessage } from 'react-intl';
+import { ResizableBox } from 'react-resizable';
+
+const initialWidth = 300;
+const maxWidth = 600;
+
+export const ExperimentSingleChatSessionScoreResults = ({ traces }: { traces: ModelTrace[] }) => {
+  const { theme } = useDesignSystemTheme();
+
+  const firstTraceInfoInSession = useMemo(() => {
+    const traceInfo = first(traces)?.info;
+    if (!traceInfo || !isV3ModelTraceInfo(traceInfo)) {
+      return undefined;
+    }
+    return traceInfo;
+  }, [traces]);
+
+  const sessionAssessments = useMemo(
+    () => firstTraceInfoInSession?.assessments?.filter(isSessionLevelAssessment) ?? [],
+    [firstTraceInfoInSession],
+  );
+
+  if (!firstTraceInfoInSession) {
+    return null;
+  }
+
+  return (
+    <div
+      css={{
+        display: 'flex',
+        flexDirection: 'column',
+        minHeight: 0,
+        paddingTop: theme.spacing.sm,
+        overflow: 'auto',
+      }}
+    >
+      <ResizableBox
+        width={initialWidth}
+        height={undefined}
+        axis="x"
+        resizeHandles={['w']}
+        minConstraints={[initialWidth, 150]}
+        maxConstraints={[maxWidth, 150]}
+        handle={
+          <div
+            css={{
+              width: theme.spacing.sm,
+              left: -(theme.spacing.sm / 2),
+              height: '100%',
+              position: 'absolute',
+              top: 0,
+              cursor: 'ew-resize',
+              '&:hover': {
+                backgroundColor: theme.colors.border,
+                opacity: 0.5,
+              },
+            }}
+          />
+        }
+        css={{
+          position: 'relative',
+          display: 'flex',
+          borderLeft: `1px solid ${theme.colors.border}`,
+          marginLeft: theme.spacing.sm,
+          paddingLeft: theme.spacing.sm,
+          flex: 1,
+        }}
+      >
+        <div
+          css={{
+            '& > div': {
+              paddingLeft: 0,
+              border: 0,
+            },
+          }}
+        >
+          <AssessmentsPane assessments={sessionAssessments} traceId={firstTraceInfoInSession.trace_id} />
+        </div>
+      </ResizableBox>
+    </div>
+  );
+};

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.test.tsx
@@ -134,7 +134,7 @@ describe('useExperimentSingleChatMetrics', () => {
     const { result } = renderHook(() => useExperimentSingleChatMetrics({ traceInfos }));
 
     // Assert
-    expect(result.current.sessionTokens).toBeUndefined();
+    expect(result.current.sessionTokens).toEqual({});
     expect(result.current.sessionLatency).toBe(1.5);
   });
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect } from '@jest/globals';
+import { renderHook } from '@testing-library/react';
+import type { ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+import { useExperimentSingleChatMetrics } from './useExperimentSingleChatMetrics';
+
+describe('useExperimentSingleChatMetrics', () => {
+  it('should return empty metrics when traceInfos is empty array', () => {
+    // Arrange
+    const { result } = renderHook(() => useExperimentSingleChatMetrics({ traceInfos: [] }));
+
+    // Assert
+    expect(result.current).toEqual({
+      sessionTokens: { input_tokens: 0, output_tokens: 0 },
+      sessionLatency: 0,
+      perTurnMetrics: [],
+    });
+  });
+
+  it('should calculate metrics for a single trace', () => {
+    // Arrange
+    const traceInfos: ModelTraceInfoV3[] = [
+      {
+        request_id: 'trace-1',
+        execution_duration: '1.5s',
+        trace_metadata: {
+          'mlflow.trace.tokenUsage': JSON.stringify({
+            input_tokens: 100,
+            output_tokens: 50,
+            total_tokens: 150,
+          }),
+        },
+      } as any,
+    ];
+
+    const { result } = renderHook(() => useExperimentSingleChatMetrics({ traceInfos }));
+
+    // Assert
+    expect(result.current.sessionTokens).toEqual({
+      input_tokens: 100,
+      output_tokens: 50,
+      total_tokens: 150,
+    });
+    expect(result.current.sessionLatency).toBe(1.5);
+    expect(result.current.perTurnMetrics).toHaveLength(1);
+    expect(result.current.perTurnMetrics?.[0]).toEqual({
+      tokens: {
+        input_tokens: 100,
+        output_tokens: 50,
+        total_tokens: 150,
+      },
+      latency: '1.5s',
+    });
+  });
+
+  it('should calculate cumulative metrics for multiple traces', () => {
+    // Arrange
+    const traceInfos: ModelTraceInfoV3[] = [
+      {
+        request_id: 'trace-1',
+        execution_duration: '1.5s',
+        trace_metadata: {
+          'mlflow.trace.tokenUsage': JSON.stringify({
+            input_tokens: 100,
+            output_tokens: 50,
+          }),
+        },
+      },
+      {
+        request_id: 'trace-2',
+        execution_duration: '2.3s',
+        trace_metadata: {
+          'mlflow.trace.tokenUsage': JSON.stringify({
+            input_tokens: 150,
+            output_tokens: 75,
+          }),
+        },
+      },
+      {
+        request_id: 'trace-3',
+        execution_duration: '1.2s',
+        trace_metadata: {
+          'mlflow.trace.tokenUsage': JSON.stringify({
+            input_tokens: 200,
+            output_tokens: 100,
+          }),
+        },
+      },
+    ] as any;
+
+    const { result } = renderHook(() => useExperimentSingleChatMetrics({ traceInfos }));
+
+    // Assert
+    // Session tokens should be from the last trace
+    expect(result.current.sessionTokens).toEqual({
+      input_tokens: 200,
+      output_tokens: 100,
+    });
+    // Session latency should be sum of all traces
+    expect(result.current.sessionLatency).toBeCloseTo(5.0);
+    // Should have metrics for all three turns
+    expect(result.current.perTurnMetrics).toHaveLength(3);
+  });
+
+  it('should handle traces with missing token usage metadata', () => {
+    // Arrange
+    const traceInfos: ModelTraceInfoV3[] = [
+      {
+        request_id: 'trace-1',
+        execution_duration: '1.5s',
+        trace_metadata: {},
+      },
+    ] as any;
+
+    const { result } = renderHook(() => useExperimentSingleChatMetrics({ traceInfos }));
+
+    // Assert
+    expect(result.current.sessionTokens).toEqual({});
+    expect(result.current.sessionLatency).toBe(1.5);
+    expect(result.current.perTurnMetrics?.[0].tokens).toEqual({});
+  });
+
+  it('should handle traces with invalid token usage JSON', () => {
+    // Arrange
+    const traceInfos: ModelTraceInfoV3[] = [
+      {
+        request_id: 'trace-1',
+        execution_duration: '1.5s',
+        trace_metadata: {
+          'mlflow.trace.tokenUsage': 'invalid-json',
+        },
+      },
+    ] as any;
+
+    const { result } = renderHook(() => useExperimentSingleChatMetrics({ traceInfos }));
+
+    // Assert
+    expect(result.current.sessionTokens).toBeUndefined();
+    expect(result.current.sessionLatency).toBe(1.5);
+  });
+
+  it('should handle traces with missing execution_duration', () => {
+    // Arrange
+    const traceInfos: ModelTraceInfoV3[] = [
+      {
+        request_id: 'trace-1',
+        trace_metadata: {
+          'mlflow.trace.tokenUsage': JSON.stringify({
+            input_tokens: 100,
+            output_tokens: 50,
+          }),
+        },
+      },
+    ] as any;
+
+    const { result } = renderHook(() => useExperimentSingleChatMetrics({ traceInfos }));
+
+    // Assert
+    expect(result.current.sessionLatency).toBe(0);
+    expect(result.current.perTurnMetrics?.[0].latency).toBeUndefined();
+  });
+});

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 
 type TraceTokenUsage = ReturnType<typeof getTraceTokenUsage>;
 export interface ExperimentSingleChatMetrics {
-  sessionTokens: TraceTokenUsage;
+  sessionTokens: TraceTokenUsage | undefined;
   sessionLatency: number | undefined;
   perTurnMetrics?: {
     tokens: TraceTokenUsage;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.tsx
@@ -1,13 +1,8 @@
-import { TOKEN_USAGE_METADATA_KEY, type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+import { getTraceTokenUsage, type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
 import { last } from 'lodash';
 import { useMemo } from 'react';
 
-interface TraceTokenUsage {
-  input_tokens: number;
-  output_tokens: number;
-  total_tokens: number;
-}
-
+type TraceTokenUsage = ReturnType<typeof getTraceTokenUsage>;
 export interface ExperimentSingleChatMetrics {
   sessionTokens: TraceTokenUsage;
   sessionLatency: number | undefined;
@@ -18,23 +13,9 @@ export interface ExperimentSingleChatMetrics {
 }
 
 const emptyMetrics: ExperimentSingleChatMetrics = {
-  sessionTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+  sessionTokens: { input_tokens: 0, output_tokens: 0 },
   sessionLatency: 0,
   perTurnMetrics: [],
-};
-
-const getTraceTokenUsage = (traceInfo: ModelTraceInfoV3): TraceTokenUsage => {
-  const tokenUsage = traceInfo?.trace_metadata?.[TOKEN_USAGE_METADATA_KEY];
-  try {
-    const parsed = tokenUsage ? JSON.parse(tokenUsage) : {};
-    return {
-      input_tokens: parsed.input_tokens ?? 0,
-      output_tokens: parsed.output_tokens ?? 0,
-      total_tokens: parsed.total_tokens ?? 0,
-    };
-  } catch {
-    return { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
-  }
 };
 
 export const useExperimentSingleChatMetrics = ({

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-chat-sessions/single-chat-view/useExperimentSingleChatMetrics.tsx
@@ -1,0 +1,83 @@
+import { TOKEN_USAGE_METADATA_KEY, type ModelTraceInfoV3 } from '@databricks/web-shared/model-trace-explorer';
+import { last } from 'lodash';
+import { useMemo } from 'react';
+
+interface TraceTokenUsage {
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+}
+
+export interface ExperimentSingleChatMetrics {
+  sessionTokens: TraceTokenUsage;
+  sessionLatency: number | undefined;
+  perTurnMetrics?: {
+    tokens: TraceTokenUsage;
+    latency: string | undefined;
+  }[];
+}
+
+const emptyMetrics: ExperimentSingleChatMetrics = {
+  sessionTokens: { input_tokens: 0, output_tokens: 0, total_tokens: 0 },
+  sessionLatency: 0,
+  perTurnMetrics: [],
+};
+
+const getTraceTokenUsage = (traceInfo: ModelTraceInfoV3): TraceTokenUsage => {
+  const tokenUsage = traceInfo?.trace_metadata?.[TOKEN_USAGE_METADATA_KEY];
+  try {
+    const parsed = tokenUsage ? JSON.parse(tokenUsage) : {};
+    return {
+      input_tokens: parsed.input_tokens ?? 0,
+      output_tokens: parsed.output_tokens ?? 0,
+      total_tokens: parsed.total_tokens ?? 0,
+    };
+  } catch {
+    return { input_tokens: 0, output_tokens: 0, total_tokens: 0 };
+  }
+};
+
+export const useExperimentSingleChatMetrics = ({
+  traceInfos,
+}: {
+  traceInfos?: ModelTraceInfoV3[];
+}): ExperimentSingleChatMetrics =>
+  useMemo(() => {
+    const lastTurn = last(traceInfos);
+    if (!lastTurn) {
+      return emptyMetrics;
+    }
+    const sessionTokens = getTraceTokenUsage(lastTurn);
+    const { sessionLatency, perTurnMetrics } =
+      traceInfos?.reduce<{
+        sessionLatency: number;
+        perTurnMetrics: {
+          tokens: TraceTokenUsage;
+          latency: string | undefined;
+        }[];
+      }>(
+        (aggregate, turnTraceInfo) => {
+          const turnTimeInSeconds = parseFloat(turnTraceInfo.execution_duration || '0');
+          return {
+            sessionLatency: aggregate.sessionLatency + turnTimeInSeconds,
+            perTurnMetrics: [
+              ...aggregate.perTurnMetrics,
+              {
+                tokens: getTraceTokenUsage(turnTraceInfo),
+                latency: turnTraceInfo.execution_duration,
+              },
+            ],
+          };
+        },
+        {
+          sessionLatency: 0,
+          perTurnMetrics: [],
+        },
+      ) ?? {};
+
+    return {
+      sessionTokens,
+      sessionLatency,
+      perTurnMetrics,
+    };
+  }, [traceInfos]);

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -714,6 +714,10 @@
     "defaultMessage": "Experiment Runs - Databricks",
     "description": "Title on a page used to manage MLflow experiments runs"
   },
+  "5IeFBG": {
+    "defaultMessage": "Session scorers{count, plural, =0 {} other { (#)}}",
+    "description": "Section title in a side panel that displays session-level scorers"
+  },
   "5Jg2dq": {
     "defaultMessage": "Last 10 traces",
     "description": "Option for last 10 traces"
@@ -1629,6 +1633,10 @@
   "Csmj/2": {
     "defaultMessage": "Select all runs",
     "description": "Experiment page > runs table > select all rows > accessible label"
+  },
+  "Cu5P8e": {
+    "defaultMessage": "Tokens",
+    "description": "Label for the total token count metric in chat session metrics"
   },
   "CyTYL6": {
     "defaultMessage": "Line chart",
@@ -3580,6 +3588,10 @@
     "defaultMessage": "Key is required if value is present",
     "description": "Error message for required key in trace tag assignment modal"
   },
+  "XHKE0m": {
+    "defaultMessage": "Latency",
+    "description": "Label for the total latency metric in chat session metrics"
+  },
   "XIWwOm": {
     "defaultMessage": "Session ID",
     "description": "Label for the session id section"
@@ -4882,6 +4894,10 @@
   "iZ0M1Y": {
     "defaultMessage": "Apply filters",
     "description": "Button label for applying the filters in the GenAI Traces Table"
+  },
+  "iZOdRI": {
+    "defaultMessage": "{latency} sec",
+    "description": "Display format for latency value in seconds in chat session metrics"
   },
   "iZm6YQ": {
     "defaultMessage": "<link>Learn more</link>",

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -714,10 +714,6 @@
     "defaultMessage": "Experiment Runs - Databricks",
     "description": "Title on a page used to manage MLflow experiments runs"
   },
-  "5IeFBG": {
-    "defaultMessage": "Session scorers{count, plural, =0 {} other { (#)}}",
-    "description": "Section title in a side panel that displays session-level scorers"
-  },
   "5Jg2dq": {
     "defaultMessage": "Last 10 traces",
     "description": "Option for last 10 traces"

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.utils.tsx
@@ -13,6 +13,7 @@ import {
   compact,
   keyBy,
   isObject,
+  isEmpty,
 } from 'lodash';
 import { useMemo } from 'react';
 
@@ -72,7 +73,7 @@ import {
   synthesizeVoltAgentChatMessages,
 } from './chat-utils';
 import { normalizeOpenAIResponsesStreamingOutput } from './chat-utils/openai';
-import { TOKEN_USAGE_METADATA_KEY } from './constants';
+import { ASSESSMENT_SESSION_METADATA_KEY, TOKEN_USAGE_METADATA_KEY } from './constants';
 import { getTimelineTreeNodesList, isNodeImportant } from './timeline-tree/TimelineTree.utils';
 
 export const FETCH_TRACE_INFO_QUERY_KEY = 'model-trace-info-v3';
@@ -1256,5 +1257,21 @@ export const getTotalTokens = (traceInfo: ModelTraceInfoV3): number | null => {
     return parsedTokenUsage?.total_tokens ?? null;
   } catch {
     return null;
+  }
+};
+
+export const isSessionLevelAssessment = (assessment: Assessment): boolean => {
+  return !isEmpty(assessment.metadata?.[ASSESSMENT_SESSION_METADATA_KEY]);
+};
+
+export const getTraceTokenUsage = (traceInfo: ModelTraceInfoV3): Record<string, number> => {
+  const tokenUsage = traceInfo?.trace_metadata?.[TOKEN_USAGE_METADATA_KEY];
+  if (!tokenUsage) {
+    return {};
+  }
+  try {
+    return JSON.parse(tokenUsage) || {};
+  } catch {
+    return {};
   }
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
@@ -22,8 +22,19 @@ export const AssessmentCreateButton = ({
 
   useEffect(() => {
     if (expanded && ref.current) {
-      // scroll form into view after the form is expanded
-      ref.current.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      // scroll form into view after the form is expanded, but only if it's not already visible
+      const element = ref.current;
+      const parent = element.offsetParent as HTMLElement;
+      if (parent) {
+        const elementTop = element.offsetTop;
+        const parentScrollTop = parent.scrollTop;
+        const parentHeight = parent.clientHeight;
+
+        // Only scroll if the element is not fully visible
+        if (elementTop < parentScrollTop || elementTop > parentScrollTop + parentHeight) {
+          ref.current.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+        }
+      }
     }
   }, [expanded]);
 

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateButton.tsx
@@ -9,11 +9,13 @@ export const AssessmentCreateButton = ({
   assessmentName,
   spanId,
   traceId,
+  defaultMetadata,
 }: {
   title: React.ReactNode;
   assessmentName?: string;
   spanId?: string;
   traceId: string;
+  defaultMetadata?: Record<string, string>;
 }) => {
   const [expanded, setExpanded] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -42,6 +44,7 @@ export const AssessmentCreateButton = ({
           spanId={spanId}
           traceId={traceId}
           setExpanded={setExpanded}
+          defaultMetadata={defaultMetadata}
         />
       )}
     </div>

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.tsx
@@ -37,6 +37,7 @@ type AssessmentCreateFormProps = {
   spanId?: string;
   traceId: string;
   setExpanded: (expanded: boolean) => void;
+  defaultMetadata?: Record<string, string>;
 };
 
 export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateFormProps>(
@@ -48,6 +49,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
       // used to close the form
       // after the assessment is created
       setExpanded,
+      defaultMetadata,
     },
     ref,
   ) => {
@@ -116,6 +118,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
           span_id: spanId,
           rationale,
           ...valueObj,
+          ...(defaultMetadata && { metadata: defaultMetadata }),
         },
       };
 
@@ -131,6 +134,7 @@ export const AssessmentCreateForm = forwardRef<HTMLDivElement, AssessmentCreateF
       spanId,
       rationale,
       createAssessmentMutation,
+      defaultMetadata,
     ]);
 
     const handleChangeSchema = useCallback(

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentsPane.tsx
@@ -58,10 +58,12 @@ export const AssessmentsPane = ({
   assessments,
   traceId,
   activeSpanId,
+  defaultMetadata,
 }: {
   assessments: Assessment[];
   traceId: string;
   activeSpanId?: string;
+  defaultMetadata?: Record<string, string>;
 }) => {
   const reconstructAssessments = useTraceCachedActions((state) => state.reconstructAssessments);
   const cachedActions = useTraceCachedActions((state) => state.assessmentActions[traceId]);
@@ -158,6 +160,7 @@ export const AssessmentsPane = ({
         }
         spanId={activeSpanId}
         traceId={traceId}
+        defaultMetadata={defaultMetadata}
       />
     </div>
   );

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/constants.ts
@@ -14,3 +14,4 @@ export const SOURCE_NAME_METADATA_KEY = 'mlflow.source.name';
 export const SOURCE_TYPE_METADATA_KEY = 'mlflow.source.type';
 export const TOKEN_USAGE_METADATA_KEY = 'mlflow.trace.tokenUsage';
 export const MLFLOW_TRACE_USER_KEY = 'mlflow.trace.user';
+export const ASSESSMENT_SESSION_METADATA_KEY = 'mlflow.trace.session';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/UpdateTraceContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/UpdateTraceContext.tsx
@@ -6,10 +6,12 @@ const ModelTraceExplorerUpdateTraceContext = React.createContext<{
   sqlWarehouseId?: string;
   modelTraceInfo?: ModelTrace['info'];
   invalidateTraceQuery?: (traceId?: string) => void;
+  chatSessionId?: string;
 }>({
   sqlWarehouseId: undefined,
   modelTraceInfo: undefined,
   invalidateTraceQuery: undefined,
+  chatSessionId: undefined,
 });
 
 /**
@@ -23,17 +25,18 @@ export const ModelTraceExplorerUpdateTraceContextProvider = ({
   modelTraceInfo,
   children,
   invalidateTraceQuery,
+  chatSessionId,
 }: {
   sqlWarehouseId?: string;
   modelTraceInfo?: ModelTrace['info'];
   children: React.ReactNode;
   invalidateTraceQuery?: (traceId?: string) => void;
+  chatSessionId?: string;
 }) => {
   const contextValue = useMemo(
-    () => ({ sqlWarehouseId, modelTraceInfo, invalidateTraceQuery }),
-    [sqlWarehouseId, modelTraceInfo, invalidateTraceQuery],
+    () => ({ sqlWarehouseId, modelTraceInfo, invalidateTraceQuery, chatSessionId }),
+    [sqlWarehouseId, modelTraceInfo, invalidateTraceQuery, chatSessionId],
   );
-
   return (
     <ModelTraceExplorerUpdateTraceContext.Provider value={contextValue}>
       {children}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/UpdateTraceContext.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/contexts/UpdateTraceContext.tsx
@@ -33,6 +33,7 @@ export const ModelTraceExplorerUpdateTraceContextProvider = ({
     () => ({ sqlWarehouseId, modelTraceInfo, invalidateTraceQuery }),
     [sqlWarehouseId, modelTraceInfo, invalidateTraceQuery],
   );
+
   return (
     <ModelTraceExplorerUpdateTraceContext.Provider value={contextValue}>
       {children}

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -40,7 +40,10 @@ export { getAssessmentValue } from './assessments-pane/utils';
 export { TracesServiceV4 } from './api';
 export { shouldUseTracesV4API } from './FeatureUtils';
 export { useUnifiedTraceTagsModal } from './hooks/useUnifiedTraceTagsModal';
-export { ModelTraceExplorerUpdateTraceContextProvider, useModelTraceExplorerUpdateTraceContext } from './contexts/UpdateTraceContext';
+export {
+  ModelTraceExplorerUpdateTraceContextProvider,
+  useModelTraceExplorerUpdateTraceContext,
+} from './contexts/UpdateTraceContext';
 export { SingleChatTurnMessages } from './session-view/SingleChatTurnMessages';
 export { ModelTraceExplorerChatMessage } from './right-pane/ModelTraceExplorerChatMessage';
 export { SingleChatTurnAssessments } from './session-view/SingleChatTurnAssessments';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -40,7 +40,7 @@ export { getAssessmentValue } from './assessments-pane/utils';
 export { TracesServiceV4 } from './api';
 export { shouldUseTracesV4API } from './FeatureUtils';
 export { useUnifiedTraceTagsModal } from './hooks/useUnifiedTraceTagsModal';
-export { ModelTraceExplorerUpdateTraceContextProvider } from './contexts/UpdateTraceContext';
+export { ModelTraceExplorerUpdateTraceContextProvider, useModelTraceExplorerUpdateTraceContext } from './contexts/UpdateTraceContext';
 export { SingleChatTurnMessages } from './session-view/SingleChatTurnMessages';
 export { ModelTraceExplorerChatMessage } from './right-pane/ModelTraceExplorerChatMessage';
 export { SingleChatTurnAssessments } from './session-view/SingleChatTurnAssessments';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -18,6 +18,7 @@ export {
   tryDeserializeAttribute,
   parseTraceUri,
   getTotalTokens,
+  getTraceTokenUsage,
   isSessionLevelAssessment,
   displayErrorNotification,
   displaySuccessNotification,
@@ -28,6 +29,7 @@ export {
   SOURCE_TYPE_METADATA_KEY,
   TOKEN_USAGE_METADATA_KEY,
   MLFLOW_TRACE_USER_KEY,
+  ASSESSMENT_SESSION_METADATA_KEY,
 } from './constants';
 export { shouldEnableTracesTabLabelingSchemas, shouldEnableAssessmentsInSessions } from './FeatureUtils';
 export { AssessmentSchemaContextProvider, type AssessmentSchema } from './contexts/AssessmentSchemaContext';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/index.ts
@@ -1,6 +1,7 @@
 export { ModelTraceExplorer } from './ModelTraceExplorer';
 export { SimplifiedModelTraceExplorer } from './SimplifiedModelTraceExplorer';
 export { ExpectationValuePreview } from './assessments-pane/ExpectationValuePreview';
+export { AssessmentsPane } from './assessments-pane/AssessmentsPane';
 export { ModelTraceExplorerSkeleton } from './ModelTraceExplorerSkeleton';
 export { ModelTraceExplorerOSSNotebookRenderer } from './oss-notebook-renderer/ModelTraceExplorerOSSNotebookRenderer';
 export { default as ModelTraceExplorerResizablePane } from './ModelTraceExplorerResizablePane';
@@ -17,6 +18,7 @@ export {
   tryDeserializeAttribute,
   parseTraceUri,
   getTotalTokens,
+  isSessionLevelAssessment,
   displayErrorNotification,
   displaySuccessNotification,
 } from './ModelTraceExplorer.utils';

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
@@ -23,8 +23,7 @@ export const SingleChatTurnAssessments = ({
   const { theme } = useDesignSystemTheme();
   const info = isV3ModelTraceInfo(trace.info) ? trace.info : null;
 
-  const turnLevelAssessments =
-    info?.assessments?.filter((assessment) => !isSessionLevelAssessment(assessment)) ?? [];
+  const turnLevelAssessments = info?.assessments?.filter((assessment) => !isSessionLevelAssessment(assessment)) ?? [];
 
   if (!info?.assessments || isEmpty(turnLevelAssessments)) {
     return (

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/session-view/SingleChatTurnAssessments.tsx
@@ -4,7 +4,7 @@ import { Button, importantify, PlusIcon, useDesignSystemTheme } from '@databrick
 import { FormattedMessage } from '@databricks/i18n';
 
 import type { Assessment, ExpectationAssessment, ModelTrace } from '../ModelTrace.types';
-import { isV3ModelTraceInfo } from '../ModelTraceExplorer.utils';
+import { isV3ModelTraceInfo, isSessionLevelAssessment } from '../ModelTraceExplorer.utils';
 import { AssessmentDisplayValue } from '../assessments-pane/AssessmentDisplayValue';
 import { getAssessmentValue } from '../assessments-pane/utils';
 
@@ -23,7 +23,10 @@ export const SingleChatTurnAssessments = ({
   const { theme } = useDesignSystemTheme();
   const info = isV3ModelTraceInfo(trace.info) ? trace.info : null;
 
-  if (!info?.assessments || isEmpty(info?.assessments)) {
+  const turnLevelAssessments =
+    info?.assessments?.filter((assessment) => !isSessionLevelAssessment(assessment)) ?? [];
+
+  if (!info?.assessments || isEmpty(turnLevelAssessments)) {
     return (
       <div css={{ display: 'flex', justifyContent: 'flex-start' }}>
         <Button
@@ -44,7 +47,7 @@ export const SingleChatTurnAssessments = ({
 
   return (
     <div css={{ display: 'flex', gap: theme.spacing.sm, flexWrap: 'wrap' }}>
-      {info?.assessments.map((assessment, index) => {
+      {turnLevelAssessments.map((assessment, index) => {
         const title = getAssessmentTitle(assessment.assessment_name);
         const value = getAssessmentValue(assessment)?.toString() ?? '';
         return (


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19410?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19410/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19410/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19410/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Adds a sidebar in the sessions-view for session-level assessments (on first trace, has special metadata). This is for feature parity with managed MLflow, this functionality was not copybara'd over yet. Note that this PR **does not** hide session-level assessments from the trace view UI or the traces tab.

### How is this PR tested?

- [ ] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

Before:
<img width="1716" height="983" alt="Screenshot 2025-12-15 at 12 03 50 PM" src="https://github.com/user-attachments/assets/6ab117f6-c955-49bb-ac63-edddc67f3f72" />


After:
<img width="1718" height="908" alt="Screenshot 2025-12-15 at 12 04 11 PM" src="https://github.com/user-attachments/assets/1cbff8dd-3cc8-410c-92f1-08fdc1261a72" />

![oss_session_assessment_sidebar](https://github.com/user-attachments/assets/866e8572-d83e-4199-be9e-c82ca76c1548)



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
