### PR TITLE
Make datasource failures fail gracefully

### DIFF
--- a/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
+++ b/mlflow/java/spark/src/main/scala/org/mlflow/spark/autologging/DatasourceAttributeExtractor.scala
@@ -102,19 +102,27 @@ object DatasourceAttributeExtractor extends DatasourceAttributeExtractorBase {
 /** Datasource attribute extractor for REPL-ID aware environments (e.g. Databricks) */
 object ReplAwareDatasourceAttributeExtractor extends DatasourceAttributeExtractorBase {
   override protected def maybeGetDeltaTableInfo(leafNode: LogicalPlan): Option[SparkTableInfo] = {
-    leafNode match {
-      case lr: LogicalRelation =>
-        // First, check whether LogicalRelation is a Delta table
-        val obj = ReflectionUtils.getScalaObjectByName("com.databricks.sql.transaction.tahoe.DeltaTable")
-        val deltaFileIndexOpt = ReflectionUtils.callMethod(obj, "unapply", Seq(lr)).asInstanceOf[Option[Any]]
-        deltaFileIndexOpt.map(fileIndex => {
-          val path = ReflectionUtils.getField(fileIndex, "path").toString
-          val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
-            ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty)
-          ).map(_.toString)
-          SparkTableInfo(path, versionOpt, Option("delta"))
-        })
-      case other => None
+    try {
+      leafNode match {
+        case lr: LogicalRelation =>
+          // First, check whether LogicalRelation is a Delta table
+          val obj = ReflectionUtils.getScalaObjectByName("com.databricks.sql.transaction.tahoe.DeltaTable")
+          val deltaFileIndexOpt = ReflectionUtils.callMethod(obj, "unapply", Seq(lr)).asInstanceOf[Option[Any]]
+          deltaFileIndexOpt.map(fileIndex => {
+            val path = ReflectionUtils.getField(fileIndex, "path").toString
+            val versionOpt = ReflectionUtils.maybeCallMethod(fileIndex, "tableVersion", Seq.empty).orElse(
+              ReflectionUtils.maybeCallMethod(fileIndex, "version", Seq.empty)
+            ).map(_.toString)
+            SparkTableInfo(path, versionOpt, Option("delta"))
+          })
+        case other => None
+      }
+    } catch {
+      case NonFatal(e) =>
+        if (logger.isTraceEnabled) {
+          logger.trace(s"Unable to extract Delta table info: ${e.getMessage}")
+        }
+        None
     }
   }
 

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -79,5 +79,4 @@ class ReflectionUtilsSuite extends AnyFunSuite {
     ).map(_.toString)
     assert(versionOpt2 == None)
   }
-
 }

--- a/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
+++ b/mlflow/java/spark/src/test/scala/org/mlflow/spark/autologging/ReflectionUtilsSuite.scala
@@ -79,4 +79,5 @@ class ReflectionUtilsSuite extends AnyFunSuite {
     ).map(_.toString)
     assert(versionOpt2 == None)
   }
+
 }


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/BenWilson2/mlflow/pull/19469?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19469/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19469/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19469/merge
```

</p>
</details>

<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Delta has had some refactoring changes made to properties of objects that are breaking changes. MLflow's DatasetSourceListener attempts to fetch these properties for logging purposes, which causes fatal exceptions to be thrown, including in jobs that are for Data Engineering tasks (no ML / AI code being run). 
In order to prevent job disruptions, attempt to collect information on data sources, but if anything happens that is a non-fatal error, silently ignore the failure for property access. 

### How is this PR tested?

- [ ] Existing unit/integration tests
- [X] New unit/integration tests
- [ ] Manual tests

<!-- Attach code, screenshot, video used for manual testing here. -->

### Does this PR require documentation update?

- [X] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [X] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [X] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [X] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [X] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
