### PR TITLE
[UI Telemetry] Add rudimentary logging for navbar clicks

### DIFF
--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -391,8 +391,8 @@ To opt out of UI telemetry, you can block network access to `https://d139nb52glx
 
 ### Opting out of UI telemetry
 
-As described above, the admin of an MLflow server can set the `MLFLOW_DISABLE_TELEMETRY`
-environment variable to disable UI telemetry globally for the server. However, if you are not
+As described above, the admin of an MLflow server can set the `MLFLOW_DISABLE_TELEMETRY` or `DO_NOT_TRACK`
+environment variables to disable UI telemetry globally for the server. However, if you are not
 an admin (i.e. you have no ability to set environment variables), you can still personally opt
 out from UI telemetry by visiting the "Settings" page in the MLflow UI (introduced in MLflow 3.8.0).
 

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -291,11 +291,6 @@ This table describes a list of metadata that may be collected together with a gi
   </thead>
   <tbody>
     <tr>
-      <td>Remote server status</td>
-      <td>A boolean indicating whether or not the MLflow server is remote or local</td>
-      <td>`true`</td>
-    </tr>
-    <tr>
       <td>Browser family</td>
       <td>An enumerated string describing the browser family</td>
       <td>`Chrome`, `Safari`, `Firefox`, `Other`</td>
@@ -322,7 +317,7 @@ This table describes a list of metadata that may be collected together with a gi
     </tr>
     <tr>
       <td>Timestamp</td>
-      <td>The client-side timestam of when the interaction occurred</td>
+      <td>The client-side timestamp of when the interaction occurred</td>
       <td>`1765789548484000`.</td>
     </tr>
   </tbody>

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -264,7 +264,7 @@ For events with None in the `Tracked Parameters` column, only the event name is 
     </tr>
     <tr>
       <td>ui_event</td>
-      <td>A UI interaction event. See the [below table](#ui-interaction-metadata) for a description on the various metadata elements</td>
+      <td>A UI interaction event. See the [below table](#ui-interaction-metadata) for a description of the various metadata elements</td>
       <td>`{ "browserFamily": "Chrome", "isMobile": false, "eventType": "onClick", "componentViewId": "88fc9edd-5e9e-4a17-abd2-c543f505b8eb", "componentId": "mlflow.prompts.list.create", "componentType": "button", timestamp_ns: 1765784028467000000 }`</td>
     </tr>
   </tbody>

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -265,7 +265,7 @@ For events with None in the `Tracked Parameters` column, only the event name is 
     <tr>
       <td>ui_event</td>
       <td>A UI interaction event. See the [below table](#ui-interaction-metadata) for a description of the various metadata elements</td>
-      <td>`{ "browserFamily": "Chrome", "isMobile": false, "eventType": "onClick", "componentViewId": "88fc9edd-5e9e-4a17-abd2-c543f505b8eb", "componentId": "mlflow.prompts.list.create", "componentType": "button", timestamp_ns: 1765784028467000000 }`</td>
+      <td>`{ "eventType": "onClick", "componentViewId": "88fc9edd-5e9e-4a17-abd2-c543f505b8eb", "componentId": "mlflow.prompts.list.create", "componentType": "button", timestamp_ns: 1765784028467000000 }`</td>
     </tr>
   </tbody>
 </Table>
@@ -287,16 +287,6 @@ This table describes a list of metadata that may be collected together with a gi
       <td>Component ID of interactive UI elements</td>
       <td>An ID string of an interactive element (e.g. button, switch, link, input field) in the UI. A log is generated upon clicking, typing, or otherwise interacting with such elements. A comprehensive list of component ID values can be found by [this search query](https://github.com/search?q=repo%3Amlflow%2Fmlflow%20componentId%3D&type=code).</td>
       <td>`mlflow.prompts.list.create` (identifier for the "Create prompt" button on the prompts page)</td>
-    </tr>
-    <tr>
-      <td>Browser family</td>
-      <td>An enumerated string describing the browser family</td>
-      <td>`Chrome`, `Safari`, `Firefox`, `Other`</td>
-    </tr>
-    <tr>
-      <td>Mobile status</td>
-      <td>A boolean indicating whether or not the event took place on a mobile device</td>
-      <td>`false`</td>
     </tr>
     <tr>
       <td>Event type</td>

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -125,18 +125,6 @@ The below section outlines the data currently collected in this version of MLflo
       <td>create_logged_model event: `{"flavor": "langchain"}`</td>
       <td>To better understand the usage pattern for each event</td>
     </tr>
-    <tr>
-      <td>Component ID of interactive UI elements</td>
-      <td>An ID string of an interactive element (e.g. button, switch, link, input field) in the UI. A log is generated upon clicking, typing, or otherwise interacting with such elements. A comprehensive list of component ID values can be found by [this search query](https://github.com/search?q=repo%3Amlflow%2Fmlflow%20componentId%3D&type=code).</td>
-      <td>`mlflow.prompts.list.create` (identifier for the "Create prompt" button on the prompts page)</td>
-      <td>To understand the usage patterns of different UI pages and features</td>
-    </tr>
-    <tr>
-      <td>Metadata associated with UI interactions</td>
-      <td>See [below table](#ui-interaction-metadata) for metadata associated with UI interaction logs.</td>
-      <td>`{ "isRemote": true, "browserFamily": "Chrome", "isMobile": false, "eventType": "onClick", "componentViewId": "88fc9edd-5e9e-4a17-abd2-c543f505b8eb", "componentId": "mlflow.prompts.list.create", "componentType": "button", timestamp_ns: 1765784028467000000 }`</td>
-      <td>To understand UI usage patterns in greater depth, and to inform prioritization of different platforms, browsers, and user flows.</td>
-    </tr>
   </tbody>
 </Table>
 
@@ -274,6 +262,11 @@ For events with None in the `Tracked Parameters` column, only the event name is 
       <td>Command key and invocation context (cli or mcp)</td>
       <td>`{"command_key": "genai/analyze_experiment", "context": "cli"}`</td>
     </tr>
+    <tr>
+      <td>ui_event</td>
+      <td>A UI interaction event. See the [below table](#ui-interaction-metadata) for a description on the various metadata elements</td>
+      <td>`{ "browserFamily": "Chrome", "isMobile": false, "eventType": "onClick", "componentViewId": "88fc9edd-5e9e-4a17-abd2-c543f505b8eb", "componentId": "mlflow.prompts.list.create", "componentType": "button", timestamp_ns: 1765784028467000000 }`</td>
+    </tr>
   </tbody>
 </Table>
 
@@ -290,6 +283,11 @@ This table describes a list of metadata that may be collected together with a gi
     </tr>
   </thead>
   <tbody>
+    <tr>
+      <td>Component ID of interactive UI elements</td>
+      <td>An ID string of an interactive element (e.g. button, switch, link, input field) in the UI. A log is generated upon clicking, typing, or otherwise interacting with such elements. A comprehensive list of component ID values can be found by [this search query](https://github.com/search?q=repo%3Amlflow%2Fmlflow%20componentId%3D&type=code).</td>
+      <td>`mlflow.prompts.list.create` (identifier for the "Create prompt" button on the prompts page)</td>
+    </tr>
     <tr>
       <td>Browser family</td>
       <td>An enumerated string describing the browser family</td>
@@ -385,9 +383,7 @@ assert get_telemetry_client() is None, "Telemetry is enabled"
 
 ### How to opt-out for your organization?
 
-Organizations can disable telemetry by blocking network access to `https://config.mlflow-telemetry.io`. When this endpoint is unreachable, MLflow automatically disables telemetry for the SDK.
-
-To opt out of UI telemetry, you can block network access to `https://d139nb52glx00z.cloudfront.net` from the MLflow server. Similar to above, if this endpoint is unreachable, UI telemetry will be disabled.
+Aside from setting the environment variables described above, organizations can additionally opt out of telemetry by blocking network access to the `mlflow-telemetry.io` domain. When this domain is unreachable, telemetry will be disabled.
 
 ### Opting out of UI telemetry
 

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -312,7 +312,7 @@ This table describes a list of metadata that may be collected together with a gi
     </tr>
     <tr>
       <td>Component View ID</td>
-      <td>A randomly generated UUID that is regernerated whenever the UI element rerenders. Can be used to link view and click events.</td>
+      <td>A randomly generated UUID that is regenerated whenever the UI element rerenders</td>
       <td>`774db636-5cfa-4ce8-8f56-7e7126dc3439`</td>
     </tr>
     <tr>
@@ -385,7 +385,9 @@ assert get_telemetry_client() is None, "Telemetry is enabled"
 
 ### How to opt-out for your organization?
 
-Organizations can disable telemetry by blocking network access to `https://config.mlflow-telemetry.io`. When this endpoint is unreachable, MLflow automatically disables telemetry.
+Organizations can disable telemetry by blocking network access to `https://config.mlflow-telemetry.io`. When this endpoint is unreachable, MLflow automatically disables telemetry for the SDK.
+
+To opt out of UI telemetry, you can block network access to `https://d139nb52glx00z.cloudfront.net` from the MLflow server. Similar to above, if this endpoint is unreachable, UI telemetry will be disabled.
 
 ### Opting out of UI telemetry
 

--- a/docs/docs/community/usage-tracking.mdx
+++ b/docs/docs/community/usage-tracking.mdx
@@ -125,6 +125,18 @@ The below section outlines the data currently collected in this version of MLflo
       <td>create_logged_model event: `{"flavor": "langchain"}`</td>
       <td>To better understand the usage pattern for each event</td>
     </tr>
+    <tr>
+      <td>Component ID of interactive UI elements</td>
+      <td>An ID string of an interactive element (e.g. button, switch, link, input field) in the UI. A log is generated upon clicking, typing, or otherwise interacting with such elements. A comprehensive list of component ID values can be found by [this search query](https://github.com/search?q=repo%3Amlflow%2Fmlflow%20componentId%3D&type=code).</td>
+      <td>`mlflow.prompts.list.create` (identifier for the "Create prompt" button on the prompts page)</td>
+      <td>To understand the usage patterns of different UI pages and features</td>
+    </tr>
+    <tr>
+      <td>Metadata associated with UI interactions</td>
+      <td>See [below table](#ui-interaction-metadata) for metadata associated with UI interaction logs.</td>
+      <td>`{ "isRemote": true, "browserFamily": "Chrome", "isMobile": false, "eventType": "onClick", "componentViewId": "88fc9edd-5e9e-4a17-abd2-c543f505b8eb", "componentId": "mlflow.prompts.list.create", "componentType": "button", timestamp_ns: 1765784028467000000 }`</td>
+      <td>To understand UI usage patterns in greater depth, and to inform prioritization of different platforms, browsers, and user flows.</td>
+    </tr>
   </tbody>
 </Table>
 
@@ -265,6 +277,57 @@ For events with None in the `Tracked Parameters` column, only the event name is 
   </tbody>
 </Table>
 
+#### UI Interaction Metadata
+
+This table describes a list of metadata that may be collected together with a given UI interaction log.
+
+<Table>
+  <thead>
+    <tr>
+      <th style={{ width: "20%" }}>Metadata Element</th>
+      <th style={{ width: "40%" }}>Explanation</th>
+      <th style={{ width: "40%" }}>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Remote server status</td>
+      <td>A boolean indicating whether or not the MLflow server is remote or local</td>
+      <td>`true`</td>
+    </tr>
+    <tr>
+      <td>Browser family</td>
+      <td>An enumerated string describing the browser family</td>
+      <td>`Chrome`, `Safari`, `Firefox`, `Other`</td>
+    </tr>
+    <tr>
+      <td>Mobile status</td>
+      <td>A boolean indicating whether or not the event took place on a mobile device</td>
+      <td>`false`</td>
+    </tr>
+    <tr>
+      <td>Event type</td>
+      <td>An enumerated categorical value describing the nature of the interaction</td>
+      <td>`onView`, `onClick`, `onValueChange`</td>
+    </tr>
+    <tr>
+      <td>Component type</td>
+      <td>An enumerated categorical value describing the type of component that the interaction happened with</td>
+      <td>`button`, `alert`, `banner`, `radio`, `input`, ...</td>
+    </tr>
+    <tr>
+      <td>Component View ID</td>
+      <td>A randomly generated UUID that is regernerated whenever the UI element rerenders. Can be used to link view and click events.</td>
+      <td>`774db636-5cfa-4ce8-8f56-7e7126dc3439`</td>
+    </tr>
+    <tr>
+      <td>Timestamp</td>
+      <td>The client-side timestam of when the interaction occurred</td>
+      <td>`1765789548484000`.</td>
+    </tr>
+  </tbody>
+</Table>
+
 ## Why is MLflow Telemetry Opt-Out?
 
 MLflow uses an opt-out telemetry model to help improve the platform for all users based on real-world usage patterns.
@@ -308,6 +371,7 @@ If you'd like support for additional CI environments, please [open an issue on o
 
 - The environment variable only takes effect in processes where it is explicitly set or inherited.
 - If you spawn subprocesses from a clean environment, those subprocesses may not inherit your shell's environment, and telemetry could remain enabled. e.g. `subprocess.run([...], env={})`
+- Setting this environment variable before running `mlflow server` also disables all UI telemetry
 
 Recommendations to ensure telemetry is consistently disabled across all environments:
 
@@ -327,6 +391,16 @@ assert get_telemetry_client() is None, "Telemetry is enabled"
 ### How to opt-out for your organization?
 
 Organizations can disable telemetry by blocking network access to `https://config.mlflow-telemetry.io`. When this endpoint is unreachable, MLflow automatically disables telemetry.
+
+### Opting out of UI telemetry
+
+As described above, the admin of an MLflow server can set the `MLFLOW_DISABLE_TELEMETRY`
+environment variable to disable UI telemetry globally for the server. However, if you are not
+an admin (i.e. you have no ability to set environment variables), you can still personally opt
+out from UI telemetry by visiting the "Settings" page in the MLflow UI (introduced in MLflow 3.8.0).
+
+Setting the toggle to "Off" will disable UI telemetry from your device, even if the admin has not
+opted out server-side.
 
 ## What are we doing with this data?
 

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -18,7 +18,7 @@ import ExperimentTrackingRoutes from '../../experiment-tracking/routes';
 import { ModelRegistryRoutes } from '../../model-registry/routes';
 import GatewayRoutes from '../../gateway/routes';
 import { CreateExperimentModal } from '../../experiment-tracking/components/modals/CreateExperimentModal';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useInvalidateExperimentList } from '../../experiment-tracking/components/experiment-page/hooks/useExperimentListQuery';
 import { CreateModelModal } from '../../model-registry/components/CreateModelModal';
 import {
@@ -42,7 +42,7 @@ export function MlflowSidebar() {
   const { theme } = useDesignSystemTheme();
   const invalidateExperimentList = useInvalidateExperimentList();
   const navigate = useNavigate();
-  const viewId = crypto.randomUUID();
+  const viewId = useMemo(() => crypto.randomUUID(), []);
 
   const [showCreateExperimentModal, setShowCreateExperimentModal] = useState(false);
   const [showCreateModelModal, setShowCreateModelModal] = useState(false);

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -9,6 +9,8 @@ import {
   PlusIcon,
   TextBoxIcon,
   useDesignSystemTheme,
+  DesignSystemEventProviderComponentTypes,
+  DesignSystemEventProviderAnalyticsEventTypes,
 } from '@databricks/design-system';
 import type { Location } from '../utils/RoutingUtils';
 import { Link, matchPath, useLocation, useNavigate } from '../utils/RoutingUtils';
@@ -25,6 +27,7 @@ import {
 } from '../../experiment-tracking/pages/prompts/hooks/useCreatePromptModal';
 import Routes from '../../experiment-tracking/routes';
 import { FormattedMessage } from 'react-intl';
+import { useLogTelemetryEvent } from '../../telemetry/hooks/useLogTelemetryEvent';
 
 const isHomeActive = (location: Location) => matchPath({ path: '/', end: true }, location.pathname);
 const isExperimentsActive = (location: Location) =>
@@ -39,6 +42,7 @@ export function MlflowSidebar() {
   const { theme } = useDesignSystemTheme();
   const invalidateExperimentList = useInvalidateExperimentList();
   const navigate = useNavigate();
+  const viewId = crypto.randomUUID();
 
   const [showCreateExperimentModal, setShowCreateExperimentModal] = useState(false);
   const [showCreateModelModal, setShowCreateModelModal] = useState(false);
@@ -56,6 +60,7 @@ export function MlflowSidebar() {
         isActive: isHomeActive,
         children: <FormattedMessage defaultMessage="Home" description="Sidebar link for home page" />,
       },
+      componentId: 'mlflow.sidebar.home_tab_link',
     },
     {
       key: 'experiments',
@@ -65,6 +70,7 @@ export function MlflowSidebar() {
         isActive: isExperimentsActive,
         children: <FormattedMessage defaultMessage="Experiments" description="Sidebar link for experiments tab" />,
       },
+      componentId: 'mlflow.sidebar.experiments_tab_link',
       dropdownProps: {
         componentId: 'mlflow_sidebar.create_experiment_button',
         onClick: () => setShowCreateExperimentModal(true),
@@ -84,6 +90,7 @@ export function MlflowSidebar() {
         isActive: isModelsActive,
         children: <FormattedMessage defaultMessage="Models" description="Sidebar link for models tab" />,
       },
+      componentId: 'mlflow.sidebar.models_tab_link',
       dropdownProps: {
         componentId: 'mlflow_sidebar.create_model_button',
         onClick: () => setShowCreateModelModal(true),
@@ -103,6 +110,7 @@ export function MlflowSidebar() {
         isActive: isPromptsActive,
         children: <FormattedMessage defaultMessage="Prompts" description="Sidebar link for prompts tab" />,
       },
+      componentId: 'mlflow.sidebar.prompts_tab_link',
       dropdownProps: {
         componentId: 'mlflow_sidebar.create_prompt_button',
         onClick: openCreatePromptModal,
@@ -122,8 +130,11 @@ export function MlflowSidebar() {
         isActive: isGatewayActive,
         children: <FormattedMessage defaultMessage="Gateway" description="Sidebar link for gateway configuration" />,
       },
+      componentId: 'mlflow.sidebar.gateway_tab_link',
     },
   ];
+
+  const logTelemetryEvent = useLogTelemetryEvent();
 
   return (
     <aside
@@ -166,7 +177,7 @@ export function MlflowSidebar() {
             margin: 0,
           }}
         >
-          {menuItems.map(({ key, icon, linkProps }) => (
+          {menuItems.map(({ key, icon, linkProps, componentId }) => (
             <li key={key}>
               <Link
                 to={linkProps.to}
@@ -189,6 +200,15 @@ export function MlflowSidebar() {
                     fontWeight: theme.typography.typographyBoldFontWeight,
                   },
                 }}
+                onClick={() =>
+                  logTelemetryEvent({
+                    componentId,
+                    componentViewId: viewId,
+                    componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+                    componentSubType: null,
+                    eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+                  })
+                }
               >
                 {icon}
                 {linkProps.children}

--- a/mlflow/server/js/src/common/components/MlflowSidebar.tsx
+++ b/mlflow/server/js/src/common/components/MlflowSidebar.tsx
@@ -149,7 +149,7 @@ export function MlflowSidebar() {
     >
       <DropdownMenu.Root modal={false}>
         <DropdownMenu.Trigger asChild>
-          <Button componentId="mlflow_sidebar.new_button" icon={<PlusIcon />}>
+          <Button componentId="mlflow.sidebar.new_button" icon={<PlusIcon />}>
             <FormattedMessage
               defaultMessage="New"
               description="Sidebar create popover button to create new experiment, model or prompt"
@@ -237,6 +237,15 @@ export function MlflowSidebar() {
               fontWeight: theme.typography.typographyBoldFontWeight,
             },
           }}
+          onClick={() =>
+            logTelemetryEvent({
+              componentId: 'mlflow.sidebar.settings_tab_link',
+              componentViewId: viewId,
+              componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+              componentSubType: null,
+              eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+            })
+          }
         >
           <GearIcon />
           <FormattedMessage defaultMessage="Settings" description="Sidebar link for settings page" />

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.test.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.test.tsx
@@ -19,6 +19,10 @@ jest.mock('../../../../common/utils/RoutingUtils', () => ({
   useParams: () => ({ experimentId: 'test-experiment-123' }),
 }));
 
+jest.mock('@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent', () => ({
+  useLogTelemetryEvent: jest.fn(() => jest.fn()),
+}));
+
 describe('ExperimentPageSideNav', () => {
   const renderTestComponent = (experimentKind: ExperimentKind, activeTab: ExperimentPageTabName) => {
     const queryClient = new QueryClient();

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.tsx
@@ -6,6 +6,7 @@ import type { ExperimentPageSideNavSectionKey } from './constants';
 import { COLLAPSED_CLASS_NAME, FULL_WIDTH_CLASS_NAME, useExperimentPageSideNavConfig } from './constants';
 import { ExperimentPageSideNavSection } from './ExperimentPageSideNavSection';
 import { useParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
+import { useLogTelemetryEvent } from '@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent';
 
 const SIDE_NAV_WIDTH = 160;
 const SIDE_NAV_COLLAPSED_WIDTH = 32;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNav.tsx
@@ -6,7 +6,6 @@ import type { ExperimentPageSideNavSectionKey } from './constants';
 import { COLLAPSED_CLASS_NAME, FULL_WIDTH_CLASS_NAME, useExperimentPageSideNavConfig } from './constants';
 import { ExperimentPageSideNavSection } from './ExperimentPageSideNavSection';
 import { useParams } from '@mlflow/mlflow/src/common/utils/RoutingUtils';
-import { useLogTelemetryEvent } from '@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent';
 
 const SIDE_NAV_WIDTH = 160;
 const SIDE_NAV_COLLAPSED_WIDTH = 32;

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
@@ -18,6 +18,7 @@ import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
 import invariant from 'invariant';
 import { isTracesRelatedTab } from './utils';
 import { useLogTelemetryEvent } from '@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent';
+import { useMemo } from 'react';
 
 export const ExperimentPageSideNavSection = ({
   sectionKey,
@@ -32,7 +33,7 @@ export const ExperimentPageSideNavSection = ({
   const { experimentId } = useParams();
   const { search } = useLocation();
   const logTelemetryEvent = useLogTelemetryEvent();
-  const viewId = crypto.randomUUID();
+  const viewId = useMemo(() => crypto.randomUUID(), []);
 
   invariant(experimentId, 'Experiment ID must be defined');
 

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/ExperimentPageSideNavSection.tsx
@@ -1,4 +1,10 @@
-import { Tooltip, Typography, useDesignSystemTheme } from '@databricks/design-system';
+import {
+  DesignSystemEventProviderAnalyticsEventTypes,
+  DesignSystemEventProviderComponentTypes,
+  Tooltip,
+  Typography,
+  useDesignSystemTheme,
+} from '@databricks/design-system';
 import {
   COLLAPSED_CLASS_NAME,
   FULL_WIDTH_CLASS_NAME,
@@ -11,6 +17,7 @@ import { Link, useLocation, useParams } from '@mlflow/mlflow/src/common/utils/Ro
 import Routes from '@mlflow/mlflow/src/experiment-tracking/routes';
 import invariant from 'invariant';
 import { isTracesRelatedTab } from './utils';
+import { useLogTelemetryEvent } from '@mlflow/mlflow/src/telemetry/hooks/useLogTelemetryEvent';
 
 export const ExperimentPageSideNavSection = ({
   sectionKey,
@@ -24,6 +31,8 @@ export const ExperimentPageSideNavSection = ({
   const { theme } = useDesignSystemTheme();
   const { experimentId } = useParams();
   const { search } = useLocation();
+  const logTelemetryEvent = useLogTelemetryEvent();
+  const viewId = crypto.randomUUID();
 
   invariant(experimentId, 'Experiment ID must be defined');
 
@@ -73,6 +82,15 @@ export const ExperimentPageSideNavSection = ({
               pathname: Routes.getExperimentPageTabRoute(experimentId, item.tabName),
               search: preserveQueryParams ? search : undefined,
             }}
+            onClick={() =>
+              logTelemetryEvent({
+                componentId: item.componentId,
+                componentViewId: viewId,
+                componentType: DesignSystemEventProviderComponentTypes.TypographyLink,
+                componentSubType: null,
+                eventType: DesignSystemEventProviderAnalyticsEventTypes.OnClick,
+              })
+            }
           >
             <div
               css={{

--- a/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/constants.tsx
+++ b/mlflow/server/js/src/experiment-tracking/pages/experiment-page-tabs/side-nav/constants.tsx
@@ -19,6 +19,7 @@ export const FULL_WIDTH_CLASS_NAME = 'mlflow-experiment-page-side-nav-full';
 export const COLLAPSED_CLASS_NAME = 'mlflow-experiment-page-side-nav-collapsed';
 
 export type ExperimentPageSideNavItem = {
+  componentId: string;
   label: React.ReactNode;
   icon: React.ReactNode;
   tabName: ExperimentPageTabName;
@@ -41,6 +42,7 @@ const ExperimentPageSideNavGenAIConfig = {
       ),
       icon: <ForkHorizontalIcon />,
       tabName: ExperimentPageTabName.Traces,
+      componentId: 'mlflow.experiment-side-nav.genai.traces',
     },
   ],
   evaluation: [
@@ -53,6 +55,7 @@ const ExperimentPageSideNavGenAIConfig = {
       ),
       icon: <DatabaseIcon />,
       tabName: ExperimentPageTabName.Datasets,
+      componentId: 'mlflow.experiment-side-nav.genai.datasets',
     },
     {
       label: (
@@ -63,6 +66,7 @@ const ExperimentPageSideNavGenAIConfig = {
       ),
       icon: <PlusMinusSquareIcon />,
       tabName: ExperimentPageTabName.EvaluationRuns,
+      componentId: 'mlflow.experiment-side-nav.genai.evaluation-runs',
     },
   ],
   'prompts-versions': [
@@ -75,6 +79,7 @@ const ExperimentPageSideNavGenAIConfig = {
       ),
       icon: <TextBoxIcon />,
       tabName: ExperimentPageTabName.Prompts,
+      componentId: 'mlflow.experiment-side-nav.genai.prompts',
     },
     {
       label: (
@@ -85,6 +90,7 @@ const ExperimentPageSideNavGenAIConfig = {
       ),
       icon: <ModelsIcon />,
       tabName: ExperimentPageTabName.Models,
+      componentId: 'mlflow.experiment-side-nav.genai.agent-versions',
     },
   ],
 };
@@ -97,6 +103,7 @@ const ExperimentPageSideNavCustomModelConfig = {
       ),
       icon: <ListIcon />,
       tabName: ExperimentPageTabName.Runs,
+      componentId: 'mlflow.experiment-side-nav.classic-ml.runs',
     },
     {
       label: (
@@ -107,6 +114,7 @@ const ExperimentPageSideNavCustomModelConfig = {
       ),
       icon: <ModelsIcon />,
       tabName: ExperimentPageTabName.Models,
+      componentId: 'mlflow.experiment-side-nav.classic-ml.models',
     },
     {
       label: (
@@ -117,6 +125,7 @@ const ExperimentPageSideNavCustomModelConfig = {
       ),
       icon: <ForkHorizontalIcon />,
       tabName: ExperimentPageTabName.Traces,
+      componentId: 'mlflow.experiment-side-nav.classic-ml.traces',
     },
   ],
 };
@@ -177,6 +186,7 @@ export const useExperimentPageSideNavConfig = ({
                 ),
                 icon: <ListIcon />,
                 tabName: ExperimentPageTabName.Runs,
+                componentId: 'mlflow.experiment-side-nav.genai.training-runs',
               },
             ],
           }
@@ -195,6 +205,7 @@ export const useExperimentPageSideNavConfig = ({
           ),
           icon: <SpeechBubbleIcon />,
           tabName: ExperimentPageTabName.ChatSessions,
+          componentId: 'mlflow.experiment-side-nav.genai.chat-sessions',
         },
       ],
       evaluation: enableScorersUI()
@@ -209,6 +220,7 @@ export const useExperimentPageSideNavConfig = ({
               ),
               icon: <GavelIcon />,
               tabName: ExperimentPageTabName.Judges,
+              componentId: 'mlflow.experiment-side-nav.genai.judges',
             },
           ]
         : ExperimentPageSideNavGenAIConfig.evaluation,

--- a/mlflow/server/js/src/setupTests.js
+++ b/mlflow/server/js/src/setupTests.js
@@ -48,6 +48,15 @@ jest.mock('./i18n/loadMessages', () => ({
   },
 }));
 
+// Mock TelemetryClient which uses import.meta.url (not supported in Jest)
+jest.mock('./telemetry/TelemetryClient', () => ({
+  telemetryClient: {
+    logEvent: jest.fn(),
+    shutdown: jest.fn(),
+    start: jest.fn(),
+  },
+}));
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   value: jest.fn((query) => ({
@@ -61,6 +70,11 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: jest.fn(),
   })),
 });
+
+// Mock crypto API for tests
+global.crypto = {
+  randomUUID: () => 'test-uuid-' + Math.random().toString(36).substring(2, 15),
+};
 
 beforeEach(() => {
   // Prevent unit tests making actual fetch calls,

--- a/mlflow/server/js/src/telemetry/hooks/useLogTelemetryEvent.tsx
+++ b/mlflow/server/js/src/telemetry/hooks/useLogTelemetryEvent.tsx
@@ -1,0 +1,11 @@
+import { useCallback } from 'react';
+import { DesignSystemObservabilityEvent } from '../types';
+import { telemetryClient } from '../TelemetryClient';
+
+export const useLogTelemetryEvent = () => {
+  const logTelemetryEvent = useCallback((event: DesignSystemObservabilityEvent) => {
+    telemetryClient.logEvent(event);
+  }, []);
+
+  return logTelemetryEvent;
+};

--- a/mlflow/server/js/src/telemetry/types.ts
+++ b/mlflow/server/js/src/telemetry/types.ts
@@ -1,7 +1,12 @@
+import type {
+  DesignSystemEventProviderComponentTypes,
+  DesignSystemEventProviderAnalyticsEventTypes,
+} from '@databricks/design-system';
+
 export interface DesignSystemObservabilityEvent {
   componentId: string;
   componentViewId: string;
-  componentType: string;
+  componentType: DesignSystemEventProviderComponentTypes;
   componentSubType?: string | null;
-  eventType: string;
+  eventType: DesignSystemEventProviderAnalyticsEventTypes;
 }


### PR DESCRIPTION
## 🥞 Stacked PR
Use this [link](https://github.com/mlflow/mlflow/pull/19480/files/85a0c7abde0407e33c823e21ad2221eb89406078..e4e6f4c07f9fda2eda277cd4fc8e4d4e2a1d4db8) to review incremental changes.
- [stack/documentation](https://github.com/mlflow/mlflow/pull/19427) [[Files changed](https://github.com/mlflow/mlflow/pull/19427/files)]
  - [**stack/logging-for-tabs**](https://github.com/mlflow/mlflow/pull/19480) [[Files changed](https://github.com/mlflow/mlflow/pull/19480/files/85a0c7abde0407e33c823e21ad2221eb89406078..e4e6f4c07f9fda2eda277cd4fc8e4d4e2a1d4db8)]

---------
<!-- Remove unused checkboxes except for the patch release section at the bottom -->

### Related Issues/PRs

<!-- Uncomment 'Resolve' if this PR can close the linked items. -->
<!-- Resolve --> #xxx

### What changes are proposed in this pull request?

Quick PR to add some rudimentary logging for tab clicks. Currently it is not logged due to the `<Link>` component not being a design system component (it's from `react-router-dom`).

Eventually it would be nice to have some context provider that automatically injects the current tab into the observability logs, but that will be a larger more complex change.

### How is this PR tested?

- [x] Existing unit/integration tests
- [ ] New unit/integration tests
- [x] Manual tests

Checked that logs are indeed logged:


https://github.com/user-attachments/assets/b49e37b4-17be-4205-8a07-ad01b6d1d100



### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.
- [ ] Yes. I've updated:
  - [ ] Examples
  - [ ] API references
  - [ ] Instructions

### Release Notes

#### Is this a user-facing change?

- [x] No. You can skip the rest of this section.
- [ ] Yes. Give a description of this change to be included in the release notes for MLflow users.

<!-- Details in 1-2 sentences. You can just refer to another PR with a description if this PR is part of a larger change. -->

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [ ] `area/tracking`: Tracking Service, tracking client APIs, autologging
- [ ] `area/models`: MLmodel format, model serialization/deserialization, flavors
- [ ] `area/model-registry`: Model Registry service, APIs, and the fluent client calls for Model Registry
- [ ] `area/scoring`: MLflow Model server, model deployment tools, Spark UDFs
- [ ] `area/evaluation`: MLflow model evaluation features, evaluation metrics, and evaluation workflows
- [ ] `area/gateway`: MLflow AI Gateway client APIs, server, and third-party integrations
- [ ] `area/prompts`: MLflow prompt engineering features, prompt templates, and prompt management
- [ ] `area/tracing`: MLflow Tracing features, tracing APIs, and LLM tracing functionality
- [ ] `area/projects`: MLproject format, project running backends
- [x] `area/uiux`: Front-end, user experience, plotting, JavaScript, JavaScript dev server
- [ ] `area/build`: Build and test infrastructure for MLflow
- [ ] `area/docs`: MLflow documentation pages

<!--
Insert an empty named anchor here to allow jumping to this section with a fragment URL
(e.g. https://github.com/mlflow/mlflow/pull/123#user-content-release-note-category).
Note that GitHub prefixes anchor names in markdown with "user-content-".
-->

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/none` - No description will be included. The PR will be mentioned only by the PR number in the "Small Bugfixes and Documentation Updates" section
- [ ] `rn/breaking-change` - The PR will be mentioned in the "Breaking Changes" section
- [ ] `rn/feature` - A new user-facing feature worth mentioning in the release notes
- [ ] `rn/bug-fix` - A user-facing bug fix worth mentioning in the release notes
- [ ] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

`Yes` should be selected for bug fixes, documentation updates, and other small changes. `No` should be selected for new features and larger changes. If you're unsure about the release classification of this PR, leave this unchecked to let the maintainers decide.

<details>
<summary>What is a minor/patch release?</summary>

- Minor release: a release that increments the second part of the version number (e.g., 1.2.0 -> 1.3.0).
  Bug fixes, doc updates and new features usually go into minor releases.
- Patch release: a release that increments the third part of the version number (e.g., 1.2.0 -> 1.2.1).
  Bug fixes and doc updates usually go into patch releases.

</details>

<!-- Do not modify or remove any text inside the parentheses. Keep both checkboxes below. -->

- [x] Yes (this PR will be cherry-picked and included in the next patch release)
- [ ] No (this PR will be included in the next minor release)
