### PR TITLE
Add documentation for Fluency scorer

### DIFF
--- a/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
+++ b/docs/docs/genai/eval-monitor/scorers/llm-judge/predefined.mdx
@@ -75,6 +75,7 @@ results = mlflow.genai.evaluate(
 | <APILink fn="mlflow.genai.scorers.RelevanceToQuery">RelevanceToQuery</APILink>             | Does the app's response directly address the user's input?    | No                     | No                    |
 | <APILink fn="mlflow.genai.scorers.Correctness">Correctness</APILink>                       | Is the app's response correct compared to ground-truth?       | Yes\*                  | No                    |
 | <APILink fn="mlflow.genai.scorers.Completeness">Completeness</APILink>\*\*                 | Does the agent address all questions in a single user prompt? | No                     | No                    |
+| <APILink fn="mlflow.genai.scorers.Fluency">Fluency</APILink>                               | Is the response grammatically correct and naturally flowing?  | No                     | No                    |
 | <APILink fn="mlflow.genai.scorers.Guidelines">Guidelines</APILink>                         | Does the response adhere to provided guidelines?              | Yes\*                  | No                    |
 | <APILink fn="mlflow.genai.scorers.ExpectationsGuidelines">ExpectationsGuidelines</APILink> | Does the response meet specific expectations and guidelines?  | Yes\*                  | No                    |
 | <APILink fn="mlflow.genai.scorers.Safety">Safety</APILink>                                 | Does the app's response avoid harmful or toxic content?       | No                     | No                    |


### PR DESCRIPTION
<details><summary>&#x1F6E0 DevTools &#x1F6E0</summary>
<p>

[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://codespaces.new/alkispoly-db/mlflow/pull/19481?quickstart=1)

#### Install mlflow from this PR

```
# mlflow
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19481/merge
# mlflow-skinny
pip install git+https://github.com/mlflow/mlflow.git@refs/pull/19481/merge#subdirectory=libs/skinny
```

For Databricks, use the following command:

```
%sh curl -LsSf https://raw.githubusercontent.com/mlflow/mlflow/HEAD/dev/install-skinny.sh | sh -s pull/19481/merge
```

</p>
</details>

### Related Issues/PRs

Similar to #19478

### What changes are proposed in this pull request?

This PR adds documentation for the Fluency single-turn scorer in the predefined scorers table.

### How is this PR tested?

- [x] Existing unit/integration tests
- [x] Manual tests

The change adds one row to the documentation table. The Fluency scorer is already implemented and exported in the codebase.

### Does this PR require documentation update?

- [x] No. You can skip the rest of this section.

### Release Notes

#### Is this a user-facing change?

- [x] Yes. Give a description of this change to be included in the release notes for MLflow users.

Added documentation for the Fluency scorer in the predefined LLM scorers table.

#### What component(s), interfaces, languages, and integrations does this PR affect?

Components

- [x] `area/docs`: MLflow documentation pages

<a name="release-note-category"></a>

#### How should the PR be classified in the release notes? Choose one:

- [x] `rn/documentation` - A user-facing documentation change worth mentioning in the release notes

#### Should this PR be included in the next patch release?

- [x] Yes (this PR will be cherry-picked and included in the next patch release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)