### PR TITLE
Add documentation for KnowledgeRetention scorer

### DIFF
--- a/docs/docs/genai/eval-monitor/running-evaluation/multi-turn.mdx
+++ b/docs/docs/genai/eval-monitor/running-evaluation/multi-turn.mdx
@@ -109,6 +109,7 @@ results = mlflow.genai.evaluate(
 MLflow provides built-in scorers for evaluating conversations:
 
 - **<APILink fn="mlflow.genai.scorers.ConversationCompleteness">ConversationCompleteness</APILink>**: Evaluates whether the agent addressed all user questions throughout the conversation (returns "complete" or "incomplete")
+- **<APILink fn="mlflow.genai.scorers.KnowledgeRetention">KnowledgeRetention</APILink>**: Evaluates whether the assistant correctly retains information from earlier user inputs without contradiction or distortion (returns "yes" or "no")
 - **<APILink fn="mlflow.genai.scorers.UserFrustration">UserFrustration</APILink>**: Detects and tracks user frustration patterns (returns "none", "resolved", or "unresolved")
 
 See the [Predefined Scorers](/genai/eval-monitor/scorers/llm-judge/predefined#multi-turn-scorers) page for detailed usage examples and API documentation.

--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
@@ -97,6 +97,7 @@ Multi-turn scorers evaluate entire conversation sessions rather than individual 
 | <APILink fn="mlflow.genai.scorers.ConversationalRoleAdherence">ConversationalRoleAdherence</APILink>\*\*           | Does the assistant maintain its assigned role throughout the conversation? | Yes               |
 | <APILink fn="mlflow.genai.scorers.ConversationalSafety">ConversationalSafety</APILink>\*\*                         | Are the assistant's responses safe and free of harmful content?            | Yes               |
 | <APILink fn="mlflow.genai.scorers.ConversationalToolCallEfficiency">ConversationalToolCallEfficiency</APILink>\*\* | Was tool usage across the conversation efficient and appropriate?          | Yes               |
+| <APILink fn="mlflow.genai.scorers.KnowledgeRetention">KnowledgeRetention</APILink>\*\*                             | Does the assistant correctly retain information from earlier user inputs?  | Yes               |
 | <APILink fn="mlflow.genai.scorers.UserFrustration">UserFrustration</APILink>\*\*                                   | Is the user frustrated? Was the frustration resolved?                      | Yes               |
 
 :::info Multi-Turn Evaluation Requirements


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/19478?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19478/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19478/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19478/merge
```

</p>
</details>

### Related Issues/PRs

Related to #19436

### What changes are proposed in this pull request?

This PR adds documentation for the new `KnowledgeRetention` scorer that evaluates whether AI assistants correctly retain, contradict, or distort information provided by users in earlier conversation turns.

Changes include:
- Added KnowledgeRetention to the Multi-Turn Scorers table in `predefined.mdx`
- Added KnowledgeRetention to the Built-in Scorers list in `multi-turn.mdx`
- Positioned alphabetically between ConversationalToolCallEfficiency and UserFrustration
- Used consistent terminology ("assistant" instead of "AI") to match existing scorer descriptions

### How is this PR tested?

- [x] Manual tests

Documentation changes were manually reviewed to ensure:
- Correct formatting and alignment in the markdown tables
- Consistent terminology with existing scorers
- Proper APILink references
- Accurate descriptions matching the scorer implementation

### Does this PR require documentation update?

- [ ] No. You can skip the rest of this section.
- [x] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [x] Instructions

### Release Notes

#### Is this a user-facing change?

- [ ] No. You can skip the rest of this section.
- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added documentation for the new KnowledgeRetention scorer in the conversational evaluation guides and predefined scorers reference.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [ ] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [x] `area/docs`: MLflow documentation pages

#### How should the PR be classified in the release notes? Choose one:

- [ ] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)