### PR TITLE
Fix custom metric telemetry

### DIFF
--- a/mlflow/genai/evaluation/telemetry.py
+++ b/mlflow/genai/evaluation/telemetry.py
@@ -1,5 +1,4 @@
 import hashlib
-import json
 import threading
 import uuid
 
@@ -7,7 +6,7 @@ import mlflow
 from mlflow.genai.scorers.base import Scorer
 from mlflow.genai.scorers.builtin_scorers import BuiltInScorer
 from mlflow.utils.databricks_utils import get_databricks_host_creds
-from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX, call_endpoint
+from mlflow.utils.rest_utils import _REST_API_PATH_PREFIX, http_request
 from mlflow.utils.uri import is_databricks_uri
 from mlflow.version import VERSION
 
@@ -56,17 +55,17 @@ def emit_custom_metric_event(
         "eval_count": eval_count,
         "metrics": metric_stats,
     }
-    call_endpoint(
+    http_request(
         host_creds=get_databricks_host_creds(),
         endpoint=_EVAL_TELEMETRY_ENDPOINT,
         method="POST",
-        headers={
+        extra_headers={
             _CLIENT_VERSION_HEADER: VERSION,
             _SESSION_ID_HEADER: _get_or_create_session_id(),
-            _BATCH_SIZE_HEADER: eval_count,
+            _BATCH_SIZE_HEADER: str(eval_count),
             _CLIENT_NAME_HEADER: "mlflow",
         },
-        json_body=json.dumps(event_payload),
+        json=event_payload,
     )
 
 

--- a/tests/genai/evaluate/test_telemetry.py
+++ b/tests/genai/evaluate/test_telemetry.py
@@ -1,4 +1,3 @@
-import json
 from unittest import mock
 
 import pytest
@@ -63,7 +62,7 @@ def test_emit_custom_metric_event():
     ]
     with (
         mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=True),
-        mock.patch("mlflow.genai.evaluation.telemetry.call_endpoint") as mock_call_endpoint,
+        mock.patch("mlflow.genai.evaluation.telemetry.http_request") as mock_http_request,
         mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
     ):
         emit_custom_metric_event(
@@ -82,19 +81,19 @@ def test_emit_custom_metric_event():
             },
         )
 
-    mock_call_endpoint.assert_called_once()
-    call_args = mock_call_endpoint.call_args[1]
+    mock_http_request.assert_called_once()
+    call_args = mock_http_request.call_args[1]
 
     assert call_args["method"] == "POST"
     assert call_args["endpoint"] == "/api/2.0/agents/evaluation-client-usage-events"
 
-    headers = call_args["headers"]
+    headers = call_args["extra_headers"]
     assert headers[_CLIENT_VERSION_HEADER] == VERSION
     assert headers[_SESSION_ID_HEADER] is not None
-    assert headers[_BATCH_SIZE_HEADER] == 10
+    assert headers[_BATCH_SIZE_HEADER] == "10"
     assert headers[_CLIENT_NAME_HEADER] == "mlflow"
 
-    event = json.loads(call_args["json_body"])
+    event = call_args["json"]
     assert len(event["metric_names"]) == 5
     assert all(isinstance(name, str) for name in event["metric_names"])
     assert event["eval_count"] == 10
@@ -133,7 +132,7 @@ def test_emit_custom_metric_event():
 def test_emit_custom_metric_usage_event_skip_outside_databricks():
     with (
         mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=False),
-        mock.patch("mlflow.genai.evaluation.telemetry.call_endpoint") as mock_call_endpoint,
+        mock.patch("mlflow.genai.evaluation.telemetry.http_request") as mock_http_request,
         mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
     ):
         emit_custom_metric_event(
@@ -141,13 +140,13 @@ def test_emit_custom_metric_usage_event_skip_outside_databricks():
             eval_count=10,
             aggregated_metrics={"is_concise/mean": 0.1, "is_correct/mean": 0.2},
         )
-    mock_call_endpoint.assert_not_called()
+    mock_http_request.assert_not_called()
 
 
 def test_emit_custom_metric_usage_event_with_sessions():
     with (
         mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=True),
-        mock.patch("mlflow.genai.evaluation.telemetry.call_endpoint") as mock_call_endpoint,
+        mock.patch("mlflow.genai.evaluation.telemetry.http_request") as mock_http_request,
         mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
     ):
         for _ in range(3):
@@ -157,10 +156,10 @@ def test_emit_custom_metric_usage_event_with_sessions():
                 aggregated_metrics={"is_concise/mean": 0.1, "is_correct/mean": 0.2},
             )
 
-    assert mock_call_endpoint.call_count == 3
+    assert mock_http_request.call_count == 3
     session_ids = [
-        mock_call_endpoint.call_args[1]["headers"][_SESSION_ID_HEADER]
-        for call_args in mock_call_endpoint.call_args_list
+        call_args[1]["extra_headers"][_SESSION_ID_HEADER]
+        for call_args in mock_http_request.call_args_list
     ]
     assert len(set(session_ids)) == 1
     assert all(session_id is not None for session_id in session_ids)

--- a/tests/genai/evaluate/test_telemetry.py
+++ b/tests/genai/evaluate/test_telemetry.py
@@ -62,7 +62,9 @@ def test_emit_custom_metric_event():
     ]
     with (
         mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=True),
-        mock.patch("mlflow.genai.evaluation.telemetry.http_request") as mock_http_request,
+        mock.patch(
+            "mlflow.genai.evaluation.telemetry.http_request", autospec=True
+        ) as mock_http_request,
         mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
     ):
         emit_custom_metric_event(
@@ -132,7 +134,9 @@ def test_emit_custom_metric_event():
 def test_emit_custom_metric_usage_event_skip_outside_databricks():
     with (
         mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=False),
-        mock.patch("mlflow.genai.evaluation.telemetry.http_request") as mock_http_request,
+        mock.patch(
+            "mlflow.genai.evaluation.telemetry.http_request", autospec=True
+        ) as mock_http_request,
         mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
     ):
         emit_custom_metric_event(
@@ -146,7 +150,9 @@ def test_emit_custom_metric_usage_event_skip_outside_databricks():
 def test_emit_custom_metric_usage_event_with_sessions():
     with (
         mock.patch("mlflow.genai.evaluation.telemetry.is_databricks_uri", return_value=True),
-        mock.patch("mlflow.genai.evaluation.telemetry.http_request") as mock_http_request,
+        mock.patch(
+            "mlflow.genai.evaluation.telemetry.http_request", autospec=True
+        ) as mock_http_request,
         mock.patch("mlflow.genai.evaluation.telemetry.get_databricks_host_creds"),
     ):
         for _ in range(3):


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/B-Step62/mlflow/pull/19465?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19465/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19465/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19465/merge
```

</p>
</details>


### Related Issues/PRs

Fix https://github.com/mlflow/mlflow/issues/19462

### What changes are proposed in this pull request?

Fixing wrong parameters passed to the custom scorer telemetry in databricks

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Verified no failure log is surfaced in databricks.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
