### PR TITLE
[TypeScript SDK] Simplify Databricks auth by delegating to Databricks SDK

### DIFF
--- a/libs/typescript/README.md
+++ b/libs/typescript/README.md
@@ -77,6 +77,46 @@ import * as mlflow from 'mlflow-tracing';
 mlflow.init(); // Uses the values from the environment
 ```
 
+### Authentication
+
+For MLflow tracking servers that require authentication, the SDK supports:
+
+1. **Basic Auth** (username/password):
+
+```typescript
+mlflow.init({
+  trackingUri: 'http://localhost:5000',
+  experimentId: '123456789',
+  trackingServerUsername: 'user',
+  trackingServerPassword: 'pass'
+});
+```
+
+Or via environment variables:
+
+```bash
+export MLFLOW_TRACKING_USERNAME=user
+export MLFLOW_TRACKING_PASSWORD=pass
+```
+
+2. **Bearer Token**:
+
+```typescript
+mlflow.init({
+  trackingUri: 'http://localhost:5000',
+  experimentId: '123456789',
+  trackingServerToken: 'my-token'
+});
+```
+
+Or via environment variable:
+
+```bash
+export MLFLOW_TRACKING_TOKEN=my-token
+```
+
+3. **No authentication** (default for local development)
+
 Create a trace:
 
 ```typescript

--- a/libs/typescript/core/package.json
+++ b/libs/typescript/core/package.json
@@ -35,6 +35,7 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
+    "@databricks/sdk-experimental": "0.15.0",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/sdk-node": "^0.201.1",
     "fast-safe-stringify": "^2.1.1",

--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -195,9 +195,7 @@ function createDatabricksAuth(options: AuthOptions): AuthProvider {
   // Resolve host - must be available synchronously
   // Priority: explicit option > env var > config file
   const host =
-    options.host ||
-    process.env.DATABRICKS_HOST ||
-    readHostFromConfigFile(configPath, profile);
+    options.host || process.env.DATABRICKS_HOST || readHostFromConfigFile(configPath, profile);
 
   if (!host) {
     throw new Error(
@@ -208,22 +206,25 @@ function createDatabricksAuth(options: AuthOptions): AuthProvider {
   }
 
   // Create Databricks SDK Config - it handles all credential resolution
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
   const databricksConfig = new Config({
     host: options.host,
     token: options.databricksToken,
     profile,
-    configFile: options.databricksConfigPath,
+    configFile: options.databricksConfigPath
   });
 
   // Headers provider delegates entirely to the SDK
   const headersProvider: HeadersProvider = async () => {
     // SDK resolves credentials from env vars, config file, OAuth, etc.
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await databricksConfig.ensureResolved();
 
     const headers = new Headers();
     headers.set('Content-Type', 'application/json');
 
     // SDK adds appropriate auth headers (Bearer token, OAuth, etc.)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-member-access
     await databricksConfig.authenticate(headers);
 
     // Convert Headers to plain object
@@ -240,7 +241,7 @@ function createDatabricksAuth(options: AuthOptions): AuthProvider {
   return {
     getHost: () => host,
     getHeadersProvider: () => headersProvider,
-    getDatabricksToken: () => databricksToken,
+    getDatabricksToken: () => databricksToken
   };
 }
 
@@ -270,6 +271,7 @@ function createOssAuth(options: AuthOptions): AuthProvider {
   }
 
   // Headers provider for OSS MLflow
+   // eslint-disable-next-line require-await, @typescript-eslint/require-await
   const headersProvider: HeadersProvider = async () => {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (authHeader) {
@@ -281,6 +283,6 @@ function createOssAuth(options: AuthOptions): AuthProvider {
   return {
     getHost: () => host,
     getHeadersProvider: () => headersProvider,
-    getDatabricksToken: () => undefined,
+    getDatabricksToken: () => undefined
   };
 }

--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -271,7 +271,7 @@ function createOssAuth(options: AuthOptions): AuthProvider {
   }
 
   // Headers provider for OSS MLflow
-   // eslint-disable-next-line require-await, @typescript-eslint/require-await
+  // eslint-disable-next-line require-await, @typescript-eslint/require-await
   const headersProvider: HeadersProvider = async () => {
     const headers: Record<string, string> = { 'Content-Type': 'application/json' };
     if (authHeader) {

--- a/libs/typescript/core/src/auth/index.ts
+++ b/libs/typescript/core/src/auth/index.ts
@@ -1,0 +1,289 @@
+/**
+ * MLflow TypeScript SDK Authentication Module
+ *
+ * This module provides authentication for MLflow tracking servers:
+ *
+ * ## Databricks-hosted MLflow
+ *
+ * For `databricks://` URIs, authentication is delegated entirely to the
+ * Databricks SDK which supports multiple authentication methods:
+ * - Personal Access Tokens (DATABRICKS_TOKEN)
+ * - OAuth M2M / Service Principals (DATABRICKS_CLIENT_ID + DATABRICKS_CLIENT_SECRET)
+ * - Azure CLI, Azure MSI, Azure Client Secret
+ * - Google Cloud credentials
+ * - Config file profiles (~/.databrickscfg)
+ *
+ * Host resolution order:
+ * 1. Explicit `host` option
+ * 2. DATABRICKS_HOST environment variable
+ * 3. Host from ~/.databrickscfg (for the specified profile)
+ *
+ * ## Self-hosted MLflow (OSS)
+ *
+ * For HTTP(S) URIs, authentication is resolved in order:
+ * 1. Basic Auth (MLFLOW_TRACKING_USERNAME + MLFLOW_TRACKING_PASSWORD)
+ * 2. Bearer Token (MLFLOW_TRACKING_TOKEN)
+ * 3. No authentication
+ *
+ * @module auth
+ */
+
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { Config } from '@databricks/sdk-experimental';
+
+/**
+ * Function that provides HTTP headers for authenticated requests.
+ * Called before each request to support token refresh for OAuth.
+ */
+export type HeadersProvider = () => Promise<Record<string, string>>;
+
+/**
+ * Authentication provider interface used by MLflow clients.
+ * Provides methods to get the host URL and authentication headers.
+ */
+export interface AuthProvider {
+  /** Get the host URL for API requests */
+  getHost(): string;
+
+  /** Get the function that provides authentication headers */
+  getHeadersProvider(): HeadersProvider;
+
+  /**
+   * Get the Databricks token if available (for backwards compatibility).
+   * Returns undefined for non-Databricks or OAuth-only authentication.
+   */
+  getDatabricksToken(): string | undefined;
+}
+
+/**
+ * Configuration options for authentication resolution.
+ */
+export interface AuthOptions {
+  /** Tracking URI: "databricks", "databricks://profile", or HTTP(S) URL */
+  trackingUri: string;
+
+  /** Explicit host override (takes precedence over environment) */
+  host?: string;
+
+  /** Explicit Databricks token override */
+  databricksToken?: string;
+
+  /** Path to Databricks config file (default: ~/.databrickscfg) */
+  databricksConfigPath?: string;
+
+  /** Basic auth username for OSS MLflow */
+  trackingServerUsername?: string;
+
+  /** Basic auth password for OSS MLflow */
+  trackingServerPassword?: string;
+
+  /** Bearer token for OSS MLflow */
+  trackingServerToken?: string;
+}
+
+/**
+ * Check if a tracking URI targets Databricks.
+ */
+export function isDatabricksUri(trackingUri: string): boolean {
+  return trackingUri === 'databricks' || trackingUri.startsWith('databricks://');
+}
+
+/**
+ * Parse profile name from a Databricks tracking URI.
+ *
+ * @example
+ * parseDatabricksProfile('databricks') // returns undefined (use DEFAULT)
+ * parseDatabricksProfile('databricks://my-profile') // returns 'my-profile'
+ */
+export function parseDatabricksProfile(trackingUri: string): string | undefined {
+  if (trackingUri === 'databricks') {
+    return undefined;
+  }
+  const match = trackingUri.match(/^databricks:\/\/(.+)$/);
+  return match?.[1] || undefined;
+}
+
+/**
+ * Create an authentication provider for the given configuration.
+ *
+ * This is the main entry point for authentication. It returns an AuthProvider
+ * with methods to get the host URL and authentication headers.
+ *
+ * @param options - Authentication configuration options
+ * @returns AuthProvider for making authenticated requests
+ * @throws Error if required configuration is missing
+ */
+export function createAuthProvider(options: AuthOptions): AuthProvider {
+  if (isDatabricksUri(options.trackingUri)) {
+    return createDatabricksAuth(options);
+  }
+  return createOssAuth(options);
+}
+
+/**
+ * Resolve authentication provider (alias for createAuthProvider).
+ * @deprecated Use createAuthProvider instead
+ */
+export const resolveAuthProvider = createAuthProvider;
+
+/**
+ * Read the host value from a Databricks config file for a specific profile.
+ *
+ * The config file uses INI format:
+ * ```
+ * [DEFAULT]
+ * host = https://my-workspace.databricks.com
+ * token = dapi123...
+ *
+ * [profile-name]
+ * host = https://other-workspace.databricks.com
+ * ```
+ *
+ * @param configPath - Path to the config file
+ * @param profile - Profile name (undefined for DEFAULT)
+ * @returns The host value or undefined if not found
+ */
+function readHostFromConfigFile(configPath: string, profile?: string): string | undefined {
+  try {
+    if (!fs.existsSync(configPath)) {
+      return undefined;
+    }
+
+    const content = fs.readFileSync(configPath, 'utf-8');
+    const targetSection = profile || 'DEFAULT';
+
+    // Simple INI parser - find the section and extract host
+    const lines = content.split('\n');
+    let inTargetSection = false;
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+
+      // Check for section header
+      const sectionMatch = trimmed.match(/^\[(.+)\]$/);
+      if (sectionMatch) {
+        inTargetSection = sectionMatch[1] === targetSection;
+        continue;
+      }
+
+      // Look for host in current section
+      if (inTargetSection) {
+        const hostMatch = trimmed.match(/^host\s*=\s*(.+)$/);
+        if (hostMatch) {
+          return hostMatch[1].trim();
+        }
+      }
+    }
+
+    return undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Create authentication for Databricks-hosted MLflow.
+ *
+ * Host resolution order:
+ * 1. Explicit `host` option
+ * 2. DATABRICKS_HOST environment variable
+ * 3. Host from config file (~/.databrickscfg)
+ *
+ * All credential resolution is delegated to the Databricks SDK.
+ * The SDK handles env vars, config files, OAuth, and cloud-specific auth.
+ */
+function createDatabricksAuth(options: AuthOptions): AuthProvider {
+  const profile = parseDatabricksProfile(options.trackingUri);
+  const configPath = options.databricksConfigPath ?? path.join(os.homedir(), '.databrickscfg');
+
+  // Resolve host - must be available synchronously
+  // Priority: explicit option > env var > config file
+  const host =
+    options.host ||
+    process.env.DATABRICKS_HOST ||
+    readHostFromConfigFile(configPath, profile);
+
+  if (!host) {
+    throw new Error(
+      'Databricks host not found. Please either:\n' +
+        '  1. Set the DATABRICKS_HOST environment variable, or\n' +
+        `  2. Add a host to your config file at ${configPath}`
+    );
+  }
+
+  // Create Databricks SDK Config - it handles all credential resolution
+  const databricksConfig = new Config({
+    host: options.host,
+    token: options.databricksToken,
+    profile,
+    configFile: options.databricksConfigPath,
+  });
+
+  // Headers provider delegates entirely to the SDK
+  const headersProvider: HeadersProvider = async () => {
+    // SDK resolves credentials from env vars, config file, OAuth, etc.
+    await databricksConfig.ensureResolved();
+
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+
+    // SDK adds appropriate auth headers (Bearer token, OAuth, etc.)
+    await databricksConfig.authenticate(headers);
+
+    // Convert Headers to plain object
+    const result: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      result[key] = value;
+    });
+    return result;
+  };
+
+  // Token for backwards compatibility (may be undefined for OAuth)
+  const databricksToken = options.databricksToken || process.env.DATABRICKS_TOKEN;
+
+  return {
+    getHost: () => host,
+    getHeadersProvider: () => headersProvider,
+    getDatabricksToken: () => databricksToken,
+  };
+}
+
+/**
+ * Create authentication for self-hosted (OSS) MLflow.
+ *
+ * Resolution order:
+ * 1. Explicit options (username/password or token)
+ * 2. Environment variables (MLFLOW_TRACKING_*)
+ * 3. No authentication
+ */
+function createOssAuth(options: AuthOptions): AuthProvider {
+  const host = options.trackingUri;
+
+  // Resolve credentials from options or environment
+  const username = options.trackingServerUsername || process.env.MLFLOW_TRACKING_USERNAME;
+  const password = options.trackingServerPassword || process.env.MLFLOW_TRACKING_PASSWORD;
+  const token = options.trackingServerToken || process.env.MLFLOW_TRACKING_TOKEN;
+
+  // Headers provider for OSS MLflow
+  const headersProvider: HeadersProvider = async () => {
+    const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+
+    // Basic auth takes precedence over token (matching Python SDK)
+    if (username && password) {
+      const encoded = Buffer.from(`${username}:${password}`).toString('base64');
+      headers['Authorization'] = `Basic ${encoded}`;
+    } else if (token) {
+      headers['Authorization'] = `Bearer ${token}`;
+    }
+
+    return headers;
+  };
+
+  return {
+    getHost: () => host,
+    getHeadersProvider: () => headersProvider,
+    getDatabricksToken: () => undefined,
+  };
+}

--- a/libs/typescript/core/src/clients/artifacts/databricks.ts
+++ b/libs/typescript/core/src/clients/artifacts/databricks.ts
@@ -72,11 +72,10 @@ export class DatabricksArtifactsClient implements ArtifactsClient {
    */
   private async getCredentialsForTraceDataUpload(traceId: string): Promise<ArtifactCredentialInfo> {
     const url = GetCredentialsForTraceDataUpload.getEndpoint(this.host, traceId);
-    const headers = await this.headersProvider();
     const response = await makeRequest<GetCredentialsForTraceDataUpload.Response>(
       'GET',
       url,
-      headers
+      this.headersProvider
     );
     return response.credential_info;
   }
@@ -89,11 +88,10 @@ export class DatabricksArtifactsClient implements ArtifactsClient {
     traceId: string
   ): Promise<ArtifactCredentialInfo> {
     const url = GetCredentialsForTraceDataDownload.getEndpoint(this.host, traceId);
-    const headers = await this.headersProvider();
     const response = await makeRequest<GetCredentialsForTraceDataDownload.Response>(
       'GET',
       url,
-      headers
+      this.headersProvider
     );
 
     if (response.credential_info) {

--- a/libs/typescript/core/src/clients/artifacts/databricks.ts
+++ b/libs/typescript/core/src/clients/artifacts/databricks.ts
@@ -2,7 +2,7 @@ import { SerializedTraceData, TraceData } from '../../core/entities/trace_data';
 import { TraceInfo } from '../../core/entities/trace_info';
 import { JSONBig } from '../../core/utils/json';
 import { GetCredentialsForTraceDataDownload, GetCredentialsForTraceDataUpload } from '../spec';
-import { getRequestHeaders, makeRequest } from '../utils';
+import { makeRequest } from '../utils';
 import { ArtifactsClient } from './base';
 import { AuthProvider, HeadersProvider } from '../../auth';
 
@@ -16,15 +16,9 @@ export interface DatabricksArtifactsClientOptions {
   host: string;
 
   /**
-   * Authentication provider (new mode)
+   * Authentication provider
    */
-  authProvider?: AuthProvider;
-
-  /**
-   * Databricks personal access token (legacy mode)
-   * @deprecated Use authProvider instead
-   */
-  databricksToken?: string;
+  authProvider: AuthProvider;
 }
 
 export class DatabricksArtifactsClient implements ArtifactsClient {
@@ -33,23 +27,7 @@ export class DatabricksArtifactsClient implements ArtifactsClient {
 
   constructor(options: DatabricksArtifactsClientOptions) {
     this.host = options.host;
-
-    if (options.authProvider) {
-      // New mode: Use AuthProvider
-      this.headersProvider = options.authProvider.getHeadersProvider();
-    } else {
-      // Legacy mode: Use databricksToken directly (backwards compatibility)
-      this.headersProvider = this.createLegacyHeadersProvider(options.databricksToken);
-    }
-  }
-
-  /**
-   * Create a legacy headers provider for backwards compatibility.
-   */
-  private createLegacyHeadersProvider(databricksToken?: string): HeadersProvider {
-    return async () => {
-      return getRequestHeaders(databricksToken);
-    };
+    this.headersProvider = options.authProvider.getHeadersProvider();
   }
 
   /**

--- a/libs/typescript/core/src/clients/artifacts/index.ts
+++ b/libs/typescript/core/src/clients/artifacts/index.ts
@@ -26,12 +26,20 @@ export interface ArtifactsClientOptions {
 /**
  * Get the appropriate artifacts client based on the tracking URI.
  *
- * @param options - Options for creating the artifacts client
+ * @param trackingUri - The tracking URI (e.g., "databricks", "http://localhost:5000")
+ * @param host - The resolved host URL for API requests
+ * @param authProvider - The authentication provider to get tokens for authenticated requests
  * @returns The appropriate artifacts client.
  */
-export function getArtifactsClient(options: ArtifactsClientOptions): ArtifactsClient {
-  const { trackingUri, host, authProvider } = options;
-
+export function getArtifactsClient({
+  trackingUri,
+  host,
+  authProvider,
+}: {
+  trackingUri: string;
+  host: string;
+  authProvider: AuthProvider;
+}): ArtifactsClient {
   if (trackingUri.startsWith('databricks')) {
     return new DatabricksArtifactsClient({ host, authProvider });
   } else {

--- a/libs/typescript/core/src/clients/artifacts/index.ts
+++ b/libs/typescript/core/src/clients/artifacts/index.ts
@@ -34,7 +34,7 @@ export interface ArtifactsClientOptions {
 export function getArtifactsClient({
   trackingUri,
   host,
-  authProvider,
+  authProvider
 }: {
   trackingUri: string;
   host: string;

--- a/libs/typescript/core/src/clients/artifacts/index.ts
+++ b/libs/typescript/core/src/clients/artifacts/index.ts
@@ -1,26 +1,47 @@
 import { ArtifactsClient } from './base';
 import { DatabricksArtifactsClient } from './databricks';
 import { MlflowArtifactsClient } from './mlflow';
+import { AuthProvider } from '../../auth';
+
+/**
+ * Options for creating an ArtifactsClient.
+ */
+export interface ArtifactsClientOptions {
+  /**
+   * The tracking URI (e.g., "databricks", "http://localhost:5000")
+   */
+  trackingUri: string;
+
+  /**
+   * The resolved host URL for API requests
+   */
+  host: string;
+
+  /**
+   * Authentication provider (new mode)
+   */
+  authProvider?: AuthProvider;
+
+  /**
+   * Databricks personal access token (legacy mode)
+   * @deprecated Use authProvider instead
+   */
+  databricksToken?: string;
+}
 
 /**
  * Get the appropriate artifacts client based on the tracking URI.
  *
- * @param trackingUri - The tracking URI to use to determine the artifacts client.
+ * @param options - Options for creating the artifacts client
  * @returns The appropriate artifacts client.
  */
-export function getArtifactsClient({
-  trackingUri,
-  host,
-  databricksToken
-}: {
-  trackingUri: string;
-  host: string;
-  databricksToken?: string;
-}): ArtifactsClient {
+export function getArtifactsClient(options: ArtifactsClientOptions): ArtifactsClient {
+  const { trackingUri, host, authProvider, databricksToken } = options;
+
   if (trackingUri.startsWith('databricks')) {
-    return new DatabricksArtifactsClient({ host, databricksToken });
+    return new DatabricksArtifactsClient({ host, authProvider, databricksToken });
   } else {
-    return new MlflowArtifactsClient({ host });
+    return new MlflowArtifactsClient({ host, authProvider });
   }
 }
 

--- a/libs/typescript/core/src/clients/artifacts/index.ts
+++ b/libs/typescript/core/src/clients/artifacts/index.ts
@@ -18,15 +18,9 @@ export interface ArtifactsClientOptions {
   host: string;
 
   /**
-   * Authentication provider (new mode)
+   * Authentication provider
    */
-  authProvider?: AuthProvider;
-
-  /**
-   * Databricks personal access token (legacy mode)
-   * @deprecated Use authProvider instead
-   */
-  databricksToken?: string;
+  authProvider: AuthProvider;
 }
 
 /**
@@ -36,10 +30,10 @@ export interface ArtifactsClientOptions {
  * @returns The appropriate artifacts client.
  */
 export function getArtifactsClient(options: ArtifactsClientOptions): ArtifactsClient {
-  const { trackingUri, host, authProvider, databricksToken } = options;
+  const { trackingUri, host, authProvider } = options;
 
   if (trackingUri.startsWith('databricks')) {
-    return new DatabricksArtifactsClient({ host, authProvider, databricksToken });
+    return new DatabricksArtifactsClient({ host, authProvider });
   } else {
     return new MlflowArtifactsClient({ host, authProvider });
   }

--- a/libs/typescript/core/src/clients/artifacts/mlflow.ts
+++ b/libs/typescript/core/src/clients/artifacts/mlflow.ts
@@ -10,7 +10,6 @@ import { AuthProvider, HeadersProvider } from '../../auth';
  */
 const TRACE_DATA_FILE_NAME = 'traces.json';
 
-
 /**
  * MLflow OSS Artifacts Client
  *
@@ -56,7 +55,11 @@ export class MlflowArtifactsClient implements ArtifactsClient {
   async downloadTraceData(traceInfo: TraceInfo): Promise<TraceData> {
     // Download the trace data file
     const artifactUrl = this.getArtifactUrlForTrace(traceInfo);
-    const traceDataJson = await makeRequest<SerializedTraceData>('GET', artifactUrl, this.headersProvider);
+    const traceDataJson = await makeRequest<SerializedTraceData>(
+      'GET',
+      artifactUrl,
+      this.headersProvider
+    );
 
     // Parse JSON back to TraceData (equivalent to Python's try_read_trace_data)
     try {

--- a/libs/typescript/core/src/clients/artifacts/mlflow.ts
+++ b/libs/typescript/core/src/clients/artifacts/mlflow.ts
@@ -1,7 +1,7 @@
 import { TraceTagKey } from '../../core/constants';
 import { SerializedTraceData, TraceData } from '../../core/entities/trace_data';
 import { TraceInfo } from '../../core/entities/trace_info';
-import { getRequestHeaders, makeRequest } from '../utils';
+import { makeRequest } from '../utils';
 import { ArtifactsClient } from './base';
 import { AuthProvider, HeadersProvider } from '../../auth';
 
@@ -20,9 +20,9 @@ export interface MlflowArtifactsClientOptions {
   host: string;
 
   /**
-   * Authentication provider (optional, for authenticated artifact endpoints)
+   * Authentication provider
    */
-  authProvider?: AuthProvider;
+  authProvider: AuthProvider;
 }
 
 /**
@@ -37,14 +37,7 @@ export class MlflowArtifactsClient implements ArtifactsClient {
 
   constructor(options: MlflowArtifactsClientOptions) {
     this.host = options.host;
-
-    if (options.authProvider) {
-      // Use AuthProvider for authenticated requests
-      this.headersProvider = options.authProvider.getHeadersProvider();
-    } else {
-      // Default: no auth (OSS MLflow artifact endpoints often don't require auth)
-      this.headersProvider = async () => getRequestHeaders();
-    }
+    this.headersProvider = options.authProvider.getHeadersProvider();
   }
 
   /**

--- a/libs/typescript/core/src/clients/client.ts
+++ b/libs/typescript/core/src/clients/client.ts
@@ -6,7 +6,6 @@ import { TraceData } from '../core/entities/trace_data';
 import { ArtifactsClient, getArtifactsClient } from './artifacts';
 import { AuthProvider, HeadersProvider } from '../auth';
 
-
 /**
  * Client for MLflow tracing operations.
  *
@@ -30,10 +29,7 @@ export class MlflowClient {
    * @param trackingUri - The tracking URI (e.g., "databricks", "http://localhost:5000")
    * @param authProvider - The authentication provider to get tokens for authenticated requests
    */
-  constructor(options: {
-    trackingUri: string;
-    authProvider: AuthProvider;
-  }) {
+  constructor(options: { trackingUri: string; authProvider: AuthProvider }) {
     this.headersProvider = options.authProvider.getHeadersProvider();
     this.hostUrl = options.authProvider.getHost();
 
@@ -62,7 +58,12 @@ export class MlflowClient {
   async createTrace(traceInfo: TraceInfo): Promise<TraceInfo> {
     const url = StartTraceV3.getEndpoint(this.hostUrl);
     const payload: StartTraceV3.Request = { trace: { trace_info: traceInfo.toJson() } };
-    const response = await makeRequest<StartTraceV3.Response>('POST', url, this.headersProvider, payload);
+    const response = await makeRequest<StartTraceV3.Response>(
+      'POST',
+      url,
+      this.headersProvider,
+      payload
+    );
     return TraceInfo.fromJson(response.trace.trace_info);
   }
 
@@ -112,7 +113,12 @@ export class MlflowClient {
   ): Promise<string> {
     const url = CreateExperiment.getEndpoint(this.hostUrl);
     const payload: CreateExperiment.Request = { name, artifact_location: artifactLocation, tags };
-    const response = await makeRequest<CreateExperiment.Response>('POST', url, this.headersProvider, payload);
+    const response = await makeRequest<CreateExperiment.Response>(
+      'POST',
+      url,
+      this.headersProvider,
+      payload
+    );
     return response.experiment_id;
   }
 

--- a/libs/typescript/core/src/clients/utils.ts
+++ b/libs/typescript/core/src/clients/utils.ts
@@ -1,4 +1,5 @@
 import { JSONBig } from '../core/utils/json';
+import { HeadersProvider } from '../auth';
 
 /**
  * Make a request to the given URL with the given method, headers, body, and timeout.
@@ -8,12 +9,13 @@ import { JSONBig } from '../core/utils/json';
 export async function makeRequest<T>(
   method: string,
   url: string,
-  headers: Record<string, string>,
+  headerProvider: HeadersProvider,
   body?: any,
   timeout?: number
 ): Promise<T> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeout ?? getDefaultTimeout());
+  const headers = await headerProvider();
 
   try {
     const response = await fetch(url, {

--- a/libs/typescript/core/src/clients/utils.ts
+++ b/libs/typescript/core/src/clients/utils.ts
@@ -1,31 +1,6 @@
 import { JSONBig } from '../core/utils/json';
 
 /**
- * Get the request headers for the given token or basic auth credentials.
- * Token will be used if provided, otherwise basic auth credentials will be used.
- *
- * @param token - The token to use to authenticate the request.
- * @param username - The username to use to authenticate the request with basic auth.
- * @param password - The password to use to authenticate the request with basic auth.
- * @returns The request headers.
- */
-export function getRequestHeaders(
-  token?: string,
-  username?: string,
-  password?: string
-): Record<string, string> {
-  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
-
-  if (token) {
-    headers['Authorization'] = `Bearer ${token}`;
-  } else if (username && password) {
-    headers['Authorization'] = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
-  }
-
-  return headers;
-}
-
-/**
  * Make a request to the given URL with the given method, headers, body, and timeout.
  *
  * TODO: add retry logic for transient errors

--- a/libs/typescript/core/src/core/provider.ts
+++ b/libs/typescript/core/src/core/provider.ts
@@ -1,7 +1,7 @@
 import { trace, Tracer } from '@opentelemetry/api';
 import { MlflowSpanExporter, MlflowSpanProcessor } from '../exporters/mlflow';
 import { NodeSDK } from '@opentelemetry/sdk-node';
-import { getConfig } from './config';
+import { getConfig, getAuthProvider } from './config';
 import { MlflowClient } from '../clients';
 
 let sdk: NodeSDK | null = null;
@@ -16,18 +16,12 @@ export function initializeSDK(): void {
   }
 
   try {
-    const hostConfig = getConfig();
-    if (!hostConfig.host) {
-      console.warn('MLflow tracking server not configured. Call init() before using tracing APIs.');
-      return;
-    }
+    const config = getConfig();
+    const authProvider = getAuthProvider();
 
     const client = new MlflowClient({
-      trackingUri: hostConfig.trackingUri,
-      host: hostConfig.host,
-      databricksToken: hostConfig.databricksToken,
-      trackingServerUsername: hostConfig.trackingServerUsername,
-      trackingServerPassword: hostConfig.trackingServerPassword
+      trackingUri: config.trackingUri,
+      authProvider
     });
     const exporter = new MlflowSpanExporter(client);
     processor = new MlflowSpanProcessor(exporter);

--- a/libs/typescript/core/tests/clients/artifacts/databricks.test.ts
+++ b/libs/typescript/core/tests/clients/artifacts/databricks.test.ts
@@ -15,9 +15,10 @@ describe('DatabricksArtifactsClient', () => {
   // Create a mock AuthProvider for testing
   const mockAuthProvider: AuthProvider = {
     getHost: () => testHost,
+    // eslint-disable-next-line require-await, @typescript-eslint/require-await
     getHeadersProvider: () => async () => ({
       'Content-Type': 'application/json',
-      'Authorization': `Bearer ${testToken}`
+      Authorization: `Bearer ${testToken}`
     }),
     getDatabricksToken: () => testToken
   };

--- a/libs/typescript/core/tests/clients/artifacts/databricks.test.ts
+++ b/libs/typescript/core/tests/clients/artifacts/databricks.test.ts
@@ -3,6 +3,7 @@ import { TraceData } from '../../../src/core/entities/trace_data';
 import { TraceLocationType } from '../../../src/core/entities/trace_location';
 import { TraceState } from '../../../src/core/entities/trace_state';
 import { DatabricksArtifactsClient } from '../../../src/clients/artifacts/databricks';
+import { AuthProvider } from '../../../src/auth';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
@@ -10,6 +11,16 @@ describe('DatabricksArtifactsClient', () => {
   let client: DatabricksArtifactsClient;
   const testHost = 'https://dbc-12345.cloud.databricks.com';
   const testToken = 'test-token';
+
+  // Create a mock AuthProvider for testing
+  const mockAuthProvider: AuthProvider = {
+    getHost: () => testHost,
+    getHeadersProvider: () => async () => ({
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${testToken}`
+    }),
+    getDatabricksToken: () => testToken
+  };
 
   let server: ReturnType<typeof setupServer>;
 
@@ -23,7 +34,7 @@ describe('DatabricksArtifactsClient', () => {
   });
 
   beforeEach(() => {
-    client = new DatabricksArtifactsClient({ host: testHost, databricksToken: testToken });
+    client = new DatabricksArtifactsClient({ host: testHost, authProvider: mockAuthProvider });
   });
 
   describe('uploadTraceData', () => {

--- a/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
+++ b/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
@@ -15,6 +15,7 @@ describe('MlflowArtifactsClient', () => {
   // Create a mock AuthProvider for testing
   const mockAuthProvider: AuthProvider = {
     getHost: () => testHost,
+    // eslint-disable-next-line require-await, @typescript-eslint/require-await
     getHeadersProvider: () => async () => ({
       'Content-Type': 'application/json'
     }),

--- a/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
+++ b/libs/typescript/core/tests/clients/artifacts/mlflow.test.ts
@@ -3,12 +3,23 @@ import { TraceInfo } from '../../../src/core/entities/trace_info';
 import { TraceData } from '../../../src/core/entities/trace_data';
 import { TraceLocationType } from '../../../src/core/entities/trace_location';
 import { TraceState } from '../../../src/core/entities/trace_state';
+import { AuthProvider } from '../../../src/auth';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 
 describe('MlflowArtifactsClient', () => {
   let client: MlflowArtifactsClient;
   let server: ReturnType<typeof setupServer>;
+  const testHost = 'http://localhost:5000';
+
+  // Create a mock AuthProvider for testing
+  const mockAuthProvider: AuthProvider = {
+    getHost: () => testHost,
+    getHeadersProvider: () => async () => ({
+      'Content-Type': 'application/json'
+    }),
+    getDatabricksToken: () => undefined
+  };
 
   beforeAll(() => {
     server = setupServer();
@@ -20,7 +31,7 @@ describe('MlflowArtifactsClient', () => {
   });
 
   beforeEach(() => {
-    client = new MlflowArtifactsClient({ host: 'http://localhost:5000' });
+    client = new MlflowArtifactsClient({ host: testHost, authProvider: mockAuthProvider });
   });
 
   describe('uploadTraceData', () => {

--- a/libs/typescript/core/tests/clients/client.test.ts
+++ b/libs/typescript/core/tests/clients/client.test.ts
@@ -3,6 +3,7 @@ import { MlflowClient } from '../../src/clients/client';
 import { TraceInfo } from '../../src/core/entities/trace_info';
 import { TraceLocationType } from '../../src/core/entities/trace_location';
 import { TraceState } from '../../src/core/entities/trace_state';
+import { createAuthProvider } from '../../src/auth';
 import { TEST_TRACKING_URI } from '../helper';
 
 describe('MlflowClient', () => {
@@ -10,7 +11,8 @@ describe('MlflowClient', () => {
   let experimentId: string;
 
   beforeEach(async () => {
-    client = new MlflowClient({ trackingUri: TEST_TRACKING_URI, host: TEST_TRACKING_URI });
+    const authProvider = createAuthProvider({ trackingUri: TEST_TRACKING_URI });
+    client = new MlflowClient({ trackingUri: TEST_TRACKING_URI, authProvider });
 
     // Create a new experiment for each test
     const experimentName = `test-experiment-${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;

--- a/libs/typescript/core/tests/core/api.test.ts
+++ b/libs/typescript/core/tests/core/api.test.ts
@@ -6,6 +6,7 @@ import { SpanStatus, SpanStatusCode } from '../../src/core/entities/span_status'
 import { TraceState } from '../../src/core/entities/trace_state';
 import { convertHrTimeToMs } from '../../src/core/utils';
 import { Trace } from '../../src/core/entities/trace';
+import { createAuthProvider } from '../../src/auth';
 import { TEST_TRACKING_URI } from '../helper';
 
 describe('API', () => {
@@ -20,7 +21,8 @@ describe('API', () => {
   };
 
   beforeAll(async () => {
-    client = new MlflowClient({ trackingUri: TEST_TRACKING_URI, host: TEST_TRACKING_URI });
+    const authProvider = createAuthProvider({ trackingUri: TEST_TRACKING_URI });
+    client = new MlflowClient({ trackingUri: TEST_TRACKING_URI, authProvider });
 
     // Create a new experiment
     const experimentName = `test-experiment-${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;

--- a/libs/typescript/core/tests/core/config.test.ts
+++ b/libs/typescript/core/tests/core/config.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { init, getConfig, readDatabricksConfig } from '../../src/core/config';
+import { init, getConfig } from '../../src/core/config';
 
 describe('Config', () => {
   describe('init and getConfig', () => {
@@ -101,7 +101,7 @@ describe('Config', () => {
       };
 
       expect(() => init(config)).toThrow(
-        "Invalid trackingUri: 'not-a-valid-uri'. Must be a valid HTTP or HTTPS URL."
+        "Invalid trackingUri: 'not-a-valid-uri'. Must be a valid HTTP or HTTPS URL, or 'databricks' / 'databricks://<profile>'."
       );
     });
 
@@ -122,16 +122,24 @@ describe('Config', () => {
 
       afterEach(() => {
         fs.rmSync(tempDir, { recursive: true, force: true });
+        delete process.env.DATABRICKS_HOST;
+        delete process.env.DATABRICKS_TOKEN;
       });
 
-      it('should read Databricks config for default profile', () => {
-        const configContent = `[DEFAULT]
-host = https://my-workspace.databricks.com
-token = dapi123456789abcdef
+      it('should throw error if host not found anywhere', () => {
+        const config = {
+          trackingUri: 'databricks',
+          experimentId: '123456789',
+          databricksConfigPath: '/nonexistent/path/.databrickscfg'
+        };
 
-[dev]
-host = https://dev-workspace.databricks.com
-token = dapi987654321fedcba`;
+        expect(() => init(config)).toThrow('Databricks host not found');
+      });
+
+      it('should read host from config file when env var not set', () => {
+        const configContent = `[DEFAULT]
+host = https://config-workspace.databricks.com
+token = dapi123456789abcdef`;
 
         fs.writeFileSync(configPath, configContent);
 
@@ -144,18 +152,17 @@ token = dapi987654321fedcba`;
         init(config);
 
         const result = getConfig();
-        expect(result.host).toBe('https://my-workspace.databricks.com');
-        expect(result.databricksToken).toBe('dapi123456789abcdef');
+        expect(result.host).toBe('https://config-workspace.databricks.com');
       });
 
-      it('should read Databricks config for specific profile', () => {
+      it('should read host from specific profile in config file', () => {
         const configContent = `[DEFAULT]
-host = https://my-workspace.databricks.com
-token = dapi123456789abcdef
+host = https://default-workspace.databricks.com
+token = default-token
 
 [dev]
 host = https://dev-workspace.databricks.com
-token = dapi987654321fedcba`;
+token = dev-token`;
 
         fs.writeFileSync(configPath, configContent);
 
@@ -169,20 +176,31 @@ token = dapi987654321fedcba`;
 
         const result = getConfig();
         expect(result.host).toBe('https://dev-workspace.databricks.com');
-        expect(result.databricksToken).toBe('dapi987654321fedcba');
       });
 
-      it('should use explicit host/token over config file', () => {
-        const configContent = `[DEFAULT]
-host = https://my-workspace.databricks.com
-token = dapi123456789abcdef`;
+      it('should use DATABRICKS_HOST from environment', () => {
+        process.env.DATABRICKS_HOST = 'https://env-workspace.databricks.com';
+        process.env.DATABRICKS_TOKEN = 'env-token';
 
-        fs.writeFileSync(configPath, configContent);
+        const config = {
+          trackingUri: 'databricks',
+          experimentId: '123456789'
+        };
+
+        init(config);
+
+        const result = getConfig();
+        expect(result.host).toBe('https://env-workspace.databricks.com');
+        expect(result.databricksToken).toBe('env-token');
+      });
+
+      it('should use explicit host/token over environment', () => {
+        process.env.DATABRICKS_HOST = 'https://env-workspace.databricks.com';
+        process.env.DATABRICKS_TOKEN = 'env-token';
 
         const config = {
           trackingUri: 'databricks',
           experimentId: '123456789',
-          databricksConfigPath: configPath,
           host: 'https://override-workspace.databricks.com',
           databricksToken: 'override-token'
         };
@@ -194,40 +212,31 @@ token = dapi123456789abcdef`;
         expect(result.databricksToken).toBe('override-token');
       });
 
-      it('should throw error if Databricks config file not found', () => {
-        const config = {
-          trackingUri: 'databricks',
-          experimentId: '123456789',
-          databricksConfigPath: '/nonexistent/path/.databrickscfg'
-        };
+      it('should prefer env var over config file for host', () => {
+        process.env.DATABRICKS_HOST = 'https://env-workspace.databricks.com';
 
-        expect(() => init(config)).toThrow(/Failed to read Databricks configuration/);
-        expect(() => init(config)).toThrow(
-          /Make sure your \/nonexistent\/path\/.databrickscfg file exists/
-        );
-      });
-
-      it('should throw error if profile not found in config', () => {
         const configContent = `[DEFAULT]
-host = https://my-workspace.databricks.com
+host = https://config-workspace.databricks.com
 token = dapi123456789abcdef`;
 
         fs.writeFileSync(configPath, configContent);
 
         const config = {
-          trackingUri: 'databricks://nonexistent',
+          trackingUri: 'databricks',
           experimentId: '123456789',
           databricksConfigPath: configPath
         };
 
-        expect(() => init(config)).toThrow(
-          /Failed to read Databricks configuration for profile 'nonexistent'/
-        );
+        init(config);
+
+        const result = getConfig();
+        // Env var takes precedence over config file
+        expect(result.host).toBe('https://env-workspace.databricks.com');
       });
 
-      it('should handle empty profile name as DEFAULT', () => {
+      it('should handle empty profile name in URI', () => {
         const configContent = `[DEFAULT]
-host = https://my-workspace.databricks.com
+host = https://default-workspace.databricks.com
 token = dapi123456789abcdef`;
 
         fs.writeFileSync(configPath, configContent);
@@ -241,212 +250,8 @@ token = dapi123456789abcdef`;
         init(config);
 
         const result = getConfig();
-        expect(result.host).toBe('https://my-workspace.databricks.com');
-        expect(result.databricksToken).toBe('dapi123456789abcdef');
+        expect(result.host).toBe('https://default-workspace.databricks.com');
       });
-
-      it('should use environment variables over config file', () => {
-        const configContent = `[DEFAULT]
-host = https://config-workspace.databricks.com
-token = config-token`;
-
-        fs.writeFileSync(configPath, configContent);
-
-        // Set environment variables
-        process.env.DATABRICKS_HOST = 'https://env-workspace.databricks.com';
-        process.env.DATABRICKS_TOKEN = 'env-token';
-
-        const config = {
-          trackingUri: 'databricks',
-          experimentId: '123456789',
-          databricksConfigPath: configPath
-        };
-
-        init(config);
-
-        const result = getConfig();
-        expect(result.host).toBe('https://env-workspace.databricks.com');
-        expect(result.databricksToken).toBe('env-token');
-
-        // Clean up environment variables
-        delete process.env.DATABRICKS_HOST;
-        delete process.env.DATABRICKS_TOKEN;
-      });
-    });
-  });
-
-  describe('readDatabricksConfig', () => {
-    const tempDir = path.join(os.tmpdir(), 'mlflow-read-test-' + Date.now());
-    const configPath = path.join(tempDir, '.databrickscfg');
-
-    beforeEach(() => {
-      fs.mkdirSync(tempDir, { recursive: true });
-    });
-
-    afterEach(() => {
-      fs.rmSync(tempDir, { recursive: true, force: true });
-    });
-
-    it('should read DEFAULT profile by default', () => {
-      const configContent = `[DEFAULT]
-host = https://default-workspace.databricks.com
-token = default-token`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      const result = readDatabricksConfig(configPath);
-      expect(result.host).toBe('https://default-workspace.databricks.com');
-      expect(result.token).toBe('default-token');
-    });
-
-    it('should read specific profile', () => {
-      const configContent = `[DEFAULT]
-host = https://default-workspace.databricks.com
-token = default-token
-
-[production]
-host = https://prod-workspace.databricks.com
-token = prod-token`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      const result = readDatabricksConfig(configPath, 'production');
-      expect(result.host).toBe('https://prod-workspace.databricks.com');
-      expect(result.token).toBe('prod-token');
-    });
-
-    it('should handle config with extra fields', () => {
-      const configContent = `[DEFAULT]
-host = https://default-workspace.databricks.com
-token = default-token
-username = user@example.com
-jobs-api-version = 2.1`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      const result = readDatabricksConfig(configPath);
-      expect(result.host).toBe('https://default-workspace.databricks.com');
-      expect(result.token).toBe('default-token');
-    });
-
-    it('should throw error if config file not found', () => {
-      expect(() => readDatabricksConfig('/nonexistent/path/.databrickscfg')).toThrow(
-        'Failed to read Databricks config: Databricks config file not found at /nonexistent/path/.databrickscfg'
-      );
-    });
-
-    it('should throw error if profile not found', () => {
-      const configContent = `[DEFAULT]
-host = https://default-workspace.databricks.com
-token = default-token`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      expect(() => readDatabricksConfig(configPath, 'nonexistent')).toThrow(
-        "Failed to read Databricks config: Profile 'nonexistent' not found in Databricks config file"
-      );
-    });
-
-    it('should throw error if host missing in profile', () => {
-      const configContent = `[DEFAULT]
-token = default-token`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      expect(() => readDatabricksConfig(configPath)).toThrow(
-        "Failed to read Databricks config: Host not found for profile 'DEFAULT' in Databricks config file"
-      );
-    });
-
-    it('should throw error if token missing in profile', () => {
-      const configContent = `[DEFAULT]
-host = https://default-workspace.databricks.com`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      expect(() => readDatabricksConfig(configPath)).toThrow(
-        "Failed to read Databricks config: Token not found for profile 'DEFAULT' in Databricks config file"
-      );
-    });
-
-    it('should handle malformed config file', () => {
-      const configContent = `This is not a valid INI file
-[missing closing bracket
-host = value`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      // The ini parser is permissive, so this might not throw, but profile won't be found
-      expect(() => readDatabricksConfig(configPath, 'DEFAULT')).toThrow(
-        /Failed to read Databricks config/
-      );
-    });
-
-    it('should read Databricks config for multiple profiles', () => {
-      const configContent = `[DEFAULT]
-host = https://default-workspace.databricks.com
-token = dapi123456789abcdef
-
-[dev]
-host = https://dev-workspace.databricks.com
-token = dapidev123456789ab
-
-[staging]
-host = https://staging-workspace.databricks.com
-token = dapistaging123456`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      // Test DEFAULT profile
-      let result = readDatabricksConfig(configPath);
-      expect(result.host).toBe('https://default-workspace.databricks.com');
-      expect(result.token).toBe('dapi123456789abcdef');
-
-      // Test dev profile
-      result = readDatabricksConfig(configPath, 'dev');
-      expect(result.host).toBe('https://dev-workspace.databricks.com');
-      expect(result.token).toBe('dapidev123456789ab');
-
-      // Test staging profile
-      result = readDatabricksConfig(configPath, 'staging');
-      expect(result.host).toBe('https://staging-workspace.databricks.com');
-      expect(result.token).toBe('dapistaging123456');
-    });
-
-    it('should handle Azure Databricks config format', () => {
-      const configContent = `[azure]
-host = https://adb-1234567890123456.7.azuredatabricks.net
-token = dapiazure123456789abcdef`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      const result = readDatabricksConfig(configPath, 'azure');
-      expect(result.host).toBe('https://adb-1234567890123456.7.azuredatabricks.net');
-      expect(result.token).toBe('dapiazure123456789abcdef');
-    });
-
-    it('should handle AWS Databricks config format', () => {
-      const configContent = `[aws]
-host = https://dbc-abcd1234-5678.cloud.databricks.com
-token = dapiaws123456789abcdef`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      const result = readDatabricksConfig(configPath, 'aws');
-      expect(result.host).toBe('https://dbc-abcd1234-5678.cloud.databricks.com');
-      expect(result.token).toBe('dapiaws123456789abcdef');
-    });
-
-    it('should handle GCP Databricks config format', () => {
-      const configContent = `[gcp]
-host = https://1234567890123456.7.gcp.databricks.com
-token = dapigcp123456789abcdef`;
-
-      fs.writeFileSync(configPath, configContent);
-
-      const result = readDatabricksConfig(configPath, 'gcp');
-      expect(result.host).toBe('https://1234567890123456.7.gcp.databricks.com');
-      expect(result.token).toBe('dapigcp123456789abcdef');
     });
   });
 });

--- a/libs/typescript/integrations/anthropic/tests/index.test.ts
+++ b/libs/typescript/integrations/anthropic/tests/index.test.ts
@@ -8,6 +8,7 @@ import { tracedAnthropic } from '../src';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { anthropicMockHandlers } from './mockAnthropicServer';
+import { createAuthProvider } from 'mlflow-tracing/src/auth';
 
 const TEST_TRACKING_URI = 'http://localhost:5000';
 
@@ -20,7 +21,8 @@ describe('tracedAnthropic', () => {
     server = setupServer(...anthropicMockHandlers);
     server.listen();
 
-    client = new mlflow.MlflowClient({ trackingUri: TEST_TRACKING_URI, host: TEST_TRACKING_URI });
+    const authProvider = createAuthProvider({ trackingUri: TEST_TRACKING_URI });
+    client = new mlflow.MlflowClient({ trackingUri: TEST_TRACKING_URI, authProvider });
 
     const experimentName = `anthropic-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
     experimentId = await client.createExperiment(experimentName);

--- a/libs/typescript/integrations/gemini/tests/index.test.ts
+++ b/libs/typescript/integrations/gemini/tests/index.test.ts
@@ -8,6 +8,7 @@ import { GoogleGenAI } from '@google/genai';
 import { http, HttpResponse } from 'msw';
 import { setupServer } from 'msw/node';
 import { geminiMockHandlers } from './mockGeminiServer';
+import { createAuthProvider } from 'mlflow-tracing/src/auth';
 
 const TEST_TRACKING_URI = 'http://localhost:5000';
 
@@ -17,7 +18,8 @@ describe('tracedGemini', () => {
   let server: ReturnType<typeof setupServer>;
 
   beforeAll(async () => {
-    client = new mlflow.MlflowClient({ trackingUri: TEST_TRACKING_URI, host: TEST_TRACKING_URI });
+    const authProvider = createAuthProvider({ trackingUri: TEST_TRACKING_URI });
+    client = new mlflow.MlflowClient({ trackingUri: TEST_TRACKING_URI, authProvider });
 
     const experimentName = `test-experiment-${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;
     experimentId = await client.createExperiment(experimentName);

--- a/libs/typescript/integrations/openai/tests/index.test.ts
+++ b/libs/typescript/integrations/openai/tests/index.test.ts
@@ -7,6 +7,7 @@ import { tracedOpenAI } from '../src';
 import { OpenAI } from 'openai';
 import { http, HttpResponse } from 'msw';
 import { openAIMswServer, useMockOpenAIServer } from '../../helpers/openaiTestHelper';
+import { createAuthProvider } from 'mlflow-tracing/src/auth';
 
 const TEST_TRACKING_URI = 'http://localhost:5000';
 
@@ -18,7 +19,8 @@ describe('tracedOpenAI', () => {
 
   beforeAll(async () => {
     // Setup MLflow client and experiment
-    client = new mlflow.MlflowClient({ trackingUri: TEST_TRACKING_URI, host: TEST_TRACKING_URI });
+    const authProvider = createAuthProvider({ trackingUri: TEST_TRACKING_URI });
+    client = new mlflow.MlflowClient({ trackingUri: TEST_TRACKING_URI, authProvider });
 
     // Create a new experiment
     const experimentName = `test-experiment-${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;

--- a/libs/typescript/package-lock.json
+++ b/libs/typescript/package-lock.json
@@ -18,6 +18,7 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@databricks/sdk-experimental": "0.15.0",
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/sdk-node": "^0.201.1",
         "bignumber.js": "^9.0.0",
@@ -602,6 +603,31 @@
       "dependencies": {
         "@types/tough-cookie": "^4.0.5",
         "tough-cookie": "^4.1.4"
+      }
+    },
+    "node_modules/@databricks/sdk-experimental": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@databricks/sdk-experimental/-/sdk-experimental-0.15.0.tgz",
+      "integrity": "sha512-HkoMiF7dNDt6WRW0xhi7oPlBJQfxJ9suJhEZRFt08VwLMaWcw2PiF8monfHlkD4lkufEYV6CTxi5njQkciqiHA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.5.0",
+        "ini": "^6.0.0",
+        "reflect-metadata": "^0.2.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": ">=22.0",
+        "npm": ">=10.0.0"
+      }
+    },
+    "node_modules/@databricks/sdk-experimental/node_modules/ini": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-6.0.0.tgz",
+      "integrity": "sha512-IBTdIkzZNOpqm7q3dRqJvMaldXjDHWkEDfrwGEQTs5eaQMWV+djAhR+wahyNNMAa+qpbDUhBMVt4ZKNwpPm7xQ==",
+      "license": "ISC",
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
@@ -2282,7 +2308,6 @@
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -2528,8 +2553,7 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -2611,8 +2635,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -2837,7 +2860,6 @@
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 12"
       }
@@ -2947,7 +2969,6 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -3326,8 +3347,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3405,7 +3425,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "node-domexception": "^1.0.0",
         "web-streams-polyfill": "^3.0.3"
@@ -3419,7 +3438,6 @@
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
       "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">= 8"
       }
@@ -3535,7 +3553,6 @@
       "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
       "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fetch-blob": "^3.1.2"
       },
@@ -3572,7 +3589,6 @@
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.2.tgz",
       "integrity": "sha512-/Szrn8nr+2TsQT1Gp8iIe/BEytJmbyfrbFh419DfGQSkEgNEhbPi7JRJuughjkTzPWgU9gBQf5AVu3DbHt0OXA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -3587,7 +3603,6 @@
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -3606,7 +3621,6 @@
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.1.tgz",
       "integrity": "sha512-dTCcAe9fRQf06ELwel6lWWFrEbstwjUBYEhr5VRGoC+iPDZQucHppCowaIp8b8v92tU1G4X4H3b/Y6zXZxkMsQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "google-logging-utils": "^1.0.0",
@@ -3780,11 +3794,10 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "10.4.2",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.4.2.tgz",
-      "integrity": "sha512-EKiQasw6aEdxSovPEf1oBxCEvxjFamZ6MPaVOSPXZMnqKFLo+rrYjHyjKlFfZcXiKi9qAH6cutr5WRqqa1jKhg==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.5.0.tgz",
+      "integrity": "sha512-7ABviyMOlX5hIVD60YOfHw4/CxOfBhyduaYB+wbFWCWoni4N7SLcV46hrVRktuBbZjFC9ONyqamZITN7q3n32w==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -3803,7 +3816,6 @@
       "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
       "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -3842,7 +3854,6 @@
       "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
       "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "gaxios": "^7.0.0",
         "jws": "^4.0.0"
@@ -3909,7 +3920,6 @@
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -4774,10 +4784,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "license": "(AFL-2.1 OR BSD-3-Clause)"
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "dev": true,
@@ -4804,7 +4810,6 @@
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -4816,7 +4821,6 @@
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
       "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jwa": "^2.0.0",
         "safe-buffer": "^5.0.1"
@@ -5142,7 +5146,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10.5.0"
       }
@@ -5619,6 +5622,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "license": "MIT",
@@ -5767,12 +5776,12 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.2",
-      "dev": true,
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6456,6 +6465,7 @@
     "node_modules/zod": {
       "version": "3.25.76",
       "license": "MIT",
+      "optional": true,
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
### What changes are proposed in this pull request?

This PR adds a new authentication module to the MLflow TypeScript SDK that provides flexible authentication for both self-hosted MLflow servers and managed MLflow services.

**Key Changes:**

1. **New `auth` module** (`libs/typescript/core/src/auth/index.ts`)
   - Provides `AuthProvider` interface with sync `getHost()` and async `getHeadersProvider()`
   - Supports basic auth (username/password) and bearer token authentication
   - Clean separation of authentication concerns from client code

2. **Updated artifacts clients**
   - Both `DatabricksArtifactsClient` and `MlflowArtifactsClient` now use `AuthProvider` pattern
   - Legacy `databricksToken` parameter kept for backwards compatibility

3. **Documentation**
   - Added authentication section to README for self-hosted MLflow servers

This change is **fully backwards compatible**.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

All 172 tests pass, including new tests for authentication configuration.

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

Updated `libs/typescript/README.md` with authentication documentation for self-hosted MLflow servers.

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

The TypeScript SDK now has a dedicated authentication module supporting basic auth and bearer token authentication for MLflow tracking servers.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [x] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)