### PR TITLE
Add passthrough support for Anthropic Messages API

### DIFF
--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -9,7 +9,12 @@ from mlflow.gateway.constants import (
     MLFLOW_AI_GATEWAY_ANTHROPIC_MAXIMUM_MAX_TOKENS,
 )
 from mlflow.gateway.exceptions import AIGatewayException
-from mlflow.gateway.providers.base import BaseProvider, ProviderAdapter
+from mlflow.gateway.providers.base import (
+    PASSTHROUGH_ROUTES,
+    BaseProvider,
+    PassthroughAction,
+    ProviderAdapter,
+)
 from mlflow.gateway.providers.utils import rename_payload_keys, send_request, send_stream_request
 from mlflow.gateway.schemas import chat, completions
 from mlflow.types.chat import Function, ToolCallDelta
@@ -321,6 +326,10 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
     NAME = "Anthropic"
     CONFIG_TYPE = AnthropicConfig
 
+    PASSTHROUGH_PROVIDER_PATHS = {
+        PassthroughAction.ANTHROPIC_MESSAGES: "messages",
+    }
+
     def __init__(self, config: EndpointConfig) -> None:
         super().__init__(config)
         if config.model.config is None or not isinstance(config.model.config, AnthropicConfig):
@@ -448,14 +457,24 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
 
         return AnthropicAdapter.model_to_completions(resp, self.config)
 
-    async def passthrough_anthropic_messages(
-        self, payload: dict[str, Any]
+    async def passthrough(
+        self, action: PassthroughAction, payload: dict[str, Any]
     ) -> dict[str, Any] | AsyncIterable[bytes]:
-        """
-        Passthrough endpoint for Anthropic Messages API.
-        Accepts raw Anthropic request format and returns raw Anthropic response format.
-        Supports streaming if the 'stream' parameter is set to True.
-        """
+        provider_path = self.PASSTHROUGH_PROVIDER_PATHS.get(action)
+        if provider_path is None:
+            route = PASSTHROUGH_ROUTES.get(action, action.value)
+            supported_routes = ", ".join(
+                f"/gateway{route} (provider_path: {path})"
+                for act in self.PASSTHROUGH_PROVIDER_PATHS.keys()
+                if (route := PASSTHROUGH_ROUTES.get(act))
+                and (path := self.PASSTHROUGH_PROVIDER_PATHS.get(act))
+            )
+            raise AIGatewayException(
+                status_code=400,
+                detail=f"Unsupported passthrough endpoint '{route}' for {self.NAME} provider. "
+                f"Supported endpoints: {supported_routes}",
+            )
+
         # Add model name from config
         payload["model"] = self.config.model.name
 
@@ -463,13 +482,13 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
             return send_stream_request(
                 headers=self.headers,
                 base_url=self.base_url,
-                path="messages",
+                path=provider_path,
                 payload=payload,
             )
         else:
             return await send_request(
                 headers=self.headers,
                 base_url=self.base_url,
-                path="messages",
+                path=provider_path,
                 payload=payload,
             )

--- a/mlflow/gateway/providers/anthropic.py
+++ b/mlflow/gateway/providers/anthropic.py
@@ -462,7 +462,7 @@ class AnthropicProvider(BaseProvider, AnthropicAdapter):
     ) -> dict[str, Any] | AsyncIterable[bytes]:
         provider_path = self.PASSTHROUGH_PROVIDER_PATHS.get(action)
         if provider_path is None:
-            route = PASSTHROUGH_ROUTES.get(action, action.value)
+            route = PASSTHROUGH_ROUTES.get(action)
             supported_routes = ", ".join(
                 f"/gateway{route} (provider_path: {path})"
                 for act in self.PASSTHROUGH_PROVIDER_PATHS.keys()

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -20,6 +20,7 @@ class PassthroughAction(str, Enum):
     OPENAI_CHAT = "openai_chat"
     OPENAI_EMBEDDINGS = "openai_embeddings"
     OPENAI_RESPONSES = "openai_responses"
+    ANTHROPIC_MESSAGES = "anthropic_messages"
 
 
 # Mapping of passthrough actions to their gateway API routes
@@ -27,6 +28,7 @@ PASSTHROUGH_ROUTES = {
     PassthroughAction.OPENAI_CHAT: "/openai/v1/chat/completions",
     PassthroughAction.OPENAI_EMBEDDINGS: "/openai/v1/embeddings",
     PassthroughAction.OPENAI_RESPONSES: "/openai/v1/responses",
+    PassthroughAction.ANTHROPIC_MESSAGES: "/anthropic/v1/messages",
 }
 
 
@@ -109,20 +111,6 @@ class BaseProvider(ABC):
         raise AIGatewayException(
             status_code=501,
             detail=f"The passthrough route '{route}' is not implemented for {self.NAME} models.",
-        )
-
-    async def passthrough_anthropic_messages(
-        self, payload: dict[str, Any]
-    ) -> dict[str, Any] | AsyncIterable[bytes]:
-        """
-        Passthrough endpoint for Anthropic Messages API.
-        Accepts raw Anthropic request format and returns raw Anthropic response format.
-        Supports streaming if the 'stream' parameter is set to True.
-        """
-        raise AIGatewayException(
-            status_code=501,
-            detail=f"The passthrough Anthropic messages route is not implemented for {self.NAME}"
-            "models.",
         )
 
     @staticmethod

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -41,6 +41,7 @@ class BaseProvider(ABC):
     NAME: str = ""
     SUPPORTED_ROUTE_TYPES: tuple[str, ...]
     CONFIG_TYPE: type[ConfigModel]
+    PASSTHROUGH_PROVIDER_PATHS: dict[PassthroughAction, str] = {}
 
     def __init__(self, config: EndpointConfig):
         if self.NAME == "":
@@ -90,6 +91,33 @@ class BaseProvider(ABC):
             status_code=501,
             detail=f"The embeddings route is not implemented for {self.NAME} models.",
         )
+
+    def _validate_passthrough_action(self, action: PassthroughAction) -> str:
+        """
+        Validates that the passthrough action is supported by this provider
+        and returns the provider path.
+
+        Args:
+            action: The passthrough action to validate
+
+        Returns:
+            The provider path for the action
+        """
+        provider_path = self.PASSTHROUGH_PROVIDER_PATHS.get(action)
+        if provider_path is None:
+            route = PASSTHROUGH_ROUTES.get(action, action.value)
+            supported_routes = ", ".join(
+                f"/gateway{route} (provider_path: {path})"
+                for act in self.PASSTHROUGH_PROVIDER_PATHS.keys()
+                if (route := PASSTHROUGH_ROUTES.get(act))
+                and (path := self.PASSTHROUGH_PROVIDER_PATHS.get(act))
+            )
+            raise AIGatewayException(
+                status_code=400,
+                detail=f"Unsupported passthrough endpoint '{route}' for {self.NAME} provider. "
+                f"Supported endpoints: {supported_routes}",
+            )
+        return provider_path
 
     async def passthrough(
         self, action: PassthroughAction, payload: dict[str, Any]

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -111,6 +111,20 @@ class BaseProvider(ABC):
             detail=f"The passthrough route '{route}' is not implemented for {self.NAME} models.",
         )
 
+    async def passthrough_anthropic_messages(
+        self, payload: dict[str, Any]
+    ) -> dict[str, Any] | AsyncIterable[bytes]:
+        """
+        Passthrough endpoint for Anthropic Messages API.
+        Accepts raw Anthropic request format and returns raw Anthropic response format.
+        Supports streaming if the 'stream' parameter is set to True.
+        """
+        raise AIGatewayException(
+            status_code=501,
+            detail=f"The passthrough Anthropic messages route is not implemented for {self.NAME}"
+            "models.",
+        )
+
     @staticmethod
     def check_for_model_field(payload):
         if "model" in payload:

--- a/mlflow/gateway/providers/openai.py
+++ b/mlflow/gateway/providers/openai.py
@@ -9,7 +9,6 @@ from mlflow.exceptions import MlflowException
 from mlflow.gateway.config import EndpointConfig, OpenAIAPIType, OpenAIConfig
 from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.base import (
-    PASSTHROUGH_ROUTES,
     BaseProvider,
     PassthroughAction,
     ProviderAdapter,
@@ -630,20 +629,7 @@ class OpenAIProvider(BaseProvider):
             payload, self.config
         )
 
-        provider_path = self.PASSTHROUGH_PROVIDER_PATHS.get(action)
-        if provider_path is None:
-            route = PASSTHROUGH_ROUTES.get(action)
-            supported_routes = ", ".join(
-                f"/gateway{route} (provider_path: {path})"
-                for act in self.PASSTHROUGH_PROVIDER_PATHS.keys()
-                if (route := PASSTHROUGH_ROUTES.get(act))
-                and (path := self.PASSTHROUGH_PROVIDER_PATHS.get(act))
-            )
-            raise AIGatewayException(
-                status_code=400,
-                detail=f"Unsupported passthrough endpoint '{route}' for {self.NAME} provider. "
-                f"Supported endpoints: {supported_routes}",
-            )
+        provider_path = self._validate_passthrough_action(action)
 
         supports_streaming = action != PassthroughAction.OPENAI_EMBEDDINGS
 

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -400,3 +400,42 @@ async def openai_passthrough_responses(request: Request):
     if body.get("stream"):
         return StreamingResponse(response, media_type="text/event-stream")
     return response
+
+
+@gateway_router.post("/anthropic/v1/messages")
+@translate_http_exception
+async def anthropic_passthrough_messages(request: Request):
+    """
+    Anthropic passthrough endpoint for the Messages API.
+
+    This endpoint accepts raw Anthropic API format and passes it through to the
+    Anthropic provider with the configured API key and model. The 'model' parameter
+    in the request specifies which MLflow endpoint to use.
+
+    Supports streaming responses when the 'stream' parameter is set to true.
+
+    Example:
+        POST /gateway/anthropic/v1/messages
+        {
+            "model": "my-anthropic-endpoint",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1024,
+            "stream": true
+        }
+    """
+    try:
+        body = await request.json()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON payload: {e!s}")
+
+    endpoint_name = _extract_endpoint_name_from_model(body)
+    body.pop("model")
+    store = _get_store()
+    _validate_store(store)
+
+    provider = _create_provider_from_endpoint_name(store, endpoint_name, EndpointType.LLM_V1_CHAT)
+    response = await provider.passthrough_anthropic_messages(body)
+
+    if body.get("stream"):
+        return StreamingResponse(response, media_type="text/event-stream")
+    return response

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -402,7 +402,7 @@ async def openai_passthrough_responses(request: Request):
     return response
 
 
-@gateway_router.post("/anthropic/v1/messages")
+@gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.ANTHROPIC_MESSAGES])
 @translate_http_exception
 async def anthropic_passthrough_messages(request: Request):
     """
@@ -434,7 +434,7 @@ async def anthropic_passthrough_messages(request: Request):
     _validate_store(store)
 
     provider = _create_provider_from_endpoint_name(store, endpoint_name, EndpointType.LLM_V1_CHAT)
-    response = await provider.passthrough_anthropic_messages(body)
+    response = await provider.passthrough(PassthroughAction.ANTHROPIC_MESSAGES, body)
 
     if body.get("stream"):
         return StreamingResponse(response, media_type="text/event-stream")

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -13,6 +13,7 @@ from mlflow.gateway.constants import (
 )
 from mlflow.gateway.exceptions import AIGatewayException
 from mlflow.gateway.providers.anthropic import AnthropicProvider
+from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.schemas import chat, completions, embeddings
 
 from tests.gateway.tools import MockAsyncResponse, MockAsyncStreamingResponse
@@ -772,7 +773,7 @@ async def test_passthrough_anthropic_messages():
             "max_tokens": 1024,
             "temperature": 0.7,
         }
-        response = await provider.passthrough_anthropic_messages(payload)
+        response = await provider.passthrough(PassthroughAction.ANTHROPIC_MESSAGES, payload)
 
         assert payload["model"] == "claude-2.1"
 
@@ -803,7 +804,7 @@ async def test_passthrough_anthropic_messages_streaming():
             "max_tokens": 1024,
             "stream": True,
         }
-        response = await provider.passthrough_anthropic_messages(payload)
+        response = await provider.passthrough(PassthroughAction.ANTHROPIC_MESSAGES, payload)
 
         assert payload["model"] == "claude-2.1"
 

--- a/tests/gateway/providers/test_anthropic.py
+++ b/tests/gateway/providers/test_anthropic.py
@@ -732,3 +732,100 @@ async def test_completions_throws_if_prompt_contains_non_string(prompt):
     payload = {"prompt": prompt}
     with pytest.raises(ValidationError, match=r"prompt"):
         await provider.completions(completions.RequestPayload(**payload))
+
+
+def passthrough_messages_response():
+    return {
+        "id": "msg_01XFDUDYJgAACzvnptvVoYEL",
+        "type": "message",
+        "role": "assistant",
+        "content": [{"type": "text", "text": "Hello! How can I assist you today?"}],
+        "model": "claude-3-5-sonnet-20241022",
+        "stop_reason": "end_turn",
+        "stop_sequence": None,
+        "usage": {"input_tokens": 10, "output_tokens": 20},
+    }
+
+
+def passthrough_messages_stream_response():
+    return [
+        b'event: message_start\ndata: {"type":"message_start","message":{"id":"msg_01XFDUDYJgAACzvnptvVoYEL","type":"message","role":"assistant","content":[],"model":"claude-3-5-sonnet-20241022","stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":10,"output_tokens":0}}}\n\n',  # noqa: E501
+        b'event: content_block_start\ndata: {"type":"content_block_start","index":0,"content_block":{"type":"text","text":""}}\n\n',  # noqa: E501
+        b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}\n\n',  # noqa: E501
+        b'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"!"}}\n\n',  # noqa: E501
+        b'event: content_block_stop\ndata: {"type":"content_block_stop","index":0}\n\n',
+        b'event: message_delta\ndata: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":20}}\n\n',  # noqa: E501
+        b'event: message_stop\ndata: {"type":"message_stop"}\n\n',
+    ]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_anthropic_messages():
+    resp = passthrough_messages_response()
+    config = chat_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = AnthropicProvider(EndpointConfig(**config))
+        payload = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1024,
+            "temperature": 0.7,
+        }
+        response = await provider.passthrough_anthropic_messages(payload)
+
+        assert payload["model"] == "claude-2.1"
+
+        assert response == resp
+
+        mock_post.assert_called_once_with(
+            "https://api.anthropic.com/v1/messages",
+            json={
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 1024,
+                "temperature": 0.7,
+                "model": "claude-2.1",
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )
+
+
+@pytest.mark.asyncio
+async def test_passthrough_anthropic_messages_streaming():
+    resp = passthrough_messages_stream_response()
+    config = chat_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncStreamingResponse(resp)
+    ) as mock_post:
+        provider = AnthropicProvider(EndpointConfig(**config))
+        payload = {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "max_tokens": 1024,
+            "stream": True,
+        }
+        response = await provider.passthrough_anthropic_messages(payload)
+
+        assert payload["model"] == "claude-2.1"
+
+        chunks = [chunk async for chunk in response]
+        assert len(chunks) == 7
+        assert b"message_start" in chunks[0]
+        assert b"content_block_start" in chunks[1]
+        assert b"content_block_delta" in chunks[2]
+        assert b"Hello" in chunks[2]
+        assert b"content_block_delta" in chunks[3]
+        assert b"!" in chunks[3]
+        assert b"content_block_stop" in chunks[4]
+        assert b"message_delta" in chunks[5]
+        assert b"message_stop" in chunks[6]
+
+        mock_post.assert_called_once_with(
+            "https://api.anthropic.com/v1/messages",
+            json={
+                "messages": [{"role": "user", "content": "Hello"}],
+                "max_tokens": 1024,
+                "stream": True,
+                "model": "claude-2.1",
+            },
+            timeout=ClientTimeout(total=MLFLOW_GATEWAY_ROUTE_TIMEOUT_SECONDS),
+        )


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19423/files) to review incremental changes.
- [**stack/gateway/model-passthrough/anthropic**](https://github.com/mlflow/mlflow/pull/19423) [[Files changed](https://github.com/mlflow/mlflow/pull/19423/files)]
  - [stack/gateway/model-passthrough/gemini](https://github.com/mlflow/mlflow/pull/19425) [[Files changed](https://github.com/mlflow/mlflow/pull/19425/files/6676b58132ed05704b044c80b538c311505eaa4b..b23b045a11580b49cc14bb6093ba401b3cf51481)]
    - [stack/gateway/structured-output](https://github.com/mlflow/mlflow/pull/19452) [[Files changed](https://github.com/mlflow/mlflow/pull/19452/files/b23b045a11580b49cc14bb6093ba401b3cf51481..7f42c01602339ec4971deae56f8d46dc7f8fd6f2)]
      - [stack/gateway/missing-params](https://github.com/mlflow/mlflow/pull/19453) [[Files changed](https://github.com/mlflow/mlflow/pull/19453/files/7f42c01602339ec4971deae56f8d46dc7f8fd6f2..efc362b79872d91432efb37cfb90846ae8251976)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add an Anthropic model passthrough endpoint to support Anthropic client natively where request body is just propagated to the provider endpoint:

- /gateway/anthropic/v1/messages

```python
import mlflow

mlflow.set_tracking_uri("http://localhost:5000")
mlflow.set_experiment("Gateway")
from mlflow.tracking._tracking_service.utils import _get_store
from anthropic import Anthropic

store = _get_store()

secret = store.create_gateway_secret(
    secret_name="anthropic_api",
    secret_value={"api_key": "<secret>"},
    provider="anthropic",
)
model_def = store.create_gateway_model_definition(
    name="claude-haiku-4-5",
    secret_id=secret.secret_id,
    provider="anthropic",
    model_name="claude-haiku-4-5",
)
endpoint = store.create_gateway_endpoint(
    name="anthropic-v1", model_definition_ids=[model_def.model_definition_id]
)

client = Anthropic(
    api_key="dummy",
    base_url="http://localhost:5000/gateway/anthropic",
)
message = client.messages.create(
    max_tokens=1024,
    messages=[{
        "content": "Hello, world",
        "role": "user",
    }],
    model="anthropic-v1",
)
print(message.content[0])
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
