### PR TITLE
Implement automatic discovery for builtin scorers

### DIFF
--- a/mlflow/genai/scorers/builtin_scorers.py
+++ b/mlflow/genai/scorers/builtin_scorers.py
@@ -1,3 +1,4 @@
+import inspect
 import logging
 import math
 from abc import abstractmethod
@@ -2313,7 +2314,6 @@ def _get_all_concrete_builtin_scorers() -> list[type[BuiltInScorer]]:
     Returns:
         List of concrete BuiltInScorer classes
     """
-    import inspect
 
     def get_concrete_subclasses(base_class: type) -> list[type]:
         """Recursively get all concrete subclasses of a base class."""
@@ -2325,7 +2325,7 @@ def _get_all_concrete_builtin_scorers() -> list[type[BuiltInScorer]]:
                 and subclass.__module__ == "mlflow.genai.scorers.builtin_scorers"
             ):
                 concrete.append(subclass)
-            # Recurse to find subclasses of subclasses (e.g., BuiltInSessionLevelScorer)
+            # Recurse to find subclasses of subclasses
             concrete.extend(get_concrete_subclasses(subclass))
         return concrete
 
@@ -2334,11 +2334,7 @@ def _get_all_concrete_builtin_scorers() -> list[type[BuiltInScorer]]:
 
 def get_all_scorers() -> list[BuiltInScorer]:
     """
-    Returns a list of all built-in scorers.
-
-    This function automatically discovers all concrete (non-abstract) BuiltInScorer
-    subclasses and instantiates them with default parameters. Scorers that require
-    constructor arguments are skipped with a debug log message.
+    Returns a list of all built-in scorers that can be instantiated with default parameters.
 
     Example:
 
@@ -2361,12 +2357,9 @@ def get_all_scorers() -> list[BuiltInScorer]:
 
     for scorer_class in scorer_classes:
         try:
-            # Try to instantiate with default parameters
             scorer = scorer_class()
             scorers.append(scorer)
         except (TypeError, pydantic.ValidationError):
-            # Skip scorers that require constructor arguments (e.g., Guidelines)
-            # These scorers can still be used by instantiating them manually
             _logger.debug(
                 f"Skipping scorer {scorer_class.__name__} - requires constructor arguments"
             )

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -579,27 +579,8 @@ def test_equivalence():
 
 def test_get_all_scorers():
     scorers = get_all_scorers()
+    scorer_class_names = {type(s).__name__ for s in scorers}
 
-    # With automatic discovery, we expect all scorers that can be instantiated with defaults
-    # Total: 17 concrete scorer classes
-    # - 1 (Guidelines requires constructor args) = 16 scorers
-    expected_count = 16
-    assert len(scorers) == expected_count, (
-        f"Expected {expected_count} scorers but got {len(scorers)}. "
-        f"Scorers: {[type(s).__name__ for s in scorers]}"
-    )
-    assert all(isinstance(scorer, Scorer) for scorer in scorers)
-
-    # Verify no duplicates
-    scorer_names = [s.name for s in scorers]
-    assert len(scorer_names) == len(set(scorer_names)), "Duplicate scorer names found"
-
-    # Verify that base classes are not included
-    scorer_class_names = [type(s).__name__ for s in scorers]
-    assert "BuiltInScorer" not in scorer_class_names
-    assert "BuiltInSessionLevelScorer" not in scorer_class_names
-
-    # Verify all expected scorers are present (excluding Guidelines)
     expected_scorers = {
         "RetrievalRelevance",
         "RetrievalSufficiency",
@@ -618,13 +599,12 @@ def test_get_all_scorers():
         "ConversationalToolCallEfficiency",
         "ConversationalRoleAdherence",
     }
-    assert set(scorer_class_names) == expected_scorers, (
-        f"Scorer mismatch. "
-        f"Missing: {expected_scorers - set(scorer_class_names)}, "
-        f"Extra: {set(scorer_class_names) - expected_scorers}"
-    )
 
-    # Verify Guidelines is correctly excluded
+    assert scorer_class_names == expected_scorers
+    assert all(isinstance(scorer, Scorer) for scorer in scorers)
+    assert len({s.name for s in scorers}) == len(scorers)
+    assert "BuiltInScorer" not in scorer_class_names
+    assert "BuiltInSessionLevelScorer" not in scorer_class_names
     assert "Guidelines" not in scorer_class_names
 
 

--- a/tests/genai/scorers/test_builtin_scorers.py
+++ b/tests/genai/scorers/test_builtin_scorers.py
@@ -603,9 +603,6 @@ def test_get_all_scorers():
     assert scorer_class_names == expected_scorers
     assert all(isinstance(scorer, Scorer) for scorer in scorers)
     assert len({s.name for s in scorers}) == len(scorers)
-    assert "BuiltInScorer" not in scorer_class_names
-    assert "BuiltInSessionLevelScorer" not in scorer_class_names
-    assert "Guidelines" not in scorer_class_names
 
 
 def test_retrieval_relevance_get_input_fields():


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/19443?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19443/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19443/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19443/merge
```

</p>
</details>

### Related Issues/PRs

N/A

### What changes are proposed in this pull request?

This PR implements automatic discovery for builtin scorers, replacing the hardcoded list in `get_all_scorers()` with a dynamic introspection-based approach using Python's `__subclasses__()` method.

**Key changes:**
- Added `_get_all_concrete_builtin_scorers()` helper function that recursively discovers all concrete `BuiltInScorer` subclasses
- Updated `get_all_scorers()` to use automatic discovery instead of maintaining a hardcoded list
- Added proper exception handling for scorers requiring constructor arguments (catches both `TypeError` and `pydantic.ValidationError`)
- Removed unused `is_databricks_uri` import
- Updated tests to expect 16+ scorers instead of the previous 9/11
- Added `test_builtin_scorer_discovery()` to verify the discovery mechanism

**Benefits:**
- **Zero maintenance**: New scorers are automatically discovered without code changes
- **Complete coverage**: Now discovers all 16 instantiable scorers (vs previous 9 OSS / 11 Databricks)
- **Adds missing scorers**: Includes 5+ scorers that were missing from the hardcoded list:
  - Fluency
  - Summarization
  - ConversationalSafety
  - ConversationalToolCallEfficiency
  - ConversationalRoleAdherence
- **Future-proof**: Adding new scorers requires no changes to `get_all_scorers()`

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

**Testing:**
- Updated `test_get_all_scorers_oss` to verify 16+ scorers are discovered
- Added `test_builtin_scorer_discovery` to validate discovery of all expected scorer classes
- Verified CLI command `mlflow scorers list --builtin` returns all 16 scorers
- All tests pass with both OSS and Databricks tracking URIs

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

The function docstring has been updated to explain the automatic discovery mechanism. No external documentation changes needed.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

`mlflow scorers list --builtin` now automatically discovers and returns all builtin scorers (16 total) instead of a hardcoded subset (9 OSS / 11 Databricks). This includes 5+ previously unavailable scorers: Fluency, Summarization, ConversationalSafety, ConversationalToolCallEfficiency, and ConversationalRoleAdherence. The `get_all_scorers()` function now uses automatic discovery, eliminating the need to manually maintain the scorer list.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

This is a feature enhancement that increases the number of available scorers, making it more appropriate for a minor release.