### PR TITLE
[ Gateway 3/10 ] Add Create API Keys functionality

### DIFF
--- a/mlflow/server/js/src/gateway/api.test.ts
+++ b/mlflow/server/js/src/gateway/api.test.ts
@@ -50,7 +50,7 @@ describe('GatewayApi', () => {
       await expect(
         GatewayApi.createSecret({
           secret_name: 'duplicate-secret',
-          secret_value: 'test-value',
+          secret_value: { api_key: 'test-value' },
         }),
       ).rejects.toThrow('Secret name already exists');
     });

--- a/mlflow/server/js/src/gateway/components/api-keys/ApiKeyDetailsDrawer.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/ApiKeyDetailsDrawer.tsx
@@ -1,0 +1,121 @@
+import { useCallback } from 'react';
+import {
+  Button,
+  Drawer,
+  KeyIcon,
+  PencilIcon,
+  Spacer,
+  TrashIcon,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { SecretDetails } from '../secrets';
+import type { SecretInfo } from '../../types';
+
+interface ApiKeyDetailsDrawerProps {
+  open: boolean;
+  secret: SecretInfo | null;
+  onClose: () => void;
+  onEdit?: (secret: SecretInfo) => void;
+  onDelete?: (secret: SecretInfo) => void;
+}
+
+export const ApiKeyDetailsDrawer = ({ open, secret, onClose, onEdit, onDelete }: ApiKeyDetailsDrawerProps) => {
+  const { theme } = useDesignSystemTheme();
+  const { formatMessage } = useIntl();
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isOpen) {
+        onClose();
+      }
+    },
+    [onClose],
+  );
+
+  const handleEditClick = useCallback(() => {
+    if (secret && onEdit) {
+      onClose();
+      onEdit(secret);
+    }
+  }, [secret, onEdit, onClose]);
+
+  const handleDeleteClick = useCallback(() => {
+    if (secret && onDelete) {
+      onClose();
+      onDelete(secret);
+    }
+  }, [secret, onDelete, onClose]);
+
+  return (
+    <Drawer.Root modal open={open} onOpenChange={handleOpenChange}>
+      <Drawer.Content
+        componentId="mlflow.gateway.api-key-details.drawer"
+        width={480}
+        title={
+          <span
+            css={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: theme.spacing.sm,
+            }}
+          >
+            <span
+              css={{
+                borderRadius: theme.borders.borderRadiusSm,
+                background: theme.colors.actionDefaultBackgroundHover,
+                padding: theme.spacing.xs,
+                color: theme.colors.blue500,
+                height: 'min-content',
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+              }}
+            >
+              <KeyIcon />
+            </span>
+            <FormattedMessage defaultMessage="API Key Details" description="Title for the API key details drawer" />
+          </span>
+        }
+      >
+        <Spacer size="md" />
+        {secret && (
+          <div css={{ display: 'flex', flexDirection: 'column' }}>
+            <SecretDetails secret={secret} showCard={false} />
+            <div css={{ marginTop: theme.spacing.lg, display: 'flex', gap: theme.spacing.sm }}>
+              <Button
+                componentId="mlflow.gateway.api-key-details.drawer.edit-button"
+                icon={<PencilIcon />}
+                onClick={handleEditClick}
+                aria-label={formatMessage({
+                  defaultMessage: 'Edit API key',
+                  description: 'Gateway > API key details drawer > Edit API key button aria label',
+                })}
+              >
+                <FormattedMessage
+                  defaultMessage="Edit API Key"
+                  description="Gateway > API key details drawer > Edit API key button"
+                />
+              </Button>
+              <Button
+                componentId="mlflow.gateway.api-key-details.drawer.delete-button"
+                danger
+                icon={<TrashIcon />}
+                onClick={handleDeleteClick}
+                aria-label={formatMessage({
+                  defaultMessage: 'Delete API key',
+                  description: 'Gateway > API key details drawer > Delete API key button aria label',
+                })}
+              >
+                <FormattedMessage
+                  defaultMessage="Delete API Key"
+                  description="Gateway > API key details drawer > Delete API key button"
+                />
+              </Button>
+            </div>
+          </div>
+        )}
+      </Drawer.Content>
+    </Drawer.Root>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/api-keys/CreateApiKeyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/CreateApiKeyModal.tsx
@@ -1,0 +1,224 @@
+import { useState, useCallback, useMemo } from 'react';
+import { Alert, Modal, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { ProviderSelect } from '../create-endpoint';
+import { SecretFormFields, type SecretFormData } from '../secrets';
+import { useCreateSecret } from '../../hooks/useCreateSecret';
+import { useProviderConfigQuery } from '../../hooks/useProviderConfigQuery';
+
+interface CreateApiKeyModalProps {
+  open: boolean;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const INITIAL_FORM_DATA: SecretFormData = {
+  name: '',
+  authMode: '',
+  secretFields: {},
+  configFields: {},
+};
+
+export const CreateApiKeyModal = ({ open, onClose, onSuccess }: CreateApiKeyModalProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const [provider, setProvider] = useState('');
+  const [formData, setFormData] = useState<SecretFormData>(INITIAL_FORM_DATA);
+  const [errors, setErrors] = useState<{
+    provider?: string;
+    name?: string;
+    secretFields?: Record<string, string>;
+    configFields?: Record<string, string>;
+  }>({});
+
+  const { mutateAsync: createSecret, isLoading, error: mutationError, reset: resetMutation } = useCreateSecret();
+
+  const { data: providerConfig } = useProviderConfigQuery({ provider });
+
+  const handleProviderChange = useCallback(
+    (newProvider: string) => {
+      setProvider(newProvider);
+      setFormData(INITIAL_FORM_DATA);
+      setErrors({});
+      resetMutation();
+    },
+    [resetMutation],
+  );
+
+  const handleFormDataChange = useCallback(
+    (newData: SecretFormData) => {
+      setFormData(newData);
+      setErrors((prev) => ({
+        ...prev,
+        name: newData.name ? undefined : prev.name,
+      }));
+      resetMutation();
+    },
+    [resetMutation],
+  );
+
+  const validateForm = useCallback((): boolean => {
+    const newErrors: typeof errors = {};
+
+    if (!provider) {
+      newErrors.provider = intl.formatMessage({
+        defaultMessage: 'Provider is required',
+        description: 'Error message when provider is not selected',
+      });
+    }
+
+    if (!formData.name.trim()) {
+      newErrors.name = intl.formatMessage({
+        defaultMessage: 'Key name is required',
+        description: 'Error message when key name is empty',
+      });
+    }
+
+    const hasSecretValues = Object.values(formData.secretFields).some((v) => Boolean(v));
+    if (!hasSecretValues) {
+      newErrors.secretFields = {};
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [provider, formData.name, formData.secretFields, intl]);
+
+  const handleClose = useCallback(() => {
+    setProvider('');
+    setFormData(INITIAL_FORM_DATA);
+    setErrors({});
+    resetMutation();
+    onClose();
+  }, [onClose, resetMutation]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!validateForm()) return;
+
+    const authConfig: Record<string, string> = { ...formData.configFields };
+    if (formData.authMode) {
+      authConfig['auth_mode'] = formData.authMode;
+    }
+    const authConfigJson = Object.keys(authConfig).length > 0 ? JSON.stringify(authConfig) : undefined;
+
+    await createSecret({
+      secret_name: formData.name,
+      secret_value: formData.secretFields,
+      provider,
+      auth_config_json: authConfigJson,
+    }).then(() => {
+      handleClose();
+      onSuccess?.();
+    });
+  }, [validateForm, formData, provider, createSecret, handleClose, onSuccess]);
+
+  const errorMessage = useMemo((): string | null => {
+    if (!mutationError) return null;
+    const message = (mutationError as Error).message;
+
+    if (message.toLowerCase().includes('unique constraint') || message.toLowerCase().includes('duplicate')) {
+      return intl.formatMessage({
+        defaultMessage: 'An API key with this name already exists. Please choose a different name.',
+        description: 'Error message for duplicate key name',
+      });
+    }
+
+    if (message.length > 200) {
+      return intl.formatMessage({
+        defaultMessage: 'An error occurred while creating the API key. Please try again.',
+        description: 'Generic error message for API key creation',
+      });
+    }
+
+    return message;
+  }, [mutationError, intl]);
+
+  const selectedAuthMode = useMemo(() => {
+    if (!providerConfig?.auth_modes?.length) return undefined;
+    if (formData.authMode) {
+      return providerConfig.auth_modes.find((m) => m.mode === formData.authMode);
+    }
+    return (
+      providerConfig.auth_modes.find((m) => m.mode === providerConfig.default_mode) ?? providerConfig.auth_modes[0]
+    );
+  }, [providerConfig, formData.authMode]);
+
+  const isFormValid = useMemo(() => {
+    if (!provider) return false;
+    if (!formData.name.trim()) return false;
+
+    const requiredSecretFields = selectedAuthMode?.secret_fields?.filter((f) => f.required) ?? [];
+    const allRequiredSecretsProvided = requiredSecretFields.every((field) =>
+      Boolean(formData.secretFields[field.name]?.trim()),
+    );
+    if (!allRequiredSecretsProvided) return false;
+
+    const requiredConfigFields = selectedAuthMode?.config_fields?.filter((f) => f.required) ?? [];
+    const allRequiredConfigsProvided = requiredConfigFields.every((field) =>
+      Boolean(formData.configFields[field.name]?.trim()),
+    );
+    if (!allRequiredConfigsProvided) return false;
+
+    return true;
+  }, [provider, formData.name, formData.secretFields, formData.configFields, selectedAuthMode]);
+
+  return (
+    <Modal
+      componentId="mlflow.gateway.create-api-key-modal"
+      title={intl.formatMessage({
+        defaultMessage: 'Create API Key',
+        description: 'Title for create API key modal',
+      })}
+      visible={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      okText={intl.formatMessage({
+        defaultMessage: 'Create API Key',
+        description: 'Create API key button text',
+      })}
+      cancelText={intl.formatMessage({
+        defaultMessage: 'Cancel',
+        description: 'Cancel button text',
+      })}
+      confirmLoading={isLoading}
+      okButtonProps={{ disabled: !isFormValid }}
+      size="normal"
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+        {errorMessage && (
+          <Alert
+            componentId="mlflow.gateway.create-api-key-modal.error"
+            type="error"
+            message={errorMessage}
+            closable={false}
+          />
+        )}
+
+        <ProviderSelect
+          value={provider}
+          onChange={handleProviderChange}
+          error={errors.provider}
+          componentIdPrefix="mlflow.gateway.create-api-key-modal.provider"
+        />
+
+        {provider && (
+          <SecretFormFields
+            provider={provider}
+            value={formData}
+            onChange={handleFormDataChange}
+            errors={errors}
+            componentIdPrefix="mlflow.gateway.create-api-key-modal"
+          />
+        )}
+
+        {!provider && (
+          <div css={{ color: theme.colors.textSecondary, textAlign: 'center', padding: theme.spacing.lg }}>
+            <FormattedMessage
+              defaultMessage="Select a provider to configure your API key"
+              description="Placeholder message when no provider selected"
+            />
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/api-keys/DeleteApiKeyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/DeleteApiKeyModal.tsx
@@ -1,0 +1,49 @@
+import { FormattedMessage } from 'react-intl';
+import { DeleteConfirmationModal } from '../common';
+import { useDeleteSecret } from '../../hooks/useDeleteSecret';
+import type { SecretInfo, ModelDefinition } from '../../types';
+
+interface DeleteApiKeyModalProps {
+  open: boolean;
+  secret: SecretInfo | null;
+  modelDefinitions: ModelDefinition[];
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export const DeleteApiKeyModal = ({ open, secret, modelDefinitions, onClose, onSuccess }: DeleteApiKeyModalProps) => {
+  const { mutateAsync: deleteSecret } = useDeleteSecret();
+
+  const modelCount = modelDefinitions.length;
+  const hasModels = modelCount > 0;
+
+  const handleConfirm = async () => {
+    if (!secret) return;
+    await deleteSecret(secret.secret_id);
+    onSuccess?.();
+  };
+
+  if (!secret) return null;
+
+  return (
+    <DeleteConfirmationModal
+      open={open}
+      onClose={onClose}
+      onConfirm={handleConfirm}
+      title="Delete API Key"
+      itemName={secret.secret_name}
+      itemType="API key"
+      componentIdPrefix="mlflow.gateway.delete-api-key-modal"
+      requireConfirmation={hasModels}
+      warningMessage={
+        hasModels ? (
+          <FormattedMessage
+            defaultMessage="This key is currently used by {modelCount, plural, one {# model definition} other {# model definitions}}. After deletion, you will need to attach a different API key to {modelCount, plural, one {this model} other {these models}} via the Edit Endpoint page."
+            description="Warning about models using this key"
+            values={{ modelCount }}
+          />
+        ) : undefined
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/gateway/components/api-keys/EditApiKeyModal.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/EditApiKeyModal.tsx
@@ -1,0 +1,102 @@
+import { Alert, Input, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { SecretFormFields } from '../secrets';
+import { useEditApiKeyModal } from '../../hooks/useEditApiKeyModal';
+import { formatProviderName } from '../../utils/providerUtils';
+import type { SecretInfo } from '../../types';
+
+interface EditApiKeyModalProps {
+  open: boolean;
+  secret: SecretInfo | null;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+export const EditApiKeyModal = ({ open, secret, onClose, onSuccess }: EditApiKeyModalProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+
+  const {
+    formData,
+    errors,
+    isLoading,
+    errorMessage,
+    isFormValid,
+    provider,
+    handleFormDataChange,
+    handleSubmit,
+    handleClose,
+  } = useEditApiKeyModal({ secret, onClose, onSuccess });
+
+  if (!secret) return null;
+
+  return (
+    <Modal
+      componentId="mlflow.gateway.edit-api-key-modal"
+      title={intl.formatMessage({
+        defaultMessage: 'Edit API Key',
+        description: 'Title for edit API key modal',
+      })}
+      visible={open}
+      onCancel={handleClose}
+      onOk={handleSubmit}
+      okText={intl.formatMessage({
+        defaultMessage: 'Save Changes',
+        description: 'Save changes button text',
+      })}
+      cancelText={intl.formatMessage({
+        defaultMessage: 'Cancel',
+        description: 'Cancel button text',
+      })}
+      confirmLoading={isLoading}
+      okButtonProps={{ disabled: !isFormValid }}
+      size="normal"
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.lg }}>
+        {errorMessage && (
+          <Alert
+            componentId="mlflow.gateway.edit-api-key-modal.error"
+            type="error"
+            message={errorMessage}
+            closable={false}
+          />
+        )}
+
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          <Typography.Text bold>
+            <FormattedMessage defaultMessage="Key Name" description="Key name label" />
+          </Typography.Text>
+          <Input
+            componentId="mlflow.gateway.edit-api-key-modal.name"
+            value={secret.secret_name}
+            disabled
+            css={{ backgroundColor: theme.colors.actionDisabledBackground }}
+          />
+        </div>
+
+        {provider && (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+            <Typography.Text bold>
+              <FormattedMessage defaultMessage="Provider" description="Provider label" />
+            </Typography.Text>
+            <Input
+              componentId="mlflow.gateway.edit-api-key-modal.provider"
+              value={formatProviderName(provider)}
+              disabled
+              css={{ backgroundColor: theme.colors.actionDisabledBackground }}
+            />
+          </div>
+        )}
+
+        <SecretFormFields
+          provider={provider}
+          value={formData}
+          onChange={handleFormDataChange}
+          errors={errors}
+          componentIdPrefix="mlflow.gateway.edit-api-key-modal"
+          hideNameField
+        />
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/api-keys/index.tsx
+++ b/mlflow/server/js/src/gateway/components/api-keys/index.tsx
@@ -1,3 +1,7 @@
 export { ApiKeysColumnsButton, ApiKeysColumn, DEFAULT_VISIBLE_COLUMNS } from './ApiKeysColumnsButton';
 export { ApiKeysFilterButton, type ApiKeysFilter } from './ApiKeysFilterButton';
 export { ApiKeysList } from './ApiKeysList';
+export { CreateApiKeyModal } from './CreateApiKeyModal';
+export { EditApiKeyModal } from './EditApiKeyModal';
+export { DeleteApiKeyModal } from './DeleteApiKeyModal';
+export { ApiKeyDetailsDrawer } from './ApiKeyDetailsDrawer';

--- a/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
+++ b/mlflow/server/js/src/gateway/components/common/DeleteConfirmationModal.tsx
@@ -1,0 +1,142 @@
+import { useState, useEffect } from 'react';
+import { Alert, Button, Input, Modal, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+
+export interface DeleteConfirmationModalProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => Promise<void>;
+  title: string;
+  itemName: string;
+  itemType: string;
+  componentIdPrefix: string;
+  warningMessage?: React.ReactNode;
+  requireConfirmation?: boolean;
+}
+
+export const DeleteConfirmationModal = ({
+  open,
+  onClose,
+  onConfirm,
+  title,
+  itemName,
+  itemType,
+  componentIdPrefix,
+  warningMessage,
+  requireConfirmation = false,
+}: DeleteConfirmationModalProps) => {
+  const { theme } = useDesignSystemTheme();
+  const intl = useIntl();
+  const [confirmationText, setConfirmationText] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const isConfirmed = !requireConfirmation || confirmationText === itemName;
+
+  useEffect(() => {
+    if (!open) {
+      setConfirmationText('');
+      setError(null);
+    }
+  }, [open]);
+
+  const handleDelete = async () => {
+    if (!isConfirmed) return;
+
+    setError(null);
+    setIsDeleting(true);
+
+    try {
+      await onConfirm();
+      handleClose();
+    } catch (err) {
+      setError(
+        intl.formatMessage(
+          {
+            defaultMessage: 'Failed to delete {itemType}. Please try again.',
+            description: 'Error message when deletion fails',
+          },
+          { itemType },
+        ),
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  const handleClose = () => {
+    setConfirmationText('');
+    setError(null);
+    onClose();
+  };
+
+  return (
+    <Modal
+      componentId={`${componentIdPrefix}.modal`}
+      title={title}
+      visible={open}
+      onCancel={handleClose}
+      footer={
+        <div css={{ display: 'flex', justifyContent: 'flex-end', gap: theme.spacing.sm }}>
+          <Button componentId={`${componentIdPrefix}.cancel`} onClick={handleClose} disabled={isDeleting}>
+            <FormattedMessage defaultMessage="Cancel" description="Cancel button text" />
+          </Button>
+          <Button
+            componentId={`${componentIdPrefix}.delete`}
+            type="primary"
+            danger
+            onClick={handleDelete}
+            disabled={!isConfirmed || isDeleting}
+            loading={isDeleting}
+          >
+            <FormattedMessage defaultMessage="Delete" description="Delete button text" />
+          </Button>
+        </div>
+      }
+      size="normal"
+    >
+      <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+        {error && <Alert componentId={`${componentIdPrefix}.error`} type="error" message={error} closable={false} />}
+
+        <Typography.Text>
+          <FormattedMessage
+            defaultMessage='Are you sure you want to delete the {itemType} "{itemName}"?'
+            description="Delete confirmation message"
+            values={{
+              itemType,
+              itemName: <strong>{itemName}</strong>,
+            }}
+          />
+        </Typography.Text>
+
+        {warningMessage && (
+          <Alert
+            componentId={`${componentIdPrefix}.warning`}
+            type="warning"
+            message={warningMessage}
+            closable={false}
+          />
+        )}
+
+        {requireConfirmation && (
+          <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+            <Typography.Text>
+              <FormattedMessage
+                defaultMessage="Type {itemName} to confirm deletion:"
+                description="Type to confirm instruction"
+                values={{ itemName: <strong>{itemName}</strong> }}
+              />
+            </Typography.Text>
+            <Input
+              componentId={`${componentIdPrefix}.confirmation-input`}
+              value={confirmationText}
+              onChange={(e) => setConfirmationText(e.target.value)}
+              placeholder={itemName}
+              disabled={isDeleting}
+            />
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/common/GatewayInput.tsx
+++ b/mlflow/server/js/src/gateway/components/common/GatewayInput.tsx
@@ -1,0 +1,15 @@
+import { Input } from '@databricks/design-system';
+import type { InputProps } from '@databricks/design-system';
+
+export const GatewayInput = (props: InputProps) => {
+  return (
+    <Input
+      {...props}
+      autoComplete="off"
+      data-1p-ignore="true"
+      data-lpignore="true"
+      data-keeper-ignore="true"
+      data-form-type="other"
+    />
+  );
+};

--- a/mlflow/server/js/src/gateway/components/common/index.ts
+++ b/mlflow/server/js/src/gateway/components/common/index.ts
@@ -1,0 +1,2 @@
+export { GatewayInput } from './GatewayInput';
+export { DeleteConfirmationModal } from './DeleteConfirmationModal';

--- a/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/ProviderSelect.tsx
@@ -1,0 +1,234 @@
+import {
+  TypeaheadComboboxRoot,
+  TypeaheadComboboxInput,
+  TypeaheadComboboxMenu,
+  TypeaheadComboboxMenuItem,
+  TypeaheadComboboxSectionHeader,
+  useComboboxState,
+  useDesignSystemTheme,
+  FormUI,
+  Spinner,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useProvidersQuery } from '../../hooks/useProvidersQuery';
+import { groupProviders, formatProviderName } from '../../utils/providerUtils';
+import { useMemo, useCallback, useState } from 'react';
+
+interface ProviderSelectProps {
+  value: string;
+  onChange: (provider: string) => void;
+  disabled?: boolean;
+  error?: string;
+  componentIdPrefix?: string;
+}
+
+interface ProviderItem {
+  provider: string;
+  displayName: string;
+  group: 'common' | 'other';
+}
+
+interface ProviderSelectComboboxProps {
+  providerItems: ProviderItem[];
+  value: string;
+  onChange: (provider: string) => void;
+  disabled?: boolean;
+  error?: string;
+  componentIdPrefix: string;
+}
+
+const ProviderSelectCombobox = ({
+  providerItems,
+  value,
+  onChange,
+  disabled,
+  error,
+  componentIdPrefix,
+}: ProviderSelectComboboxProps) => {
+  const intl = useIntl();
+  const [filteredItems, setFilteredItems] = useState<(ProviderItem | null)[]>(providerItems);
+
+  const selectedItem = useMemo(() => {
+    return providerItems.find((item) => item.provider === value) ?? null;
+  }, [providerItems, value]);
+
+  const handleChange = useCallback(
+    (item: ProviderItem | null) => {
+      onChange(item?.provider ?? '');
+    },
+    [onChange],
+  );
+
+  const deferredFormOnChange = useCallback(
+    (item: ProviderItem | null) => {
+      setTimeout(() => handleChange(item), 0);
+    },
+    [handleChange],
+  );
+
+  const comboboxState = useComboboxState<ProviderItem | null>({
+    componentId: componentIdPrefix,
+    allItems: providerItems,
+    items: filteredItems,
+    setItems: setFilteredItems,
+    multiSelect: false,
+    itemToString: (item) => item?.displayName ?? '',
+    matcher: (item, query) => {
+      if (!item) return false;
+      const lowerQuery = query.toLowerCase();
+      return item.displayName.toLowerCase().includes(lowerQuery) || item.provider.toLowerCase().includes(lowerQuery);
+    },
+    formValue: selectedItem,
+    formOnChange: deferredFormOnChange,
+    initialInputValue: selectedItem?.displayName ?? '',
+  });
+
+  const handleFocus = useCallback(() => {
+    if (selectedItem) {
+      comboboxState.setInputValue('');
+      onChange('');
+    }
+  }, [selectedItem, comboboxState, onChange]);
+
+  const groupedItems = useMemo(() => {
+    const validItems = filteredItems.filter((item): item is ProviderItem => item !== null);
+    const common = validItems.filter((item) => item.group === 'common');
+    const other = validItems.filter((item) => item.group === 'other');
+    return { common, other };
+  }, [filteredItems]);
+
+  const menuItems = useMemo(() => {
+    const commonOffset = 0;
+    const otherOffset = groupedItems.common.length;
+
+    return [
+      ...(groupedItems.common.length > 0
+        ? [
+            <TypeaheadComboboxSectionHeader key="common-header">
+              {intl.formatMessage({
+                defaultMessage: 'Common Providers',
+                description: 'Section header for common providers',
+              })}
+            </TypeaheadComboboxSectionHeader>,
+            ...groupedItems.common.map((item, idx) => (
+              <TypeaheadComboboxMenuItem
+                key={item.provider}
+                item={item}
+                index={commonOffset + idx}
+                comboboxState={comboboxState}
+                data-testid={`${componentIdPrefix}.option.${item.provider}`}
+              >
+                {item.displayName}
+              </TypeaheadComboboxMenuItem>
+            )),
+          ]
+        : []),
+      ...(groupedItems.other.length > 0
+        ? [
+            <TypeaheadComboboxSectionHeader key="other-header">
+              {intl.formatMessage({
+                defaultMessage: 'Other Providers',
+                description: 'Section header for other providers',
+              })}
+            </TypeaheadComboboxSectionHeader>,
+            ...groupedItems.other.map((item, idx) => (
+              <TypeaheadComboboxMenuItem
+                key={item.provider}
+                item={item}
+                index={otherOffset + idx}
+                comboboxState={comboboxState}
+                data-testid={`${componentIdPrefix}.option.${item.provider}`}
+              >
+                {item.displayName}
+              </TypeaheadComboboxMenuItem>
+            )),
+          ]
+        : []),
+    ];
+  }, [groupedItems, comboboxState, intl, componentIdPrefix]);
+
+  return (
+    <>
+      <TypeaheadComboboxRoot id={componentIdPrefix} comboboxState={comboboxState}>
+        <TypeaheadComboboxInput
+          placeholder={intl.formatMessage({
+            defaultMessage: 'Search for a provider...',
+            description: 'Placeholder for provider search input',
+          })}
+          comboboxState={comboboxState}
+          formOnChange={handleChange}
+          validationState={error ? 'error' : undefined}
+          disabled={disabled}
+          allowClear
+          showComboboxToggleButton
+          onFocus={handleFocus}
+        />
+        <TypeaheadComboboxMenu comboboxState={comboboxState} matchTriggerWidth minWidth={300}>
+          {menuItems}
+        </TypeaheadComboboxMenu>
+      </TypeaheadComboboxRoot>
+      {error && <FormUI.Message type="error" message={error} />}
+    </>
+  );
+};
+
+export const ProviderSelect = ({
+  value,
+  onChange,
+  disabled,
+  error,
+  componentIdPrefix = 'mlflow.gateway.provider-select',
+}: ProviderSelectProps) => {
+  const { theme } = useDesignSystemTheme();
+  const { data: providers, isLoading } = useProvidersQuery();
+
+  const allProviderItems = useMemo((): ProviderItem[] => {
+    if (!providers) return [];
+
+    const { common, other } = groupProviders(providers);
+
+    const commonItems: ProviderItem[] = common.map((p) => ({
+      provider: p,
+      displayName: formatProviderName(p),
+      group: 'common' as const,
+    }));
+
+    const otherItems: ProviderItem[] = other.map((p) => ({
+      provider: p,
+      displayName: formatProviderName(p),
+      group: 'other' as const,
+    }));
+
+    return [...commonItems, ...otherItems];
+  }, [providers]);
+
+  if (isLoading || allProviderItems.length === 0) {
+    return (
+      <div>
+        <FormUI.Label htmlFor={componentIdPrefix}>
+          <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
+        </FormUI.Label>
+        <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm, marginTop: theme.spacing.xs }}>
+          <Spinner size="small" />
+          <FormattedMessage defaultMessage="Loading providers..." description="Loading message for providers" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ minWidth: 300 }}>
+      <FormUI.Label htmlFor={componentIdPrefix}>
+        <FormattedMessage defaultMessage="Provider" description="Label for provider select field" />
+      </FormUI.Label>
+      <ProviderSelectCombobox
+        providerItems={allProviderItems}
+        value={value}
+        onChange={onChange}
+        disabled={disabled}
+        error={error}
+        componentIdPrefix={componentIdPrefix}
+      />
+    </div>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/create-endpoint/index.ts
+++ b/mlflow/server/js/src/gateway/components/create-endpoint/index.ts
@@ -1,0 +1,1 @@
+export { ProviderSelect } from './ProviderSelect';

--- a/mlflow/server/js/src/gateway/components/secrets/MaskedValueDisplay.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/MaskedValueDisplay.tsx
@@ -1,0 +1,57 @@
+import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useMemo } from 'react';
+import { formatCredentialFieldName } from '../../utils/providerUtils';
+
+interface MaskedValueDisplayProps {
+  maskedValue: Record<string, string>;
+  compact?: boolean;
+}
+
+export const MaskedValueDisplay = ({ maskedValue, compact = false }: MaskedValueDisplayProps) => {
+  const { theme } = useDesignSystemTheme();
+
+  const entries = useMemo(() => Object.entries(maskedValue), [maskedValue]);
+
+  const isSingleValue = entries.length === 1;
+  const singleValue = isSingleValue ? entries[0][1] : null;
+
+  if (isSingleValue && singleValue) {
+    return (
+      <Typography.Text
+        css={{
+          fontFamily: 'monospace',
+          fontSize: theme.typography.fontSizeSm,
+          backgroundColor: theme.colors.tagDefault,
+          padding: `${theme.spacing.xs / 2}px ${theme.spacing.xs}px`,
+          borderRadius: theme.general.borderRadiusBase,
+          width: 'fit-content',
+        }}
+      >
+        {singleValue}
+      </Typography.Text>
+    );
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: compact ? 2 : theme.spacing.xs / 2 }}>
+      {entries.map(([key, value]) => (
+        <div key={key} css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.xs }}>
+          <Typography.Text color="secondary" css={{ fontSize: theme.typography.fontSizeSm }}>
+            {formatCredentialFieldName(key)}:
+          </Typography.Text>
+          <Typography.Text
+            css={{
+              fontFamily: 'monospace',
+              fontSize: theme.typography.fontSizeSm,
+              backgroundColor: theme.colors.tagDefault,
+              padding: `${theme.spacing.xs / 4}px ${theme.spacing.xs}px`,
+              borderRadius: theme.general.borderRadiusBase,
+            }}
+          >
+            {value}
+          </Typography.Text>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/secrets/SecretDetails.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretDetails.tsx
@@ -1,0 +1,165 @@
+import { useMemo } from 'react';
+import { Spacer, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { formatProviderName, formatAuthMethodName, formatCredentialFieldName } from '../../utils/providerUtils';
+import { TimeAgo } from '../../../shared/web-shared/browse/TimeAgo';
+import { MaskedValueDisplay } from './MaskedValueDisplay';
+import type { SecretInfo } from '../../types';
+
+type Theme = ReturnType<typeof useDesignSystemTheme>['theme'];
+
+const getStyles = (theme: Theme) => ({
+  labelStyle: {
+    minWidth: 100,
+    flexShrink: 0,
+  } as const,
+  rowStyle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing.sm,
+  } as const,
+  rowStyleFlexStart: {
+    display: 'flex',
+    alignItems: 'flex-start',
+    gap: theme.spacing.sm,
+  } as const,
+  containerStyle: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing.sm,
+  } as const,
+  configColumnStyle: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing.xs,
+  } as const,
+  configRowStyle: {
+    display: 'flex',
+    gap: theme.spacing.xs,
+  } as const,
+  timestampRowStyle: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing.xs,
+  } as const,
+  cardStyle: {
+    padding: theme.spacing.md,
+    border: `1px solid ${theme.colors.borderDecorative}`,
+    borderRadius: theme.general.borderRadiusBase,
+    backgroundColor: theme.colors.backgroundSecondary,
+  } as const,
+  monoStyle: {
+    fontFamily: 'monospace',
+    wordBreak: 'break-all',
+  } as const,
+});
+
+interface SecretDetailsProps {
+  secret: SecretInfo;
+  showCard?: boolean;
+}
+
+export const SecretDetails = ({ secret, showCard = true }: SecretDetailsProps) => {
+  const { theme } = useDesignSystemTheme();
+  const styles = useMemo(() => getStyles(theme), [theme]);
+
+  const authConfig = useMemo(() => {
+    return secret.auth_config ?? null;
+  }, [secret.auth_config]);
+
+  const content = (
+    <div css={{ display: 'flex', flexDirection: 'column' }}>
+      <Typography.Title level={3} css={{ margin: 0 }}>
+        {secret.secret_name}
+      </Typography.Title>
+      <Spacer size="md" />
+
+      <div css={styles.containerStyle}>
+        {secret.provider && (
+          <div css={styles.rowStyle}>
+            <Typography.Text color="secondary" css={styles.labelStyle}>
+              <FormattedMessage defaultMessage="Provider" description="Secret provider label" />
+            </Typography.Text>
+            <Typography.Text>{formatProviderName(secret.provider)}</Typography.Text>
+          </div>
+        )}
+
+        {authConfig?.['auth_mode'] && (
+          <div css={styles.rowStyle}>
+            <Typography.Text color="secondary" css={styles.labelStyle}>
+              <FormattedMessage defaultMessage="Auth Type" description="Auth type label" />
+            </Typography.Text>
+            <Typography.Text>{formatAuthMethodName(String(authConfig['auth_mode']))}</Typography.Text>
+          </div>
+        )}
+
+        <div css={styles.rowStyleFlexStart}>
+          <Typography.Text color="secondary" css={styles.labelStyle}>
+            <FormattedMessage defaultMessage="Masked Key" description="Masked API key label" />
+          </Typography.Text>
+          <MaskedValueDisplay maskedValue={secret.masked_values} />
+        </div>
+
+        {authConfig && Object.keys(authConfig).filter((k) => k !== 'auth_mode').length > 0 && (
+          <div css={styles.rowStyle}>
+            <Typography.Text color="secondary" css={styles.labelStyle}>
+              <FormattedMessage defaultMessage="Config" description="Auth config label" />
+            </Typography.Text>
+            <div css={styles.configColumnStyle}>
+              {Object.entries(authConfig)
+                .filter(([key]) => key !== 'auth_mode')
+                .map(([key, value]) => (
+                  <div key={key} css={styles.configRowStyle}>
+                    <Typography.Text color="secondary">{formatCredentialFieldName(key)}:</Typography.Text>
+                    <Typography.Text css={styles.monoStyle}>{String(value)}</Typography.Text>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        <div css={styles.rowStyle}>
+          <Typography.Text color="secondary" css={styles.labelStyle}>
+            <FormattedMessage defaultMessage="Created" description="Secret created label" />
+          </Typography.Text>
+          <div css={styles.timestampRowStyle}>
+            <TimeAgo date={new Date(secret.created_at)} />
+            {secret.created_by && (
+              <Typography.Text color="secondary">
+                <FormattedMessage
+                  defaultMessage="by {user}"
+                  description="Created by user"
+                  values={{ user: secret.created_by }}
+                />
+              </Typography.Text>
+            )}
+          </div>
+        </div>
+
+        <div css={styles.rowStyle}>
+          <Typography.Text color="secondary" css={styles.labelStyle}>
+            <FormattedMessage defaultMessage="Updated" description="Secret last updated label" />
+          </Typography.Text>
+          <div css={styles.timestampRowStyle}>
+            <TimeAgo date={new Date(secret.last_updated_at)} />
+            {secret.last_updated_by && (
+              <Typography.Text color="secondary">
+                <FormattedMessage
+                  defaultMessage="by {user}"
+                  description="Updated by user"
+                  values={{ user: secret.last_updated_by }}
+                />
+              </Typography.Text>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+
+  if (!showCard) {
+    return content;
+  }
+
+  return <div css={styles.cardStyle}>{content}</div>;
+};

--- a/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretFormFields.tsx
@@ -1,0 +1,209 @@
+import type { ChangeEvent } from 'react';
+import { FormUI, Spinner, useDesignSystemTheme, Radio, type RadioChangeEvent } from '@databricks/design-system';
+import { GatewayInput } from '../common';
+import { useMemo, useCallback } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { useProviderConfigQuery } from '../../hooks/useProviderConfigQuery';
+import { formatCredentialFieldName } from '../../utils/providerUtils';
+import { SecretInput } from './SecretInput';
+import type { AuthMode, ConfigField, SecretField } from '../../types';
+import type { SecretFormData } from './types';
+
+export interface SecretFormFieldsProps {
+  provider: string;
+  value: SecretFormData;
+  onChange: (value: SecretFormData) => void;
+  errors?: {
+    name?: string;
+    secretFields?: Record<string, string>;
+    configFields?: Record<string, string>;
+  };
+  disabled?: boolean;
+  componentIdPrefix?: string;
+  hideNameField?: boolean;
+}
+
+export const SecretFormFields = ({
+  provider,
+  value,
+  onChange,
+  errors,
+  disabled,
+  componentIdPrefix = 'mlflow.gateway.secret-form',
+  hideNameField = false,
+}: SecretFormFieldsProps) => {
+  const { theme } = useDesignSystemTheme();
+  const { formatMessage } = useIntl();
+  const { data: providerConfig, isLoading } = useProviderConfigQuery({ provider });
+
+  const authModes = useMemo(() => providerConfig?.auth_modes ?? [], [providerConfig?.auth_modes]);
+  const hasMultipleModes = authModes.length > 1;
+
+  const selectedAuthMode = useMemo((): AuthMode | undefined => {
+    if (!authModes.length) return undefined;
+    if (value.authMode) {
+      const matched = authModes.find((m) => m.mode === value.authMode);
+      if (matched) return matched;
+    }
+    return authModes.find((m) => m.mode === providerConfig?.default_mode) ?? authModes[0];
+  }, [authModes, value.authMode, providerConfig?.default_mode]);
+
+  const effectiveAuthMode = value.authMode || selectedAuthMode?.mode || '';
+
+  const handleNameChange = useCallback(
+    (newName: string) => {
+      onChange({ ...value, name: newName });
+    },
+    [onChange, value],
+  );
+
+  const handleSecretFieldChange = useCallback(
+    (fieldName: string, fieldValue: string) => {
+      onChange({
+        ...value,
+        secretFields: { ...value.secretFields, [fieldName]: fieldValue },
+      });
+    },
+    [onChange, value],
+  );
+
+  const handleConfigFieldChange = useCallback(
+    (fieldName: string, fieldValue: string) => {
+      onChange({
+        ...value,
+        configFields: { ...value.configFields, [fieldName]: fieldValue },
+      });
+    },
+    [onChange, value],
+  );
+
+  const handleAuthModeChange = useCallback(
+    (mode: string) => {
+      onChange({
+        ...value,
+        authMode: mode,
+        secretFields: {},
+        configFields: {},
+      });
+    },
+    [onChange, value],
+  );
+
+  if (!provider) {
+    return (
+      <div css={{ color: theme.colors.textSecondary }}>
+        <FormattedMessage
+          defaultMessage="Select a provider to configure API key"
+          description="Message when no provider selected for API key form"
+        />
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div css={{ display: 'flex', justifyContent: 'center', padding: theme.spacing.lg }}>
+        <Spinner size="small" />
+      </div>
+    );
+  }
+
+  return (
+    <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+      {!hideNameField && (
+        <div>
+          <FormUI.Label htmlFor={`${componentIdPrefix}.name`}>
+            <FormattedMessage defaultMessage="API key name" description="Label for API key name input" />
+            <span css={{ color: theme.colors.textValidationDanger }}> *</span>
+          </FormUI.Label>
+          <GatewayInput
+            id={`${componentIdPrefix}.name`}
+            componentId={`${componentIdPrefix}.name`}
+            value={value.name}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => handleNameChange(e.target.value)}
+            placeholder={formatMessage({
+              defaultMessage: 'my-api-key',
+              description: 'Placeholder for secret name input',
+            })}
+            validationState={errors?.name ? 'error' : undefined}
+            disabled={disabled}
+          />
+          {errors?.name && <FormUI.Message type="error" message={errors.name} />}
+        </div>
+      )}
+
+      {hasMultipleModes && (
+        <div>
+          <FormUI.Label>
+            <FormattedMessage defaultMessage="Authentication method" description="Label for auth mode selector" />
+          </FormUI.Label>
+          <Radio.Group
+            name={`${componentIdPrefix}.auth-mode`}
+            componentId={`${componentIdPrefix}.auth-mode`}
+            value={effectiveAuthMode}
+            onChange={(e: RadioChangeEvent) => handleAuthModeChange(e.target.value)}
+            disabled={disabled}
+          >
+            <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+              {authModes.map((mode) => (
+                <Radio key={mode.mode} value={mode.mode}>
+                  <div>
+                    <div css={{ fontWeight: theme.typography.typographyBoldFontWeight }}>{mode.display_name}</div>
+                    {mode.description && (
+                      <div css={{ color: theme.colors.textSecondary, fontSize: theme.typography.fontSizeSm }}>
+                        {mode.description}
+                      </div>
+                    )}
+                  </div>
+                </Radio>
+              ))}
+            </div>
+          </Radio.Group>
+        </div>
+      )}
+
+      {selectedAuthMode?.secret_fields?.map((field: SecretField) => (
+        <div key={field.name}>
+          <FormUI.Label htmlFor={`${componentIdPrefix}.secret.${field.name}`}>
+            {formatCredentialFieldName(field.name)}
+            {field.required && <span css={{ color: theme.colors.textValidationDanger }}> *</span>}
+          </FormUI.Label>
+          <SecretInput
+            id={`${componentIdPrefix}.secret.${field.name}`}
+            componentId={`${componentIdPrefix}.secret.${field.name}`}
+            value={value.secretFields[field.name] ?? ''}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => handleSecretFieldChange(field.name, e.target.value)}
+            placeholder={field.description}
+            validationState={errors?.secretFields?.[field.name] ? 'error' : undefined}
+            disabled={disabled}
+          />
+          {errors?.secretFields?.[field.name] && (
+            <FormUI.Message type="error" message={errors.secretFields[field.name]} />
+          )}
+        </div>
+      ))}
+
+      {selectedAuthMode?.config_fields?.map((field: ConfigField) => (
+        <div key={field.name}>
+          <FormUI.Label htmlFor={`${componentIdPrefix}.config.${field.name}`}>
+            {formatCredentialFieldName(field.name)}
+            {field.required && <span css={{ color: theme.colors.textValidationDanger }}> *</span>}
+          </FormUI.Label>
+          <GatewayInput
+            id={`${componentIdPrefix}.config.${field.name}`}
+            componentId={`${componentIdPrefix}.config.${field.name}`}
+            value={value.configFields[field.name] ?? ''}
+            onChange={(e: ChangeEvent<HTMLInputElement>) => handleConfigFieldChange(field.name, e.target.value)}
+            placeholder={field.description}
+            validationState={errors?.configFields?.[field.name] ? 'error' : undefined}
+            disabled={disabled}
+          />
+          {field.description && !errors?.configFields?.[field.name] && <FormUI.Hint>{field.description}</FormUI.Hint>}
+          {errors?.configFields?.[field.name] && (
+            <FormUI.Message type="error" message={errors.configFields[field.name]} />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/mlflow/server/js/src/gateway/components/secrets/SecretInput.tsx
+++ b/mlflow/server/js/src/gateway/components/secrets/SecretInput.tsx
@@ -1,0 +1,52 @@
+import { useState, useCallback } from 'react';
+import { Button, useDesignSystemTheme, VisibleIcon, VisibleOffIcon } from '@databricks/design-system';
+import type { InputProps } from '@databricks/design-system';
+import { GatewayInput } from '../common';
+
+export interface SecretInputProps extends Omit<InputProps, 'type' | 'suffix'> {
+  value: string;
+  onChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+export const SecretInput = ({ value, onChange, disabled, componentId, ...props }: SecretInputProps) => {
+  const { theme } = useDesignSystemTheme();
+  const [isVisible, setIsVisible] = useState(false);
+
+  const toggleVisibility = useCallback(() => {
+    setIsVisible((prev) => !prev);
+  }, []);
+
+  return (
+    <GatewayInput
+      {...props}
+      componentId={componentId}
+      type="text"
+      css={{
+        fontFamily: 'monospace',
+        WebkitTextSecurity: isVisible ? 'none' : 'disc',
+      }}
+      value={value}
+      onChange={onChange}
+      disabled={disabled}
+      suffix={
+        <Button
+          componentId={`${componentId}.toggle-visibility`}
+          type="tertiary"
+          size="small"
+          icon={isVisible ? <VisibleOffIcon /> : <VisibleIcon />}
+          onClick={toggleVisibility}
+          disabled={disabled}
+          aria-label={isVisible ? 'Hide value' : 'Show value'}
+          data-1p-ignore="true"
+          data-lpignore="true"
+          data-keeper-ignore="true"
+          data-form-type="other"
+          css={{
+            minWidth: 'auto',
+            padding: theme.spacing.xs,
+          }}
+        />
+      }
+    />
+  );
+};

--- a/mlflow/server/js/src/gateway/components/secrets/index.ts
+++ b/mlflow/server/js/src/gateway/components/secrets/index.ts
@@ -1,0 +1,5 @@
+export { SecretInput, type SecretInputProps } from './SecretInput';
+export { SecretFormFields } from './SecretFormFields';
+export { SecretDetails } from './SecretDetails';
+export { MaskedValueDisplay } from './MaskedValueDisplay';
+export type { SecretFormData } from './types';

--- a/mlflow/server/js/src/gateway/components/secrets/types.ts
+++ b/mlflow/server/js/src/gateway/components/secrets/types.ts
@@ -1,0 +1,16 @@
+export interface SecretFormData {
+  name: string;
+  /** Selected authentication mode */
+  authMode: string;
+  /** Secret field values (e.g., api_key, aws_access_key_id, aws_secret_access_key) */
+  secretFields: Record<string, string>;
+  /** Additional config field values (e.g., aws_region_name) */
+  configFields: Record<string, string>;
+}
+
+export const DEFAULT_SECRET_FORM_DATA: SecretFormData = {
+  name: '',
+  authMode: '',
+  secretFields: {},
+  configFields: {},
+};

--- a/mlflow/server/js/src/gateway/hooks/useApiKeysListData.ts
+++ b/mlflow/server/js/src/gateway/hooks/useApiKeysListData.ts
@@ -4,7 +4,7 @@ import { useEndpointsQuery } from './useEndpointsQuery';
 import { useBindingsQuery } from './useBindingsQuery';
 import { useModelDefinitionsQuery } from './useModelDefinitionsQuery';
 import type { SecretInfo, Endpoint, EndpointBinding, ModelDefinition } from '../types';
-import type { ApiKeysFilter } from '../components/api-keys/ApiKeysFilterButton';
+import type { ApiKeysFilter } from '../components/api-keys';
 
 interface UseApiKeysListDataParams {
   searchFilter: string;

--- a/mlflow/server/js/src/gateway/hooks/useCreateSecret.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useCreateSecret.test.tsx
@@ -1,0 +1,86 @@
+import { describe, afterEach, test, jest, expect, beforeEach } from '@jest/globals';
+import { renderHook, cleanup, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useCreateSecret } from './useCreateSecret';
+import { GatewayApi } from '../api';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useCreateSecret', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('creates secret successfully', async () => {
+    const mockResponse = {
+      secret: {
+        secret_id: 'secret-123',
+        secret_name: 'my-api-key',
+        masked_values: { api_key: 'sk-...xxx' },
+        provider: 'openai',
+        created_at: 1700000000000,
+        last_updated_at: 1700000000000,
+      },
+    };
+
+    jest.spyOn(GatewayApi, 'createSecret').mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useCreateSecret(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        secret_name: 'my-api-key',
+        secret_value: { api_key: 'sk-real-key' },
+        provider: 'openai',
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(GatewayApi.createSecret).toHaveBeenCalledWith({
+      secret_name: 'my-api-key',
+      secret_value: { api_key: 'sk-real-key' },
+      provider: 'openai',
+    });
+  });
+
+  test('handles error state', async () => {
+    const mockError = new Error('Duplicate key name');
+    jest.spyOn(GatewayApi, 'createSecret').mockRejectedValue(mockError);
+
+    const { result } = renderHook(() => useCreateSecret(), { wrapper: createWrapper() });
+
+    let caughtError: Error | undefined;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          secret_name: 'existing-key',
+          secret_value: { api_key: 'sk-key' },
+          provider: 'openai',
+        });
+      } catch (e) {
+        caughtError = e as Error;
+      }
+    });
+
+    expect(caughtError?.message).toBe('Duplicate key name');
+    expect(GatewayApi.createSecret).toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/gateway/hooks/useCreateSecret.ts
+++ b/mlflow/server/js/src/gateway/hooks/useCreateSecret.ts
@@ -1,0 +1,14 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import type { CreateSecretRequest, CreateSecretInfoResponse } from '../types';
+
+export const useCreateSecret = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<CreateSecretInfoResponse, Error, CreateSecretRequest>({
+    mutationFn: (request) => GatewayApi.createSecret(request),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['gateway_secrets']);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/hooks/useDeleteSecret.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useDeleteSecret.test.tsx
@@ -1,0 +1,62 @@
+import { describe, afterEach, test, jest, expect, beforeEach } from '@jest/globals';
+import { renderHook, cleanup, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useDeleteSecret } from './useDeleteSecret';
+import { GatewayApi } from '../api';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useDeleteSecret', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('deletes secret successfully', async () => {
+    jest.spyOn(GatewayApi, 'deleteSecret').mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteSecret(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync('secret-123');
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(GatewayApi.deleteSecret).toHaveBeenCalledWith('secret-123');
+  });
+
+  test('handles error state', async () => {
+    jest.spyOn(GatewayApi, 'deleteSecret').mockRejectedValue(new Error('Secret not found'));
+
+    const { result } = renderHook(() => useDeleteSecret(), { wrapper: createWrapper() });
+
+    let caughtError: Error | undefined;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync('nonexistent');
+      } catch (e) {
+        caughtError = e as Error;
+      }
+    });
+
+    expect(caughtError?.message).toBe('Secret not found');
+    expect(GatewayApi.deleteSecret).toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/gateway/hooks/useDeleteSecret.ts
+++ b/mlflow/server/js/src/gateway/hooks/useDeleteSecret.ts
@@ -1,0 +1,13 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+
+export const useDeleteSecret = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (secretId: string) => GatewayApi.deleteSecret(secretId),
+    onSuccess: () => {
+      queryClient.invalidateQueries(['gateway_secrets']);
+    },
+  });
+};

--- a/mlflow/server/js/src/gateway/hooks/useEditApiKeyModal.ts
+++ b/mlflow/server/js/src/gateway/hooks/useEditApiKeyModal.ts
@@ -1,0 +1,157 @@
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useIntl } from 'react-intl';
+import { useUpdateSecret } from './useUpdateSecret';
+import { useProviderConfigQuery } from './useProviderConfigQuery';
+import type { SecretFormData } from '../components/secrets/types';
+import type { SecretInfo } from '../types';
+
+interface UseEditApiKeyModalParams {
+  secret: SecretInfo | null;
+  onClose: () => void;
+  onSuccess?: () => void;
+}
+
+const INITIAL_FORM_DATA: SecretFormData = {
+  name: '',
+  authMode: '',
+  secretFields: {},
+  configFields: {},
+};
+
+export const useEditApiKeyModal = ({ secret, onClose, onSuccess }: UseEditApiKeyModalParams) => {
+  const intl = useIntl();
+  const [formData, setFormData] = useState<SecretFormData>(INITIAL_FORM_DATA);
+  const [errors, setErrors] = useState<{
+    secretFields?: Record<string, string>;
+    configFields?: Record<string, string>;
+  }>({});
+
+  const { mutateAsync: updateSecret, isLoading, error: mutationError, reset: resetMutation } = useUpdateSecret();
+
+  const provider = secret?.provider ?? '';
+  const { data: providerConfig } = useProviderConfigQuery({ provider });
+
+  const resetMutationRef = useRef(resetMutation);
+  resetMutationRef.current = resetMutation;
+
+  useEffect(() => {
+    if (secret) {
+      let authMode = '';
+      if (secret.auth_config?.['auth_mode']) {
+        authMode = String(secret.auth_config['auth_mode']);
+      }
+      setFormData({
+        name: secret.secret_name,
+        authMode,
+        secretFields: {},
+        configFields: {},
+      });
+      setErrors({});
+      resetMutationRef.current();
+    }
+  }, [secret]);
+
+  const handleFormDataChange = useCallback(
+    (newData: SecretFormData) => {
+      setFormData(newData);
+      resetMutation();
+    },
+    [resetMutation],
+  );
+
+  const validateForm = useCallback((): boolean => {
+    const newErrors: typeof errors = {};
+
+    const hasSecretValues = Object.values(formData.secretFields).some((v) => Boolean(v));
+    if (!hasSecretValues) {
+      newErrors.secretFields = {};
+    }
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  }, [formData.secretFields]);
+
+  const handleClose = useCallback(() => {
+    setFormData(INITIAL_FORM_DATA);
+    setErrors({});
+    resetMutation();
+    onClose();
+  }, [onClose, resetMutation]);
+
+  const errorMessage = useMemo((): string | null => {
+    if (!mutationError) return null;
+    const message = (mutationError as Error).message;
+
+    if (message.length > 200) {
+      return intl.formatMessage({
+        defaultMessage: 'An error occurred while updating the API key. Please try again.',
+        description: 'Generic error message for API key update',
+      });
+    }
+
+    return message;
+  }, [mutationError, intl]);
+
+  const selectedAuthMode = useMemo(() => {
+    if (!providerConfig?.auth_modes?.length) return undefined;
+    if (formData.authMode) {
+      return providerConfig.auth_modes.find((m) => m.mode === formData.authMode);
+    }
+    return (
+      providerConfig.auth_modes.find((m) => m.mode === providerConfig.default_mode) ?? providerConfig.auth_modes[0]
+    );
+  }, [providerConfig, formData.authMode]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!secret || !validateForm()) return;
+
+    try {
+      const effectiveAuthMode = formData.authMode || selectedAuthMode?.mode;
+      const authConfig: Record<string, string> = { ...formData.configFields };
+      if (effectiveAuthMode) {
+        authConfig['auth_mode'] = effectiveAuthMode;
+      }
+      const authConfigJson = Object.keys(authConfig).length > 0 ? JSON.stringify(authConfig) : undefined;
+
+      await updateSecret({
+        secret_id: secret.secret_id,
+        secret_value: formData.secretFields,
+        auth_config_json: authConfigJson,
+      });
+
+      handleClose();
+      onSuccess?.();
+    } catch {
+      // Error is handled by mutation state
+    }
+  }, [secret, validateForm, formData, selectedAuthMode, updateSecret, handleClose, onSuccess]);
+
+  const isFormValid = useMemo(() => {
+    const requiredSecretFields = selectedAuthMode?.secret_fields?.filter((f) => f.required) ?? [];
+    const allRequiredSecretsProvided = requiredSecretFields.every((field) =>
+      Boolean(formData.secretFields[field.name]?.trim()),
+    );
+    if (!allRequiredSecretsProvided) return false;
+
+    const requiredConfigFields = selectedAuthMode?.config_fields?.filter((f) => f.required) ?? [];
+    const allRequiredConfigsProvided = requiredConfigFields.every((field) =>
+      Boolean(formData.configFields[field.name]?.trim()),
+    );
+    if (!allRequiredConfigsProvided) return false;
+
+    return true;
+  }, [formData.secretFields, formData.configFields, selectedAuthMode]);
+
+  return {
+    formData,
+    errors,
+    isLoading,
+    errorMessage,
+    selectedAuthMode,
+    isFormValid,
+    provider,
+    handleFormDataChange,
+    handleSubmit,
+    handleClose,
+  };
+};

--- a/mlflow/server/js/src/gateway/hooks/useSecretQuery.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useSecretQuery.test.tsx
@@ -1,0 +1,75 @@
+import { describe, afterEach, test, jest, expect, beforeEach } from '@jest/globals';
+import { renderHook, cleanup, waitFor } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useSecretQuery } from './useSecretQuery';
+import { GatewayApi } from '../api';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useSecretQuery', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('fetches secret by ID successfully', async () => {
+    const mockResponse = {
+      secret: {
+        secret_id: 'secret-123',
+        secret_name: 'my-api-key',
+        masked_values: { api_key: 'sk-...xxx' },
+        provider: 'openai',
+        created_at: 1700000000000,
+        last_updated_at: 1700000000000,
+      },
+    };
+
+    jest.spyOn(GatewayApi, 'getSecret').mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useSecretQuery('secret-123'), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(GatewayApi.getSecret).toHaveBeenCalledWith('secret-123');
+    expect(result.current.data?.secret.secret_id).toBe('secret-123');
+    expect(result.current.error).toBeFalsy();
+  });
+
+  test('does not fetch when secretId is undefined', () => {
+    jest.spyOn(GatewayApi, 'getSecret');
+
+    const { result } = renderHook(() => useSecretQuery(undefined), { wrapper: createWrapper() });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(GatewayApi.getSecret).not.toHaveBeenCalled();
+    expect(result.current.data).toBeUndefined();
+  });
+
+  test('handles error state', async () => {
+    jest.spyOn(GatewayApi, 'getSecret').mockRejectedValue(new Error('Secret not found'));
+
+    const { result } = renderHook(() => useSecretQuery('nonexistent'), { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBeInstanceOf(Error);
+    expect((result.current.error as Error).message).toBe('Secret not found');
+  });
+});

--- a/mlflow/server/js/src/gateway/hooks/useSecretQuery.ts
+++ b/mlflow/server/js/src/gateway/hooks/useSecretQuery.ts
@@ -1,0 +1,9 @@
+import { useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+
+export const useSecretQuery = (secretId: string | undefined) => {
+  return useQuery(['gateway_secret', secretId], {
+    queryFn: () => GatewayApi.getSecret(secretId!),
+    enabled: Boolean(secretId),
+  });
+};

--- a/mlflow/server/js/src/gateway/hooks/useSecretsQuery.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useSecretsQuery.test.tsx
@@ -52,7 +52,7 @@ describe('useSecretsQuery', () => {
 
     expect(result.current.data).toHaveLength(2);
     expect(result.current.data[0].secret_id).toBe('secret-1');
-    expect(result.current.error).toBeUndefined();
+    expect(result.current.error).toBeFalsy();
   });
 
   test('returns empty array when no secrets exist', async () => {
@@ -67,7 +67,7 @@ describe('useSecretsQuery', () => {
     });
 
     expect(result.current.data).toEqual([]);
-    expect(result.current.error).toBeUndefined();
+    expect(result.current.error).toBeFalsy();
   });
 
   test('filters secrets by provider', async () => {

--- a/mlflow/server/js/src/gateway/hooks/useUpdateSecret.test.tsx
+++ b/mlflow/server/js/src/gateway/hooks/useUpdateSecret.test.tsx
@@ -1,0 +1,82 @@
+import { describe, afterEach, test, jest, expect, beforeEach } from '@jest/globals';
+import { renderHook, cleanup, waitFor, act } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useUpdateSecret } from './useUpdateSecret';
+import { GatewayApi } from '../api';
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useUpdateSecret', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  test('updates secret successfully', async () => {
+    const mockResponse = {
+      secret: {
+        secret_id: 'secret-123',
+        secret_name: 'my-api-key',
+        masked_values: { api_key: 'sk-...new' },
+        provider: 'openai',
+        created_at: 1700000000000,
+        last_updated_at: 1700001000000,
+      },
+    };
+
+    jest.spyOn(GatewayApi, 'updateSecret').mockResolvedValue(mockResponse);
+
+    const { result } = renderHook(() => useUpdateSecret(), { wrapper: createWrapper() });
+
+    await act(async () => {
+      await result.current.mutateAsync({
+        secret_id: 'secret-123',
+        secret_value: { api_key: 'sk-new-key' },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(GatewayApi.updateSecret).toHaveBeenCalledWith({
+      secret_id: 'secret-123',
+      secret_value: { api_key: 'sk-new-key' },
+    });
+  });
+
+  test('handles error state', async () => {
+    jest.spyOn(GatewayApi, 'updateSecret').mockRejectedValue(new Error('Secret not found'));
+
+    const { result } = renderHook(() => useUpdateSecret(), { wrapper: createWrapper() });
+
+    let caughtError: Error | undefined;
+    await act(async () => {
+      try {
+        await result.current.mutateAsync({
+          secret_id: 'nonexistent',
+          secret_value: { api_key: 'sk-key' },
+        });
+      } catch (e) {
+        caughtError = e as Error;
+      }
+    });
+
+    expect(caughtError?.message).toBe('Secret not found');
+    expect(GatewayApi.updateSecret).toHaveBeenCalled();
+  });
+});

--- a/mlflow/server/js/src/gateway/hooks/useUpdateSecret.ts
+++ b/mlflow/server/js/src/gateway/hooks/useUpdateSecret.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { GatewayApi } from '../api';
+import type { UpdateSecretRequest, UpdateSecretInfoResponse } from '../types';
+
+export const useUpdateSecret = () => {
+  return useMutation<UpdateSecretInfoResponse, Error, UpdateSecretRequest>({
+    mutationFn: (request) => GatewayApi.updateSecret(request),
+  });
+};

--- a/mlflow/server/js/src/gateway/pages/ApiKeysPage.tsx
+++ b/mlflow/server/js/src/gateway/pages/ApiKeysPage.tsx
@@ -1,11 +1,13 @@
-import { Typography, useDesignSystemTheme } from '@databricks/design-system';
+import { useState } from 'react';
+import { Button, PlusIcon, Typography, useDesignSystemTheme } from '@databricks/design-system';
 import { FormattedMessage } from 'react-intl';
 import { withErrorBoundary } from '../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../common/utils/ErrorUtils';
-import { ApiKeysList } from '../components/api-keys';
+import { ApiKeysList, CreateApiKeyModal } from '../components/api-keys';
 
 const ApiKeysPage = () => {
   const { theme } = useDesignSystemTheme();
+  const [isCreateModalOpen, setIsCreateModalOpen] = useState(false);
 
   return (
     <div css={{ display: 'flex', flexDirection: 'column', flex: 1, overflow: 'hidden' }}>
@@ -21,11 +23,28 @@ const ApiKeysPage = () => {
         <Typography.Title level={3} css={{ margin: 0 }}>
           <FormattedMessage defaultMessage="API Keys" description="API Keys page title" />
         </Typography.Title>
+        <Button
+          componentId="mlflow.gateway.api-keys.create-button"
+          type="primary"
+          icon={<PlusIcon />}
+          onClick={() => setIsCreateModalOpen(true)}
+        >
+          <FormattedMessage
+            defaultMessage="Create API key"
+            description="Gateway > API keys page > Create API key button"
+          />
+        </Button>
       </div>
 
       <div css={{ flex: 1, overflow: 'auto', padding: theme.spacing.md }}>
         <ApiKeysList />
       </div>
+
+      <CreateApiKeyModal
+        open={isCreateModalOpen}
+        onClose={() => setIsCreateModalOpen(false)}
+        onSuccess={() => setIsCreateModalOpen(false)}
+      />
     </div>
   );
 };

--- a/mlflow/server/js/src/gateway/types.ts
+++ b/mlflow/server/js/src/gateway/types.ts
@@ -57,7 +57,7 @@ export interface SecretInfo {
 
 export interface CreateSecretRequest {
   secret_name: string;
-  secret_value: string;
+  secret_value: Record<string, string>;
   provider?: string;
   auth_config_json?: string;
   created_by?: string;
@@ -73,7 +73,7 @@ export interface GetSecretInfoResponse {
 
 export interface UpdateSecretRequest {
   secret_id: string;
-  secret_value: string;
+  secret_value: Record<string, string>;
   auth_config_json?: string;
   updated_by?: string;
 }

--- a/mlflow/server/js/src/gateway/utils/providerUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/providerUtils.ts
@@ -1,3 +1,36 @@
+export const COMMON_PROVIDERS = [
+  'openai',
+  'anthropic',
+  'databricks',
+  'bedrock',
+  'gemini',
+  'vertex_ai',
+  'azure',
+  'xai',
+] as const;
+
+export function groupProviders(providers: string[]): {
+  common: string[];
+  other: string[];
+} {
+  const commonSet = new Set<string>(COMMON_PROVIDERS);
+  const common: string[] = [];
+  const other: string[] = [];
+
+  for (const provider of providers) {
+    if (commonSet.has(provider)) {
+      common.push(provider);
+    } else {
+      other.push(provider);
+    }
+  }
+
+  common.sort((a, b) => COMMON_PROVIDERS.indexOf(a as any) - COMMON_PROVIDERS.indexOf(b as any));
+  other.sort((a, b) => a.localeCompare(b));
+
+  return { common, other };
+}
+
 export function formatProviderName(provider: string): string {
   const formatMap: Record<string, string> = {
     openai: 'OpenAI',
@@ -22,4 +55,43 @@ export function formatProviderName(provider: string): string {
     cerebras: 'Cerebras',
   };
   return formatMap[provider] ?? provider.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function formatAuthMethodName(authMethod: string): string {
+  const formatMap: Record<string, string> = {
+    auth_token: 'Auth Token',
+    api_key: 'API Key',
+    access_key: 'Access Key',
+    sts: 'STS (Assume Role)',
+    oauth: 'OAuth',
+    oauth2: 'OAuth 2.0',
+    service_account: 'Service Account',
+    bearer_token: 'Bearer Token',
+    basic_auth: 'Basic Auth',
+    pat: 'Personal Access Token',
+  };
+  return formatMap[authMethod] ?? authMethod.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+export function formatCredentialFieldName(fieldName: string): string {
+  const formatMap: Record<string, string> = {
+    api_key: 'API Key',
+    aws_access_key_id: 'AWS Access Key ID',
+    aws_secret_access_key: 'AWS Secret Access Key',
+    aws_session_token: 'AWS Session Token',
+    aws_region_name: 'AWS Region',
+    aws_role_name: 'AWS Role Name',
+    aws_session_name: 'AWS Session Name',
+    client_secret: 'Client Secret',
+    client_id: 'Client ID',
+    tenant_id: 'Tenant ID',
+    api_base: 'API Base URL',
+    api_version: 'API Version',
+    vertex_credentials: 'Service Account Credentials',
+    vertex_project: 'Project ID',
+    vertex_location: 'Location',
+    databricks_token: 'Databricks Token',
+    databricks_host: 'Databricks Host',
+  };
+  return formatMap[fieldName] ?? fieldName.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
 }

--- a/mlflow/server/js/src/gateway/utils/secretUtils.ts
+++ b/mlflow/server/js/src/gateway/utils/secretUtils.ts
@@ -1,0 +1,10 @@
+import type { SecretInfo } from '../types';
+
+export function parseAuthConfig(secret: SecretInfo | undefined | null): Record<string, string> | null {
+  if (!secret) return null;
+  return secret.auth_config ?? null;
+}
+
+export function isSingleMaskedValue(maskedValue: Record<string, string>): boolean {
+  return Object.keys(maskedValue).length === 1;
+}

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -239,6 +239,10 @@
     "defaultMessage": "Show exceptions",
     "description": "Checkbox label for a setting that enables showing spans with exceptions in the trace explorer regardless of filter conditions."
   },
+  "/y0ZU4": {
+    "defaultMessage": "Updated",
+    "description": "Secret last updated label"
+  },
   "033qfw": {
     "defaultMessage": "Select a framework and follow the instructions to log traces with MLflow.",
     "description": "Helper text shown at the top of the log traces drawer"
@@ -310,6 +314,10 @@
   "0pdAuV": {
     "defaultMessage": "Active",
     "description": "Linked model dropdown option to show active experiment runs"
+  },
+  "0sy/fq": {
+    "defaultMessage": "Create API key",
+    "description": "Gateway > API keys page > Create API key button"
   },
   "0tU5gv": {
     "defaultMessage": "Cancel",
@@ -638,6 +646,10 @@
     "defaultMessage": "Value (optional)",
     "description": "Key-value tag editor modal > Value input label"
   },
+  "4CNVbz": {
+    "defaultMessage": "API key name",
+    "description": "Label for API key name input"
+  },
   "4GPLHq": {
     "defaultMessage": "Aliases allow you to assign a mutable, named reference to a particular prompt version.",
     "description": "Description for the edit aliases modal on the registered prompt details page"
@@ -809,6 +821,10 @@
   "5m2VPy": {
     "defaultMessage": "Image grid",
     "description": "Experiment tracking > runs charts > add chart menu > image grid"
+  },
+  "5qRFq/": {
+    "defaultMessage": "Delete",
+    "description": "Delete button text"
   },
   "5xPlEu": {
     "defaultMessage": "Source run",
@@ -1186,6 +1202,10 @@
     "defaultMessage": "Pin group",
     "description": "A tooltip for the pin icon button in the runs table next to the not pinned run group"
   },
+  "8iJrii": {
+    "defaultMessage": "Edit API Key",
+    "description": "Gateway > API key details drawer > Edit API key button"
+  },
   "8ikgws": {
     "defaultMessage": "Turn {turnNumber}",
     "description": "Label for a single turn within an experiment chat session"
@@ -1217,6 +1237,10 @@
   "9/KT56": {
     "defaultMessage": "Prompts",
     "description": "Label for the prompts tab in the MLflow experiment navbar"
+  },
+  "90097b": {
+    "defaultMessage": "Masked Key",
+    "description": "Masked API key label"
   },
   "93BFzC": {
     "defaultMessage": "Outputs",
@@ -1373,6 +1397,10 @@
   "AFI74W": {
     "defaultMessage": "Group by: {value}",
     "description": "Experiment page > group by runs control > trigger button label > with value"
+  },
+  "AGLzB5": {
+    "defaultMessage": "my-api-key",
+    "description": "Placeholder for secret name input"
   },
   "AGWpnl": {
     "defaultMessage": "Add tags",
@@ -1562,6 +1590,10 @@
     "defaultMessage": "Only the top {evalResultsCount} results are shown",
     "description": "Evaluation review > evaluations list > sample info tooltip"
   },
+  "BrQez2": {
+    "defaultMessage": "Provider",
+    "description": "Label for provider select field"
+  },
   "Bs2X0L": {
     "defaultMessage": "Created by",
     "description": "Label for the creator of a logged model on the logged model details page"
@@ -1722,6 +1754,10 @@
     "defaultMessage": "Thank you for exploring the new Model Registry UI. We are dedicated to providing the best experience, and your feedback is invaluable. Please share your thoughts with us <link>here</link>.",
     "description": "Model registry > Switcher for the new model registry UI containing aliases > disable confirmation modal content"
   },
+  "DMKCLJ": {
+    "defaultMessage": "API Key Details",
+    "description": "Title for the API key details drawer"
+  },
   "DMOaoR": {
     "defaultMessage": "Safe",
     "description": "Evaluation results > safety assessment > positive value label. Displayed if evaluation result is considered as safe."
@@ -1749,6 +1785,10 @@
   "Dm4Ez0": {
     "defaultMessage": "Filter",
     "description": "Label for the filter button in the trace explorer."
+  },
+  "DwsF2a": {
+    "defaultMessage": "Other Providers",
+    "description": "Section header for other providers"
   },
   "E+x0F4": {
     "defaultMessage": "Gateway",
@@ -2350,6 +2390,10 @@
     "defaultMessage": "Hugging Face",
     "description": "Experiment dataset drawer > source type > Hugging Face source type label"
   },
+  "JwhonN": {
+    "defaultMessage": "Authentication method",
+    "description": "Label for auth mode selector"
+  },
   "Jxhb2w": {
     "defaultMessage": "We've automatically detected the experiment type to be ''{kindLabel}''. {isEditable, select, true {You can either confirm or change the type.} other {}}",
     "description": "Popover message for inferred experiment kind"
@@ -2401,6 +2445,10 @@
   "KMVqUP": {
     "defaultMessage": "Tags",
     "description": "Header for the tags column in the registered prompts table"
+  },
+  "KRzwkL": {
+    "defaultMessage": "Type {itemName} to confirm deletion:",
+    "description": "Type to confirm instruction"
   },
   "KV3BXl": {
     "defaultMessage": "Select as baseline version",
@@ -2537,6 +2585,10 @@
   "LpdcPw": {
     "defaultMessage": "Model versions",
     "description": "Label for the model versions of a logged model on the logged model details page"
+  },
+  "Lpz85i": {
+    "defaultMessage": "Edit API Key",
+    "description": "Title for edit API key modal"
   },
   "Ls2ris": {
     "defaultMessage": "Mark as reviewed",
@@ -2842,6 +2894,10 @@
     "defaultMessage": "Running",
     "description": "Run page > Overview > Run status cell > Value for running state"
   },
+  "OxQK9l": {
+    "defaultMessage": "Key name is required",
+    "description": "Error message when key name is empty"
+  },
   "OzyPl3": {
     "defaultMessage": "Please select parameters",
     "description": "Placeholder text for parameters in parallel coordinates plot in MLflow"
@@ -3049,9 +3105,21 @@
     "defaultMessage": "Advanced settings (optional)",
     "description": "Toggle button for advanced settings in prompt creation modal"
   },
+  "R2NKiZ": {
+    "defaultMessage": "Config",
+    "description": "Auth config label"
+  },
   "R3Lb6z": {
     "defaultMessage": "The requested resource was not found.",
     "description": "Resource not found (HTTP STATUS 404) generic error message"
+  },
+  "R3TrL7": {
+    "defaultMessage": "Provider",
+    "description": "Provider label"
+  },
+  "R7s1xC": {
+    "defaultMessage": "Provider is required",
+    "description": "Error message when provider is not selected"
   },
   "RCjxf0": {
     "defaultMessage": "Compare runs",
@@ -3157,6 +3225,10 @@
     "defaultMessage": "Description",
     "description": "Row heading in a table that contains the description of a function parameter."
   },
+  "SMVe/s": {
+    "defaultMessage": "Save Changes",
+    "description": "Save changes button text"
+  },
   "SNvZyR": {
     "defaultMessage": "Time",
     "description": "Label for the time axis on the runs compare chart"
@@ -3252,6 +3324,10 @@
   "T4eipT": {
     "defaultMessage": "Line Smoothness",
     "description": "Label for the smoothness slider for the graph plot for metrics"
+  },
+  "T6s9Mi": {
+    "defaultMessage": "Delete API Key",
+    "description": "Gateway > API key details drawer > Delete API key button"
   },
   "TBX+Gs": {
     "defaultMessage": "Add/Edit tags",
@@ -3395,6 +3471,10 @@
   "UWHfmZ": {
     "defaultMessage": "Group:",
     "description": "Label for a group of runs in the evaluation runs table"
+  },
+  "UXdH8W": {
+    "defaultMessage": "Create API Key",
+    "description": "Create API key button text"
   },
   "UYSMKb": {
     "defaultMessage": "Schema is too large to display all rows. Please search for a column name to filter the results. Currently showing {currentResults} results from {allResults} total rows.",
@@ -3803,6 +3883,10 @@
     "defaultMessage": "Compare",
     "description": "Label for the compare experiments action on the experiments list page"
   },
+  "YGo9ni": {
+    "defaultMessage": "Select a provider to configure API key",
+    "description": "Message when no provider selected for API key form"
+  },
   "YINJEO": {
     "defaultMessage": "Metric",
     "description": "Column title for the column displaying the metric names for a run"
@@ -3887,6 +3971,10 @@
     "defaultMessage": "Confirm",
     "description": "A label for the confirmation button in the modal displayed when the experiment type could not be inferred"
   },
+  "Z4cZMo": {
+    "defaultMessage": "by {user}",
+    "description": "Created by user"
+  },
   "Z5en2d": {
     "defaultMessage": "Versions",
     "description": "Title text for the versions section under details tab on the\n                       model view page"
@@ -3894,6 +3982,10 @@
   "Z6kodo": {
     "defaultMessage": "Move down",
     "description": "Experiment page > compare runs tab > chart header > move down option"
+  },
+  "ZAqdq9": {
+    "defaultMessage": "Edit API key",
+    "description": "Gateway > API key details drawer > Edit API key button aria label"
   },
   "ZBRK9J": {
     "defaultMessage": "Export traces to datasets",
@@ -4078,6 +4170,10 @@
   "aQxQIF": {
     "defaultMessage": "(empty)",
     "description": "Experiment page > artifact compare view > results table > no result (empty cell)"
+  },
+  "aTnlkS": {
+    "defaultMessage": "Search for a provider...",
+    "description": "Placeholder for provider search input"
   },
   "aUOkOC": {
     "defaultMessage": "The chunk-relevance-precision LLM judge determines whether the chunks returned by the retriever are relevant to the input request. Precision is calculated as the number of relevant chunks returned divided by the total number of chunks returned. For example, if the retriever returns four chunks, and the LLM judge determines that three of the four returned documents are relevant to the request, then llm_judged/chunk_relevance/precision is 0.75.",
@@ -4291,6 +4387,10 @@
     "defaultMessage": "Maximum number of language tokens returned from evaluation.",
     "description": "Experiment page > prompt lab > max tokens parameter help text"
   },
+  "cGGc0A": {
+    "defaultMessage": "Delete API key",
+    "description": "Gateway > API key details drawer > Delete API key button aria label"
+  },
   "cHDnV/": {
     "defaultMessage": "LLM template",
     "description": "Section header for LLM template selection"
@@ -4346,6 +4446,10 @@
   "coo35p": {
     "defaultMessage": "No runs have been logged yet. <link>Learn more</link> about how to create ML model training runs in this experiment.",
     "description": "Empty state description text for experiment runs page when no runs are logged in the experiment"
+  },
+  "crFjQx": {
+    "defaultMessage": "Loading providers...",
+    "description": "Loading message for providers"
   },
   "crTWax": {
     "defaultMessage": "Key",
@@ -4843,6 +4947,10 @@
     "defaultMessage": "Model",
     "description": "Experiment page > runs table > models column > default label for no specific model"
   },
+  "gleX6d": {
+    "defaultMessage": "This key is currently used by {modelCount, plural, one {# model definition} other {# model definitions}}. After deletion, you will need to attach a different API key to {modelCount, plural, one {this model} other {these models}} via the Edit Endpoint page.",
+    "description": "Warning about models using this key"
+  },
   "glxGz2": {
     "defaultMessage": "Parallel coordinates chart does not support aggregated string values.",
     "description": "Experiment page > compare runs > parallel coordinates chart > unsupported string values warning > title"
@@ -4898,6 +5006,10 @@
   "hIBLi9": {
     "defaultMessage": "Violates guidelines",
     "description": "Evaluation results > guideline adherence assessment > negative value label. Displayed if evaluation result does not adhere to the guidelines."
+  },
+  "hJcrnh": {
+    "defaultMessage": "Provider",
+    "description": "Secret provider label"
   },
   "hR2Zvd": {
     "defaultMessage": "Create a custom judge function using the {decorator} decorator. Implement your scoring logic in the function body. {link}",
@@ -5014,6 +5126,10 @@
   "iLFoPb": {
     "defaultMessage": "State",
     "description": "Filtering label to filter experiments based on state of active or deleted"
+  },
+  "iN/n6b": {
+    "defaultMessage": "Auth Type",
+    "description": "Auth type label"
   },
   "iPTAj8": {
     "defaultMessage": "Retrieval",
@@ -5323,6 +5439,10 @@
     "defaultMessage": "We encountered an issue loading the judges interface. Please refresh the page or contact support if the problem persists.",
     "description": "Error description for experiment judges page loading failure"
   },
+  "lI+Eu2": {
+    "defaultMessage": "Failed to delete {itemType}. Please try again.",
+    "description": "Error message when deletion fails"
+  },
   "lISqyJ": {
     "defaultMessage": "Run details",
     "description": "Compare table title on the compare runs page"
@@ -5446,6 +5566,10 @@
   "mIk1MU": {
     "defaultMessage": "Create Model",
     "description": "Title text for creating model in the model registry"
+  },
+  "mMR/YQ": {
+    "defaultMessage": "Select a provider to configure your API key",
+    "description": "Placeholder message when no provider selected"
   },
   "mN6m2e": {
     "defaultMessage": "Only display data points between the p5 and p95 of the data. This can help with chart readability in cases where outliers significantly affect the Y-axis range",
@@ -5967,6 +6091,10 @@
     "defaultMessage": "Add rationale (optional)",
     "description": "Evaluation review > assessments > rationale input placeholder"
   },
+  "r0mM8+": {
+    "defaultMessage": "An error occurred while creating the API key. Please try again.",
+    "description": "Generic error message for API key creation"
+  },
   "r3/K3V": {
     "defaultMessage": "Make Predictions",
     "description": "Heading text for the prediction section on the registered model from the experiment run"
@@ -6030,6 +6158,10 @@
   "raa3Ij": {
     "defaultMessage": "Registered Models",
     "description": "Text for link back to model page under the header on the model view page"
+  },
+  "rdrvCs": {
+    "defaultMessage": "Created",
+    "description": "Secret created label"
   },
   "rgSaFx": {
     "defaultMessage": "Span type",
@@ -6107,6 +6239,10 @@
     "defaultMessage": "Tags",
     "description": "Section header for the tags in a 'group by' selector"
   },
+  "sEheG0": {
+    "defaultMessage": "Key Name",
+    "description": "Key name label"
+  },
   "sGXhV4": {
     "defaultMessage": "Welcome to MLflow",
     "description": "Home page hero title"
@@ -6139,9 +6275,17 @@
     "defaultMessage": "Trace LLM applications for debugging and monitoring.",
     "description": "Home page quick action description for logging traces"
   },
+  "sSLvV0": {
+    "defaultMessage": "by {user}",
+    "description": "Updated by user"
+  },
   "sTp/V3": {
     "defaultMessage": "Parallel Coordinates Plot",
     "description": "Tab pane title for parallel coordinate plots on the compare runs page"
+  },
+  "sUDP3e": {
+    "defaultMessage": "Common Providers",
+    "description": "Section header for common providers"
   },
   "sWbj1n": {
     "defaultMessage": "Apply filters",
@@ -6195,6 +6339,10 @@
     "defaultMessage": "Value",
     "description": "Run page > Overview > Metrics table > Value column header"
   },
+  "tCkDwC": {
+    "defaultMessage": "Create API Key",
+    "description": "Title for create API key modal"
+  },
   "tD0/e2": {
     "defaultMessage": "Model {modelName} does not exist",
     "description": "Sub-message text for error message on overall model page"
@@ -6218,6 +6366,10 @@
   "tNL+F4": {
     "defaultMessage": "Full trace with an agent using the right part of the trace to use to judge",
     "description": "Description for trace variable"
+  },
+  "tPUQUF": {
+    "defaultMessage": "An API key with this name already exists. Please choose a different name.",
+    "description": "Error message for duplicate key name"
   },
   "tQrhZ8": {
     "defaultMessage": "An error occurred while rendering this component.",
@@ -6607,6 +6759,10 @@
     "defaultMessage": "Created by",
     "description": "Column title text for creator username in model version table"
   },
+  "xTsXb6": {
+    "defaultMessage": "Are you sure you want to delete the {itemType} \"{itemName}\"?",
+    "description": "Delete confirmation message"
+  },
   "xUnYdk": {
     "defaultMessage": "Save",
     "description": "experiment page > description modal > save button"
@@ -6822,6 +6978,10 @@
   "zRKlAL": {
     "defaultMessage": "Metadata",
     "description": "Label for the metadata section"
+  },
+  "zRwy1a": {
+    "defaultMessage": "An error occurred while updating the API key. Please try again.",
+    "description": "Generic error message for API key update"
   },
   "zUoxV1": {
     "defaultMessage": "Expectations",


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19442/files) to review incremental changes.
- [**stack/gateway-ui/key-creation**](https://github.com/mlflow/mlflow/pull/19442) [[Files changed](https://github.com/mlflow/mlflow/pull/19442/files)]
  - [stack/gateway-ui/update-delete-keys](https://github.com/mlflow/mlflow/pull/19446) [[Files changed](https://github.com/mlflow/mlflow/pull/19446/files/eaa48f8054a94ed98ba5ab8563b37a3fdf363a05..9aee4996cb6a491cec2b5ee355f216d2eb8c6b43)]
    - [stack/gateway-ui/endpoint-list-page](https://github.com/mlflow/mlflow/pull/19474) [[Files changed](https://github.com/mlflow/mlflow/pull/19474/files/9aee4996cb6a491cec2b5ee355f216d2eb8c6b43..4a04b60678aaa3a7bfb8cf318b02c6d4cf67c40f)]
      - [stack/gateway-ui/create-endpoint](https://github.com/mlflow/mlflow/pull/19475) [[Files changed](https://github.com/mlflow/mlflow/pull/19475/files/4a04b60678aaa3a7bfb8cf318b02c6d4cf67c40f..251128d8b2a67c15df96ff5e40163f91cd58507a)]
        - [stack/gateway-ui/model-select](https://github.com/mlflow/mlflow/pull/19477) [[Files changed](https://github.com/mlflow/mlflow/pull/19477/files/251128d8b2a67c15df96ff5e40163f91cd58507a..5b022d9e145250c0e687167e85fc523ad86caa2f)]
          - [stack/gateway-ui/endpoint-auth](https://github.com/mlflow/mlflow/pull/19494) [[Files changed](https://github.com/mlflow/mlflow/pull/19494/files/5b022d9e145250c0e687167e85fc523ad86caa2f..1bfb2aaaa777fb1088fc07831b7ad6606e7ee17b)]
            - [stack/gateway-ui/endpoint-edit](https://github.com/mlflow/mlflow/pull/19502) [[Files changed](https://github.com/mlflow/mlflow/pull/19502/files/1bfb2aaaa777fb1088fc07831b7ad6606e7ee17b..ea9967db97ac158b55e858cfd8401e84b7a9c508)]
              - [stack/gateway-ui/provider-optimization](https://github.com/mlflow/mlflow/pull/19503) [[Files changed](https://github.com/mlflow/mlflow/pull/19503/files/ea9967db97ac158b55e858cfd8401e84b7a9c508..1546d7bbcdfb80dbb5ffab01dd1c18cc65a18525)]
                - [stack/gateway-ui/endpoint-details](https://github.com/mlflow/mlflow/pull/19537) [[Files changed](https://github.com/mlflow/mlflow/pull/19537/files/1546d7bbcdfb80dbb5ffab01dd1c18cc65a18525..25b49c242795f77871e31f9bd2d88efaa420aa3d)]
                  - [stack/gateway-ui/refine](https://github.com/mlflow/mlflow/pull/19538) [[Files changed](https://github.com/mlflow/mlflow/pull/19538/files/25b49c242795f77871e31f9bd2d88efaa420aa3d..f91bcf6b4dc7a91bf9ef9c54cdbad2b298fd5400)]
                    - [stack/gateway-ui/complex-combobox](https://github.com/mlflow/mlflow/pull/19546) [[Files changed](https://github.com/mlflow/mlflow/pull/19546/files/f91bcf6b4dc7a91bf9ef9c54cdbad2b298fd5400..b4894bb478e2cc2fd4713e6a30be9cb0be484c9b)]

---------
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

This PR adds the capability of creating API Keys, adding the 'Create' button to the API Keys listing page. 
The create button brings up a new modal that allows for selecting a provider and entering in security configuration options. 

<img width="1956" height="1410" alt="Screenshot 2025-12-16 at 5 26 02 PM" src="https://github.com/user-attachments/assets/b0d662fd-2e2c-4d7e-91ce-eb22ce76bca7" />


Fixes over previous state:
- Unified 'do not look' properties on the secret input fields (to prevent LastPass / Keeper / 1Pass / google password manager from inspecting the state and attempting to store the API Key / other secret information)
- Refactoring of components to use hooks for data acquisition operations and leaving render components separate from the core logic
- Additional test coverage for hooks and utils
- naming consistency updates
- additional memoization
- removal of a useEffect async state fetch logic (changed to have the parent component handle the state management and pass the resolved state through props)

### How is this PR tested?

- [ ] Existing unit/integration tests
- [ ] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [X] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/artifacts`: Artifact stores and artifact logging
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/deployments`: MLflow Deployments client APIs, server, and third-party Deployments integrations
- [ ] `area/docs`: MLflow documentation pages
- [ ] `area/examples`: Example code
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/recipes`: Recipes, Recipe APIs, Recipe configs, Recipe Templates
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/server-infra`: MLflow Tracking server backend
- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging

Interface

- [X] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/docker`: Docker use across MLflow's components, such as MLflow Projects and MLflow Models
- [ ] `area/sqlalchemy`: Use of SQLAlchemy in the Tracking Service or Model Registry
- [ ] `area/windows`: Windows support

Language

- [ ] `language/r`: R APIs and clients
- [ ] `language/java`: Java APIs and clients
- [ ] `language/new`: Proposals for new client languages

Integrations

- [ ] `integrations/azure`: Azure and Azure ML integrations
- [ ] `integrations/sagemaker`: SageMaker integrations
- [ ] `integrations/databricks`: Databricks integrations

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [X] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

<!-- patch -->

- [ ] Yes
- [X] No
