### PR TITLE
Job backend: Update job backend to use static names rather than function full names

### DIFF
--- a/mlflow/entities/_job.py
+++ b/mlflow/entities/_job.py
@@ -14,7 +14,7 @@ class Job(_MlflowObject):
         self,
         job_id: str,
         creation_time: int,
-        function_fullname: str,
+        job_name: str,
         params: str,
         timeout: float | None,
         status: JobStatus,
@@ -25,7 +25,7 @@ class Job(_MlflowObject):
         super().__init__()
         self._job_id = job_id
         self._creation_time = creation_time
-        self._function_fullname = function_fullname
+        self._job_name = job_name
         self._params = params
         self._timeout = timeout
         self._status = status
@@ -44,12 +44,13 @@ class Job(_MlflowObject):
         return self._creation_time
 
     @property
-    def function_fullname(self) -> str:
+    def job_name(self) -> str:
         """
-        String containing the fully-qualified function name,
-        in the form of `<module_name>.<function_name>`
+        String containing the fully-qualified job name
+        (formerly `function_fullname`), in the form of
+        `<module_name>.<function_name>`.
         """
-        return self._function_fullname
+        return self._job_name
 
     @property
     def params(self) -> str:
@@ -104,4 +105,4 @@ class Job(_MlflowObject):
         return self._last_update_time
 
     def __repr__(self) -> str:
-        return f"<Job(job_id={self.job_id}, function_fullname={self.function_fullname})>"
+        return f"<Job(job_id={self.job_id}, job_name={self.job_name})>"

--- a/mlflow/entities/_job.py
+++ b/mlflow/entities/_job.py
@@ -46,9 +46,7 @@ class Job(_MlflowObject):
     @property
     def job_name(self) -> str:
         """
-        String containing the fully-qualified job name
-        (formerly `function_fullname`), in the form of
-        `<module_name>.<function_name>`.
+        String containing the static job name that uniquely identifies the decorated job function.
         """
         return self._job_name
 

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -22,7 +22,7 @@ class Job(BaseModel):
 
     job_id: str
     creation_time: int
-    function_fullname: str
+    job_name: str
     params: dict[str, Any]
     timeout: float | None
     status: JobStatus
@@ -35,7 +35,7 @@ class Job(BaseModel):
         return cls(
             job_id=job.job_id,
             creation_time=job.creation_time,
-            function_fullname=job.function_fullname,
+            job_name=job.job_name,
             params=json.loads(job.params),
             timeout=job.timeout,
             status=job.status,

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -73,8 +73,8 @@ def submit_job(payload: SubmitJobPayload) -> Job:
     from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
 
     job_name = payload.job_name
-    function_fullname = get_job_fn_fullname(job_name)
     try:
+        function_fullname = get_job_fn_fullname(job_name)
         function = _load_function(function_fullname)
         job = submit_job(function, payload.params, payload.timeout)
         return Job.from_job_entity(job)
@@ -86,7 +86,7 @@ def submit_job(payload: SubmitJobPayload) -> Job:
 
 
 class SearchJobPayload(BaseModel):
-    function_fullname: str | None = None
+    job_name: str | None = None
     params: dict[str, Any] | None = None
     statuses: list[JobStatus] | None = None
 
@@ -108,7 +108,7 @@ def search_jobs(payload: SearchJobPayload) -> SearchJobsResponse:
         job_results = [
             Job.from_job_entity(job)
             for job in store.list_jobs(
-                job_name=payload.function_fullname,
+                job_name=payload.job_name,
                 statuses=payload.statuses,
                 params=payload.params,
             )

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -12,8 +12,6 @@ from mlflow.entities._job import Job as JobEntity
 from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
 
-# _build_job_name_to_fn_fullname_map()
-
 job_api_router = APIRouter(prefix="/ajax-api/3.0/jobs", tags=["Job"])
 
 

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -12,6 +12,8 @@ from mlflow.entities._job import Job as JobEntity
 from mlflow.entities._job_status import JobStatus
 from mlflow.exceptions import MlflowException
 
+# _build_job_name_to_fn_fullname_map()
+
 job_api_router = APIRouter(prefix="/ajax-api/3.0/jobs", tags=["Job"])
 
 

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -105,7 +105,7 @@ def search_jobs(payload: SearchJobPayload) -> SearchJobsResponse:
         job_results = [
             Job.from_job_entity(job)
             for job in store.list_jobs(
-                function_fullname=payload.function_fullname,
+                job_name=payload.function_fullname,
                 statuses=payload.statuses,
                 params=payload.params,
             )

--- a/mlflow/server/job_api.py
+++ b/mlflow/server/job_api.py
@@ -62,7 +62,7 @@ def get_job(job_id: str) -> Job:
 
 
 class SubmitJobPayload(BaseModel):
-    function_fullname: str
+    job_name: str
     params: dict[str, Any]
     timeout: float | None = None
 
@@ -70,9 +70,10 @@ class SubmitJobPayload(BaseModel):
 @job_api_router.post("/", response_model=Job)
 def submit_job(payload: SubmitJobPayload) -> Job:
     from mlflow.server.jobs import submit_job
-    from mlflow.server.jobs.utils import _load_function
+    from mlflow.server.jobs.utils import _load_function, get_job_fn_fullname
 
-    function_fullname = payload.function_fullname
+    job_name = payload.job_name
+    function_fullname = get_job_fn_fullname(job_name)
     try:
         function = _load_function(function_fullname)
         job = submit_job(function, payload.params, payload.timeout)

--- a/mlflow/server/jobs/_job_runner.py
+++ b/mlflow/server/jobs/_job_runner.py
@@ -15,9 +15,9 @@ import os
 import time
 
 from mlflow.server import HUEY_STORAGE_PATH_ENV_VAR
-from mlflow.server.jobs import _ALLOWED_JOB_FUNCTION_LIST
 from mlflow.server.jobs.utils import (
     _enqueue_unfinished_jobs,
+    _job_name_to_fn_fullname_map,
     _launch_huey_consumer,
     _start_watcher_to_kill_job_runner_if_mlflow_server_dies,
 )
@@ -29,13 +29,11 @@ if __name__ == "__main__":
 
     huey_store_path = os.environ[HUEY_STORAGE_PATH_ENV_VAR]
 
-    for job_fn_fullname in _ALLOWED_JOB_FUNCTION_LIST:
+    for job_name in _job_name_to_fn_fullname_map:
         try:
-            _launch_huey_consumer(job_fn_fullname)
+            _launch_huey_consumer(job_name)
         except Exception as e:
-            logging.warning(
-                f"Launch Huey consumer for {job_fn_fullname} jobs failed, root cause: {e!r}"
-            )
+            logging.warning(f"Launch Huey consumer for {job_name} jobs failed, root cause: {e!r}")
 
     time.sleep(10)  # wait for huey consumer launching
     _enqueue_unfinished_jobs(server_up_time)

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -24,6 +24,7 @@ from mlflow.environment_variables import (
 from mlflow.exceptions import MlflowException
 from mlflow.server.constants import HUEY_STORAGE_PATH_ENV_VAR
 from mlflow.utils.environment import _PythonEnv
+from mlflow.utils.import_hooks import register_post_import_hook
 
 if TYPE_CHECKING:
     import huey
@@ -214,7 +215,7 @@ def _exec_job_in_subproc(
 
 def _exec_job(
     job_id: str,
-    fn_fullname: str,
+    job_name: str,
     params: dict[str, Any],
     timeout: float | None,
 ) -> None:
@@ -223,6 +224,7 @@ def _exec_job(
     job_store = _get_job_store()
     job_store.start_job(job_id)
 
+    fn_fullname = get_job_fn_fullname(job_name)
     function = _load_function(fn_fullname)
     fn_metadata = function._job_fn_metadata
 
@@ -314,14 +316,15 @@ def _get_or_init_huey_instance(instance_key: str):
         return _huey_instance_map[instance_key]
 
 
-def _launch_huey_consumer(job_fn_fullname: str) -> None:
-    _logger.info(f"Starting huey consumer for job function {job_fn_fullname}")
-    job_fn = _load_function(job_fn_fullname)
+def _launch_huey_consumer(job_name: str) -> None:
+    _logger.info(f"Starting huey consumer for job function {job_name}")
+
+    fn_fullname = get_job_fn_fullname(job_name)
+    job_fn = _load_function(fn_fullname)
 
     if not hasattr(job_fn, "_job_fn_metadata"):
         raise MlflowException.invalid_parameter_value(
-            f"The job function {job_fn_fullname} is not decorated by "
-            "'mlflow.server.jobs.job_function'."
+            f"The job function {job_name} is not decorated by 'mlflow.server.jobs.job_function'."
         )
 
     max_job_parallelism = job_fn._job_fn_metadata.max_workers
@@ -331,7 +334,7 @@ def _launch_huey_consumer(job_fn_fullname: str) -> None:
             # start MLflow job runner process
             # Put it inside the loop to ensure the job runner process alive
             job_runner_proc = _start_huey_consumer_proc(
-                job_fn_fullname,
+                job_name,
                 max_job_parallelism,
             )
             job_runner_proc.wait()
@@ -340,7 +343,7 @@ def _launch_huey_consumer(job_fn_fullname: str) -> None:
     # start job runner.
     threading.Thread(
         target=_huey_consumer_thread,
-        name=f"MLflow-huey-consumer-{job_fn_fullname}-watcher",
+        name=f"MLflow-huey-consumer-{job_name}-watcher",
         daemon=False,
     ).start()
 
@@ -466,3 +469,35 @@ def _check_requirements(backend_store_uri: str | None = None) -> None:
         raise MlflowException(
             f"MLflow job backend requires a database backend store URI but got {backend_store_uri}"
         )
+
+
+# The map from job name to the job function's fullname.
+_job_name_to_fn_fullname_map = {}
+
+
+def get_job_fn_fullname(job_name):
+    if job_name not in _job_name_to_fn_fullname_map:
+        raise MlflowException.invalid_parameter_value(f"Invalid job name: {job_name}")
+    return _job_name_to_fn_fullname_map[job_name]
+
+
+def _build_job_name_to_fn_fullname_map():
+    from mlflow.server.jobs import _ALLOWED_JOB_FUNCTION_LIST
+
+    for fn_fullname in set(_ALLOWED_JOB_FUNCTION_LIST):
+        try:
+            fn_meta = _load_function(fn_fullname)._job_fn_metadata
+            if exist_fullname := _job_name_to_fn_fullname_map.get(fn_meta.name):
+                if exist_fullname != fn_fullname:
+                    _logger.warning(
+                        f"The 2 job functions {fn_fullname} and {exist_fullname} have the same "
+                        f"job name {fn_meta.name}, this is not allowed, skip loading function "
+                        f"{fn_fullname}."
+                    )
+            else:
+                _job_name_to_fn_fullname_map[fn_meta.name] = fn_fullname
+        except Exception as e:
+            _logger.warning(f"loading job function {fn_fullname} failed: {e!r}", exc_info=True)
+
+
+register_post_import_hook(lambda m: _build_job_name_to_fn_fullname_map(), __name__)

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -410,8 +410,8 @@ def _enqueue_unfinished_jobs(server_launching_timestamp: int) -> None:
         params = json.loads(job.params)
         timeout = job.timeout
         # enqueue job
-        _get_or_init_huey_instance(job.function_fullname).submit_task(
-            job.job_id, job.function_fullname, params, timeout
+        _get_or_init_huey_instance(job.job_name).submit_task(
+            job.job_id, job.job_name, params, timeout
         )
 
 

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -475,7 +475,7 @@ def _check_requirements(backend_store_uri: str | None = None) -> None:
 _job_name_to_fn_fullname_map = {}
 
 
-def get_job_fn_fullname(job_name):
+def get_job_fn_fullname(job_name: str):
     if job_name not in _job_name_to_fn_fullname_map:
         raise MlflowException.invalid_parameter_value(f"Invalid job name: {job_name}")
     return _job_name_to_fn_fullname_map[job_name]

--- a/mlflow/server/jobs/utils.py
+++ b/mlflow/server/jobs/utils.py
@@ -482,9 +482,9 @@ def get_job_fn_fullname(job_name: str):
 
 
 def _build_job_name_to_fn_fullname_map():
-    from mlflow.server.jobs import _ALLOWED_JOB_FUNCTION_LIST
+    from mlflow.server.jobs import _SUPPORTED_JOB_FUNCTION_LIST
 
-    for fn_fullname in set(_ALLOWED_JOB_FUNCTION_LIST):
+    for fn_fullname in set(_SUPPORTED_JOB_FUNCTION_LIST):
         try:
             fn_meta = _load_function(fn_fullname)._job_fn_metadata
             if exist_fullname := _job_name_to_fn_fullname_map.get(fn_meta.name):

--- a/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
+++ b/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
@@ -20,6 +20,8 @@ def upgrade():
         batch_op.drop_index("index_jobs_function_status_creation_time")
         # Rename the column
         batch_op.alter_column("function_fullname", new_column_name="job_name")
+
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
         # Recreate the index referencing the new column name
         batch_op.create_index(
             "index_jobs_name_status_creation_time",
@@ -33,6 +35,8 @@ def downgrade():
     with op.batch_alter_table("jobs", schema=None) as batch_op:
         batch_op.drop_index("index_jobs_name_status_creation_time")
         batch_op.alter_column("job_name", new_column_name="function_fullname")
+
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
         batch_op.create_index(
             "index_jobs_function_status_creation_time",
             ["function_fullname", "status", "creation_time"],

--- a/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
+++ b/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
@@ -20,7 +20,9 @@ def upgrade():
         # Drop old index that referenced `function_fullname`
         batch_op.drop_index("index_jobs_function_status_creation_time")
         # Rename the column
-        batch_op.alter_column("function_fullname", new_column_name="job_name", existing_type=String(500))
+        batch_op.alter_column(
+            "function_fullname", new_column_name="job_name", existing_type=String(500)
+        )
 
     with op.batch_alter_table("jobs", schema=None) as batch_op:
         # Recreate the index referencing the new column name
@@ -43,4 +45,3 @@ def downgrade():
             ["function_fullname", "status", "creation_time"],
             unique=False,
         )
-

--- a/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
+++ b/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
@@ -37,7 +37,9 @@ def downgrade():
     # Revert column rename `job_name` -> `function_fullname` and restore the original index
     with op.batch_alter_table("jobs", schema=None) as batch_op:
         batch_op.drop_index("index_jobs_name_status_creation_time")
-        batch_op.alter_column("job_name", new_column_name="function_fullname")
+        batch_op.alter_column(
+            "job_name", new_column_name="function_fullname", existing_type=String(500)
+        )
 
     with op.batch_alter_table("jobs", schema=None) as batch_op:
         batch_op.create_index(

--- a/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
+++ b/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
@@ -5,6 +5,7 @@ Create Date: 2025-12-16 16:31:47.921120
 """
 
 from alembic import op
+from sqlalchemy import String
 
 # revision identifiers, used by Alembic.
 revision = "5d2d30f0abce"
@@ -19,7 +20,7 @@ def upgrade():
         # Drop old index that referenced `function_fullname`
         batch_op.drop_index("index_jobs_function_status_creation_time")
         # Rename the column
-        batch_op.alter_column("function_fullname", new_column_name="job_name")
+        batch_op.alter_column("function_fullname", new_column_name="job_name", existing_type=String(500))
 
     with op.batch_alter_table("jobs", schema=None) as batch_op:
         # Recreate the index referencing the new column name
@@ -42,3 +43,4 @@ def downgrade():
             ["function_fullname", "status", "creation_time"],
             unique=False,
         )
+

--- a/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
+++ b/mlflow/store/db_migrations/versions/5d2d30f0abce_update_job_table.py
@@ -1,0 +1,40 @@
+"""update job table
+
+Create Date: 2025-12-16 16:31:47.921120
+
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "5d2d30f0abce"
+down_revision = "b7c8d9e0f1a2"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Rename column `function_fullname` -> `job_name` and update the related index
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        # Drop old index that referenced `function_fullname`
+        batch_op.drop_index("index_jobs_function_status_creation_time")
+        # Rename the column
+        batch_op.alter_column("function_fullname", new_column_name="job_name")
+        # Recreate the index referencing the new column name
+        batch_op.create_index(
+            "index_jobs_name_status_creation_time",
+            ["job_name", "status", "creation_time"],
+            unique=False,
+        )
+
+
+def downgrade():
+    # Revert column rename `job_name` -> `function_fullname` and restore the original index
+    with op.batch_alter_table("jobs", schema=None) as batch_op:
+        batch_op.drop_index("index_jobs_name_status_creation_time")
+        batch_op.alter_column("job_name", new_column_name="function_fullname")
+        batch_op.create_index(
+            "index_jobs_function_status_creation_time",
+            ["function_fullname", "status", "creation_time"],
+            unique=False,
+        )

--- a/mlflow/store/jobs/abstract_store.py
+++ b/mlflow/store/jobs/abstract_store.py
@@ -13,12 +13,12 @@ class AbstractJobStore(ABC):
     """
 
     @abstractmethod
-    def create_job(self, function_fullname: str, params: str, timeout: float | None = None) -> Job:
+    def create_job(self, job_name: str, params: str, timeout: float | None = None) -> Job:
         """
         Create a new job with the specified function and parameters.
 
         Args:
-            function_fullname: The full name of the function to execute
+            job_name: The fully-qualified job name (`<module>.<function>`) to execute
             params: The job parameters that are serialized as a JSON string
             timeout: The job execution timeout in seconds
 
@@ -92,7 +92,7 @@ class AbstractJobStore(ABC):
     @abstractmethod
     def list_jobs(
         self,
-        function_fullname: str | None = None,
+        job_name: str | None = None,
         statuses: list[JobStatus] | None = None,
         begin_timestamp: int | None = None,
         end_timestamp: int | None = None,
@@ -102,7 +102,7 @@ class AbstractJobStore(ABC):
         List jobs based on the provided filters.
 
         Args:
-            function_fullname: Filter by function full name (exact match)
+            job_name: Filter by job name (exact match)
             statuses: Filter by a list of job status (PENDING, RUNNING, DONE, FAILED, TIMEOUT)
             begin_timestamp: Filter jobs created after this timestamp (inclusive)
             end_timestamp: Filter jobs created before this timestamp (inclusive)

--- a/mlflow/store/jobs/abstract_store.py
+++ b/mlflow/store/jobs/abstract_store.py
@@ -18,7 +18,7 @@ class AbstractJobStore(ABC):
         Create a new job with the specified function and parameters.
 
         Args:
-            job_name: The fully-qualified job name (`<module>.<function>`) to execute
+            job_name: The static job name that identifies the decorated job function
             params: The job parameters that are serialized as a JSON string
             timeout: The job execution timeout in seconds
 

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -66,7 +66,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         Create a new job with the specified function and parameters.
 
         Args:
-            job_name: The fully-qualified job name (`<module>.<function>`) to execute
+            job_name: The static job name that identifies the decorated job function
             params: The job parameters that are serialized as a JSON string
             timeout: The job execution timeout in seconds
 

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -61,12 +61,12 @@ class SqlAlchemyJobStore(AbstractJobStore):
         SessionMaker = sqlalchemy.orm.sessionmaker(bind=self.engine)
         self.ManagedSessionMaker = _get_managed_session_maker(SessionMaker, self.db_type)
 
-    def create_job(self, function_fullname: str, params: str, timeout: float | None = None) -> Job:
+    def create_job(self, job_name: str, params: str, timeout: float | None = None) -> Job:
         """
         Create a new job with the specified function and parameters.
 
         Args:
-            function_fullname: The full name of the function to execute
+            job_name: The fully-qualified job name (`<module>.<function>`) to execute
             params: The job parameters that are serialized as a JSON string
             timeout: The job execution timeout in seconds
 
@@ -80,7 +80,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job = SqlJob(
                 id=job_id,
                 creation_time=creation_time,
-                job_name=function_fullname,
+                job_name=job_name,
                 params=params,
                 timeout=timeout,
                 status=JobStatus.PENDING.to_int(),
@@ -206,7 +206,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
 
     def list_jobs(
         self,
-        function_fullname: str | None = None,
+        job_name: str | None = None,
         statuses: list[JobStatus] | None = None,
         begin_timestamp: int | None = None,
         end_timestamp: int | None = None,
@@ -216,7 +216,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
         List jobs based on the provided filters.
 
         Args:
-            function_fullname: Filter by function full name (exact match)
+            job_name: Filter by job name (exact match)
             statuses: Filter by a list of job status (PENDING, RUNNING, DONE, FAILED, TIMEOUT)
             begin_timestamp: Filter jobs created after this timestamp (inclusive)
             end_timestamp: Filter jobs created before this timestamp (inclusive)
@@ -245,8 +245,8 @@ class SqlAlchemyJobStore(AbstractJobStore):
                 query = session.query(SqlJob)
 
                 # Apply filters
-                if function_fullname is not None:
-                    query = query.filter(SqlJob.job_name == function_fullname)
+                if job_name is not None:
+                    query = query.filter(SqlJob.job_name == job_name)
 
                 if statuses:
                     query = query.filter(

--- a/mlflow/store/jobs/sqlalchemy_store.py
+++ b/mlflow/store/jobs/sqlalchemy_store.py
@@ -80,7 +80,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
             job = SqlJob(
                 id=job_id,
                 creation_time=creation_time,
-                function_fullname=function_fullname,
+                job_name=function_fullname,
                 params=params,
                 timeout=timeout,
                 status=JobStatus.PENDING.to_int(),
@@ -246,7 +246,7 @@ class SqlAlchemyJobStore(AbstractJobStore):
 
                 # Apply filters
                 if function_fullname is not None:
-                    query = query.filter(SqlJob.function_fullname == function_fullname)
+                    query = query.filter(SqlJob.job_name == function_fullname)
 
                 if statuses:
                     query = query.filter(

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2001,9 +2001,9 @@ class SqlJob(Base):
     Creation timestamp: `BigInteger`.
     """
 
-    function_fullname = Column(String(500), nullable=False)
+    job_name = Column(String(500), nullable=False)
     """
-    Function fullname: `String` (limit 500 characters).
+    Job name: `String` (limit 500 characters).
     """
 
     params = Column(Text, nullable=False)
@@ -2040,14 +2040,14 @@ class SqlJob(Base):
         PrimaryKeyConstraint("id", name="jobs_pk"),
         Index(
             "index_jobs_function_status_creation_time",
-            "function_fullname",
+            "job_name",
             "status",
             "creation_time",
         ),
     )
 
     def __repr__(self):
-        return f"<SqlJob ({self.id}, {self.function_fullname}, {self.status})>"
+        return f"<SqlJob ({self.id}, {self.job_name}, {self.status})>"
 
     def to_mlflow_entity(self):
         """
@@ -2062,7 +2062,7 @@ class SqlJob(Base):
         return Job(
             job_id=self.id,
             creation_time=self.creation_time,
-            function_fullname=self.function_fullname,
+            job_name=self.job_name,
             params=self.params,
             timeout=self.timeout,
             status=JobStatus.from_int(self.status),

--- a/mlflow/store/tracking/dbmodels/models.py
+++ b/mlflow/store/tracking/dbmodels/models.py
@@ -2039,7 +2039,7 @@ class SqlJob(Base):
     __table_args__ = (
         PrimaryKeyConstraint("id", name="jobs_pk"),
         Index(
-            "index_jobs_function_status_creation_time",
+            "index_jobs_name_status_creation_time",
             "job_name",
             "status",
             "creation_time",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -433,15 +433,7 @@ example-rules = [
 [tool.clint.forbidden-top-level-imports]
 "mlflow/gateway/providers/*" = ["fastapi", "starlette", "aiohttp"]
 # Databricks SDK/Agents should not be imported at the top level
-# "mlflow.server.job" should not be imported at the top level,
-# to avoid importing all job functions (except under mlflow/server/job itself)
-"mlflow/**" = ["databricks", "mlflow.server.job"]
-
-[[tool.clint.overrides]]
-paths = ["mlflow/server/jobs/**"]
-
-[tool.clint.overrides.forbidden-top-level-imports]
-"mlflow/**" = ["databricks"]
+"mlflow/*" = ["databricks"]
 
 # typos
 [tool.typos.default.extend-words]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -433,7 +433,15 @@ example-rules = [
 [tool.clint.forbidden-top-level-imports]
 "mlflow/gateway/providers/*" = ["fastapi", "starlette", "aiohttp"]
 # Databricks SDK/Agents should not be imported at the top level
-"mlflow/*" = ["databricks"]
+# "mlflow.server.job" should not be imported at the top level,
+# to avoid importing all job functions (except under mlflow/server/job itself)
+"mlflow/**" = ["databricks", "mlflow.server.job"]
+
+[[tool.clint.overrides]]
+paths = ["mlflow/server/jobs/**"]
+
+[tool.clint.overrides.forbidden-top-level-imports]
+"mlflow/**" = ["databricks"]
 
 # typos
 [tool.typos.default.extend-words]

--- a/tests/db/schemas/mssql.sql
+++ b/tests/db/schemas/mssql.sql
@@ -74,7 +74,7 @@ CREATE TABLE inputs (
 CREATE TABLE jobs (
 	id VARCHAR(36) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	creation_time BIGINT NOT NULL,
-	function_fullname VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
+	job_name VARCHAR(500) COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	params VARCHAR COLLATE "SQL_Latin1_General_CP1_CI_AS" NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,

--- a/tests/db/schemas/mysql.sql
+++ b/tests/db/schemas/mysql.sql
@@ -75,7 +75,7 @@ CREATE TABLE inputs (
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
 	creation_time BIGINT NOT NULL,
-	function_fullname VARCHAR(500) NOT NULL,
+	job_name VARCHAR(500),
 	params TEXT NOT NULL,
 	timeout DOUBLE,
 	status INTEGER NOT NULL,

--- a/tests/db/schemas/postgresql.sql
+++ b/tests/db/schemas/postgresql.sql
@@ -76,7 +76,7 @@ CREATE TABLE inputs (
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
 	creation_time BIGINT NOT NULL,
-	function_fullname VARCHAR(500) NOT NULL,
+	job_name VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
 	timeout DOUBLE PRECISION,
 	status INTEGER NOT NULL,

--- a/tests/db/schemas/sqlite.sql
+++ b/tests/db/schemas/sqlite.sql
@@ -76,7 +76,7 @@ CREATE TABLE inputs (
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
 	creation_time BIGINT NOT NULL,
-	function_fullname VARCHAR(500) NOT NULL,
+	job_name VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,

--- a/tests/resources/db/latest_schema.sql
+++ b/tests/resources/db/latest_schema.sql
@@ -76,7 +76,7 @@ CREATE TABLE inputs (
 CREATE TABLE jobs (
 	id VARCHAR(36) NOT NULL,
 	creation_time BIGINT NOT NULL,
-	function_fullname VARCHAR(500) NOT NULL,
+	job_name VARCHAR(500) NOT NULL,
 	params TEXT NOT NULL,
 	timeout FLOAT,
 	status INTEGER NOT NULL,

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -36,10 +36,10 @@ class Client:
         self.server_url = server_url
 
     def submit_job(
-        self, function_fullname: str, params: dict[str, Any], timeout: float | None = None
+        self, job_name: str, params: dict[str, Any], timeout: float | None = None
     ) -> dict[str, Any]:
         payload = {
-            "function_fullname": function_fullname,
+            "job_name": job_name,
             "params": params,
             "timeout": timeout,
         }
@@ -140,7 +140,7 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
 
 def test_job_endpoint(client: Client):
     job_id = client.submit_job(
-        function_fullname="test_endpoint.simple_job_fun",
+        job_name="simple_job_fun",
         params={"x": 3, "y": 4},
     )["job_id"]
     job_json = client.wait_job(job_id)

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -110,6 +110,7 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
             "_MLFLOW_SUPPORTED_JOB_FUNCTION_LIST": (
                 "test_endpoint.simple_job_fun,test_endpoint.job_assert_tracking_uri"
             ),
+            "_MLFLOW_ALLOWED_JOB_NAME_LIST": ("simple_job_fun,job_assert_tracking_uri"),
         },
         start_new_session=True,  # new session & process group
     ) as server_proc:

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -16,7 +16,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@job(max_workers=1)
+@job(name="simple_job_fun", max_workers=1)
 def simple_job_fun(x: int, y: int, sleep_secs: int = 0) -> dict[str, Any]:
     if sleep_secs:
         time.sleep(sleep_secs)
@@ -26,7 +26,7 @@ def simple_job_fun(x: int, y: int, sleep_secs: int = 0) -> dict[str, Any]:
     }
 
 
-@job(max_workers=1)
+@job(name="job_assert_tracking_uri", max_workers=1)
 def job_assert_tracking_uri(server_url: str) -> None:
     assert mlflow.get_tracking_uri() == server_url
 
@@ -108,8 +108,9 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
             "PYTHONPATH": os.path.dirname(__file__),
             "MLFLOW_SERVER_ENABLE_JOB_EXECUTION": "true",
             "_MLFLOW_ALLOWED_JOB_FUNCTION_LIST": (
-                "test_endpoint.simple_job_fun,invalid_format_no_module,"
-                "non_existent_module.some_function,os.non_existent_function,"
+                "test_endpoint.simple_job_fun,"
+                # "invalid_format_no_module,"
+                # "non_existent_module.some_function,os.non_existent_function,"
                 "test_endpoint.job_assert_tracking_uri"
             ),
         },
@@ -147,7 +148,7 @@ def test_job_endpoint(client: Client):
     job_json.pop("last_update_time")
     assert job_json == {
         "job_id": job_id,
-        "function_fullname": "test_endpoint.simple_job_fun",
+        "job_name": "simple_job_fun",
         "params": {"x": 3, "y": 4},
         "timeout": None,
         "status": "SUCCEEDED",

--- a/tests/server/jobs/test_endpoint.py
+++ b/tests/server/jobs/test_endpoint.py
@@ -107,7 +107,7 @@ def client(tmp_path_factory: pytest.TempPathFactory) -> Client:
             **os.environ,
             "PYTHONPATH": os.path.dirname(__file__),
             "MLFLOW_SERVER_ENABLE_JOB_EXECUTION": "true",
-            "_MLFLOW_ALLOWED_JOB_FUNCTION_LIST": (
+            "_MLFLOW_SUPPORTED_JOB_FUNCTION_LIST": (
                 "test_endpoint.simple_job_fun,test_endpoint.job_assert_tracking_uri"
             ),
         },

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -118,7 +118,7 @@ def test_job_json_input_output(monkeypatch, tmp_path):
         wait_job_finalize(submitted_job.job_id)
         job = get_job(submitted_job.job_id)
         assert job.job_id == submitted_job.job_id
-        assert job.function_fullname == "tests.server.jobs.test_jobs.json_in_out_fun"
+        assert job.job_name == "json_in_out_fun"
         assert job.params == '{"data": {"x": 3, "y": 4}}'
         assert job.result == '{"res": 7}'
         assert job.parsed_result == {"res": 7}
@@ -143,7 +143,7 @@ def test_error_job(monkeypatch, tmp_path):
 
         # check database record correctness.
         assert job.job_id == submitted_job.job_id
-        assert job.function_fullname == "tests.server.jobs.test_jobs.err_fun"
+        assert job.job_name == "err_fun"
         assert job.params == '{"data": null}'
         assert job.result.startswith("RuntimeError()")
         assert job.status == JobStatus.FAILED
@@ -270,12 +270,12 @@ def test_job_queue_parallelism(monkeypatch, tmp_path):
 
             jobs = list(job_store.list_jobs())
             for job in jobs:
-                if job.function_fullname.endswith("job_fun_parallelism2"):
+                if job.job_name == "job_fun_parallelism2":
                     if job.status == JobStatus.RUNNING:
                         p2_parallelism += 1
                     elif job.status == JobStatus.SUCCEEDED:
                         p2_succeeded_count += 1
-                elif job.function_fullname.endswith("job_fun_parallelism3"):
+                elif job.job_name == "job_fun_parallelism3":
                     if job.status == JobStatus.RUNNING:
                         p3_parallelism += 1
                     elif job.status == JobStatus.SUCCEEDED:
@@ -466,7 +466,7 @@ def test_job_timeout(monkeypatch, tmp_path):
 
         # check database record correctness.
         assert job.job_id == job_id
-        assert job.function_fullname == "tests.server.jobs.test_jobs.sleep_fun"
+        assert job.job_name == "sleep_fun"
         assert job.timeout == 3.0
         assert job.result is None
         assert job.status == JobStatus.TIMEOUT

--- a/tests/server/jobs/test_jobs.py
+++ b/tests/server/jobs/test_jobs.py
@@ -15,7 +15,14 @@ from mlflow.server import (
     HUEY_STORAGE_PATH_ENV_VAR,
 )
 from mlflow.server.handlers import _get_job_store
-from mlflow.server.jobs import _ALLOWED_JOB_FUNCTION_LIST, TransientError, get_job, job, submit_job
+from mlflow.server.jobs import (
+    _ALLOWED_JOB_NAME_LIST,
+    _SUPPORTED_JOB_FUNCTION_LIST,
+    TransientError,
+    get_job,
+    job,
+    submit_job,
+)
 from mlflow.server.jobs.utils import _launch_job_runner
 from mlflow.store.jobs.sqlalchemy_store import SqlAlchemyJobStore
 
@@ -47,7 +54,8 @@ def _launch_job_runner_for_test():
 def _setup_job_runner(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
-    allowed_job_functions: list[str],
+    supported_job_functions: list[str],
+    allowed_job_names: list[str],
     backend_store_uri: str | None = None,
 ):
     backend_store_uri = backend_store_uri or f"sqlite:///{tmp_path / 'mlflow.db'}"
@@ -59,9 +67,12 @@ def _setup_job_runner(
         monkeypatch.setenv(BACKEND_STORE_URI_ENV_VAR, backend_store_uri)
         monkeypatch.setenv(ARTIFACT_ROOT_ENV_VAR, default_artifact_root)
         monkeypatch.setenv(HUEY_STORAGE_PATH_ENV_VAR, str(huey_store_path))
-        monkeypatch.setenv("_MLFLOW_ALLOWED_JOB_FUNCTION_LIST", ",".join(allowed_job_functions))
-        _ALLOWED_JOB_FUNCTION_LIST.clear()
-        _ALLOWED_JOB_FUNCTION_LIST.extend(allowed_job_functions)
+        monkeypatch.setenv("_MLFLOW_SUPPORTED_JOB_FUNCTION_LIST", ",".join(supported_job_functions))
+        monkeypatch.setenv("_MLFLOW_ALLOWED_JOB_NAME_LIST", ",".join(allowed_job_names))
+        _SUPPORTED_JOB_FUNCTION_LIST.clear()
+        _SUPPORTED_JOB_FUNCTION_LIST.extend(supported_job_functions)
+        _ALLOWED_JOB_NAME_LIST.clear()
+        _ALLOWED_JOB_NAME_LIST.extend(allowed_job_names)
 
         with _launch_job_runner_for_test() as job_runner_proc:
             time.sleep(10)
@@ -86,7 +97,10 @@ def basic_job_fun(x, y, sleep_secs=0):
 
 def test_basic_job(monkeypatch, tmp_path):
     with _setup_job_runner(
-        monkeypatch, tmp_path, allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"]
+        monkeypatch,
+        tmp_path,
+        supported_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        allowed_job_names=["basic_job_fun"],
     ):
         submitted_job = submit_job(basic_job_fun, {"x": 3, "y": 4})
         wait_job_finalize(submitted_job.job_id)
@@ -112,7 +126,8 @@ def test_job_json_input_output(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.json_in_out_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.json_in_out_fun"],
+        allowed_job_names=["json_in_out_fun"],
     ):
         submitted_job = submit_job(json_in_out_fun, {"data": {"x": 3, "y": 4}})
         wait_job_finalize(submitted_job.job_id)
@@ -135,7 +150,8 @@ def test_error_job(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.err_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.err_fun"],
+        allowed_job_names=["err_fun"],
     ):
         submitted_job = submit_job(err_fun, {"data": None})
         wait_job_finalize(submitted_job.job_id)
@@ -160,7 +176,8 @@ def test_job_resume_on_job_runner_restart(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        allowed_job_names=["basic_job_fun"],
     ) as job_runner_proc:
         job1_id = submit_job(basic_job_fun, {"x": 3, "y": 4, "sleep_secs": 0}).job_id
         job2_id = submit_job(basic_job_fun, {"x": 5, "y": 6, "sleep_secs": 2}).job_id
@@ -197,7 +214,8 @@ def test_job_resume_on_new_job_runner(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         runner1_tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        allowed_job_names=["basic_job_fun"],
         backend_store_uri=backend_store_uri,
     ) as job_runner_proc:
         job1_id = submit_job(basic_job_fun, {"x": 3, "y": 4, "sleep_secs": 0}).job_id
@@ -216,7 +234,8 @@ def test_job_resume_on_new_job_runner(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         runner2_tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        allowed_job_names=["basic_job_fun"],
         backend_store_uri=backend_store_uri,
     ):
         wait_job_finalize(job2_id)
@@ -245,10 +264,11 @@ def test_job_queue_parallelism(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=[
+        supported_job_functions=[
             "tests.server.jobs.test_jobs.job_fun_parallelism2",
             "tests.server.jobs.test_jobs.job_fun_parallelism3",
         ],
+        allowed_job_names=["job_fun_parallelism2", "job_fun_parallelism3"],
     ):
         for x in range(4):
             submit_job(job_fun_parallelism2, {"x": x, "y": 1, "sleep_secs": 2})
@@ -356,10 +376,15 @@ def test_job_retry_on_transient_error(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=[
+        supported_job_functions=[
             "tests.server.jobs.test_jobs.transient_err_fun_always_fail",
             "tests.server.jobs.test_jobs.transient_err_fun_fail_then_succeed",
             "tests.server.jobs.test_jobs.transient_err_fun2_fail_then_succeed",
+        ],
+        allowed_job_names=[
+            "transient_err_fun_always_fail",
+            "transient_err_fun_fail_then_succeed",
+            "transient_err_fun2_fail_then_succeed",
         ],
     ):
         store = _get_job_store()
@@ -408,7 +433,8 @@ def test_submit_jobs_from_multi_processes(monkeypatch, tmp_path):
         _setup_job_runner(
             monkeypatch,
             tmp_path,
-            allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+            supported_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+            allowed_job_names=["basic_job_fun"],
         ),
         context.Pool(2) as pool,
     ):
@@ -442,7 +468,8 @@ def test_job_timeout(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.sleep_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.sleep_fun"],
+        allowed_job_names=["sleep_fun"],
     ):
         job_tmp_path = tmp_path / "job"
         job_tmp_path.mkdir()
@@ -480,7 +507,8 @@ def test_list_job_pagination(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        allowed_job_names=["basic_job_fun"],
     ):
         job_ids = [submit_job(basic_job_fun, {"x": x, "y": 4}).job_id for x in range(10)]
 
@@ -496,7 +524,8 @@ def test_job_function_without_decorator(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.bad_job_function"],
+        supported_job_functions=["tests.server.jobs.test_jobs.bad_job_function"],
+        allowed_job_names=["bad_job_function"],
     ):
         with pytest.raises(
             MlflowException,
@@ -514,7 +543,8 @@ def test_job_use_process(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.job_use_process"],
+        supported_job_functions=["tests.server.jobs.test_jobs.job_use_process"],
+        allowed_job_names=["job_use_process"],
     ):
         job_tmp_path = tmp_path / "job"
         job_tmp_path.mkdir()
@@ -530,7 +560,8 @@ def test_submit_job_bad_call(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        supported_job_functions=["tests.server.jobs.test_jobs.basic_job_fun"],
+        allowed_job_names=["basic_job_fun"],
     ):
         with pytest.raises(
             MlflowException,
@@ -560,7 +591,8 @@ def test_job_with_python_env(monkeypatch, tmp_path):
     with _setup_job_runner(
         monkeypatch,
         tmp_path,
-        allowed_job_functions=["tests.server.jobs.test_jobs.check_python_env_fn"],
+        supported_job_functions=["tests.server.jobs.test_jobs.check_python_env_fn"],
+        allowed_job_names=["check_python_env_fn"],
     ):
         job_id = submit_job(check_python_env_fn, params={}).job_id
         wait_job_finalize(job_id, timeout=600)

--- a/tests/server/jobs/test_utils.py
+++ b/tests/server/jobs/test_utils.py
@@ -3,7 +3,7 @@ import os
 import pytest
 
 from mlflow.exceptions import MlflowException
-from mlflow.server.jobs.utils import _validate_function_parameters
+from mlflow.server.jobs.utils import _load_function, _validate_function_parameters
 
 pytestmark = pytest.mark.skipif(
     os.name == "nt", reason="MLflow job execution is not supported on Windows"
@@ -74,3 +74,18 @@ def test_job_status_conversion():
         MlflowException, match="The string 'ABC' can't be converted to JobStatus enum value."
     ):
         JobStatus.from_str("ABC")
+
+
+def test_load_function_invalid_function_format():
+    with pytest.raises(MlflowException, match="Invalid function fullname format"):
+        _load_function("invalid_format_no_module")
+
+
+def test_load_function_module_not_found():
+    with pytest.raises(MlflowException, match="Module not found"):
+        _load_function("non_existent_module.some_function")
+
+
+def test_load_function_function_not_found():
+    with pytest.raises(MlflowException, match="Function not found in module"):
+        _load_function("os.non_exist_function")


### PR DESCRIPTION
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

<!-- Please fill in changes proposed in this PR. -->
Motivation: The job backend uses function full name module.func_name as a unique identifier for the job function. This blocks us from moving function module in the future, because it will cause inconsistency between client and server in different versions. Each job function should have its own unique name and MLflow should maintain the mapping

In this PR, I updated the `job` decorator to add a `name` param, like:

```
@job(name="the_static_name")
def my_job_function():
    ...
```

then, the job function is associated with the decorated static name, in newer MLflow versions, the job function can be renamed or moved to other module, we only need to keep the job static name unchanged, then the job function can work across different Mlflow versions.

For REST API request, user should set the static job name in the payload, and in the REST response, the job static name is returned. The real job function name is no longer exposed to front-end.

For job backend SQL table storage, it only saves the job static name, instead of the full function name. So that the unfinished job resumption can work across different MLFlow versions, and it can guarantee to query out all history jobs (submitted via different MLFlow versions) via the static job name.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [x] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->
`job` decorator provides a `name` param, for marking the static name of the job function.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [x] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [x] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)
