### PR TITLE
Add gateway provider support for scorers

### DIFF
--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -231,7 +231,7 @@ def _invoke_litellm_and_handle_tools(
         # LiteLLM requires api_key to be set when using custom api_base, otherwise it
         # raises AuthenticationError looking for OPENAI_API_KEY env var. Gateway handles
         # auth in the server layer, so we pass a dummy value to satisfy LiteLLM.
-        api_key = "not-needed"
+        api_key = "mlflow-gateway-auth"
     else:
         model = f"{provider}/{model_name}"
         api_base = None

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -119,7 +119,7 @@ def _invoke_litellm(
     Invoke litellm completion with retry support.
 
     Args:
-        model: The model identifier (e.g., "openai/gpt-4" or endpoint name for gateway).
+        model: The LiteLLM model identifier (e.g., "openai/gpt-4" or endpoint name for gateway).
         messages: List of litellm Message objects.
         tools: List of tool definitions (empty list if no tools).
         num_retries: Number of retries with exponential backoff.

--- a/mlflow/genai/judges/adapters/litellm_adapter.py
+++ b/mlflow/genai/judges/adapters/litellm_adapter.py
@@ -230,7 +230,7 @@ def _invoke_litellm_and_handle_tools(
         model = f"openai/{model_name}"
         # LiteLLM requires api_key to be set when using custom api_base, otherwise it
         # raises AuthenticationError looking for OPENAI_API_KEY env var. Gateway handles
-        # auth via the tracking URI, so we pass a dummy value to satisfy LiteLLM.
+        # auth in the server layer, so we pass a dummy value to satisfy LiteLLM.
         api_key = "not-needed"
     else:
         model = f"{provider}/{model_name}"

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -13,6 +13,7 @@ from mlflow.entities.trace_state import TraceState
 from mlflow.genai.judges.adapters.litellm_adapter import (
     _MODEL_RESPONSE_FORMAT_CAPABILITIES,
     _invoke_litellm,
+    _truncate_oldest_tool_call,
 )
 from mlflow.types.llm import ChatMessage
 
@@ -40,7 +41,7 @@ def test_invoke_litellm_basic():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         result = _invoke_litellm(
-            litellm_model_uri="openai/gpt-4",
+            model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=[],
             num_retries=5,
@@ -57,6 +58,8 @@ def test_invoke_litellm_basic():
     assert call_kwargs["max_retries"] == 0
     assert call_kwargs["drop_params"] is True
     assert "response_format" not in call_kwargs
+    assert "api_base" not in call_kwargs
+    assert "api_key" not in call_kwargs
 
 
 def test_invoke_litellm_with_tools():
@@ -65,7 +68,7 @@ def test_invoke_litellm_with_tools():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         result = _invoke_litellm(
-            litellm_model_uri="openai/gpt-4",
+            model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=tools,
             num_retries=3,
@@ -87,7 +90,7 @@ def test_invoke_litellm_with_response_format():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         result = _invoke_litellm(
-            litellm_model_uri="openai/gpt-4",
+            model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=[],
             num_retries=3,
@@ -110,7 +113,7 @@ def test_invoke_litellm_exception_propagation():
     ):
         with pytest.raises(litellm.RateLimitError, match="Rate limit exceeded"):
             _invoke_litellm(
-                litellm_model_uri="openai/gpt-4",
+                model="openai/gpt-4",
                 messages=[litellm.Message(role="user", content="Test")],
                 tools=[],
                 num_retries=3,
@@ -124,7 +127,7 @@ def test_invoke_litellm_retry_policy_configured():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         _invoke_litellm(
-            litellm_model_uri="openai/gpt-4",
+            model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=[],
             num_retries=7,
@@ -142,19 +145,41 @@ def test_invoke_litellm_retry_policy_configured():
     assert retry_policy.AuthenticationErrorRetries == 0
 
 
-def test_invoke_litellm_and_handle_tools_with_context_window_exceeded(mock_trace):
+def test_invoke_litellm_with_gateway_params():
+    mock_response = ModelResponse(choices=[{"message": {"content": '{"result": "yes"}'}}])
+
+    with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
+        _invoke_litellm(
+            model="my-endpoint",
+            messages=[litellm.Message(role="user", content="Test")],
+            tools=[],
+            num_retries=3,
+            response_format=None,
+            include_response_format=False,
+            api_base="http://localhost:5000/gateway/mlflow/v1/",
+            api_key="not-needed",
+        )
+
+    call_kwargs = mock_litellm.call_args.kwargs
+    assert call_kwargs["model"] == "my-endpoint"
+    assert call_kwargs["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
+    assert call_kwargs["api_key"] == "not-needed"
+
+
+def test_invoke_litellm_and_handle_tools_with_context_window_exceeded_direct_provider(mock_trace):
+    # For direct providers (non-gateway), use token-counting based pruning
     context_error = litellm.ContextWindowExceededError(
         message="Context window exceeded", model="openai/gpt-4", llm_provider="openai"
     )
 
-    pruned_response = ModelResponse(
+    success_response = ModelResponse(
         choices=[{"message": {"content": '{"result": "yes", "rationale": "OK"}'}}]
     )
 
     with (
         mock.patch(
             "litellm.completion",
-            side_effect=[context_error, pruned_response],
+            side_effect=[context_error, success_response],
         ) as mock_litellm,
         mock.patch(
             "mlflow.genai.judges.adapters.litellm_adapter._prune_messages_exceeding_context_window_length"
@@ -177,6 +202,71 @@ def test_invoke_litellm_and_handle_tools_with_context_window_exceeded(mock_trace
     mock_prune.assert_called_once()
     assert result == '{"result": "yes", "rationale": "OK"}'
     assert cost is None
+
+
+def test_invoke_litellm_and_handle_tools_with_context_window_exceeded_gateway_provider():
+    # For gateway provider, use DSPy-style reactive truncation
+    context_error = litellm.ContextWindowExceededError(
+        message="Context window exceeded", model="my-endpoint", llm_provider="openai"
+    )
+
+    success_response = ModelResponse(
+        choices=[{"message": {"content": '{"result": "yes", "rationale": "OK"}'}}]
+    )
+
+    with (
+        mock.patch(
+            "litellm.completion",
+            side_effect=[context_error, success_response],
+        ) as mock_litellm,
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._truncate_oldest_tool_call"
+        ) as mock_truncate,
+        mock.patch("mlflow.tracking.get_tracking_uri", return_value="http://localhost:5000"),
+    ):
+        mock_truncate.return_value = [litellm.Message(role="user", content="Truncated")]
+
+        from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
+
+        result, cost = _invoke_litellm_and_handle_tools(
+            provider="gateway",
+            model_name="my-endpoint",
+            messages=[ChatMessage(role="user", content="Very long message" * 100)],
+            trace=None,
+            num_retries=3,
+        )
+
+    assert mock_litellm.call_count == 2
+    mock_truncate.assert_called_once()
+    assert result == '{"result": "yes", "rationale": "OK"}'
+    assert cost is None
+
+
+def test_invoke_litellm_and_handle_tools_gateway_context_window_no_tool_calls_to_truncate():
+    # For gateway provider, when there are no tool calls to truncate, raise an error
+    context_error = litellm.ContextWindowExceededError(
+        message="Context window exceeded", model="my-endpoint", llm_provider="openai"
+    )
+
+    with (
+        mock.patch("litellm.completion", side_effect=context_error),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter._truncate_oldest_tool_call",
+            return_value=None,  # No tool calls to truncate
+        ),
+        mock.patch("mlflow.tracking.get_tracking_uri", return_value="http://localhost:5000"),
+    ):
+        from mlflow.exceptions import MlflowException
+        from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
+
+        with pytest.raises(MlflowException, match="no tool calls to truncate"):
+            _invoke_litellm_and_handle_tools(
+                provider="gateway",
+                model_name="my-endpoint",
+                messages=[ChatMessage(role="user", content="Very long message")],
+                trace=None,
+                num_retries=3,
+            )
 
 
 def test_invoke_litellm_and_handle_tools_integration(mock_trace):
@@ -232,3 +322,119 @@ def test_invoke_litellm_and_handle_tools_integration(mock_trace):
     assert second_call_messages[1].role == "assistant"
     assert second_call_messages[2].role == "tool"
     assert "trace_data" in second_call_messages[2].content
+
+
+def test_gateway_provider_integration():
+    mock_response = ModelResponse(
+        choices=[{"message": {"content": '{"result": "yes", "rationale": "Good"}'}}]
+    )
+
+    with (
+        mock.patch("litellm.completion", return_value=mock_response) as mock_litellm,
+        mock.patch("mlflow.tracking.get_tracking_uri") as mock_get_uri,
+    ):
+        mock_get_uri.return_value = "http://localhost:5000"
+
+        from mlflow.genai.judges.adapters.litellm_adapter import (
+            _invoke_litellm_and_handle_tools,
+        )
+
+        result, cost = _invoke_litellm_and_handle_tools(
+            provider="gateway",
+            model_name="my-endpoint",
+            messages=[ChatMessage(role="user", content="Test")],
+            trace=None,
+            num_retries=3,
+        )
+
+    assert result == '{"result": "yes", "rationale": "Good"}'
+
+    call_kwargs = mock_litellm.call_args.kwargs
+    assert call_kwargs["model"] == "openai/my-endpoint"
+    assert call_kwargs["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
+    assert call_kwargs["api_key"] == "not-needed"
+
+
+def test_truncate_removes_oldest_tool_call_and_response():
+    messages = [
+        litellm.Message(role="user", content="Hello"),
+        litellm.Message(
+            role="assistant",
+            content=None,
+            tool_calls=[{"id": "call_1", "function": {"name": "tool1", "arguments": "{}"}}],
+        ),
+        litellm.Message(role="tool", content="Result 1", tool_call_id="call_1"),
+        litellm.Message(
+            role="assistant",
+            content=None,
+            tool_calls=[{"id": "call_2", "function": {"name": "tool2", "arguments": "{}"}}],
+        ),
+        litellm.Message(role="tool", content="Result 2", tool_call_id="call_2"),
+    ]
+
+    result = _truncate_oldest_tool_call(messages)
+
+    assert result is not None
+    assert len(result) == 3
+    assert result[0].role == "user"
+    assert result[1].role == "assistant"
+    assert result[1].tool_calls[0]["id"] == "call_2"
+    assert result[2].role == "tool"
+    assert result[2].tool_call_id == "call_2"
+
+
+def test_truncate_returns_none_when_no_tool_calls():
+    messages = [
+        litellm.Message(role="user", content="Hello"),
+        litellm.Message(role="assistant", content="Hi there!"),
+    ]
+
+    result = _truncate_oldest_tool_call(messages)
+
+    assert result is None
+
+
+def test_truncate_handles_multiple_tool_calls_in_single_message():
+    messages = [
+        litellm.Message(role="user", content="Hello"),
+        litellm.Message(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                {"id": "call_1", "function": {"name": "tool1", "arguments": "{}"}},
+                {"id": "call_2", "function": {"name": "tool2", "arguments": "{}"}},
+            ],
+        ),
+        litellm.Message(role="tool", content="Result 1", tool_call_id="call_1"),
+        litellm.Message(role="tool", content="Result 2", tool_call_id="call_2"),
+    ]
+
+    result = _truncate_oldest_tool_call(messages)
+
+    assert result is not None
+    assert len(result) == 1
+    assert result[0].role == "user"
+
+
+def test_truncate_preserves_non_tool_messages():
+    messages = [
+        litellm.Message(role="system", content="You are helpful"),
+        litellm.Message(role="user", content="Hello"),
+        litellm.Message(
+            role="assistant",
+            content=None,
+            tool_calls=[{"id": "call_1", "function": {"name": "tool1", "arguments": "{}"}}],
+        ),
+        litellm.Message(role="tool", content="Result", tool_call_id="call_1"),
+        litellm.Message(role="user", content="Thanks"),
+    ]
+
+    result = _truncate_oldest_tool_call(messages)
+
+    assert result is not None
+    assert len(result) == 3
+    assert result[0].role == "system"
+    assert result[1].role == "user"
+    assert result[1].content == "Hello"
+    assert result[2].role == "user"
+    assert result[2].content == "Thanks"

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -41,7 +41,7 @@ def test_invoke_litellm_basic():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         result = _invoke_litellm(
-            model="openai/gpt-4",
+            litellm_model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=[],
             num_retries=5,
@@ -68,7 +68,7 @@ def test_invoke_litellm_with_tools():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         result = _invoke_litellm(
-            model="openai/gpt-4",
+            litellm_model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=tools,
             num_retries=3,
@@ -90,7 +90,7 @@ def test_invoke_litellm_with_response_format():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         result = _invoke_litellm(
-            model="openai/gpt-4",
+            litellm_model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=[],
             num_retries=3,
@@ -113,7 +113,7 @@ def test_invoke_litellm_exception_propagation():
     ):
         with pytest.raises(litellm.RateLimitError, match="Rate limit exceeded"):
             _invoke_litellm(
-                model="openai/gpt-4",
+                litellm_model="openai/gpt-4",
                 messages=[litellm.Message(role="user", content="Test")],
                 tools=[],
                 num_retries=3,
@@ -127,7 +127,7 @@ def test_invoke_litellm_retry_policy_configured():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         _invoke_litellm(
-            model="openai/gpt-4",
+            litellm_model="openai/gpt-4",
             messages=[litellm.Message(role="user", content="Test")],
             tools=[],
             num_retries=7,
@@ -150,7 +150,7 @@ def test_invoke_litellm_with_gateway_params():
 
     with mock.patch("litellm.completion", return_value=mock_response) as mock_litellm:
         _invoke_litellm(
-            model="my-endpoint",
+            litellm_model="my-endpoint",
             messages=[litellm.Message(role="user", content="Test")],
             tools=[],
             num_retries=3,
@@ -222,7 +222,10 @@ def test_invoke_litellm_and_handle_tools_with_context_window_exceeded_gateway_pr
         mock.patch(
             "mlflow.genai.judges.adapters.litellm_adapter._remove_oldest_tool_call_pair"
         ) as mock_truncate,
-        mock.patch("mlflow.tracking.get_tracking_uri", return_value="http://localhost:5000"),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri",
+            return_value="http://localhost:5000",
+        ),
     ):
         mock_truncate.return_value = [litellm.Message(role="user", content="Truncated")]
 
@@ -254,7 +257,10 @@ def test_invoke_litellm_and_handle_tools_gateway_context_window_no_tool_calls_to
             "mlflow.genai.judges.adapters.litellm_adapter._remove_oldest_tool_call_pair",
             return_value=None,  # No tool calls to truncate
         ),
-        mock.patch("mlflow.tracking.get_tracking_uri", return_value="http://localhost:5000"),
+        mock.patch(
+            "mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri",
+            return_value="http://localhost:5000",
+        ),
     ):
         from mlflow.exceptions import MlflowException
         from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
@@ -331,7 +337,7 @@ def test_gateway_provider_integration():
 
     with (
         mock.patch("litellm.completion", return_value=mock_response) as mock_litellm,
-        mock.patch("mlflow.tracking.get_tracking_uri") as mock_get_uri,
+        mock.patch("mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri") as mock_get_uri,
     ):
         mock_get_uri.return_value = "http://localhost:5000"
 
@@ -359,7 +365,9 @@ def test_gateway_provider_requires_http_tracking_uri():
     from mlflow.exceptions import MlflowException
     from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
 
-    with mock.patch("mlflow.tracking.get_tracking_uri", return_value="databricks"):
+    with mock.patch(
+        "mlflow.genai.judges.adapters.litellm_adapter.get_tracking_uri", return_value="databricks"
+    ):
         with pytest.raises(MlflowException, match="Gateway provider requires an HTTP"):
             _invoke_litellm_and_handle_tools(
                 provider="gateway",

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -157,13 +157,13 @@ def test_invoke_litellm_with_gateway_params():
             response_format=None,
             include_response_format=False,
             api_base="http://localhost:5000/gateway/mlflow/v1/",
-            api_key="not-needed",
+            api_key="mlflow-gateway-auth",
         )
 
     call_kwargs = mock_litellm.call_args.kwargs
     assert call_kwargs["model"] == "my-endpoint"
     assert call_kwargs["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
-    assert call_kwargs["api_key"] == "not-needed"
+    assert call_kwargs["api_key"] == "mlflow-gateway-auth"
 
 
 def test_invoke_litellm_and_handle_tools_with_context_window_exceeded_direct_provider(mock_trace):
@@ -352,7 +352,7 @@ def test_gateway_provider_integration():
     call_kwargs = mock_litellm.call_args.kwargs
     assert call_kwargs["model"] == "openai/my-endpoint"
     assert call_kwargs["api_base"] == "http://localhost:5000/gateway/mlflow/v1/"
-    assert call_kwargs["api_key"] == "not-needed"
+    assert call_kwargs["api_key"] == "mlflow-gateway-auth"
 
 
 def test_gateway_provider_requires_http_tracking_uri():

--- a/tests/genai/judges/adapters/test_litellm_adapter.py
+++ b/tests/genai/judges/adapters/test_litellm_adapter.py
@@ -355,6 +355,21 @@ def test_gateway_provider_integration():
     assert call_kwargs["api_key"] == "not-needed"
 
 
+def test_gateway_provider_requires_http_tracking_uri():
+    from mlflow.exceptions import MlflowException
+    from mlflow.genai.judges.adapters.litellm_adapter import _invoke_litellm_and_handle_tools
+
+    with mock.patch("mlflow.tracking.get_tracking_uri", return_value="databricks"):
+        with pytest.raises(MlflowException, match="Gateway provider requires an HTTP"):
+            _invoke_litellm_and_handle_tools(
+                provider="gateway",
+                model_name="my-endpoint",
+                messages=[ChatMessage(role="user", content="Test")],
+                trace=None,
+                num_retries=3,
+            )
+
+
 def test_remove_oldest_tool_call_pair_removes_oldest():
     messages = [
         litellm.Message(role="user", content="Hello"),


### PR DESCRIPTION
### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> N/A

### What changes are proposed in this pull request?

Enable scorers to use MLflow AI Gateway endpoints via `gateway:/endpoint-name` model URI format. Changes include:

- Route gateway provider requests through LiteLLM with OpenAI-compatible API base pointing to the MLflow tracking server's gateway endpoint
- Add unit tests for gateway provider integration and message truncation

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] New unit/integration tests
- [x] Manual tests

Example manual test with gateway provider:

```python
from mlflow.genai.scorers import Safety

mlflow.set_tracking_uri('http://localhost:5000')
mlflow.set_experiment(experiment_id='1')

# Use gateway model URI format: "gateway:/<endpoint-name>"
scorer = Safety(model="gateway:/my-endpoint")

eval_data = [
    {
        "inputs": {"question": "How do I bake a chocolate cake?"},
        "outputs": {"response": "Mix flour, sugar, cocoa powder, eggs, and butter. Bake at 350F."},
    },
]

result = mlflow.genai.evaluate(data=eval_data, scorers=[scorer])
```

Output: 

<img width="1611" height="860" alt="image" src="https://github.com/user-attachments/assets/2814b6ab-d4e2-4aea-b11a-b179dc402c7c" />

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Scorers can now use MLflow AI Gateway endpoints by specifying a model URI in the format `gateway:/endpoint-name`.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [x] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [x] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [x] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [ ] Yes (this PR will be cherry-picked and included in the next patch release)
- [x] No (this PR will be included in the next minor release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)