### PR TITLE
Add passthrough support for Gemini generateContent and streamGenerateContent APIs

### DIFF
--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -141,6 +141,30 @@ class BaseProvider(ABC):
             detail=f"The passthrough route '{route}' is not implemented for {self.NAME} models.",
         )
 
+    async def passthrough_gemini_generate_content(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """
+        Passthrough endpoint for Gemini generateContent API.
+        Accepts raw Gemini request format and returns raw Gemini response format.
+        """
+        raise AIGatewayException(
+            status_code=501,
+            detail="The passthrough Gemini generateContent route is not implemented for "
+            f"{self.NAME} models.",
+        )
+
+    async def passthrough_gemini_stream_generate_content(
+        self, payload: dict[str, Any]
+    ) -> AsyncIterable[bytes]:
+        """
+        Passthrough endpoint for Gemini streamGenerateContent API.
+        Accepts raw Gemini request format and returns raw Gemini streaming response format.
+        """
+        raise AIGatewayException(
+            status_code=501,
+            detail=f"The passthrough Gemini streamGenerateContent route is not implemented for "
+            f"{self.NAME} models.",
+        )
+
     @staticmethod
     def check_for_model_field(payload):
         if "model" in payload:

--- a/mlflow/gateway/providers/base.py
+++ b/mlflow/gateway/providers/base.py
@@ -21,6 +21,8 @@ class PassthroughAction(str, Enum):
     OPENAI_EMBEDDINGS = "openai_embeddings"
     OPENAI_RESPONSES = "openai_responses"
     ANTHROPIC_MESSAGES = "anthropic_messages"
+    GEMINI_GENERATE_CONTENT = "gemini_generate_content"
+    GEMINI_STREAM_GENERATE_CONTENT = "gemini_stream_generate_content"
 
 
 # Mapping of passthrough actions to their gateway API routes
@@ -29,6 +31,8 @@ PASSTHROUGH_ROUTES = {
     PassthroughAction.OPENAI_EMBEDDINGS: "/openai/v1/embeddings",
     PassthroughAction.OPENAI_RESPONSES: "/openai/v1/responses",
     PassthroughAction.ANTHROPIC_MESSAGES: "/anthropic/v1/messages",
+    PassthroughAction.GEMINI_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:generateContent",  # noqa: E501
+    PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT: "/gemini/v1beta/models/{endpoint_name}:streamGenerateContent",  # noqa: E501
 }
 
 
@@ -139,30 +143,6 @@ class BaseProvider(ABC):
         raise AIGatewayException(
             status_code=501,
             detail=f"The passthrough route '{route}' is not implemented for {self.NAME} models.",
-        )
-
-    async def passthrough_gemini_generate_content(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """
-        Passthrough endpoint for Gemini generateContent API.
-        Accepts raw Gemini request format and returns raw Gemini response format.
-        """
-        raise AIGatewayException(
-            status_code=501,
-            detail="The passthrough Gemini generateContent route is not implemented for "
-            f"{self.NAME} models.",
-        )
-
-    async def passthrough_gemini_stream_generate_content(
-        self, payload: dict[str, Any]
-    ) -> AsyncIterable[bytes]:
-        """
-        Passthrough endpoint for Gemini streamGenerateContent API.
-        Accepts raw Gemini request format and returns raw Gemini streaming response format.
-        """
-        raise AIGatewayException(
-            status_code=501,
-            detail=f"The passthrough Gemini streamGenerateContent route is not implemented for "
-            f"{self.NAME} models.",
         )
 
     @staticmethod

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -741,7 +741,7 @@ class GeminiProvider(BaseProvider):
     ) -> dict[str, Any] | AsyncIterable[bytes]:
         provider_path_template = self.PASSTHROUGH_PROVIDER_PATHS.get(action)
         if provider_path_template is None:
-            route = PASSTHROUGH_ROUTES.get(action, action.value)
+            route = PASSTHROUGH_ROUTES.get(action)
             supported_routes = ", ".join(
                 f"/gateway{route} (provider_path: {path})"
                 for act in self.PASSTHROUGH_PROVIDER_PATHS.keys()

--- a/mlflow/gateway/providers/gemini.py
+++ b/mlflow/gateway/providers/gemini.py
@@ -725,3 +725,29 @@ class GeminiProvider(BaseProvider):
                 break
             resp = json.loads(data)
             yield self.adapter_class.model_to_chat_streaming(resp, self.config)
+
+    async def passthrough_gemini_generate_content(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """
+        Passthrough endpoint for Gemini generateContent API.
+        Accepts raw Gemini request format and returns raw Gemini response format.
+        """
+        return await send_request(
+            headers=self.headers,
+            base_url=self.base_url,
+            path=f"{self.config.model.name}:generateContent",
+            payload=payload,
+        )
+
+    async def passthrough_gemini_stream_generate_content(
+        self, payload: dict[str, Any]
+    ) -> AsyncIterable[bytes]:
+        """
+        Passthrough endpoint for Gemini streamGenerateContent API.
+        Accepts raw Gemini request format and returns raw Gemini streaming response format.
+        """
+        return send_stream_request(
+            headers=self.headers,
+            base_url=self.base_url,
+            path=f"{self.config.model.name}:streamGenerateContent?alt=sse",
+            payload=payload,
+        )

--- a/mlflow/server/gateway_api.py
+++ b/mlflow/server/gateway_api.py
@@ -441,7 +441,7 @@ async def anthropic_passthrough_messages(request: Request):
     return response
 
 
-@gateway_router.post("/gemini/v1beta/models/{endpoint_name}:generateContent")
+@gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.GEMINI_GENERATE_CONTENT])
 @translate_http_exception
 async def gemini_passthrough_generate_content(endpoint_name: str, request: Request):
     """
@@ -471,10 +471,10 @@ async def gemini_passthrough_generate_content(endpoint_name: str, request: Reque
     _validate_store(store)
 
     provider = _create_provider_from_endpoint_name(store, endpoint_name, EndpointType.LLM_V1_CHAT)
-    return await provider.passthrough_gemini_generate_content(body)
+    return await provider.passthrough(PassthroughAction.GEMINI_GENERATE_CONTENT, body)
 
 
-@gateway_router.post("/gemini/v1beta/models/{endpoint_name}:streamGenerateContent")
+@gateway_router.post(PASSTHROUGH_ROUTES[PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT])
 @translate_http_exception
 async def gemini_passthrough_stream_generate_content(endpoint_name: str, request: Request):
     """
@@ -504,5 +504,5 @@ async def gemini_passthrough_stream_generate_content(endpoint_name: str, request
     _validate_store(store)
 
     provider = _create_provider_from_endpoint_name(store, endpoint_name, EndpointType.LLM_V1_CHAT)
-    response = await provider.passthrough_gemini_stream_generate_content(body)
+    response = await provider.passthrough(PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT, body)
     return StreamingResponse(response, media_type="text/event-stream")

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -1019,3 +1019,88 @@ async def test_gemini_completions_stream(resp):
         json=mock.ANY,
         timeout=mock.ANY,
     )
+
+
+def passthrough_generate_content_response():
+    return {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "Hello! How can I assist you today?"}],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 10,
+            "totalTokenCount": 15,
+        },
+    }
+
+
+def passthrough_stream_generate_content_response():
+    return [
+        b'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}\n\n',
+        b'data: {"candidates":[{"content":{"parts":[{"text":"!"}],"role":"model"}}]}\n\n',
+        b'data: {"candidates":[{"content":{"parts":[{"text":" How can I help you?"}],"role":"model"},"finishReason":"STOP"}]}\n\n',  # noqa: E501
+    ]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_gemini_generate_content():
+    resp = passthrough_generate_content_response()
+    config = chat_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncResponse(resp)
+    ) as mock_post:
+        provider = GeminiProvider(EndpointConfig(**config))
+        payload = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": "Hello"}],
+                }
+            ]
+        }
+        response = await provider.passthrough_gemini_generate_content(payload)
+
+        assert response == resp
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert "gemini-2.0-flash:generateContent" in call_args[0][0]
+        assert call_args[1]["json"]["contents"] == [{"role": "user", "parts": [{"text": "Hello"}]}]
+
+
+@pytest.mark.asyncio
+async def test_passthrough_gemini_stream_generate_content():
+    resp = passthrough_stream_generate_content_response()
+    config = chat_config()
+    with mock.patch(
+        "aiohttp.ClientSession.post", return_value=MockAsyncStreamingResponse(resp)
+    ) as mock_post:
+        provider = GeminiProvider(EndpointConfig(**config))
+        payload = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": "Hello"}],
+                }
+            ]
+        }
+        response = await provider.passthrough_gemini_stream_generate_content(payload)
+
+        chunks = [chunk async for chunk in response]
+
+        assert len(chunks) == 3
+        assert b"Hello" in chunks[0]
+        assert b"!" in chunks[1]
+        assert b"How can I help you?" in chunks[2]
+        assert b"STOP" in chunks[2]
+
+        mock_post.assert_called_once()
+        call_args = mock_post.call_args
+        assert "gemini-2.0-flash:streamGenerateContent?alt=sse" in call_args[0][0]
+        assert call_args[1]["json"]["contents"] == [{"role": "user", "parts": [{"text": "Hello"}]}]

--- a/tests/gateway/providers/test_gemini.py
+++ b/tests/gateway/providers/test_gemini.py
@@ -5,6 +5,7 @@ from fastapi.encoders import jsonable_encoder
 
 from mlflow.gateway.config import EndpointConfig
 from mlflow.gateway.exceptions import AIGatewayException
+from mlflow.gateway.providers.base import PassthroughAction
 from mlflow.gateway.providers.gemini import GeminiProvider
 from mlflow.gateway.schemas import chat, completions, embeddings
 
@@ -1064,7 +1065,7 @@ async def test_passthrough_gemini_generate_content():
                 }
             ]
         }
-        response = await provider.passthrough_gemini_generate_content(payload)
+        response = await provider.passthrough(PassthroughAction.GEMINI_GENERATE_CONTENT, payload)
 
         assert response == resp
 
@@ -1090,7 +1091,9 @@ async def test_passthrough_gemini_stream_generate_content():
                 }
             ]
         }
-        response = await provider.passthrough_gemini_stream_generate_content(payload)
+        response = await provider.passthrough(
+            PassthroughAction.GEMINI_STREAM_GENERATE_CONTENT, payload
+        )
 
         chunks = [chunk async for chunk in response]
 

--- a/tests/server/test_gateway_api.py
+++ b/tests/server/test_gateway_api.py
@@ -31,6 +31,8 @@ from mlflow.server.gateway_api import (
     anthropic_passthrough_messages,
     chat_completions,
     gateway_router,
+    gemini_passthrough_generate_content,
+    gemini_passthrough_stream_generate_content,
     invocations,
     openai_passthrough_chat,
     openai_passthrough_embeddings,
@@ -1287,3 +1289,137 @@ async def test_anthropic_passthrough_messages_streaming(store: SqlAlchemyStore):
         assert b"content_block_stop" in chunks[4]
         assert b"message_delta" in chunks[5]
         assert b"message_stop" in chunks[6]
+
+
+# =============================================================================
+# Gemini generateContent/streamGenerateContent passthrough endpoint tests
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_gemini_passthrough_generate_content(store: SqlAlchemyStore):
+    secret = store.create_gateway_secret(
+        secret_name="gemini-passthrough-key",
+        secret_value={"api_key": "test-key"},
+        provider="gemini",
+    )
+    model_def = store.create_gateway_model_definition(
+        name="gemini-passthrough-model",
+        secret_id=secret.secret_id,
+        provider="gemini",
+        model_name="gemini-2.0-flash",
+    )
+    store.create_gateway_endpoint(
+        name="gemini-passthrough-endpoint",
+        model_definition_ids=[model_def.model_definition_id],
+    )
+
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(
+        return_value={
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": "Hello"}],
+                }
+            ]
+        }
+    )
+
+    mock_response = {
+        "candidates": [
+            {
+                "content": {
+                    "parts": [{"text": "Hello! How can I assist you today?"}],
+                    "role": "model",
+                },
+                "finishReason": "STOP",
+            }
+        ],
+        "usageMetadata": {
+            "promptTokenCount": 5,
+            "candidatesTokenCount": 10,
+            "totalTokenCount": 15,
+        },
+    }
+
+    with mock.patch(
+        "mlflow.gateway.providers.gemini.send_request", return_value=mock_response
+    ) as mock_send:
+        response = await gemini_passthrough_generate_content(
+            "gemini-passthrough-endpoint", mock_request
+        )
+
+        assert mock_send.called
+        call_args = mock_send.call_args
+        assert call_args[1]["path"] == "gemini-2.0-flash:generateContent"
+        assert call_args[1]["payload"]["contents"] == [
+            {"role": "user", "parts": [{"text": "Hello"}]}
+        ]
+
+        assert (
+            response["candidates"][0]["content"]["parts"][0]["text"]
+            == "Hello! How can I assist you today?"
+        )
+        assert response["usageMetadata"]["totalTokenCount"] == 15
+
+
+@pytest.mark.asyncio
+async def test_gemini_passthrough_stream_generate_content(store: SqlAlchemyStore):
+    secret = store.create_gateway_secret(
+        secret_name="gemini-stream-passthrough-key",
+        secret_value={"api_key": "test-stream-key"},
+        provider="gemini",
+    )
+    model_def = store.create_gateway_model_definition(
+        name="gemini-stream-passthrough-model",
+        secret_id=secret.secret_id,
+        provider="gemini",
+        model_name="gemini-2.0-flash",
+    )
+    store.create_gateway_endpoint(
+        name="gemini-stream-passthrough-endpoint",
+        model_definition_ids=[model_def.model_definition_id],
+    )
+
+    mock_request = MagicMock()
+    mock_request.json = AsyncMock(
+        return_value={
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": "Hello"}],
+                }
+            ]
+        }
+    )
+
+    mock_stream_chunks = [
+        b'data: {"candidates":[{"content":{"parts":[{"text":"Hello"}],"role":"model"}}]}\n\n',
+        b'data: {"candidates":[{"content":{"parts":[{"text":"!"}],"role":"model"}}]}\n\n',
+        b'data: {"candidates":[{"content":{"parts":[{"text":" How can I help you?"}],"role":"model"},"finishReason":"STOP"}]}\n\n',  # noqa: E501
+    ]
+
+    async def mock_stream_generator():
+        for chunk in mock_stream_chunks:
+            yield chunk
+
+    with mock.patch(
+        "mlflow.gateway.providers.gemini.send_stream_request",
+        return_value=mock_stream_generator(),
+    ) as mock_send_stream:
+        response = await gemini_passthrough_stream_generate_content(
+            "gemini-stream-passthrough-endpoint", mock_request
+        )
+
+        assert mock_send_stream.called
+        assert isinstance(response, StreamingResponse)
+        assert response.media_type == "text/event-stream"
+
+        chunks = [chunk async for chunk in response.body_iterator]
+
+        assert len(chunks) == 3
+        assert b"Hello" in chunks[0]
+        assert b"!" in chunks[1]
+        assert b"How can I help you?" in chunks[2]
+        assert b"STOP" in chunks[2]


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19425/files) to review incremental changes.
- [**stack/gateway/model-passthrough/gemini**](https://github.com/mlflow/mlflow/pull/19425) [[Files changed](https://github.com/mlflow/mlflow/pull/19425/files)]
  - [stack/gateway/structured-output](https://github.com/mlflow/mlflow/pull/19452) [[Files changed](https://github.com/mlflow/mlflow/pull/19452/files/880b16b9a1f3e578728470c9eafa014f7d68f917..cf538ad3668a5d3c6eb93aa59a3a98ae6d574a89)]
    - [stack/gateway/missing-params](https://github.com/mlflow/mlflow/pull/19453) [[Files changed](https://github.com/mlflow/mlflow/pull/19453/files/cf538ad3668a5d3c6eb93aa59a3a98ae6d574a89..1c241f22fd658eedae6b0debfd0f63330a65365c)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

n/a

### What changes are proposed in this pull request?

Add following Gemini model passthrough endpoints where request body is just propagated to the provider endpoint:

- /gateway/gemini/v1beta/models/{endpoint_name}:generateContent
- /gateway/gemini/v1beta/models/{endpoint_name}:streamGenerateContent

```python
from google import genai
from google.genai import types
import mlflow

mlflow.set_tracking_uri("http://localhost:5000")
mlflow.set_experiment("Gateway")
from mlflow.tracking._tracking_service.utils import _get_store

store = _get_store()

secret = store.create_gateway_secret(
    secret_name="gemini_api",
    secret_value={"api_key": "<secret>"},
    provider="gemini",
)
model_def = store.create_gateway_model_definition(
    name="gemini-2.5-flash",
    secret_id=secret.secret_id,
    provider="gemini",
    model_name="gemini-2.5-flash",
)
endpoint = store.create_gateway_endpoint(
    name="gemini-v1", model_definition_ids=[model_def.model_definition_id]
)

client = genai.Client(
    api_key='dummy',
    http_options={
        'base_url': "http://localhost:5000/gateway/gemini",
    })
response = client.models.generate_content(
    model="gemini-v1",
    contents='Hello',
)
client.close()
print(response.candidates[0].content.parts[0].text)
```

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
