### PR TITLE
Add workspace UI

### DIFF
--- a/mlflow/server/js/src/MlflowRouter.tsx
+++ b/mlflow/server/js/src/MlflowRouter.tsx
@@ -9,13 +9,17 @@ import {
   RouterProvider,
   Outlet,
   createLazyRouteElement,
+  useLocation,
+  useNavigate,
   useParams,
   usePageTitle,
+  useSearchParams,
 } from './common/utils/RoutingUtils';
 import { MlflowHeader } from './common/components/MlflowHeader';
 import { useDarkThemeContext } from './common/contexts/DarkThemeContext';
 import { WorkflowTypeProvider } from './common/contexts/WorkflowTypeContext';
 import { shouldEnableWorkflowBasedNavigation } from './common/utils/FeatureUtils';
+import { useWorkspacesEnabled } from './common/utils/ServerFeaturesContext';
 
 // Route definition imports:
 import { getRouteDefs as getExperimentTrackingRouteDefs } from './experiment-tracking/route-defs';
@@ -26,6 +30,21 @@ import { useInitializeExperimentRunColors } from './experiment-tracking/componen
 import { MlflowSidebar } from './common/components/MlflowSidebar';
 import { AssistantProvider, AssistantRouteContextProvider } from './assistant';
 import { RootAssistantLayout } from './common/components/RootAssistantLayout';
+import {
+  extractWorkspaceFromSearchParams,
+  getActiveWorkspace,
+  isGlobalRoute,
+  setActiveWorkspace,
+} from './workspaces/utils/WorkspaceUtils';
+import { useWorkspaces } from './workspaces/hooks/useWorkspaces';
+
+type MlflowRouteDef = {
+  path?: string;
+  element?: React.ReactNode;
+  pageId?: string;
+  children?: MlflowRouteDef[];
+  [key: string]: unknown;
+};
 
 /**
  * This is root element for MLflow routes, containing app header.
@@ -95,9 +114,82 @@ const MlflowRootRoute = () => {
     </AssistantProvider>
   );
 };
+
+const WorkspaceRouterSync = ({ workspacesEnabled }: { workspacesEnabled: boolean }) => {
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate({ bypassWorkspacePrefix: true });
+  const { workspaces, isLoading } = useWorkspaces(workspacesEnabled);
+
+  useEffect(() => {
+    if (!workspacesEnabled) {
+      setActiveWorkspace(null);
+      return;
+    }
+
+    // Extract workspace from query param
+    const workspaceFromQuery = extractWorkspaceFromSearchParams(searchParams);
+    const activeWorkspace = getActiveWorkspace();
+    const isRootPath = location.pathname === '/' || location.pathname === '';
+
+    // If workspace is in query param, validate it once workspaces are loaded
+    if (workspaceFromQuery) {
+      if (isLoading) {
+        // Still loading workspaces, optimistically set the workspace
+        // (will validate once loaded)
+        if (activeWorkspace !== workspaceFromQuery) {
+          setActiveWorkspace(workspaceFromQuery);
+        }
+        return;
+      }
+
+      // Workspaces loaded - validate
+      const workspaceExists = workspaces.some((ws) => ws.name === workspaceFromQuery);
+      if (!workspaceExists) {
+        // Invalid workspace - clear it and redirect to workspace selector
+        setActiveWorkspace(null);
+        navigate('/', { replace: true });
+        return;
+      }
+
+      // Valid workspace - sync to active state
+      if (activeWorkspace !== workspaceFromQuery) {
+        setActiveWorkspace(workspaceFromQuery);
+      }
+      return;
+    }
+
+    // No workspace query param - check if this is a global route
+    const isOnGlobalRoute = isRootPath || isGlobalRoute(location.pathname);
+
+    if (isOnGlobalRoute) {
+      // Clear active workspace on global routes (workspace selector, settings)
+      if (activeWorkspace) {
+        setActiveWorkspace(null);
+      }
+      return;
+    }
+
+    // No workspace query param on a workspace-scoped route - redirect to selector
+    setActiveWorkspace(null);
+    navigate('/', { replace: true });
+  }, [location, navigate, workspacesEnabled, searchParams, workspaces, isLoading]);
+
+  return null;
+};
+
+const WorkspaceAwareRootRoute = ({ workspacesEnabled }: { workspacesEnabled: boolean }) => (
+  <>
+    <WorkspaceRouterSync workspacesEnabled={workspacesEnabled} />
+    <MlflowRootRoute />
+  </>
+);
+
 export const MlflowRouter = () => {
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  const routes = useMemo(
+  const { workspacesEnabled, loading: featuresLoading } = useWorkspacesEnabled();
+
+  // Routes are the same regardless of workspace mode - workspace context comes from query param
+  const routes = useMemo<MlflowRouteDef[]>(
     () => [
       ...getExperimentTrackingRouteDefs(),
       ...getModelRegistryRouteDefs(),
@@ -106,18 +198,26 @@ export const MlflowRouter = () => {
     ],
     [],
   );
-  // eslint-disable-next-line react-hooks/rules-of-hooks
+
   const hashRouter = useMemo(
     () =>
-      createHashRouter([
-        {
-          path: '/',
-          element: <MlflowRootRoute />,
-          children: routes,
-        },
-      ]),
-    [routes],
+      // Don't create router while still loading features
+      featuresLoading
+        ? null
+        : createHashRouter([
+            {
+              path: '/',
+              element: <WorkspaceAwareRootRoute workspacesEnabled={workspacesEnabled} />,
+              children: routes,
+            },
+          ]),
+    [routes, workspacesEnabled, featuresLoading],
   );
+
+  // Show loading skeleton while determining if workspaces are enabled
+  if (featuresLoading || !hashRouter) {
+    return <LegacySkeleton />;
+  }
 
   return (
     <React.Suspense fallback={<LegacySkeleton />}>

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { ApolloProvider } from '@mlflow/mlflow/src/common/utils/graphQLHooks';
 import { RawIntlProvider } from 'react-intl';
 
@@ -20,37 +20,16 @@ import { MlflowRouter as MlflowRouter } from './MlflowRouter';
 import { useMLflowDarkTheme } from './common/hooks/useMLflowDarkTheme';
 import { DarkThemeProvider } from './common/contexts/DarkThemeContext';
 import { telemetryClient } from './telemetry';
-import { ServerFeaturesProvider, SERVER_FEATURES_QUERY_KEY } from './common/utils/ServerFeaturesContext';
-import { subscribeToWorkspaceChanges } from './workspaces/utils/WorkspaceUtils';
+import { ServerFeaturesProvider } from './common/utils/ServerFeaturesContext';
 
 export function MLFlowRoot() {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const intl = useI18nInit();
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
-  // Create clients once - we'll clear caches on workspace changes instead of recreating
   const apolloClient = useMemo(() => createApolloClient(), []);
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const queryClient = useMemo(() => new QueryClient(), []);
-
-  // Reset caches when workspace changes instead of recreating clients
-  useEffect(() => {
-    const unsubscribe = subscribeToWorkspaceChanges(() => {
-      // Reset React Query cache except server features (they don't change with workspace)
-      // resetQueries removes cached data AND triggers refetch
-      queryClient.resetQueries({
-        predicate: (query) => {
-          // Keep server features cached
-          return query.queryKey[0] !== SERVER_FEATURES_QUERY_KEY[0];
-        },
-      });
-
-      // Clear Apollo cache
-      apolloClient.clearStore();
-    });
-
-    return unsubscribe;
-  }, [queryClient, apolloClient]);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const [isDarkTheme, setIsDarkTheme, MlflowThemeGlobalStyles] = useMLflowDarkTheme();

--- a/mlflow/server/js/src/app.tsx
+++ b/mlflow/server/js/src/app.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import { ApolloProvider } from '@mlflow/mlflow/src/common/utils/graphQLHooks';
 import { RawIntlProvider } from 'react-intl';
 
@@ -20,14 +20,37 @@ import { MlflowRouter as MlflowRouter } from './MlflowRouter';
 import { useMLflowDarkTheme } from './common/hooks/useMLflowDarkTheme';
 import { DarkThemeProvider } from './common/contexts/DarkThemeContext';
 import { telemetryClient } from './telemetry';
+import { ServerFeaturesProvider, SERVER_FEATURES_QUERY_KEY } from './common/utils/ServerFeaturesContext';
+import { subscribeToWorkspaceChanges } from './workspaces/utils/WorkspaceUtils';
 
 export function MLFlowRoot() {
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const intl = useI18nInit();
+
   // eslint-disable-next-line react-hooks/rules-of-hooks
+  // Create clients once - we'll clear caches on workspace changes instead of recreating
   const apolloClient = useMemo(() => createApolloClient(), []);
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const queryClient = useMemo(() => new QueryClient(), []);
+
+  // Reset caches when workspace changes instead of recreating clients
+  useEffect(() => {
+    const unsubscribe = subscribeToWorkspaceChanges(() => {
+      // Reset React Query cache except server features (they don't change with workspace)
+      // resetQueries removes cached data AND triggers refetch
+      queryClient.resetQueries({
+        predicate: (query) => {
+          // Keep server features cached
+          return query.queryKey[0] !== SERVER_FEATURES_QUERY_KEY[0];
+        },
+      });
+
+      // Clear Apollo cache
+      apolloClient.clearStore();
+    });
+
+    return unsubscribe;
+  }, [queryClient, apolloClient]);
 
   // eslint-disable-next-line react-hooks/rules-of-hooks
   const [isDarkTheme, setIsDarkTheme, MlflowThemeGlobalStyles] = useMLflowDarkTheme();
@@ -54,7 +77,9 @@ export function MLFlowRoot() {
               <MlflowThemeGlobalStyles />
               <DarkThemeProvider setIsDarkTheme={setIsDarkTheme}>
                 <QueryClientProvider client={queryClient}>
-                  <MlflowRouter />
+                  <ServerFeaturesProvider>
+                    <MlflowRouter />
+                  </ServerFeaturesProvider>
                 </QueryClientProvider>
               </DarkThemeProvider>
             </DesignSystemContainer>

--- a/mlflow/server/js/src/assistant/AssistantService.ts
+++ b/mlflow/server/js/src/assistant/AssistantService.ts
@@ -10,7 +10,7 @@ import type {
   HealthCheckResult,
   InstallSkillsResponse,
 } from './types';
-import { getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
+import { getAjaxUrl, getDefaultHeaders } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 
 const API_BASE = getAjaxUrl('ajax-api/3.0/mlflow/assistant');
 
@@ -145,10 +145,12 @@ export const sendMessageStream = async (
 
   try {
     // Step 1: POST the message to initiate processing
+    // eslint-disable-next-line no-restricted-globals -- See go/spog-fetch
     const response = await fetch(`${API_BASE}/message`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
+        ...getDefaultHeaders(document.cookie),
       },
       body: JSON.stringify(request),
     });

--- a/mlflow/server/js/src/common/components/MlflowHeader.tsx
+++ b/mlflow/server/js/src/common/components/MlflowHeader.tsx
@@ -4,6 +4,7 @@ import { HomePageDocsUrl, Version } from '../constants';
 import { DarkThemeSwitch } from '@mlflow/mlflow/src/common/components/DarkThemeSwitch';
 import { Button, MenuIcon, useDesignSystemTheme } from '@databricks/design-system';
 import { MlflowLogo } from './MlflowLogo';
+import { WorkspaceSelector } from '../../workspaces/components/WorkspaceSelector';
 
 export const MlflowHeader = ({
   isDarkTheme = false,
@@ -66,7 +67,8 @@ export const MlflowHeader = ({
         </span>
       </div>
       <div css={{ flex: 1 }} />
-      <div css={{ display: 'flex', gap: theme.spacing.md, alignItems: 'center' }}>
+      <div css={{ display: 'flex', gap: theme.spacing.lg, alignItems: 'center' }}>
+        <WorkspaceSelector />
         <DarkThemeSwitch isDarkTheme={isDarkTheme} setIsDarkTheme={setIsDarkTheme} />
         <a href="https://github.com/mlflow/mlflow">GitHub</a>
         <a href={HomePageDocsUrl}>Docs</a>

--- a/mlflow/server/js/src/common/utils/ArtifactUtils.test.ts
+++ b/mlflow/server/js/src/common/utils/ArtifactUtils.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, test } from '@jest/globals';
+
+import { getArtifactLocationUrl, getLoggedModelArtifactLocationUrl } from './ArtifactUtils';
+import { setActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
+
+describe('ArtifactUtils workspace-aware URLs', () => {
+  afterEach(() => {
+    setActiveWorkspace(null);
+  });
+
+  test('getArtifactLocationUrl omits workspace segment and relies on headers', () => {
+    setActiveWorkspace('team-a');
+    const url = getArtifactLocationUrl('file.txt', 'run-123');
+
+    expect(url).toContain('get-artifact');
+    expect(url).not.toContain('workspaces');
+    expect(url).toContain('path=file.txt');
+    expect(url).toContain('run_uuid=run-123');
+  });
+
+  test('getLoggedModelArtifactLocationUrl omits workspace segment and relies on headers', () => {
+    setActiveWorkspace('team-b');
+    const url = getLoggedModelArtifactLocationUrl('dir/file.txt', '42');
+
+    expect(url).toContain('mlflow/logged-models/42/artifacts/files');
+    expect(url).not.toContain('workspaces');
+    expect(url).toContain('artifact_file_path=dir%2Ffile.txt');
+  });
+});

--- a/mlflow/server/js/src/common/utils/ArtifactUtils.ts
+++ b/mlflow/server/js/src/common/utils/ArtifactUtils.ts
@@ -6,7 +6,7 @@
  */
 
 import { ErrorWrapper } from './ErrorWrapper';
-import { getDefaultHeaders, HTTPMethods } from './FetchUtils';
+import { getAjaxUrl, getDefaultHeaders, HTTPMethods } from './FetchUtils';
 
 /**
  * Async function to fetch and return the specified artifact blob from response.
@@ -114,12 +114,12 @@ export function getArtifactBytesContent(artifactLocation: any) {
 }
 
 export const getLoggedModelArtifactLocationUrl = (path: string, loggedModelId: string) => {
-  return `ajax-api/2.0/mlflow/logged-models/${loggedModelId}/artifacts/files?artifact_file_path=${encodeURIComponent(
-    path,
-  )}`;
+  return getAjaxUrl(
+    `ajax-api/2.0/mlflow/logged-models/${loggedModelId}/artifacts/files?artifact_file_path=${encodeURIComponent(path)}`,
+  );
 };
 
 export const getArtifactLocationUrl = (path: string, runUuid: string) => {
   const artifactEndpointPath = 'get-artifact';
-  return `${artifactEndpointPath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(runUuid)}`;
+  return getAjaxUrl(`${artifactEndpointPath}?path=${encodeURIComponent(path)}&run_uuid=${encodeURIComponent(runUuid)}`);
 };

--- a/mlflow/server/js/src/common/utils/FeatureUtils.ts
+++ b/mlflow/server/js/src/common/utils/FeatureUtils.ts
@@ -3,6 +3,15 @@
  * In the OSS version, you can override them in local development by manually changing the return values.
  */
 
+import { getWorkspacesEnabledSync } from './ServerFeaturesContext';
+
+// Returns the current workspaces enabled state from the cached server features.
+// This is synchronous and returns the cached value (false if not yet loaded).
+// For React components, prefer using the useWorkspacesEnabled hook instead.
+export const shouldEnableWorkspaces = () => getWorkspacesEnabledSync();
+
+export const shouldEnableWorkspacePermissions = () => shouldEnableWorkspaces();
+
 export const shouldEnableRunDetailsPageAutoRefresh = () => true;
 
 /**

--- a/mlflow/server/js/src/common/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/common/utils/FetchUtils.ts
@@ -10,8 +10,8 @@ import JsonBigInt from 'json-bigint';
 import yaml from 'js-yaml';
 import { isNil, pickBy } from 'lodash';
 import { ErrorWrapper } from './ErrorWrapper';
-import { matchPredefinedError } from '@databricks/web-shared/errors';
-import { matchPredefinedErrorFromResponse } from '@databricks/web-shared/errors';
+import { matchPredefinedError, matchPredefinedErrorFromResponse } from '@databricks/web-shared/errors';
+import { getActiveWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 
 export const HTTPMethods = {
   GET: 'GET',
@@ -48,8 +48,13 @@ export const getDefaultHeadersFromCookies = (cookieStr: any) => {
 
 export const getDefaultHeaders = (cookieStr: any) => {
   const cookieHeaders = getDefaultHeadersFromCookies(cookieStr);
+
+  // getActiveWorkspace() returns null if workspaces feature is not enabled
+  const workspace = getActiveWorkspace();
+
   return {
     ...cookieHeaders,
+    ...(workspace ? { 'X-MLFLOW-WORKSPACE': workspace } : {}),
   };
 };
 
@@ -453,19 +458,32 @@ function serializeRequestBody(payload: any | FormData | Blob) {
     : JSON.stringify(payload);
 }
 
+export type FetchAPIOptions = Omit<RequestInit, 'body'> & {
+  body?: any;
+};
+
 // Helper method to make a request to the backend.
-export const fetchAPI = async (url: string, method: 'POST' | 'GET' | 'PATCH' | 'DELETE' = 'GET', body?: any) => {
-  // eslint-disable-next-line no-restricted-globals
-  const fetchFn = fetch;
-  const headers = {
-    ...(body ? { 'Content-Type': 'application/json' } : {}),
-    ...getDefaultHeaders(document.cookie),
+export const fetchAPI = async (url: string, options: FetchAPIOptions = {}) => {
+  const { method, headers, body, ...restOptions } = options;
+
+  let cookieString = '';
+  if (typeof document !== 'undefined' && typeof document.cookie === 'string') {
+    cookieString = document.cookie || '';
+  }
+
+  const fetchOptions: RequestInit = {
+    ...restOptions,
+    method: method || HTTPMethods.GET,
+    headers: {
+      ...getDefaultHeaders(cookieString),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...headers,
+    },
+    ...(body && { body: serializeRequestBody(body) }),
   };
-  const response = await fetchFn(url, {
-    method,
-    body: serializeRequestBody(body),
-    headers,
-  });
+
+  // eslint-disable-next-line no-restricted-globals -- See go/spog-fetch
+  const response = await fetch(url, fetchOptions);
   if (!response.ok) {
     const predefinedError = matchPredefinedError(response);
     if (predefinedError) {
@@ -484,6 +502,7 @@ export const fetchAPI = async (url: string, method: 'POST' | 'GET' | 'PATCH' | '
 /**
  * Wrapper around fetch that throws on non-OK responses
  * Returns the Response object for further processing (.json(), .text(), etc.)
+ * Automatically includes default headers (cookies and workspace).
  *
  * @param input - URL or Request object
  * @param options - Fetch options
@@ -491,8 +510,21 @@ export const fetchAPI = async (url: string, method: 'POST' | 'GET' | 'PATCH' | '
  * @throws PredefinedError (NotFoundError, PermissionError, etc.) if response is not OK
  */
 export async function fetchOrFail(input: RequestInfo | URL, options?: RequestInit): Promise<Response> {
+  let cookieString = '';
+  if (typeof document !== 'undefined' && typeof document.cookie === 'string') {
+    cookieString = document.cookie || '';
+  }
+
+  const fetchOptions: RequestInit = {
+    ...options,
+    headers: {
+      ...getDefaultHeaders(cookieString),
+      ...options?.headers,
+    },
+  };
+
   // eslint-disable-next-line no-restricted-globals -- See go/spog-fetch
-  const response = await fetch(input, options);
+  const response = await fetch(input, fetchOptions);
   if (!response.ok) {
     const error = matchPredefinedErrorFromResponse(response);
     throw error;

--- a/mlflow/server/js/src/common/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/common/utils/FetchUtils.ts
@@ -482,8 +482,9 @@ export const fetchAPI = async (url: string, options: FetchAPIOptions = {}) => {
     ...(body && { body: serializeRequestBody(body) }),
   };
 
-  // eslint-disable-next-line no-restricted-globals -- See go/spog-fetch
-  const response = await fetch(url, fetchOptions);
+  // eslint-disable-next-line no-restricted-globals
+  const fetchFn = fetch;
+  const response = await fetchFn(url, fetchOptions);
   if (!response.ok) {
     const predefinedError = matchPredefinedError(response);
     if (predefinedError) {

--- a/mlflow/server/js/src/common/utils/RoutingUtils.tsx
+++ b/mlflow/server/js/src/common/utils/RoutingUtils.tsx
@@ -14,7 +14,7 @@ import {
   generatePath,
   Route,
   UNSAFE_NavigationContext,
-  NavLink,
+  NavLink as NavLinkDirect,
   Outlet as OutletDirect,
   Link as LinkDirect,
   useNavigate as useNavigateDirect,
@@ -30,6 +30,7 @@ import {
   type Location,
   type NavigateFunction,
   type Params,
+  type PathMatch,
 } from 'react-router-dom';
 
 /**
@@ -37,7 +38,15 @@ import {
  */
 import { HashRouter as HashRouterV5, Link as LinkV5, NavLink as NavLinkV5 } from 'react-router-dom';
 import type { ComponentProps } from 'react';
-import React from 'react';
+import React, { useCallback } from 'react';
+
+import {
+  prefixRouteWithWorkspace,
+  getActiveWorkspace,
+  isGlobalRoute,
+  WORKSPACE_QUERY_PARAM,
+} from '../../workspaces/utils/WorkspaceUtils';
+import { getWorkspacesEnabledSync } from './ServerFeaturesContext';
 
 const useLocation = useLocationDirect;
 
@@ -45,13 +54,102 @@ const useSearchParams = useSearchParamsDirect;
 
 const useParams = useParamsDirect;
 
-const useNavigate = useNavigateDirect;
+type UseNavigateOptions = {
+  bypassWorkspacePrefix?: boolean;
+};
+
+const useNavigate = (options: UseNavigateOptions = { bypassWorkspacePrefix: false }): NavigateFunction => {
+  const { bypassWorkspacePrefix } = options;
+  const navigate = useNavigateDirect();
+  const wrappedNavigate = useCallback(
+    (to: To | number, options?: NavigateOptions) => {
+      if (typeof to === 'number') {
+        navigate(to);
+        return;
+      }
+      navigate(bypassWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to), options);
+    },
+    [navigate, bypassWorkspacePrefix],
+  );
+
+  return wrappedNavigate as NavigateFunction;
+};
 
 const useMatches = useMatchesDirect;
 
 const Outlet = OutletDirect;
 
-const Link = LinkDirect;
+/**
+ * Add workspace query param to a To object (used by Link/NavLink/navigate).
+ * Handles both string and object forms of To.
+ */
+const prefixRouteWithWorkspaceForTo = (to: To): To => {
+  // String form - delegate to prefixRouteWithWorkspace
+  if (typeof to === 'string') {
+    return prefixRouteWithWorkspace(to);
+  }
+
+  // Object form - need to handle pathname and search separately
+  if (typeof to === 'object' && to !== null) {
+    const pathname = 'pathname' in to ? to.pathname : undefined;
+
+    // Skip if workspaces not enabled or pathname not provided
+    if (!getWorkspacesEnabledSync() || typeof pathname !== 'string') {
+      return to;
+    }
+
+    // Skip workspace param for global routes
+    if (isGlobalRoute(pathname)) {
+      // Remove workspace param if present in existing search
+      if (to.search) {
+        const params = new URLSearchParams(to.search);
+        params.delete(WORKSPACE_QUERY_PARAM);
+        const newSearch = params.toString();
+        return {
+          ...to,
+          search: newSearch ? `?${newSearch}` : undefined,
+        };
+      }
+      return to;
+    }
+
+    // Add workspace query param
+    const workspace = getActiveWorkspace();
+    if (!workspace) {
+      return to;
+    }
+
+    // Merge workspace into existing search params
+    const existingSearch = to.search || '';
+    const params = new URLSearchParams(existingSearch.startsWith('?') ? existingSearch.slice(1) : existingSearch);
+    params.set(WORKSPACE_QUERY_PARAM, workspace);
+
+    return {
+      ...to,
+      search: `?${params.toString()}`,
+    };
+  }
+
+  return to;
+};
+
+const Link = React.forwardRef<
+  HTMLAnchorElement,
+  ComponentProps<typeof LinkDirect> & { disableWorkspacePrefix?: boolean }
+>(function Link(props, ref) {
+  const { to, disableWorkspacePrefix, ...rest } = props;
+  const finalTo = disableWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to);
+  return <LinkDirect ref={ref} to={finalTo} {...rest} />;
+});
+
+const NavLink = React.forwardRef<
+  HTMLAnchorElement,
+  ComponentProps<typeof NavLinkDirect> & { disableWorkspacePrefix?: boolean }
+>(function NavLink(props, ref) {
+  const { to, disableWorkspacePrefix, ...rest } = props;
+  const finalTo = disableWorkspacePrefix ? to : prefixRouteWithWorkspaceForTo(to);
+  return <NavLinkDirect ref={ref} to={finalTo} {...rest} />;
+});
 
 export const createMLflowRoutePath = (routePath: string) => {
   return routePath;
@@ -63,6 +161,7 @@ export {
   MemoryRouter,
   HashRouter,
   Link,
+  NavLink,
   useNavigate,
   useLocation,
   useParams,
@@ -145,4 +244,4 @@ export const useAssistantPrompts = (): string[] => {
   return DEFAULT_ASSISTANT_PROMPTS;
 };
 
-export type { Location, NavigateFunction, Params, To, NavigateOptions };
+export type { Location, NavigateFunction, Params, To, NavigateOptions, PathMatch };

--- a/mlflow/server/js/src/common/utils/ServerFeaturesContext.test.tsx
+++ b/mlflow/server/js/src/common/utils/ServerFeaturesContext.test.tsx
@@ -1,0 +1,196 @@
+import { jest, describe, beforeEach, afterEach, test, expect } from '@jest/globals';
+import { render, waitFor, screen } from '@testing-library/react';
+import React from 'react';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import {
+  ServerFeaturesProvider,
+  useWorkspacesEnabled,
+  getWorkspacesEnabledSync,
+  resetServerFeaturesCache,
+} from './ServerFeaturesContext';
+
+// Mock fetch globally
+const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
+global.fetch = mockFetch;
+
+const TestComponent = () => {
+  const { workspacesEnabled, loading } = useWorkspacesEnabled();
+  return (
+    <div>
+      <span data-testid="loading">{loading ? 'loading' : 'loaded'}</span>
+      <span data-testid="workspaces-enabled">{workspacesEnabled ? 'true' : 'false'}</span>
+    </div>
+  );
+};
+
+// Helper to create a fresh QueryClient for each test
+const createTestQueryClient = () =>
+  new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+// Helper to render with providers
+const renderWithProviders = (ui: React.ReactElement, queryClient: QueryClient) => {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ServerFeaturesProvider>{ui}</ServerFeaturesProvider>
+    </QueryClientProvider>,
+  );
+};
+
+describe('ServerFeaturesContext', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = createTestQueryClient();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    resetServerFeaturesCache();
+    queryClient.clear();
+  });
+
+  test('should show loading state initially', async () => {
+    // Never resolve the fetch to test loading state
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    renderWithProviders(<TestComponent />, queryClient);
+
+    expect(screen.getByTestId('loading').textContent).toBe('loading');
+  });
+
+  test('should fetch server features and enable workspaces when server returns enabled', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ workspaces_enabled: true }),
+    } as Response);
+
+    renderWithProviders(<TestComponent />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('loaded');
+    });
+
+    expect(screen.getByTestId('workspaces-enabled').textContent).toBe('true');
+    expect(getWorkspacesEnabledSync()).toBe(true);
+  });
+
+  test('should disable workspaces when server returns disabled', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ workspaces_enabled: false }),
+    } as Response);
+
+    renderWithProviders(<TestComponent />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('loaded');
+    });
+
+    expect(screen.getByTestId('workspaces-enabled').textContent).toBe('false');
+    expect(getWorkspacesEnabledSync()).toBe(false);
+  });
+
+  test('should disable workspaces when server returns 404 (old backend)', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 404,
+      json: async () => ({}),
+    } as Response);
+
+    renderWithProviders(<TestComponent />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('loaded');
+    });
+
+    expect(screen.getByTestId('workspaces-enabled').textContent).toBe('false');
+    expect(getWorkspacesEnabledSync()).toBe(false);
+  });
+
+  test('should disable workspaces when fetch fails with network error', async () => {
+    mockFetch.mockRejectedValue(new Error('Network error'));
+
+    renderWithProviders(<TestComponent />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('loaded');
+    });
+
+    expect(screen.getByTestId('workspaces-enabled').textContent).toBe('false');
+    expect(getWorkspacesEnabledSync()).toBe(false);
+  });
+
+  test('should disable workspaces when server returns error status', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response);
+
+    renderWithProviders(<TestComponent />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('loaded');
+    });
+
+    expect(screen.getByTestId('workspaces-enabled').textContent).toBe('false');
+    expect(getWorkspacesEnabledSync()).toBe(false);
+  });
+
+  test('should cache server features via React Query and not fetch again', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ workspaces_enabled: true }),
+    } as Response);
+
+    const { unmount } = renderWithProviders(<TestComponent />, queryClient);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('loading').textContent).toBe('loaded');
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Unmount and remount - use same queryClient to test caching
+    unmount();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <ServerFeaturesProvider>
+          <TestComponent />
+        </ServerFeaturesProvider>
+      </QueryClientProvider>,
+    );
+
+    // Should immediately show loaded since React Query has cached the data
+    expect(screen.getByTestId('loading').textContent).toBe('loaded');
+    expect(screen.getByTestId('workspaces-enabled').textContent).toBe('true');
+
+    // Should not have called fetch again - React Query handles deduplication
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  test('getWorkspacesEnabledSync returns false before fetch completes', () => {
+    // Create a fresh queryClient without any cached data
+    const freshQueryClient = createTestQueryClient();
+    mockFetch.mockImplementation(() => new Promise(() => {}));
+
+    // Before render, no queryClient reference is set
+    expect(getWorkspacesEnabledSync()).toBe(false);
+
+    // Render to set up the queryClient reference
+    renderWithProviders(<TestComponent />, freshQueryClient);
+
+    // While still loading (fetch not complete), should return false
+    expect(getWorkspacesEnabledSync()).toBe(false);
+  });
+});

--- a/mlflow/server/js/src/common/utils/ServerFeaturesContext.tsx
+++ b/mlflow/server/js/src/common/utils/ServerFeaturesContext.tsx
@@ -1,0 +1,137 @@
+import React, { createContext, useContext, useMemo, ReactNode, useEffect } from 'react';
+import { useQuery, useQueryClient, QueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { getAjaxUrl, getDefaultHeaders } from './FetchUtils';
+
+const SERVER_FEATURES_ENDPOINT = 'ajax-api/3.0/mlflow/server-features';
+
+// Query key for React Query caching and deduplication
+export const SERVER_FEATURES_QUERY_KEY = ['serverFeatures'] as const;
+
+interface ServerFeatures {
+  workspacesEnabled: boolean;
+}
+
+interface ServerFeaturesContextValue {
+  features: ServerFeatures;
+  loading: boolean;
+  error: Error | null;
+}
+
+const defaultFeatures: ServerFeatures = {
+  workspacesEnabled: false,
+};
+
+const ServerFeaturesContext = createContext<ServerFeaturesContextValue>({
+  features: defaultFeatures,
+  loading: true,
+  error: null,
+});
+
+// Module-level reference to the QueryClient for synchronous access
+let queryClientRef: QueryClient | null = null;
+
+/**
+ * Query function for fetching server features.
+ * Handles 404 (old backend) by returning workspacesEnabled: false.
+ * Uses default headers for OAuth/K8s deployments that rely on cookie-derived headers + Authorization.
+ */
+async function fetchServerFeatures(): Promise<ServerFeatures> {
+  try {
+    let cookieString = '';
+    if (typeof document !== 'undefined' && typeof document.cookie === 'string') {
+      cookieString = document.cookie || '';
+    }
+
+    const response = await fetch(getAjaxUrl(SERVER_FEATURES_ENDPOINT), {
+      headers: {
+        ...getDefaultHeaders(cookieString),
+      },
+    });
+
+    if (response.status === 404) {
+      return { workspacesEnabled: Boolean(process.env['MLFLOW_ENABLE_WORKSPACES']) };
+    }
+
+    if (!response.ok) {
+      // Other error - assume workspaces disabled for safety
+      return { workspacesEnabled: false };
+    }
+
+    const data = await response.json();
+    return {
+      workspacesEnabled: Boolean(data?.workspaces_enabled),
+    };
+  } catch {
+    // Network error or other issue - assume workspaces disabled
+    return { workspacesEnabled: false };
+  }
+}
+
+interface ServerFeaturesProviderProps {
+  children: ReactNode;
+}
+
+export const ServerFeaturesProvider = ({ children }: ServerFeaturesProviderProps) => {
+  const queryClient = useQueryClient();
+
+  // Store queryClient reference for synchronous access during render
+  queryClientRef = queryClient;
+
+  useEffect(() => {
+    return () => {
+      // Only clear if this is still the active reference
+      if (queryClientRef === queryClient) {
+        queryClientRef = null;
+      }
+    };
+  }, [queryClient]);
+
+  const { data, isLoading, error } = useQuery<ServerFeatures, Error, ServerFeatures, typeof SERVER_FEATURES_QUERY_KEY>(
+    SERVER_FEATURES_QUERY_KEY,
+    {
+      queryFn: fetchServerFeatures,
+      staleTime: Infinity, // Never refetch automatically - features don't change during session
+      cacheTime: Infinity, // Keep in cache indefinitely
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+    },
+  );
+
+  const features: ServerFeatures = data ?? defaultFeatures;
+
+  const value = useMemo(
+    () => ({
+      features,
+      loading: isLoading,
+      error: error ?? null,
+    }),
+    [features, isLoading, error],
+  );
+
+  return <ServerFeaturesContext.Provider value={value}>{children}</ServerFeaturesContext.Provider>;
+};
+
+export const useServerFeatures = (): ServerFeaturesContextValue => {
+  return useContext(ServerFeaturesContext);
+};
+
+export const useWorkspacesEnabled = (): { workspacesEnabled: boolean; loading: boolean } => {
+  const { features, loading } = useServerFeatures();
+  return {
+    workspacesEnabled: features.workspacesEnabled,
+    loading,
+  };
+};
+
+// For synchronous access (e.g., in WorkspaceUtils)
+// Returns the cached value from React Query or false if not yet loaded
+export const getWorkspacesEnabledSync = (): boolean => {
+  const cachedData = queryClientRef?.getQueryData<ServerFeatures>(SERVER_FEATURES_QUERY_KEY);
+  return cachedData?.workspacesEnabled ?? false;
+};
+
+// For testing purposes - allows resetting the cached state
+export const resetServerFeaturesCache = (): void => {
+  queryClientRef?.removeQueries({ queryKey: SERVER_FEATURES_QUERY_KEY });
+};

--- a/mlflow/server/js/src/common/utils/TestUtils.react18.tsx
+++ b/mlflow/server/js/src/common/utils/TestUtils.react18.tsx
@@ -5,6 +5,7 @@ import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 import { DEFAULT_LOCALE } from '../../i18n/loadMessages';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 
 const defaultIntlProviderProps = {
   locale: DEFAULT_LOCALE,
@@ -15,7 +16,9 @@ const defaultIntlProviderProps = {
 export function renderWithDesignSystem(ui: React.ReactElement, renderOptions = {}, providerProps = {}): RenderResult {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <IntlProvider {...defaultIntlProviderProps}>
-      <DesignSystemProvider {...providerProps}>{children}</DesignSystemProvider>
+      <TooltipProvider>
+        <DesignSystemProvider {...providerProps}>{children}</DesignSystemProvider>
+      </TooltipProvider>
     </IntlProvider>
   );
 
@@ -28,7 +31,9 @@ export function renderWithIntl(ui: React.ReactElement, renderOptions = {}, provi
     ...providerProps,
   };
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <IntlProvider {...mergedProviderProps}>{children}</IntlProvider>
+    <IntlProvider {...mergedProviderProps}>
+      <TooltipProvider>{children}</TooltipProvider>
+    </IntlProvider>
   );
 
   return render(ui, { wrapper, ...renderOptions });

--- a/mlflow/server/js/src/common/utils/TestUtils.react18.tsx
+++ b/mlflow/server/js/src/common/utils/TestUtils.react18.tsx
@@ -5,7 +5,6 @@ import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 import { DEFAULT_LOCALE } from '../../i18n/loadMessages';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 
 const defaultIntlProviderProps = {
   locale: DEFAULT_LOCALE,
@@ -16,9 +15,7 @@ const defaultIntlProviderProps = {
 export function renderWithDesignSystem(ui: React.ReactElement, renderOptions = {}, providerProps = {}): RenderResult {
   const wrapper = ({ children }: { children: React.ReactNode }) => (
     <IntlProvider {...defaultIntlProviderProps}>
-      <TooltipProvider>
-        <DesignSystemProvider {...providerProps}>{children}</DesignSystemProvider>
-      </TooltipProvider>
+      <DesignSystemProvider {...providerProps}>{children}</DesignSystemProvider>
     </IntlProvider>
   );
 
@@ -31,9 +28,7 @@ export function renderWithIntl(ui: React.ReactElement, renderOptions = {}, provi
     ...providerProps,
   };
   const wrapper = ({ children }: { children: React.ReactNode }) => (
-    <IntlProvider {...mergedProviderProps}>
-      <TooltipProvider>{children}</TooltipProvider>
-    </IntlProvider>
+    <IntlProvider {...mergedProviderProps}>{children}</IntlProvider>
   );
 
   return render(ui, { wrapper, ...renderOptions });

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunBox.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunBox.test.tsx
@@ -5,6 +5,10 @@ import { renderWithIntl, screen } from '../../common/utils/TestUtils.react18';
 import type { RunInfoEntity } from '../types';
 import { CompareRunBox } from './CompareRunBox';
 
+jest.mock('./LazyPlot', () => ({
+  LazyPlot: ({ children }: any) => <div data-testid="lazy-plot">{children}</div>,
+}));
+
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(30000); // Larger timeout for integration testing (plotly rendering)
 

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
@@ -7,6 +7,8 @@ import { setupTestRouter, testRoute, TestRouter } from '../../common/utils/Routi
 import { setupServer } from '../../common/utils/setup-msw';
 import { rest } from 'msw';
 import { EXPERIMENT_RUNS_MOCK_STORE } from './experiment-page/fixtures/experiment-runs.fixtures';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
+import { DesignSystemProvider } from '@databricks/design-system';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(60000);
@@ -73,7 +75,11 @@ describe('CompareRunPage', () => {
           }
         >
           <IntlProvider locale="en">
-            <TestRouter routes={[testRoute(<>{children}</>, '/')]} history={history} initialEntries={[routerUrl]} />
+            <TooltipProvider>
+              <DesignSystemProvider>
+                <TestRouter routes={[testRoute(<>{children}</>, '/')]} history={history} initialEntries={[routerUrl]} />
+              </DesignSystemProvider>
+            </TooltipProvider>
           </IntlProvider>
         </MockedReduxStoreProvider>
       ),

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunPage.test.tsx
@@ -7,7 +7,6 @@ import { setupTestRouter, testRoute, TestRouter } from '../../common/utils/Routi
 import { setupServer } from '../../common/utils/setup-msw';
 import { rest } from 'msw';
 import { EXPERIMENT_RUNS_MOCK_STORE } from './experiment-page/fixtures/experiment-runs.fixtures';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { DesignSystemProvider } from '@databricks/design-system';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
@@ -75,11 +74,9 @@ describe('CompareRunPage', () => {
           }
         >
           <IntlProvider locale="en">
-            <TooltipProvider>
-              <DesignSystemProvider>
-                <TestRouter routes={[testRoute(<>{children}</>, '/')]} history={history} initialEntries={[routerUrl]} />
-              </DesignSystemProvider>
-            </TooltipProvider>
+            <DesignSystemProvider>
+              <TestRouter routes={[testRoute(<>{children}</>, '/')]} history={history} initialEntries={[routerUrl]} />
+            </DesignSystemProvider>
           </IntlProvider>
         </MockedReduxStoreProvider>
       ),

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.tsx
@@ -4,17 +4,14 @@ import { MockedReduxStoreProvider } from '../../common/utils/TestUtils';
 import { render, screen, waitFor } from '../../common/utils/TestUtils.react18';
 import CompareRunView from './CompareRunView';
 import { testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { DesignSystemProvider } from '@databricks/design-system';
 
 describe('CompareRunView', () => {
   const wrapper = ({ children }: { children?: React.ReactNode }) => (
     <IntlProvider locale="en">
-      <TooltipProvider>
-        <DesignSystemProvider>
-          <TestRouter routes={[testRoute(<>{children}</>)]} />
-        </DesignSystemProvider>
-      </TooltipProvider>
+      <DesignSystemProvider>
+        <TestRouter routes={[testRoute(<>{children}</>)]} />
+      </DesignSystemProvider>
     </IntlProvider>
   );
   test('Will display title for two runs', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/CompareRunView.test.tsx
@@ -4,11 +4,17 @@ import { MockedReduxStoreProvider } from '../../common/utils/TestUtils';
 import { render, screen, waitFor } from '../../common/utils/TestUtils.react18';
 import CompareRunView from './CompareRunView';
 import { testRoute, TestRouter } from '../../common/utils/RoutingTestUtils';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
+import { DesignSystemProvider } from '@databricks/design-system';
 
 describe('CompareRunView', () => {
   const wrapper = ({ children }: { children?: React.ReactNode }) => (
     <IntlProvider locale="en">
-      <TestRouter routes={[testRoute(<>{children}</>)]} />
+      <TooltipProvider>
+        <DesignSystemProvider>
+          <TestRouter routes={[testRoute(<>{children}</>)]} />
+        </DesignSystemProvider>
+      </TooltipProvider>
     </IntlProvider>
   );
   test('Will display title for two runs', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/DirectRunPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/DirectRunPage.test.tsx
@@ -9,6 +9,11 @@ import { DirectRunPage } from './DirectRunPage';
 import { useEffect } from 'react';
 import { renderWithIntl, screen, act } from '../../common/utils/TestUtils.react18';
 
+jest.mock('../../common/utils/ServerFeaturesContext', () => ({
+  getWorkspacesEnabledSync: () => false,
+  useWorkspacesEnabled: () => ({ workspacesEnabled: false, loading: false }),
+}));
+
 jest.mock('../../common/components/PageNotFoundView', () => ({
   PageNotFoundView: () => <div>Page not found</div>,
 }));

--- a/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/ExperimentListView.tsx
@@ -27,8 +27,17 @@ import { useUpdateExperimentTags } from './experiment-page/hooks/useUpdateExperi
 import { useSearchFilter } from './experiment-page/hooks/useSearchFilter';
 import { TagFilter, useTagsFilter } from './experiment-page/hooks/useTagsFilter';
 import { ExperimentListViewTagsFilter } from './experiment-page/components/ExperimentListViewTagsFilter';
+import { shouldEnableWorkspaces } from '../../common/utils/FeatureUtils';
+import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
+import { useSearchParams } from '../../common/utils/RoutingUtils';
 
 export const ExperimentListView = () => {
+  const [searchParams] = useSearchParams();
+  const workspacesEnabled = shouldEnableWorkspaces();
+  const workspaceFromUrl = extractWorkspaceFromSearchParams(searchParams);
+  // Only show creation buttons when: workspaces are disabled OR a workspace is selected
+  const showCreationButtons = !workspacesEnabled || workspaceFromUrl !== null;
+
   const [searchFilter, setSearchFilter] = useSearchFilter();
   const { tagsFilter, setTagsFilter, isTagsFilterOpen, setIsTagsFilterOpen } = useTagsFilter();
 
@@ -95,17 +104,19 @@ export const ExperimentListView = () => {
         title={<FormattedMessage defaultMessage="Experiments" description="Header title for the experiments page" />}
         buttons={
           <>
-            <Button
-              componentId="mlflow.experiment_list_view.new_experiment_button"
-              type="primary"
-              onClick={handleCreateExperiment}
-              data-testid="create-experiment-button"
-            >
-              <FormattedMessage
-                defaultMessage="Create"
-                description="Label for the create experiment action on the experiments list page"
-              />
-            </Button>
+            {showCreationButtons && (
+              <Button
+                componentId="mlflow.experiment_list_view.new_experiment_button"
+                type="primary"
+                onClick={handleCreateExperiment}
+                data-testid="create-experiment-button"
+              >
+                <FormattedMessage
+                  defaultMessage="Create"
+                  description="Label for the create experiment action on the experiments list page"
+                />
+              </Button>
+            )}
             <Button
               componentId="mlflow.experiment_list_view.compare_experiments_button"
               onClick={pushExperimentRoute}

--- a/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.enzyme.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/RunLinksPopover.enzyme.test.tsx
@@ -12,6 +12,7 @@ import { shallow, mount } from 'enzyme';
 
 import { RunLinksPopover } from './RunLinksPopover';
 import Routes from '../routes';
+import { prefixRouteWithWorkspace } from '../../workspaces/utils/WorkspaceUtils';
 
 describe('unit tests', () => {
   let wrapper;
@@ -68,7 +69,7 @@ describe('unit tests', () => {
 
     props.runItems.forEach(({ runId, name, color, y }: any, index: any) => {
       const link = links[index];
-      const hrefExpected = Routes.getRunPageRoute(props.experimentId, runId);
+      const hrefExpected = prefixRouteWithWorkspace(Routes.getRunPageRoute(props.experimentId, runId));
       expect(link.getAttribute('href')).toBe(hrefExpected);
 
       const p = link.querySelector('p');

--- a/mlflow/server/js/src/experiment-tracking/components/RunView.nav.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/RunView.nav.test.tsx
@@ -14,6 +14,11 @@ import { useRunDetailsPageData } from './run-page/hooks/useRunDetailsPageData';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 import { DesignSystemProvider } from '@databricks/design-system';
 
+jest.mock('../../common/utils/ServerFeaturesContext', () => ({
+  getWorkspacesEnabledSync: () => false,
+  useWorkspacesEnabled: () => ({ workspacesEnabled: false, loading: false }),
+}));
+
 // Mock tab contents
 jest.mock('./run-page/RunViewMetricCharts', () => ({
   // @ts-expect-error 'props' is of type 'unknown'

--- a/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/utils/fetchArtifactUnified.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/artifact-view-components/utils/fetchArtifactUnified.test.tsx
@@ -1,7 +1,18 @@
-import { jest, describe, it, expect } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, it, jest } from '@jest/globals';
 import { rest } from 'msw';
 import { setupServer } from '../../../../common/utils/setup-msw';
 import { fetchArtifactUnified } from './fetchArtifactUnified';
+import { setActiveWorkspace } from '../../../../workspaces/utils/WorkspaceUtils';
+import { getWorkspacesEnabledSync } from '../../../../common/utils/ServerFeaturesContext';
+
+jest.mock('../../../../common/utils/ServerFeaturesContext', () => ({
+  ...jest.requireActual<typeof import('../../../../common/utils/ServerFeaturesContext')>(
+    '../../../../common/utils/ServerFeaturesContext',
+  ),
+  getWorkspacesEnabledSync: jest.fn(),
+}));
+
+const getWorkspacesEnabledSyncMock = jest.mocked(getWorkspacesEnabledSync);
 
 describe('fetchArtifactUnified', () => {
   const experimentId = 'test-experiment-id';
@@ -14,19 +25,38 @@ describe('fetchArtifactUnified', () => {
   const loggedModelArtifactContent = 'test-logged-model-artifact-content';
 
   const server = setupServer(
-    rest.get('/get-artifact', (req, res, ctx) => {
+    rest.get(/\/?get-artifact/, (req, res, ctx) => {
+      expect(req.headers.get('X-MLFLOW-WORKSPACE')).toBe('team-a');
       return res(ctx.body(runArtifactContent));
     }),
-    rest.get('/ajax-api/2.0/mlflow/get-artifact', (req, res, ctx) => {
+    rest.get(/\/?ajax-api\/2\.0\/mlflow\/get-artifact/, (req, res, ctx) => {
+      expect(req.headers.get('X-MLFLOW-WORKSPACE')).toBe('team-a');
       return res(ctx.body(runArtifactContent));
     }),
-    rest.get('/ajax-api/2.0/mlflow/logged-models/test-logged-model-id/artifacts/files', (req, res, ctx) => {
+    rest.get(/\/?ajax-api\/2\.0\/mlflow\/logged-models\/test-logged-model-id\/artifacts\/files/, (req, res, ctx) => {
+      expect(req.headers.get('X-MLFLOW-WORKSPACE')).toBe('team-a');
       return res(ctx.body(loggedModelArtifactContent));
     }),
   );
 
+  beforeAll(() => {
+    getWorkspacesEnabledSyncMock.mockReturnValue(true);
+    setActiveWorkspace('team-a');
+    server.listen();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    setActiveWorkspace(null);
+    jest.restoreAllMocks();
+    server.close();
+  });
+
   it('fetches run artifact from workspace API', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const result = await fetchArtifactUnified({
       experimentId,
       path,
@@ -36,14 +66,14 @@ describe('fetchArtifactUnified', () => {
     });
 
     expect(result).toEqual(runArtifactContent);
-    jest.restoreAllMocks();
+    consoleErrorSpy.mockRestore();
   });
 
   it('fetches logged model artifact from workspace API', async () => {
-    jest.spyOn(console, 'error').mockImplementation(() => {});
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
     const result = await fetchArtifactUnified({ experimentId, path, runUuid, isLoggedModelsMode, loggedModelId });
 
     expect(result).toEqual(loggedModelArtifactContent);
-    jest.restoreAllMocks();
+    consoleErrorSpy.mockRestore();
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/evaluations/EvaluationRunCompareSelector.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/evaluations/EvaluationRunCompareSelector.tsx
@@ -14,6 +14,7 @@ import { useCallback, useMemo } from 'react';
 import { useGetExperimentRunColor } from '../experiment-page/hooks/useExperimentRunColor';
 import { useIntl } from '@databricks/i18n';
 import Routes from '../../routes';
+import { useLocation, useNavigate } from '../../../common/utils/RoutingUtils';
 import {
   useGenAiExperimentRunsForComparison,
   COMPARE_TO_RUN_DROPDOWN_COMPONENT_ID,
@@ -70,20 +71,16 @@ export const EvaluationRunCompareSelector = ({
   const currentRunInfo = experimentRunInfos?.find((runInfo) => runInfo.runUuid === currentRunUuid);
   const compareToRunInfo = experimentRunInfos?.find((runInfo) => runInfo.runUuid === compareToRunUuid);
 
+  const navigate = useNavigate();
+  const location = useLocation();
+
   const defaultSetCurrentRunUuid = useCallback(
     (runUuid: string) => {
       const link = Routes.getRunPageRoute(experimentId, runUuid) + '/evaluations';
-      // Propagate all the current URL query params.
-      const currentParams = new URLSearchParams(window.location.search);
-
-      const newUrl = new URL(link, window.location.origin);
-      currentParams.forEach((value, key) => {
-        newUrl.searchParams.set(key, value);
-      });
-
-      window.location.href = newUrl.toString();
+      // Navigate using React Router, preserving all current query params (including workspace)
+      navigate({ pathname: link, search: location.search });
     },
-    [experimentId],
+    [experimentId, location.search, navigate],
   );
 
   const setCurrentRunUuid = setCurrentRunUuidProp ?? defaultSetCurrentRunUuid;

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsArtifacts.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelDetailsArtifacts.test.tsx
@@ -1,4 +1,4 @@
-import { jest, describe, beforeAll, test, expect } from '@jest/globals';
+import { afterAll, afterEach, beforeAll, describe, expect, jest, test } from '@jest/globals';
 import { DesignSystemProvider } from '@databricks/design-system';
 import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
@@ -12,12 +12,24 @@ import { render, waitFor } from '../../../common/utils/TestUtils.react18';
 import { apis, artifactsByRunUuid } from '../../reducers/Reducers';
 import { ExperimentLoggedModelDetailsArtifacts } from './ExperimentLoggedModelDetailsArtifacts';
 import { setupTestRouter, testRoute, TestRouter } from '../../../common/utils/RoutingTestUtils';
+import { setActiveWorkspace } from '../../../workspaces/utils/WorkspaceUtils';
+import { getWorkspacesEnabledSync } from '../../../common/utils/ServerFeaturesContext';
+
+jest.mock('../../../common/utils/ServerFeaturesContext', () => ({
+  ...jest.requireActual<typeof import('../../../common/utils/ServerFeaturesContext')>(
+    '../../../common/utils/ServerFeaturesContext',
+  ),
+  getWorkspacesEnabledSync: jest.fn(),
+}));
+
+const getWorkspacesEnabledSyncMock = jest.mocked(getWorkspacesEnabledSync);
 
 describe('ExperimentLoggedModelDetailsArtifacts integration test', () => {
   const { history } = setupTestRouter();
   const server = setupServer(
-    rest.get('/ajax-api/2.0/mlflow/logged-models/:modelId/artifacts/directories', (req, res, ctx) =>
-      res(
+    rest.get(/\/?ajax-api\/2\.0\/mlflow\/logged-models\/[^/]+\/artifacts\/directories/, (req, res, ctx) => {
+      expect(req.headers.get('X-MLFLOW-WORKSPACE')).toBe('team-a');
+      return res(
         ctx.json({
           root_uri: 'dbfs:/databricks/mlflow-tracking/123/logged_models/test-model-id/artifacts',
           files: [
@@ -33,14 +45,16 @@ describe('ExperimentLoggedModelDetailsArtifacts integration test', () => {
             },
           ],
         }),
-      ),
-    ),
-    rest.get('/ajax-api/2.0/mlflow/logged-models/:modelId/artifacts/files', (req, res, ctx) =>
-      res(ctx.text('this is text file content of ' + req.url.searchParams.get('artifact_file_path'))),
-    ),
-    rest.get('/get-artifact', (req, res, ctx) =>
-      res(ctx.text('this is text file content of ' + req.url.searchParams.get('path'))),
-    ),
+      );
+    }),
+    rest.get(/\/?ajax-api\/2\.0\/mlflow\/logged-models\/[^/]+\/artifacts\/files/, (req, res, ctx) => {
+      expect(req.headers.get('X-MLFLOW-WORKSPACE')).toBe('team-a');
+      return res(ctx.text('this is text file content of ' + req.url.searchParams.get('artifact_file_path')));
+    }),
+    rest.get(/\/?get-artifact/, (req, res, ctx) => {
+      expect(req.headers.get('X-MLFLOW-WORKSPACE')).toBe('team-a');
+      return res(ctx.text('this is text file content of ' + req.url.searchParams.get('path')));
+    }),
   );
 
   const renderTestComponent = () => {
@@ -77,8 +91,20 @@ describe('ExperimentLoggedModelDetailsArtifacts integration test', () => {
   };
 
   beforeAll(() => {
+    getWorkspacesEnabledSyncMock.mockReturnValue(true);
+    setActiveWorkspace('team-a');
     process.env['MLFLOW_USE_ABSOLUTE_AJAX_URLS'] = 'true';
     server.listen();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+    setActiveWorkspace(null);
+    server.close();
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
   });
 
   test('should render list of artifacts and display file contents', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageColumnSelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageColumnSelector.test.tsx
@@ -4,7 +4,6 @@ import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { IntlProvider } from 'react-intl';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import {
   ExperimentLoggedModelListPageKnownColumns,
   useExperimentLoggedModelListPageTableColumns,
@@ -62,9 +61,7 @@ describe('ExperimentLoggedModelListPageColumnSelector', () => {
     render(<TestComponent />, {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <TooltipProvider>
-            <DesignSystemProvider>{children}</DesignSystemProvider>
-          </TooltipProvider>
+          <DesignSystemProvider>{children}</DesignSystemProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageColumnSelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageColumnSelector.test.tsx
@@ -1,13 +1,18 @@
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, jest } from '@jest/globals';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 import { IntlProvider } from 'react-intl';
+import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import {
   ExperimentLoggedModelListPageKnownColumns,
   useExperimentLoggedModelListPageTableColumns,
 } from './hooks/useExperimentLoggedModelListPageTableColumns';
 import { ExperimentLoggedModelListPageColumnSelector } from './ExperimentLoggedModelListPageColumnSelector';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 
 const getMetric = (key: string, datasetName: string | undefined) => ({
   key,
@@ -55,7 +60,13 @@ describe('ExperimentLoggedModelListPageColumnSelector', () => {
       );
     };
     render(<TestComponent />, {
-      wrapper: ({ children }) => <IntlProvider locale="en">{children}</IntlProvider>,
+      wrapper: ({ children }) => (
+        <IntlProvider locale="en">
+          <TooltipProvider>
+            <DesignSystemProvider>{children}</DesignSystemProvider>
+          </TooltipProvider>
+        </IntlProvider>
+      ),
     });
   };
   test('should handle enabling and disabling arbitrary columns', async () => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageOrderBySelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageOrderBySelector.test.tsx
@@ -6,7 +6,6 @@ import { render, screen, waitFor, within } from '../../../common/utils/TestUtils
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(30000);
@@ -80,9 +79,7 @@ describe('ExperimentLoggedModelListPageOrderBySelector', () => {
     return render(<TestComponent />, {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <TooltipProvider>
-            <DesignSystemProvider>{children}</DesignSystemProvider>
-          </TooltipProvider>
+          <DesignSystemProvider>{children}</DesignSystemProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageOrderBySelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/ExperimentLoggedModelListPageOrderBySelector.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import { useState } from 'react';
 import { useExperimentLoggedModelListPageTableColumns } from './hooks/useExperimentLoggedModelListPageTableColumns';
 import { ExperimentLoggedModelListPageOrderBySelector } from './ExperimentLoggedModelListPageOrderBySelector';
@@ -6,6 +6,10 @@ import { render, screen, waitFor, within } from '../../../common/utils/TestUtils
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 
 const metrics = [
   { dataset_name: 'train', dataset_digest: '123456', key: 'rmse', value: 0.1 },
@@ -75,9 +79,11 @@ describe('ExperimentLoggedModelListPageOrderBySelector', () => {
 
     return render(<TestComponent />, {
       wrapper: ({ children }) => (
-        <DesignSystemProvider>
-          <IntlProvider locale="en">{children}</IntlProvider>
-        </DesignSystemProvider>
+        <IntlProvider locale="en">
+          <TooltipProvider>
+            <DesignSystemProvider>{children}</DesignSystemProvider>
+          </TooltipProvider>
+        </IntlProvider>
       ),
     });
   };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelDeleteModal.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelDeleteModal.tsx
@@ -22,7 +22,7 @@ export const useExperimentLoggedModelDeleteModal = ({
     }
   >({
     mutationFn: async ({ loggedModelId }) => {
-      await fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}`), 'DELETE');
+      await fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}`), { method: 'DELETE' });
     },
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelListPageMode.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-logged-models/hooks/useExperimentLoggedModelListPageMode.tsx
@@ -16,7 +16,11 @@ export const useExperimentLoggedModelListPageMode = () => {
     ExperimentLoggedModelListPageMode.TABLE,
   );
   const setViewMode = (mode: ExperimentLoggedModelListPageMode) => {
-    setParams({ [VIEW_MODE_QUERY_PARAM]: mode });
+    setParams((prevParams) => {
+      const newParams = new URLSearchParams(prevParams);
+      newParams.set(VIEW_MODE_QUERY_PARAM, mode);
+      return newParams;
+    });
   };
   return { viewMode, setViewMode } as const;
 };

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActionsSelectTags.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsControlsActionsSelectTags.test.tsx
@@ -14,7 +14,7 @@ jest.mock('@mlflow/mlflow/src/experiment-tracking/actions', () => ({
 }));
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
-jest.setTimeout(10000);
+jest.setTimeout(30000);
 
 describe('ExperimentViewRunsControlsActionsSelectTags', () => {
   beforeEach(() => {

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsGroupBySelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsGroupBySelector.test.tsx
@@ -5,7 +5,6 @@ import type { ExperimentRunsSelectorResult } from '../../utils/experimentRuns.se
 import { ExperimentViewRunsGroupBySelector } from './ExperimentViewRunsGroupBySelector';
 import userEventGlobal, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import type { RunsGroupByConfig } from '../../utils/experimentPage.group-row-utils';
 import { RunGroupingAggregateFunction, RunGroupingMode } from '../../utils/experimentPage.row-types';
 import { useState } from 'react';
@@ -66,9 +65,7 @@ describe('ExperimentViewRunsGroupBySelector', () => {
     return render(<TestComponent />, {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <TooltipProvider>
-            <DesignSystemProvider>{children}</DesignSystemProvider>
-          </TooltipProvider>
+          <DesignSystemProvider>{children}</DesignSystemProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsGroupBySelector.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsGroupBySelector.test.tsx
@@ -5,9 +5,13 @@ import type { ExperimentRunsSelectorResult } from '../../utils/experimentRuns.se
 import { ExperimentViewRunsGroupBySelector } from './ExperimentViewRunsGroupBySelector';
 import userEventGlobal, { PointerEventsCheckLevel } from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import type { RunsGroupByConfig } from '../../utils/experimentPage.group-row-utils';
 import { RunGroupingAggregateFunction, RunGroupingMode } from '../../utils/experimentPage.row-types';
 import { useState } from 'react';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 
 const userEvent = userEventGlobal.setup({ pointerEventsCheck: PointerEventsCheckLevel.Never });
 
@@ -62,7 +66,9 @@ describe('ExperimentViewRunsGroupBySelector', () => {
     return render(<TestComponent />, {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <DesignSystemProvider>{children}</DesignSystemProvider>
+          <TooltipProvider>
+            <DesignSystemProvider>{children}</DesignSystemProvider>
+          </TooltipProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsSortSelectorV2.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsSortSelectorV2.test.tsx
@@ -3,7 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../../../common/utils/TestUtils.react18';
 import { ExperimentViewRunsSortSelectorV2 } from './ExperimentViewRunsSortSelectorV2';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { MemoryRouter, useSearchParams } from '../../../../../common/utils/RoutingUtils';
 import { IntlProvider } from 'react-intl';
 
@@ -49,9 +48,7 @@ describe('ExperimentViewRunsSortSelectorV2', () => {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <IntlProvider locale="en">
-            <TooltipProvider>
-              <DesignSystemProvider>{children}</DesignSystemProvider>
-            </TooltipProvider>
+            <DesignSystemProvider>{children}</DesignSystemProvider>
           </IntlProvider>
         </MemoryRouter>
       ),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsSortSelectorV2.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/runs/ExperimentViewRunsSortSelectorV2.test.tsx
@@ -3,8 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../../../common/utils/TestUtils.react18';
 import { ExperimentViewRunsSortSelectorV2 } from './ExperimentViewRunsSortSelectorV2';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { MemoryRouter, useSearchParams } from '../../../../../common/utils/RoutingUtils';
 import { IntlProvider } from 'react-intl';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 
 const metricKeys = ['metric_alpha', 'metric_beta'];
 const paramKeys = ['param_1', 'param_2', 'param_3'];
@@ -45,7 +49,9 @@ describe('ExperimentViewRunsSortSelectorV2', () => {
       wrapper: ({ children }) => (
         <MemoryRouter>
           <IntlProvider locale="en">
-            <DesignSystemProvider>{children}</DesignSystemProvider>
+            <TooltipProvider>
+              <DesignSystemProvider>{children}</DesignSystemProvider>
+            </TooltipProvider>
           </IntlProvider>
         </MemoryRouter>
       ),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
@@ -3,9 +3,13 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { TracesV3Logs } from './TracesV3Logs';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 import { IntlProvider } from '@databricks/i18n';
 import { QueryClient, QueryClientProvider, type UseMutateAsyncFunction } from '@databricks/web-shared/query-client';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import {
   useMlflowTracesTableMetadata,
   useSearchMlflowTraces,
@@ -75,6 +79,10 @@ jest.mock('./TracesV3EmptyState', () => ({
   TracesV3EmptyState: jest.fn(() => null),
 }));
 
+jest.mock('../../../../pages/experiment-evaluation-datasets/components/ExportTracesToDatasetModal', () => ({
+  ExportTracesToDatasetModal: jest.fn(() => null),
+}));
+
 const renderComponent = (props = {}) => {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -88,11 +96,13 @@ const renderComponent = (props = {}) => {
         testRoute(
           <IntlProvider locale="en">
             <QueryClientProvider client={queryClient}>
-              <DesignSystemProvider>
-                <GenAITracesTableProvider isGroupedBySession={false}>
-                  <TracesV3Logs experimentId="test-experiment" endpointName="test-endpoint" {...props} />
-                </GenAITracesTableProvider>
-              </DesignSystemProvider>
+              <TooltipProvider>
+                <DesignSystemProvider>
+                  <GenAITracesTableProvider isGroupedBySession={false}>
+                    <TracesV3Logs experimentId="test-experiment" endpointName="test-endpoint" {...props} />
+                  </GenAITracesTableProvider>
+                </DesignSystemProvider>
+              </TooltipProvider>
             </QueryClientProvider>
           </IntlProvider>,
         ),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/components/traces-v3/TracesV3Logs.test.tsx
@@ -9,7 +9,6 @@ jest.setTimeout(30000);
 import { IntlProvider } from '@databricks/i18n';
 import { QueryClient, QueryClientProvider, type UseMutateAsyncFunction } from '@databricks/web-shared/query-client';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import {
   useMlflowTracesTableMetadata,
   useSearchMlflowTraces,
@@ -96,13 +95,11 @@ const renderComponent = (props = {}) => {
         testRoute(
           <IntlProvider locale="en">
             <QueryClientProvider client={queryClient}>
-              <TooltipProvider>
-                <DesignSystemProvider>
-                  <GenAITracesTableProvider isGroupedBySession={false}>
-                    <TracesV3Logs experimentId="test-experiment" endpointName="test-endpoint" {...props} />
-                  </GenAITracesTableProvider>
-                </DesignSystemProvider>
-              </TooltipProvider>
+              <DesignSystemProvider>
+                <GenAITracesTableProvider isGroupedBySession={false}>
+                  <TracesV3Logs experimentId="test-experiment" endpointName="test-endpoint" {...props} />
+                </GenAITracesTableProvider>
+              </DesignSystemProvider>
             </QueryClientProvider>
           </IntlProvider>,
         ),

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
@@ -27,7 +27,6 @@ const ExperimentPageRoutePathToTabNameMap = map(
 const getTabNameFromRoutePath = (pathname: string) =>
   ExperimentPageRoutePathToTabNameMap
     // Find the first route path that matches the given pathname
-    // Note: With query param-based workspace routing, pathname no longer contains workspace prefix
     .find(({ routePath }) => Boolean(matchPath(routePath, pathname)))?.tabName;
 
 // Maps exact tab names to top-level tab names

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useGetExperimentPageActiveTabByRoute.tsx
@@ -27,6 +27,7 @@ const ExperimentPageRoutePathToTabNameMap = map(
 const getTabNameFromRoutePath = (pathname: string) =>
   ExperimentPageRoutePathToTabNameMap
     // Find the first route path that matches the given pathname
+    // Note: With query param-based workspace routing, pathname no longer contains workspace prefix
     .find(({ routePath }) => Boolean(matchPath(routePath, pathname)))?.tabName;
 
 // Maps exact tab names to top-level tab names

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useNavigateToExperimentPageTab.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useNavigateToExperimentPageTab.test.tsx
@@ -10,6 +10,11 @@ import type { MlflowGetExperimentQuery } from '../../../../graphql/__generated__
 import { ExperimentKind } from '../../../constants';
 import { QueryClient, QueryClientProvider } from '../../../../common/utils/reactQueryHooks';
 
+jest.mock('../../../../common/utils/ServerFeaturesContext', () => ({
+  getWorkspacesEnabledSync: () => false,
+  useWorkspacesEnabled: () => ({ workspacesEnabled: false, loading: false }),
+}));
+
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(60000); // Larger timeout for integration testing
 

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.test.tsx
@@ -16,6 +16,10 @@ import { MlflowService } from '../../../sdk/MlflowService';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 
 jest.mock('../../../../common/utils/LocalStorageUtils');
 
@@ -54,9 +58,11 @@ describe('useUpdateExperimentTags', () => {
     renderHook(() => useUpdateExperimentTags({ onSuccess }), {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <DesignSystemProvider>
-            <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
-          </DesignSystemProvider>
+          <TooltipProvider>
+            <DesignSystemProvider>
+              <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+            </DesignSystemProvider>
+          </TooltipProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/experiment-page/hooks/useUpdateExperimentTags.test.tsx
@@ -16,7 +16,6 @@ import { MlflowService } from '../../../sdk/MlflowService';
 import { IntlProvider } from 'react-intl';
 import userEvent from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(30000);
@@ -58,11 +57,9 @@ describe('useUpdateExperimentTags', () => {
     renderHook(() => useUpdateExperimentTags({ onSuccess }), {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <TooltipProvider>
-            <DesignSystemProvider>
-              <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
-            </DesignSystemProvider>
-          </TooltipProvider>
+          <DesignSystemProvider>
+            <QueryClientProvider client={new QueryClient()}>{children}</QueryClientProvider>
+          </DesignSystemProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/modals/CreateExperimentForm.tsx
@@ -9,6 +9,7 @@ import React, { Component } from 'react';
 
 import { injectIntl } from 'react-intl';
 import { Input, LegacyForm } from '@databricks/design-system';
+import { shouldEnableWorkspaces } from '../../../common/utils/FeatureUtils';
 
 export const EXP_NAME_FIELD = 'experimentName';
 export const ARTIFACT_LOCATION = 'artifactLocation';
@@ -26,6 +27,8 @@ type Props = {
  */
 class CreateExperimentFormComponent extends Component<Props> {
   render() {
+    const workspacesEnabled = shouldEnableWorkspaces();
+
     return (
       // @ts-expect-error TS(2322): Type '{ children: Element[]; ref: any; layout: "ve... Remove this comment to see the full error message
       <LegacyForm ref={this.props.innerRef} layout="vertical">
@@ -57,26 +60,28 @@ class CreateExperimentFormComponent extends Component<Props> {
             autoFocus
           />
         </LegacyForm.Item>
-        <LegacyForm.Item
-          name={ARTIFACT_LOCATION}
-          label={this.props.intl.formatMessage({
-            defaultMessage: 'Artifact Location',
-            description: 'Label for create experiment modal to enter a artifact location',
-          })}
-          rules={[
-            {
-              required: false,
-            },
-          ]}
-        >
-          <Input
-            componentId="codegen_mlflow_app_src_experiment-tracking_components_modals_createexperimentform.tsx_71"
-            placeholder={this.props.intl.formatMessage({
-              defaultMessage: 'Input an artifact location (optional)',
-              description: 'Input placeholder to enter artifact location for create experiment',
+        {!workspacesEnabled && (
+          <LegacyForm.Item
+            name={ARTIFACT_LOCATION}
+            label={this.props.intl.formatMessage({
+              defaultMessage: 'Artifact Location',
+              description: 'Label for create experiment modal to enter a artifact location',
             })}
-          />
-        </LegacyForm.Item>
+            rules={[
+              {
+                required: false,
+              },
+            ]}
+          >
+            <Input
+              componentId="codegen_mlflow_app_src_experiment-tracking_components_modals_createexperimentform.tsx_71"
+              placeholder={this.props.intl.formatMessage({
+                defaultMessage: 'Input an artifact location (optional)',
+                description: 'Input placeholder to enter artifact location for create experiment',
+              })}
+            />
+          </LegacyForm.Item>
+        )}
       </LegacyForm>
     );
   }

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeader.intg.test.tsx
@@ -8,6 +8,7 @@ import { ExperimentKind, ExperimentPageTabName } from '@mlflow/mlflow/src/experi
 import { EXPERIMENT_KIND_TAG_KEY } from '../../utils/ExperimentKindUtils';
 import { TestRouter, testRoute, waitForRoutesToBeRendered } from '@mlflow/mlflow/src/common/utils/RoutingTestUtils';
 import Routes from '../../routes';
+import { prefixRouteWithWorkspace } from '@mlflow/mlflow/src/workspaces/utils/WorkspaceUtils';
 
 jest.mock('../../../common/utils/FeatureUtils', () => ({
   shouldEnableExperimentPageHeaderV2: () => true,
@@ -92,7 +93,9 @@ describe('RunViewHeader - integration test', () => {
 
     const experimentLink = screen.getByTestId('experiment-observatory-link-runs');
     expect(experimentLink.textContent).toBe('Evaluations');
-    const expectedPath = Routes.getExperimentPageTabRoute(testExperimentId, ExperimentPageTabName.EvaluationRuns);
+    const expectedPath = prefixRouteWithWorkspace(
+      Routes.getExperimentPageTabRoute(testExperimentId, ExperimentPageTabName.EvaluationRuns),
+    );
     expect(experimentLink.getAttribute('href')).toBe(expectedPath);
   });
 
@@ -116,7 +119,9 @@ describe('RunViewHeader - integration test', () => {
 
     const experimentLink = screen.getByTestId('experiment-observatory-link-runs');
     expect(experimentLink.textContent).toBe('Runs');
-    const expectedPath = Routes.getExperimentPageTabRoute(testExperimentId, ExperimentPageTabName.Runs);
+    const expectedPath = prefixRouteWithWorkspace(
+      Routes.getExperimentPageTabRoute(testExperimentId, ExperimentPageTabName.Runs),
+    );
     expect(experimentLink.getAttribute('href')).toBe(expectedPath);
   });
 
@@ -135,7 +140,9 @@ describe('RunViewHeader - integration test', () => {
 
     const experimentLink = screen.getByTestId('experiment-observatory-link-runs');
     expect(experimentLink.textContent).toBe('Runs');
-    const expectedPath = Routes.getExperimentPageTabRoute(testExperimentId, ExperimentPageTabName.Runs);
+    const expectedPath = prefixRouteWithWorkspace(
+      Routes.getExperimentPageTabRoute(testExperimentId, ExperimentPageTabName.Runs),
+    );
     expect(experimentLink.getAttribute('href')).toBe(expectedPath);
   });
 });

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/RunViewHeaderRegisterModelButton.test.tsx
@@ -8,6 +8,7 @@ import { DesignSystemProvider } from '@databricks/design-system';
 import type { KeyValueEntity } from '../../../common/types';
 import userEvent from '@testing-library/user-event';
 import type { RunPageModelVersionSummary } from './hooks/useUnifiedRegisteredModelVersionsSummariesForRun';
+import { prefixRouteWithWorkspace } from '../../../workspaces/utils/WorkspaceUtils';
 
 jest.mock('../../../model-registry/actions', () => ({
   searchRegisteredModelsApi: jest.fn(() => ({ type: 'MOCKED_ACTION', payload: Promise.resolve() })),
@@ -102,7 +103,7 @@ describe('RunViewHeaderRegisterModelButton', () => {
     expect(screen.queryByRole('button', { name: 'Register model' })).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Model registered' })).toHaveAttribute(
       'href',
-      createMLflowRoutePath('/models/test-model/versions/7'),
+      prefixRouteWithWorkspace(createMLflowRoutePath('/models/test-model/versions/7')),
     );
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewChildRunsBox.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewChildRunsBox.test.tsx
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, jest, test } from '@jest/globals';
 import { renderWithIntl, screen, waitFor } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
-import { createMLflowRoutePath, MemoryRouter } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { MemoryRouter } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
 import { DesignSystemProvider } from '@databricks/design-system';
 import { RunViewChildRunsBox } from './RunViewChildRunsBox';
 import { MlflowService } from '../../../sdk/MlflowService';
 import userEvent from '@testing-library/user-event';
 import type { RunInfoEntity } from '../../../types';
+import { prefixRouteWithWorkspace } from '../../../../workspaces/utils/WorkspaceUtils';
+import Routes from '../../../routes';
 
 jest.mock('../../../sdk/MlflowService', () => ({
   MlflowService: {
@@ -55,7 +57,7 @@ describe('RunViewChildRunsBox', () => {
     expect(await screen.findByText('Child runs')).toBeInTheDocument();
 
     const link = await screen.findByRole('link', { name: 'Child run 1' });
-    expect(link).toHaveAttribute('href', createMLflowRoutePath(`/experiments/${experimentId}/runs/child-1`));
+    expect(link).toHaveAttribute('href', prefixRouteWithWorkspace(Routes.getRunPageRoute(experimentId, 'child-1')));
     expect(screen.queryByText('Child runs loading')).not.toBeInTheDocument();
   });
 

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewTagsBox.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewTagsBox.intg.test.tsx
@@ -7,6 +7,10 @@ import { setRunTagsBulkApi } from '../../../actions';
 import type { KeyValueEntity } from '../../../../common/types';
 import { RunViewTagsBox } from './RunViewTagsBox';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 
 const testRunUuid = 'test-run-uuid';
 
@@ -19,11 +23,13 @@ describe('RunViewTagsBox integration', () => {
 
   function renderTestComponent(existingTags: Record<string, KeyValueEntity> = {}) {
     renderWithIntl(
-      <DesignSystemProvider>
-        <MockedReduxStoreProvider>
-          <RunViewTagsBox onTagsUpdated={onTagsUpdated} runUuid={testRunUuid} tags={existingTags} />,
-        </MockedReduxStoreProvider>
-      </DesignSystemProvider>,
+      <TooltipProvider>
+        <DesignSystemProvider>
+          <MockedReduxStoreProvider>
+            <RunViewTagsBox onTagsUpdated={onTagsUpdated} runUuid={testRunUuid} tags={existingTags} />,
+          </MockedReduxStoreProvider>
+        </DesignSystemProvider>
+      </TooltipProvider>,
     );
   }
 

--- a/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewTagsBox.intg.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/components/run-page/overview/RunViewTagsBox.intg.test.tsx
@@ -7,7 +7,6 @@ import { setRunTagsBulkApi } from '../../../actions';
 import type { KeyValueEntity } from '../../../../common/types';
 import { RunViewTagsBox } from './RunViewTagsBox';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
 jest.setTimeout(30000);
@@ -23,13 +22,11 @@ describe('RunViewTagsBox integration', () => {
 
   function renderTestComponent(existingTags: Record<string, KeyValueEntity> = {}) {
     renderWithIntl(
-      <TooltipProvider>
-        <DesignSystemProvider>
-          <MockedReduxStoreProvider>
-            <RunViewTagsBox onTagsUpdated={onTagsUpdated} runUuid={testRunUuid} tags={existingTags} />,
-          </MockedReduxStoreProvider>
-        </DesignSystemProvider>
-      </TooltipProvider>,
+      <DesignSystemProvider>
+        <MockedReduxStoreProvider>
+          <RunViewTagsBox onTagsUpdated={onTagsUpdated} runUuid={testRunUuid} tags={existingTags} />,
+        </MockedReduxStoreProvider>
+      </DesignSystemProvider>,
     );
   }
 

--- a/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useGetLoggedModelQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useGetLoggedModelQuery.tsx
@@ -14,7 +14,7 @@ const getQueryKey = (loggedModelId: string): UseGetLoggedModelQueryKey => ['GET_
 const queryFn = async ({
   queryKey: [, loggedModelId],
 }: QueryFunctionContext<UseGetLoggedModelQueryKey>): Promise<UseGetLoggedModelQueryResponseType> =>
-  fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}`), 'GET');
+  fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}`));
 
 /**
  * Retrieve logged model from API based on its ID
@@ -69,7 +69,7 @@ export const asyncGetLoggedModel = async (
   failSilently = false,
 ): Promise<UseGetLoggedModelQueryResponseType | undefined> => {
   try {
-    const data = await fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}`), 'GET');
+    const data = await fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}`));
     return data;
   } catch (error) {
     if (failSilently) {

--- a/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useGetLoggedModelsQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useGetLoggedModelsQuery.tsx
@@ -25,7 +25,7 @@ const queryFn = async ({ queryKey: [, loggedModelIds] }: QueryFunctionContext<Qu
       for (const id of chunkedIds) {
         queryParams.append('model_ids', id);
       }
-      return fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models:batchGet?${queryParams.toString()}`), 'GET');
+      return fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models:batchGet?${queryParams.toString()}`));
     }),
   );
 };

--- a/mlflow/server/js/src/experiment-tracking/hooks/logged-models/usePatchLoggedModelsTags.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/logged-models/usePatchLoggedModelsTags.tsx
@@ -9,7 +9,10 @@ export const usePatchLoggedModelsTags = ({ loggedModelId }: { loggedModelId?: st
         tags: entries(variables).map(([key, value]) => ({ key, value })),
       };
 
-      return fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}/tags`), 'PATCH', requestBody);
+      return fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/logged-models/${loggedModelId}/tags`), {
+        method: 'PATCH',
+        body: requestBody,
+      });
     },
   });
 

--- a/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useSearchLoggedModelsQuery.tsx
+++ b/mlflow/server/js/src/experiment-tracking/hooks/logged-models/useSearchLoggedModelsQuery.tsx
@@ -67,7 +67,7 @@ export const useSearchLoggedModelsQuery = (
         datasets: !isEmpty(selectedFilterDatasets) ? selectedFilterDatasets : undefined,
       };
 
-      return fetchAPI(getAjaxUrl('ajax-api/2.0/mlflow/logged-models/search'), 'POST', requestBody);
+      return fetchAPI(getAjaxUrl('ajax-api/2.0/mlflow/logged-models/search'), { method: 'POST', body: requestBody });
     },
     cacheTime: 0,
     getNextPageParam: (lastPage) => lastPage.next_page_token,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCheckMultiturnDatasets.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCheckMultiturnDatasets.tsx
@@ -17,7 +17,7 @@ export const useCheckMultiturnDatasets = ({ datasetIds }: { datasetIds: string[]
 
         const response = await fetchAPI(
           getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}/records?${queryParams.toString()}`),
-          'GET',
+          { method: 'GET' },
         ).catch(() => null);
         if (!response) return false;
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useCreateEvaluationDatasetMutation.tsx
@@ -28,11 +28,10 @@ export const useCreateEvaluationDatasetMutation = ({
         experiment_ids: experimentIds,
       };
 
-      const response = (await fetchAPI(
-        getAjaxUrl('ajax-api/3.0/mlflow/datasets/create'),
-        'POST',
-        requestBody,
-      )) as CreateDatasetResponse;
+      const response = (await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/datasets/create'), {
+        method: 'POST',
+        body: requestBody,
+      })) as CreateDatasetResponse;
 
       return response.dataset;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useDeleteEvaluationDatasetMutation.tsx
@@ -13,7 +13,7 @@ export const useDeleteEvaluationDatasetMutation = ({
 
   const { mutate: deleteEvaluationDatasetMutation, isLoading } = useMutation({
     mutationFn: async ({ datasetId }: { datasetId: string }) => {
-      await fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}`), 'DELETE');
+      await fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}`), { method: 'DELETE' });
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [SEARCH_EVALUATION_DATASETS_QUERY_KEY] });

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useGetDatasetRecords.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useGetDatasetRecords.tsx
@@ -29,7 +29,6 @@ export const useGetDatasetRecords = ({ datasetId, enabled = true }: { datasetId:
 
       return (await fetchAPI(
         getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}/records?${queryParams.toString()}`),
-        'GET',
       )) as GetDatasetRecordsResponse;
     },
     cacheTime: 0,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useSearchEvaluationDatasets.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useSearchEvaluationDatasets.tsx
@@ -35,11 +35,10 @@ export const useSearchEvaluationDatasets = ({
         page_token: pageParam,
       };
 
-      return (await fetchAPI(
-        getAjaxUrl('ajax-api/3.0/mlflow/datasets/search'),
-        'POST',
-        requestBody,
-      )) as SearchEvaluationDatasetsResponse;
+      return (await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/datasets/search'), {
+        method: 'POST',
+        body: requestBody,
+      })) as SearchEvaluationDatasetsResponse;
     },
     cacheTime: 0,
     refetchOnWindowFocus: false,

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-evaluation-datasets/hooks/useUpsertDatasetRecordsMutation.tsx
@@ -26,11 +26,10 @@ export const useUpsertDatasetRecordsMutation = ({
         records: records,
       };
 
-      const response = (await fetchAPI(
-        getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}/records`),
-        'POST',
-        requestBody,
-      )) as UpsertDatasetRecordsResponse;
+      const response = (await fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/datasets/${datasetId}/records`), {
+        method: 'POST',
+        body: requestBody,
+      })) as UpsertDatasetRecordsResponse;
 
       return response;
     },

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-logged-models/ExperimentLoggedModelListPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-logged-models/ExperimentLoggedModelListPage.test.tsx
@@ -8,12 +8,14 @@ import { TestApolloProvider } from '../../../common/utils/TestApolloProvider';
 import { MockedReduxStoreProvider } from '../../../common/utils/TestUtils';
 import { IntlProvider } from 'react-intl';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import userEvent from '@testing-library/user-event';
 import { LoggedModelStatusProtoEnum } from '../../types';
 import { first, orderBy } from 'lodash';
 import type { RunsChartsBarCardConfig } from '../../components/runs-charts/runs-charts.types';
 import type { RunsChartsRunData } from '../../components/runs-charts/components/RunsCharts.common';
 import { createMLflowRoutePath } from '../../../common/utils/RoutingUtils';
+import { prefixRouteWithWorkspace } from '../../../workspaces/utils/WorkspaceUtils';
 import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
@@ -164,13 +166,15 @@ describe('ExperimentLoggedModelListPage', () => {
         <QueryClientProvider client={queryClient}>
           <MockedReduxStoreProvider state={{ entities: { experimentTagsByExperimentId: {} } }}>
             <IntlProvider locale="en">
-              <DesignSystemProvider>
-                <TestRouter
-                  routes={[testRoute(<ExperimentLoggedModelListPage />, '/experiments/:experimentId')]}
-                  history={history}
-                  initialEntries={['/experiments/test-experiment']}
-                />
-              </DesignSystemProvider>
+              <TooltipProvider>
+                <DesignSystemProvider>
+                  <TestRouter
+                    routes={[testRoute(<ExperimentLoggedModelListPage />, '/experiments/:experimentId')]}
+                    history={history}
+                    initialEntries={['/experiments/test-experiment']}
+                  />
+                </DesignSystemProvider>
+              </TooltipProvider>
             </IntlProvider>
           </MockedReduxStoreProvider>
         </QueryClientProvider>
@@ -243,7 +247,7 @@ describe('ExperimentLoggedModelListPage', () => {
     // The link should point to the run page
     expect(first(screen.getAllByRole('link', { name: 'Test run name' }))).toHaveAttribute(
       'href',
-      createMLflowRoutePath('/experiments/test-experiment/runs/test-run'),
+      prefixRouteWithWorkspace(createMLflowRoutePath('/experiments/test-experiment/runs/test-run')),
     );
   });
 
@@ -258,7 +262,7 @@ describe('ExperimentLoggedModelListPage', () => {
     // Expect model 6 to have a link to the registered model version
     expect(screen.getByRole('link', { name: /registered-model-name-6 v1/ })).toHaveAttribute(
       'href',
-      createMLflowRoutePath('/models/registered-model-name-6/versions/1'),
+      prefixRouteWithWorkspace(createMLflowRoutePath('/models/registered-model-name-6/versions/1')),
     );
 
     // Expect model 5 to not have any registered model version links

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-logged-models/ExperimentLoggedModelListPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-logged-models/ExperimentLoggedModelListPage.test.tsx
@@ -8,7 +8,6 @@ import { TestApolloProvider } from '../../../common/utils/TestApolloProvider';
 import { MockedReduxStoreProvider } from '../../../common/utils/TestUtils';
 import { IntlProvider } from 'react-intl';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import userEvent from '@testing-library/user-event';
 import { LoggedModelStatusProtoEnum } from '../../types';
 import { first, orderBy } from 'lodash';
@@ -166,15 +165,13 @@ describe('ExperimentLoggedModelListPage', () => {
         <QueryClientProvider client={queryClient}>
           <MockedReduxStoreProvider state={{ entities: { experimentTagsByExperimentId: {} } }}>
             <IntlProvider locale="en">
-              <TooltipProvider>
-                <DesignSystemProvider>
-                  <TestRouter
-                    routes={[testRoute(<ExperimentLoggedModelListPage />, '/experiments/:experimentId')]}
-                    history={history}
-                    initialEntries={['/experiments/test-experiment']}
-                  />
-                </DesignSystemProvider>
-              </TooltipProvider>
+              <DesignSystemProvider>
+                <TestRouter
+                  routes={[testRoute(<ExperimentLoggedModelListPage />, '/experiments/:experimentId')]}
+                  history={history}
+                  initialEntries={['/experiments/test-experiment']}
+                />
+              </DesignSystemProvider>
             </IntlProvider>
           </MockedReduxStoreProvider>
         </QueryClientProvider>

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/ExperimentPageTabs.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { Button, PageWrapper, Spacer, ParagraphSkeleton, useDesignSystemTheme } from '@databricks/design-system';
 import { PredefinedError } from '@databricks/web-shared/errors';
 import invariant from 'invariant';
-import { useNavigate, useParams, Outlet, matchPath, useLocation } from '../../../common/utils/RoutingUtils';
+import { useNavigate, useParams, Outlet, useLocation, matchPath } from '../../../common/utils/RoutingUtils';
 import { useGetExperimentQuery } from '../../hooks/useExperimentQuery';
 import { useExperimentReduxStoreCompat } from '../../hooks/useExperimentReduxStoreCompat';
 import { ExperimentPageHeaderWithDescription } from '../../components/experiment-page/components/ExperimentPageHeaderWithDescription';
@@ -84,6 +84,7 @@ const ExperimentPageTabsImpl = () => {
 
   // Check if the user landed on the experiment page without a specific tab (sub-route)...
   const { pathname } = useLocation();
+  // With query param-based workspace routing, pathname no longer contains workspace prefix
   const matchedExperimentPageWithoutTab = Boolean(matchPath(RoutePaths.experimentPage, pathname));
   // ...if true, we want to navigate to the appropriate tab based on the experiment kind.
   // However, if experiment kind inference is enabled (no kind tag exists), we should

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/api.ts
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/api.ts
@@ -162,9 +162,7 @@ export async function updateOnlineScoringConfig(
   sampleRate: number,
   filterString?: string,
 ): Promise<{ config: OnlineScoringConfig }> {
-  const url = getAjaxUrl('ajax-api/3.0/mlflow/scorers/online-config');
-  // eslint-disable-next-line no-restricted-globals -- Need direct fetch for proper error handling
-  const response = await fetch(url, {
+  return fetchOrFail(getAjaxUrl('ajax-api/3.0/mlflow/scorers/online-config'), {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -175,15 +173,7 @@ export async function updateOnlineScoringConfig(
       sample_rate: sampleRate,
       filter_string: filterString || null,
     }),
-  });
-
-  if (!response.ok) {
-    // Extract error message from response body
-    const body = await response.json().catch(() => ({}));
-    const errorMessage = body?.message || body?.error_code || `Request failed with status ${response.status}`;
-    const error = new Error(errorMessage);
-    throw error;
-  }
-
-  return response.json();
+  })
+    .then((res) => res.json())
+    .catch(catchNetworkErrorIfExists);
 }

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-scorers/useEvaluateTracesAsync.tsx
@@ -282,11 +282,14 @@ export const useEvaluateTracesAsync = ({
     { evaluateParams: EvaluateTracesParams; traceIds: string[]; requestKey: string }
   >({
     mutationFn: async ({ evaluateParams, traceIds }) =>
-      fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/scorer/invoke'), 'POST', {
-        experiment_id: evaluateParams.experimentId,
-        serialized_scorer: evaluateParams.serializedScorer,
-        trace_ids: traceIds,
-        log_assessments: evaluateParams.saveAssessment,
+      fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/scorer/invoke'), {
+        method: 'POST',
+        body: {
+          experiment_id: evaluateParams.experimentId,
+          serialized_scorer: evaluateParams.serializedScorer,
+          trace_ids: traceIds,
+          log_assessments: evaluateParams.saveAssessment,
+        },
       }),
     onSuccess: (data, { requestKey }) => {
       const jobIds = data.jobs.map((j) => j.job_id);
@@ -377,7 +380,7 @@ export const useEvaluateTracesAsync = ({
         return;
       }
       for (const jobId of evaluation.jobIds) {
-        fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/cancel/${jobId}`), 'PATCH').catch(() => {});
+        fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/cancel/${jobId}`), { method: 'PATCH' }).catch(() => {});
       }
       finalizedRef.current.add(requestKey);
       setEvaluations((prev) => {
@@ -393,7 +396,7 @@ export const useEvaluateTracesAsync = ({
       for (const ev of Object.values(evaluationsRef.current)) {
         if (!finalizedRef.current.has(ev.requestKey)) {
           for (const jobId of ev.jobIds) {
-            fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/cancel/${jobId}`), 'PATCH').catch(() => {});
+            fetchAPI(getAjaxUrl(`ajax-api/3.0/jobs/cancel/${jobId}`), { method: 'PATCH' }).catch(() => {});
           }
         }
       }

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
@@ -17,11 +17,12 @@ import {
 } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { getTableRowByCellText } from '@databricks/design-system/test-utils/rtl';
 import { MockedReduxStoreProvider } from '../../../common/utils/TestUtils';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
-jest.setTimeout(30000); // increase timeout due to heavier use of tables, modals and forms
+jest.setTimeout(60000); // increase timeout due to heavier use of tables, modals and forms
 
 describe('PromptsDetailsPage', () => {
   const server = setupServer(
@@ -39,20 +40,22 @@ describe('PromptsDetailsPage', () => {
     render(<PromptsDetailsPage />, {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <DesignSystemProvider>
-            <MockedReduxStoreProvider>
-              <TestRouter
-                routes={[
-                  testRoute(
-                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
-                    '/prompt/:promptName',
-                  ),
-                  testRoute(<div />, '*'),
-                ]}
-                initialEntries={['/prompt/prompt1']}
-              />
-            </MockedReduxStoreProvider>
-          </DesignSystemProvider>
+          <TooltipProvider>
+            <DesignSystemProvider>
+              <MockedReduxStoreProvider>
+                <TestRouter
+                  routes={[
+                    testRoute(
+                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+                      '/prompt/:promptName',
+                    ),
+                    testRoute(<div />, '*'),
+                  ]}
+                  initialEntries={['/prompt/prompt1']}
+                />
+              </MockedReduxStoreProvider>
+            </DesignSystemProvider>
+          </TooltipProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsDetailsPage.test.tsx
@@ -17,7 +17,6 @@ import {
 } from './test-utils';
 import userEvent from '@testing-library/user-event';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { getTableRowByCellText } from '@databricks/design-system/test-utils/rtl';
 import { MockedReduxStoreProvider } from '../../../common/utils/TestUtils';
 
@@ -40,22 +39,20 @@ describe('PromptsDetailsPage', () => {
     render(<PromptsDetailsPage />, {
       wrapper: ({ children }) => (
         <IntlProvider locale="en">
-          <TooltipProvider>
-            <DesignSystemProvider>
-              <MockedReduxStoreProvider>
-                <TestRouter
-                  routes={[
-                    testRoute(
-                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
-                      '/prompt/:promptName',
-                    ),
-                    testRoute(<div />, '*'),
-                  ]}
-                  initialEntries={['/prompt/prompt1']}
-                />
-              </MockedReduxStoreProvider>
-            </DesignSystemProvider>
-          </TooltipProvider>
+          <DesignSystemProvider>
+            <MockedReduxStoreProvider>
+              <TestRouter
+                routes={[
+                  testRoute(
+                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>,
+                    '/prompt/:promptName',
+                  ),
+                  testRoute(<div />, '*'),
+                ]}
+                initialEntries={['/prompt/prompt1']}
+              />
+            </MockedReduxStoreProvider>
+          </DesignSystemProvider>
         </IntlProvider>
       ),
     });

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
@@ -14,6 +14,7 @@ import {
   getMockedRegisteredPromptVersionSetTagsResponse,
 } from './test-utils';
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { rest } from 'msw';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
@@ -30,9 +31,11 @@ describe('PromptsPage', () => {
           <TestRouter
             routes={[
               testRoute(
-                <DesignSystemProvider>
-                  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                </DesignSystemProvider>,
+                <TooltipProvider>
+                  <DesignSystemProvider>
+                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                  </DesignSystemProvider>
+                </TooltipProvider>,
                 '/',
               ),
               testRoute(<div />, '*'),
@@ -224,9 +227,11 @@ describe('PromptsPage', () => {
             <TestRouter
               routes={[
                 testRoute(
-                  <DesignSystemProvider>
-                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                  </DesignSystemProvider>,
+                  <TooltipProvider>
+                    <DesignSystemProvider>
+                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                    </DesignSystemProvider>
+                  </TooltipProvider>,
                   '/',
                 ),
                 testRoute(<div />, '*'),
@@ -267,9 +272,11 @@ describe('PromptsPage', () => {
             <TestRouter
               routes={[
                 testRoute(
-                  <DesignSystemProvider>
-                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                  </DesignSystemProvider>,
+                  <TooltipProvider>
+                    <DesignSystemProvider>
+                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                    </DesignSystemProvider>
+                  </TooltipProvider>,
                   '/',
                 ),
                 testRoute(<div />, '*'),
@@ -333,9 +340,11 @@ describe('PromptsPage', () => {
             <TestRouter
               routes={[
                 testRoute(
-                  <DesignSystemProvider>
-                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                  </DesignSystemProvider>,
+                  <TooltipProvider>
+                    <DesignSystemProvider>
+                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                    </DesignSystemProvider>
+                  </TooltipProvider>,
                   '/',
                 ),
                 testRoute(<div />, '*'),

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.test.tsx
@@ -14,7 +14,6 @@ import {
   getMockedRegisteredPromptVersionSetTagsResponse,
 } from './test-utils';
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { rest } from 'msw';
 
 // eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
@@ -31,11 +30,9 @@ describe('PromptsPage', () => {
           <TestRouter
             routes={[
               testRoute(
-                <TooltipProvider>
-                  <DesignSystemProvider>
-                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                  </DesignSystemProvider>
-                </TooltipProvider>,
+                <DesignSystemProvider>
+                  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                </DesignSystemProvider>,
                 '/',
               ),
               testRoute(<div />, '*'),
@@ -227,11 +224,9 @@ describe('PromptsPage', () => {
             <TestRouter
               routes={[
                 testRoute(
-                  <TooltipProvider>
-                    <DesignSystemProvider>
-                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                    </DesignSystemProvider>
-                  </TooltipProvider>,
+                  <DesignSystemProvider>
+                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                  </DesignSystemProvider>,
                   '/',
                 ),
                 testRoute(<div />, '*'),
@@ -272,11 +267,9 @@ describe('PromptsPage', () => {
             <TestRouter
               routes={[
                 testRoute(
-                  <TooltipProvider>
-                    <DesignSystemProvider>
-                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                    </DesignSystemProvider>
-                  </TooltipProvider>,
+                  <DesignSystemProvider>
+                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                  </DesignSystemProvider>,
                   '/',
                 ),
                 testRoute(<div />, '*'),
@@ -340,11 +333,9 @@ describe('PromptsPage', () => {
             <TestRouter
               routes={[
                 testRoute(
-                  <TooltipProvider>
-                    <DesignSystemProvider>
-                      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
-                    </DesignSystemProvider>
-                  </TooltipProvider>,
+                  <DesignSystemProvider>
+                    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+                  </DesignSystemProvider>,
                   '/',
                 ),
                 testRoute(<div />, '*'),

--- a/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/prompts/PromptsPage.tsx
@@ -8,11 +8,13 @@ import { PromptsListTable } from './components/PromptsListTable';
 import { useUpdateRegisteredPromptTags } from './hooks/useUpdateRegisteredPromptTags';
 import { CreatePromptModalMode, useCreatePromptModal } from './hooks/useCreatePromptModal';
 import Routes from '../../routes';
-import { useNavigate } from '../../../common/utils/RoutingUtils';
+import { useNavigate, useSearchParams } from '../../../common/utils/RoutingUtils';
 import { withErrorBoundary } from '../../../common/utils/withErrorBoundary';
 import ErrorUtils from '../../../common/utils/ErrorUtils';
 import { PromptPageErrorHandler } from './components/PromptPageErrorHandler';
 import { useDebounce } from 'use-debounce';
+import { shouldEnableWorkspaces } from '../../../common/utils/FeatureUtils';
+import { extractWorkspaceFromSearchParams } from '../../../workspaces/utils/WorkspaceUtils';
 
 export type PromptsListComponentId =
   | 'mlflow.prompts.global.list.create'
@@ -51,6 +53,12 @@ const EXPERIMENT_COMPONENT_IDS: PromptsListComponentIds = {
 };
 
 const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
+  const [searchParams] = useSearchParams();
+  const workspacesEnabled = shouldEnableWorkspaces();
+  const workspaceFromUrl = extractWorkspaceFromSearchParams(searchParams);
+  // Only show creation buttons when: workspaces are disabled OR a workspace is selected
+  const showCreationButtons = !workspacesEnabled || workspaceFromUrl !== null;
+
   const [searchFilter, setSearchFilter] = useState('');
   const navigate = useNavigate();
   const componentIds = experimentId ? EXPERIMENT_COMPONENT_IDS : GLOBAL_COMPONENT_IDS;
@@ -73,12 +81,14 @@ const PromptsPage = ({ experimentId }: { experimentId?: string } = {}) => {
       <Header
         title={<FormattedMessage defaultMessage="Prompts" description="Header title for the registered prompts page" />}
         buttons={
-          <Button componentId={componentIds.create} type="primary" onClick={openCreateVersionModal}>
-            <FormattedMessage
-              defaultMessage="Create prompt"
-              description="Label for the create prompt button on the registered prompts page"
-            />
-          </Button>
+          showCreationButtons && (
+            <Button componentId={componentIds.create} type="primary" onClick={openCreateVersionModal}>
+              <FormattedMessage
+                defaultMessage="Create prompt"
+                description="Label for the create prompt button on the registered prompts page"
+              />
+            </Button>
+          )
         }
       />
       <Spacer shrinks={false} />

--- a/mlflow/server/js/src/experiment-tracking/route-defs.ts
+++ b/mlflow/server/js/src/experiment-tracking/route-defs.ts
@@ -217,7 +217,7 @@ const getExperimentPageRouteDefs = () => {
 export const getRouteDefs = () => [
   {
     path: RoutePaths.rootRoute,
-    element: createLazyRouteElement(() => import('../home/HomePage')),
+    element: createLazyRouteElement(() => import('../home/RootPage')),
     pageId: PageId.home,
     handle: {
       getPageTitle: () => 'Home',
@@ -229,6 +229,7 @@ export const getRouteDefs = () => [
     element: createLazyRouteElement(() => import('../settings/SettingsPage')),
     pageId: PageId.settingsPage,
     handle: { getPageTitle: () => 'Settings' } satisfies RouteHandle,
+    globalRoute: true, // Settings is a global route, not workspace-specific
   },
   ...getExperimentPageRouteDefs(),
   {

--- a/mlflow/server/js/src/experiment-tracking/routes.ts
+++ b/mlflow/server/js/src/experiment-tracking/routes.ts
@@ -7,6 +7,7 @@ import type { ExperimentPageTabName } from './constants';
  */
 export enum PageId {
   home = 'mlflow.home',
+  workspacesPage = 'mlflow.workspaces',
   settingsPage = 'mlflow.settings',
   promptsPage = 'mlflow.prompts',
   promptDetailsPage = 'mlflow.prompts.details',
@@ -304,6 +305,7 @@ class Routes {
    * Routes for prompts management.
    * Featured exclusively in open source MLflow.
    */
+
   static get promptsPageRoute() {
     return RoutePaths.promptsPage;
   }

--- a/mlflow/server/js/src/graphql/client.test.ts
+++ b/mlflow/server/js/src/graphql/client.test.ts
@@ -1,0 +1,43 @@
+import 'whatwg-fetch';
+import { afterAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+
+import { graphqlFetch } from './client';
+
+jest.mock('@mlflow/mlflow/src/common/utils/FetchUtils', () => ({
+  getAjaxUrl: jest.fn(),
+}));
+
+const fetchUtils = jest.requireMock<typeof import('@mlflow/mlflow/src/common/utils/FetchUtils')>(
+  '@mlflow/mlflow/src/common/utils/FetchUtils',
+);
+const getAjaxUrl = jest.mocked(fetchUtils.getAjaxUrl);
+
+describe('graphqlFetch', () => {
+  const originalFetch = global.fetch;
+  const fetchMock = jest.fn<typeof global.fetch>();
+
+  beforeEach(() => {
+    fetchMock.mockResolvedValue({ ok: true } as Response);
+    global.fetch = fetchMock;
+    getAjaxUrl.mockReset();
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('resolves graphql requests via the ajax url helper', async () => {
+    const resolvedUrl = '/graphql';
+    getAjaxUrl.mockImplementation(() => resolvedUrl);
+
+    await graphqlFetch('graphql', { headers: { 'X-Test': '1' } });
+
+    expect(getAjaxUrl).toHaveBeenCalledWith('graphql');
+    expect(fetchMock).toHaveBeenCalledWith(
+      resolvedUrl,
+      expect.objectContaining({
+        headers: expect.any(Headers),
+      }),
+    );
+  });
+});

--- a/mlflow/server/js/src/graphql/client.ts
+++ b/mlflow/server/js/src/graphql/client.ts
@@ -10,6 +10,7 @@ import {
   RetryLink,
   DefaultHeadersLink as OssDefaultHeadersLink,
 } from '@mlflow/mlflow/src/common/utils/graphQLHooks';
+import { getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 
 function containsMutation(op: Operation): boolean {
   const definitions = (op.query && op.query.definitions) || [];
@@ -20,13 +21,15 @@ const backgroundLinkTimeoutMs = 10000;
 
 const possibleTypes: Record<string, string[]> = {};
 
-const graphqlFetch = async (uri: any, options: any): Promise<Response> => {
+export const graphqlFetch = async (uri: any, options: any): Promise<Response> => {
   const headers = new Headers({
     ...options.headers,
   });
 
+  const resolvedUri = typeof uri === 'string' ? getAjaxUrl(uri) : uri;
+
   // eslint-disable-next-line no-restricted-globals -- See go/spog-fetch
-  return fetch(uri, { ...options, headers }).then((res) => res);
+  return fetch(resolvedUri, { ...options, headers }).then((res) => res);
 };
 
 const apolloCache = new InMemoryCache({

--- a/mlflow/server/js/src/home/RootPage.tsx
+++ b/mlflow/server/js/src/home/RootPage.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { useSearchParams } from '../common/utils/RoutingUtils';
+import { shouldEnableWorkspaces } from '../common/utils/FeatureUtils';
+import { extractWorkspaceFromSearchParams } from '../workspaces/utils/WorkspaceUtils';
+
+const WorkspaceLandingPage = React.lazy(() => import('./WorkspaceLandingPage'));
+const HomePage = React.lazy(() => import('./HomePage'));
+
+/**
+ * Root page component that conditionally renders based on workspace mode and query param.
+ *
+ * When workspaces are enabled:
+ * - /?workspace=<name> → HomePage (workspace home)
+ * - / (no workspace param) → WorkspaceLandingPage (workspace selector)
+ *
+ * When workspaces are disabled:
+ * - / → HomePage
+ */
+export const RootPage = () => {
+  const [searchParams] = useSearchParams();
+  const workspacesEnabled = shouldEnableWorkspaces();
+
+  // If not in workspace mode, always show HomePage
+  if (!workspacesEnabled) {
+    return <HomePage />;
+  }
+
+  // Check if we're inside a workspace context via query param
+  const workspaceFromQuery = extractWorkspaceFromSearchParams(searchParams);
+
+  // If inside a workspace, show the workspace's home page
+  if (workspaceFromQuery) {
+    return <HomePage />;
+  }
+
+  // Otherwise (no workspace param), show the workspace landing page (selector)
+  return <WorkspaceLandingPage />;
+};
+
+export default RootPage;

--- a/mlflow/server/js/src/home/WorkspaceLandingPage.test.tsx
+++ b/mlflow/server/js/src/home/WorkspaceLandingPage.test.tsx
@@ -1,0 +1,132 @@
+import { describe, jest, beforeEach, test, expect } from '@jest/globals';
+import { waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from '../common/utils/RoutingUtils';
+import WorkspaceLandingPage from './WorkspaceLandingPage';
+import { useWorkspaces } from '../workspaces/hooks/useWorkspaces';
+import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+
+jest.mock('../workspaces/hooks/useWorkspaces');
+jest.mock('../workspaces/utils/WorkspaceUtils', () => ({
+  ...jest.requireActual<typeof import('../workspaces/utils/WorkspaceUtils')>('../workspaces/utils/WorkspaceUtils'),
+  getActiveWorkspace: jest.fn().mockReturnValue('default'),
+  setActiveWorkspace: jest.fn(),
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('../common/utils/RoutingUtils', () => ({
+  ...jest.requireActual<typeof import('../common/utils/RoutingUtils')>('../common/utils/RoutingUtils'),
+  useNavigate: () => mockNavigate,
+}));
+
+// Mock child components to simplify testing
+jest.mock('./components/GetStarted', () => ({
+  __esModule: true,
+  default: () => <div data-testid="get-started">Get Started Component</div>,
+}));
+
+jest.mock('./components/DiscoverNews', () => ({
+  __esModule: true,
+  default: () => <div data-testid="discover-news">Discover News Component</div>,
+}));
+
+jest.mock('./components/LogTracesDrawerLoader', () => ({
+  __esModule: true,
+  default: () => <div data-testid="log-traces-drawer">Log Traces Drawer</div>,
+}));
+
+jest.mock('../telemetry/TelemetryInfoAlert', () => ({
+  TelemetryInfoAlert: () => <div data-testid="telemetry-alert">Telemetry Alert</div>,
+}));
+
+describe('WorkspaceLandingPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [
+        { name: 'ml-research', description: 'Research experiments' },
+        { name: 'production-models', description: 'Production models' },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+  });
+
+  const renderComponent = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <WorkspaceLandingPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  };
+
+  test('renders Welcome to MLflow header', () => {
+    renderComponent();
+    expect(screen.getByText('Welcome to MLflow')).toBeInTheDocument();
+  });
+
+  test('renders all main sections', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('telemetry-alert')).toBeInTheDocument();
+      expect(screen.getByTestId('get-started')).toBeInTheDocument();
+      expect(screen.getByTestId('log-traces-drawer')).toBeInTheDocument();
+    });
+  });
+
+  test('renders workspaces section', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Workspaces')).toBeInTheDocument();
+      expect(screen.getByText('Select a workspace to start experiments')).toBeInTheDocument();
+    });
+  });
+
+  test('renders workspace list', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('ml-research')).toBeInTheDocument();
+      expect(screen.getByText('Research experiments')).toBeInTheDocument();
+      expect(screen.getByText('production-models')).toBeInTheDocument();
+      expect(screen.getByText('Production models')).toBeInTheDocument();
+    });
+  });
+
+  test('shows create workspace button', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Create new workspace')).toBeInTheDocument();
+    });
+  });
+
+  test('opens create workspace modal when button clicked', async () => {
+    renderComponent();
+
+    await waitFor(() => {
+      expect(screen.getByText('Create new workspace')).toBeInTheDocument();
+    });
+
+    const createButton = screen.getByText('Create new workspace');
+    await userEvent.click(createButton);
+
+    // Modal should open with title
+    await waitFor(() => {
+      expect(screen.getByText('Create Workspace')).toBeInTheDocument();
+    });
+  });
+});

--- a/mlflow/server/js/src/home/WorkspaceLandingPage.tsx
+++ b/mlflow/server/js/src/home/WorkspaceLandingPage.tsx
@@ -3,8 +3,7 @@ import { Header, TableSkeleton, TitleSkeleton, useDesignSystemTheme } from '@dat
 import { FormattedMessage } from 'react-intl';
 import { ScrollablePageWrapper } from '../common/components/ScrollablePageWrapper';
 import { useCreateWorkspaceModal } from './components/CreateWorkspaceModal';
-import { useNavigate } from '../common/utils/RoutingUtils';
-import { setActiveWorkspace, WORKSPACE_QUERY_PARAM } from '../workspaces/utils/WorkspaceUtils';
+import { setLastUsedWorkspace, WORKSPACE_QUERY_PARAM } from '../workspaces/utils/WorkspaceUtils';
 
 // Loaders and lazy imports for expensive components
 import LogTracesDrawerLoader from './components/LogTracesDrawerLoader';
@@ -14,13 +13,13 @@ const WorkspacesHomeView = React.lazy(() => import('./components/WorkspacesHomeV
 
 const WorkspaceLandingPage = () => {
   const { theme } = useDesignSystemTheme();
-  const navigate = useNavigate();
 
   const { CreateWorkspaceModal, openModal } = useCreateWorkspaceModal({
     onSuccess: (workspaceName: string) => {
-      // Set the newly created workspace as active and navigate to home with workspace query param
-      setActiveWorkspace(workspaceName);
-      navigate(`/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspaceName)}`);
+      // Persist to localStorage then hard reload to cleanly switch to the new workspace
+      setLastUsedWorkspace(workspaceName);
+      window.location.hash = `#/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspaceName)}`;
+      window.location.reload();
     },
   });
 

--- a/mlflow/server/js/src/home/WorkspaceLandingPage.tsx
+++ b/mlflow/server/js/src/home/WorkspaceLandingPage.tsx
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Header, TableSkeleton, TitleSkeleton, useDesignSystemTheme } from '@databricks/design-system';
+import { FormattedMessage } from 'react-intl';
+import { ScrollablePageWrapper } from '../common/components/ScrollablePageWrapper';
+import { useCreateWorkspaceModal } from './components/CreateWorkspaceModal';
+import { useNavigate } from '../common/utils/RoutingUtils';
+import { setActiveWorkspace, WORKSPACE_QUERY_PARAM } from '../workspaces/utils/WorkspaceUtils';
+
+// Loaders and lazy imports for expensive components
+import LogTracesDrawerLoader from './components/LogTracesDrawerLoader';
+import { TelemetryInfoAlert } from '../telemetry/TelemetryInfoAlert';
+const GetStarted = React.lazy(() => import('./components/GetStarted'));
+const WorkspacesHomeView = React.lazy(() => import('./components/WorkspacesHomeView'));
+
+const WorkspaceLandingPage = () => {
+  const { theme } = useDesignSystemTheme();
+  const navigate = useNavigate();
+
+  const { CreateWorkspaceModal, openModal } = useCreateWorkspaceModal({
+    onSuccess: (workspaceName: string) => {
+      // Set the newly created workspace as active and navigate to home with workspace query param
+      setActiveWorkspace(workspaceName);
+      navigate(`/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspaceName)}`);
+    },
+  });
+
+  return (
+    <ScrollablePageWrapper
+      css={{
+        padding: theme.spacing.md,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.lg,
+        height: 'min-content',
+      }}
+    >
+      <Header
+        title={<FormattedMessage defaultMessage="Welcome to MLflow" description="Workspace landing page title" />}
+      />
+      <TelemetryInfoAlert />
+      <React.Suspense fallback={<HomePageSectionSkeleton />}>
+        <GetStarted />
+      </React.Suspense>
+      <React.Suspense fallback={<HomePageSectionSkeleton />}>
+        <WorkspacesHomeView onCreateWorkspace={openModal} />
+      </React.Suspense>
+
+      {CreateWorkspaceModal}
+      <LogTracesDrawerLoader />
+    </ScrollablePageWrapper>
+  );
+};
+
+const HomePageSectionSkeleton = () => {
+  return (
+    <div>
+      <TitleSkeleton />
+      <TableSkeleton lines={3} />
+    </div>
+  );
+};
+
+export default WorkspaceLandingPage;

--- a/mlflow/server/js/src/home/components/CreateWorkspaceModal.test.tsx
+++ b/mlflow/server/js/src/home/components/CreateWorkspaceModal.test.tsx
@@ -1,0 +1,224 @@
+import { describe, jest, beforeEach, test, expect } from '@jest/globals';
+import { waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { useCreateWorkspaceModal } from './CreateWorkspaceModal';
+import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { act } from 'react-dom/test-utils';
+
+jest.mock('../../common/utils/FetchUtils');
+
+describe('CreateWorkspaceModal', () => {
+  const mockOnSuccess = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const TestComponent = () => {
+    const { CreateWorkspaceModal, openModal } = useCreateWorkspaceModal({
+      onSuccess: mockOnSuccess,
+    });
+
+    return (
+      <>
+        <button onClick={openModal}>Open Modal</button>
+        {CreateWorkspaceModal}
+      </>
+    );
+  };
+
+  const renderComponent = () => {
+    return renderWithIntl(<TestComponent />);
+  };
+
+  const openModal = async () => {
+    const openButton = screen.getByText('Open Modal');
+    await userEvent.click(openButton);
+  };
+
+  test('renders modal when open', async () => {
+    renderComponent();
+    await openModal();
+    expect(screen.getByText('Create Workspace')).toBeInTheDocument();
+    expect(screen.getByText(/Workspace Name/i)).toBeInTheDocument();
+    expect(screen.getByText(/Description \(optional\)/i)).toBeInTheDocument();
+  });
+
+  test('does not render modal when closed', () => {
+    renderComponent();
+    expect(screen.queryByText('Create Workspace')).not.toBeInTheDocument();
+  });
+
+  test('renders input fields with correct placeholders', async () => {
+    renderComponent();
+    await openModal();
+
+    expect(screen.getByPlaceholderText('Enter workspace name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Enter workspace description')).toBeInTheDocument();
+  });
+
+  test('renders Create button', async () => {
+    renderComponent();
+    await openModal();
+
+    expect(screen.getByText('Create')).toBeInTheDocument();
+  });
+
+  test('allows typing in workspace name field', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, 'my-workspace');
+
+    expect(nameInput).toHaveValue('my-workspace');
+  });
+
+  test('allows typing in description field', async () => {
+    renderComponent();
+    await openModal();
+
+    const descInput = screen.getByPlaceholderText('Enter workspace description');
+    await userEvent.type(descInput, 'My workspace description');
+
+    expect(descInput).toHaveValue('My workspace description');
+  });
+
+  test('shows validation error when name is empty and form is submitted', async () => {
+    renderComponent();
+    await openModal();
+
+    const createButton = screen.getByText('Create');
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Please input a name for the new workspace.')).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error for invalid workspace name with spaces', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, 'Invalid Name With Spaces');
+
+    const createButton = screen.getByText('Create');
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Workspace name must be lowercase alphanumeric with optional single hyphens (no consecutive hyphens).',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error for workspace name starting with hyphen', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, '-invalid');
+
+    const createButton = screen.getByText('Create');
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Workspace name must be lowercase alphanumeric with optional single hyphens (no consecutive hyphens).',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error for workspace name ending with hyphen', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, 'invalid-');
+
+    const createButton = screen.getByText('Create');
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Workspace name must be lowercase alphanumeric with optional single hyphens (no consecutive hyphens).',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error for workspace name with uppercase letters', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, 'InvalidName');
+
+    const createButton = screen.getByText('Create');
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Workspace name must be lowercase alphanumeric with optional single hyphens (no consecutive hyphens).',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error for workspace name with consecutive hyphens', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, 'my--workspace');
+
+    const createButton = screen.getByText('Create');
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          'Workspace name must be lowercase alphanumeric with optional single hyphens (no consecutive hyphens).',
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  test('shows validation error for workspace name that is too short', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, 'a');
+
+    const createButton = screen.getByText('Create');
+    await userEvent.click(createButton);
+
+    await waitFor(() => {
+      expect(screen.getByText('Workspace name must be between 2 and 63 characters.')).toBeInTheDocument();
+    });
+  });
+
+  test('submits form when Enter key is pressed in workspace name field', async () => {
+    renderComponent();
+    await openModal();
+
+    const nameInput = screen.getByPlaceholderText('Enter workspace name');
+    await userEvent.type(nameInput, 'test-workspace');
+
+    // Press Enter to submit
+    await userEvent.keyboard('{Enter}');
+
+    // Since FetchUtils is mocked and we don't have a proper mock implementation,
+    // we just verify the Enter key doesn't cause any errors
+    expect(nameInput).toBeInTheDocument();
+  });
+});

--- a/mlflow/server/js/src/home/components/CreateWorkspaceModal.tsx
+++ b/mlflow/server/js/src/home/components/CreateWorkspaceModal.tsx
@@ -1,0 +1,173 @@
+import { useState } from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Alert, FormUI, Modal, RHFControlledComponents, Spacer } from '@databricks/design-system';
+import { fetchAPI, getAjaxUrl, HTTPMethods } from '../../common/utils/FetchUtils';
+import { validateWorkspaceName } from '../../workspaces/utils/WorkspaceUtils';
+
+type CreateWorkspaceFormData = {
+  workspaceName: string;
+  workspaceDescription?: string;
+  workspaceArtifactRoot?: string;
+};
+
+export const useCreateWorkspaceModal = ({ onSuccess }: { onSuccess?: (workspaceName: string) => void }) => {
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const intl = useIntl();
+
+  const form = useForm<CreateWorkspaceFormData>({
+    defaultValues: {
+      workspaceName: '',
+      workspaceDescription: '',
+      workspaceArtifactRoot: '',
+    },
+  });
+
+  const handleSubmit = async (values: CreateWorkspaceFormData) => {
+    setError(null);
+    setIsLoading(true);
+
+    const requestBody: { name: string; description?: string; default_artifact_root?: string } = {
+      name: values.workspaceName,
+    };
+
+    if (values.workspaceDescription) {
+      requestBody.description = values.workspaceDescription;
+    }
+
+    if (values.workspaceArtifactRoot) {
+      requestBody.default_artifact_root = values.workspaceArtifactRoot;
+    }
+
+    try {
+      await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/workspaces'), {
+        method: HTTPMethods.POST,
+        body: JSON.stringify(requestBody),
+      });
+
+      onSuccess?.(values.workspaceName);
+      setOpen(false);
+      form.reset();
+    } catch (err: any) {
+      setError(err?.message || 'Failed to create workspace');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const modalElement = (
+    <FormProvider {...form}>
+      <Modal
+        componentId="mlflow.home.create_workspace_modal"
+        visible={open}
+        onCancel={() => setOpen(false)}
+        title={<FormattedMessage defaultMessage="Create Workspace" description="Title for create workspace modal" />}
+        okText={
+          <FormattedMessage defaultMessage="Create" description="Confirm button text for create workspace modal" />
+        }
+        okButtonProps={{ loading: isLoading }}
+        onOk={form.handleSubmit(handleSubmit)}
+        cancelText={
+          <FormattedMessage defaultMessage="Cancel" description="Cancel button text for create workspace modal" />
+        }
+      >
+        <div
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              form.handleSubmit(handleSubmit)();
+            }
+          }}
+        >
+          {error && (
+            <>
+              <Alert
+                componentId="mlflow.home.create_workspace_modal.error"
+                closable={false}
+                message={error}
+                type="error"
+              />
+              <Spacer />
+            </>
+          )}
+          <FormUI.Label htmlFor="mlflow.home.create_workspace_modal.workspace_name">
+            <FormattedMessage defaultMessage="Workspace Name" description="Label for workspace name field" />:
+          </FormUI.Label>
+          <RHFControlledComponents.Input
+            control={form.control}
+            id="mlflow.home.create_workspace_modal.workspace_name"
+            componentId="mlflow.home.create_workspace_modal.workspace_name_input"
+            name="workspaceName"
+            autoFocus
+            rules={{
+              required: {
+                value: true,
+                message: intl.formatMessage({
+                  defaultMessage: 'Please input a name for the new workspace.',
+                  description: 'Error message for name requirement in create workspace modal',
+                }),
+              },
+              validate: (value) => {
+                if (!value) {
+                  return true; // Let required rule handle empty values
+                }
+                const result = validateWorkspaceName(value);
+                return result.valid || result.error;
+              },
+            }}
+            placeholder={intl.formatMessage({
+              defaultMessage: 'Enter workspace name',
+              description: 'Input placeholder for workspace name in create workspace modal',
+            })}
+            validationState={form.formState.errors.workspaceName ? 'error' : undefined}
+          />
+          {form.formState.errors.workspaceName && (
+            <FormUI.Message type="error" message={form.formState.errors.workspaceName.message} />
+          )}
+          <Spacer />
+          <FormUI.Label htmlFor="mlflow.home.create_workspace_modal.workspace_description">
+            <FormattedMessage defaultMessage="Description (optional)" description="Label for description field" />:
+          </FormUI.Label>
+          <RHFControlledComponents.Input
+            control={form.control}
+            id="mlflow.home.create_workspace_modal.workspace_description"
+            componentId="mlflow.home.create_workspace_modal.workspace_description_input"
+            name="workspaceDescription"
+            placeholder={intl.formatMessage({
+              defaultMessage: 'Enter workspace description',
+              description: 'Input placeholder for workspace description in create workspace modal',
+            })}
+          />
+          <Spacer />
+          <FormUI.Label htmlFor="mlflow.home.create_workspace_modal.workspace_artifact_root">
+            <FormattedMessage
+              defaultMessage="Default Artifact Root (optional)"
+              description="Label for artifact root field"
+            />
+            :
+          </FormUI.Label>
+          <RHFControlledComponents.Input
+            control={form.control}
+            id="mlflow.home.create_workspace_modal.workspace_artifact_root"
+            componentId="mlflow.home.create_workspace_modal.workspace_artifact_root_input"
+            name="workspaceArtifactRoot"
+            placeholder={intl.formatMessage({
+              defaultMessage: 'Enter default artifact root URI',
+              description: 'Input placeholder for artifact root in create workspace modal',
+            })}
+          />
+        </div>
+      </Modal>
+    </FormProvider>
+  );
+
+  const openModal = () => {
+    setError(null);
+    form.reset();
+    setOpen(true);
+  };
+
+  return { CreateWorkspaceModal: modalElement, openModal };
+};

--- a/mlflow/server/js/src/home/components/LogTracesDrawer.tsx
+++ b/mlflow/server/js/src/home/components/LogTracesDrawer.tsx
@@ -14,8 +14,9 @@ import { TraceTableGenericQuickstart } from '@mlflow/mlflow/src/experiment-track
 import type { QUICKSTART_FLAVOR } from '@mlflow/mlflow/src/experiment-tracking/components/traces/quickstart/TraceTableQuickstart.utils';
 import { CopyButton } from '@mlflow/mlflow/src/shared/building_blocks/CopyButton';
 import { CodeSnippet } from '@databricks/web-shared/snippet';
-import { Link } from '../../common/utils/RoutingUtils';
+import { Link, useSearchParams } from '../../common/utils/RoutingUtils';
 import Routes from '../../experiment-tracking/routes';
+import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
 import OpenAiLogo from '../../common/static/logos/openai.svg';
 import OpenAiLogoDark from '../../common/static/logos/openai-dark.svg';
 import LangChainLogo from '../../common/static/logos/langchain.svg';
@@ -106,17 +107,23 @@ const MORE_INTEGRATIONS_URL = 'https://mlflow.org/docs/latest/genai/tracing/#one
 
 const TRACING_DOCS_URL = 'https://mlflow.org/docs/latest/genai/tracing/';
 
-const CONFIGURE_EXPERIMENT_SNIPPET = `import mlflow
+const getConfigureExperimentSnippet = (workspace?: string | null) => {
+  const workspaceLine = workspace ? `mlflow.set_workspace("${workspace}")\n` : '';
+  return `import mlflow
 
 # Specify the tracking server URI, e.g. http://localhost:5000
 mlflow.set_tracking_uri("http://<tracking-server-host>:<port>")
-# If the experiment with the name "traces-quickstart" doesn't exist, MLflow will create it
+${workspaceLine}# If the experiment with the name "traces-quickstart" doesn't exist, MLflow will create it
 mlflow.set_experiment("traces-quickstart")`;
+};
 
 export const LogTracesDrawer = () => {
   const { theme } = useDesignSystemTheme();
   const [selectedFramework, setSelectedFramework] = useState<SupportedQuickstartFlavor>('openai');
   const { isLogTracesDrawerOpen, closeLogTracesDrawer } = useHomePageViewState();
+  const [searchParams] = useSearchParams();
+  const activeWorkspace = extractWorkspaceFromSearchParams(searchParams);
+  const configureSnippet = getConfigureExperimentSnippet(activeWorkspace);
 
   const handleOpenChange = (open: boolean) => {
     if (!open) {
@@ -277,7 +284,7 @@ export const LogTracesDrawer = () => {
                   componentId="mlflow.home.log_traces.drawer.configure.copy"
                   css={{ zIndex: 1, position: 'absolute', top: theme.spacing.xs, right: theme.spacing.xs }}
                   showLabel={false}
-                  copyText={CONFIGURE_EXPERIMENT_SNIPPET}
+                  copyText={configureSnippet}
                   icon={<CopyIcon />}
                 />
                 <CodeSnippet
@@ -289,7 +296,7 @@ export const LogTracesDrawer = () => {
                     marginTop: theme.spacing.xs,
                   }}
                 >
-                  {CONFIGURE_EXPERIMENT_SNIPPET}
+                  {configureSnippet}
                 </CodeSnippet>
               </div>
             </section>

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
@@ -116,13 +116,23 @@ describe('WorkspacesHomeView', () => {
       refetch: jest.fn(),
     });
 
+    // Mock window.location for hard reload workspace switching
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, hash: '', reload: jest.fn() },
+    });
+
     renderComponent();
 
     const workspaceLink = screen.getByText('ml-research');
     await userEvent.click(workspaceLink);
 
-    // Now uses query param instead of path prefix
-    expect(mockNavigate).toHaveBeenCalledWith('/?workspace=ml-research');
+    // Hard reload with workspace query param
+    expect(window.location.hash).toBe('#/?workspace=ml-research');
+    expect(window.location.reload).toHaveBeenCalled();
+
+    Object.defineProperty(window, 'location', { writable: true, value: originalLocation });
   });
 
   test('encodes workspace name in URL', async () => {
@@ -133,13 +143,23 @@ describe('WorkspacesHomeView', () => {
       refetch: jest.fn(),
     });
 
+    // Mock window.location for hard reload workspace switching
+    const originalLocation = window.location;
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: { ...originalLocation, hash: '', reload: jest.fn() },
+    });
+
     renderComponent();
 
     const workspaceLink = screen.getByText('team-a/special');
     await userEvent.click(workspaceLink);
 
-    // Now uses query param instead of path prefix
-    expect(mockNavigate).toHaveBeenCalledWith('/?workspace=team-a%2Fspecial');
+    // Hard reload with encoded workspace query param
+    expect(window.location.hash).toBe('#/?workspace=team-a%2Fspecial');
+    expect(window.location.reload).toHaveBeenCalled();
+
+    Object.defineProperty(window, 'location', { writable: true, value: originalLocation });
   });
 
   test('shows create new workspace button when workspaces exist', () => {

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.test.tsx
@@ -1,0 +1,185 @@
+import { describe, jest, beforeEach, test, expect } from '@jest/globals';
+import { waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import userEvent from '@testing-library/user-event';
+import { WorkspacesHomeView } from './WorkspacesHomeView';
+import { useWorkspaces } from '../../workspaces/hooks/useWorkspaces';
+import { getLastUsedWorkspace } from '../../workspaces/utils/WorkspaceUtils';
+import { renderWithIntl, screen } from '@mlflow/mlflow/src/common/utils/TestUtils.react18';
+import { MemoryRouter } from '../../common/utils/RoutingUtils';
+import { QueryClient, QueryClientProvider } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+
+jest.mock('../../workspaces/hooks/useWorkspaces');
+jest.mock('../../workspaces/utils/WorkspaceUtils');
+
+const mockNavigate = jest.fn();
+jest.mock('../../common/utils/RoutingUtils', () => ({
+  ...jest.requireActual<typeof import('../../common/utils/RoutingUtils')>('../../common/utils/RoutingUtils'),
+  useNavigate: () => mockNavigate,
+}));
+
+describe('WorkspacesHomeView', () => {
+  const mockOnCreateWorkspace = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock last used workspace for "Last used" badge
+    (getLastUsedWorkspace as jest.Mock).mockReturnValue('ml-research');
+  });
+
+  const renderComponent = () => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    return renderWithIntl(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <WorkspacesHomeView onCreateWorkspace={mockOnCreateWorkspace} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  };
+
+  test('renders loading state', () => {
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [],
+      isLoading: true,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    renderComponent();
+    expect(screen.getByText('Loading workspaces...')).toBeInTheDocument();
+  });
+
+  test('renders empty state when no workspaces', () => {
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    renderComponent();
+    expect(screen.getByText('Create your first workspace')).toBeInTheDocument();
+    expect(
+      screen.getByText('Create a workspace to organize and logically isolate your experiments and models.'),
+    ).toBeInTheDocument();
+  });
+
+  test('calls onCreateWorkspace when create button clicked in empty state', async () => {
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    renderComponent();
+    const createButton = screen.getByText('Create workspace');
+    await userEvent.click(createButton);
+    expect(mockOnCreateWorkspace).toHaveBeenCalledTimes(1);
+  });
+
+  test('renders workspace list with Last used badge', () => {
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [
+        { name: 'ml-research', description: 'Research experiments for new ML models' },
+        { name: 'production-models', description: 'Production-ready models' },
+        { name: 'data-science-team', description: null },
+      ],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    renderComponent();
+
+    expect(screen.getByText('ml-research')).toBeInTheDocument();
+    expect(screen.getByText('Research experiments for new ML models')).toBeInTheDocument();
+    expect(screen.getByText('production-models')).toBeInTheDocument();
+    expect(screen.getByText('Production-ready models')).toBeInTheDocument();
+    expect(screen.getByText('data-science-team')).toBeInTheDocument();
+
+    // Last used badge should appear for ml-research
+    expect(screen.getByText('Last used')).toBeInTheDocument();
+  });
+
+  test('navigates to workspace when row clicked', async () => {
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [{ name: 'ml-research', description: 'Research experiments' }],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    renderComponent();
+
+    const workspaceLink = screen.getByText('ml-research');
+    await userEvent.click(workspaceLink);
+
+    // Now uses query param instead of path prefix
+    expect(mockNavigate).toHaveBeenCalledWith('/?workspace=ml-research');
+  });
+
+  test('encodes workspace name in URL', async () => {
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [{ name: 'team-a/special', description: 'Special workspace' }],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    renderComponent();
+
+    const workspaceLink = screen.getByText('team-a/special');
+    await userEvent.click(workspaceLink);
+
+    // Now uses query param instead of path prefix
+    expect(mockNavigate).toHaveBeenCalledWith('/?workspace=team-a%2Fspecial');
+  });
+
+  test('shows create new workspace button when workspaces exist', () => {
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [{ name: 'ml-research', description: 'Research experiments' }],
+      isLoading: false,
+      isError: false,
+      refetch: jest.fn(),
+    });
+
+    renderComponent();
+    expect(screen.getByText('Create new workspace')).toBeInTheDocument();
+  });
+
+  test('renders error state', () => {
+    const mockRefetch = jest.fn();
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [],
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetch,
+    });
+
+    renderComponent();
+    expect(screen.getByText("We couldn't load your workspaces.")).toBeInTheDocument();
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+  });
+
+  test('calls refetch when retry button clicked', async () => {
+    const mockRefetch = jest.fn();
+    (useWorkspaces as jest.Mock).mockReturnValue({
+      workspaces: [],
+      isLoading: false,
+      isError: true,
+      refetch: mockRefetch,
+    });
+
+    renderComponent();
+    const retryButton = screen.getByText('Retry');
+    await userEvent.click(retryButton);
+    expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -1,0 +1,441 @@
+import { useMemo, useState } from 'react';
+import {
+  Alert,
+  Button,
+  Input,
+  Modal,
+  Pagination,
+  PencilIcon,
+  Spacer,
+  Table,
+  TableCell,
+  TableHeader,
+  TableRow,
+  Typography,
+  useDesignSystemTheme,
+  Tag,
+} from '@databricks/design-system';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { Link, useNavigate } from '../../common/utils/RoutingUtils';
+import { useWorkspaces, type Workspace } from '../../workspaces/hooks/useWorkspaces';
+import { getLastUsedWorkspace, setActiveWorkspace, WORKSPACE_QUERY_PARAM } from '../../workspaces/utils/WorkspaceUtils';
+import { useUpdateWorkspace } from '../../workspaces/hooks/useUpdateWorkspace';
+import Utils from '../../common/utils/Utils';
+
+type WorkspacesHomeViewProps = {
+  onCreateWorkspace: () => void;
+};
+
+const WorkspacesEmptyState = ({ onCreateWorkspace }: { onCreateWorkspace: () => void }) => {
+  const { theme } = useDesignSystemTheme();
+
+  return (
+    <div
+      css={{
+        padding: theme.spacing.lg,
+        textAlign: 'center',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: theme.spacing.md,
+      }}
+    >
+      <Typography.Title level={4} css={{ margin: 0 }}>
+        <FormattedMessage
+          defaultMessage="Create your first workspace"
+          description="Home page workspaces empty state title"
+        />
+      </Typography.Title>
+      <Typography.Text css={{ color: theme.colors.textSecondary }}>
+        <FormattedMessage
+          defaultMessage="Create a workspace to organize and logically isolate your experiments and models."
+          description="Home page workspaces empty state description"
+        />
+      </Typography.Text>
+      <Button componentId="mlflow.home.workspaces.create" onClick={onCreateWorkspace}>
+        <FormattedMessage defaultMessage="Create workspace" description="Home page workspaces empty state CTA" />
+      </Button>
+    </div>
+  );
+};
+
+const WorkspaceRow = ({ workspace, isLastUsed }: { workspace: Workspace; isLastUsed: boolean }) => {
+  const { theme } = useDesignSystemTheme();
+  const navigate = useNavigate();
+  const intl = useIntl();
+  const { mutate: updateWorkspace, isLoading: isPending } = useUpdateWorkspace();
+
+  const [editingField, setEditingField] = useState<'description' | 'artifact_root' | null>(null);
+  const [editValue, setEditValue] = useState('');
+
+  const handleNameClick = () => {
+    setActiveWorkspace(workspace.name);
+    // Navigate to the home page with workspace query param
+    navigate(`/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`);
+  };
+
+  const handleEditClick = (field: 'description' | 'artifact_root', currentValue: string | null | undefined) => {
+    setEditingField(field);
+    setEditValue(currentValue || '');
+  };
+
+  const handleSave = () => {
+    if (editingField === null) return;
+
+    const updateData: { name: string; description?: string; default_artifact_root?: string } = {
+      name: workspace.name,
+    };
+
+    if (editingField === 'description') {
+      updateData.description = editValue;
+    } else if (editingField === 'artifact_root') {
+      updateData.default_artifact_root = editValue;
+    }
+
+    updateWorkspace(updateData, {
+      onSuccess: () => {
+        setEditingField(null);
+        setEditValue('');
+      },
+      onError: (error: any) => {
+        // Display error notification to user
+        Utils.logErrorAndNotifyUser(error);
+      },
+    });
+  };
+
+  const handleCancel = () => {
+    setEditingField(null);
+    setEditValue('');
+  };
+
+  return (
+    <>
+      <TableRow
+        css={{
+          '&:hover': {
+            backgroundColor: theme.colors.actionDefaultBackgroundHover,
+          },
+          height: theme.general.buttonHeight,
+        }}
+        data-testid="workspace-list-item"
+      >
+        <TableCell>
+          <div css={{ display: 'flex', alignItems: 'center', gap: theme.spacing.sm }}>
+            <Link
+              disableWorkspacePrefix
+              to={`/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`}
+              onClick={(e) => {
+                e.preventDefault();
+                handleNameClick();
+              }}
+              css={{
+                color: theme.colors.actionLinkDefault,
+                textDecoration: 'none',
+                fontWeight: theme.typography.typographyBoldFontWeight,
+                '&:hover': {
+                  color: theme.colors.actionLinkHover,
+                  textDecoration: 'underline',
+                },
+              }}
+            >
+              {workspace.name}
+            </Link>
+            {isLastUsed && (
+              <Tag componentId="mlflow.home.workspaces.last_used_badge" color="lemon">
+                <FormattedMessage defaultMessage="Last used" description="Badge for last used workspace" />
+              </Tag>
+            )}
+          </div>
+        </TableCell>
+        <TableCell>
+          <div css={{ display: 'flex' }}>
+            <div
+              css={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                color: theme.colors.textSecondary,
+              }}
+            >
+              {workspace.description}
+            </div>
+            <Button
+              componentId={`mlflow.home.workspaces.edit_description.${workspace.name}`}
+              size="small"
+              type="tertiary"
+              icon={workspace.description ? <PencilIcon /> : undefined}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleEditClick('description', workspace.description);
+              }}
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Edit description',
+                description: 'Label for edit description button in workspaces table',
+              })}
+              css={{
+                flexShrink: 0,
+                opacity: 0,
+                '[role=row]:hover &': {
+                  opacity: 1,
+                },
+                '[role=row]:focus-within &': {
+                  opacity: 1,
+                },
+              }}
+            >
+              {!workspace.description ? (
+                <FormattedMessage
+                  defaultMessage="Set description"
+                  description="Label for set description button in workspaces table"
+                />
+              ) : undefined}
+            </Button>
+          </div>
+        </TableCell>
+        <TableCell>
+          <div css={{ display: 'flex' }}>
+            <div
+              css={{
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                whiteSpace: 'nowrap',
+                color: theme.colors.textSecondary,
+              }}
+            >
+              {workspace.default_artifact_root}
+            </div>
+            <Button
+              componentId={`mlflow.home.workspaces.edit_artifact_root.${workspace.name}`}
+              size="small"
+              type="tertiary"
+              icon={workspace.default_artifact_root ? <PencilIcon /> : undefined}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleEditClick('artifact_root', workspace.default_artifact_root);
+              }}
+              aria-label={intl.formatMessage({
+                defaultMessage: 'Edit artifact root',
+                description: 'Label for edit artifact root button in workspaces table',
+              })}
+              css={{
+                flexShrink: 0,
+                opacity: 0,
+                '[role=row]:hover &': {
+                  opacity: 1,
+                },
+                '[role=row]:focus-within &': {
+                  opacity: 1,
+                },
+              }}
+            >
+              {!workspace.default_artifact_root ? (
+                <FormattedMessage
+                  defaultMessage="Set artifact root"
+                  description="Label for set artifact root button in workspaces table"
+                />
+              ) : undefined}
+            </Button>
+          </div>
+        </TableCell>
+      </TableRow>
+
+      <Modal
+        componentId={`mlflow.home.workspaces.edit_modal.${workspace.name}`}
+        visible={editingField !== null}
+        onCancel={handleCancel}
+        onOk={handleSave}
+        okButtonProps={{ loading: isPending }}
+        okText={intl.formatMessage({
+          defaultMessage: 'Save',
+          description: 'Save button text for edit workspace modal',
+        })}
+        cancelText={intl.formatMessage({
+          defaultMessage: 'Cancel',
+          description: 'Cancel button text for edit workspace modal',
+        })}
+        title={
+          editingField === 'description'
+            ? intl.formatMessage({
+                defaultMessage: 'Edit Description',
+                description: 'Title for edit workspace description modal',
+              })
+            : intl.formatMessage({
+                defaultMessage: 'Edit Artifact Root',
+                description: 'Title for edit workspace artifact root modal',
+              })
+        }
+      >
+        <div
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleSave();
+            }
+          }}
+        >
+          <Input
+            componentId={`mlflow.home.workspaces.edit_${editingField}_input`}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            placeholder={
+              editingField === 'description'
+                ? intl.formatMessage({
+                    defaultMessage: 'Enter description',
+                    description: 'Placeholder for description input in edit modal',
+                  })
+                : intl.formatMessage({
+                    defaultMessage: 'Enter artifact root URI',
+                    description: 'Placeholder for artifact root input in edit modal',
+                  })
+            }
+            autoFocus
+          />
+        </div>
+      </Modal>
+    </>
+  );
+};
+
+const WORKSPACES_PER_PAGE = 10;
+
+export const WorkspacesHomeView = ({ onCreateWorkspace }: WorkspacesHomeViewProps) => {
+  const { theme } = useDesignSystemTheme();
+  const { workspaces, isLoading, isError, refetch } = useWorkspaces(true);
+  // Get last used workspace from localStorage for the "Last used" badge
+  const lastUsedWorkspace = getLastUsedWorkspace();
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const shouldShowEmptyState = !isLoading && !isError && workspaces.length === 0;
+
+  // Calculate paginated workspaces
+  const paginatedWorkspaces = useMemo(() => {
+    const startIndex = (currentPage - 1) * WORKSPACES_PER_PAGE;
+    const endIndex = startIndex + WORKSPACES_PER_PAGE;
+    return workspaces.slice(startIndex, endIndex);
+  }, [workspaces, currentPage]);
+
+  // Reset to page 1 when workspaces change
+  useMemo(() => {
+    if (currentPage > 1 && paginatedWorkspaces.length === 0 && workspaces.length > 0) {
+      setCurrentPage(1);
+    }
+  }, [workspaces.length, currentPage, paginatedWorkspaces.length]);
+
+  return (
+    <section css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.sm }}>
+      <div
+        css={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: theme.spacing.md,
+        }}
+      >
+        <div css={{ display: 'flex', flexDirection: 'column', gap: theme.spacing.xs }}>
+          <Typography.Title level={3} css={{ margin: 0 }}>
+            <FormattedMessage defaultMessage="Workspaces" description="Home page workspaces section title" />
+          </Typography.Title>
+          <Typography.Text color="secondary">
+            <FormattedMessage
+              defaultMessage="Select a workspace to start experiments"
+              description="Home page workspaces section subtitle"
+            />
+          </Typography.Text>
+        </div>
+        {!shouldShowEmptyState && (
+          <Button componentId="mlflow.home.workspaces.create_button" onClick={onCreateWorkspace}>
+            <FormattedMessage defaultMessage="Create new workspace" description="Create workspace button" />
+          </Button>
+        )}
+      </div>
+      <div
+        css={{
+          border: `1px solid ${theme.colors.border}`,
+          overflow: 'hidden',
+          backgroundColor: theme.colors.backgroundPrimary,
+        }}
+      >
+        {isError ? (
+          <div css={{ padding: theme.spacing.lg, display: 'flex', flexDirection: 'column', gap: theme.spacing.md }}>
+            <Alert
+              type="error"
+              closable={false}
+              componentId="mlflow.home.workspaces.error"
+              message={
+                <FormattedMessage
+                  defaultMessage="We couldn't load your workspaces."
+                  description="Home page workspaces error message"
+                />
+              }
+            />
+            <div>
+              <Button componentId="mlflow.home.workspaces.retry" onClick={() => refetch()}>
+                <FormattedMessage defaultMessage="Retry" description="Home page workspaces retry CTA" />
+              </Button>
+            </div>
+          </div>
+        ) : shouldShowEmptyState ? (
+          <WorkspacesEmptyState onCreateWorkspace={onCreateWorkspace} />
+        ) : (
+          <Table>
+            <TableRow isHeader>
+              <TableHeader componentId="mlflow.home.workspaces_table.header.name">
+                <FormattedMessage defaultMessage="Name" description="Workspaces table name column header" />
+              </TableHeader>
+              <TableHeader componentId="mlflow.home.workspaces_table.header.description">
+                <FormattedMessage
+                  defaultMessage="Description"
+                  description="Workspaces table description column header"
+                />
+              </TableHeader>
+              <TableHeader componentId="mlflow.home.workspaces_table.header.artifact_root">
+                <FormattedMessage
+                  defaultMessage="Artifact Root"
+                  description="Workspaces table artifact root column header"
+                />
+              </TableHeader>
+            </TableRow>
+            {isLoading ? (
+              <TableRow>
+                <TableCell />
+                <TableCell css={{ padding: theme.spacing.lg, textAlign: 'center' }}>
+                  <FormattedMessage defaultMessage="Loading workspaces..." description="Loading workspaces message" />
+                </TableCell>
+                <TableCell />
+              </TableRow>
+            ) : (
+              paginatedWorkspaces.map((workspace) => (
+                <WorkspaceRow
+                  key={workspace.name}
+                  workspace={workspace}
+                  isLastUsed={workspace.name === lastUsedWorkspace}
+                />
+              ))
+            )}
+          </Table>
+        )}
+        {!shouldShowEmptyState && !isLoading && !isError && workspaces.length > WORKSPACES_PER_PAGE && (
+          <div
+            css={{
+              padding: theme.spacing.md,
+              display: 'flex',
+              justifyContent: 'center',
+              borderTop: `1px solid ${theme.colors.border}`,
+            }}
+          >
+            <Pagination
+              componentId="mlflow.home.workspaces.pagination"
+              currentPageIndex={currentPage}
+              numTotal={workspaces.length}
+              pageSize={WORKSPACES_PER_PAGE}
+              onChange={(newPageNumber) => setCurrentPage(newPageNumber)}
+            />
+          </div>
+        )}
+      </div>
+      <Spacer shrinks={false} />
+    </section>
+  );
+};
+
+export default WorkspacesHomeView;

--- a/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
+++ b/mlflow/server/js/src/home/components/WorkspacesHomeView.tsx
@@ -16,9 +16,13 @@ import {
   Tag,
 } from '@databricks/design-system';
 import { FormattedMessage, useIntl } from 'react-intl';
-import { Link, useNavigate } from '../../common/utils/RoutingUtils';
+import { Link } from '../../common/utils/RoutingUtils';
 import { useWorkspaces, type Workspace } from '../../workspaces/hooks/useWorkspaces';
-import { getLastUsedWorkspace, setActiveWorkspace, WORKSPACE_QUERY_PARAM } from '../../workspaces/utils/WorkspaceUtils';
+import {
+  getLastUsedWorkspace,
+  setLastUsedWorkspace,
+  WORKSPACE_QUERY_PARAM,
+} from '../../workspaces/utils/WorkspaceUtils';
 import { useUpdateWorkspace } from '../../workspaces/hooks/useUpdateWorkspace';
 import Utils from '../../common/utils/Utils';
 
@@ -60,7 +64,6 @@ const WorkspacesEmptyState = ({ onCreateWorkspace }: { onCreateWorkspace: () => 
 
 const WorkspaceRow = ({ workspace, isLastUsed }: { workspace: Workspace; isLastUsed: boolean }) => {
   const { theme } = useDesignSystemTheme();
-  const navigate = useNavigate();
   const intl = useIntl();
   const { mutate: updateWorkspace, isLoading: isPending } = useUpdateWorkspace();
 
@@ -68,9 +71,10 @@ const WorkspaceRow = ({ workspace, isLastUsed }: { workspace: Workspace; isLastU
   const [editValue, setEditValue] = useState('');
 
   const handleNameClick = () => {
-    setActiveWorkspace(workspace.name);
-    // Navigate to the home page with workspace query param
-    navigate(`/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`);
+    // Persist to localStorage for UI hints then hard reload to cleanly switch workspace
+    setLastUsedWorkspace(workspace.name);
+    window.location.hash = `#/?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace.name)}`;
+    window.location.reload();
   };
 
   const handleEditClick = (field: 'description' | 'artifact_root', currentValue: string | null | undefined) => {

--- a/mlflow/server/js/src/lang/default/en.json
+++ b/mlflow/server/js/src/lang/default/en.json
@@ -215,6 +215,10 @@
     "defaultMessage": "Inputs",
     "description": "Model trace explorer > selected span > inputs header"
   },
+  "/TolHF": {
+    "defaultMessage": "Please input a name for the new workspace.",
+    "description": "Error message for name requirement in create workspace modal"
+  },
   "/UktTY": {
     "defaultMessage": "Are the expected facts supported by the response?",
     "description": "Hint for Correctness template"
@@ -534,6 +538,10 @@
   "2+EUFB": {
     "defaultMessage": "Cancel",
     "description": "Delete evaluation runs cancel button text"
+  },
+  "2+uccV": {
+    "defaultMessage": "Workspaces",
+    "description": "Home page workspaces section title"
   },
   "2/B9Zg": {
     "defaultMessage": "added {when} by {user}",
@@ -1138,6 +1146,10 @@
     "defaultMessage": "Total: {total}%",
     "description": "Total weight display"
   },
+  "6i/EoY": {
+    "defaultMessage": "Save",
+    "description": "Save button text for edit workspace modal"
+  },
   "6jqEbB": {
     "defaultMessage": "Model",
     "description": "Section header for model selection"
@@ -1281,6 +1293,10 @@
   "7Y0hIS": {
     "defaultMessage": "Run the following code to validate model inference works on the example input data and logged model dependencies, prior to deploying it to a serving endpoint",
     "description": "Section heading to display the code block on how we can validate a model locally prior to serving"
+  },
+  "7YANiA": {
+    "defaultMessage": "Workspaces",
+    "description": "Sidebar link for workspaces page"
   },
   "7ZzboF": {
     "defaultMessage": "Link prompts to your traces by loading your registered prompts inside the traced function.",
@@ -1474,6 +1490,10 @@
     "defaultMessage": "X-axis:",
     "description": "Label text for X-axis in box plot comparison in MLflow"
   },
+  "8xpU1t": {
+    "defaultMessage": "Edit Artifact Root",
+    "description": "Title for edit workspace artifact root modal"
+  },
   "8xzQsr": {
     "defaultMessage": "Train models",
     "description": "Home page quick action title for training models"
@@ -1577,6 +1597,10 @@
   "9dX4XQ": {
     "defaultMessage": "Select parameter or metric",
     "description": "Placeholder text for parameter/metric selector in box plot comparison in MLflow"
+  },
+  "9eWlQw": {
+    "defaultMessage": "Artifact Root",
+    "description": "Workspaces table artifact root column header"
   },
   "9fVZg8": {
     "defaultMessage": "Delete",
@@ -1741,6 +1765,10 @@
   "AhfXyS": {
     "defaultMessage": "Previous",
     "description": "Button text for previous trace"
+  },
+  "AoDwev": {
+    "defaultMessage": "Description (optional)",
+    "description": "Label for description field"
   },
   "Aqq08o": {
     "defaultMessage": "HTTP",
@@ -1933,6 +1961,10 @@
   "Bs2X0L": {
     "defaultMessage": "Created by",
     "description": "Label for the creator of a logged model on the logged model details page"
+  },
+  "Bsuyal": {
+    "defaultMessage": "Description",
+    "description": "Workspaces table description column header"
   },
   "BuykLs": {
     "defaultMessage": "Delete judge",
@@ -2470,6 +2502,10 @@
     "defaultMessage": "Start Time:",
     "description": "Text for start time row header in the main table in the model comparison\n                page"
   },
+  "GOdou5": {
+    "defaultMessage": "Default Artifact Root (optional)",
+    "description": "Label for artifact root field"
+  },
   "GRaplV": {
     "defaultMessage": "Context sufficiency",
     "description": "Evaluation results > known type of evaluation result assessment > context sufficiency assessment. Used to indicate if the retrieved context is sufficient to generate the expected response. Label displayed if user provided custom value, e.g. \"Context Sufficiency: mostly sufficient\""
@@ -2581,6 +2617,10 @@
   "HYQHVk": {
     "defaultMessage": "See more",
     "description": "Model trace explorer > selected span > code snippet > see more button"
+  },
+  "HZH8Yr": {
+    "defaultMessage": "Set artifact root",
+    "description": "Label for set artifact root button in workspaces table"
   },
   "HZdpLU": {
     "defaultMessage": "Only alphanumeric characters, underscores, hyphens, and dots are allowed",
@@ -3070,6 +3110,10 @@
     "defaultMessage": "Not registered",
     "description": "Tag for not registered model on the logged model details page"
   },
+  "LLANE+": {
+    "defaultMessage": "Edit Description",
+    "description": "Title for edit workspace description modal"
+  },
   "LLm5Bo": {
     "defaultMessage": "Displaying Runs from {numExperiments} Experiments",
     "description": "Breadcrumb nav item to link to the compare-experiments page on compare runs page"
@@ -3354,6 +3398,10 @@
     "defaultMessage": "Provider{count}",
     "description": "Provider filter button label with count"
   },
+  "NW59bs": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button text for edit workspace modal"
+  },
   "NWbmIK": {
     "defaultMessage": "Is the text grammatically correct and naturally flowing?",
     "description": "Hint for Fluency template"
@@ -3429,6 +3477,10 @@
   "O+/hDQ": {
     "defaultMessage": "For local development, MLflow uses a default passphrase. For production deployments, server administrators must set a secure encryption passphrase on the tracking server before starting it:",
     "description": "AI Gateway setup guide > Step 3 description"
+  },
+  "O+hq1Q": {
+    "defaultMessage": "Create Workspace",
+    "description": "Title for create workspace modal"
   },
   "O1rYVN": {
     "defaultMessage": "Load model as a Spark UDF. Override result_type if the model does not return double values.",
@@ -3640,6 +3692,10 @@
   "PpP8du": {
     "defaultMessage": "Model configuration",
     "description": "Label for model configuration section"
+  },
+  "PuXTcZ": {
+    "defaultMessage": "Welcome to MLflow",
+    "description": "Workspace landing page title"
   },
   "PwQiIn": {
     "defaultMessage": "Actions{count}",
@@ -3981,6 +4037,10 @@
     "defaultMessage": "Evaluating traces: ON",
     "description": "Status label for active scorer"
   },
+  "SSwoap": {
+    "defaultMessage": "Select a workspace to start experiments",
+    "description": "Home page workspaces section subtitle"
+  },
   "STEhnv": {
     "defaultMessage": "Description",
     "description": "Header for the description column in the experiments table"
@@ -4292,6 +4352,10 @@
     "defaultMessage": "Transition to",
     "description": "Text for transitioning a model version to a different stage under\n                 dropdown menu in model version page"
   },
+  "UjInB0": {
+    "defaultMessage": "Enter workspace description",
+    "description": "Input placeholder for workspace description in create workspace modal"
+  },
   "UkVgwL": {
     "defaultMessage": "Create endpoint",
     "description": "Page title for create endpoint"
@@ -4544,6 +4608,10 @@
     "defaultMessage": "Details & Timeline",
     "description": "Label for the details & timeline view tab in the model trace explorer"
   },
+  "WiML15": {
+    "defaultMessage": "Create your first workspace",
+    "description": "Home page workspaces empty state title"
+  },
   "WiaEQ3": {
     "defaultMessage": "Model output",
     "description": "Evaluation review > Response section > model output > title"
@@ -4691,6 +4759,10 @@
     "defaultMessage": "Search metric charts",
     "description": "Run page > Charts tab > Filter metric charts input > placeholder"
   },
+  "Xt8M9f": {
+    "defaultMessage": "Loading workspaces...",
+    "description": "Loading workspaces message"
+  },
   "Xuz/xh": {
     "defaultMessage": "Models",
     "description": "Sidebar link for models tab"
@@ -4810,6 +4882,10 @@
   "Yd5ANL": {
     "defaultMessage": "PASS",
     "description": "Header label for pass/fail assessment type for the pass rate"
+  },
+  "YeIhTa": {
+    "defaultMessage": "Enter artifact root URI",
+    "description": "Placeholder for artifact root input in edit modal"
   },
   "Yhydp3": {
     "defaultMessage": "Relevance",
@@ -5523,6 +5599,10 @@
     "defaultMessage": "Passthrough APIs",
     "description": "Passthrough APIs tab title"
   },
+  "dQvz5p": {
+    "defaultMessage": "Workspace Name",
+    "description": "Label for workspace name field"
+  },
   "dTLq6E": {
     "defaultMessage": "expand {title}",
     "description": "Common component > collapsible section > alternative label when collapsed"
@@ -5530,6 +5610,14 @@
   "dTjHiD": {
     "defaultMessage": "Add a custom expectation to this trace.",
     "description": "Hint message prompting user to add a new expectation"
+  },
+  "dUY9eq": {
+    "defaultMessage": "Edit description",
+    "description": "Label for edit description button in workspaces table"
+  },
+  "dUm30k": {
+    "defaultMessage": "Create a workspace to organize and logically isolate your experiments and models.",
+    "description": "Home page workspaces empty state description"
   },
   "dVh69l": {
     "defaultMessage": "Run name",
@@ -5975,6 +6063,10 @@
     "defaultMessage": "An endpoint with this name already exists",
     "description": "Error message when endpoint name already exists"
   },
+  "gXb1Ab": {
+    "defaultMessage": "Create new workspace",
+    "description": "Create workspace button"
+  },
   "gYOuKs": {
     "defaultMessage": "Rationale",
     "description": "Label for the rationale of an expectation assessment"
@@ -6075,6 +6167,10 @@
     "defaultMessage": "{count, plural, one {1 session selected} other {# sessions selected}}",
     "description": "Label for the number of sessions selected"
   },
+  "hN4qL/": {
+    "defaultMessage": "Create workspace",
+    "description": "Home page workspaces empty state CTA"
+  },
   "hR2Zvd": {
     "defaultMessage": "Create a custom judge function using the {decorator} decorator. Implement your scoring logic in the function body. {link}",
     "description": "Step 2 description for defining judge function"
@@ -6102,6 +6198,10 @@
   "hWHLjo": {
     "defaultMessage": "True",
     "description": "Label for an assessment with a 'true' boolean value"
+  },
+  "hYrjzD": {
+    "defaultMessage": "Create",
+    "description": "Confirm button text for create workspace modal"
   },
   "hcDB9U": {
     "defaultMessage": "+∞",
@@ -6170,6 +6270,10 @@
   "i1Hj20": {
     "defaultMessage": "{count, plural, =1 {1 hour} other {# hours}} ago",
     "description": "Time duration in hours"
+  },
+  "i3T+JQ": {
+    "defaultMessage": "Retry",
+    "description": "Home page workspaces retry CTA"
   },
   "i49wE6": {
     "defaultMessage": "We couldn't load your experiments.",
@@ -6278,6 +6382,10 @@
   "icBP3T": {
     "defaultMessage": "TRUE",
     "description": "Header label for boolean assessment type for the true rate"
+  },
+  "ie1fGj": {
+    "defaultMessage": "Edit artifact root",
+    "description": "Label for edit artifact root button in workspaces table"
   },
   "ieY8lf": {
     "defaultMessage": "Evaluating {isTraces, select, true {traces} other {sessions}}...",
@@ -6451,6 +6559,14 @@
     "defaultMessage": "Failed to load child runs",
     "description": "Run page > Overview > Child runs error"
   },
+  "k2bPN+": {
+    "defaultMessage": "Last used",
+    "description": "Badge for last used workspace"
+  },
+  "k8oXRo": {
+    "defaultMessage": "Enter description",
+    "description": "Placeholder for description input in edit modal"
+  },
   "kA+QJr": {
     "defaultMessage": "Overview",
     "description": "Run details page > tab selector > overview tab"
@@ -6607,6 +6723,10 @@
     "defaultMessage": "Run details",
     "description": "Compare table title on the compare runs page"
   },
+  "lIURTA": {
+    "defaultMessage": "Name",
+    "description": "Workspaces table name column header"
+  },
   "lJQEW4": {
     "defaultMessage": "Using controls above, select at least one \"group by\" column.",
     "description": "Experiment page > artifact compare view > empty state for no group by columns selected > title"
@@ -6686,6 +6806,10 @@
   "loe2Ov": {
     "defaultMessage": "Version {version}",
     "description": "A label for the version number in the prompt details page"
+  },
+  "lpEsIz": {
+    "defaultMessage": "We couldn't load your workspaces.",
+    "description": "Home page workspaces error message"
   },
   "ls3868": {
     "defaultMessage": "Guidelines",
@@ -6875,6 +6999,10 @@
     "defaultMessage": "Edit history",
     "description": "Title of a modal that shows the edit history of an assessment"
   },
+  "nAhHpm": {
+    "defaultMessage": "Cancel",
+    "description": "Cancel button text for create workspace modal"
+  },
   "nBKx6U": {
     "defaultMessage": "Edit endpoint name",
     "description": "Tooltip for edit endpoint name button"
@@ -7054,6 +7182,10 @@
   "oMP6X7": {
     "defaultMessage": "Structured Output",
     "description": "Filter option for structured JSON output support"
+  },
+  "oQO1tC": {
+    "defaultMessage": "Enter workspace name",
+    "description": "Input placeholder for workspace name in create workspace modal"
   },
   "oShuJS": {
     "defaultMessage": "Logged from",
@@ -7711,6 +7843,10 @@
     "defaultMessage": "Value",
     "description": "Key-value tag editor modal > Value input label (required)"
   },
+  "tJ+7No": {
+    "defaultMessage": "Set description",
+    "description": "Label for set description button in workspaces table"
+  },
   "tLb7+M": {
     "defaultMessage": "{timeSince, plural, =1 {1 day} other {# days}} ago",
     "description": "Text for time in days since given date for MLflow views"
@@ -8106,6 +8242,10 @@
   "wjOGl2": {
     "defaultMessage": "Columns",
     "description": "Evaluation review > evaluations list > filter dropdown button"
+  },
+  "wnN8R0": {
+    "defaultMessage": "Enter default artifact root URI",
+    "description": "Input placeholder for artifact root in create workspace modal"
   },
   "womPSY": {
     "defaultMessage": "Session",

--- a/mlflow/server/js/src/model-registry/components/ModelListView.tsx
+++ b/mlflow/server/js/src/model-registry/components/ModelListView.tsx
@@ -20,12 +20,13 @@ import { PageHeader } from '../../shared/building_blocks/PageHeader';
 
 import { FormattedMessage, type IntlShape, injectIntl } from 'react-intl';
 import { Alert, CursorPagination, Spacer as DuBoisSpacer, Spacer, Typography } from '@databricks/design-system';
-import { shouldShowModelsNextUI } from '../../common/utils/FeatureUtils';
+import { shouldShowModelsNextUI, shouldEnableWorkspaces } from '../../common/utils/FeatureUtils';
 import { ModelListFilters } from './model-list/ModelListFilters';
 import { ModelListTable } from './model-list/ModelListTable';
 import { PageContainer } from '../../common/components/PageContainer';
 import { ModelsNextUIToggleSwitch } from './ModelsNextUIToggleSwitch';
 import { withNextModelsUIContext } from '../hooks/useNextModelsUI';
+import { extractWorkspaceFromSearchParams } from '../../workspaces/utils/WorkspaceUtils';
 
 const NAME_COLUMN_INDEX = 'name';
 const LAST_MODIFIED_COLUMN_INDEX = 'last_updated_timestamp';
@@ -154,6 +155,12 @@ export class ModelListViewImpl extends React.Component<ModelListViewImplProps, M
       // prettier-ignore
       Boolean(searchInput);
 
+    // Only show creation buttons when: workspaces are disabled OR a workspace is selected
+    const workspacesEnabled = shouldEnableWorkspaces();
+    const searchParams = new URLSearchParams(window.location.search);
+    const workspaceFromUrl = extractWorkspaceFromSearchParams(searchParams);
+    const showCreationButtons = !workspacesEnabled || workspaceFromUrl !== null;
+
     const title = (
       <FormattedMessage
         defaultMessage="Registered Models"
@@ -164,7 +171,7 @@ export class ModelListViewImpl extends React.Component<ModelListViewImplProps, M
       <PageContainer data-testid="ModelListView-container" usesFullHeight>
         <div>
           <PageHeader title={title} spacerSize="xs">
-            <CreateModelButton />
+            {showCreationButtons && <CreateModelButton />}
           </PageHeader>
           {/* TODO[SHIP-6202]: Move the description to the Header prop 'description' once it's been added */}
           <Typography.Hint>

--- a/mlflow/server/js/src/model-registry/components/model-list/ModelListTable.enzyme.test.tsx
+++ b/mlflow/server/js/src/model-registry/components/model-list/ModelListTable.enzyme.test.tsx
@@ -7,6 +7,9 @@ import type { ModelListTableProps } from './ModelListTable';
 import { ModelListTable } from './ModelListTable';
 import { DesignSystemProvider } from '@databricks/design-system';
 
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
+
 import { Stages } from '../../constants';
 import Utils from '../../../common/utils/Utils';
 import { withNextModelsUIContext } from '../../hooks/useNextModelsUI';

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.test.tsx
@@ -777,19 +777,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles span status filters with EQUALS operator', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -817,10 +814,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.status = 'ERROR'`,
       max_results: 10000,

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.test.tsx
@@ -29,7 +29,7 @@ import {
 } from './useTableColumns';
 import { FilterOperator, TracesTableColumnGroup, TracesTableColumnType } from '../types';
 import { shouldUseTracesV4API } from '../utils/FeatureUtils';
-import { fetchFn } from '../utils/FetchUtils';
+import { fetchAPI } from '../utils/FetchUtils';
 
 // Mock shouldEnableUnifiedEvalTab
 jest.mock('../utils/FeatureUtils', () => ({
@@ -44,10 +44,11 @@ jest.mock('./useGenAiTraceEvaluationArtifacts', () => ({
   useGenAiTraceEvaluationArtifacts: jest.fn(),
 }));
 
-// Mock fetchFn
+// Mock fetch utilities
 jest.mock('../utils/FetchUtils', () => ({
-  fetchFn: jest.fn(),
+  fetchAPI: jest.fn(),
   getAjaxUrl: jest.fn().mockImplementation((relativeUrl) => '/' + relativeUrl),
+  getDefaultHeaders: jest.fn().mockReturnValue({}),
 }));
 
 // Mock global window.fetch
@@ -98,19 +99,17 @@ describe('useMlflowTracesTableMetadata', () => {
       isLoading: false,
     } as any);
 
-    jest.mocked(fetchFn).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            tags: {
-              'mlflow.linkedPrompts': JSON.stringify([{ name: 'qa-agent-system-prompt', version: '4' }]),
-            },
+    jest.mocked(fetchAPI).mockResolvedValue({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          tags: {
+            'mlflow.linkedPrompts': JSON.stringify([{ name: 'qa-agent-system-prompt', version: '4' }]),
           },
-        ],
-      }),
-    } as any);
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -142,31 +141,29 @@ describe('useMlflowTracesTableMetadata', () => {
       isLoading: false,
     } as any);
 
-    jest.mocked(fetchFn).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            tags: {
-              'mlflow.linkedPrompts': JSON.stringify([
-                { name: 'qa-agent-system-prompt', version: '4' },
-                { name: 'chat-assistant-prompt', version: '1' },
-              ]),
-            },
+    jest.mocked(fetchAPI).mockResolvedValue({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          tags: {
+            'mlflow.linkedPrompts': JSON.stringify([
+              { name: 'qa-agent-system-prompt', version: '4' },
+              { name: 'chat-assistant-prompt', version: '1' },
+            ]),
           },
-          {
-            trace_id: 'trace_2',
-            tags: {
-              'mlflow.linkedPrompts': JSON.stringify([
-                { name: 'qa-agent-system-prompt', version: '4' },
-                { name: 'chat-assistant-prompt', version: '2' },
-              ]),
-            },
+        },
+        {
+          trace_id: 'trace_2',
+          tags: {
+            'mlflow.linkedPrompts': JSON.stringify([
+              { name: 'qa-agent-system-prompt', version: '4' },
+              { name: 'chat-assistant-prompt', version: '2' },
+            ]),
           },
-        ],
-      }),
-    } as any);
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -202,25 +199,23 @@ describe('useMlflowTracesTableMetadata', () => {
       isLoading: false,
     } as any);
 
-    jest.mocked(fetchFn).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            tags: {
-              'mlflow.linkedPrompts': 'invalid-json',
-            },
+    jest.mocked(fetchAPI).mockResolvedValue({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          tags: {
+            'mlflow.linkedPrompts': 'invalid-json',
           },
-          {
-            trace_id: 'trace_2',
-            tags: {
-              'mlflow.linkedPrompts': JSON.stringify([{ name: 'valid-prompt', version: '1' }]),
-            },
+        },
+        {
+          trace_id: 'trace_2',
+          tags: {
+            'mlflow.linkedPrompts': JSON.stringify([{ name: 'valid-prompt', version: '1' }]),
           },
-        ],
-      }),
-    } as any);
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -250,7 +245,7 @@ describe('useMlflowTracesTableMetadata', () => {
 describe('useSearchMlflowTraces', () => {
   beforeEach(() => {
     jest.mocked(shouldUseTracesV4API).mockReturnValue(false);
-    jest.mocked(fetchFn).mockClear();
+    jest.mocked(fetchAPI).mockClear();
   });
   test('returns empty data and isLoading = false when disabled is true', async () => {
     const { result } = renderHook(
@@ -276,19 +271,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('makes network call to fetch traces when enabled', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -309,7 +301,7 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(fetchFn).toHaveBeenCalledTimes(1); // only one page
+    expect(fetchAPI).toHaveBeenCalledTimes(1); // only one page
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data?.[0]).toEqual({
       trace_id: 'trace_1',
@@ -319,19 +311,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('uses filters to fetch traces', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -416,10 +405,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `attributes.run_id = 'run-xyz' AND attributes.timestamp_ms > 100 AND attributes.timestamp_ms < 200 AND feedback.\`overall\` = 'success' AND tags.user = 'user_1' AND tags.user = 'user_2' AND attributes.execution_time_ms > 1000 AND request_metadata."mlflow.trace.user" = 'user_3' AND attributes.run_id = 'run_1' AND request_metadata."mlflow.modelId" = 'version_1' AND attributes.status = 'OK' AND attributes.name = 'trace_1'`,
       max_results: 10000,
@@ -427,24 +416,21 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles custom metadata filters correctly', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-            trace_metadata: {
-              user_id: 'user123',
-              environment: 'production',
-              'mlflow.internal.key': 'internal_value', // Should be excluded
-            },
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+          trace_metadata: {
+            user_id: 'user123',
+            environment: 'production',
+            'mlflow.internal.key': 'internal_value', // Should be excluded
           },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -482,10 +468,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `request_metadata.user_id = 'user123' AND request_metadata.environment = 'production' AND request_metadata.mlflow.trace.session ILIKE '%%'`,
       max_results: 10000,
@@ -493,24 +479,21 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('excludes MLflow internal keys from custom metadata filters', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-            trace_metadata: {
-              user_id: 'user123',
-              'mlflow.run_id': 'run123', // Should be excluded
-              'mlflow.internal.key': 'internal_value', // Should be excluded
-            },
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+          trace_metadata: {
+            user_id: 'user123',
+            'mlflow.run_id': 'run123', // Should be excluded
+            'mlflow.internal.key': 'internal_value', // Should be excluded
           },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -543,10 +526,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `request_metadata.user_id = 'user123' AND request_metadata.mlflow.run_id = 'run123'`,
       max_results: 10000,
@@ -554,19 +537,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles span name filters with case-insensitive equals', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -594,10 +574,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.name ILIKE 'my_span'`,
       max_results: 10000,
@@ -605,19 +585,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles span name filters with CONTAINS operator', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -645,10 +622,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.name ILIKE '%span%'`,
       max_results: 10000,
@@ -656,19 +633,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles span name filters with NOT_EQUALS operator', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -696,10 +670,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.name != 'excluded_span'`,
       max_results: 10000,
@@ -707,19 +681,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles span type filters with case-insensitive equals', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -747,10 +718,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.type ILIKE 'llm'`,
       max_results: 10000,
@@ -758,19 +729,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles span type filters with CONTAINS operator', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -798,10 +766,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.type ILIKE '%chain%'`,
       max_results: 10000,
@@ -860,19 +828,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles multiple span filters combined', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -905,10 +870,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.name ILIKE '%query%' AND span.type ILIKE 'llm'`,
       max_results: 10000,
@@ -916,19 +881,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('handles span content filter with CONTAINS operator', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -956,10 +918,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `span.content ILIKE '%search text%'`,
       max_results: 10000,
@@ -967,10 +929,9 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test.each([INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID])('handles %s filter with RLIKE operator', async (testedColumn) => {
-    const fetchBodySpy = jest.fn();
-    jest.mocked(fetchFn).mockImplementation((_url, requestInit) => {
-      fetchBodySpy(JSON.parse(String(requestInit?.body)));
-      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [],
+      next_page_token: undefined,
     });
 
     const { result } = renderHook(
@@ -999,7 +960,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(fetchBodySpy).toHaveBeenCalledWith({
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
+
+    expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `${testedColumn} RLIKE 'hello.*world'`,
       max_results: 10000,
@@ -1009,10 +973,9 @@ describe('useSearchMlflowTraces', () => {
   test.each([INPUTS_COLUMN_ID, RESPONSE_COLUMN_ID])(
     'handles %s filter with "equals" operator',
     async (testedColumn) => {
-      const fetchBodySpy = jest.fn();
-      jest.mocked(fetchFn).mockImplementation((_url, requestInit) => {
-        fetchBodySpy(JSON.parse(String(requestInit?.body)));
-        return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+      jest.mocked(fetchAPI).mockResolvedValueOnce({
+        traces: [],
+        next_page_token: undefined,
       });
 
       const { result } = renderHook(
@@ -1041,7 +1004,10 @@ describe('useSearchMlflowTraces', () => {
 
       await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-      expect(fetchBodySpy).toHaveBeenCalledWith({
+      const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
+
+      expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
+      expect(body).toEqual({
         locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
         filter: `${testedColumn} = 'hello.*world'`,
         max_results: 10000,
@@ -1050,10 +1016,9 @@ describe('useSearchMlflowTraces', () => {
   );
 
   test('handles combined request and response filters', async () => {
-    const fetchBodySpy = jest.fn();
-    jest.mocked(fetchFn).mockImplementation((_url, requestInit) => {
-      fetchBodySpy(JSON.parse(String(requestInit?.body)));
-      return Promise.resolve({ ok: true, json: async () => ({}) } as Response);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [],
+      next_page_token: undefined,
     });
 
     const { result } = renderHook(
@@ -1087,7 +1052,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    expect(fetchBodySpy).toHaveBeenCalledWith({
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
+
+    expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `request RLIKE 'hello' AND response = 'world'`,
       max_results: 10000,
@@ -1095,19 +1063,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('uses order_by to fetch traces for server sortable column', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1138,10 +1103,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `attributes.run_id = 'run-xyz' AND attributes.timestamp_ms > 100 AND attributes.timestamp_ms < 200`,
       max_results: 10000,
@@ -1150,19 +1115,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('Does not use order_by to fetch traces for non-server sortable column', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1193,10 +1155,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `attributes.run_id = 'run-xyz' AND attributes.timestamp_ms > 100 AND attributes.timestamp_ms < 200`,
       max_results: 10000,
@@ -1205,19 +1167,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test("use loggedModelId and sqlWarehouseId to fetch model's online traces", async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value"}',
-            response: '{"output": "value"}',
-          },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value"}',
+          response: '{"output": "value"}',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1241,10 +1200,10 @@ describe('useSearchMlflowTraces', () => {
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
 
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body)).toEqual({
+    expect(body).toEqual({
       locations: [{ mlflow_experiment: { experiment_id: 'experiment-xyz' }, type: 'MLFLOW_EXPERIMENT' }],
       filter: `attributes.run_id = 'run-xyz'`,
       max_results: 10000,
@@ -1255,37 +1214,34 @@ describe('useSearchMlflowTraces', () => {
 
   it('handles assessment filters via backend', async () => {
     // Mock returns only matching trace (simulating backend filtering)
-    jest.mocked(fetchFn).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value1"}',
-            response: '{"output": "value"}',
-            assessments: [
-              {
-                assessment_id: 'overall_assessment',
-                assessment_name: 'overall_assessment',
-                trace_id: 'trace_1',
-                feedback: {
-                  value: 'pass',
-                },
+    jest.mocked(fetchAPI).mockResolvedValue({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value1"}',
+          response: '{"output": "value"}',
+          assessments: [
+            {
+              assessment_id: 'overall_assessment',
+              assessment_name: 'overall_assessment',
+              trace_id: 'trace_1',
+              feedback: {
+                value: 'pass',
               },
-              {
-                assessment_id: 'correctness',
-                assessment_name: 'correctness_assessment',
-                trace_id: 'trace_1',
-                feedback: {
-                  value: 'pass',
-                },
+            },
+            {
+              assessment_id: 'correctness',
+              assessment_name: 'correctness_assessment',
+              trace_id: 'trace_1',
+              feedback: {
+                value: 'pass',
               },
-            ],
-          },
-        ] as ModelTraceInfoV3[],
-        next_page_token: undefined,
-      }),
-    } as any);
+            },
+          ],
+        },
+      ] as ModelTraceInfoV3[],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1321,9 +1277,9 @@ describe('useSearchMlflowTraces', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     // Verify the assessment filter was sent to the backend
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body).filter).toContain("feedback.`overall_assessment` = 'pass'");
+    expect(body.filter).toContain("feedback.`overall_assessment` = 'pass'");
 
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data?.[0].trace_id).toBe('trace_1');
@@ -1335,19 +1291,16 @@ describe('useSearchMlflowTraces', () => {
   });
 
   it('handles search query filtering via backend', async () => {
-    jest.mocked(fetchFn).mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            request: '{"input": "value1"}',
-            response: '{"output": "value"}',
-          },
-        ] as ModelTraceInfoV3[],
-        next_page_token: undefined,
-      }),
-    } as any);
+    jest.mocked(fetchAPI).mockResolvedValue({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          request: '{"input": "value1"}',
+          response: '{"output": "value"}',
+        },
+      ] as ModelTraceInfoV3[],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1370,9 +1323,9 @@ describe('useSearchMlflowTraces', () => {
     await waitFor(() => expect(result.current.isLoading).toBe(false));
 
     // Verify the search query was sent to the backend
-    const [url, { body }] = jest.mocked(fetchFn).mock.lastCall as any;
+    const [url, { body }] = jest.mocked(fetchAPI).mock.lastCall as any;
     expect(url).toEqual('/ajax-api/3.0/mlflow/traces/search');
-    expect(JSON.parse(body).filter).toContain("span.attributes.`mlflow.spanInputs` ILIKE '%test query%'");
+    expect(body.filter).toContain("span.attributes.`mlflow.spanInputs` ILIKE '%test query%'");
 
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data?.[0].trace_id).toBe('trace_1');
@@ -1458,53 +1411,50 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('filters out assessments belong to another run', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            client_request_id: 'req-1',
-            trace_location: {
-              type: 'MLFLOW_EXPERIMENT',
-              mlflow_experiment: { experiment_id: 'experiment-xyz' },
-            },
-            request_time: '2024-01-01T00:00:00Z',
-            state: 'OK',
-            assessments: [
-              {
-                assessment_id: 'a-1',
-                assessment_name: 'overall',
-                trace_id: 'trace_1',
-                create_time: '2024-01-01T00:00:00Z',
-                last_update_time: '2024-01-01T00:00:00Z',
-                metadata: { 'mlflow.assessment.sourceRunId': 'run-xyz' },
-                feedback: { value: 'pass' },
-              },
-              {
-                assessment_id: 'a-2',
-                assessment_name: 'overall',
-                trace_id: 'trace_1',
-                create_time: '2024-01-01T00:00:00Z',
-                last_update_time: '2024-01-01T00:00:00Z',
-                metadata: { 'mlflow.assessment.sourceRunId': 'other-run-1' },
-                feedback: { value: 'pass' },
-              },
-              {
-                assessment_id: 'a-3',
-                assessment_name: 'guidelines',
-                trace_id: 'trace_1',
-                create_time: '2024-01-01T00:00:00Z',
-                last_update_time: '2024-01-01T00:00:00Z',
-                metadata: { 'mlflow.assessment.sourceRunId': 'other-run-2' },
-                feedback: { value: 'pass' },
-              },
-            ],
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          client_request_id: 'req-1',
+          trace_location: {
+            type: 'MLFLOW_EXPERIMENT',
+            mlflow_experiment: { experiment_id: 'experiment-xyz' },
           },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+          request_time: '2024-01-01T00:00:00Z',
+          state: 'OK',
+          assessments: [
+            {
+              assessment_id: 'a-1',
+              assessment_name: 'overall',
+              trace_id: 'trace_1',
+              create_time: '2024-01-01T00:00:00Z',
+              last_update_time: '2024-01-01T00:00:00Z',
+              metadata: { 'mlflow.assessment.sourceRunId': 'run-xyz' },
+              feedback: { value: 'pass' },
+            },
+            {
+              assessment_id: 'a-2',
+              assessment_name: 'overall',
+              trace_id: 'trace_1',
+              create_time: '2024-01-01T00:00:00Z',
+              last_update_time: '2024-01-01T00:00:00Z',
+              metadata: { 'mlflow.assessment.sourceRunId': 'other-run-1' },
+              feedback: { value: 'pass' },
+            },
+            {
+              assessment_id: 'a-3',
+              assessment_name: 'guidelines',
+              trace_id: 'trace_1',
+              create_time: '2024-01-01T00:00:00Z',
+              last_update_time: '2024-01-01T00:00:00Z',
+              metadata: { 'mlflow.assessment.sourceRunId': 'other-run-2' },
+              feedback: { value: 'pass' },
+            },
+          ],
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1528,24 +1478,21 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('keep traces without assessments', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            client_request_id: 'req-1',
-            trace_location: {
-              type: 'MLFLOW_EXPERIMENT',
-              mlflow_experiment: { experiment_id: 'experiment-xyz' },
-            },
-            request_time: '2024-01-01T00:00:00Z',
-            state: 'OK',
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          client_request_id: 'req-1',
+          trace_location: {
+            type: 'MLFLOW_EXPERIMENT',
+            mlflow_experiment: { experiment_id: 'experiment-xyz' },
           },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+          request_time: '2024-01-01T00:00:00Z',
+          state: 'OK',
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1565,50 +1512,47 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('keep traces with manual assessments', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            client_request_id: 'req-1',
-            trace_location: {
-              type: 'MLFLOW_EXPERIMENT',
-              mlflow_experiment: { experiment_id: 'experiment-xyz' },
-            },
-            request_time: '2024-01-01T00:00:00Z',
-            state: 'OK',
-            assessments: [
-              {
-                assessment_id: 'a-1',
-                assessment_name: 'overall',
-                trace_id: 'trace_1',
-                create_time: '2024-01-01T00:00:00Z',
-                last_update_time: '2024-01-01T00:00:00Z',
-                feedback: { value: 'pass' },
-                source: {
-                  source_type: 'HUMAN',
-                  source_id: 'user-1',
-                },
-              },
-              {
-                assessment_id: 'a-2',
-                assessment_name: 'overall',
-                trace_id: 'trace_1',
-                create_time: '2024-01-01T00:00:00Z',
-                last_update_time: '2024-01-01T00:00:00Z',
-                expectation: { value: 'expected value' },
-                source: {
-                  source_type: 'HUMAN',
-                  source_id: 'user-2',
-                },
-              },
-            ],
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          client_request_id: 'req-1',
+          trace_location: {
+            type: 'MLFLOW_EXPERIMENT',
+            mlflow_experiment: { experiment_id: 'experiment-xyz' },
           },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+          request_time: '2024-01-01T00:00:00Z',
+          state: 'OK',
+          assessments: [
+            {
+              assessment_id: 'a-1',
+              assessment_name: 'overall',
+              trace_id: 'trace_1',
+              create_time: '2024-01-01T00:00:00Z',
+              last_update_time: '2024-01-01T00:00:00Z',
+              feedback: { value: 'pass' },
+              source: {
+                source_type: 'HUMAN',
+                source_id: 'user-1',
+              },
+            },
+            {
+              assessment_id: 'a-2',
+              assessment_name: 'overall',
+              trace_id: 'trace_1',
+              create_time: '2024-01-01T00:00:00Z',
+              last_update_time: '2024-01-01T00:00:00Z',
+              expectation: { value: 'expected value' },
+              source: {
+                source_type: 'HUMAN',
+                source_id: 'user-2',
+              },
+            },
+          ],
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1635,27 +1579,24 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('filters out scorer traces', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            client_request_id: 'req-1',
-            trace_location: {
-              type: 'MLFLOW_EXPERIMENT',
-              mlflow_experiment: { experiment_id: 'experiment-xyz' },
-            },
-            request_time: '2024-01-01T00:00:00Z',
-            state: 'OK',
-            tags: {
-              'mlflow.trace.sourceScorer': 'scorer-1',
-            },
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          client_request_id: 'req-1',
+          trace_location: {
+            type: 'MLFLOW_EXPERIMENT',
+            mlflow_experiment: { experiment_id: 'experiment-xyz' },
           },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+          request_time: '2024-01-01T00:00:00Z',
+          state: 'OK',
+          tags: {
+            'mlflow.trace.sourceScorer': 'scorer-1',
+          },
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>
@@ -1674,43 +1615,40 @@ describe('useSearchMlflowTraces', () => {
   });
 
   test('keeps traces when assessments match the run or lack metadata', async () => {
-    jest.mocked(fetchFn).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        traces: [
-          {
-            trace_id: 'trace_1',
-            client_request_id: 'req-1',
-            trace_location: {
-              type: 'MLFLOW_EXPERIMENT',
-              mlflow_experiment: { experiment_id: 'experiment-xyz' },
-            },
-            request_time: '2024-01-01T00:00:00Z',
-            state: 'OK',
-            assessments: [
-              {
-                assessment_id: 'a-1',
-                assessment_name: 'overall',
-                trace_id: 'trace_1',
-                create_time: '2024-01-01T00:00:00Z',
-                last_update_time: '2024-01-01T00:00:00Z',
-                metadata: { 'mlflow.assessment.sourceRunId': 'run-xyz' },
-                feedback: { value: 'pass' },
-              },
-              {
-                assessment_id: 'a-2',
-                assessment_name: 'guidelines',
-                trace_id: 'trace_1',
-                create_time: '2024-01-01T00:00:00Z',
-                last_update_time: '2024-01-01T00:00:00Z',
-                feedback: { value: 'pass' },
-              },
-            ],
+    jest.mocked(fetchAPI).mockResolvedValueOnce({
+      traces: [
+        {
+          trace_id: 'trace_1',
+          client_request_id: 'req-1',
+          trace_location: {
+            type: 'MLFLOW_EXPERIMENT',
+            mlflow_experiment: { experiment_id: 'experiment-xyz' },
           },
-        ],
-        next_page_token: undefined,
-      }),
-    } as any);
+          request_time: '2024-01-01T00:00:00Z',
+          state: 'OK',
+          assessments: [
+            {
+              assessment_id: 'a-1',
+              assessment_name: 'overall',
+              trace_id: 'trace_1',
+              create_time: '2024-01-01T00:00:00Z',
+              last_update_time: '2024-01-01T00:00:00Z',
+              metadata: { 'mlflow.assessment.sourceRunId': 'run-xyz' },
+              feedback: { value: 'pass' },
+            },
+            {
+              assessment_id: 'a-2',
+              assessment_name: 'guidelines',
+              trace_id: 'trace_1',
+              create_time: '2024-01-01T00:00:00Z',
+              last_update_time: '2024-01-01T00:00:00Z',
+              feedback: { value: 'pass' },
+            },
+          ],
+        },
+      ],
+      next_page_token: undefined,
+    });
 
     const { result } = renderHook(
       () =>

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/hooks/useMlflowTraces.tsx
@@ -3,7 +3,6 @@ import { useMemo } from 'react';
 
 import { useIntl } from '@databricks/i18n';
 import type { NetworkRequestError } from '@databricks/web-shared/errors';
-import { matchPredefinedErrorFromResponse } from '@databricks/web-shared/errors';
 import type { QueryClient, UseQueryOptions, UseQueryResult } from '@databricks/web-shared/query-client';
 import { useQuery } from '@databricks/web-shared/query-client';
 
@@ -51,7 +50,7 @@ import {
 import { ERROR_KEY, getAssessmentInfos } from '../utils/AggregationUtils';
 import { filterEvaluationResults } from '../utils/EvaluationsFilterUtils';
 import { getMlflowTracesSearchPageSize, getEvalTabTotalTracesLimit, shouldUseTracesV4API } from '../utils/FeatureUtils';
-import { fetchFn, getAjaxUrl } from '../utils/FetchUtils';
+import { fetchAPI, getAjaxUrl } from '../utils/FetchUtils';
 import MlflowUtils from '../utils/MlflowUtils';
 import {
   convertTraceInfoV3ToRunEvalEntry,
@@ -511,16 +510,11 @@ export const searchMlflowTracesQueryFn = async ({
     if (pageToken) {
       payload.page_token = pageToken;
     }
-    const queryResponse = await fetchFn(getAjaxUrl('ajax-api/3.0/mlflow/traces/search'), {
+    const json = (await fetchAPI(getAjaxUrl('ajax-api/3.0/mlflow/traces/search'), {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
+      body: payload,
       signal,
-    });
-    if (!queryResponse.ok) throw matchPredefinedErrorFromResponse(queryResponse);
-    const json = (await queryResponse.json()) as { traces: ModelTraceInfoV3[]; next_page_token?: string };
+    })) as { traces: ModelTraceInfoV3[]; next_page_token?: string };
     const traces = json.traces;
     if (!isNil(traces)) {
       allTraces = allTraces.concat(traces);

--- a/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FetchUtils.ts
+++ b/mlflow/server/js/src/shared/web-shared/genai-traces-table/utils/FetchUtils.ts
@@ -1,58 +1,32 @@
-import { matchPredefinedError } from '../../errors';
+import cookie from 'cookie';
 
 // eslint-disable-next-line no-restricted-globals
 export const fetchFn = fetch; // use global fetch for oss
 
-export const makeRequest = async <T>(path: string, method: 'POST' | 'GET', body?: T, signal?: AbortSignal) => {
-  const options: RequestInit = {
-    method,
-    signal,
-    headers: {
-      ...(body ? { 'Content-Type': 'application/json' } : {}),
-      ...getDefaultHeaders(document.cookie),
-    },
-  };
+const WORKSPACE_STORAGE_KEY = 'mlflow.activeWorkspace';
 
-  if (body) {
-    options.body = JSON.stringify(body);
+/**
+ * Get the currently active workspace from localStorage.
+ * This is a minimal implementation for the shared library that cannot depend on main mlflow code.
+ */
+const getActiveWorkspace = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
   }
-  const response = await fetchFn(path, options);
-
-  if (!response.ok) {
-    const error = matchPredefinedError(response);
-    try {
-      const errorMessageFromResponse = await (await response.json()).message;
-      if (errorMessageFromResponse) {
-        error.message = errorMessageFromResponse;
-      }
-    } catch {
-      // do nothing
-    }
-    throw error;
+  try {
+    return window.localStorage.getItem(WORKSPACE_STORAGE_KEY);
+  } catch {
+    return null;
   }
-
-  return response.json();
 };
 
-export const getAjaxUrl = (relativeUrl: any) => {
-  if (process.env['MLFLOW_USE_ABSOLUTE_AJAX_URLS'] === 'true' && !relativeUrl.startsWith('/')) {
-    return '/' + relativeUrl;
-  }
-  return relativeUrl;
-};
-
-// Parse cookies from document.cookie
-function parseCookies(cookieString = document.cookie) {
-  return cookieString.split(';').reduce((cookies: { [key: string]: string }, cookie: string) => {
-    const [name, value] = cookie.trim().split('=');
-    cookies[name] = decodeURIComponent(value || '');
-    return cookies;
-  }, {});
-}
-
-export const getDefaultHeadersFromCookies = (cookieStr: any) => {
+/**
+ * Parse cookies to extract request headers.
+ * Minimal implementation for shared library.
+ */
+export const getDefaultHeadersFromCookies = (cookieStr: string) => {
   const headerCookiePrefix = 'mlflow-request-header-';
-  const parsedCookie = parseCookies(cookieStr);
+  const parsedCookie = cookie.parse(cookieStr);
   if (!parsedCookie || Object.keys(parsedCookie).length === 0) {
     return {};
   }
@@ -67,9 +41,75 @@ export const getDefaultHeadersFromCookies = (cookieStr: any) => {
     );
 };
 
-export const getDefaultHeaders = (cookieStr: any) => {
+/**
+ * Get default headers including workspace header if active.
+ * Minimal implementation for shared library.
+ */
+export const getDefaultHeaders = (cookieStr: string) => {
   const cookieHeaders = getDefaultHeadersFromCookies(cookieStr);
+  const workspace = getActiveWorkspace();
+
   return {
     ...cookieHeaders,
+    ...(workspace ? { 'X-MLFLOW-WORKSPACE': workspace } : {}),
   };
+};
+
+/**
+ * Convert relative URL to absolute if needed.
+ * Minimal implementation for shared library.
+ */
+export const getAjaxUrl = (relativeUrl: string) => {
+  if (
+    process.env['MLFLOW_USE_ABSOLUTE_AJAX_URLS'] === 'true' &&
+    typeof relativeUrl === 'string' &&
+    !relativeUrl.startsWith('/')
+  ) {
+    return '/' + relativeUrl;
+  }
+  return relativeUrl;
+};
+
+/**
+ * Helper method to make a request to the backend with workspace support.
+ * Minimal implementation for shared library.
+ */
+export const fetchAPI = async (url: string, options: Omit<RequestInit, 'body'> & { body?: any } = {}) => {
+  const { method, headers, body, ...restOptions } = options;
+
+  let cookieString = '';
+  if (typeof document !== 'undefined' && typeof document.cookie === 'string') {
+    cookieString = document.cookie || '';
+  }
+
+  const serializeBody = (payload: any) => {
+    if (payload === undefined) {
+      return undefined;
+    }
+    return typeof payload === 'string' || payload instanceof FormData || payload instanceof Blob
+      ? payload
+      : JSON.stringify(payload);
+  };
+
+  const fetchOptions: RequestInit = {
+    ...restOptions,
+    method: method || 'GET',
+    headers: {
+      ...getDefaultHeaders(cookieString),
+      ...(body ? { 'Content-Type': 'application/json' } : {}),
+      ...headers,
+    },
+    ...(body && { body: serializeBody(body) }),
+  };
+
+  // eslint-disable-next-line no-restricted-globals
+  const response = await fetch(url, fetchOptions);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+  }
+  return response.json();
+};
+
+export const makeRequest = async <T>(path: string, method: 'POST' | 'GET', body?: T, signal?: AbortSignal) => {
+  return fetchAPI(path, { method, body, signal });
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.request.utils.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/ModelTraceExplorer.request.utils.tsx
@@ -1,4 +1,5 @@
 import { matchPredefinedError } from '@databricks/web-shared/errors';
+import { getActiveWorkspace } from '@mlflow/mlflow/src/workspaces/utils/WorkspaceUtils';
 
 // eslint-disable-next-line no-restricted-globals -- See go/spog-fetch
 const fetchFn = fetch;
@@ -83,7 +84,12 @@ export const getDefaultHeadersFromCookies = (cookieStr: any) => {
 
 export const getDefaultHeaders = (cookieStr: any) => {
   const cookieHeaders = getDefaultHeadersFromCookies(cookieStr);
+
+  // getActiveWorkspace() returns null if workspaces feature is not enabled
+  const workspace = getActiveWorkspace();
+
   return {
     ...cookieHeaders,
+    ...(workspace ? { 'X-MLFLOW-WORKSPACE': workspace } : {}),
   };
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { DesignSystemProvider } from '@databricks/design-system';
+import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { IntlProvider } from '@databricks/i18n';
 import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
 
@@ -10,6 +11,9 @@ import { AssessmentCreateForm } from './AssessmentCreateForm';
 import type { Assessment } from '../ModelTrace.types';
 import { MOCK_ASSESSMENT, MOCK_EXPECTATION } from '../ModelTraceExplorer.test-utils';
 import { AssessmentSchemaContextProvider } from '../contexts/AssessmentSchemaContext';
+
+// eslint-disable-next-line no-restricted-syntax -- TODO(FEINF-4392)
+jest.setTimeout(30000);
 
 // Mock the hooks
 jest.mock('../hooks/useCreateAssessment', () => ({
@@ -30,11 +34,13 @@ const TestWrapper = ({ children, assessments = [] }: { children: React.ReactNode
 
   return (
     <IntlProvider locale="en">
-      <DesignSystemProvider>
-        <QueryClientProvider client={queryClient}>
-          <AssessmentSchemaContextProvider assessments={assessments}>{children}</AssessmentSchemaContextProvider>
-        </QueryClientProvider>
-      </DesignSystemProvider>
+      <TooltipProvider>
+        <DesignSystemProvider>
+          <QueryClientProvider client={queryClient}>
+            <AssessmentSchemaContextProvider assessments={assessments}>{children}</AssessmentSchemaContextProvider>
+          </QueryClientProvider>
+        </DesignSystemProvider>
+      </TooltipProvider>
     </IntlProvider>
   );
 };
@@ -79,7 +85,8 @@ describe('AssessmentCreateForm', () => {
 
       // Change assessment type to expectation and data type to number
       await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
+      const expectationOption = await screen.findByText('Expectation');
+      await user.click(expectationOption);
       await waitFor(() => {
         expect(assessmentTypeSelect).toHaveTextContent('Expectation');
       });
@@ -128,7 +135,8 @@ describe('AssessmentCreateForm', () => {
 
       // Change assessment type to expectation and data type to number
       await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
+      const expectationOption = await screen.findByText('Expectation');
+      await user.click(expectationOption);
       await waitFor(() => {
         expect(assessmentTypeSelect).toHaveTextContent('Expectation');
       });
@@ -179,7 +187,8 @@ describe('AssessmentCreateForm', () => {
 
       // Change to non-default values
       await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
+      const expectationOption = await screen.findByText('Expectation');
+      await user.click(expectationOption);
 
       await user.click(dataTypeSelect);
       await user.click(screen.getAllByText('String')[0]);
@@ -218,7 +227,8 @@ describe('AssessmentCreateForm', () => {
 
       // Change some values
       await user.click(assessmentTypeSelect);
-      await user.click(screen.getByText('Expectation'));
+      const expectationOption = await screen.findByText('Expectation');
+      await user.click(expectationOption);
 
       const nameInput = screen.getByPlaceholderText('Enter an assessment name');
       await user.type(nameInput, 'test_name');

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateForm.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { DesignSystemProvider } from '@databricks/design-system';
-import { TooltipProvider } from '@radix-ui/react-tooltip';
 import { IntlProvider } from '@databricks/i18n';
 import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
 
@@ -34,13 +33,11 @@ const TestWrapper = ({ children, assessments = [] }: { children: React.ReactNode
 
   return (
     <IntlProvider locale="en">
-      <TooltipProvider>
-        <DesignSystemProvider>
-          <QueryClientProvider client={queryClient}>
-            <AssessmentSchemaContextProvider assessments={assessments}>{children}</AssessmentSchemaContextProvider>
-          </QueryClientProvider>
-        </DesignSystemProvider>
-      </TooltipProvider>
+      <DesignSystemProvider>
+        <QueryClientProvider client={queryClient}>
+          <AssessmentSchemaContextProvider assessments={assessments}>{children}</AssessmentSchemaContextProvider>
+        </QueryClientProvider>
+      </DesignSystemProvider>
     </IntlProvider>
   );
 };

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateNameTypeahead.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/assessments-pane/AssessmentCreateNameTypeahead.tsx
@@ -1,5 +1,5 @@
 import type { Dispatch, SetStateAction } from 'react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   FormUI,
@@ -57,11 +57,14 @@ export const AssessmentCreateNameTypeahead = ({
   const formOnChange = useCallback(
     (newSelectedItem: AssessmentSchema | null) => {
       setSelectedItem(newSelectedItem);
-      handleChangeSchema(newSelectedItem);
       setNameError(null);
     },
-    [handleChangeSchema, setNameError],
+    [setNameError],
   );
+
+  useEffect(() => {
+    handleChangeSchema(selectedItem);
+  }, [handleChangeSchema, selectedItem]);
 
   const comboboxState = useComboboxState<AssessmentSchema | null>({
     componentId: 'shared.model-trace-explorer.assessment-name-typeahead',

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useUpdateTraceTagsMutation.test.tsx
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/hooks/useUpdateTraceTagsMutation.test.tsx
@@ -1,22 +1,29 @@
-import { describe, jest, beforeAll, beforeEach, it, expect } from '@jest/globals';
+import { describe, jest, beforeEach, it, expect } from '@jest/globals';
 import { renderHook, waitFor } from '@testing-library/react';
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
 
 import { QueryClientProvider, QueryClient } from '@databricks/web-shared/query-client';
 
 import { useUpdateTraceTagsMutation } from './useUpdateTraceTagsMutation';
 import { shouldUseTracesV4API } from '../FeatureUtils';
 import type { ModelTraceInfoV3, ModelTraceLocation } from '../ModelTrace.types';
+import { TracesServiceV3, TracesServiceV4 } from '../api';
 
 jest.mock('../FeatureUtils', () => ({
   shouldUseTracesV4API: jest.fn(),
 }));
 
-describe('useUpdateTraceTagsMutation', () => {
-  const server = setupServer();
-  beforeAll(() => server.listen());
+jest.mock('../api', () => ({
+  TracesServiceV3: {
+    setTraceTagV3: jest.fn(),
+    deleteTraceTagV3: jest.fn(),
+  },
+  TracesServiceV4: {
+    setTraceTagV4: jest.fn(),
+    deleteTraceTagV4: jest.fn(),
+  },
+}));
 
+describe('useUpdateTraceTagsMutation', () => {
   const wrapper = ({ children }: { children: React.ReactNode }) => {
     const queryClient = new QueryClient();
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
@@ -49,6 +56,11 @@ describe('useUpdateTraceTagsMutation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Mock services to resolve successfully by default
+    jest.mocked(TracesServiceV3.setTraceTagV3).mockResolvedValue({});
+    jest.mocked(TracesServiceV3.deleteTraceTagV3).mockResolvedValue({});
+    jest.mocked(TracesServiceV4.setTraceTagV4).mockResolvedValue({});
+    jest.mocked(TracesServiceV4.deleteTraceTagV4).mockResolvedValue({});
   });
 
   describe('when V4 API is enabled', () => {
@@ -70,20 +82,6 @@ describe('useUpdateTraceTagsMutation', () => {
         trace_location: ucSchemaLocation,
       };
 
-      const patchSpy = jest.fn();
-      const deleteSpy = jest.fn();
-
-      server.use(
-        rest.patch('ajax-api/4.0/mlflow/traces/my_catalog.my_schema/trace-456/tags', async (req, res, ctx) => {
-          patchSpy(await req.json());
-          return res(ctx.json({}));
-        }),
-        rest.delete('ajax-api/4.0/mlflow/traces/my_catalog.my_schema/trace-456/tags/:tagKey', async (req, res, ctx) => {
-          deleteSpy(req.params['tagKey']);
-          return res(ctx.json({}));
-        }),
-      );
-
       const { result } = renderHook(() => useUpdateTraceTagsMutation({}), {
         wrapper,
       });
@@ -95,8 +93,20 @@ describe('useUpdateTraceTagsMutation', () => {
       });
 
       await waitFor(() => {
-        expect(patchSpy).toHaveBeenCalledWith({ key: 'tag1', value: 'value1' });
-        expect(deleteSpy).toHaveBeenCalledWith('tag2');
+        expect(TracesServiceV4.setTraceTagV4).toHaveBeenCalledTimes(1);
+        expect(TracesServiceV4.deleteTraceTagV4).toHaveBeenCalledTimes(1);
+        // Check call for new tag
+        expect(TracesServiceV4.setTraceTagV4).toHaveBeenCalledWith({
+          tag: { key: 'tag1', value: 'value1' },
+          traceLocation: ucSchemaLocation,
+          traceId: 'trace-456',
+        });
+        // Check call for deleted tag
+        expect(TracesServiceV4.deleteTraceTagV4).toHaveBeenCalledWith({
+          tagKey: 'tag2',
+          traceLocation: ucSchemaLocation,
+          traceId: 'trace-456',
+        });
       });
     });
   });
@@ -107,19 +117,6 @@ describe('useUpdateTraceTagsMutation', () => {
     });
 
     it('should use V3 endpoints', async () => {
-      const v3TagRequests: { method: string; body?: any; url: string }[] = [];
-
-      server.use(
-        rest.patch('http://localhost/ajax-api/3.0/mlflow/traces/trace-456/tags', async (req, res, ctx) => {
-          v3TagRequests.push({ method: 'PATCH', body: await req.json(), url: req.url.href });
-          return res(ctx.json({}));
-        }),
-        rest.delete('http://localhost/ajax-api/3.0/mlflow/traces/trace-456/tags', async (req, res, ctx) => {
-          v3TagRequests.push({ method: 'DELETE', url: req.url.href });
-          return res(ctx.json({}));
-        }),
-      );
-
       const { result } = renderHook(() => useUpdateTraceTagsMutation({}), {
         wrapper,
       });
@@ -131,20 +128,29 @@ describe('useUpdateTraceTagsMutation', () => {
       });
 
       await waitFor(() => {
-        expect(v3TagRequests).toHaveLength(4);
+        expect(TracesServiceV3.setTraceTagV3).toHaveBeenCalledTimes(2);
+        expect(TracesServiceV3.deleteTraceTagV3).toHaveBeenCalledTimes(2);
       });
 
-      // Verify creation requests
-      const createRequests = v3TagRequests.filter((req) => req.method === 'PATCH');
-      expect(createRequests).toHaveLength(2);
-      expect(createRequests[0].body).toEqual({ key: 'tag1', value: 'value1' });
-      expect(createRequests[1].body).toEqual({ key: 'tag2', value: 'value2' });
+      // Verify calls for new tags
+      expect(TracesServiceV3.setTraceTagV3).toHaveBeenCalledWith({
+        tag: { key: 'tag1', value: 'value1' },
+        traceId: 'trace-456',
+      });
+      expect(TracesServiceV3.setTraceTagV3).toHaveBeenCalledWith({
+        tag: { key: 'tag2', value: 'value2' },
+        traceId: 'trace-456',
+      });
 
-      // Verify deletion requests
-      const deleteRequests = v3TagRequests.filter((req) => req.method === 'DELETE');
-      expect(deleteRequests).toHaveLength(2);
-      expect(deleteRequests[0].url).toContain('key=tag3');
-      expect(deleteRequests[1].url).toContain('key=tag4');
+      // Verify calls for deleted tags
+      expect(TracesServiceV3.deleteTraceTagV3).toHaveBeenCalledWith({
+        tagKey: 'tag3',
+        traceId: 'trace-456',
+      });
+      expect(TracesServiceV3.deleteTraceTagV3).toHaveBeenCalledWith({
+        tagKey: 'tag4',
+        traceId: 'trace-456',
+      });
     });
   });
 
@@ -155,12 +161,6 @@ describe('useUpdateTraceTagsMutation', () => {
 
     it('should call onSuccess callback after successful mutation', async () => {
       const onSuccess = jest.fn();
-
-      server.use(
-        rest.patch('http://localhost/ajax-api/3.0/mlflow/traces/trace-456/tags', async (req, res, ctx) => {
-          return res(ctx.json({}));
-        }),
-      );
 
       const { result } = renderHook(() => useUpdateTraceTagsMutation({ onSuccess }), {
         wrapper,
@@ -173,6 +173,7 @@ describe('useUpdateTraceTagsMutation', () => {
       });
 
       await waitFor(() => {
+        expect(TracesServiceV3.setTraceTagV3).toHaveBeenCalledTimes(1);
         expect(onSuccess).toHaveBeenCalledTimes(1);
       });
     });
@@ -198,18 +199,11 @@ describe('useUpdateTraceTagsMutation', () => {
       await waitFor(() => {
         expect(result.current.isSuccess).toBe(true);
       });
+      expect(TracesServiceV3.setTraceTagV3).not.toHaveBeenCalled();
+      expect(TracesServiceV3.deleteTraceTagV3).not.toHaveBeenCalled();
     });
 
     it('should handle only newTags', async () => {
-      const v3TagRequests: { method: string }[] = [];
-
-      server.use(
-        rest.patch('http://localhost/ajax-api/3.0/mlflow/traces/trace-456/tags', async (req, res, ctx) => {
-          v3TagRequests.push({ method: 'PATCH' });
-          return res(ctx.json({}));
-        }),
-      );
-
       const { result } = renderHook(() => useUpdateTraceTagsMutation({}), {
         wrapper,
       });
@@ -221,21 +215,16 @@ describe('useUpdateTraceTagsMutation', () => {
       });
 
       await waitFor(() => {
-        expect(v3TagRequests).toHaveLength(1);
-        expect(v3TagRequests[0].method).toBe('PATCH');
+        expect(TracesServiceV3.setTraceTagV3).toHaveBeenCalledTimes(1);
+        expect(TracesServiceV3.setTraceTagV3).toHaveBeenCalledWith({
+          tag: { key: 'tag1', value: 'value1' },
+          traceId: 'trace-456',
+        });
+        expect(TracesServiceV3.deleteTraceTagV3).not.toHaveBeenCalled();
       });
     });
 
     it('should handle only deletedTags', async () => {
-      const v3TagRequests: { method: string }[] = [];
-
-      server.use(
-        rest.delete('http://localhost/ajax-api/3.0/mlflow/traces/trace-456/tags', async (req, res, ctx) => {
-          v3TagRequests.push({ method: 'DELETE' });
-          return res(ctx.json({}));
-        }),
-      );
-
       const { result } = renderHook(() => useUpdateTraceTagsMutation({}), {
         wrapper,
       });
@@ -247,8 +236,12 @@ describe('useUpdateTraceTagsMutation', () => {
       });
 
       await waitFor(() => {
-        expect(v3TagRequests).toHaveLength(1);
-        expect(v3TagRequests[0].method).toBe('DELETE');
+        expect(TracesServiceV3.deleteTraceTagV3).toHaveBeenCalledTimes(1);
+        expect(TracesServiceV3.deleteTraceTagV3).toHaveBeenCalledWith({
+          tagKey: 'tag1',
+          traceId: 'trace-456',
+        });
+        expect(TracesServiceV3.setTraceTagV3).not.toHaveBeenCalled();
       });
     });
   });

--- a/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/mlflow-fetch-utils.ts
+++ b/mlflow/server/js/src/shared/web-shared/model-trace-explorer/oss-notebook-renderer/mlflow-fetch-utils.ts
@@ -1,14 +1,11 @@
 import type { ModelTrace, ModelTraceData } from '@databricks/web-shared/model-trace-explorer';
-import { getAjaxUrl } from '../ModelTraceExplorer.request.utils';
+import { fetchAPI, getAjaxUrl } from '@mlflow/mlflow/src/common/utils/FetchUtils';
 
 // returns ModelTrace if the request is successful, otherwise returns an error message
 export async function getTraceArtifact(requestId: string): Promise<ModelTrace | string> {
   try {
-    // eslint-disable-next-line no-restricted-globals -- See go/spog-fetch
-    const result = await fetch(getAjaxUrl(`ajax-api/2.0/mlflow/get-trace-artifact?request_id=${requestId}`));
-    const text = await result.text();
+    const jsonData = await fetchAPI(getAjaxUrl(`ajax-api/2.0/mlflow/get-trace-artifact?request_id=${requestId}`));
 
-    const jsonData = JSON.parse(text);
     // successful request containing span data
     if (jsonData.spans) {
       return {

--- a/mlflow/server/js/src/workspaces/components/WorkspaceSelector.test.tsx
+++ b/mlflow/server/js/src/workspaces/components/WorkspaceSelector.test.tsx
@@ -1,0 +1,262 @@
+import { describe, jest, beforeEach, it, expect } from '@jest/globals';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+import { QueryClient, QueryClientProvider } from '@databricks/web-shared/query-client';
+import { DesignSystemProvider } from '@databricks/design-system';
+
+import { WorkspaceSelector } from './WorkspaceSelector';
+import { shouldEnableWorkspaces } from '../../common/utils/FeatureUtils';
+import { setActiveWorkspace } from '../utils/WorkspaceUtils';
+import { MemoryRouter, useNavigate, useLocation, useSearchParams } from '../../common/utils/RoutingUtils';
+import { fetchAPI } from '../../common/utils/FetchUtils';
+
+jest.mock('../../common/utils/FeatureUtils', () => ({
+  shouldEnableWorkspaces: jest.fn(),
+}));
+
+jest.mock('../../common/utils/RoutingUtils', () => ({
+  ...jest.requireActual<typeof import('../../common/utils/RoutingUtils')>('../../common/utils/RoutingUtils'),
+  useNavigate: jest.fn(),
+  useLocation: jest.fn(),
+  useSearchParams: jest.fn(),
+}));
+
+jest.mock('../../common/utils/FetchUtils', () => ({
+  ...jest.requireActual<typeof import('../../common/utils/FetchUtils')>('../../common/utils/FetchUtils'),
+  fetchAPI: jest.fn(),
+}));
+
+const shouldEnableWorkspacesMock = jest.mocked(shouldEnableWorkspaces);
+const useNavigateMock = jest.mocked(useNavigate);
+const useLocationMock = jest.mocked(useLocation);
+const useSearchParamsMock = jest.mocked(useSearchParams);
+const fetchAPIMock = jest.mocked(fetchAPI);
+
+describe('WorkspaceSelector', () => {
+  const mockNavigate = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    shouldEnableWorkspacesMock.mockReturnValue(true);
+    useNavigateMock.mockReturnValue(mockNavigate);
+    useLocationMock.mockReturnValue({
+      pathname: '/experiments',
+      search: '?workspace=default',
+      hash: '',
+      state: null,
+      key: 'default',
+    });
+    // Mock useSearchParams to return URLSearchParams with workspace=default
+    useSearchParamsMock.mockReturnValue([new URLSearchParams('workspace=default'), jest.fn()]);
+    setActiveWorkspace('default');
+  });
+
+  const renderWithProviders = (component: React.ReactElement) => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+
+    return render(
+      <QueryClientProvider client={queryClient}>
+        <DesignSystemProvider>
+          <MemoryRouter initialEntries={['/experiments?workspace=default']}>{component}</MemoryRouter>
+        </DesignSystemProvider>
+      </QueryClientProvider>,
+    );
+  };
+
+  it('returns null when workspaces feature is disabled', () => {
+    shouldEnableWorkspacesMock.mockReturnValue(false);
+
+    const { container } = renderWithProviders(<WorkspaceSelector />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders combobox trigger with current workspace name', async () => {
+    fetchAPIMock.mockResolvedValue({ workspaces: [{ name: 'default' }, { name: 'team-a' }] });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+  });
+
+  it('shows loading state while fetching workspaces', async () => {
+    fetchAPIMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ workspaces: [{ name: 'default' }] }), 100);
+        }),
+    );
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    // Verify the combobox trigger is rendered
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+
+    // Wait for loading to complete
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error message when workspace fetch fails', async () => {
+    fetchAPIMock.mockRejectedValue(new Error('Server error'));
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    // Click to open dropdown
+    const trigger = screen.getByRole('combobox');
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(screen.getByText('Failed to load workspaces')).toBeInTheDocument();
+    });
+  });
+
+  it('displays all available workspaces in dropdown', async () => {
+    fetchAPIMock.mockResolvedValue({
+      workspaces: [
+        { name: 'default', description: 'Default workspace' },
+        { name: 'team-a', description: 'Team A' },
+        { name: 'team-b', description: null },
+      ],
+    });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    // Wait for data to load and verify the trigger shows current workspace
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    // Verify the combobox is rendered with the workspaces data loaded
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+    expect(fetchAPIMock).toHaveBeenCalled();
+  });
+
+  it('fetches workspaces when enabled', async () => {
+    fetchAPIMock.mockResolvedValue({
+      workspaces: [
+        { name: 'default', description: 'Default' },
+        { name: 'team-a', description: 'Team A' },
+        { name: 'team-b', description: 'Team B' },
+      ],
+    });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    // Verify fetchAPI was called to get workspaces
+    expect(fetchAPIMock).toHaveBeenCalled();
+
+    // Verify combobox trigger exists
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it('renders with single workspace', async () => {
+    fetchAPIMock.mockResolvedValue({ workspaces: [{ name: 'default' }] });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it('renders workspace selector with correct label', async () => {
+    fetchAPIMock.mockResolvedValue({ workspaces: [{ name: 'default' }, { name: 'team-a' }] });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    // Verify the combobox is labeled "Workspace"
+    const trigger = screen.getByRole('combobox', { name: /workspace/i });
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it('renders correctly on different navigation sections', async () => {
+    fetchAPIMock.mockResolvedValue({ workspaces: [{ name: 'default' }, { name: 'team-a' }] });
+
+    // Test with /models path
+    useLocationMock.mockReturnValue({
+      pathname: '/models',
+      search: '?workspace=default',
+      hash: '',
+      state: null,
+      key: 'default',
+    });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it('calls refetch when combobox is opened', async () => {
+    let fetchCount = 0;
+    fetchAPIMock.mockImplementation(() => {
+      fetchCount++;
+      return Promise.resolve({ workspaces: [{ name: 'default' }] });
+    });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    expect(fetchCount).toBe(1);
+
+    // Open dropdown - should trigger refetch
+    const trigger = screen.getByRole('combobox');
+    await userEvent.click(trigger);
+
+    await waitFor(() => {
+      expect(fetchCount).toBe(2);
+    });
+  });
+
+  it('loads workspace with description', async () => {
+    fetchAPIMock.mockResolvedValue({
+      workspaces: [{ name: 'default', description: 'This is the default workspace' }],
+    });
+
+    renderWithProviders(<WorkspaceSelector />);
+
+    await waitFor(() => {
+      expect(screen.getByText('default')).toBeInTheDocument();
+    });
+
+    // Verify component rendered successfully with workspace that has description
+    const trigger = screen.getByRole('combobox');
+    expect(trigger).toBeInTheDocument();
+  });
+
+  // Note: Workspace validation tests moved to MlflowRouter tests
+  // WorkspaceSelector is now a pure UI component without validation logic
+});

--- a/mlflow/server/js/src/workspaces/components/WorkspaceSelector.tsx
+++ b/mlflow/server/js/src/workspaces/components/WorkspaceSelector.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import {
+  DialogCombobox,
+  DialogComboboxContent,
+  DialogComboboxTrigger,
+  DialogComboboxOptionList,
+  DialogComboboxOptionListSearch,
+  DialogComboboxOptionListSelectItem,
+  useDesignSystemTheme,
+  Tooltip,
+} from '@databricks/design-system';
+import { uniqBy } from 'lodash';
+
+import { shouldEnableWorkspaces } from '../../common/utils/FeatureUtils';
+import {
+  extractWorkspaceFromSearchParams,
+  setActiveWorkspace,
+  WORKSPACE_QUERY_PARAM,
+} from '../../workspaces/utils/WorkspaceUtils';
+import { useLocation, useNavigate, useSearchParams } from '../../common/utils/RoutingUtils';
+import { useWorkspaces, type Workspace } from '../hooks/useWorkspaces';
+
+export const WorkspaceSelector = () => {
+  const workspacesEnabled = shouldEnableWorkspaces();
+  const [searchValue, setSearchValue] = useState('');
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate({ bypassWorkspacePrefix: true });
+  const { theme } = useDesignSystemTheme();
+
+  // Extract workspace from query param
+  const currentWorkspace = extractWorkspaceFromSearchParams(searchParams);
+
+  // Fetch workspaces using custom hook
+  const { workspaces, isLoading, isError, refetch } = useWorkspaces(workspacesEnabled);
+
+  // Smart redirect - preserve navigation context
+  const getNavigationSection = (pathname: string): string => {
+    if (pathname.includes('/experiments')) return '/experiments';
+    if (pathname.includes('/models')) return '/models';
+    if (pathname.includes('/prompts')) return '/prompts';
+    return '';
+  };
+
+  const handleWorkspaceChange = useCallback(
+    (nextWorkspace?: string) => {
+      if (!nextWorkspace || nextWorkspace === currentWorkspace) {
+        return;
+      }
+
+      setActiveWorkspace(nextWorkspace);
+
+      // Smart redirect - preserve navigation section with workspace query param
+      const currentSection = getNavigationSection(location.pathname);
+      const targetPath = currentSection || '/';
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set(WORKSPACE_QUERY_PARAM, nextWorkspace);
+
+      navigate(`${targetPath}?${newParams.toString()}`);
+      setSearchValue(''); // Clear search on selection
+    },
+    [currentWorkspace, location.pathname, searchParams, navigate],
+  );
+
+  // Refresh workspaces when combobox is opened to catch label selector changes
+  const handleOpenChange = (isOpen: boolean) => {
+    if (isOpen) {
+      refetch();
+    }
+  };
+
+  const options = useMemo(() => {
+    const allWorkspaces = [...workspaces];
+
+    // Add current workspace if it's not in the list (might be invalid)
+    if (currentWorkspace && !workspaces.some((w) => w.name === currentWorkspace)) {
+      allWorkspaces.push({ name: currentWorkspace, description: null });
+    }
+
+    return uniqBy(allWorkspaces, 'name');
+  }, [workspaces, currentWorkspace]);
+
+  // Client-side filtering
+  const filteredOptions = useMemo(() => {
+    if (!searchValue) {
+      return options;
+    }
+    const lowerSearch = searchValue.toLowerCase();
+    return options.filter((workspace) => workspace.name.toLowerCase().includes(lowerSearch));
+  }, [options, searchValue]);
+
+  if (!workspacesEnabled) {
+    return null;
+  }
+
+  return (
+    <DialogCombobox
+      componentId="workspace_selector"
+      label="Workspace"
+      value={!currentWorkspace ? [] : [currentWorkspace]}
+      onOpenChange={handleOpenChange}
+    >
+      <DialogComboboxTrigger
+        withInlineLabel={false}
+        placeholder="Select workspace"
+        renderDisplayedValue={() => currentWorkspace}
+        allowClear={false}
+      />
+      <DialogComboboxContent style={{ zIndex: theme.options.zIndexBase + 100 }} loading={isLoading}>
+        {isError && (
+          <div css={{ padding: theme.spacing.sm, color: theme.colors.textValidationDanger }}>
+            Failed to load workspaces
+          </div>
+        )}
+
+        {!isError && (
+          <DialogComboboxOptionList>
+            <DialogComboboxOptionListSearch onSearch={(value) => setSearchValue(value)}>
+              {filteredOptions.length === 0 && searchValue ? (
+                // Provide a dummy item when no results to prevent crash
+                <DialogComboboxOptionListSelectItem value="" onChange={() => {}} checked={false} disabled>
+                  No workspaces found
+                </DialogComboboxOptionListSelectItem>
+              ) : (
+                filteredOptions.map((workspace) => {
+                  const item = (
+                    <DialogComboboxOptionListSelectItem
+                      key={workspace.name}
+                      value={workspace.name}
+                      onChange={(value) => handleWorkspaceChange(value)}
+                      checked={workspace.name === currentWorkspace}
+                    >
+                      {workspace.name}
+                    </DialogComboboxOptionListSelectItem>
+                  );
+
+                  // Wrap with Tooltip if workspace has description
+                  if (workspace.description) {
+                    return (
+                      <Tooltip
+                        key={workspace.name}
+                        componentId={`workspace_selector.tooltip.${workspace.name}`}
+                        content={workspace.description}
+                        side="right"
+                      >
+                        {item}
+                      </Tooltip>
+                    );
+                  }
+
+                  return item;
+                })
+              )}
+            </DialogComboboxOptionListSearch>
+          </DialogComboboxOptionList>
+        )}
+      </DialogComboboxContent>
+    </DialogCombobox>
+  );
+};

--- a/mlflow/server/js/src/workspaces/components/WorkspaceSelector.tsx
+++ b/mlflow/server/js/src/workspaces/components/WorkspaceSelector.tsx
@@ -14,10 +14,10 @@ import { uniqBy } from 'lodash';
 import { shouldEnableWorkspaces } from '../../common/utils/FeatureUtils';
 import {
   extractWorkspaceFromSearchParams,
-  setActiveWorkspace,
+  setLastUsedWorkspace,
   WORKSPACE_QUERY_PARAM,
 } from '../../workspaces/utils/WorkspaceUtils';
-import { useLocation, useNavigate, useSearchParams } from '../../common/utils/RoutingUtils';
+import { useLocation, useSearchParams } from '../../common/utils/RoutingUtils';
 import { useWorkspaces, type Workspace } from '../hooks/useWorkspaces';
 
 export const WorkspaceSelector = () => {
@@ -25,7 +25,6 @@ export const WorkspaceSelector = () => {
   const [searchValue, setSearchValue] = useState('');
   const location = useLocation();
   const [searchParams] = useSearchParams();
-  const navigate = useNavigate({ bypassWorkspacePrefix: true });
   const { theme } = useDesignSystemTheme();
 
   // Extract workspace from query param
@@ -48,18 +47,16 @@ export const WorkspaceSelector = () => {
         return;
       }
 
-      setActiveWorkspace(nextWorkspace);
+      // Persist to localStorage for UI hints
+      setLastUsedWorkspace(nextWorkspace);
 
-      // Smart redirect - preserve navigation section with workspace query param
+      // Hard reload to cleanly switch workspace context (clears all caches)
       const currentSection = getNavigationSection(location.pathname);
       const targetPath = currentSection || '/';
-      const newParams = new URLSearchParams(searchParams);
-      newParams.set(WORKSPACE_QUERY_PARAM, nextWorkspace);
-
-      navigate(`${targetPath}?${newParams.toString()}`);
-      setSearchValue(''); // Clear search on selection
+      window.location.hash = `#${targetPath}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(nextWorkspace)}`;
+      window.location.reload();
     },
-    [currentWorkspace, location.pathname, searchParams, navigate],
+    [currentWorkspace, location.pathname],
   );
 
   // Refresh workspaces when combobox is opened to catch label selector changes

--- a/mlflow/server/js/src/workspaces/hooks/useUpdateWorkspace.ts
+++ b/mlflow/server/js/src/workspaces/hooks/useUpdateWorkspace.ts
@@ -1,0 +1,47 @@
+import { useMutation, useQueryClient } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { fetchAPI, getAjaxUrl, HTTPMethods } from '../../common/utils/FetchUtils';
+
+type UpdateWorkspaceParams = {
+  name: string;
+  description?: string;
+  default_artifact_root?: string;
+};
+
+type UpdateWorkspaceResponse = {
+  workspace: {
+    name: string;
+    description?: string;
+    default_artifact_root?: string;
+  };
+};
+
+/**
+ * Custom hook to update workspace metadata.
+ * Uses React Query mutation for efficient state management.
+ */
+export const useUpdateWorkspace = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation<UpdateWorkspaceResponse, Error, UpdateWorkspaceParams>({
+    mutationFn: async ({ name, description, default_artifact_root }) => {
+      const requestBody: { description?: string; default_artifact_root?: string } = {};
+
+      if (description !== undefined) {
+        requestBody.description = description;
+      }
+
+      if (default_artifact_root !== undefined) {
+        requestBody.default_artifact_root = default_artifact_root;
+      }
+
+      return fetchAPI(getAjaxUrl(`ajax-api/3.0/mlflow/workspaces/${encodeURIComponent(name)}`), {
+        method: HTTPMethods.PATCH,
+        body: JSON.stringify(requestBody),
+      });
+    },
+    onSuccess: () => {
+      // Invalidate workspaces query to trigger refetch
+      queryClient.invalidateQueries({ queryKey: ['workspaces'] });
+    },
+  });
+};

--- a/mlflow/server/js/src/workspaces/hooks/useWorkspaces.test.tsx
+++ b/mlflow/server/js/src/workspaces/hooks/useWorkspaces.test.tsx
@@ -1,0 +1,174 @@
+import { describe, jest, beforeEach, it, expect } from '@jest/globals';
+import { renderHook, waitFor } from '@testing-library/react';
+
+import { QueryClientProvider, QueryClient } from '@databricks/web-shared/query-client';
+
+import { useWorkspaces } from './useWorkspaces';
+import { fetchAPI } from '../../common/utils/FetchUtils';
+
+jest.mock('../../common/utils/FetchUtils', () => ({
+  ...jest.requireActual<typeof import('../../common/utils/FetchUtils')>('../../common/utils/FetchUtils'),
+  fetchAPI: jest.fn(),
+}));
+
+const fetchAPIMock = jest.mocked(fetchAPI);
+
+describe('useWorkspaces', () => {
+  const wrapper = ({ children }: { children: React.ReactNode }) => {
+    const queryClient = new QueryClient({
+      defaultOptions: {
+        queries: {
+          retry: false,
+        },
+      },
+    });
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns empty workspaces array when disabled', () => {
+    const { result } = renderHook(() => useWorkspaces(false), { wrapper });
+
+    // When disabled, query doesn't run
+    expect(result.current.workspaces).toEqual([]);
+    expect(result.current.isError).toBe(false);
+    // Verify fetchAPI was never called since enabled=false
+    expect(fetchAPIMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches workspaces from API and returns them when enabled', async () => {
+    fetchAPIMock.mockResolvedValue({
+      workspaces: [
+        { name: 'default', description: 'Default workspace' },
+        { name: 'team-a', description: 'Team A workspace' },
+        { name: 'team-b', description: null },
+      ],
+    });
+
+    const { result } = renderHook(() => useWorkspaces(true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaces).toHaveLength(3);
+    expect(result.current.workspaces[0]).toEqual({
+      name: 'default',
+      description: 'Default workspace',
+      default_artifact_root: null,
+    });
+    expect(result.current.workspaces[1]).toEqual({
+      name: 'team-a',
+      description: 'Team A workspace',
+      default_artifact_root: null,
+    });
+    expect(result.current.workspaces[2]).toEqual({ name: 'team-b', description: null, default_artifact_root: null });
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('handles loading state correctly', async () => {
+    fetchAPIMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          setTimeout(() => resolve({ workspaces: [{ name: 'default' }] }), 100);
+        }),
+    );
+
+    const { result } = renderHook(() => useWorkspaces(true), { wrapper });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.workspaces).toEqual([]);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaces).toHaveLength(1);
+  });
+
+  it('handles API error gracefully', async () => {
+    fetchAPIMock.mockRejectedValue(new Error('Internal server error'));
+
+    const { result } = renderHook(() => useWorkspaces(true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.workspaces).toEqual([]);
+  });
+
+  it('filters out invalid workspace objects from response', async () => {
+    fetchAPIMock.mockResolvedValue({
+      workspaces: [
+        { name: 'valid-workspace', description: 'Valid' },
+        { notAName: 'invalid' }, // Missing 'name' field
+        { name: 123 }, // Invalid type for 'name'
+        null, // Null item
+        { name: 'another-valid', description: 'Also valid' },
+      ],
+    });
+
+    const { result } = renderHook(() => useWorkspaces(true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaces).toHaveLength(2);
+    expect(result.current.workspaces[0].name).toBe('valid-workspace');
+    expect(result.current.workspaces[1].name).toBe('another-valid');
+  });
+
+  it('does not send X-MLFLOW-WORKSPACE header in request', async () => {
+    fetchAPIMock.mockResolvedValue({ workspaces: [{ name: 'default' }] });
+
+    const { result } = renderHook(() => useWorkspaces(true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Verify fetchAPI was called with header that sets X-MLFLOW-WORKSPACE to empty string
+    expect(fetchAPIMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          'X-MLFLOW-WORKSPACE': '',
+        }),
+      }),
+    );
+  });
+
+  it('allows refetching workspaces', async () => {
+    let callCount = 0;
+    fetchAPIMock.mockImplementation(() => {
+      callCount++;
+      if (callCount === 1) {
+        return Promise.resolve({ workspaces: [{ name: 'initial' }] });
+      }
+      return Promise.resolve({ workspaces: [{ name: 'updated' }] });
+    });
+
+    const { result } = renderHook(() => useWorkspaces(true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.workspaces[0].name).toBe('initial');
+
+    // Trigger refetch
+    result.current.refetch();
+
+    await waitFor(() => {
+      expect(result.current.workspaces[0].name).toBe('updated');
+    });
+
+    expect(callCount).toBe(2);
+  });
+});

--- a/mlflow/server/js/src/workspaces/hooks/useWorkspaces.ts
+++ b/mlflow/server/js/src/workspaces/hooks/useWorkspaces.ts
@@ -1,0 +1,65 @@
+import { useMemo, useEffect } from 'react';
+import { useQuery } from '@mlflow/mlflow/src/common/utils/reactQueryHooks';
+import { fetchAPI, getAjaxUrl, HTTPMethods } from '../../common/utils/FetchUtils';
+
+type Workspace = {
+  name: string;
+  description?: string | null;
+  default_artifact_root?: string | null;
+};
+
+type WorkspacesResponse = {
+  workspaces?: Workspace[];
+};
+
+const WORKSPACES_ENDPOINT = 'ajax-api/3.0/mlflow/workspaces';
+
+/**
+ * Custom hook to fetch and manage workspaces data.
+ * Uses React Query for efficient data fetching and caching.
+ */
+export const useWorkspaces = (enabled: boolean) => {
+  // Fetch workspaces using React Query
+  const { data, isLoading, isError, refetch } = useQuery<WorkspacesResponse, Error>({
+    queryKey: ['workspaces'],
+    queryFn: async () => {
+      // Don't send X-MLFLOW-WORKSPACE header when listing workspaces
+      // Otherwise we get stuck when current workspace is filtered out
+      return fetchAPI(getAjaxUrl(WORKSPACES_ENDPOINT), {
+        method: HTTPMethods.GET,
+        headers: {
+          'X-MLFLOW-WORKSPACE': '',
+        },
+      });
+    },
+    enabled,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  // Transform and filter workspaces data
+  const workspaces = useMemo(() => {
+    const fetched = Array.isArray(data?.workspaces) ? data.workspaces : [];
+    const filteredWorkspaces: Workspace[] = [];
+    for (const item of fetched as Array<Workspace | Record<string, unknown>>) {
+      if (item && typeof (item as Workspace)?.name === 'string') {
+        const workspaceItem = item as Workspace;
+        filteredWorkspaces.push({
+          name: workspaceItem.name,
+          description: workspaceItem.description ?? null,
+          default_artifact_root: workspaceItem.default_artifact_root ?? null,
+        });
+      }
+    }
+    return filteredWorkspaces;
+  }, [data]);
+
+  return {
+    workspaces,
+    isLoading,
+    isError,
+    refetch,
+  } as const;
+};
+
+export type { Workspace };

--- a/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.test.ts
+++ b/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.test.ts
@@ -1,0 +1,429 @@
+import { describe, jest, beforeEach, afterEach, it, expect } from '@jest/globals';
+import {
+  getActiveWorkspace,
+  getLastUsedWorkspace,
+  setActiveWorkspace,
+  extractWorkspaceFromSearchParams,
+  prefixRouteWithWorkspace,
+  appendWorkspaceSearchParams,
+  validateWorkspaceName,
+  isGlobalRoute,
+  removeWorkspaceQueryParam,
+  WORKSPACE_NAME_MIN_LENGTH,
+  WORKSPACE_NAME_MAX_LENGTH,
+} from './WorkspaceUtils';
+import { getWorkspacesEnabledSync } from '../../common/utils/ServerFeaturesContext';
+
+jest.mock('../../common/utils/ServerFeaturesContext', () => ({
+  ...jest.requireActual<typeof import('../../common/utils/ServerFeaturesContext')>(
+    '../../common/utils/ServerFeaturesContext',
+  ),
+  getWorkspacesEnabledSync: jest.fn(),
+}));
+
+const getWorkspacesEnabledSyncMock = jest.mocked(getWorkspacesEnabledSync);
+
+describe('validateWorkspaceName', () => {
+  it('accepts valid workspace names', () => {
+    expect(validateWorkspaceName('my-workspace')).toEqual({ valid: true });
+    expect(validateWorkspaceName('workspace1')).toEqual({ valid: true });
+    expect(validateWorkspaceName('a1')).toEqual({ valid: true });
+    expect(validateWorkspaceName('team-a-project-1')).toEqual({ valid: true });
+  });
+
+  it('rejects names shorter than minimum length', () => {
+    const result = validateWorkspaceName('a');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(`between ${WORKSPACE_NAME_MIN_LENGTH} and ${WORKSPACE_NAME_MAX_LENGTH}`);
+  });
+
+  it('rejects names longer than maximum length', () => {
+    const longName = 'a'.repeat(WORKSPACE_NAME_MAX_LENGTH + 1);
+    const result = validateWorkspaceName(longName);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain(`between ${WORKSPACE_NAME_MIN_LENGTH} and ${WORKSPACE_NAME_MAX_LENGTH}`);
+  });
+
+  it('rejects names with uppercase letters', () => {
+    const result = validateWorkspaceName('MyWorkspace');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('lowercase alphanumeric');
+  });
+
+  it('rejects names with consecutive hyphens', () => {
+    const result = validateWorkspaceName('my--workspace');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('no consecutive hyphens');
+  });
+
+  it('rejects names starting with hyphen', () => {
+    const result = validateWorkspaceName('-workspace');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('lowercase alphanumeric');
+  });
+
+  it('rejects names ending with hyphen', () => {
+    const result = validateWorkspaceName('workspace-');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('lowercase alphanumeric');
+  });
+
+  it('rejects names with spaces', () => {
+    const result = validateWorkspaceName('my workspace');
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('lowercase alphanumeric');
+  });
+
+  it('rejects non-string values', () => {
+    // @ts-expect-error Testing invalid type
+    const result = validateWorkspaceName(123);
+    expect(result.valid).toBe(false);
+    expect(result.error).toContain('must be a string');
+  });
+});
+
+describe('WorkspaceUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getWorkspacesEnabledSyncMock.mockReturnValue(true);
+    // Clear any stored workspace
+    setActiveWorkspace(null);
+    // Clear localStorage
+    if (typeof window !== 'undefined') {
+      window.localStorage.clear();
+    }
+  });
+
+  afterEach(() => {
+    setActiveWorkspace(null);
+  });
+
+  describe('getLastUsedWorkspace', () => {
+    it('returns null when no workspace has been used', () => {
+      expect(getLastUsedWorkspace()).toBeNull();
+    });
+
+    it('returns workspace from localStorage', () => {
+      setActiveWorkspace('team-a');
+      expect(getLastUsedWorkspace()).toBe('team-a');
+    });
+
+    it('persists across page loads (localStorage)', () => {
+      setActiveWorkspace('persistent-workspace');
+      const stored = window.localStorage.getItem('mlflow.activeWorkspace');
+      expect(stored).toBe('persistent-workspace');
+      expect(getLastUsedWorkspace()).toBe('persistent-workspace');
+    });
+  });
+
+  describe('getActiveWorkspace / setActiveWorkspace', () => {
+    it('returns null when no workspace is in URL', () => {
+      expect(getActiveWorkspace()).toBeNull();
+    });
+
+    it('returns the in-memory workspace even when window.location is unavailable (SSR)', () => {
+      setActiveWorkspace('team-a');
+
+      // Mock SSR environment (no window.location)
+      const originalLocation = window.location;
+      delete (window as any).location;
+
+      // getActiveWorkspace returns in-memory value regardless of window.location
+      expect(getActiveWorkspace()).toBe('team-a');
+
+      // And getLastUsedWorkspace should also work
+      (window as any).location = originalLocation;
+      expect(getLastUsedWorkspace()).toBe('team-a');
+    });
+
+    it('persists workspace to localStorage', () => {
+      setActiveWorkspace('team-b');
+      const stored = window.localStorage.getItem('mlflow.activeWorkspace');
+      expect(stored).toBe('team-b');
+    });
+
+    it('clears in-memory workspace but leaves localStorage intact when setting to null', () => {
+      setActiveWorkspace('team-c');
+      expect(window.localStorage.getItem('mlflow.activeWorkspace')).toBe('team-c');
+      expect(getActiveWorkspace()).toBe('team-c');
+
+      // setActiveWorkspace(null) clears in-memory but doesn't clear localStorage
+      // (localStorage keeps last used workspace for UI hints)
+      setActiveWorkspace(null);
+      expect(getActiveWorkspace()).toBeNull();
+      expect(window.localStorage.getItem('mlflow.activeWorkspace')).toBe('team-c');
+    });
+
+    it('returns in-memory workspace regardless of URL params', () => {
+      // Set active workspace in memory
+      setActiveWorkspace('cached-workspace');
+
+      // Mock URL with no workspace param
+      const originalLocation = window.location;
+      delete (window as any).location;
+      (window as any).location = { ...originalLocation, search: '?other=param' };
+
+      // getActiveWorkspace returns in-memory value, doesn't read from URL
+      expect(getActiveWorkspace()).toBe('cached-workspace');
+
+      // Restore original location
+      (window as any).location = originalLocation;
+    });
+
+    it('returns null when creating new workspace (no query param, no cache)', () => {
+      // Clear localStorage
+      setActiveWorkspace(null);
+
+      // Mock URL with no workspace param (e.g., creating new workspace)
+      const originalLocation = window.location;
+      delete (window as any).location;
+      (window as any).location = { ...originalLocation, search: '' };
+
+      // Should return null (no workspace header will be sent)
+      expect(getActiveWorkspace()).toBeNull();
+
+      // Restore original location
+      (window as any).location = originalLocation;
+    });
+  });
+
+  describe('extractWorkspaceFromSearchParams', () => {
+    it('extracts workspace from URLSearchParams', () => {
+      const params = new URLSearchParams('workspace=default');
+      expect(extractWorkspaceFromSearchParams(params)).toBe('default');
+    });
+
+    it('extracts workspace from query string', () => {
+      expect(extractWorkspaceFromSearchParams('workspace=team-a')).toBe('team-a');
+      expect(extractWorkspaceFromSearchParams('?workspace=team-b')).toBe('team-b');
+    });
+
+    it('returns null when workspace param is missing', () => {
+      expect(extractWorkspaceFromSearchParams('')).toBeNull();
+      expect(extractWorkspaceFromSearchParams('other=value')).toBeNull();
+    });
+
+    it('returns null for invalid workspace names', () => {
+      expect(extractWorkspaceFromSearchParams('workspace=UPPERCASE')).toBeNull();
+      expect(extractWorkspaceFromSearchParams('workspace=has spaces')).toBeNull();
+      expect(extractWorkspaceFromSearchParams('workspace=has--double-hyphen')).toBeNull();
+    });
+
+    it('handles URL-encoded workspace names', () => {
+      // Valid name that's URL-encoded
+      expect(extractWorkspaceFromSearchParams('workspace=team-a')).toBe('team-a');
+    });
+  });
+
+  describe('isGlobalRoute', () => {
+    it('returns false for root path (handled specially in prefixRouteWithWorkspace)', () => {
+      // Root path is NOT in ALWAYS_GLOBAL_ROUTES - it's handled specially:
+      // - '/' without workspace param = workspace selector (no workspace added)
+      // - '/?workspace=foo' = workspace home (preserve workspace)
+      expect(isGlobalRoute('/')).toBe(false);
+    });
+
+    it('returns true for settings path (always global)', () => {
+      expect(isGlobalRoute('/settings')).toBe(true);
+      expect(isGlobalRoute('/settings/general')).toBe(true);
+    });
+
+    it('returns false for workspace-scoped paths', () => {
+      expect(isGlobalRoute('/experiments')).toBe(false);
+      expect(isGlobalRoute('/models')).toBe(false);
+      expect(isGlobalRoute('/prompts')).toBe(false);
+    });
+
+    it('ignores query params and hash', () => {
+      expect(isGlobalRoute('/?workspace=default')).toBe(false);
+      expect(isGlobalRoute('/settings?tab=general#section')).toBe(true);
+    });
+  });
+
+  describe('removeWorkspaceQueryParam', () => {
+    it('removes workspace param from query string', () => {
+      expect(removeWorkspaceQueryParam('/experiments?workspace=default')).toBe('/experiments');
+    });
+
+    it('preserves other query params', () => {
+      expect(removeWorkspaceQueryParam('/experiments?workspace=default&filter=active')).toBe(
+        '/experiments?filter=active',
+      );
+    });
+
+    it('handles hash prefix', () => {
+      expect(removeWorkspaceQueryParam('#/experiments?workspace=default')).toBe('#/experiments');
+    });
+
+    it('preserves hash fragment', () => {
+      expect(removeWorkspaceQueryParam('/experiments?workspace=default#section')).toBe('/experiments#section');
+    });
+
+    it('returns unchanged if no workspace param', () => {
+      expect(removeWorkspaceQueryParam('/experiments?filter=active')).toBe('/experiments?filter=active');
+    });
+  });
+
+  describe('getActiveWorkspace', () => {
+    it('returns the in-memory active workspace', () => {
+      expect(getActiveWorkspace()).toBeNull();
+
+      setActiveWorkspace('workspace-1');
+      expect(getActiveWorkspace()).toBe('workspace-1');
+
+      setActiveWorkspace('another-workspace');
+      expect(getActiveWorkspace()).toBe('another-workspace');
+
+      setActiveWorkspace(null);
+      expect(getActiveWorkspace()).toBeNull();
+    });
+  });
+
+  describe('prefixRouteWithWorkspace', () => {
+    beforeEach(() => {
+      // Set active workspace for these tests
+      setActiveWorkspace('default');
+    });
+
+    afterEach(() => {
+      // Clear active workspace
+      setActiveWorkspace(null);
+    });
+
+    it('returns original string for empty/undefined values', () => {
+      expect(prefixRouteWithWorkspace('')).toBe('');
+      // @ts-expect-error Testing undefined case
+      expect(prefixRouteWithWorkspace(undefined)).toBeUndefined();
+    });
+
+    it('returns original string when workspaces disabled', () => {
+      getWorkspacesEnabledSyncMock.mockReturnValue(false);
+      expect(prefixRouteWithWorkspace('/experiments')).toBe('/experiments');
+    });
+
+    it('returns original string for absolute URLs', () => {
+      expect(prefixRouteWithWorkspace('https://example.com/path')).toBe('https://example.com/path');
+      expect(prefixRouteWithWorkspace('http://localhost:3000')).toBe('http://localhost:3000');
+    });
+
+    it('returns original string for relative navigation (no leading /)', () => {
+      expect(prefixRouteWithWorkspace('experiments')).toBe('experiments');
+      expect(prefixRouteWithWorkspace('models/123')).toBe('models/123');
+    });
+
+    it('adds workspace query param to absolute paths', () => {
+      expect(prefixRouteWithWorkspace('/experiments')).toBe('/experiments?workspace=default');
+      expect(prefixRouteWithWorkspace('/models/123')).toBe('/models/123?workspace=default');
+    });
+
+    it('handles hash prefix correctly', () => {
+      expect(prefixRouteWithWorkspace('#/experiments')).toBe('#/experiments?workspace=default');
+    });
+
+    it('preserves existing hash fragments', () => {
+      expect(prefixRouteWithWorkspace('/experiments#section')).toBe('/experiments?workspace=default#section');
+    });
+
+    it('preserves existing query params', () => {
+      expect(prefixRouteWithWorkspace('/experiments?search=test')).toBe('/experiments?search=test&workspace=default');
+    });
+
+    it('handles query strings and hash together', () => {
+      expect(prefixRouteWithWorkspace('/models?filter=active#top')).toBe('/models?filter=active&workspace=default#top');
+    });
+
+    it('preserves explicit workspace param in URL', () => {
+      // If URL already has explicit workspace, preserve it (don't override with active workspace)
+      const path = '/experiments?workspace=old-workspace';
+      expect(prefixRouteWithWorkspace(path)).toBe('/experiments?workspace=old-workspace');
+    });
+
+    it('returns path without workspace param when no workspace set', () => {
+      setActiveWorkspace(null);
+      expect(prefixRouteWithWorkspace('/experiments')).toBe('/experiments');
+    });
+
+    it('adds workspace param to root path when workspace is active (workspace home)', () => {
+      // Root path with active workspace gets workspace param added (workspace home)
+      expect(prefixRouteWithWorkspace('/')).toBe('/?workspace=default');
+    });
+
+    it('does not add workspace param to root path when no workspace is active', () => {
+      setActiveWorkspace(null);
+      expect(prefixRouteWithWorkspace('/')).toBe('/');
+    });
+
+    it('preserves explicit workspace param on root path', () => {
+      // Root path with explicit workspace is preserved as-is
+      expect(prefixRouteWithWorkspace('/?workspace=old')).toBe('/?workspace=old');
+    });
+
+    it('removes workspace param for global routes (settings)', () => {
+      expect(prefixRouteWithWorkspace('/settings')).toBe('/settings');
+      expect(prefixRouteWithWorkspace('/settings?workspace=old')).toBe('/settings');
+    });
+
+    it('uses different workspace when set', () => {
+      setActiveWorkspace('team-a');
+      expect(prefixRouteWithWorkspace('/experiments')).toBe('/experiments?workspace=team-a');
+    });
+
+    it('encodes workspace name in query param', () => {
+      setActiveWorkspace('team-with-hyphen');
+      expect(prefixRouteWithWorkspace('/experiments')).toBe('/experiments?workspace=team-with-hyphen');
+    });
+  });
+
+  describe('prefixPathnameWithWorkspace', () => {
+    beforeEach(() => {
+      // Set active workspace for these tests
+      setActiveWorkspace('default');
+    });
+
+    afterEach(() => {
+      // Clear active workspace
+      setActiveWorkspace(null);
+    });
+
+    it('returns undefined for undefined pathname', () => {
+      expect(appendWorkspaceSearchParams(undefined)).toBeUndefined();
+    });
+
+    it('returns original for absolute URLs', () => {
+      expect(appendWorkspaceSearchParams('https://example.com')).toBe('https://example.com');
+    });
+
+    it('adds workspace query param to pathname', () => {
+      expect(appendWorkspaceSearchParams('/experiments')).toBe('/experiments?workspace=default');
+      expect(appendWorkspaceSearchParams('/models/123')).toBe('/models/123?workspace=default');
+    });
+
+    it('adds workspace param to root path when workspace is active', () => {
+      expect(appendWorkspaceSearchParams('/')).toBe('/?workspace=default');
+    });
+
+    it('returns root path unchanged when no workspace is active', () => {
+      setActiveWorkspace(null);
+      expect(appendWorkspaceSearchParams('/')).toBe('/');
+    });
+
+    it('returns always-global routes unchanged (settings)', () => {
+      expect(appendWorkspaceSearchParams('/settings')).toBe('/settings');
+    });
+
+    it('returns pathname without workspace when feature disabled', () => {
+      getWorkspacesEnabledSyncMock.mockReturnValue(false);
+      expect(appendWorkspaceSearchParams('/experiments')).toBe('/experiments');
+    });
+
+    it('uses active workspace when set', () => {
+      setActiveWorkspace('team-b');
+      expect(appendWorkspaceSearchParams('/models')).toBe('/models?workspace=team-b');
+    });
+
+    it('returns pathname unchanged when no workspace set', () => {
+      setActiveWorkspace(null);
+      expect(appendWorkspaceSearchParams('/experiments')).toBe('/experiments');
+    });
+  });
+});

--- a/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.ts
+++ b/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.ts
@@ -4,13 +4,11 @@ const WORKSPACE_STORAGE_KEY = 'mlflow.activeWorkspace';
 export const WORKSPACE_QUERY_PARAM = 'workspace';
 
 let activeWorkspace: string | null = null;
-const listeners = new Set<(workspace: string | null) => void>();
 
 export const getActiveWorkspace = () => activeWorkspace;
 
 export const setActiveWorkspace = (workspace: string | null) => {
   activeWorkspace = workspace;
-  listeners.forEach((listener) => listener(activeWorkspace));
   if (workspace) {
     setLastUsedWorkspace(workspace);
   }
@@ -29,15 +27,6 @@ export const getLastUsedWorkspace = (): string | null => {
   } catch {
     return null;
   }
-};
-
-/** Subscribe to workspace changes. Returns unsubscribe function. */
-export const subscribeToWorkspaceChanges = (listener: (workspace: string | null) => void) => {
-  listeners.add(listener);
-  listener(getActiveWorkspace());
-  return () => {
-    listeners.delete(listener);
-  };
 };
 
 /**

--- a/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.ts
+++ b/mlflow/server/js/src/workspaces/utils/WorkspaceUtils.ts
@@ -1,0 +1,243 @@
+import { getWorkspacesEnabledSync } from '../../common/utils/ServerFeaturesContext';
+
+const WORKSPACE_STORAGE_KEY = 'mlflow.activeWorkspace';
+export const WORKSPACE_QUERY_PARAM = 'workspace';
+
+let activeWorkspace: string | null = null;
+const listeners = new Set<(workspace: string | null) => void>();
+
+export const getActiveWorkspace = () => activeWorkspace;
+
+export const setActiveWorkspace = (workspace: string | null) => {
+  activeWorkspace = workspace;
+  listeners.forEach((listener) => listener(activeWorkspace));
+  if (workspace) {
+    setLastUsedWorkspace(workspace);
+  }
+};
+
+/**
+ * Get the last used workspace from localStorage.
+ * Used for UI hints like the "Last used" badge.
+ */
+export const getLastUsedWorkspace = (): string | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem(WORKSPACE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+};
+
+/** Subscribe to workspace changes. Returns unsubscribe function. */
+export const subscribeToWorkspaceChanges = (listener: (workspace: string | null) => void) => {
+  listeners.add(listener);
+  listener(getActiveWorkspace());
+  return () => {
+    listeners.delete(listener);
+  };
+};
+
+/**
+ * Set the active workspace in localStorage and notify listeners.
+ * Used for syncing state with URL and for UI hints via getLastUsedWorkspace().
+ */
+export const setLastUsedWorkspace = (workspace: string | null) => {
+  if (typeof window !== 'undefined') {
+    try {
+      if (workspace) {
+        window.localStorage.setItem(WORKSPACE_STORAGE_KEY, workspace);
+      } else {
+        window.localStorage.removeItem(WORKSPACE_STORAGE_KEY);
+      }
+    } catch {
+      // no-op: localStorage might be unavailable (e.g., private browsing)
+    }
+  }
+};
+
+// Workspace name validation constants (must match backend: mlflow/store/workspace/abstract_store.py)
+export const WORKSPACE_NAME_PATTERN = /^(?!.*--)[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
+export const WORKSPACE_NAME_MIN_LENGTH = 2;
+export const WORKSPACE_NAME_MAX_LENGTH = 63;
+
+export type WorkspaceValidationResult = {
+  valid: boolean;
+  error?: string;
+};
+
+/** Validates workspace name against backend rules. Reserved names checked by API. */
+export const validateWorkspaceName = (name: string): WorkspaceValidationResult => {
+  if (typeof name !== 'string') {
+    return { valid: false, error: 'Workspace name must be a string.' };
+  }
+
+  if (name.length < WORKSPACE_NAME_MIN_LENGTH || name.length > WORKSPACE_NAME_MAX_LENGTH) {
+    return {
+      valid: false,
+      error: `Workspace name must be between ${WORKSPACE_NAME_MIN_LENGTH} and ${WORKSPACE_NAME_MAX_LENGTH} characters.`,
+    };
+  }
+
+  if (!WORKSPACE_NAME_PATTERN.test(name)) {
+    return {
+      valid: false,
+      error: 'Workspace name must be lowercase alphanumeric with optional single hyphens (no consecutive hyphens).',
+    };
+  }
+
+  return { valid: true };
+};
+
+/** Extract and validate workspace from URL search params. */
+export const extractWorkspaceFromSearchParams = (search: string | URLSearchParams): string | null => {
+  const params = typeof search === 'string' ? new URLSearchParams(search) : search;
+  const workspaceName = params.get(WORKSPACE_QUERY_PARAM);
+
+  if (!workspaceName || !WORKSPACE_NAME_PATTERN.test(workspaceName)) {
+    return null;
+  }
+
+  return workspaceName;
+};
+
+const isAbsoluteUrl = (value: string) => /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(value);
+
+/** Routes that never have workspace context (e.g., /settings). Root '/' is contextual. */
+const ALWAYS_GLOBAL_ROUTES = ['/settings'];
+
+/** Check if pathname is always global (workspace-agnostic). */
+export const isGlobalRoute = (pathname: string): boolean => {
+  const normalizedPath = pathname.split('?')[0].split('#')[0];
+  return ALWAYS_GLOBAL_ROUTES.some((route) => normalizedPath === route || normalizedPath.startsWith(route + '/'));
+};
+
+/** Add workspace query param to URL, preserving existing params and hash. */
+const addWorkspaceQueryParam = (url: string, workspace: string): string => {
+  const hashPrefix = url.startsWith('#') ? '#' : '';
+  const urlWithoutHashPrefix = hashPrefix ? url.slice(1) : url;
+
+  let pathname = urlWithoutHashPrefix;
+  let existingQuery = '';
+  let hashFragment = '';
+
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex >= 0) {
+    hashFragment = pathname.slice(hashIndex);
+    pathname = pathname.slice(0, hashIndex);
+  }
+
+  const queryIndex = pathname.indexOf('?');
+  if (queryIndex >= 0) {
+    existingQuery = pathname.slice(queryIndex + 1);
+    pathname = pathname.slice(0, queryIndex);
+  }
+
+  const params = new URLSearchParams(existingQuery);
+  params.set(WORKSPACE_QUERY_PARAM, workspace);
+
+  return `${hashPrefix}${pathname}?${params.toString()}${hashFragment}`;
+};
+
+/** Remove workspace query param from URL. */
+export const removeWorkspaceQueryParam = (url: string): string => {
+  const hashPrefix = url.startsWith('#') ? '#' : '';
+  const urlWithoutHashPrefix = hashPrefix ? url.slice(1) : url;
+
+  let pathname = urlWithoutHashPrefix;
+  let existingQuery = '';
+  let hashFragment = '';
+
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex >= 0) {
+    hashFragment = pathname.slice(hashIndex);
+    pathname = pathname.slice(0, hashIndex);
+  }
+
+  const queryIndex = pathname.indexOf('?');
+  if (queryIndex >= 0) {
+    existingQuery = pathname.slice(queryIndex + 1);
+    pathname = pathname.slice(0, queryIndex);
+  }
+
+  const params = new URLSearchParams(existingQuery);
+  params.delete(WORKSPACE_QUERY_PARAM);
+
+  const queryString = params.toString();
+  return `${hashPrefix}${pathname}${queryString ? '?' + queryString : ''}${hashFragment}`;
+};
+
+/**
+ * Prefix route with workspace query param. Removes workspace from global routes.
+ * Relative paths unchanged. Root '/' is contextual based on workspace param.
+ */
+export const prefixRouteWithWorkspace = (to: string): string => {
+  if (typeof to !== 'string' || to.length === 0) {
+    return to;
+  }
+
+  if (!getWorkspacesEnabledSync() || isAbsoluteUrl(to)) {
+    return to;
+  }
+
+  const hashPrefix = to.startsWith('#') ? '#' : '';
+  const urlWithoutHashPrefix = hashPrefix ? to.slice(1) : to;
+
+  const isAbsoluteNavigation = hashPrefix !== '' || urlWithoutHashPrefix.startsWith('/');
+  if (!isAbsoluteNavigation) {
+    return to;
+  }
+
+  let pathname = urlWithoutHashPrefix;
+  let existingQuery = '';
+  const hashIndex = pathname.indexOf('#');
+  if (hashIndex >= 0) {
+    pathname = pathname.slice(0, hashIndex);
+  }
+  const queryIndex = pathname.indexOf('?');
+  if (queryIndex >= 0) {
+    existingQuery = pathname.slice(queryIndex + 1);
+    pathname = pathname.slice(0, queryIndex);
+  }
+
+  const existingParams = new URLSearchParams(existingQuery);
+  const hasExplicitWorkspace = existingParams.has(WORKSPACE_QUERY_PARAM);
+
+  if (isGlobalRoute(pathname || '/')) {
+    return removeWorkspaceQueryParam(to);
+  }
+
+  if (hasExplicitWorkspace) {
+    return to;
+  }
+
+  const workspace = getActiveWorkspace();
+  if (!workspace) {
+    return to;
+  }
+
+  return addWorkspaceQueryParam(to, workspace);
+};
+
+/** Prefix pathname with workspace query param. Similar to prefixRouteWithWorkspace. */
+export const appendWorkspaceSearchParams = (pathname: string | undefined): string | undefined => {
+  if (!pathname) {
+    return pathname;
+  }
+  if (!getWorkspacesEnabledSync() || isAbsoluteUrl(pathname)) {
+    return pathname;
+  }
+
+  if (isGlobalRoute(pathname)) {
+    return pathname;
+  }
+
+  const workspace = getActiveWorkspace();
+  if (!workspace) {
+    return pathname;
+  }
+
+  return `${pathname}?${WORKSPACE_QUERY_PARAM}=${encodeURIComponent(workspace)}`;
+};

--- a/mlflow/tracking/_tracking_service/client.py
+++ b/mlflow/tracking/_tracking_service/client.py
@@ -776,13 +776,14 @@ class TrackingServiceClient:
         if is_databricks_uri(self.tracking_uri):
             experiment_url = f"{host_url}/ml/experiments/{experiment_id}"
         else:
-            workspace = get_request_workspace()
-            if workspace and workspace != DEFAULT_WORKSPACE_NAME:
-                encoded = urllib_parse.quote(workspace, safe="")
-                experiment_url = f"{host_url}/#/workspaces/{encoded}/experiments/{experiment_id}"
-            else:
-                experiment_url = f"{host_url}/#/experiments/{experiment_id}"
+            experiment_url = f"{host_url}/#/experiments/{experiment_id}"
         run_url = f"{experiment_url}/runs/{run_id}"
+
+        workspace = get_request_workspace()
+        if workspace and workspace != DEFAULT_WORKSPACE_NAME:
+            encoded = urllib_parse.quote(workspace, safe="")
+            experiment_url = f"{experiment_url}?workspace={encoded}"
+            run_url = f"{run_url}?workspace={encoded}"
 
         sys.stdout.write(f"🏃 View run {run_name} at: {run_url}\n")
         sys.stdout.write(f"🧪 View experiment at: {experiment_url}\n")

--- a/tests/tracking/test_rest_tracking.py
+++ b/tests/tracking/test_rest_tracking.py
@@ -3403,13 +3403,13 @@ def test_log_url_includes_workspace_when_set(mlflow_client: MlflowClient, monkey
         "mlflow.tracking._tracking_service.client.get_workspace_url", lambda: "http://localhost"
     )
     monkeypatch.setattr(
-        "mlflow.tracking._tracking_service.client.get_request_workspace", lambda: "team space"
+        "mlflow.tracking._tracking_service.client.get_request_workspace", lambda: "team-space"
     )
 
     mlflow_client._tracking_client._log_url(run.info.run_id)
 
     out = captured_output.getvalue()
-    expected_fragment = f"/#/workspaces/team%20space/experiments/{exp_id}/runs/{run.info.run_id}"
+    expected_fragment = f"/#/experiments/{exp_id}/runs/{run.info.run_id}?workspace=team-space"
     assert expected_fragment in out
 
 


### PR DESCRIPTION
### Related Issues/PRs

#1464
#5844
Design document: https://docs.google.com/document/d/1IbFfceCmWV3knJfc0ninn58EXLVbHUh1meV_pknOM40/edit

### What changes are proposed in this pull request?

This PR adds the frontend UI components for multi-workspace support in MLflow.

**⚠️ Important: Backward Compatibility**
The new workspace UI behavior is **only activated** when the server's `/ajax-api/2.0/mlflow/server-features` endpoint returns `{ "workspacesEnabled": true }`. When workspaces are not enabled (default behavior), the UI operates exactly as before with no visible changes.

**New Components:**
- `WorkspaceSelector` - Dropdown component with search and tooltips for selecting workspaces
- `WorkspacePermissionError` - Error page displayed when accessing an unauthorized workspace
- `useWorkspaces` hook - Custom hook for fetching available workspaces from the API
- `ServerFeaturesContext` - Context provider for detecting server feature flags via `/ajax-api/2.0/mlflow/server-features`
- `WorkspaceUtils` - Utilities for workspace state management and URL handling
- `WorkspaceRouteUtils` - Utilities for prefixing routes with workspace paths

**Core Changes:**
- `MlflowRouter` - Added workspace-aware routing with `WorkspaceRouterSync` component (only active when workspaces enabled)
- `app.tsx` - Integrated `ServerFeaturesProvider` for feature detection
- `FetchUtils` - Added `X-MLFLOW-WORKSPACE` header injection for all API requests (only when workspace is set)
- `graphql/client` - Added workspace header support for GraphQL requests

**Behavior when workspaces are enabled:**
- Frontend URLs include workspace: `/#/workspaces/team-a/experiments`
- Backend API calls pass workspace via `X-MLFLOW-WORKSPACE` header (not URL path)
- Workspace selector appears in header
- Automatic redirect to default workspace when none is specified
- Workspace state persisted to localStorage

**Behavior when workspaces are disabled (default):**
- No workspace selector shown
- No workspace prefix in URLs
- No `X-MLFLOW-WORKSPACE` header sent
- UI operates exactly as before

<img width="1196" height="605" alt="image" src="https://github.com/user-attachments/assets/865e9dd3-8d4a-4dc0-bbc5-ffac99bcaf50" />
<img width="464" height="236" alt="image" src="https://github.com/user-attachments/assets/58b3c53a-fdec-4f16-b776-1ae01ebc7e4b" />


### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [ ] Manual tests

New tests added for:
- `ServerFeaturesContext.test.tsx` - Tests feature detection and workspace enabled/disabled states
- `WorkspaceRouteUtils.test.ts` - Tests route prefixing logic
- `ArtifactUtils.test.ts` - Tests workspace header injection
- `graphql/client.test.ts` - Tests GraphQL workspace header support
- Updated existing tests to mock workspace context

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

Documentation will be added in a follow-up PR once the full workspace feature is complete.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added multi-workspace UI support allowing users to switch between different workspaces via a dropdown selector in the MLflow header. This feature is only enabled when the MLflow server is configured with workspace support (determined by the `/ajax-api/2.0/mlflow/server-features` endpoint). When workspaces are not enabled, the UI behaves exactly as before.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)