### PR TITLE
Rename get_judge to be get_scorer for deepeval integration

### DIFF
--- a/mlflow/genai/scorers/deepeval/__init__.py
+++ b/mlflow/genai/scorers/deepeval/__init__.py
@@ -2,16 +2,16 @@
 DeepEval integration for MLflow.
 
 This module provides integration with DeepEval metrics, allowing them to be used
-with MLflow's judge interface.
+with MLflow's scorer interface.
 
 Example usage:
 
 .. code-block:: python
 
-    from mlflow.genai.scorers.deepeval import get_judge
+    from mlflow.genai.scorers.deepeval import get_scorer
 
-    judge = get_judge("AnswerRelevancy", threshold=0.7, model="openai:/gpt-4")
-    feedback = judge(inputs="What is MLflow?", outputs="MLflow is a platform...")
+    scorer = get_scorer("AnswerRelevancy", threshold=0.7, model="openai:/gpt-4")
+    feedback = scorer(inputs="What is MLflow?", outputs="MLflow is a platform...")
 """
 
 from __future__ import annotations
@@ -137,13 +137,13 @@ class DeepEvalScorer(Scorer):
 
 @experimental(version="3.8.0")
 @format_docstring(_MODEL_API_DOC)
-def get_judge(
+def get_scorer(
     metric_name: str,
     model: str = "databricks",
     **metric_kwargs,
 ) -> DeepEvalScorer:
     """
-    Get a DeepEval metric as an MLflow judge.
+    Get a DeepEval metric as an MLflow scorer.
 
     Args:
         metric_name: Name of the DeepEval metric (e.g., "AnswerRelevancy", "Faithfulness")
@@ -151,17 +151,17 @@ def get_judge(
         metric_kwargs: Additional metric-specific parameters (e.g., threshold, include_reason)
 
     Returns:
-        DeepEvalScorer instance that can be called with MLflow's judge interface
+        DeepEvalScorer instance that can be called with MLflow's scorer interface
 
     Examples:
 
     .. code-block:: python
 
-        judge = get_judge("AnswerRelevancy", threshold=0.7, model="openai:/gpt-4")
-        feedback = judge(inputs="What is MLflow?", outputs="MLflow is a platform...")
+        scorer = get_scorer("AnswerRelevancy", threshold=0.7, model="openai:/gpt-4")
+        feedback = scorer(inputs="What is MLflow?", outputs="MLflow is a platform...")
 
-        judge = get_judge("Faithfulness", model="openai:/gpt-4")
-        feedback = judge(trace=trace)
+        scorer = get_scorer("Faithfulness", model="openai:/gpt-4")
+        feedback = scorer(trace=trace)
     """
     return DeepEvalScorer(
         metric_name=metric_name,
@@ -207,7 +207,7 @@ from mlflow.genai.scorers.deepeval.scorers import (
 __all__ = [
     # Core classes
     "DeepEvalScorer",
-    "get_judge",
+    "get_scorer",
     # RAG metrics
     "AnswerRelevancy",
     "Faithfulness",

--- a/tests/genai/scorers/deepeval/test_deepeval_scorer.py
+++ b/tests/genai/scorers/deepeval/test_deepeval_scorer.py
@@ -3,12 +3,12 @@ from unittest.mock import Mock, patch
 from mlflow.entities.assessment import Feedback
 from mlflow.entities.assessment_source import AssessmentSourceType
 from mlflow.genai.judges.utils import CategoricalRating
-from mlflow.genai.scorers.deepeval import get_judge
+from mlflow.genai.scorers.deepeval import get_scorer
 
 
 def test_deepeval_scorer_with_exact_match_metric():
-    judge = get_judge("ExactMatch")
-    result = judge(
+    scorer = get_scorer("ExactMatch")
+    result = scorer(
         inputs="What is MLflow?",
         outputs="MLflow is a platform",
         expectations={"expected_output": "MLflow is a platform"},
@@ -23,8 +23,8 @@ def test_deepeval_scorer_with_exact_match_metric():
 
 
 def test_deepeval_scorer_handles_failure_with_exact_match():
-    judge = get_judge("ExactMatch")
-    result = judge(
+    scorer = get_scorer("ExactMatch")
+    result = scorer(
         inputs="What is MLflow?",
         outputs="MLflow is different",
         expectations={"expected_output": "MLflow is a platform"},
@@ -48,7 +48,7 @@ def test_metric_kwargs_passed_to_deepeval_metric():
         with patch("mlflow.genai.scorers.deepeval.create_deepeval_model") as mock_create_model:
             mock_create_model.return_value = Mock()
 
-            get_judge("AnswerRelevancy", threshold=0.9, include_reason=True, custom_param="value")
+            get_scorer("AnswerRelevancy", threshold=0.9, include_reason=True, custom_param="value")
 
             call_kwargs = mock_metric_class.call_args[1]
             assert call_kwargs["threshold"] == 0.9
@@ -69,8 +69,8 @@ def test_deepeval_scorer_returns_error_feedback_on_exception():
         with patch("mlflow.genai.scorers.deepeval.create_deepeval_model") as mock_create_model:
             mock_create_model.return_value = Mock()
 
-            judge = get_judge("AnswerRelevancy")
-            result = judge(inputs="What is MLflow?", outputs="Test output")
+            scorer = get_scorer("AnswerRelevancy")
+            result = scorer(inputs="What is MLflow?", outputs="Test output")
 
             assert isinstance(result, Feedback)
             assert result.name == "AnswerRelevancy"


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/smoorjani/mlflow/pull/19411?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19411/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19411/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19411/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
As titled - this removes the conflation of a deepeval judge as a scorer - we are actually returning scorer objects and thus rename this to `get_scorer`. This functionality is undocumented (to be documented before 3.8.0) and experimental.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
